### PR TITLE
Add more integration tests for client credentials grant

### DIFF
--- a/internal/identity/oauth2/granthandlers/clientcredentials.go
+++ b/internal/identity/oauth2/granthandlers/clientcredentials.go
@@ -42,7 +42,7 @@ func (h *ClientCredentialsGrantHandler) ValidateGrant(tokenRequest *model.TokenR
 	if tokenRequest.ClientId == "" || tokenRequest.ClientSecret == "" {
 		return &model.ErrorResponse{
 			Error:            constants.ERROR_INVALID_REQUEST,
-			ErrorDescription: "Client ID and secret are required",
+			ErrorDescription: "Client Id and secret are required",
 		}
 	}
 

--- a/tests/integration/identity/oauth2/token/token_test.go
+++ b/tests/integration/identity/oauth2/token/token_test.go
@@ -20,6 +20,7 @@ package token
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -29,16 +30,10 @@ import (
 )
 
 const (
-	testServerURL   = "https://localhost:8095"
-	clientID        = "client123"
-	clientSecret    = "secret123"
-	requestedScopes = "internal_user_mgt_view internal_group_mgt_view internal_group_mgt_edit"
+	testServerURL = "https://localhost:8095"
+	clientId      = "client123"
+	clientSecret  = "secret123"
 )
-
-var expectedScopes = []string{
-	"internal_user_mgt_view",
-	"internal_group_mgt_view",
-}
 
 type TokenTestSuite struct {
 	suite.Suite
@@ -49,72 +44,253 @@ func TestTokenTestSuite(t *testing.T) {
 	suite.Run(t, new(TokenTestSuite))
 }
 
-func (ts *TokenTestSuite) TestClientCredentialsGrant() {
+func (ts *TokenTestSuite) runClientCredentialsTestCase(request *http.Request,
+	expectedStatus int, expectedScopes []string, expectedError string) {
 
-	// Prepare the request
-	reqBody := strings.NewReader("grant_type=client_credentials&scope=" + requestedScopes)
-	req, err := http.NewRequest("POST", testServerURL+"/oauth2/token", reqBody)
-	if err != nil {
-		ts.T().Fatalf("Failed to create request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(clientID, clientSecret)
-
-	// Configure the HTTP client to skip TLS verification
+	// Configure the HTTP client to skip TLS verification.
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // Skip certificate verification
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
 
-	// Send the request
-	resp, err := client.Do(req)
+	// Send the request.
+	resp, err := client.Do(request)
 	if err != nil {
 		ts.T().Fatalf("Failed to send request: %v", err)
 	}
 	defer resp.Body.Close()
 
-	// Validate the response
-	if resp.StatusCode != http.StatusOK {
-		ts.T().Fatalf("Expected status 200, got %d", resp.StatusCode)
+	// Validate the response status.
+	if resp.StatusCode != expectedStatus {
+		ts.T().Fatalf("Expected status %d, got %d", expectedStatus, resp.StatusCode)
 	}
 
-	// Parse the response body
+	// Parse the response body.
 	var respBody map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&respBody)
 	if err != nil {
 		ts.T().Fatalf("Failed to parse response body: %v", err)
 	}
 
-	if _, ok := respBody["access_token"]; !ok {
-		ts.T().Fatalf("Response does not contain access_token")
-	}
-	if _, ok := respBody["token_type"]; !ok {
-		ts.T().Fatalf("Response does not contain token_type")
-	}
-	if _, ok := respBody["expires_in"]; !ok {
-		ts.T().Fatalf("Response does not contain expires_in")
-	}
-
-	// validate the scopes
-	if _, ok := respBody["scope"]; !ok {
-		ts.T().Fatalf("Response does not contain scope")
-	}
-
-	scopes := strings.Fields(respBody["scope"].(string))
-	if len(scopes) != len(expectedScopes) {
-		ts.T().Fatalf("Expected %d scopes, got %d", len(expectedScopes), len(scopes))
-	}
-	for _, expectedScope := range expectedScopes {
-		found := false
-		for _, scope := range scopes {
-			if scope == expectedScope {
-				found = true
-				break
+	// Validate the response content.
+	if expectedStatus == http.StatusOK {
+		if _, ok := respBody["access_token"]; !ok {
+			ts.T().Fatalf("Response does not contain access_token")
+		}
+		if _, ok := respBody["token_type"]; !ok {
+			ts.T().Fatalf("Response does not contain token_type")
+		}
+		if _, ok := respBody["expires_in"]; !ok {
+			ts.T().Fatalf("Response does not contain expires_in")
+		}
+		if len(expectedScopes) > 0 {
+			if _, ok := respBody["scope"]; !ok {
+				ts.T().Fatalf("Response does not contain scope")
 			}
+			scopes := strings.Fields(respBody["scope"].(string))
+			if len(scopes) != len(expectedScopes) {
+				ts.T().Fatalf("Expected %d scopes, got %d", len(expectedScopes), len(scopes))
+			}
+			for _, expectedScope := range expectedScopes {
+				found := false
+				for _, scope := range scopes {
+					if scope == expectedScope {
+						found = true
+						break
+					}
+				}
+				if !found {
+					ts.T().Fatalf("Expected scope %s not found in response", expectedScope)
+				}
+			}
+		} else if _, ok := respBody["scope"]; ok {
+			ts.T().Fatalf("Response should not contain scope when no scopes are requested")
 		}
-		if !found {
-			ts.T().Fatalf("Expected scope %s not found in response", expectedScope)
+	} else if expectedStatus == http.StatusBadRequest {
+		if _, ok := respBody["error"]; !ok {
+			ts.T().Fatalf("Response does not contain error")
+		}
+		if respBody["error"] != expectedError {
+			ts.T().Fatalf("Expected error '%s', got '%v'", expectedError, respBody["error"])
 		}
 	}
+}
+
+func (ts *TokenTestSuite) TestClientCredentialsGrantWithHeaderCredentials() {
+
+	testCases := []struct {
+		testName        string
+		requestedScopes string
+		expectedStatus  int
+		expectedScopes  []string
+	}{
+		{
+			testName:        "WithAuthorizedScopes",
+			requestedScopes: "internal_user_mgt_view internal_user_mgt_edit internal_group_mgt_view",
+			expectedStatus:  http.StatusOK,
+			expectedScopes:  []string{"internal_user_mgt_view", "internal_user_mgt_edit", "internal_group_mgt_view"},
+		},
+		{
+			testName:        "WithoutScopes",
+			requestedScopes: "",
+			expectedStatus:  http.StatusOK,
+			expectedScopes:  nil,
+		},
+		{
+			testName:        "WithAuthorizedAndUnauthorizedScopes",
+			requestedScopes: "internal_user_mgt_view internal_group_mgt_view internal_group_mgt_edit",
+			expectedStatus:  http.StatusOK,
+			expectedScopes:  []string{"internal_user_mgt_view", "internal_group_mgt_view"},
+		},
+		{
+			testName:        "WithInvalidScopes",
+			requestedScopes: "invalid_scope",
+			expectedStatus:  http.StatusOK,
+			expectedScopes:  nil,
+		},
+		{
+			testName:        "WithAuthorizedAndInvalidScopes",
+			requestedScopes: "internal_user_mgt_view invalid_scope",
+			expectedStatus:  http.StatusOK,
+			expectedScopes:  []string{"internal_user_mgt_view"},
+		},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.testName, func() {
+			// Prepare the request.
+			reqBody := strings.NewReader("grant_type=client_credentials&scope=" + tc.requestedScopes)
+			request, err := http.NewRequest("POST", testServerURL+"/oauth2/token", reqBody)
+			if err != nil {
+				ts.T().Fatalf("Failed to create request: %v", err)
+			}
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			request.SetBasicAuth(clientId, clientSecret)
+
+			// Run the test.
+			ts.runClientCredentialsTestCase(request, tc.expectedStatus, tc.expectedScopes, "")
+		})
+	}
+}
+
+func (ts *TokenTestSuite) TestClientCredentialsGrantWithBodyCredentials() {
+
+	testCases := []struct {
+		testName        string
+		requestedScopes string
+		expectedStatus  int
+		expectedScopes  []string
+	}{
+		{
+			testName:        "WithAuthorizedScopes",
+			requestedScopes: "internal_user_mgt_view internal_user_mgt_edit",
+			expectedStatus:  http.StatusOK,
+			expectedScopes:  []string{"internal_user_mgt_view", "internal_user_mgt_edit"},
+		},
+		{
+			testName:        "WithoutScopes",
+			requestedScopes: "",
+			expectedStatus:  http.StatusOK,
+			expectedScopes:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.testName, func() {
+			reqBody := strings.NewReader("grant_type=client_credentials&scope=" + tc.requestedScopes +
+				"&client_id=" + clientId + "&client_secret=" + clientSecret)
+			request, err := http.NewRequest("POST", testServerURL+"/oauth2/token", reqBody)
+			if err != nil {
+				ts.T().Fatalf("Failed to create request: %v", err)
+			}
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			ts.runClientCredentialsTestCase(request, tc.expectedStatus, tc.expectedScopes, "")
+		})
+	}
+}
+
+func (ts *TokenTestSuite) TestClientCredentialsGrantNegativeCases() {
+
+	testCases := []struct {
+		testName       string
+		requestBody    string
+		authHeader     string
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			testName:       "InvalidHeaderCredentials",
+			requestBody:    "grant_type=client_credentials",
+			authHeader:     "Basic " + basicAuth("invalid", "invalid"),
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "invalid_client",
+		},
+		{
+			testName:       "IncorrectHeaderCredentials",
+			requestBody:    "grant_type=client_credentials",
+			authHeader:     "Basic invalid_base64",
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "invalid_client",
+		},
+		{
+			testName:       "InvalidHeaderCredentials",
+			requestBody:    "grant_type=client_credentials",
+			authHeader:     "Basic invalid_base64",
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "invalid_client",
+		},
+		{
+			testName:       "InvalidCredentialsInBody",
+			requestBody:    "grant_type=client_credentials&client_id=invalid&client_secret=invalid",
+			authHeader:     "",
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "invalid_client",
+		},
+		{
+			testName:       "MissingCredentialsInBody",
+			requestBody:    "grant_type=client_credentials",
+			authHeader:     "",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid_request",
+		},
+		{
+			testName:       "InvalidGrantType",
+			requestBody:    "grant_type=invalid_grant",
+			authHeader:     "Basic " + basicAuth(clientId, clientSecret),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "unsupported_grant_type",
+		},
+		{
+			testName:       "MissingGrantType",
+			requestBody:    "",
+			authHeader:     "Basic " + basicAuth(clientId, clientSecret),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid_request",
+		},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.testName, func() {
+			// Prepare the request.
+			reqBody := strings.NewReader(tc.requestBody)
+			request, err := http.NewRequest("POST", testServerURL+"/oauth2/token", reqBody)
+			if err != nil {
+				ts.T().Fatalf("Failed to create request: %v", err)
+			}
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			if tc.authHeader != "" {
+				request.Header.Set("Authorization", tc.authHeader)
+			}
+
+			// Run the test.
+			ts.runClientCredentialsTestCase(request, tc.expectedStatus, nil, tc.expectedError)
+		})
+	}
+}
+
+func basicAuth(username, password string) string {
+
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 }

--- a/tests/integration/run_tests.go
+++ b/tests/integration/run_tests.go
@@ -71,7 +71,7 @@ func main() {
 
 func runTests() {
 
-	cmd := exec.Command("go", "test", "./...")
+	cmd := exec.Command("go", "test", "-v", "./...")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()


### PR DESCRIPTION
## Purpose

This pull request refactors and enhances the integration tests for the OAuth2 client credentials grant, improves error handling, and introduces minor updates to test execution. The most significant changes include restructuring test cases for better modularity, adding negative test cases, and improving the test command for better output visibility.

### Refactoring and Enhancements to Integration Tests:
* Refactored `TestClientCredentialsGrant` into modular test functions (`runClientCredentialsTestCase`, `TestClientCredentialsGrantWithHeaderCredentials`, `TestClientCredentialsGrantWithBodyCredentials`, and `TestClientCredentialsGrantNegativeCases`) to improve readability and maintainability. These changes include the addition of parameterized test cases for various scenarios, such as valid, invalid, and missing credentials. [[1]](diffhunk://#diff-f250c67e9bdf0a8ac12ac9357b9046b119a44d8c4359c8075ae4faa0aeaa6deaL52-R77) [[2]](diffhunk://#diff-f250c67e9bdf0a8ac12ac9357b9046b119a44d8c4359c8075ae4faa0aeaa6deaR107-R295)
* Added negative test cases to validate error handling for scenarios like invalid credentials, missing grant type, and unsupported grant type.
* Introduced a helper function `basicAuth` to encode credentials in base64 for use in Authorization headers.

### Improvements to Error Handling:
* Updated error message in `ValidateGrant` to standardize the casing of "Client Id".

### Updates to Test Execution:
* Modified the test execution command in `run_tests.go` to include the `-v` flag for verbose output, making it easier to debug test failures.
