### PR TITLE
Add initial session data store implementation

### DIFF
--- a/internal/identity/oauth2/model/parameter.go
+++ b/internal/identity/oauth2/model/parameter.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+type OAuthParameters struct {
+	SessionDataKey string
+	State          string
+	ClientId       string
+	RedirectUri    string
+	ResponseType   string
+	Scopes         string
+}

--- a/internal/identity/oauth2/token/tokenhandler.go
+++ b/internal/identity/oauth2/token/tokenhandler.go
@@ -50,6 +50,7 @@ func (th *TokenHandler) HandleTokenRequest(respWriter http.ResponseWriter, reque
 	grantType := request.FormValue(constants.GRANT_TYPE)
 	if grantType == "" {
 		utils.WriteJSONError(respWriter, constants.ERROR_INVALID_REQUEST, "Missing grant_type parameter", http.StatusBadRequest, nil)
+		return
 	}
 
 	var grantHandler granthandlers.GrantHandler

--- a/internal/identity/session/model/sessiondata.go
+++ b/internal/identity/session/model/sessiondata.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"time"
+
+	oauthmodel "github.com/asgardeo/thunder/internal/identity/oauth2/model"
+)
+
+// TODO: Temporary adding the AuthenticatedUser struct here. Should be moved to a appropriate place.
+type AuthenticatedUser struct {
+	UserId                 string
+	Username               string
+	Domain                 string
+	AuthenticatedSubjectId string
+	Attributes             map[string]string
+}
+
+type SessionData struct {
+	OAuthParameters oauthmodel.OAuthParameters
+	LoggedInUser    AuthenticatedUser
+	AuthTime        time.Time
+}

--- a/internal/identity/session/store/sessiondatastore.go
+++ b/internal/identity/session/store/sessiondatastore.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package store
+
+import (
+	"sync"
+	"time"
+
+	"github.com/asgardeo/thunder/internal/identity/session/model"
+)
+
+type SessionDataStoreInterface interface {
+	AddSession(key string, value model.SessionData)
+	GetSession(key string) (bool, model.SessionData)
+	ClearSession(key string)
+	ClearSessionStore()
+}
+
+// sessionStoreEntry represents an entry in the session data store.
+type sessionStoreEntry struct {
+	sessionData model.SessionData
+	expiryTime  time.Time
+}
+
+// SessionDataStore provides the session data store functionality.
+type SessionDataStore struct {
+	sessionStore   map[string]sessionStoreEntry
+	validityPeriod time.Duration
+	mu             sync.RWMutex
+}
+
+var instance *SessionDataStore
+var mu sync.Mutex
+
+// GetSessionDataStore returns a singleton instance of SessionDataStore.
+func GetSessionDataStore() SessionDataStoreInterface {
+
+	if instance == nil {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if instance == nil {
+			instance = &SessionDataStore{
+				sessionStore: make(map[string]sessionStoreEntry),
+				// Set a default validity period.
+				validityPeriod: 10 * time.Minute,
+			}
+		}
+	}
+
+	return instance
+}
+
+// AddSession adds a session data entry to the session store.
+func (sds *SessionDataStore) AddSession(key string, value model.SessionData) {
+
+	if key == "" {
+		return
+	}
+
+	sds.mu.Lock()
+	defer sds.mu.Unlock()
+
+	sds.sessionStore[key] = sessionStoreEntry{
+		sessionData: value,
+		expiryTime:  time.Now().Add(sds.validityPeriod),
+	}
+}
+
+// GetSession retrieves a session data entry from the session store.
+func (sdc *SessionDataStore) GetSession(key string) (bool, model.SessionData) {
+
+	if key == "" {
+		return false, model.SessionData{}
+	}
+
+	sdc.mu.RLock()
+	defer sdc.mu.RUnlock()
+
+	if entry, exists := sdc.sessionStore[key]; exists {
+		if time.Now().Before(entry.expiryTime) {
+			return true, entry.sessionData
+		} else {
+			// Remove the expired entry.
+			delete(sdc.sessionStore, key)
+		}
+	}
+
+	return false, model.SessionData{}
+}
+
+// ClearSession removes a specific session data entry from the session store.
+func (sdc *SessionDataStore) ClearSession(key string) {
+
+	if key == "" {
+		return
+	}
+
+	sdc.mu.Lock()
+	defer sdc.mu.Unlock()
+	delete(sdc.sessionStore, key)
+}
+
+// ClearSessionStore removes all session data entries from the session store.
+func (sdc *SessionDataStore) ClearSessionStore() {
+
+	sdc.mu.Lock()
+	defer sdc.mu.Unlock()
+
+	sdc.sessionStore = make(map[string]sessionStoreEntry)
+}


### PR DESCRIPTION
## Purpose

This pull request defines new models for OAuth2 and session management. Below is a breakdown of the most important changes:

### Session Management Enhancements:

* [`internal/identity/session/model/sessiondata.go`](diffhunk://#diff-faf8035cca137084ce280e8715ee35617c80701d754220e92321f589a4619677R1-R40): Added `SessionData` struct to encapsulate OAuth2 parameters, authenticated user details, and authentication time. Introduced a temporary `AuthenticatedUser` struct for user details, with a note to relocate it later.
* [`internal/identity/session/store/sessiondatastore.go`](diffhunk://#diff-ef1b22cdb51e6e64d732c452dc9fd01a424555283ad22c6ed312e821fefa77b2R1-R127): Implemented `SessionDataStore`, a thread-safe in-memory store for managing session data with methods to add, retrieve, and clear sessions. Introduced a singleton pattern for accessing the store.