### PR TITLE
Fix application api tests

### DIFF
--- a/dbscripts/thunderdb/sqlite.sql
+++ b/dbscripts/thunderdb/sqlite.sql
@@ -1,9 +1,9 @@
 -- Table to store basic service provider (app) details.
 CREATE TABLE SP_APP (
     ID INTEGER PRIMARY KEY AUTOINCREMENT,
-    APP_NAME VARCHAR(255) NOT NULL,
     APP_ID VARCHAR(36) UNIQUE NOT NULL,
-    VERSION VARCHAR(50) NOT NULL
+    APP_NAME VARCHAR(255) NOT NULL,
+    DESCRIPTION VARCHAR(50) NOT NULL
 );
 
 -- Table to store OAuth configurations for SP apps.
@@ -72,7 +72,7 @@ CREATE TABLE AUTHORIZED_SCOPE (
 );
 
 -- Insert sample data into the tables.
-INSERT INTO SP_APP (APP_NAME, APP_ID, VERSION) VALUES ('Test SPA', '550e8400-e29b-41d4-a716-446655440000', '1.0');
+INSERT INTO SP_APP (APP_NAME, APP_ID, DESCRIPTION) VALUES ('Test SPA', '550e8400-e29b-41d4-a716-446655440000', 'Initial testing App');
 
 INSERT INTO IDN_OAUTH_CONSUMER_APPS (CONSUMER_KEY, CONSUMER_SECRET, APP_ID, CALLBACK_URIS, GRANT_TYPES)
 VALUES ('client123', 'secret123', '550e8400-e29b-41d4-a716-446655440000', 'https://localhost:3000', 'client_credentials,authorization_code');

--- a/tests/integration/application/applicationapi_test.go
+++ b/tests/integration/application/applicationapi_test.go
@@ -38,8 +38,8 @@ var (
 		Name:                "Test SPA",
 		Description:         "Initial testing App",
 		ClientID:            "client123",
-		CallbackURL:         []string{"http://example.com/callback"},
-		SupportedGrantTypes: []string{"client_credentials"},
+		CallbackURL:         []string{"https://localhost:3000"},
+		SupportedGrantTypes: []string{"client_credentials", "authorization_code"},
 	}
 
 	appToCreate = Application{


### PR DESCRIPTION
## Purpose
This pull request includes changes to the database schema, sample data, and integration tests to update the structure and behavior of the `SP_APP` table and related configurations. The most important changes include replacing the `VERSION` column with a `DESCRIPTION` column in the `SP_APP` table, updating sample data to reflect this change, and modifying integration tests to align with the updated schema and OAuth configuration.

### Database schema updates:
* [`dbscripts/thunderdb/sqlite.sql`](diffhunk://#diff-0d30131a01d4802d5bfe51a4be6f8adfcc1443277b7d538e6714443a881e60f9L4-R6): Replaced the `VERSION` column in the `SP_APP` table with a `DESCRIPTION` column to provide a more descriptive field for applications.

### Sample data updates:
* [`dbscripts/thunderdb/sqlite.sql`](diffhunk://#diff-0d30131a01d4802d5bfe51a4be6f8adfcc1443277b7d538e6714443a881e60f9L75-R75): Updated the sample data insertion for the `SP_APP` table to include a description (`'Initial testing App'`) instead of a version.

### Integration test updates:
* [`tests/integration/application/applicationapi_test.go`](diffhunk://#diff-bfafc838eb5b33bb0becca517f15643bd99a65ff3069e907fcc03a9eea3a3c9fL41-R42): Modified integration tests to reflect the updated schema and OAuth configuration. Specifically, updated the `CallbackURL` to use `https://localhost:3000` and added the `authorization_code` grant type to `SupportedGrantTypes`.