### PR TITLE
Add default user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ curl -k -X POST https://localhost:8090/oauth2/token \
   - **Username:** `thunder`
   - **Password:** `thunder`
 
-    **Note:** The credentials can be configured in the `repository/conf/deployment.yaml` file under the `oauth.auth_credentials` section.
+    **Note:** The credentials can be configured in the `repository/conf/deployment.yaml` file under the `user_store` section.
 
       Example:
       ```yaml
-      oauth:
-        auth_credentials:
-          username: "thunder"
-          password: "thunder"
+      user_store:
+        default_user:
+          username: "thor"
+          password: "thor123"
       ```
 
 - After successful authentication, you will be redirected to the redirect URI with the authorization code and state.

--- a/cmd/server/repository/conf/deployment.yaml
+++ b/cmd/server/repository/conf/deployment.yaml
@@ -14,7 +14,7 @@ database:
     type: "sqlite"
     path: "repository/database/runtimedb.db"
 
-oauth:
-  auth_credentials:
-    username: "thunder"
-    password: "thunder"
+user_store:
+  default_user:
+    username: "thor"
+    password: "thor123"

--- a/internal/services/authnservice.go
+++ b/internal/services/authnservice.go
@@ -66,8 +66,8 @@ func (s *AuthenticationService) HandleAuthenticationRequest(w http.ResponseWrite
 
 	// Read the valid username and password from the configuration.
 	config := config.GetThunderRuntime().Config
-	validUsername := config.OAuth.AuthCredentials.Username
-	validPassword := config.OAuth.AuthCredentials.Password
+	validUsername := config.UserStore.DefaultUser.Username
+	validPassword := config.UserStore.DefaultUser.Password
 
 	// Create a new session data object.
 	newSessionDataKey := oauthutils.GenerateNewSessionDataKey()

--- a/internal/system/config/config.go
+++ b/internal/system/config/config.go
@@ -50,20 +50,20 @@ type DatabaseConfig struct {
 	Runtime  DataSource `yaml:"runtime"`
 }
 
-type AuthCredentials struct {
+type DefaultUser struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
 }
 
-type OAuthConfig struct {
-	AuthCredentials AuthCredentials `yaml:"auth_credentials"`
+type UserStore struct {
+	DefaultUser DefaultUser `yaml:"default_user"`
 }
 
 type Config struct {
-	Server   ServerConfig   `yaml:"server"`
-	Security SecurityConfig `yaml:"security"`
-	Database DatabaseConfig `yaml:"database"`
-	OAuth    OAuthConfig    `yaml:"oauth"`
+	Server    ServerConfig   `yaml:"server"`
+	Security  SecurityConfig `yaml:"security"`
+	Database  DatabaseConfig `yaml:"database"`
+	UserStore UserStore      `yaml:"user_store"`
 }
 
 // LoadConfig loads the configurations from the specified YAML file.

--- a/tests/integration/resources/deployment.yaml
+++ b/tests/integration/resources/deployment.yaml
@@ -14,8 +14,7 @@ database:
     type: "sqlite"
     path: "repository/database/runtimedb.db"
 
-
-oauth:
-  auth_credentials:
-    username: "thunder"
-    password: "thunder"
+user_store:
+  default_user:
+    username: "thor"
+    password: "thor123"


### PR DESCRIPTION
## Purpose

This pull request refactors the configuration structure for user credentials by replacing the `oauth.auth_credentials` section with a new `user_store.default_user` section. The changes affect configuration files, documentation, and related code to align with the new structure.

### Configuration Refactoring:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R76): Updated the documentation to reflect the new `user_store.default_user` section for configuring credentials, replacing the old `oauth.auth_credentials` section. Example credentials were also updated.
* [`cmd/server/repository/conf/deployment.yaml`](diffhunk://#diff-e2d5d08a43b2b2ff5b57e20a8127235faddb793b97936ea20140f894afa8d48fL17-R20): Replaced the `oauth.auth_credentials` section with the `user_store.default_user` section for defining default user credentials.
* [`tests/integration/resources/deployment.yaml`](diffhunk://#diff-fa16f82fbd9c2018c25d37ee4909e22538213c338bac42adcf7ddb10e244507cL17-R20): Updated the test deployment configuration file to use the `user_store.default_user` section for credentials instead of `oauth.auth_credentials`.

### Code Updates:

* [`internal/services/authnservice.go`](diffhunk://#diff-2d496a070ddcfa8872dfe34e2451560d5d47bdfcf692e2230b9d5426480293ccL69-R70): Updated the authentication service to read credentials from the `user_store.default_user` section instead of `oauth.auth_credentials`.
* [`internal/system/config/config.go`](diffhunk://#diff-14d413301bd18da13e972b64ac2ef4260be639274b1f27291ae109005e365ad8L53-R66): Refactored the configuration struct by replacing the `AuthCredentials` and `OAuthConfig` types with `DefaultUser` and `UserStore` types, respectively. Updated the `Config` struct to use the new `user_store` field.