### PR TITLE
Fix init script to accept named arguments and recreate DBs during tests

### DIFF
--- a/backend/internal/system/database/provider/dbprovider.go
+++ b/backend/internal/system/database/provider/dbprovider.go
@@ -94,7 +94,8 @@ func getDBConfig(dataSource config.DataSource) (dbConfig, error) {
 			dataSource.Name, dataSource.SSLMode)
 	case "sqlite":
 		dbConfig.driverName = "sqlite"
-		dbConfig.dsn = path.Join(config.GetThunderRuntime().ThunderHome, dataSource.Path)
+		dbConfig.dsn = fmt.Sprintf("%s?_journal_mode=WAL&_busy_timeout=3000",
+			path.Join(config.GetThunderRuntime().ThunderHome, dataSource.Path))
 	}
 
 	return dbConfig, nil

--- a/backend/scripts/init_script.sh
+++ b/backend/scripts/init_script.sh
@@ -17,67 +17,111 @@
 # under the License.
 # ----------------------------------------------------------------------------
 
+# Initialize variables
+DB=""
+TYPE=""
+HOST=""
+PORT=""
+NAME=""
+USERNAME=""
+PASSWORD=""
+RECREATE="false"
+
+# Parse named arguments
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -db) DB="$2"; shift 2;;
+    -type) TYPE="$2"; shift 2;;
+    -host) HOST="$2"; shift 2;;
+    -port) PORT="$2"; shift 2;;
+    -name) NAME="$2"; shift 2;;
+    -username) USERNAME="$2"; shift 2;;
+    -password) PASSWORD="$2"; shift 2;;
+    -recreate) RECREATE="true"; shift;;
+    *) echo "Unknown parameter passed: $1"; exit 1;;
+  esac
+done
+
 # Validate required arguments
-if [ "$#" -ne 7 ]; then
-  echo "Usage: $0 <db_type> <db_hostname> <db_port> <db_name> <db_username> <db_password> <type>"
+if [ -z "$DB" ] || [ -z "$TYPE" ] || [ -z "$NAME" ]; then
+  echo "Usage: $0 -db <db> -type <type> -name <name> [-host <host> -port <port> -username <username> -password <password> (required for postgres)]"
   exit 1
 fi
 
-DB_TYPE=$1
-DB_HOSTNAME=$2
-DB_PORT=$3
-DB_NAME=$4
-DB_USERNAME=$5
-DB_PASSWORD=$6
-TYPE=$7
+if [ "$TYPE" = "postgres" ]; then
+  if [ -z "$HOST" ] || [ -z "$PORT" ] || [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+    echo "For postgres, -host, -port, -username, and -password are required."
+    exit 1
+  fi
+fi
 
 # Check if the type is provided
-if [ -z "$TYPE" ]; then
-  echo "Type is not provided. Please provide a valid type."
+if [ -z "$DB" ]; then
+  echo "DB is not provided. Please provide a valid db type."
   exit 1
 fi
 
 # Check if the type is valid
-if [ "$TYPE" != "thunderdb" ] && [ "$TYPE" != "runtimedb" ]; then
-  echo "Invalid type provided. Please provide either 'thunderdb' or 'runtimedb'."
+if [ "$DB" != "thunderdb" ] && [ "$DB" != "runtimedb" ]; then
+  echo "Invalid DB type provided. Please provide either 'thunderdb' or 'runtimedb'."
   exit 1
 fi
 
 echo "Initializing the database..."
 
-case "$DB_TYPE" in
+case "$TYPE" in
   postgres)
-    SCHEMA_FILE="../../backend/dbscripts/$TYPE/postgresql.sql"
+    SCHEMA_FILE="../../backend/dbscripts/$DB/postgresql.sql"
     if [ ! -f "$SCHEMA_FILE" ]; then
       echo "Database schema file not found: $SCHEMA_FILE"
       exit 1
     fi
 
-    PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOSTNAME" -p "$DB_PORT" -U "$DB_USERNAME" -d "$DB_NAME" -f "$SCHEMA_FILE"
+    if [ "$RECREATE" = "true" ]; then
+      echo "Dropping existing database..."
+      PGPASSWORD="$PASSWORD" psql -h "$HOST" -p "$PORT" -U "$USERNAME" -c "DROP DATABASE IF EXISTS $NAME;"
+      if [ $? -ne 0 ]; then
+        echo "Failed to drop existing database."
+        exit 1
+      fi
+      echo "Creating new database..."
+      PGPASSWORD="$PASSWORD" psql -h "$HOST" -p "$PORT" -U "$USERNAME" -c "CREATE DATABASE $NAME;"
+      if [ $? -ne 0 ]; then
+        echo "Failed to create new database."
+        exit 1
+      fi
+    fi
+
+    PGPASSWORD="$PASSWORD" psql -h "$HOST" -p "$PORT" -U "$USERNAME" -d "$NAME" -f "$SCHEMA_FILE"
     ;;
   sqlite)
-    SCHEMA_FILE="../../backend/dbscripts/$TYPE/sqlite.sql"
+    SCHEMA_FILE="../../backend/dbscripts/$DB/sqlite.sql"
     if [ ! -f "$SCHEMA_FILE" ]; then
       echo "Database schema file not found: $SCHEMA_FILE"
       exit 1
     fi
 
     # Ensure the directory for the database file exists
-    DB_DIR=$(dirname "$DB_NAME")
+    DB_DIR=$(dirname "$NAME")
     if [ ! -d "$DB_DIR" ]; then
       echo "Database directory not found. Creating directory: $DB_DIR"
       mkdir -p "$DB_DIR"
     fi
 
-    if [ ! -f "$DB_NAME" ]; then
-      echo "Database file not found. Creating and initializing the database..."
-      sqlite3 "$DB_NAME" < "$SCHEMA_FILE"
+    if [ "$RECREATE" = "true" ] && [ -f "$NAME" ]; then
+      echo "Removing existing SQLite database file..."
+      rm -f "$NAME"
+    fi
+
+    if [ ! -f "$NAME" ]; then
+      echo "Creating and initializing the database..."
+      sqlite3 "$NAME" < "$SCHEMA_FILE"
     else
       echo "Database file already exists. Skipping initialization."
     fi
     ;;
   *)
-    echo "Unsupported database type: $DB_TYPE"
+    echo "Unsupported database type: $TYPE"
     exit 1
     ;;
 esac

--- a/tests/integration/testutils/testutils.go
+++ b/tests/integration/testutils/testutils.go
@@ -215,7 +215,8 @@ func RunInitScript() error {
 	initScript := filepath.Join(productHome, InitScriptPath)
 
 	thunderDbPath := filepath.Join(productHome, DatabaseFileBasePath, "thunderdb.db")
-	cmd := exec.Command("bash", initScript, "sqlite", "", "", thunderDbPath, "", "", "thunderdb")
+	cmd := exec.Command("bash", initScript, "-db", "thunderdb", "-type", "sqlite", "-name", thunderDbPath, "-recreate")
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
@@ -224,7 +225,8 @@ func RunInitScript() error {
 	}
 
 	runtimeDbPath := filepath.Join(productHome, DatabaseFileBasePath, "runtimedb.db")
-	cmd = exec.Command("bash", initScript, "sqlite", "", "", runtimeDbPath, "", "", "runtimedb")
+	cmd = exec.Command("bash", initScript, "-db", "runtimedb", "-type", "sqlite", "-name", runtimeDbPath, "-recreate")
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()


### PR DESCRIPTION
## Purpose

This pull request refactors the `init_script.sh` and updates its usage in the integration test utility. The changes improve flexibility by introducing named arguments, adding support for optional database recreation, and enhancing readability and maintainability.

### Script improvements:
* Refactored `scripts/init_script.sh` to use named arguments (`-db`, `-type`, `-name`, etc.) instead of positional arguments, improving clarity and usability.
* Added support for optional database recreation via the `-recreate` flag, allowing users to drop and recreate databases if needed.
* Updated validation logic to ensure required arguments are provided, with specific checks for PostgreSQL parameters.

### Integration test updates:
* Modified `RunInitScript` in `tests/integration/testutils/testutils.go` to use the updated `init_script.sh` with named arguments and added the `-recreate` flag for SQLite database initialization. [[1]](diffhunk://#diff-61a218234e78a428ae3a088ad1d8fadcd9ec87523b327ea241e207fa7a7e8fafL205-R207) [[2]](diffhunk://#diff-61a218234e78a428ae3a088ad1d8fadcd9ec87523b327ea241e207fa7a7e8fafL214-R218)