### PR TITLE
Introduce execute function to DBClient

### DIFF
--- a/backend/internal/application/service/applicationservice.go
+++ b/backend/internal/application/service/applicationservice.go
@@ -69,7 +69,7 @@ func (as *ApplicationService) GetOAuthApplication(clientID string) (*model.OAuth
 		}
 	}()
 
-	results, err := dbClient.ExecuteQuery(store.QueryGetApplicationByClientID, clientID)
+	results, err := dbClient.Query(store.QueryGetApplicationByClientID, clientID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/application/store/store.go
+++ b/backend/internal/application/store/store.go
@@ -65,7 +65,7 @@ func GetApplicationList() ([]model.Application, error) {
 		}
 	}(dbClient)
 
-	results, err := dbClient.ExecuteQuery(QueryGetApplicationList)
+	results, err := dbClient.Query(QueryGetApplicationList)
 	if err != nil {
 		logger.Error("Failed to execute query", log.Error(err))
 		return nil, fmt.Errorf("failed to execute query: %w", err)
@@ -101,7 +101,7 @@ func GetApplication(id string) (model.Application, error) {
 		}
 	}()
 
-	results, err := dbClient.ExecuteQuery(QueryGetApplicationByAppID, id)
+	results, err := dbClient.Query(QueryGetApplicationByAppID, id)
 	if err != nil {
 		logger.Error("Failed to execute query", log.Error(err))
 		return model.Application{}, fmt.Errorf("failed to execute query: %w", err)
@@ -160,7 +160,7 @@ func DeleteApplication(id string) error {
 		}
 	}()
 
-	_, err = dbClient.ExecuteQuery(QueryDeleteApplicationByAppID, id)
+	_, err = dbClient.Execute(QueryDeleteApplicationByAppID, id)
 	if err != nil {
 		logger.Error("Failed to execute query", log.Error(err))
 		return fmt.Errorf("failed to execute query: %w", err)

--- a/backend/internal/oauth/oauth2/authz/codepersistence.go
+++ b/backend/internal/oauth/oauth2/authz/codepersistence.go
@@ -102,7 +102,7 @@ func GetAuthorizationCode(clientID, authCode string) (model.AuthorizationCode, e
 		}
 	}()
 
-	results, err := dbClient.ExecuteQuery(constants.QueryGetAuthorizationCode, clientID, authCode)
+	results, err := dbClient.Query(constants.QueryGetAuthorizationCode, clientID, authCode)
 	if err != nil {
 		return model.AuthorizationCode{}, errors.New("error while retrieving authorization code: " + err.Error())
 	}
@@ -148,7 +148,7 @@ func updateAuthorizationCodeState(authzCode model.AuthorizationCode, newState st
 		}
 	}()
 
-	_, err = dbClient.ExecuteQuery(constants.QueryUpdateAuthorizationCodeState, newState, authzCode.CodeID)
+	_, err = dbClient.Execute(constants.QueryUpdateAuthorizationCodeState, newState, authzCode.CodeID)
 	return err
 }
 

--- a/backend/internal/oauth/scope/validator/scopevalidator.go
+++ b/backend/internal/oauth/scope/validator/scopevalidator.go
@@ -69,7 +69,7 @@ func (sv *APIScopeValidator) ValidateScopes(requestedScopes, clientID string) (s
 	}()
 
 	// Query authorized scopes for the client.
-	results, err := dbClient.ExecuteQuery(constants.QueryGetAuthorizedScopesByClientID, clientID)
+	results, err := dbClient.Query(constants.QueryGetAuthorizedScopesByClientID, clientID)
 	if err != nil {
 		logger.Error("Failed to execute scope query", log.Error(err))
 		return "", &ScopeError{

--- a/backend/internal/system/server/serveroperation.go
+++ b/backend/internal/system/server/serveroperation.go
@@ -40,7 +40,7 @@ func GetAllowedOrigins() ([]string, error) {
 		}
 	}()
 
-	results, err := dbClient.ExecuteQuery(QueryAllowedOrigins)
+	results, err := dbClient.Query(QueryAllowedOrigins)
 	if err != nil {
 		logger.Error("Failed to execute query", log.Error(err))
 		return nil, err


### PR DESCRIPTION
## Purpose
This pull request refactors database client methods to improve clarity and functionality by replacing the `ExecuteQuery` method with two distinct methods: `Query` for SELECT operations and `Execute` for non-SELECT operations. It also updates all relevant function calls across the codebase to use these new methods.

### Database Client Enhancements:
* Introduced `Query` and `Execute` methods in `DBClientInterface` to separate SELECT queries from non-SELECT operations. Updated their implementations in `backend/internal/system/database/client/dbclient.go`. (`[[1]](diffhunk://#diff-848200784aa14c671eb132579fae6350a6d79894b8eef5c7d7be69f373eb2754L35-R41)`, `[[2]](diffhunk://#diff-848200784aa14c671eb132579fae6350a6d79894b8eef5c7d7be69f373eb2754L52-R58)`, `[[3]](diffhunk://#diff-848200784aa14c671eb132579fae6350a6d79894b8eef5c7d7be69f373eb2754R100-R117)`)

### Refactoring of Database Calls:
* Replaced `ExecuteQuery` with `Query` for SELECT operations in various files, including:
  - `GetOAuthApplication` in `applicationservice.go`. (`[backend/internal/application/service/applicationservice.goL72-R72](diffhunk://#diff-184bf5335b299c8ffcabe997d2252f1818e2a249d828d4fd2f2aafa891589fb5L72-R72)`)
  - `GetApplicationList`, `GetApplication`, and `GetAllowedOrigins` in `store.go` and `serveroperation.go`. (`[[1]](diffhunk://#diff-8fffc8586a1c0bef0f3abb5dd8c224dcdd31ee2645c7fcf352e15ed49617c841L68-R68)`, `[[2]](diffhunk://#diff-8fffc8586a1c0bef0f3abb5dd8c224dcdd31ee2645c7fcf352e15ed49617c841L104-R104)`, `[[3]](diffhunk://#diff-97cda576915657fc3b49749557a043c55ef4be8817095a016108dcf5cf29f153L43-R43)`)
  - `GetAuthorizationCode` and `ValidateScopes` in `codepersistence.go` and `scopevalidator.go`. (`[[1]](diffhunk://#diff-2a6a5c76f53cb2d677962489c7062478f1f81ac754b5a49afae8e58fc3b3ec67L105-R105)`, `[[2]](diffhunk://#diff-ba3c88e258dcb742a2b345bd180cb9b18ceff4bdc6b086ccb29e01ef69b4d5b2L72-R72)`)

* Replaced `ExecuteQuery` with `Execute` for non-SELECT operations in:
  - `DeleteApplication` in `store.go`. (`[backend/internal/application/store/store.goL163-R163](diffhunk://#diff-8fffc8586a1c0bef0f3abb5dd8c224dcdd31ee2645c7fcf352e15ed49617c841L163-R163)`)
  - `updateAuthorizationCodeState` in `codepersistence.go`. (`[backend/internal/oauth/oauth2/authz/codepersistence.goL151-R151](diffhunk://#diff-2a6a5c76f53cb2d677962489c7062478f1f81ac754b5a49afae8e58fc3b3ec67L151-R151)`)