### PR TITLE
Generate gate app's and sample app's keys and certs during the build

### DIFF
--- a/backend/cmd/server/repository/conf/deployment.yaml
+++ b/backend/cmd/server/repository/conf/deployment.yaml
@@ -7,7 +7,7 @@ gate_client:
   port: 9090
 
 security:
-  cert_file: "repository/resources/security/server.crt"
+  cert_file: "repository/resources/security/server.cert"
   key_file: "repository/resources/security/server.key"
 
 database:


### PR DESCRIPTION
## Purpose
This pull request introduces changes to improve certificate management and enhance the build script's structure. The most important updates include fixing a file extension issue in the deployment configuration, refactoring the build script to dynamically ensure certificates for multiple directories, and adding new directory variables for better organization.

### Certificate Management Updates:
* [`backend/cmd/server/repository/conf/deployment.yaml`](diffhunk://#diff-fb7b89dae773382f1ed4977c550448c9098477d2f747a254a3345d923c5e0eb8L10-R10): Corrected the certificate file extension from `.crt` to `.cert` to align with standard naming conventions.
* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L85-R132): Refactored the `run` function to delegate certificate generation to a new `ensure_certificates` function, which supports multiple directories (`BACKEND_DIR`, `FRONTEND_GATE_APP_DIR`, and `SAMPLE_OAUTH_APP_DIR`). This ensures certificates are dynamically created if missing.

### Build Script Enhancements:
* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R39-R42): Added new directory variables (`FRONTEND_BASE_DIR`, `FRONTEND_GATE_APP_DIR`, `SAMPLE_BASE_DIR`, `SAMPLE_OAUTH_APP_DIR`) to improve clarity and organization of paths used in the script.