### PR TITLE
Add sample postman collection for initial user api

### DIFF
--- a/samples/api/postman/user.json
+++ b/samples/api/postman/user.json
@@ -1,0 +1,139 @@
+{
+	"info": {
+		"_postman_id": "006c25df-a830-4283-988d-234ba796ed4f",
+		"name": "User",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "1345875",
+		"_collection_link": "https://crimson-star-3787-1.postman.co/workspace/Thunder~c701067e-ec85-4671-b7d7-95674bd8e7e4/collection/1345875-006c25df-a830-4283-988d-234ba796ed4f?action=share&source=collection_link&creator=1345875"
+	},
+	"item": [
+		{
+			"name": "List Users",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://localhost:8090/users",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "8090",
+					"path": [
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create User",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"org_id\": \"456e8400-e29b-41d4-a716-446655440001\",\n    \"type\": \"person\",\n    \"attributes\": {\n        \"age\": 34,\n        \"roles\": [\n            \"admin\",\n            \"user\"\n        ],\n        \"address\": {\n            \"city\": \"Colombo\",\n            \"zip\": \"00100\"\n        }\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://localhost:8090/users",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "8090",
+					"path": [
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get User",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://localhost:8090/users/550e8400-e29b-41d4-a716-446655440000",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "8090",
+					"path": [
+						"users",
+						"550e8400-e29b-41d4-a716-446655440000"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Update User",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "PUT",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"org_id\": \"456e8400-e29b-41d4-a716-446655440001\",\n    \"type\": \"employee\",\n    \"attributes\": {\n        \"age\": 37,\n        \"roles\": [\n            \"admin\",\n            \"user\"\n        ],\n        \"address\": {\n            \"city\": \"Colombo\",\n            \"zip\": \"00100\"\n        }\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://localhost:8090/users/185d95c2-ad85-4588-81f0-6111c652de1c",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "8090",
+					"path": [
+						"users",
+						"185d95c2-ad85-4588-81f0-6111c652de1c"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete User",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "https://localhost:8090/users/185d95c2-ad85-4588-81f0-6111c652de1c",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "8090",
+					"path": [
+						"users",
+						"185d95c2-ad85-4588-81f0-6111c652de1c"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
## Purpose
This pull request adds a new Postman collection file, `samples/api/postman/user.json`, to define and document API endpoints for user-related operations. The collection includes endpoints for standard CRUD operations on users.

### Additions to Postman collection:

* Added a new Postman collection file, `samples/api/postman/user.json`, which includes the following endpoints:
  - **List Users**: A `GET` endpoint to retrieve a list of users.
  - **Create User**: A `POST` endpoint to create a new user, with a JSON body containing user details such as organization ID, type, attributes (age, roles, address), etc.
  - **Get User**: A `GET` endpoint to retrieve details of a specific user by their ID.
  - **Update User**: A `PUT` endpoint to update an existing user's details, including their organization ID, type, and attributes.
  - **Delete User**: A `DELETE` endpoint to remove a specific user by their ID.