### PR TITLE
Make the sample app run command shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ curl -k -X POST https://localhost:8090/oauth2/token \
 - And run this command
 
   ```bash
-  pnpm oauth-sample
+  pnpm sample
   ```
 
 - Enter the following credentials:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "pnpm i && make run",
     "run": "make run",
     "dev": "pnpm i && pnpm build && pnpm --filter gate dev",
-    "oauth-sample": "pnpm --filter oauth dev",
+    "sample": "pnpm --filter oauth dev",
     "build": "nx run-many --target=build --all",
     "lint": "nx run-many --target=lint --all",
     "test": "nx run-many --target=test --all",


### PR DESCRIPTION
## Purpose
This pull request renames the `oauth-sample` script to `sample` for consistency and updates the corresponding references in the documentation.

Script and documentation updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R9): Renamed the `oauth-sample` script to `sample` to simplify the naming convention.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141-R141): Updated the command example to use `pnpm sample` instead of `pnpm oauth-sample` to reflect the script name change.