### PR TITLE
Add the ability to run the sample app without the dev mode

### DIFF
--- a/samples/apps/oauth/package.json
+++ b/samples/apps/oauth/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "start": "tsc -b && vite build && vite preview",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/samples/apps/oauth/vite.config.ts
+++ b/samples/apps/oauth/vite.config.ts
@@ -31,4 +31,8 @@ export default defineConfig({
     port: 3000,
     host: 'localhost',
   },
+  preview: {
+    port: 3000,
+    host: 'localhost'
+  }
 })


### PR DESCRIPTION
## Purpose
This pull request introduces a new `start` script to the `package.json` file and updates the Vite configuration to include a `preview` section. These changes streamline the development workflow and enhance consistency in the preview environment.

### Development Workflow Enhancements:
* [`samples/apps/oauth/package.json`](diffhunk://#diff-9cd0f80d59179651a39b4b35eac82fd2abe6cb2d8d6429140d54b7e29407c88aR9): Added a `start` script that combines building the project (`tsc -b` and `vite build`) and starting the preview server (`vite preview`).

### Configuration Updates:
* [`samples/apps/oauth/vite.config.ts`](diffhunk://#diff-4553e5b48255db876bb802c6f7db56b4387aa7f3924b47db4c746bf3ce116033R34-R37): Added a `preview` configuration block to specify the `port` and `host`, ensuring consistent settings for the preview server.