### PR TITLE
Remove pnpm run

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "scripts": {
     "start": "pnpm i && make run",
-    "run": "make run",
     "dev": "pnpm i && pnpm build && pnpm --filter gate dev",
     "sample": "pnpm --filter oauth dev",
     "build": "nx run-many --target=build --all",


### PR DESCRIPTION
## Purpose
This pull request includes a minor update to the `package.json` file. The change removes the `"run": "make run"` script, streamlining the script definitions.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7): Removed the `"run": "make run"` script from the `scripts` section, as it may no longer be necessary or has been replaced by other commands.