### PR TITLE
Refactor key generation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -69,23 +69,12 @@ function package() {
     cp -r "$SERVER_DB_SCRIPTS_DIR" "$OUTPUT_DIR/$PRODUCT_FOLDER/"
     mkdir -p "$OUTPUT_DIR/$PRODUCT_FOLDER/$SECURITY_DIR"
 
-    echo "Generating SSL certificates..."
-    OPENSSL_ERR=$(
-        openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-            -keyout "$OUTPUT_DIR/$PRODUCT_FOLDER/$SECURITY_DIR/server.key" \
-            -out "$OUTPUT_DIR/$PRODUCT_FOLDER/$SECURITY_DIR/server.crt" \
-            -subj "/O=WSO2/OU=Thunder/CN=localhost" \
-            > /dev/null 2>&1
-    )
-    if [[ $? -ne 0 ]]; then
-        echo "Error generating SSL certificates: $OPENSSL_ERR"
-        exit 1
-    fi
-    echo "Certificates generated successfully."
+    echo "=== Ensuring server certificates exist in the distribution ==="
+    ensure_certificates "$OUTPUT_DIR/$PRODUCT_FOLDER/$SECURITY_DIR"
 
     echo "Creating zip file..."
     (cd "$OUTPUT_DIR" && zip -r "$PRODUCT_FOLDER.zip" "$PRODUCT_FOLDER")
-    rm -rf "$OUTPUT_DIR/$PRODUCT_FOLDER" "$BUILD_DIR"
+    rm -rf "${OUTPUT_DIR:?}/$PRODUCT_FOLDER" "$BUILD_DIR"
 }
 
 function test_integration() {


### PR DESCRIPTION
## Purpose
This pull request modifies the `build.sh` script to improve the handling of SSL certificates and enhance safety in file operations. The most important changes include replacing inline SSL certificate generation with a reusable function and adding a safeguard against accidental path deletion.

### SSL Certificate Handling:
* Replaced the inline SSL certificate generation with a call to the `ensure_certificates` function, simplifying the script and promoting reusability. (`[build.shL72-R77](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L72-R77)`)

### File Operation Safety:
* Updated the `rm -rf` command to use `${OUTPUT_DIR:?}` to prevent accidental deletion of unintended paths if the `OUTPUT_DIR` variable is empty. (`[build.shL72-R77](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L72-R77)`)