### PR TITLE
Make thunder binary target architecture configurable

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -63,4 +63,4 @@ jobs:
       - name: 🔨 Build and Run Tests
         run: |
           set -e
-          make all
+          make all ARCH=amd64

--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,16 @@ prepare:
 	chmod +x build.sh
 
 clean:
-	./build.sh clean
+	./build.sh clean $(ARCH)
 
 build:
-	./build.sh build
+	./build.sh build $(ARCH)
 
 test:
-	./build.sh test
+	./build.sh test $(ARCH)
 
 run:
-	./build.sh run
+	./build.sh run $(ARCH)
 
 lint: golangci-lint
 	cd backend && $(GOLANGCI_LINT) run ./...

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ SAMPLE_BASE_DIR=samples
 SAMPLE_OAUTH_APP_DIR=$SAMPLE_BASE_DIR/apps/oauth
 
 GOOS=darwin
-GOARCH=amd64
+GOARCH=${2:-arm64}
 
 function clean() {
     echo "Cleaning build artifacts..."
@@ -203,7 +203,7 @@ case "$1" in
         run
         ;;
     *)
-        echo "Usage: ./build.sh {clean|build|test|run}"
+        echo "Usage: ./build.sh {clean|build|test|run} [ARCH]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Purpose
This pull request introduces changes to make the build process architecture-aware by adding support for specifying the target architecture (`ARCH`) across the build system. The most important changes include updates to the `Makefile`, `build.sh` script, and GitHub Actions workflow to incorporate the `ARCH` parameter.

### Build system updates:

* **`Makefile`:** Updated all relevant targets (`clean`, `build`, `test`, `run`) to pass the `ARCH` parameter to `build.sh`, ensuring architecture-specific builds. (`[MakefileL41-R50](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L41-R50)`)

* **`build.sh`:**
  * Modified the `GOARCH` variable to default to `arm64` if no architecture is specified, allowing flexibility in specifying the target architecture. (`[build.shL49-R49](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L49-R49)`)
  * Updated the usage instructions to reflect the new optional `[ARCH]` argument for the script. (`[build.shL206-R206](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L206-R206)`)

### CI workflow updates:

* **`.github/workflows/pr-builder.yml`:** Updated the `make all` command in the GitHub Actions workflow to explicitly specify `ARCH=amd64`, ensuring consistent builds in the CI pipeline. (`[.github/workflows/pr-builder.ymlL66-R66](diffhunk://#diff-5274abb9a1f90be1adf589d21c49758b213e3aac969ac7335bfe26b7963a348eL66-R66)`)