### PR TITLE
Add group & organization unit API specs

### DIFF
--- a/docs/apis/group.yaml
+++ b/docs/apis/group.yaml
@@ -1,0 +1,336 @@
+openapi: 3.0.3
+info:
+  title: Group Management API
+  version: "1.0"
+  description: This API is used to manage groups.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://{host}:{port}
+    variables:
+      host:
+        default: "localhost"
+      port:
+        default: "8090"
+
+tags:
+  - name: groups
+    description: Operations related to group management
+
+paths:
+  /groups:
+    get:
+      tags:
+        - groups
+      summary: List groups
+      parameters:
+        - in: query
+          name: parent
+          description: Filter to get immediate children of the specified group
+          required: false
+          schema:
+            type: string
+            format: uuid
+            example: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+      responses:
+        "200":
+          description: List of groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupBasic'
+              examples:
+                root-groups:
+                  summary: List root groups (without parent param)
+                  value:
+                    - id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                      name: "Sports"
+                      description: "Sports group"
+                      parent:
+                        type: "organizationUnit"
+                        id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                      users:
+                        - "7a4b1f8e-5c69-4b60-9232-2b0aaf65ef3c"
+                        - "9f1e47d3-0347-4464-9f02-e0bfae02e896"
+                      groups:
+                        - "6b1e7b8d-7e19-41eb-8fa2-c0ee5bb67a94"
+                    - id: "257e528f-eb24-48b6-884d-20460e190957"
+                      name: "Managers"
+                      description: "Manager group"
+                      parent:
+                        type: "organizationUnit"
+                        id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                      users:
+                        - "28c2e8f9-878d-423b-9e03-bad8c6d3fe8f"
+                        - "c685f5a2-9ec7-44e1-a0b8-814b65d6857b"
+                        - "f3678f40-e074-451c-acc2-31de500cd939"
+                      groups:
+                        - "e4888068-7eea-4a00-8142-07b88a725139"
+                        - "3057ff4e-23e9-4afe-9faa-d7e9b7c85699"
+                nested-groups:
+                  summary: List groups for a specific parent (with parent param)
+                  value:
+                    - id: "6b1e7b8d-7e19-41eb-8fa2-c0ee5bb67a94"
+                      name: "Hockey"
+                      description: "Hockey group"
+                      parent:
+                        type: "organizationUnit"
+                        id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                      users:
+                        - "2cbb94c7-81f1-44e3-8e9e-75e0c3dd36da"
+                      groups: []
+        "400":
+          description: Bad request
+        "404":
+          description: Parent group not found
+        "500":
+          description: Internal server error
+
+    post:
+      tags:
+        - groups
+      summary: Create a new group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGroupRequest'
+            examples:
+              root-group:
+                summary: Root group
+                value:
+                  name: "Sports"
+                  description: "Sports group"
+                  parent:
+                    type: "organizationUnit"
+                    id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                  users:
+                    - "7a4b1f8e-5c69-4b60-9232-2b0aaf65ef3c"
+                    - "9f1e47d3-0347-4464-9f02-e0bfae02e896"
+              nested-group:
+                summary: Nested group
+                value:
+                  name: "Hockey"
+                  description: "Hockey group"
+                  parent:
+                    type: "group"
+                    id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                  users:
+                    - "2cbb94c7-81f1-44e3-8e9e-75e0c3dd36da"
+      responses:
+        "201":
+          description: Group created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+              examples:
+                root-group:
+                  summary: Root group
+                  value:
+                    id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    name: "Sports"
+                    description: "Sports group"
+                    parent:
+                      type: "organizationUnit"
+                      id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                    users:
+                      - "7a4b1f8e-5c69-4b60-9232-2b0aaf65ef3c"
+                      - "9f1e47d3-0347-4464-9f02-e0bfae02e896"
+                nested-group:
+                  summary: Nested group
+                  value:
+                    id: "6b1e7b8d-7e19-41eb-8fa2-c0ee5bb67a94"
+                    name: "Hockey"
+                    description: "Hockey group"
+                    parent:
+                      type: "group"
+                      id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    users:
+                      - "2cbb94c7-81f1-44e3-8e9e-75e0c3dd36da"
+        "400":
+          description: Bad request
+        "409":
+          description: A group with the same name exists under the same parent
+        "500":
+          description: Internal server error
+
+  /groups/{id}:
+    get:
+      tags:
+        - groups
+      summary: Get a group by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Group details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+              example:
+                id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                name: "Sports"
+                description: "Sports group"
+                parent:
+                  type: "organizationUnit"
+                  id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                users:
+                  - "7a4b1f8e-5c69-4b60-9232-2b0aaf65ef3c"
+                  - "9f1e47d3-0347-4464-9f02-e0bfae02e896"
+                groups:
+                  - "6b1e7b8d-7e19-41eb-8fa2-c0ee5bb67a94"
+        "404":
+          description: Group not found
+        "500":
+          description: Internal server error
+
+    put:
+      tags:
+        - groups
+      summary: Update a group by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGroupRequest'
+            example:
+              name: "Activities"
+              description: "Activities group"
+              parent:
+                type: "organizationUnit"
+                id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+              users:
+                - "7a4b1f8e-5c69-4b60-9232-2b0aaf65ef3c"
+                - "9f1e47d3-0347-4464-9f02-e0bfae02e896"
+                - "2cbb94c7-81f1-44e3-8e9e-75e0c3dd36da"
+              groups:
+                - "6b1e7b8d-7e19-41eb-8fa2-c0ee5bb67a94"
+      responses:
+        "200":
+          description: Group updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+              example:
+                id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                name: "Activities"
+                description: "Activities group"
+                parent:
+                  type: "organizationUnit"
+                  id: "a839f4bd-39dc-4eaa-b5cc-210d8ecaee87"
+                users:
+                  - "7a4b1f8e-5c69-4b60-9232-2b0aaf65ef3c"
+                  - "9f1e47d3-0347-4464-9f02-e0bfae02e896"
+                  - "2cbb94c7-81f1-44e3-8e9e-75e0c3dd36da"
+                groups:
+                  - "6b1e7b8d-7e19-41eb-8fa2-c0ee5bb67a94"
+        "400":
+          description: Bad request
+        "404":
+          description: Group not found
+        "409":
+          description: A group with the same name exists under the same parent
+        "500":
+          description: Internal server error
+
+    delete:
+      tags:
+        - groups
+      summary: Delete a group by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Group deleted
+        "400":
+          description: Cannot delete group with child groups
+        "500":
+          description: Internal server error
+
+components:
+  schemas:
+    Parent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - group
+            - organizationUnit
+        id:
+          type: string
+          format: uuid
+    GroupBasic:
+      type: object
+      required: [id, name, parent, groups]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        parent:
+          $ref: '#/components/schemas/Parent'
+        groups:
+          type: array
+          items:
+            type: string
+            format: uuid
+    Group:
+      allOf:
+        - $ref: '#/components/schemas/GroupBasic'
+      properties:
+        users:
+          type: array
+          items:
+            type: string
+            format: uuid
+
+    CreateGroupRequest:
+      type: object
+      required: [name, parent]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        parent:
+          $ref: '#/components/schemas/Parent'
+        users:
+          type: array
+          items:
+            type: string
+            format: uuid
+
+    UpdateGroupRequest:
+      allOf:
+        - $ref: '#/components/schemas/CreateGroupRequest'

--- a/docs/apis/ou.yaml
+++ b/docs/apis/ou.yaml
@@ -1,0 +1,290 @@
+openapi: 3.0.3
+info:
+  title: OrganizationUnit Management API
+  version: "1.0"
+  description: This API is used to manage organization units.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://{host}:{port}
+    variables:
+      host:
+        default: "localhost"
+      port:
+        default: "8090"
+
+tags:
+  - name: organization-units
+    description: Operations related to organization unit management
+
+paths:
+  /organization-units:
+    get:
+      tags:
+        - organization-units
+      summary: List organization units
+      parameters:
+        - in: query
+          name: parent
+          description: Filter to get immediate children of the specified organization unit
+          required: false
+          schema:
+            type: string
+            format: uuid
+            example: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+      responses:
+        "200":
+          description: List of organization units
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OrganizationUnitBasic'
+              examples:
+                root-ous:
+                  summary: List root organization units (without parent param)
+                  value:
+                    - id: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+                      name: "Engineering"
+                      description: "Engineering Unit"
+                      parent: null
+                      sub-organization-units:
+                        - "6b59f277-fd79-40b1-afca-dce75d3709f7"
+                    - id: "b7c40de6-95cd-4c45-8725-9c7cb5b9cafd"
+                      name: "Sales"
+                      description: "Sales Unit"
+                      parent: null
+                      sub-organization-units: []
+                nested-ous:
+                  summary: List organization units for a specific parent (with parent param)
+                  value:
+                    - id: "6b59f277-fd79-40b1-afca-dce75d3709f7"
+                      name: "Frontend Team"
+                      description: "Handles UI/UX work"
+                      parent: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+                      sub-organization-units: []
+                    - id: "4d4cb83a-9bb8-4fd7-970e-36b65f9c8ea4"
+        "400":
+          description: Bad request
+        "404":
+          description: Parent organization unit not found
+        "500":
+          description: Internal server error
+
+    post:
+      tags:
+        - organization-units
+      summary: Create a new organization unit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrganizationUnitRequest'
+            examples:
+              root-ou:
+                summary: Root organization unit
+                value:
+                  name: "Engineering"
+                  description: "Engineering Unit"
+                  parent: null
+              nested-ou:
+                summary: Nested organization unit
+                value:
+                  name: "Frontend Team"
+                  description: "Handles UI/UX work"
+                  parent: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+      responses:
+        "201":
+          description: Organization unit created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationUnit'
+              examples:
+                root-ou:
+                  summary: Root organization unit
+                  value:
+                    id: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+                    name: "Engineering"
+                    description: "Engineering Unit"
+                    parent: null
+                nested-ou:
+                  summary: Nested organization unit
+                  value:
+                    id: "4d4cb83a-9bb8-4fd7-970e-36b65f9c8ea4"
+                    name: "Frontend Team"
+                    description: "Handles UI/UX work"
+                    parent: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+        "400":
+          description: Bad request
+        "409":
+          description: An organization unit with the same name exists under the same parent
+        "500":
+          description: Internal server error
+
+  /organization-units/{id}:
+    get:
+      tags:
+        - organization-units
+      summary: Get an organization unit by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Organization unit details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationUnit'
+              example:
+                id: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+                name: "Engineering Team"
+                description: "Engineering unit that handles all engineering tasks"
+                parent: null
+                users:
+                  - "3f9d5c8e-3c56-4f09-a1db-bb3d5e3f4b5d"
+                  - "9f4bc2ee-8d1e-4e21-a3b4-17d9b612e320"
+                  - "20eb225a-e8c3-4ccf-9d47-b659e26014d7"
+                groups:
+                  - "c2a4f62d-7c79-46f2-b2de-8e8cb4f1c456"
+                  - "8a8e4fa2-2e55-478d-bf0f-4a2ddaf9ee7d"
+                sub-organization-units:
+                  - "6b59f277-fd79-40b1-afca-dce75d3709f7"
+        "404":
+          description: Organization unit not found
+        "500":
+          description: Internal server error
+
+    put:
+      tags:
+        - organization-units
+      summary: Update an organization unit by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateOrganizationUnitRequest'
+            example:
+              name: "Engineering Team"
+              description: "Engineering unit that handles all engineering tasks"
+              parent: null
+      responses:
+        "200":
+          description: Organization unit updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationUnit'
+              example:
+                id: "afc77cfd-620b-4cf0-a31c-7377b0ea8902"
+                name: "Engineering Team"
+                description: "Engineering unit that handles all engineering tasks"
+                parent: null
+                users:
+                  - "3f9d5c8e-3c56-4f09-a1db-bb3d5e3f4b5d"
+                  - "9f4bc2ee-8d1e-4e21-a3b4-17d9b612e320"
+                  - "20eb225a-e8c3-4ccf-9d47-b659e26014d7"
+                groups:
+                  - "c2a4f62d-7c79-46f2-b2de-8e8cb4f1c456"
+                  - "8a8e4fa2-2e55-478d-bf0f-4a2ddaf9ee7d"
+                sub-organization-units:
+                  - "6b59f277-fd79-40b1-afca-dce75d3709f7"
+        "400":
+          description: Bad request
+        "404":
+          description: Organization unit not found
+        "409":
+          description: An organization unit with the same name exists under the same parent
+        "500":
+          description: Internal server error
+
+    delete:
+      tags:
+        - organization-units
+      summary: Delete an organization unit by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Organization unit deleted
+        "400":
+          description: Cannot delete organization unit with children
+        "500":
+          description: Internal server error
+
+components:
+  schemas:
+    OrganizationUnitBasic:
+      type: object
+      required: [id, name, parent, organization-units]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        organization-units:
+          type: array
+          items:
+            type: string
+            format: uuid
+
+    OrganizationUnit:
+      allOf:
+        - $ref: '#/components/schemas/OrganizationUnitBasic'
+      properties:
+        users:
+          type: array
+          items:
+            type: string
+            format: uuid
+        groups:
+          type: array
+          items:
+            type: string
+            format: uuid
+
+    CreateOrganizationUnitRequest:
+      type: object
+      required: [name, parent]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+
+    UpdateOrganizationUnitRequest:
+      allOf:
+        - $ref: '#/components/schemas/CreateOrganizationUnitRequest'


### PR DESCRIPTION
## Purpose
This pull request introduces two new OpenAPI specifications for managing groups and organization units. These APIs define endpoints for CRUD operations, including listing, creating, updating, and deleting entities, along with their associated schemas and examples.

### New API Specifications:

#### Group Management API:
* Added `docs/apis/group.yaml` to define the Group Management API for handling groups. It includes endpoints for listing, creating, retrieving, updating, and deleting groups, with support for parent-child relationships and user associations.

#### Organization Unit Management API:
* Added `docs/apis/ou.yaml` to define the Organization Unit Management API for managing organizational units. It includes similar CRUD operations, with hierarchical relationships and associations with groups and users.