### PR TITLE
Fix flow initiation curl command & refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,8 @@ curl -k -X POST https://localhost:8090/oauth2/token \
   ```bash
   curl -kL -H 'Accept: application/json' -H 'Content-Type: application/json' https://localhost:8090/flow/execution \
   -d '{
-      "applicationId": "<application_id>",
-  }
-  '
+      "applicationId": "<application_id>"
+  }'
   ```
 
   You'll receive a response similar to the following:
@@ -133,8 +132,7 @@ curl -k -X POST https://localhost:8090/oauth2/token \
           "username": "thor",
           "password": "thor123"
       }
-  }
-  '
+  }'
   ```
 
 - If the login is successful, you will receive a response with the auth assertion.
@@ -184,9 +182,8 @@ curl -k -X POST https://localhost:8090/oauth2/token \
   ```bash
   curl -kL -H 'Accept: application/json' -H 'Content-Type: application/json' https://localhost:8090/flow/execution \
   -d '{
-      "applicationId": "<application_id>",
-  }
-  '
+      "applicationId": "<application_id>"
+  }'
   ```
 
   You'll receive a response similar to the following:
@@ -227,8 +224,7 @@ curl -k -X POST https://localhost:8090/oauth2/token \
       "inputs": {
           "code": "<code>"
       }
-  }
-  '
+  }'
   ```
 
 - If the login is successful, you will receive a response with the auth assertion.
@@ -279,9 +275,8 @@ curl -k -X POST https://localhost:8090/oauth2/token \
   ```bash
   curl -kL -H 'Accept: application/json' -H 'Content-Type: application/json' https://localhost:8090/flow/execution \
   -d '{
-      "applicationId": "<application_id>",
-  }
-  '
+      "applicationId": "<application_id>"
+  }'
   ```
 
   You'll receive a response similar to the following:
@@ -327,8 +322,7 @@ curl -k -X POST https://localhost:8090/oauth2/token \
       "inputs": {
           "code": "<code>"
       }
-  }
-  '
+  }'
   ```
 
 - If the login is successful, you will receive a response with the auth assertion.


### PR DESCRIPTION
## Purpose
This pull request updates the `README.md` file to fix formatting issues in several `curl` command examples by removing unnecessary trailing commas and adjusting the closing of JSON payloads. These changes ensure the examples are syntactically correct and easier to follow.

Formatting fixes in `README.md`:

* Removed unnecessary trailing commas and adjusted the closing of JSON payloads in multiple `curl` command examples to ensure proper syntax. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R99) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R135) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L187-R186) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L230-R227) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L282-R279) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R325)