### PR TITLE
Refactor FlowContext into EngineContext and NodeContext

### DIFF
--- a/backend/internal/executor/authassert/authassertexecutor.go
+++ b/backend/internal/executor/authassert/authassertexecutor.go
@@ -61,7 +61,7 @@ func (a *AuthAssertExecutor) GetProperties() flowmodel.ExecutorProperties {
 }
 
 // Execute executes the authentication assertion logic.
-func (a *AuthAssertExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel.ExecutorResponse, error) {
+func (a *AuthAssertExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, a.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -64,7 +64,7 @@ func (b *BasicAuthExecutor) GetProperties() flowmodel.ExecutorProperties {
 }
 
 // Execute executes the basic authentication logic.
-func (b *BasicAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel.ExecutorResponse, error) {
+func (b *BasicAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, b.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))
@@ -114,7 +114,7 @@ func (b *BasicAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel.Exec
 
 // requiredInputData checks and adds the required input data for basic authentication.
 // Returns true if needed to request user input data.
-func (b *BasicAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext, execResp *flowmodel.ExecutorResponse) bool {
+func (b *BasicAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, b.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))
@@ -136,7 +136,7 @@ func (b *BasicAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext, execRe
 	// Check for the required input data. Also appends the authenticator specific input data.
 	// TODO: This validation should be moved to the flow composer. Ideally the validation and appending
 	//  should happen during the flow definition creation.
-	requiredData := ctx.CurrentNode.GetInputData()
+	requiredData := ctx.NodeInputData
 	if len(requiredData) == 0 {
 		logger.Debug("No required input data defined for basic authentication executor")
 		requiredData = basicReqData

--- a/backend/internal/executor/githubauth/githubauthexecutor.go
+++ b/backend/internal/executor/githubauth/githubauthexecutor.go
@@ -98,7 +98,7 @@ func NewGithubOIDCAuthExecutor(id, name, clientID, clientSecret, redirectURI str
 }
 
 // Execute executes the GitHub OIDC authentication flow.
-func (g *GithubOIDCAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel.ExecutorResponse, error) {
+func (g *GithubOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug("Executing GitHub OIDC auth executor",
 		log.String("executorID", g.GetID()), log.String("flowID", ctx.FlowID))
@@ -128,7 +128,7 @@ func (g *GithubOIDCAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel
 }
 
 // ProcessAuthFlowResponse processes the response from the GitHub OIDC authentication flow.
-func (o *GithubOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.FlowContext,
+func (o *GithubOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
 	execResp *flowmodel.ExecutorResponse) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String("executorID", o.GetID()), log.String("flowID", ctx.FlowID))
@@ -213,7 +213,7 @@ func (o *GithubOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.FlowCont
 
 // requiredInputData adds the required input data for the GitHub OIDC authentication flow.
 // Returns true if input data should be requested from the user.
-func (g *GithubOIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext,
+func (g *GithubOIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext,
 	execResp *flowmodel.ExecutorResponse) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
@@ -234,7 +234,7 @@ func (g *GithubOIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext,
 	// Check for the required input data. Also appends the authenticator specific input data.
 	// TODO: This validation should be moved to the flow composer. Ideally the validation and appending
 	//  should happen during the flow definition creation.
-	requiredData := ctx.CurrentNode.GetInputData()
+	requiredData := ctx.NodeInputData
 	if len(requiredData) == 0 {
 		logger.Debug("No required input data defined for GitHub OIDC auth executor")
 		// If no required input data is defined, use the default required data.
@@ -285,7 +285,7 @@ func (g *GithubOIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext,
 }
 
 // GetUserInfo fetches user information from the GitHub OIDC provider using the access token.
-func (o *GithubOIDCAuthExecutor) GetUserInfo(ctx *flowmodel.FlowContext,
+func (o *GithubOIDCAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext,
 	accessToken string) (map[string]string, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug("Fetching user info from Github OIDC provider",

--- a/backend/internal/executor/googleauth/googleauthexecutor.go
+++ b/backend/internal/executor/googleauth/googleauthexecutor.go
@@ -96,7 +96,7 @@ func NewGoogleOIDCAuthExecutor(id, name, clientID, clientSecret, redirectURI str
 }
 
 // Execute executes the Google OIDC authentication flow.
-func (g *GoogleOIDCAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel.ExecutorResponse, error) {
+func (g *GoogleOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug("Executing Google OIDC auth executor",
 		log.String("executorID", g.GetID()), log.String("flowID", ctx.FlowID))
@@ -126,7 +126,7 @@ func (g *GoogleOIDCAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel
 }
 
 // ProcessAuthFlowResponse processes the response from the Google OIDC authentication flow.
-func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.FlowContext,
+func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
 	execResp *flowmodel.ExecutorResponse) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String("executorID", g.GetID()), log.String("flowID", ctx.FlowID))
@@ -268,7 +268,7 @@ func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.FlowCont
 
 // requiredInputData adds the required input data for the Google OIDC authentication flow.
 // Returns true if input data should be requested from the user.
-func (g *GoogleOIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext,
+func (g *GoogleOIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext,
 	execResp *flowmodel.ExecutorResponse) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
@@ -289,7 +289,7 @@ func (g *GoogleOIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext,
 	// Check for the required input data. Also appends the authenticator specific input data.
 	// TODO: This validation should be moved to the flow composer. Ideally the validation and appending
 	//  should happen during the flow definition creation.
-	requiredData := ctx.CurrentNode.GetInputData()
+	requiredData := ctx.NodeInputData
 	if len(requiredData) == 0 {
 		logger.Debug("No required input data defined for Google OIDC auth executor")
 		// If no required input data is defined, use the default required data.

--- a/backend/internal/executor/oidcauth/oidcauthexecutor.go
+++ b/backend/internal/executor/oidcauth/oidcauthexecutor.go
@@ -46,8 +46,8 @@ const loggerComponentName = "OIDCAuthExecutor"
 // OIDCAuthExecutorInterface defines the interface for OIDC authentication executors.
 type OIDCAuthExecutorInterface interface {
 	flowmodel.ExecutorInterface
-	BuildAuthorizeFlow(ctx *flowmodel.FlowContext, execResp *flowmodel.ExecutorResponse)
-	ProcessAuthFlowResponse(ctx *flowmodel.FlowContext, execResp *flowmodel.ExecutorResponse)
+	BuildAuthorizeFlow(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse)
+	ProcessAuthFlowResponse(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse)
 	GetOIDCProperties() model.OIDCExecProperties
 	GetCallBackURL() string
 	GetAuthorizationEndpoint() string
@@ -55,8 +55,8 @@ type OIDCAuthExecutorInterface interface {
 	GetUserInfoEndpoint() string
 	GetLogoutEndpoint() string
 	GetJWKSEndpoint() string
-	ExchangeCodeForToken(ctx *flowmodel.FlowContext, code string) (*model.OIDCTokenResponse, error)
-	GetUserInfo(ctx *flowmodel.FlowContext, accessToken string) (map[string]string, error)
+	ExchangeCodeForToken(ctx *flowmodel.NodeContext, code string) (*model.OIDCTokenResponse, error)
+	GetUserInfo(ctx *flowmodel.NodeContext, accessToken string) (map[string]string, error)
 	ValidateIDToken(idToken string) error
 	GetIDTokenClaims(idToken string) (map[string]interface{}, error)
 }
@@ -131,7 +131,7 @@ func (o *OIDCAuthExecutor) GetJWKSEndpoint() string {
 }
 
 // Execute executes the OIDC authentication logic.
-func (o *OIDCAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel.ExecutorResponse, error) {
+func (o *OIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, o.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))
@@ -158,7 +158,7 @@ func (o *OIDCAuthExecutor) Execute(ctx *flowmodel.FlowContext) (*flowmodel.Execu
 }
 
 // BuildAuthorizeFlow constructs the redirection to the external OIDC provider for user authentication.
-func (o *OIDCAuthExecutor) BuildAuthorizeFlow(ctx *flowmodel.FlowContext, execResp *flowmodel.ExecutorResponse) {
+func (o *OIDCAuthExecutor) BuildAuthorizeFlow(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, o.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))
@@ -209,7 +209,7 @@ func (o *OIDCAuthExecutor) BuildAuthorizeFlow(ctx *flowmodel.FlowContext, execRe
 }
 
 // ProcessAuthFlowResponse processes the response from the OIDC authentication flow and authenticates the user.
-func (o *OIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.FlowContext, execResp *flowmodel.ExecutorResponse) {
+func (o *OIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, o.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))
@@ -294,7 +294,7 @@ func (o *OIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.FlowContext, e
 
 // requiredInputData adds the required input data for the OIDC authentication flow to the executor response.
 // Returns true if input data should be requested from the user.
-func (o *OIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext, execResp *flowmodel.ExecutorResponse) bool {
+func (o *OIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, o.GetID()), log.String(log.LoggerKeyFlowID, ctx.FlowID))
 
@@ -315,7 +315,7 @@ func (o *OIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext, execRes
 	// Check for the required input data. Also appends the authenticator specific input data.
 	// TODO: This validation should be moved to the flow composer. Ideally the validation and appending
 	//  should happen during the flow definition creation.
-	requiredData := ctx.CurrentNode.GetInputData()
+	requiredData := ctx.NodeInputData
 	if len(requiredData) == 0 {
 		logger.Debug("No required input data defined for OIDC authentication executor")
 		// If no required input data is defined, use the default required data.
@@ -367,7 +367,7 @@ func (o *OIDCAuthExecutor) requiredInputData(ctx *flowmodel.FlowContext, execRes
 }
 
 // ExchangeCodeForToken exchanges the authorization code for an access token.
-func (o *OIDCAuthExecutor) ExchangeCodeForToken(ctx *flowmodel.FlowContext,
+func (o *OIDCAuthExecutor) ExchangeCodeForToken(ctx *flowmodel.NodeContext,
 	code string) (*model.OIDCTokenResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, o.GetID()),
@@ -424,7 +424,7 @@ func (o *OIDCAuthExecutor) ExchangeCodeForToken(ctx *flowmodel.FlowContext,
 }
 
 // GetUserInfo fetches user information from the OIDC provider using the access token.
-func (o *OIDCAuthExecutor) GetUserInfo(ctx *flowmodel.FlowContext, accessToken string) (map[string]string, error) {
+func (o *OIDCAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, accessToken string) (map[string]string, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String(log.LoggerKeyExecutorID, o.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))

--- a/backend/internal/executor/oidcauth/utils/utils.go
+++ b/backend/internal/executor/oidcauth/utils/utils.go
@@ -35,7 +35,7 @@ const paramPlaceHolderEnd = "}"
 
 // GetResolvedAdditionalParam resolves the additional parameter value by replacing placeholders
 // with actual values.
-func GetResolvedAdditionalParam(paramName, paramValue string, ctx *flowmodel.FlowContext) (string, error) {
+func GetResolvedAdditionalParam(paramName, paramValue string, ctx *flowmodel.NodeContext) (string, error) {
 	if strings.Contains(paramValue, paramPlaceHolderStart) && strings.Contains(paramValue, paramPlaceHolderEnd) {
 		startIndex := strings.Index(paramValue, paramPlaceHolderStart)
 		endIndex := strings.Index(paramValue, paramPlaceHolderEnd)

--- a/backend/internal/flow/flowservice.go
+++ b/backend/internal/flow/flowservice.go
@@ -47,7 +47,7 @@ type FlowServiceInterface interface {
 
 // FlowService is the implementation of FlowServiceInterface
 type FlowService struct {
-	store map[string]model.FlowContext
+	store map[string]model.EngineContext
 	mu    sync.Mutex
 }
 
@@ -55,7 +55,7 @@ type FlowService struct {
 func GetFlowService() FlowServiceInterface {
 	once.Do(func() {
 		instance = &FlowService{
-			store: make(map[string]model.FlowContext),
+			store: make(map[string]model.EngineContext),
 		}
 	})
 	return instance
@@ -118,8 +118,8 @@ func (s *FlowService) Execute(appID, flowID, actionID string,
 
 // loadContext loads or initializes a flow context based on the provided parameters.
 func (s *FlowService) loadContext(appID, flowID, actionID string, inputData map[string]string,
-	logger *log.Logger) (*model.FlowContext, *serviceerror.ServiceError) {
-	var context model.FlowContext
+	logger *log.Logger) (*model.EngineContext, *serviceerror.ServiceError) {
+	var context model.EngineContext
 	if flowID == "" && actionID == "" && len(inputData) == 0 {
 		ctx, err := s.initContext(appID, logger)
 		if err != nil {
@@ -138,13 +138,13 @@ func (s *FlowService) loadContext(appID, flowID, actionID string, inputData map[
 }
 
 // initContext initializes a new flow context with the given details.
-func (s *FlowService) initContext(appID string, logger *log.Logger) (*model.FlowContext, *serviceerror.ServiceError) {
+func (s *FlowService) initContext(appID string, logger *log.Logger) (*model.EngineContext, *serviceerror.ServiceError) {
 	graphID, svcErr := validateApplication(appID)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
-	ctx := model.FlowContext{}
+	ctx := model.EngineContext{}
 	flowID := sysutils.GenerateUUID()
 	ctx.FlowID = flowID
 
@@ -186,7 +186,7 @@ func validateApplication(appID string) (string, *serviceerror.ServiceError) {
 
 // loadContextFromStore retrieves the flow context from the store based on the given details.
 func (s *FlowService) loadContextFromStore(flowID, actionID string, inputData map[string]string,
-	logger *log.Logger) (*model.FlowContext, *serviceerror.ServiceError) {
+	logger *log.Logger) (*model.EngineContext, *serviceerror.ServiceError) {
 	if flowID == "" {
 		return nil, &constants.ErrorInvalidFlowID
 	}
@@ -212,7 +212,7 @@ func (s *FlowService) loadContextFromStore(flowID, actionID string, inputData ma
 }
 
 // updateContext updates the flow context in the store based on the flow step status.
-func (s *FlowService) updateContext(ctx *model.FlowContext, flowStep *model.FlowStep, logger *log.Logger) {
+func (s *FlowService) updateContext(ctx *model.EngineContext, flowStep *model.FlowStep, logger *log.Logger) {
 	if flowStep.Status != "" && flowStep.Status == constants.Complete {
 		s.mu.Lock()
 		delete(s.store, ctx.FlowID)

--- a/backend/internal/flow/model/executor.go
+++ b/backend/internal/flow/model/executor.go
@@ -47,7 +47,7 @@ type ExecutorConfig struct {
 
 // ExecutorInterface defines the interface for executors.
 type ExecutorInterface interface {
-	Execute(ctx *FlowContext) (*ExecutorResponse, error)
+	Execute(ctx *NodeContext) (*ExecutorResponse, error)
 	GetID() string
 	GetName() string
 	GetProperties() ExecutorProperties
@@ -76,7 +76,7 @@ func (e *Executor) GetProperties() ExecutorProperties {
 }
 
 // Execute executes the executor logic.
-func (e *Executor) Execute(ctx *FlowContext) (*ExecutorResponse, error) {
+func (e *Executor) Execute(ctx *NodeContext) (*ExecutorResponse, error) {
 	// Implement the logic for executing the executor here.
 	// This is just a placeholder implementation
 	return nil, nil

--- a/backend/internal/flow/model/flowmodel.go
+++ b/backend/internal/flow/model/flowmodel.go
@@ -24,8 +24,8 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/constants"
 )
 
-// FlowContext holds the overall context for flow execution
-type FlowContext struct {
+// EngineContext holds the overall context used by the flow engine during execution.
+type EngineContext struct {
 	FlowID        string
 	AppID         string
 	UserInputData map[string]string
@@ -35,6 +35,17 @@ type FlowContext struct {
 	CurrentActionID     string
 
 	Graph GraphInterface
+
+	AuthenticatedUser authnmodel.AuthenticatedUser
+}
+
+// NodeContext holds the context for a specific node in the flow execution.
+type NodeContext struct {
+	FlowID string
+	AppID  string
+
+	NodeInputData []InputData
+	UserInputData map[string]string
 
 	AuthenticatedUser authnmodel.AuthenticatedUser
 }

--- a/backend/internal/flow/model/node.go
+++ b/backend/internal/flow/model/node.go
@@ -35,7 +35,7 @@ type NodeResponse struct {
 
 // NodeInterface defines the interface for nodes in the graph
 type NodeInterface interface {
-	Execute(ctx *FlowContext) (*NodeResponse, *serviceerror.ServiceError)
+	Execute(ctx *NodeContext) (*NodeResponse, *serviceerror.ServiceError)
 	GetID() string
 	GetType() string
 	IsStartNode() bool
@@ -80,7 +80,7 @@ func NewNode(id string, _type string, isStartNode bool, isFinalNode bool) NodeIn
 }
 
 // Execute executes the node's executor
-func (n *Node) Execute(ctx *FlowContext) (*NodeResponse, *serviceerror.ServiceError) {
+func (n *Node) Execute(ctx *NodeContext) (*NodeResponse, *serviceerror.ServiceError) {
 	if n.executorConfig == nil || n.executorConfig.Executor == nil {
 		return nil, &constants.ErrorNodeExecutorNotFound
 	}


### PR DESCRIPTION
## Purpose

This pull request refactors the flow execution context across multiple authentication executors and the flow engine, replacing `FlowContext` with `NodeContext` or `EngineContext` as appropriate. The changes aim to streamline context handling and improve data encapsulation for individual nodes and the overall flow execution.
