### PR TITLE
Refactor the flow model with proper status handling and executor hierarchy

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
@@ -13,7 +13,7 @@
                 }
             ],
             "executor": {
-                "name": "GithubAuthExecutor",
+                "name": "GithubOAuthExecutor",
                 "idpName": "Github"
             }
         },

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
@@ -18,7 +18,7 @@
                 }
             ],
             "executor": {
-                "name": "GoogleAuthExecutor",
+                "name": "GoogleOIDCAuthExecutor",
                 "idpName": "Google"
             }
         },

--- a/backend/internal/executor/githubauth/githubauthexecutor.go
+++ b/backend/internal/executor/githubauth/githubauthexecutor.go
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-// Package githubauth provides the GitHub OIDC authentication executor.
+// Package githubauth provides the GitHub OAuth authentication executor.
 package githubauth
 
 import (
@@ -29,8 +29,8 @@ import (
 	"time"
 
 	authnmodel "github.com/asgardeo/thunder/internal/authn/model"
-	"github.com/asgardeo/thunder/internal/executor/oidcauth"
-	"github.com/asgardeo/thunder/internal/executor/oidcauth/model"
+	"github.com/asgardeo/thunder/internal/executor/oauth"
+	"github.com/asgardeo/thunder/internal/executor/oauth/model"
 	flowconst "github.com/asgardeo/thunder/internal/flow/constants"
 	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
 	"github.com/asgardeo/thunder/internal/system/constants"
@@ -38,44 +38,49 @@ import (
 	systemutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
-const loggerComponentName = "GithubAuthExecutor"
+const loggerComponentName = "GithubOAuthExecutor"
 
-// GithubOIDCAuthExecutor implements the OIDC authentication executor for GitHub.
-type GithubOIDCAuthExecutor struct {
-	*oidcauth.OIDCAuthExecutor
+// GithubOAuthExecutor implements the OAuth authentication executor for GitHub.
+type GithubOAuthExecutor struct {
+	*oauth.OAuthExecutor
 }
 
-// NewGithubOIDCAuthExecutorFromProps creates a new instance of GithubOIDCAuthExecutor with the provided properties.
-func NewGithubOIDCAuthExecutorFromProps(execProps flowmodel.ExecutorProperties,
-	oidcProps *model.BasicOIDCExecProperties) oidcauth.OIDCAuthExecutorInterface {
-	// Prepare the complete OIDC properties for GitHub
-	compOIDCProps := &model.OIDCExecProperties{
+// NewGithubOAuthExecutorFromProps creates a new instance of GithubOAuthExecutor with the provided properties.
+func NewGithubOAuthExecutorFromProps(execProps flowmodel.ExecutorProperties,
+	oAuthProps *model.BasicOAuthExecProperties) oauth.OAuthExecutorInterface {
+	// Prepare the complete OAuth properties for GitHub
+	compOAuthProps := &model.OAuthExecProperties{
 		AuthorizationEndpoint: githubAuthorizeEndpoint,
 		TokenEndpoint:         githubTokenEndpoint,
 		UserInfoEndpoint:      githubUserInfoEndpoint,
-		ClientID:              oidcProps.ClientID,
-		ClientSecret:          oidcProps.ClientSecret,
-		RedirectURI:           oidcProps.RedirectURI,
-		Scopes:                oidcProps.Scopes,
-		AdditionalParams:      oidcProps.AdditionalParams,
+		ClientID:              oAuthProps.ClientID,
+		ClientSecret:          oAuthProps.ClientSecret,
+		RedirectURI:           oAuthProps.RedirectURI,
+		Scopes:                oAuthProps.Scopes,
+		AdditionalParams:      oAuthProps.AdditionalParams,
 	}
 
-	base := oidcauth.NewOIDCAuthExecutor("github_oidc_auth_executor", execProps.Name, compOIDCProps)
+	base := oauth.NewOAuthExecutor("github_oauth_executor", execProps.Name, compOAuthProps)
 
-	exec, ok := base.(*oidcauth.OIDCAuthExecutor)
+	exec, ok := base.(*oauth.OAuthExecutor)
 	if !ok {
-		panic("failed to cast GithubOIDCAuthExecutor to OIDCAuthExecutor")
+		panic("failed to cast GithubOAuthExecutor to OAuthExecutor")
 	}
-	return &GithubOIDCAuthExecutor{
-		OIDCAuthExecutor: exec,
+	return &GithubOAuthExecutor{
+		OAuthExecutor: exec,
 	}
 }
 
-// NewGithubOIDCAuthExecutor creates a new instance of GithubOIDCAuthExecutor with the provided details.
-func NewGithubOIDCAuthExecutor(id, name, clientID, clientSecret, redirectURI string,
-	scopes []string, additionalParams map[string]string) oidcauth.OIDCAuthExecutorInterface {
-	// Prepare the OIDC properties for GitHub
-	oidcProps := &model.OIDCExecProperties{
+// NewGithubOAuthExecutor creates a new instance of GithubOAuthExecutor with the provided details.
+func // The code appears to be written in a comment and does not actually execute any functionality. It
+// seems to be written in Go language and mentions a "NewGithubOAuthExecutor" which could
+// potentially be a constructor or function related to handling GitHub OAuth authentication.
+// However, without the actual implementation details or context, it is difficult to determine the
+// exact purpose or functionality of this code snippet.
+NewGithubOAuthExecutor(id, name, clientID, clientSecret, redirectURI string,
+	scopes []string, additionalParams map[string]string) oauth.OAuthExecutorInterface {
+	// Prepare the OAuth properties for GitHub
+	oAuthProps := &model.OAuthExecProperties{
 		AuthorizationEndpoint: githubAuthorizeEndpoint,
 		TokenEndpoint:         githubTokenEndpoint,
 		UserInfoEndpoint:      githubUserInfoEndpoint,
@@ -86,21 +91,20 @@ func NewGithubOIDCAuthExecutor(id, name, clientID, clientSecret, redirectURI str
 		AdditionalParams:      additionalParams,
 	}
 
-	base := oidcauth.NewOIDCAuthExecutor(id, name, oidcProps)
-
-	exec, ok := base.(*oidcauth.OIDCAuthExecutor)
+	base := oauth.NewOAuthExecutor(id, name, oAuthProps)
+	exec, ok := base.(*oauth.OAuthExecutor)
 	if !ok {
-		panic("failed to cast GithubOIDCAuthExecutor to OIDCAuthExecutor")
+		panic("failed to cast GithubOAuthExecutor to OAuthExecutor")
 	}
-	return &GithubOIDCAuthExecutor{
-		OIDCAuthExecutor: exec,
+	return &GithubOAuthExecutor{
+		OAuthExecutor: exec,
 	}
 }
 
-// Execute executes the GitHub OIDC authentication flow.
-func (g *GithubOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
+// Execute executes the GitHub OAuth authentication flow.
+func (g *GithubOAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Executing GitHub OIDC auth executor",
+	logger.Debug("Executing GitHub OAuth executor",
 		log.String("executorID", g.GetID()), log.String("flowID", ctx.FlowID))
 
 	execResp := &flowmodel.ExecutorResponse{}
@@ -108,16 +112,22 @@ func (g *GithubOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel
 	// Check if the required input data is provided
 	if g.requiredInputData(ctx, execResp) {
 		// If required input data is not provided, return incomplete status with redirection to github.
-		logger.Debug("Required input data for GitHub OIDC auth executor is not provided")
+		logger.Debug("Required input data for GitHub OAuth executor is not provided")
 
-		g.BuildAuthorizeFlow(ctx, execResp)
+		err := g.BuildAuthorizeFlow(ctx, execResp)
+		if err != nil {
+			return nil, err
+		}
 
-		logger.Debug("GitHub OIDC auth executor execution completed",
+		logger.Debug("GitHub OAuth executor execution completed",
 			log.String("status", string(execResp.Status)))
 	} else {
-		g.ProcessAuthFlowResponse(ctx, execResp)
+		err := g.ProcessAuthFlowResponse(ctx, execResp)
+		if err != nil {
+			return nil, err
+		}
 
-		logger.Debug("GitHub OIDC auth executor execution completed",
+		logger.Debug("GitHub OAuth executor execution completed",
 			log.String("status", string(execResp.Status)),
 			log.Bool("isAuthenticated", ctx.AuthenticatedUser.IsAuthenticated))
 	}
@@ -125,12 +135,12 @@ func (g *GithubOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel
 	return execResp, nil
 }
 
-// ProcessAuthFlowResponse processes the response from the GitHub OIDC authentication flow.
-func (o *GithubOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
+// ProcessAuthFlowResponse processes the response from the GitHub OAuth authentication flow.
+func (o *GithubOAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
 	execResp *flowmodel.ExecutorResponse) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String("executorID", o.GetID()), log.String("flowID", ctx.FlowID))
-	logger.Debug("Processing GitHub OIDC auth flow response")
+	logger.Debug("Processing GitHub OAuth flow response")
 
 	// Process authorization code if available
 	code, ok := ctx.UserInputData["code"]
@@ -207,9 +217,9 @@ func (o *GithubOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeCont
 	return nil
 }
 
-// requiredInputData adds the required input data for the GitHub OIDC authentication flow.
+// requiredInputData adds the required input data for the GitHub OAuth authentication flow.
 // Returns true if input data should be requested from the user.
-func (g *GithubOIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext,
+func (g *GithubOAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext,
 	execResp *flowmodel.ExecutorResponse) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
@@ -232,7 +242,7 @@ func (g *GithubOIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext,
 	//  should happen during the flow definition creation.
 	requiredData := ctx.NodeInputData
 	if len(requiredData) == 0 {
-		logger.Debug("No required input data defined for GitHub OIDC auth executor")
+		logger.Debug("No required input data defined for GitHub OAuth executor")
 		// If no required input data is defined, use the default required data.
 		requiredData = gitReqData
 	} else {
@@ -280,11 +290,11 @@ func (g *GithubOIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext,
 	return requireData
 }
 
-// GetUserInfo fetches user information from the GitHub OIDC provider using the access token.
-func (o *GithubOIDCAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
+// GetUserInfo fetches user information from the GitHub OAuth provider using the access token.
+func (o *GithubOAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
 	accessToken string) (map[string]string, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Fetching user info from Github OIDC provider",
+	logger.Debug("Fetching user info from Github OAuth provider",
 		log.String("userInfoEndpoint", o.GetUserInfoEndpoint()))
 
 	// Create HTTP request
@@ -297,7 +307,7 @@ func (o *GithubOIDCAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, execRes
 	req.Header.Set(constants.AcceptHeaderName, "application/json")
 
 	// Execute the request
-	logger.Debug("Sending userinfo request to GitHub OIDC provider")
+	logger.Debug("Sending userinfo request to GitHub OAuth provider")
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
@@ -312,7 +322,7 @@ func (o *GithubOIDCAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, execRes
 			logger.Error("Failed to close userinfo response body", log.Error(closeErr))
 		}
 	}()
-	logger.Debug("Userinfo response received from GitHub OIDC provider",
+	logger.Debug("Userinfo response received from GitHub OAuth provider",
 		log.Int("statusCode", resp.StatusCode))
 
 	if resp.StatusCode != http.StatusOK {
@@ -338,7 +348,7 @@ func (o *GithubOIDCAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, execRes
 	// If the user info doesn't contain the email, but scopes contain "user" or "user:email",
 	// then fetch the primary email from the email endpoint.
 	email := userInfo["email"]
-	scopes := o.GetOIDCProperties().Scopes
+	scopes := o.GetOAuthProperties().Scopes
 	if (email == nil || email == "") &&
 		(slices.Contains(scopes, userScope) || slices.Contains(scopes, userEmailScope)) {
 		logger.Debug("Fetching user email from Github email endpoint",

--- a/backend/internal/executor/googleauth/googleauthexecutor.go
+++ b/backend/internal/executor/googleauth/googleauthexecutor.go
@@ -20,6 +20,7 @@
 package googleauth
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -101,9 +102,7 @@ func (g *GoogleOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel
 	logger.Debug("Executing Google OIDC auth executor",
 		log.String("executorID", g.GetID()), log.String("flowID", ctx.FlowID))
 
-	execResp := &flowmodel.ExecutorResponse{
-		Status: flowconst.ExecIncomplete,
-	}
+	execResp := &flowmodel.ExecutorResponse{}
 
 	// Check if the required input data is provided
 	if g.requiredInputData(ctx, execResp) {
@@ -127,31 +126,30 @@ func (g *GoogleOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel
 
 // ProcessAuthFlowResponse processes the response from the Google OIDC authentication flow.
 func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
-	execResp *flowmodel.ExecutorResponse) {
+	execResp *flowmodel.ExecutorResponse) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
 		log.String("executorID", g.GetID()), log.String("flowID", ctx.FlowID))
 	logger.Debug("Processing Google OIDC auth flow response")
-
-	execResp.Status = flowconst.ExecIncomplete
 
 	// Process authorization code if available
 	code, okCode := ctx.UserInputData["code"]
 	if okCode && code != "" {
 		// Exchange authorization code for tokenResp
-		tokenResp, err := g.ExchangeCodeForToken(ctx, code)
+		tokenResp, err := g.ExchangeCodeForToken(ctx, execResp, code)
 		if err != nil {
-			logger.Error("Failed to exchange code for a token", log.Error(err))
-			execResp.Status = flowconst.ExecError
-			execResp.Error = "Failed to authenticate with OIDC provider: " + err.Error()
-			return
+			logger.Error("Failed to exchange authorization code for token", log.Error(err))
+			return fmt.Errorf("failed to exchange code for token: %w", err)
+		}
+		if execResp.Status == flowconst.ExecFailure {
+			return nil
 		}
 
 		// Validate the token response
 		if tokenResp.AccessToken == "" {
 			logger.Debug("Access token is empty in the token response")
-			execResp.Status = flowconst.ExecUserError
-			execResp.Error = "Access token is empty in the token response. Please provide a valid authorization code."
-			return
+			execResp.Status = flowconst.ExecFailure
+			execResp.FailureReason = "Access token is empty in the token response."
+			return nil
 		}
 
 		if tokenResp.Scope == "" {
@@ -167,39 +165,37 @@ func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeCont
 			// If scopes contains openid, check if the id token is present.
 			if slices.Contains(g.GetOIDCProperties().Scopes, "openid") && tokenResp.IDToken == "" {
 				logger.Debug("ID token is empty in the token response")
-				execResp.Status = flowconst.ExecUserError
-				execResp.Error = "ID token is empty in the token response. Please provide a valid authorization code."
-				return
+				execResp.Status = flowconst.ExecFailure
+				execResp.FailureReason = "ID token is empty in the token response."
+				return nil
 			}
 
 			userClaims := make(map[string]string)
 
 			if tokenResp.IDToken != "" {
 				// Validate the id token.
-				if err := g.ValidateIDToken(tokenResp.IDToken); err != nil {
-					execResp.Status = flowconst.ExecUserError
-					execResp.Error = "ID token validation failed: " + err.Error()
-					return
+				if err := g.ValidateIDToken(execResp, tokenResp.IDToken); err != nil {
+					return errors.New("failed to validate ID token: " + err.Error())
+				}
+				if execResp.Status == flowconst.ExecFailure {
+					return nil
 				}
 
 				// Extract claims from the id token.
-				idTokenClaims, err := g.GetIDTokenClaims(tokenResp.IDToken)
+				idTokenClaims, err := g.GetIDTokenClaims(execResp, tokenResp.IDToken)
 				if err != nil {
-					logger.Error("Failed to extract ID token claims", log.Error(err))
-					execResp.Status = flowconst.ExecUserError
-					execResp.Error = "Failed to extract ID token claims: " + err.Error()
-					return
+					return errors.New("failed to extract ID token claims: " + err.Error())
+				}
+				if execResp.Status == flowconst.ExecFailure {
+					return nil
 				}
 				if len(idTokenClaims) != 0 {
 					// Validate nonce if configured.
 					if nonce, ok := ctx.UserInputData["nonce"]; ok && nonce != "" {
 						if idTokenClaims["nonce"] != nonce {
-							logger.Debug("Nonce mismatch in ID token claims",
-								log.String("expectedNonce", nonce),
-								log.String("idTokenNonce", idTokenClaims["nonce"].(string)))
-							execResp.Status = flowconst.ExecUserError
-							execResp.Error = "Nonce mismatch in ID token claims."
-							return
+							execResp.Status = flowconst.ExecFailure
+							execResp.FailureReason = "Nonce mismatch in ID token claims."
+							return nil
 						}
 					}
 
@@ -218,12 +214,12 @@ func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeCont
 				logger.Debug("No additional scopes configured.")
 			} else {
 				// Get user info using the access token
-				userInfo, err := g.GetUserInfo(ctx, tokenResp.AccessToken)
+				userInfo, err := g.GetUserInfo(ctx, execResp, tokenResp.AccessToken)
 				if err != nil {
-					logger.Error("Failed to get user info", log.Error(err))
-					execResp.Status = flowconst.ExecUserError
-					execResp.Error = "Failed to get user information: " + err.Error()
-					return
+					return errors.New("failed to get user info: " + err.Error())
+				}
+				if execResp.Status == flowconst.ExecFailure {
+					return nil
 				}
 				for key, value := range userInfo {
 					userClaims[key] = value
@@ -260,10 +256,11 @@ func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeCont
 	if ctx.AuthenticatedUser.IsAuthenticated {
 		execResp.Status = flowconst.ExecComplete
 	} else {
-		execResp.Status = flowconst.ExecUserError
-		execResp.Type = flowconst.ExecRedirection
-		execResp.Error = "User is not authenticated. Please provide a valid authorization code."
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "Authentication failed. Authorization code not provided or invalid."
 	}
+
+	return nil
 }
 
 // requiredInputData adds the required input data for the Google OIDC authentication flow.
@@ -340,7 +337,7 @@ func (g *GoogleOIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext,
 }
 
 // ValidateIDToken validates the ID token received from Google.
-func (g *GoogleOIDCAuthExecutor) ValidateIDToken(idToken string) error {
+func (g *GoogleOIDCAuthExecutor) ValidateIDToken(execResp *flowmodel.ExecutorResponse, idToken string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug("Validating ID token")
 
@@ -351,50 +348,68 @@ func (g *GoogleOIDCAuthExecutor) ValidateIDToken(idToken string) error {
 	// Verify the id token signature.
 	signErr := jwtutils.VerifyJWTSignatureWithJWKS(idToken, g.GetJWKSEndpoint())
 	if signErr != nil {
-		return fmt.Errorf("ID token signature verification failed: %w", signErr)
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "ID token signature verification failed: " + signErr.Error()
+		return nil
 	}
 
 	// Parse the JWT claims from the ID token.
 	claims, err := jwtutils.ParseJWTClaims(idToken)
 	if err != nil {
-		return fmt.Errorf("failed to parse ID token claims: %w", err)
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "Failed to parse ID token claims: " + err.Error()
+		return nil
 	}
 
 	// Validate issuer
 	iss, ok := claims["iss"].(string)
 	if !ok || (iss != "accounts.google.com" && iss != "https://accounts.google.com") {
-		return fmt.Errorf("invalid issuer: %s", iss)
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = fmt.Sprintf("Invalid issuer: %s in the id token", iss)
+		return nil
 	}
 
 	// Validate audience
 	aud, ok := claims["aud"].(string)
 	if !ok || aud != g.GetOIDCProperties().ClientID {
-		return fmt.Errorf("invalid audience: %s", aud)
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = fmt.Sprintf("Invalid audience: %s in the id token", aud)
+		return nil
 	}
 
 	// Validate expiration time
 	exp, ok := claims["exp"].(float64)
 	if !ok {
-		return fmt.Errorf("missing expiration claim")
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "Missing expiration claim in the id token"
+		return nil
 	}
 	if time.Now().Unix() >= int64(exp) {
-		return fmt.Errorf("token has expired")
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "ID token has expired"
+		return nil
 	}
 
 	// Check if token was issued in the future (to prevent clock skew issues)
 	iat, ok := claims["iat"].(float64)
 	if !ok {
-		return fmt.Errorf("missing issued at claim")
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "Missing issued at claim in the id token"
+		return nil
 	}
 	if time.Now().Unix() < int64(iat) {
-		return fmt.Errorf("token was issued in the future")
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "ID token was issued in the future"
+		return nil
 	}
 
 	// Check for specific domain if configured in additional params
 	if hd, found := claims["hd"]; found {
 		if domain, exists := g.GetOIDCProperties().AdditionalParams["hd"]; exists && domain != "" {
 			if hdStr, ok := hd.(string); !ok || hdStr != domain {
-				return fmt.Errorf("token is not from the expected hosted domain")
+				execResp.Status = flowconst.ExecFailure
+				execResp.FailureReason = fmt.Sprintf("ID token is not from the expected hosted domain: %s", domain)
+				return nil
 			}
 		}
 	}

--- a/backend/internal/executor/oauth/model/model.go
+++ b/backend/internal/executor/oauth/model/model.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package model provides the data structures for OAuth authentication properties and responses.
+package model
+
+// BasicOAuthExecProperties holds the basic properties required for OAuth authentication.
+type BasicOAuthExecProperties struct {
+	ClientID         string            `json:"clientID"`
+	ClientSecret     string            `json:"clientSecret"`
+	RedirectURI      string            `json:"redirectURI"`
+	Scopes           []string          `json:"scopes"`
+	AdditionalParams map[string]string `json:"additionalParams"`
+	Properties       map[string]string `json:"properties"`
+}
+
+// OAuthExecProperties holds the properties required for OAuth authentication.
+type OAuthExecProperties struct {
+	AuthorizationEndpoint string            `json:"authorizationEndpoint"`
+	TokenEndpoint         string            `json:"tokenEndpoint"`
+	UserInfoEndpoint      string            `json:"userInfoEndpoint"`
+	LogoutEndpoint        string            `json:"logoutEndpoint"`
+	JwksEndpoint          string            `json:"jwksEndpoint"`
+	ClientID              string            `json:"clientID"`
+	ClientSecret          string            `json:"clientSecret"`
+	RedirectURI           string            `json:"redirectURI"`
+	Scopes                []string          `json:"scopes"`
+	AdditionalParams      map[string]string `json:"additionalParams"`
+	Properties            map[string]string `json:"properties"`
+}
+
+// TokenResponse represents the response from the token endpoint.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	ExpiresIn    int    `json:"expires_in"`
+}

--- a/backend/internal/executor/oauth/oauthexecutor.go
+++ b/backend/internal/executor/oauth/oauthexecutor.go
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package oauth provides the OAuth authentication executor for handling OAuth-based authentication flows.
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	authnmodel "github.com/asgardeo/thunder/internal/authn/model"
+	authnutils "github.com/asgardeo/thunder/internal/authn/utils"
+	"github.com/asgardeo/thunder/internal/executor/oauth/model"
+	"github.com/asgardeo/thunder/internal/executor/oauth/utils"
+	flowconst "github.com/asgardeo/thunder/internal/flow/constants"
+	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
+	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/log"
+	systemutils "github.com/asgardeo/thunder/internal/system/utils"
+)
+
+const loggerComponentName = "OAuthExecutor"
+
+// OAuthExecutorInterface defines the interface for OAuth authentication executors.
+type OAuthExecutorInterface interface {
+	flowmodel.ExecutorInterface
+	BuildAuthorizeFlow(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) error
+	ProcessAuthFlowResponse(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) error
+	GetOAuthProperties() model.OAuthExecProperties
+	GetCallBackURL() string
+	GetAuthorizationEndpoint() string
+	GetTokenEndpoint() string
+	GetUserInfoEndpoint() string
+	GetLogoutEndpoint() string
+	GetJWKSEndpoint() string
+	ExchangeCodeForToken(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
+		code string) (*model.TokenResponse, error)
+	GetUserInfo(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
+		accessToken string) (map[string]string, error)
+}
+
+// OAuthExecutor implements the OAuthExecutorInterface for handling generic OAuth authentication flows.
+type OAuthExecutor struct {
+	internal        flowmodel.Executor
+	oAuthProperties model.OAuthExecProperties
+}
+
+// NewOAuthExecutor creates a new instance of OAuthExecutor.
+func NewOAuthExecutor(id, name string, oAuthProps *model.OAuthExecProperties) OAuthExecutorInterface {
+	return &OAuthExecutor{
+		internal: flowmodel.Executor{
+			Properties: flowmodel.ExecutorProperties{
+				ID:   id,
+				Name: name,
+			},
+		},
+		oAuthProperties: *oAuthProps,
+	}
+}
+
+// GetID returns the ID of the OAuthExecutor.
+func (o *OAuthExecutor) GetID() string {
+	return o.internal.GetID()
+}
+
+// GetName returns the name of the OAuthExecutor.
+func (o *OAuthExecutor) GetName() string {
+	return o.internal.GetName()
+}
+
+// GetProperties returns the properties of the OAuthExecutor.
+func (o *OAuthExecutor) GetProperties() flowmodel.ExecutorProperties {
+	return o.internal.Properties
+}
+
+// GetOAuthProperties returns the OAuth properties of the executor.
+func (o *OAuthExecutor) GetOAuthProperties() model.OAuthExecProperties {
+	return o.oAuthProperties
+}
+
+// GetCallBackURL returns the callback URL for the OAuth authentication.
+func (o *OAuthExecutor) GetCallBackURL() string {
+	return o.oAuthProperties.RedirectURI
+}
+
+// GetAuthorizationEndpoint returns the authorization endpoint of the OAuth authentication.
+func (o *OAuthExecutor) GetAuthorizationEndpoint() string {
+	return o.oAuthProperties.AuthorizationEndpoint
+}
+
+// GetTokenEndpoint returns the token endpoint of the OAuth authentication.
+func (o *OAuthExecutor) GetTokenEndpoint() string {
+	return o.oAuthProperties.TokenEndpoint
+}
+
+// GetUserInfoEndpoint returns the user info endpoint of the OAuth authentication.
+func (o *OAuthExecutor) GetUserInfoEndpoint() string {
+	return o.oAuthProperties.UserInfoEndpoint
+}
+
+// GetLogoutEndpoint returns the logout endpoint of the OAuth authentication.
+func (o *OAuthExecutor) GetLogoutEndpoint() string {
+	return o.oAuthProperties.LogoutEndpoint
+}
+
+// GetJWKSEndpoint returns the JWKs endpoint of the OAuth authentication.
+func (o *OAuthExecutor) GetJWKSEndpoint() string {
+	return o.oAuthProperties.JwksEndpoint
+}
+
+// Execute executes the OAuth authentication flow.
+func (o *OAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.ExecutorResponse, error) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
+		log.String(log.LoggerKeyExecutorID, o.GetID()),
+		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Executing OAuth authentication executor")
+
+	execResp := &flowmodel.ExecutorResponse{}
+
+	// Check if the required input data is provided
+	if o.requiredInputData(ctx, execResp) {
+		// If required input data is not provided, return incomplete status with redirection.
+		logger.Debug("Required input data for OAuth authentication executor is not provided")
+		err := o.BuildAuthorizeFlow(ctx, execResp)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := o.ProcessAuthFlowResponse(ctx, execResp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	logger.Debug("OAuth authentication executor execution completed",
+		log.String("status", string(execResp.Status)),
+		log.Bool("isAuthenticated", ctx.AuthenticatedUser.IsAuthenticated))
+
+	return execResp, nil
+}
+
+// BuildAuthorizeFlow constructs the redirection to the external OAuth provider for user authentication.
+func (o *OAuthExecutor) BuildAuthorizeFlow(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) error {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
+		log.String(log.LoggerKeyExecutorID, o.GetID()),
+		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Initiating OAuth authentication flow")
+
+	// Construct and add the redirect URL for OAuth authentication
+	var queryParams = make(map[string]string)
+	queryParams[oauth2const.ClientID] = o.oAuthProperties.ClientID
+	queryParams[oauth2const.RedirectURI] = o.oAuthProperties.RedirectURI
+	queryParams[oauth2const.ResponseType] = oauth2const.Code
+	queryParams[oauth2const.Scope] = authnutils.GetScopesString(o.oAuthProperties.Scopes)
+
+	// append any configured additional parameters as query params.
+	additionalParams := o.oAuthProperties.AdditionalParams
+	if len(additionalParams) > 0 {
+		for key, value := range additionalParams {
+			if key != "" && value != "" {
+				resolvedValue, err := utils.GetResolvedAdditionalParam(key, value, ctx)
+				if err != nil {
+					logger.Error("Failed to resolve additional parameter", log.String("key", key), log.Error(err))
+					return fmt.Errorf("failed to resolve additional parameter %s: %w", key, err)
+				}
+				queryParams[key] = resolvedValue
+			}
+		}
+	}
+
+	// Construct the authorization URL
+	authURL, err := systemutils.GetURIWithQueryParams(o.GetAuthorizationEndpoint(), queryParams)
+	if err != nil {
+		logger.Error("Failed to prepare authorization URL", log.Error(err))
+		return fmt.Errorf("failed to prepare authorization URL: %w", err)
+	}
+
+	// Set the response to redirect the user to the authorization URL.
+	execResp.Status = flowconst.ExecExternalRedirection
+	execResp.AdditionalInfo = map[string]string{
+		flowconst.DataRedirectURL: authURL,
+		flowconst.DataIDPName:     o.GetName(),
+	}
+
+	return nil
+}
+
+// ProcessAuthFlowResponse processes the response from the OAuth authentication flow and authenticates the user.
+func (o *OAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
+	execResp *flowmodel.ExecutorResponse) error {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
+		log.String(log.LoggerKeyExecutorID, o.GetID()),
+		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Processing OAuth authentication response")
+
+	// Process authorization code if available
+	code, ok := ctx.UserInputData["code"]
+	if ok && code != "" {
+		// Exchange authorization code for tokenResp
+		tokenResp, err := o.ExchangeCodeForToken(ctx, execResp, code)
+		if err != nil {
+			logger.Error("Failed to exchange code for a token", log.Error(err))
+			return fmt.Errorf("failed to exchange code for token: %w", err)
+		}
+		if execResp.Status == flowconst.ExecFailure {
+			return nil
+		}
+
+		// Validate the token response
+		if tokenResp.AccessToken == "" {
+			logger.Debug("Access token is empty in the token response")
+			execResp.Status = flowconst.ExecFailure
+			execResp.FailureReason = "Access token is empty in the token response."
+			return nil
+		}
+
+		if tokenResp.Scope == "" {
+			logger.Debug("Scope is empty in the token response")
+			ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
+				IsAuthenticated:        true,
+				UserID:                 "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
+				Username:               "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
+				Domain:                 o.GetName(),
+				AuthenticatedSubjectID: "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
+			}
+		} else {
+			// Get user info using the access token
+			userInfo, err := o.GetUserInfo(ctx, execResp, tokenResp.AccessToken)
+			if err != nil {
+				logger.Error("Failed to get user info", log.Error(err))
+				return fmt.Errorf("failed to get user info: %w", err)
+			}
+			if execResp.Status == flowconst.ExecFailure {
+				return nil
+			}
+
+			// Populate authenticated user from user info
+			username := userInfo["username"]
+
+			attributes := make(map[string]string)
+			for key, value := range userInfo {
+				if key != "username" && key != "sub" {
+					attributes[key] = value
+				}
+			}
+
+			ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
+				IsAuthenticated:        true,
+				UserID:                 "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
+				Username:               username,
+				Domain:                 o.GetName(),
+				AuthenticatedSubjectID: username,
+				Attributes:             attributes,
+			}
+		}
+	} else {
+		// Fail the authentication if the authorization code is not provided
+		ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
+			IsAuthenticated: false,
+		}
+	}
+
+	// Set the flow response status based on the authentication result.
+	if ctx.AuthenticatedUser.IsAuthenticated {
+		execResp.Status = flowconst.ExecComplete
+	} else {
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "Authentication failed. Authorization code not provided or invalid."
+	}
+
+	return nil
+}
+
+// requiredInputData adds the required input data for the OAuth authentication flow to the executor response.
+// Returns true if input data should be requested from the user.
+func (o *OAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) bool {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
+		log.String(log.LoggerKeyExecutorID, o.GetID()), log.String(log.LoggerKeyFlowID, ctx.FlowID))
+
+	// Check if the authorization code is already provided
+	if code, ok := ctx.UserInputData["code"]; ok && code != "" {
+		return false
+	}
+
+	// Define the authenticator specific required input data.
+	gitReqData := []flowmodel.InputData{
+		{
+			Name:     "code",
+			Type:     "string",
+			Required: true,
+		},
+	}
+
+	// Check for the required input data. Also appends the authenticator specific input data.
+	// TODO: This validation should be moved to the flow composer. Ideally the validation and appending
+	//  should happen during the flow definition creation.
+	requiredData := ctx.NodeInputData
+	if len(requiredData) == 0 {
+		logger.Debug("No required input data defined for OAuth authentication executor")
+		// If no required input data is defined, use the default required data.
+		requiredData = gitReqData
+	} else {
+		// Append the default required data if not already present.
+		for _, inputData := range gitReqData {
+			exists := false
+			for _, existingInputData := range requiredData {
+				if existingInputData.Name == inputData.Name {
+					exists = true
+					break
+				}
+			}
+			// If the input data already exists, skip adding it again.
+			if !exists {
+				requiredData = append(requiredData, inputData)
+			}
+		}
+	}
+
+	requireData := false
+
+	if execResp.RequiredData == nil {
+		execResp.RequiredData = make([]flowmodel.InputData, 0)
+	}
+
+	if len(ctx.UserInputData) == 0 {
+		execResp.RequiredData = append(execResp.RequiredData, requiredData...)
+		return true
+	}
+
+	// Check if the required input data is provided by the user.
+	for _, inputData := range requiredData {
+		if _, ok := ctx.UserInputData[inputData.Name]; !ok {
+			if !inputData.Required {
+				logger.Debug("Skipping optional input data that is not provided by user",
+					log.String("inputDataName", inputData.Name))
+				continue
+			}
+			execResp.RequiredData = append(execResp.RequiredData, inputData)
+			requireData = true
+			logger.Debug("Required input data not provided by user",
+				log.String("inputDataName", inputData.Name))
+		}
+	}
+
+	return requireData
+}
+
+// ExchangeCodeForToken exchanges the authorization code for an access token.
+func (o *OAuthExecutor) ExchangeCodeForToken(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
+	code string) (*model.TokenResponse, error) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
+		log.String(log.LoggerKeyExecutorID, o.GetID()),
+		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Exchanging authorization code for a token", log.String("tokenEndpoint", o.GetTokenEndpoint()))
+
+	// Prepare the token request
+	data := url.Values{}
+	data.Set(oauth2const.ClientID, o.oAuthProperties.ClientID)
+	data.Set(oauth2const.ClientSecret, o.oAuthProperties.ClientSecret)
+	data.Set(oauth2const.RedirectURI, o.oAuthProperties.RedirectURI)
+	data.Set(oauth2const.Code, code)
+	data.Set(oauth2const.GrantType, oauth2const.GrantTypeAuthorizationCode)
+
+	// Create HTTP request
+	req, err := http.NewRequest("POST", o.GetTokenEndpoint(), strings.NewReader(data.Encode()))
+	if err != nil {
+		logger.Error("Failed to create token request", log.Error(err))
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+
+	req.Header.Add(constants.ContentTypeHeaderName, "application/x-www-form-urlencoded")
+	req.Header.Add(constants.AcceptHeaderName, "application/json")
+
+	// Execute the request
+	logger.Debug("Sending token request to OAuth provider")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error("Failed to send token request", log.Error(err))
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "Failed to exchange authorization code for token: " + err.Error()
+		return nil, nil
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.Error("Failed to close response body", log.Error(closeErr))
+		}
+	}()
+	logger.Debug("Token response received from OAuth provider", log.Int("statusCode", resp.StatusCode))
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = fmt.Sprintf("Token request failed with status %s: %s", resp.Status, string(body))
+		return nil, nil
+	}
+
+	// Parse the response
+	var tokenResp model.TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		logger.Error("Failed to parse token response", log.Error(err))
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	return &tokenResp, nil
+}
+
+// GetUserInfo fetches user information from the OAuth provider using the access token.
+func (o *OAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
+	accessToken string) (map[string]string, error) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
+		log.String(log.LoggerKeyExecutorID, o.GetID()),
+		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Fetching user info from OAuth provider", log.String("userInfoEndpoint", o.GetUserInfoEndpoint()))
+
+	// Create HTTP request
+	req, err := http.NewRequest("GET", o.GetUserInfoEndpoint(), nil)
+	if err != nil {
+		logger.Error("Failed to create userinfo request", log.Error(err))
+		return nil, fmt.Errorf("failed to create userinfo request: %w", err)
+	}
+	req.Header.Set(constants.AuthorizationHeaderName, constants.TokenTypeBearer+" "+accessToken)
+	req.Header.Set(constants.AcceptHeaderName, "application/json")
+
+	// Execute the request
+	logger.Debug("Sending userinfo request to OAuth provider")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error("Failed to send userinfo request", log.Error(err))
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "Failed to fetch user information: " + err.Error()
+		return nil, nil
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.Error("Failed to close userinfo response body", log.Error(closeErr))
+		}
+	}()
+	logger.Debug("Userinfo response received from OAuth provider", log.Int("statusCode", resp.StatusCode))
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = fmt.Sprintf("Userinfo request failed with status %s: %s", resp.Status, string(body))
+		return nil, nil
+	}
+
+	// Parse the response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Failed to read userinfo response body", log.Error(err))
+		return nil, fmt.Errorf("failed to read userinfo response body: %w", err)
+	}
+
+	var userInfo map[string]interface{}
+	if err := json.Unmarshal(body, &userInfo); err != nil {
+		logger.Error("Failed to parse userinfo response", log.Error(err))
+		return nil, fmt.Errorf("failed to parse userinfo response: %w", err)
+	}
+
+	return systemutils.ConvertInterfaceMapToStringMap(userInfo), nil
+}

--- a/backend/internal/executor/oauth/utils/utils.go
+++ b/backend/internal/executor/oauth/utils/utils.go
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-// Package utils provides utility functions for oidc auth flow executors.
+// Package utils provides utility functions for OAuth flow executors.
 package utils
 
 import (

--- a/backend/internal/executor/oidcauth/constants.go
+++ b/backend/internal/executor/oidcauth/constants.go
@@ -16,15 +16,7 @@
  * under the License.
  */
 
-// Package model provides the data structures for OIDC authentication properties and responses.
-package model
+package oidcauth
 
-// OIDCTokenResponse represents the response from the OIDC token endpoint.
-type OIDCTokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	TokenType    string `json:"token_type"`
-	Scope        string `json:"scope"`
-	RefreshToken string `json:"refresh_token"`
-	IDToken      string `json:"id_token"`
-	ExpiresIn    int    `json:"expires_in"`
-}
+// idTokenNonUserAttributes contains the list of non-user attributes that are expected in the ID token.
+var idTokenNonUserAttributes = []string{"aud", "exp", "iat", "iss", "at_hash", "azp"}

--- a/backend/internal/executor/oidcauth/oidcauthexecutor.go
+++ b/backend/internal/executor/oidcauth/oidcauthexecutor.go
@@ -20,22 +20,16 @@
 package oidcauth
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
+	"slices"
 
 	authnmodel "github.com/asgardeo/thunder/internal/authn/model"
-	authnutils "github.com/asgardeo/thunder/internal/authn/utils"
-	"github.com/asgardeo/thunder/internal/executor/oidcauth/model"
-	"github.com/asgardeo/thunder/internal/executor/oidcauth/utils"
+	"github.com/asgardeo/thunder/internal/executor/oauth"
+	"github.com/asgardeo/thunder/internal/executor/oauth/model"
+	oauthmodel "github.com/asgardeo/thunder/internal/executor/oauth/model"
 	flowconst "github.com/asgardeo/thunder/internal/flow/constants"
 	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
-	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
-	"github.com/asgardeo/thunder/internal/system/constants"
 	jwtutils "github.com/asgardeo/thunder/internal/system/crypto/jwt/utils"
 	"github.com/asgardeo/thunder/internal/system/log"
 	systemutils "github.com/asgardeo/thunder/internal/system/utils"
@@ -45,40 +39,38 @@ const loggerComponentName = "OIDCAuthExecutor"
 
 // OIDCAuthExecutorInterface defines the interface for OIDC authentication executors.
 type OIDCAuthExecutorInterface interface {
-	flowmodel.ExecutorInterface
-	BuildAuthorizeFlow(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) error
-	ProcessAuthFlowResponse(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) error
-	GetOIDCProperties() model.OIDCExecProperties
-	GetCallBackURL() string
-	GetAuthorizationEndpoint() string
-	GetTokenEndpoint() string
-	GetUserInfoEndpoint() string
-	GetLogoutEndpoint() string
-	GetJWKSEndpoint() string
-	ExchangeCodeForToken(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
-		code string) (*model.OIDCTokenResponse, error)
-	GetUserInfo(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
-		accessToken string) (map[string]string, error)
+	oauth.OAuthExecutorInterface
 	ValidateIDToken(execResp *flowmodel.ExecutorResponse, idToken string) error
 	GetIDTokenClaims(execResp *flowmodel.ExecutorResponse, idToken string) (map[string]interface{}, error)
 }
 
 // OIDCAuthExecutor implements the OIDCAuthExecutorInterface for handling generic OIDC authentication flows.
 type OIDCAuthExecutor struct {
-	internal       flowmodel.Executor
-	oidcProperties model.OIDCExecProperties
+	internal oauth.OAuthExecutorInterface
 }
 
 // NewOIDCAuthExecutor creates a new instance of OIDCAuthExecutor.
-func NewOIDCAuthExecutor(id, name string, oidcProps *model.OIDCExecProperties) OIDCAuthExecutorInterface {
+func NewOIDCAuthExecutor(id, name string, oAuthProps *oauthmodel.OAuthExecProperties) OIDCAuthExecutorInterface {
+	scopes := oAuthProps.Scopes
+	if !slices.Contains(scopes, "openid") {
+		scopes = append(scopes, "openid")
+	}
+	base := oauth.NewOAuthExecutor(id, name, &oauthmodel.OAuthExecProperties{
+		AuthorizationEndpoint: oAuthProps.AuthorizationEndpoint,
+		TokenEndpoint:         oAuthProps.TokenEndpoint,
+		UserInfoEndpoint:      oAuthProps.UserInfoEndpoint,
+		LogoutEndpoint:        oAuthProps.LogoutEndpoint,
+		JwksEndpoint:          oAuthProps.JwksEndpoint,
+		ClientID:              oAuthProps.ClientID,
+		ClientSecret:          oAuthProps.ClientSecret,
+		RedirectURI:           oAuthProps.RedirectURI,
+		Scopes:                scopes,
+		AdditionalParams:      oAuthProps.AdditionalParams,
+		Properties:            oAuthProps.Properties,
+	})
+
 	return &OIDCAuthExecutor{
-		internal: flowmodel.Executor{
-			Properties: flowmodel.ExecutorProperties{
-				ID:   id,
-				Name: name,
-			},
-		},
-		oidcProperties: *oidcProps,
+		internal: base,
 	}
 }
 
@@ -94,42 +86,42 @@ func (o *OIDCAuthExecutor) GetName() string {
 
 // GetProperties returns the properties of the OIDCAuthExecutor.
 func (o *OIDCAuthExecutor) GetProperties() flowmodel.ExecutorProperties {
-	return o.internal.Properties
+	return o.internal.GetProperties()
 }
 
-// GetOIDCProperties returns the OIDC properties of the executor.
-func (o *OIDCAuthExecutor) GetOIDCProperties() model.OIDCExecProperties {
-	return o.oidcProperties
+// GetOAuthProperties returns the OAuth properties of the executor.
+func (o *OIDCAuthExecutor) GetOAuthProperties() oauthmodel.OAuthExecProperties {
+	return o.internal.GetOAuthProperties()
 }
 
 // GetCallBackURL returns the callback URL for the OIDC authentication.
 func (o *OIDCAuthExecutor) GetCallBackURL() string {
-	return o.oidcProperties.RedirectURI
+	return o.internal.GetCallBackURL()
 }
 
 // GetAuthorizationEndpoint returns the authorization endpoint of the OIDC authentication.
 func (o *OIDCAuthExecutor) GetAuthorizationEndpoint() string {
-	return o.oidcProperties.AuthorizationEndpoint
+	return o.internal.GetAuthorizationEndpoint()
 }
 
 // GetTokenEndpoint returns the token endpoint of the OIDC authentication.
 func (o *OIDCAuthExecutor) GetTokenEndpoint() string {
-	return o.oidcProperties.TokenEndpoint
+	return o.internal.GetTokenEndpoint()
 }
 
 // GetUserInfoEndpoint returns the user info endpoint of the OIDC authentication.
 func (o *OIDCAuthExecutor) GetUserInfoEndpoint() string {
-	return o.oidcProperties.UserInfoEndpoint
+	return o.internal.GetUserInfoEndpoint()
 }
 
 // GetLogoutEndpoint returns the logout endpoint of the OIDC authentication.
 func (o *OIDCAuthExecutor) GetLogoutEndpoint() string {
-	return o.oidcProperties.LogoutEndpoint
+	return o.internal.GetLogoutEndpoint()
 }
 
 // GetJWKSEndpoint returns the JWKs endpoint of the OIDC authentication.
 func (o *OIDCAuthExecutor) GetJWKSEndpoint() string {
-	return o.oidcProperties.JwksEndpoint
+	return o.internal.GetJWKSEndpoint()
 }
 
 // Execute executes the OIDC authentication logic.
@@ -145,9 +137,15 @@ func (o *OIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.Execu
 	if o.requiredInputData(ctx, execResp) {
 		// If required input data is not provided, return incomplete status with redirection to OIDC provider.
 		logger.Debug("Required input data for OIDC authentication executor is not provided")
-		o.BuildAuthorizeFlow(ctx, execResp)
+		err := o.BuildAuthorizeFlow(ctx, execResp)
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		o.ProcessAuthFlowResponse(ctx, execResp)
+		err := o.ProcessAuthFlowResponse(ctx, execResp)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	logger.Debug("OIDC authentication executor execution completed",
@@ -159,48 +157,7 @@ func (o *OIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.Execu
 
 // BuildAuthorizeFlow constructs the redirection to the external OIDC provider for user authentication.
 func (o *OIDCAuthExecutor) BuildAuthorizeFlow(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
-		log.String(log.LoggerKeyExecutorID, o.GetID()),
-		log.String(log.LoggerKeyFlowID, ctx.FlowID))
-	logger.Debug("Initiating OIDC authentication flow")
-
-	// Construct and add the redirect URL for OIDC authentication
-	var queryParams = make(map[string]string)
-	queryParams[oauth2const.ClientID] = o.oidcProperties.ClientID
-	queryParams[oauth2const.RedirectURI] = o.oidcProperties.RedirectURI
-	queryParams[oauth2const.ResponseType] = oauth2const.Code
-	queryParams[oauth2const.Scope] = authnutils.GetScopesString(o.oidcProperties.Scopes)
-
-	// append any configured additional parameters as query params.
-	additionalParams := o.oidcProperties.AdditionalParams
-	if len(additionalParams) > 0 {
-		for key, value := range additionalParams {
-			if key != "" && value != "" {
-				resolvedValue, err := utils.GetResolvedAdditionalParam(key, value, ctx)
-				if err != nil {
-					logger.Error("Failed to resolve additional parameter", log.String("key", key), log.Error(err))
-					return fmt.Errorf("failed to resolve additional parameter %s: %w", key, err)
-				}
-				queryParams[key] = resolvedValue
-			}
-		}
-	}
-
-	// Construct the authorization URL
-	authURL, err := systemutils.GetURIWithQueryParams(o.GetAuthorizationEndpoint(), queryParams)
-	if err != nil {
-		logger.Error("Failed to prepare authorization URL", log.Error(err))
-		return fmt.Errorf("failed to prepare authorization URL: %w", err)
-	}
-
-	// Set the response to redirect the user to the OIDC provider
-	execResp.Status = flowconst.ExecExternalRedirection
-	execResp.AdditionalInfo = map[string]string{
-		flowconst.DataRedirectURL: authURL,
-		flowconst.DataIDPName:     o.GetName(),
-	}
-
-	return nil
+	return o.internal.BuildAuthorizeFlow(ctx, execResp)
 }
 
 // ProcessAuthFlowResponse processes the response from the OIDC authentication flow and authenticates the user.
@@ -232,44 +189,73 @@ func (o *OIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
 			return nil
 		}
 
-		if tokenResp.Scope == "" {
-			logger.Debug("Scope is empty in the token response")
-			ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
-				IsAuthenticated:        true,
-				UserID:                 "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
-				Username:               "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
-				Domain:                 o.GetName(),
-				AuthenticatedSubjectID: "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
+		if tokenResp.Scope == "" && tokenResp.IDToken == "" {
+			execResp.Status = flowconst.ExecFailure
+			execResp.FailureReason = "ID token is empty in the token response."
+			return nil
+		}
+
+		userClaims := make(map[string]string)
+
+		// Validate the id token.
+		if err := o.ValidateIDToken(execResp, tokenResp.IDToken); err != nil {
+			return errors.New("failed to validate ID token: " + err.Error())
+		}
+		if execResp.Status == flowconst.ExecFailure {
+			return nil
+		}
+
+		// Extract claims from the id token.
+		idTokenClaims, err := o.GetIDTokenClaims(execResp, tokenResp.IDToken)
+		if err != nil {
+			return errors.New("failed to extract ID token claims: " + err.Error())
+		}
+		if execResp.Status == flowconst.ExecFailure {
+			return nil
+		}
+		if len(idTokenClaims) != 0 {
+			// Filter non-user claims from the ID token claims.
+			for attr, val := range idTokenClaims {
+				if !slices.Contains(idTokenNonUserAttributes, attr) {
+					userClaims[attr] = systemutils.ConvertInterfaceValueToString(val)
+				}
 			}
+			logger.Debug("Extracted ID token claims", log.Any("claims", userClaims))
+		}
+
+		if len(o.GetOAuthProperties().Scopes) == 1 && slices.Contains(o.GetOAuthProperties().Scopes, "openid") {
+			logger.Debug("No additional scopes configured.")
 		} else {
 			// Get user info using the access token
 			userInfo, err := o.GetUserInfo(ctx, execResp, tokenResp.AccessToken)
 			if err != nil {
-				logger.Error("Failed to get user info", log.Error(err))
-				return fmt.Errorf("failed to get user info: %w", err)
+				return errors.New("failed to get user info: " + err.Error())
 			}
 			if execResp.Status == flowconst.ExecFailure {
 				return nil
 			}
-
-			// Populate authenticated user from user info
-			username := userInfo["username"]
-
-			attributes := make(map[string]string)
 			for key, value := range userInfo {
-				if key != "username" && key != "sub" {
-					attributes[key] = value
-				}
+				userClaims[key] = value
 			}
+		}
 
-			ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
-				IsAuthenticated:        true,
-				UserID:                 "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
-				Username:               username,
-				Domain:                 o.GetName(),
-				AuthenticatedSubjectID: username,
-				Attributes:             attributes,
-			}
+		// Determine username from the user claims.
+		username := ""
+		if sub, ok := userClaims["sub"]; ok {
+			username = sub
+			delete(userClaims, "sub")
+		}
+		if email, ok := userClaims["email"]; ok && email != "" {
+			username = email
+		}
+
+		ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
+			IsAuthenticated:        true,
+			UserID:                 "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
+			Username:               username,
+			Domain:                 o.GetName(),
+			AuthenticatedSubjectID: username,
+			Attributes:             userClaims,
 		}
 	} else {
 		// Fail the authentication if the authorization code is not provided
@@ -363,124 +349,16 @@ func (o *OIDCAuthExecutor) requiredInputData(ctx *flowmodel.NodeContext, execRes
 	return requireData
 }
 
-// TODO: Return failure reason
-
 // ExchangeCodeForToken exchanges the authorization code for an access token.
 func (o *OIDCAuthExecutor) ExchangeCodeForToken(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
-	code string) (*model.OIDCTokenResponse, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
-		log.String(log.LoggerKeyExecutorID, o.GetID()),
-		log.String(log.LoggerKeyFlowID, ctx.FlowID))
-	logger.Debug("Exchanging authorization code for a token", log.String("tokenEndpoint", o.GetTokenEndpoint()))
-
-	// Prepare the token request
-	data := url.Values{}
-	data.Set(oauth2const.ClientID, o.oidcProperties.ClientID)
-	data.Set(oauth2const.ClientSecret, o.oidcProperties.ClientSecret)
-	data.Set(oauth2const.RedirectURI, o.oidcProperties.RedirectURI)
-	data.Set(oauth2const.Code, code)
-	data.Set(oauth2const.GrantType, oauth2const.GrantTypeAuthorizationCode)
-
-	// Create HTTP request
-	req, err := http.NewRequest("POST", o.GetTokenEndpoint(), strings.NewReader(data.Encode()))
-	if err != nil {
-		logger.Error("Failed to create token request", log.Error(err))
-		return nil, fmt.Errorf("failed to create token request: %w", err)
-	}
-
-	req.Header.Add(constants.ContentTypeHeaderName, "application/x-www-form-urlencoded")
-	req.Header.Add(constants.AcceptHeaderName, "application/json")
-
-	// Execute the request
-	logger.Debug("Sending token request to OIDC provider")
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		logger.Error("Failed to send token request", log.Error(err))
-		execResp.Status = flowconst.ExecFailure
-		execResp.FailureReason = "Failed to exchange authorization code for token: " + err.Error()
-		return nil, nil
-	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close response body", log.Error(closeErr))
-		}
-	}()
-	logger.Debug("Token response received from OIDC provider", log.Int("statusCode", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		execResp.Status = flowconst.ExecFailure
-		execResp.FailureReason = fmt.Sprintf("Token request failed with status %s: %s", resp.Status, string(body))
-		return nil, nil
-	}
-
-	// Parse the response
-	var tokenResp model.OIDCTokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		logger.Error("Failed to parse token response", log.Error(err))
-		return nil, fmt.Errorf("failed to parse token response: %w", err)
-	}
-
-	return &tokenResp, nil
+	code string) (*model.TokenResponse, error) {
+	return o.internal.ExchangeCodeForToken(ctx, execResp, code)
 }
 
-// GetUserInfo fetches user information from the OIDC provider using the access token.
+// GetUserInfo fetches user information from the OAuth provider using the access token.
 func (o *OIDCAuthExecutor) GetUserInfo(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
 	accessToken string) (map[string]string, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
-		log.String(log.LoggerKeyExecutorID, o.GetID()),
-		log.String(log.LoggerKeyFlowID, ctx.FlowID))
-	logger.Debug("Fetching user info from OIDC provider", log.String("userInfoEndpoint", o.GetUserInfoEndpoint()))
-
-	// Create HTTP request
-	req, err := http.NewRequest("GET", o.GetUserInfoEndpoint(), nil)
-	if err != nil {
-		logger.Error("Failed to create userinfo request", log.Error(err))
-		return nil, fmt.Errorf("failed to create userinfo request: %w", err)
-	}
-	req.Header.Set(constants.AuthorizationHeaderName, constants.TokenTypeBearer+" "+accessToken)
-	req.Header.Set(constants.AcceptHeaderName, "application/json")
-
-	// Execute the request
-	logger.Debug("Sending userinfo request to OIDC provider")
-
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		logger.Error("Failed to send userinfo request", log.Error(err))
-		execResp.Status = flowconst.ExecFailure
-		execResp.FailureReason = "Failed to fetch user information: " + err.Error()
-		return nil, nil
-	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close userinfo response body", log.Error(closeErr))
-		}
-	}()
-	logger.Debug("Userinfo response received from OIDC provider", log.Int("statusCode", resp.StatusCode))
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		execResp.Status = flowconst.ExecFailure
-		execResp.FailureReason = fmt.Sprintf("Userinfo request failed with status %s: %s", resp.Status, string(body))
-		return nil, nil
-	}
-
-	// Parse the response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("Failed to read userinfo response body", log.Error(err))
-		return nil, fmt.Errorf("failed to read userinfo response body: %w", err)
-	}
-
-	var userInfo map[string]interface{}
-	if err := json.Unmarshal(body, &userInfo); err != nil {
-		logger.Error("Failed to parse userinfo response", log.Error(err))
-		return nil, fmt.Errorf("failed to parse userinfo response: %w", err)
-	}
-
-	return systemutils.ConvertInterfaceMapToStringMap(userInfo), nil
+	return o.internal.GetUserInfo(ctx, execResp, accessToken)
 }
 
 // ValidateIDToken validates the ID token.

--- a/backend/internal/flow/constants/constants.go
+++ b/backend/internal/flow/constants/constants.go
@@ -39,8 +39,6 @@ const (
 	StepTypeView FlowStepType = "VIEW"
 	// StepTypeRedirection represents a step in the flow that redirects the user to another URL.
 	StepTypeRedirection FlowStepType = "REDIRECTION"
-	// StepTypeRetry represents a step in the flow indicating a retry response.
-	StepTypeRetry FlowStepType = "RETRY"
 )
 
 // NodeType defines the node types in the flow execution.
@@ -95,7 +93,7 @@ const (
 	ExecExternalRedirection ExecutorStatus = "EXTERNAL_REDIRECTION"
 	// ExecFailure indicates that the executor has failed during its execution.
 	ExecFailure ExecutorStatus = "FAILURE"
-
+	// ExecRetry indicates that the executor is retrying its execution.
 	ExecRetry ExecutorStatus = "RETRY"
 )
 

--- a/backend/internal/flow/constants/constants.go
+++ b/backend/internal/flow/constants/constants.go
@@ -23,38 +23,64 @@ package constants
 type FlowStatus string
 
 const (
-	// Complete indicates that the flow execution is complete.
-	Complete FlowStatus = "COMPLETE"
-	// Incomplete indicates that the flow execution is incomplete.
-	Incomplete FlowStatus = "INCOMPLETE"
-	// PromptOnly indicates that the flow execution is in a prompt-only state.
-	PromptOnly FlowStatus = "PROMPT_ONLY"
-	// Error indicates that there was an error during the flow execution.
-	Error FlowStatus = "ERROR"
+	// FlowStatusComplete indicates that the flow execution is complete.
+	FlowStatusComplete FlowStatus = "COMPLETE"
+	// FlowStatusIncomplete indicates that the flow execution is incomplete.
+	FlowStatusIncomplete FlowStatus = "INCOMPLETE"
+	// FlowStatusError indicates that there was an error during the flow execution.
+	FlowStatusError FlowStatus = "ERROR"
 )
 
 // FlowStepType defines the type of a step in the flow execution.
 type FlowStepType string
 
 const (
-	// View represents a step in the flow that requires user interaction.
-	View FlowStepType = "VIEW"
-	// Redirection represents a step in the flow that redirects the user to another URL.
-	Redirection FlowStepType = "REDIRECTION"
+	// StepTypeView represents a step in the flow that requires user interaction.
+	StepTypeView FlowStepType = "VIEW"
+	// StepTypeRedirection represents a step in the flow that redirects the user to another URL.
+	StepTypeRedirection FlowStepType = "REDIRECTION"
+	// StepTypeRetry represents a step in the flow indicating a retry response.
+	StepTypeRetry FlowStepType = "RETRY"
 )
 
 // NodeType defines the node types in the flow execution.
 type NodeType string
 
 const (
-	// AuthSuccessNode represents a node that does auth assertion
-	AuthSuccessNode NodeType = "AUTHENTICATION_SUCCESS"
-	// TaskExecutionNode represents a task execution node
-	TaskExecutionNode NodeType = "TASK_EXECUTION"
-	// PromptOnlyNode represents a prompt-only node
-	PromptOnlyNode NodeType = "PROMPT_ONLY"
-	// DecisionNode represents a decision node
-	DecisionNode NodeType = "DECISION"
+	// NodeTypeAuthSuccess represents a node that does auth assertion
+	NodeTypeAuthSuccess NodeType = "AUTHENTICATION_SUCCESS"
+	// NodeTypeTaskExecution represents a task execution node
+	NodeTypeTaskExecution NodeType = "TASK_EXECUTION"
+	// NodeTypePromptOnly represents a prompt-only node
+	NodeTypePromptOnly NodeType = "PROMPT_ONLY"
+	// NodeTypeDecision represents a decision node
+	NodeTypeDecision NodeType = "DECISION"
+)
+
+// NodeStatus defines the status of a node in the flow execution.
+type NodeStatus string
+
+const (
+	// NodeStatusComplete indicates that the node has completed its execution successfully.
+	NodeStatusComplete NodeStatus = "COMPLETE"
+	// NodeStatusIncomplete indicates that the node has not completed its execution.
+	NodeStatusIncomplete NodeStatus = "INCOMPLETE"
+	// NodeStatusPromptOnly indicates that the node is in a prompt-only state, waiting for user input.
+	NodeStatusPromptOnly NodeStatus = "PROMPT_ONLY"
+	// NodeStatusFailure indicates that the node has failed during its execution.
+	NodeStatusFailure NodeStatus = "FAILURE"
+)
+
+// NodeResponseType defines the type of response from a node in the flow execution.
+type NodeResponseType string
+
+const (
+	// NodeResponseTypeView indicates that the node response is a view type, requiring user interaction.
+	NodeResponseTypeView NodeResponseType = "VIEW"
+	// NodeResponseTypeRedirection indicates that the node response is a redirection type, redirecting to another URL.
+	NodeResponseTypeRedirection NodeResponseType = "REDIRECTION"
+	// NodeResponseTypeRetry indicates that the node response is a retry type, indicating a retry action.
+	NodeResponseTypeRetry NodeResponseType = "RETRY"
 )
 
 // ExecutorStatus defines the status of an executor in the flow execution.
@@ -63,26 +89,14 @@ type ExecutorStatus string
 const (
 	// ExecComplete indicates that the executor has completed its execution successfully.
 	ExecComplete ExecutorStatus = "COMPLETE"
-	// ExecIncomplete indicates that the executor has not completed its execution.
-	ExecIncomplete ExecutorStatus = "INCOMPLETE"
 	// ExecUserInputRequired indicates that the executor requires user input to proceed.
 	ExecUserInputRequired ExecutorStatus = "USER_INPUT_REQUIRED"
 	// ExecExternalRedirection indicates that the executor is redirecting to an external URL.
 	ExecExternalRedirection ExecutorStatus = "EXTERNAL_REDIRECTION"
-	// ExecError indicates that there was an error during the executor's execution.
-	ExecError ExecutorStatus = "ERROR"
-	// ExecUserError indicates that there was a user error during the executor's execution.
-	ExecUserError ExecutorStatus = "USER_ERROR"
-)
+	// ExecFailure indicates that the executor has failed during its execution.
+	ExecFailure ExecutorStatus = "FAILURE"
 
-// ExecutorResponseType defines the type of response from an executor in the flow execution.
-type ExecutorResponseType string
-
-const (
-	// ExecView indicates that the executor response is a view type, requiring user interaction.
-	ExecView ExecutorResponseType = "VIEW"
-	// ExecRedirection indicates that the executor response is a redirection type, redirecting to another URL.
-	ExecRedirection ExecutorResponseType = "REDIRECTION"
+	ExecRetry ExecutorStatus = "RETRY"
 )
 
 const (

--- a/backend/internal/flow/handler/flowexechandler.go
+++ b/backend/internal/flow/handler/flowexechandler.go
@@ -75,6 +75,7 @@ func (h *FlowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 		Inputs:         flowStep.InputData,
 		AdditionalInfo: flowStep.AdditionalInfo,
 		Assertion:      flowStep.Assertion,
+		FailureReason:  flowStep.FailureReason,
 	}
 
 	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)

--- a/backend/internal/flow/model/executor.go
+++ b/backend/internal/flow/model/executor.go
@@ -22,12 +22,11 @@ import "github.com/asgardeo/thunder/internal/flow/constants"
 
 // ExecutorResponse represents the response from an executor
 type ExecutorResponse struct {
-	Status         constants.ExecutorStatus       `json:"status"`
-	Type           constants.ExecutorResponseType `json:"type"`
-	Error          string                         `json:"error,omitempty"`
-	RequiredData   []InputData                    `json:"required_data,omitempty"`
-	AdditionalInfo map[string]string              `json:"additional_info,omitempty"`
-	Assertion      string                         `json:"assertion,omitempty"`
+	Status         constants.ExecutorStatus `json:"status"`
+	RequiredData   []InputData              `json:"required_data,omitempty"`
+	AdditionalInfo map[string]string        `json:"additional_info,omitempty"`
+	Assertion      string                   `json:"assertion,omitempty"`
+	FailureReason  string                   `json:"failure_reason,omitempty"`
 }
 
 // ExecutorProperties holds the properties of an executor.

--- a/backend/internal/flow/model/flowmodel.go
+++ b/backend/internal/flow/model/flowmodel.go
@@ -60,6 +60,7 @@ type FlowStep struct {
 	Actions        []Action
 	Assertion      string
 	AdditionalInfo map[string]string
+	FailureReason  string
 }
 
 // InputData represents the input data required for a flow step
@@ -99,4 +100,5 @@ type FlowResponse struct {
 	Inputs         []InputData       `json:"inputs,omitempty"`
 	AdditionalInfo map[string]string `json:"additionalInfo,omitempty"`
 	Assertion      string            `json:"assertion,omitempty"`
+	FailureReason  string            `json:"failureReason,omitempty"`
 }

--- a/backend/internal/flow/model/node.go
+++ b/backend/internal/flow/model/node.go
@@ -25,12 +25,12 @@ import (
 
 // NodeResponse represents the response from a node execution
 type NodeResponse struct {
-	Status         constants.FlowStatus   `json:"status"`
-	Type           constants.FlowStepType `json:"type"`
-	Error          string                 `json:"error,omitempty"`
-	RequiredData   []InputData            `json:"required_data,omitempty"`
-	AdditionalInfo map[string]string      `json:"additional_info,omitempty"`
-	Assertion      string                 `json:"assertion,omitempty"`
+	Status         constants.NodeStatus       `json:"status"`
+	Type           constants.NodeResponseType `json:"type"`
+	FailureReason  string                     `json:"failure_reason,omitempty"`
+	RequiredData   []InputData                `json:"required_data,omitempty"`
+	AdditionalInfo map[string]string          `json:"additional_info,omitempty"`
+	Assertion      string                     `json:"assertion,omitempty"`
 }
 
 // NodeInterface defines the interface for nodes in the graph
@@ -96,23 +96,29 @@ func (n *Node) Execute(ctx *NodeContext) (*NodeResponse, *serviceerror.ServiceEr
 	}
 
 	nodeResp := &NodeResponse{
-		Error:          execResp.Error,
+		FailureReason:  execResp.FailureReason,
 		RequiredData:   execResp.RequiredData,
 		AdditionalInfo: execResp.AdditionalInfo,
 		Assertion:      execResp.Assertion,
 	}
 
 	if execResp.Status == constants.ExecComplete {
-		nodeResp.Status = constants.Complete
+		nodeResp.Status = constants.NodeStatusComplete
 		nodeResp.Type = ""
 	} else if execResp.Status == constants.ExecUserInputRequired {
-		nodeResp.Status = constants.Incomplete
-		nodeResp.Type = constants.View
+		nodeResp.Status = constants.NodeStatusIncomplete
+		nodeResp.Type = constants.NodeResponseTypeView
 	} else if execResp.Status == constants.ExecExternalRedirection {
-		nodeResp.Status = constants.Incomplete
-		nodeResp.Type = constants.Redirection
+		nodeResp.Status = constants.NodeStatusIncomplete
+		nodeResp.Type = constants.NodeResponseTypeRedirection
+	} else if execResp.Status == constants.ExecRetry {
+		nodeResp.Status = constants.NodeStatusIncomplete
+		nodeResp.Type = constants.NodeResponseTypeRetry
+	} else if execResp.Status == constants.ExecFailure {
+		nodeResp.Status = constants.NodeStatusFailure
+		nodeResp.Type = ""
 	} else {
-		nodeResp.Status = constants.Error
+		nodeResp.Status = constants.NodeStatusIncomplete
 		nodeResp.Type = ""
 	}
 

--- a/backend/internal/flow/utils/utils.go
+++ b/backend/internal/flow/utils/utils.go
@@ -173,14 +173,14 @@ func getExecutorConfigByName(execDef jsonmodel.ExecutorDefinition) (*model.Execu
 			Name:    "BasicAuthExecutor",
 			IdpName: "Local",
 		}
-	case "GithubAuthExecutor":
+	case "GithubOAuthExecutor":
 		executor = model.ExecutorConfig{
-			Name:    "GithubAuthExecutor",
+			Name:    "GithubOAuthExecutor",
 			IdpName: execDef.IdpName,
 		}
-	case "GoogleAuthExecutor":
+	case "GoogleOIDCAuthExecutor":
 		executor = model.ExecutorConfig{
-			Name:    "GoogleAuthExecutor",
+			Name:    "GoogleOIDCAuthExecutor",
 			IdpName: execDef.IdpName,
 		}
 	case "AuthAssertExecutor":
@@ -215,17 +215,17 @@ func GetExecutorByName(execConfig *model.ExecutorConfig) (model.ExecutorInterfac
 			return nil, fmt.Errorf("error while getting IDP for BasicAuthExecutor: %w", err)
 		}
 		executor = basicauth.NewBasicAuthExecutor(idp.ID, idp.Name)
-	case "GithubAuthExecutor":
+	case "GithubOAuthExecutor":
 		idp, err := getIDP(execConfig.IdpName)
 		if err != nil {
-			return nil, fmt.Errorf("error while getting IDP for GithubAuthExecutor: %w", err)
+			return nil, fmt.Errorf("error while getting IDP for GithubOAuthExecutor: %w", err)
 		}
-		executor = githubauth.NewGithubOIDCAuthExecutor(idp.ID, idp.Name, idp.ClientID, idp.ClientSecret,
+		executor = githubauth.NewGithubOAuthExecutor(idp.ID, idp.Name, idp.ClientID, idp.ClientSecret,
 			idp.RedirectURI, idp.Scopes, map[string]string{})
-	case "GoogleAuthExecutor":
+	case "GoogleOIDCAuthExecutor":
 		idp, err := getIDP(execConfig.IdpName)
 		if err != nil {
-			return nil, fmt.Errorf("error while getting IDP for GoogleAuthExecutor: %w", err)
+			return nil, fmt.Errorf("error while getting IDP for GoogleOIDCAuthExecutor: %w", err)
 		}
 		executor = googleauth.NewGoogleOIDCAuthExecutor(idp.ID, idp.Name, idp.ClientID, idp.ClientSecret,
 			idp.RedirectURI, idp.Scopes, map[string]string{})

--- a/backend/internal/flow/utils/utils.go
+++ b/backend/internal/flow/utils/utils.go
@@ -74,7 +74,7 @@ func BuildGraphFromDefinition(definition *jsonmodel.GraphDefinition) (model.Grap
 	// Add all nodes to the graph
 	for _, nodeDef := range definition.Nodes {
 		isStartNode := (nodeDef.ID == startNodeID)
-		isFinalNode := (nodeDef.Type == string(constants.AuthSuccessNode))
+		isFinalNode := (nodeDef.Type == string(constants.NodeTypeAuthSuccess))
 
 		// Construct a new node
 		node := model.NewNode(nodeDef.ID, nodeDef.Type, isStartNode, isFinalNode)
@@ -97,7 +97,7 @@ func BuildGraphFromDefinition(definition *jsonmodel.GraphDefinition) (model.Grap
 				return nil, fmt.Errorf("error while getting executor %s: %w", nodeDef.Executor, err)
 			}
 			node.SetExecutorConfig(executor)
-		} else if nodeDef.Type == string(constants.AuthSuccessNode) {
+		} else if nodeDef.Type == string(constants.NodeTypeAuthSuccess) {
 			executor, err := getExecutorConfigByName(jsonmodel.ExecutorDefinition{
 				Name: "AuthAssertExecutor",
 			})

--- a/samples/apps/oauth/src/pages/LoginPage.tsx
+++ b/samples/apps/oauth/src/pages/LoginPage.tsx
@@ -59,6 +59,7 @@ const LoginPage = () => {
     const [showRememberMe] = useState<boolean>(false);
     const [showForgotPassword] = useState<boolean>(false);
     const [error, setError] = useState<boolean>(false);
+    const [errorMessage, setErrorMessage] = useState<string>('Login failed');
     const [connectionError, setConnectionError] = useState<boolean>(false);
 
     const [flowId, setFlowId] = useState<string>(sessionStorage.getItem(FLOW_ID_KEY) || '');
@@ -147,6 +148,9 @@ const LoginPage = () => {
                 if (data.flowStatus && data.flowStatus === 'COMPLETE' && data.assertion) {
                     setToken(data.assertion);
                     setError(false);
+                } else if (data.flowStatus && data.flowStatus === 'ERROR') {
+                    setError(true);
+                    setErrorMessage(data.failureReason || 'Login failed. Please check your credentials.');
                 }
             }).catch((error) => {
                 console.error("Error during authentication:", error);
@@ -250,7 +254,7 @@ const LoginPage = () => {
 
                             {error && !connectionError && (
                                 <Alert severity="error" sx={{ my: 2 }}>
-                                    Login failed. Please check your credentials.
+                                    {errorMessage}
                                 </Alert>
                             )}
 


### PR DESCRIPTION
## Purpose

This pull request introduces significant updates to the authentication executors, focusing on improving error handling and refining the response structure. The changes include replacing generic error messages with detailed failure reasons, ensuring consistent handling of authentication failures, and modifying method signatures to return errors explicitly where applicable. Additionally, the `ExecutorResponse` initialization has been simplified across multiple executors.

- With this fix we assume any error returned from a executor/ node as a server error and failures returned in the response body as client errors.
- Also this PR fixes the issue of not able to silently execute an executor when required inputs are present in the initial request.
- Also the existing OIDCAuthExecutor is splitted into `OAuthExecutor` and `OIDCAuthExecutor`

### Error Handling Improvements:
* [`backend/internal/executor/authassert/authassertexecutor.go`]: Replaced generic error messages with explicit failure reasons and adjusted the `ExecutorResponse` structure to differentiate between `ExecFailure` and `ExecComplete` statuses.

### Response Structure Refinements:
* [`backend/internal/executor/basicauth/basicauthexecutor.go`]: Simplified `ExecutorResponse` initialization and replaced error-based statuses with `ExecFailure` and detailed failure reasons for authentication failures.

### OIDC Executors Updates:
* Split OAuth and OIDC execution in to two separate executors; `OAuthExecutor` and `OIDCAuthExecutor`.
* [`backend/internal/executor/githubauth/githubauthexecutor.go`]: Enhanced error handling by introducing explicit failure reasons, modifying method signatures to return errors, and refining response statuses for user info and token validation failures.
