### PR TITLE
Fix typo in the handler method name

### DIFF
--- a/backend/internal/system/healthcheck/handler/healthcheckhandler.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler.go
@@ -45,8 +45,8 @@ func (hch *HealthCheckHandler) HandleLivenessRequest(w http.ResponseWriter, r *h
 	logger.Debug("Health Check Liveness response sent")
 }
 
-// HandleRedinessRequest handles the health check readiness request.
-func (hch *HealthCheckHandler) HandleRedinessRequest(w http.ResponseWriter, r *http.Request) {
+// HandleReadinessRequest handles the health check readiness request.
+func (hch *HealthCheckHandler) HandleReadinessRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 
 	healthcheckProvider := provider.NewHealthCheckProvider()

--- a/backend/internal/system/services/healthcheckservice.go
+++ b/backend/internal/system/services/healthcheckservice.go
@@ -60,5 +60,5 @@ func (h *HealthCheckService) RegisterRoutes(mux *http.ServeMux) {
 	server.WrapHandleFunction(mux, "OPTIONS /health/readiness", &opts1, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
-	server.WrapHandleFunction(mux, "GET /health/readiness", &opts1, h.healthCheckHandler.HandleRedinessRequest)
+	server.WrapHandleFunction(mux, "GET /health/readiness", &opts1, h.healthCheckHandler.HandleReadinessRequest)
 }


### PR DESCRIPTION
## Purpose
This pull request corrects a typo in the method name `HandleRedinessRequest` by renaming it to `HandleReadinessRequest` across the codebase. The changes ensure consistency and accuracy in naming conventions.

### Typo correction:

* Renamed the method `HandleRedinessRequest` to `HandleReadinessRequest` in the `HealthCheckHandler` implementation to fix a spelling error. (`backend/internal/system/healthcheck/handler/healthcheckhandler.go`)
* Updated the usage of `HandleRedinessRequest` to `HandleReadinessRequest` in the route registration for the health check service. (`backend/internal/system/services/healthcheckservice.go`)