### PR TITLE
Fix integration test execution

### DIFF
--- a/tests/integration/testutils/testutils.go
+++ b/tests/integration/testutils/testutils.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	TargetDir                   = "../../target/dist"
-	ZipFilePattern              = "thunder_darwin_arm64-*.zip"
+	ZipFilePattern              = "thunder-*-macos-arm64.zip"
 	ExtractedDir                = "../../target/out/.test"
 	ServerBinary                = "thunder"
 	TestDeploymentYamlPath      = "./resources/deployment.yaml"


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the `ZipFilePattern` constant in `tests/integration/testutils/testutils.go` to reflect a new naming convention for zip files.

* [`tests/integration/testutils/testutils.go`](diffhunk://#diff-61a218234e78a428ae3a088ad1d8fadcd9ec87523b327ea241e207fa7a7e8fafL33-R33): Updated the `ZipFilePattern` constant to `"thunder-*-macos-arm64.zip"` to align with the new file naming convention.