### PR TITLE
Add support for decision nodes

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
@@ -1,0 +1,58 @@
+{
+    "id": "auth_flow_config_basic_google",
+    "type": "AUTHENTICATION",
+    "nodes": [
+        {
+            "id": "choose_auth",
+            "type": "DECISION"
+        },
+        {
+            "id": "basic_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "username",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "BasicAuthExecutor"
+            }
+        },
+        {
+            "id": "google_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "code",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "nonce",
+                    "type": "string",
+                    "required": false
+                }
+            ],
+            "executor": {
+                "name": "GoogleOIDCAuthExecutor",
+                "idpName": "Google"
+            }
+        },
+        {
+            "id": "authenticated",
+            "type": "AUTHENTICATION_SUCCESS"
+        }
+    ],
+    "edges": {
+        "choose_auth": ["basic_auth", "google_auth"],
+        "basic_auth": ["authenticated"],
+        "google_auth": ["authenticated"]
+    }
+}

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
@@ -1,5 +1,5 @@
 {
-    "id": "auth_flow_config_basic_or_google",
+    "id": "auth_flow_config_basic_google_github",
     "type": "AUTHENTICATION",
     "nodes": [
         {
@@ -46,13 +46,29 @@
             }
         },
         {
+            "id": "github_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "code",
+                    "type": "string",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "GithubOAuthExecutor",
+                "idpName": "Github"
+            }
+        },
+        {
             "id": "authenticated",
             "type": "AUTHENTICATION_SUCCESS"
         }
     ],
     "edges": {
-        "choose_auth": ["basic_auth", "google_auth"],
+        "choose_auth": ["basic_auth", "google_auth", "github_auth"],
         "basic_auth": ["authenticated"],
-        "google_auth": ["authenticated"]
+        "google_auth": ["authenticated"],
+        "github_auth": ["authenticated"]
     }
 }

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_or_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_or_google.json
@@ -1,0 +1,58 @@
+{
+    "id": "auth_flow_config_basic_or_google",
+    "type": "AUTHENTICATION",
+    "nodes": [
+        {
+            "id": "choose_auth",
+            "type": "DECISION"
+        },
+        {
+            "id": "basic_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "username",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "BasicAuthExecutor"
+            }
+        },
+        {
+            "id": "google_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "code",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "nonce",
+                    "type": "string",
+                    "required": false
+                }
+            ],
+            "executor": {
+                "name": "GoogleOIDCAuthExecutor",
+                "idpName": "Google"
+            }
+        },
+        {
+            "id": "authenticated",
+            "type": "AUTHENTICATION_SUCCESS"
+        }
+    ],
+    "edges": {
+        "choose_auth": ["basic_auth", "google_auth"],
+        "basic_auth": ["authenticated"],
+        "google_auth": ["authenticated"]
+    }
+}

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
@@ -3,7 +3,7 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
-            "id": "git_auth",
+            "id": "github_auth",
             "type": "TASK_EXECUTION",
             "inputData": [
                 {
@@ -23,6 +23,6 @@
         }
     ],
     "edges": {
-        "git_auth": ["authenticated"]
+        "github_auth": ["authenticated"]
     }
 }

--- a/backend/internal/flow/constants/constants.go
+++ b/backend/internal/flow/constants/constants.go
@@ -101,3 +101,13 @@ const (
 	// DataIDPName is the key used for the identity provider name in the flow response.
 	DataIDPName = "idpName"
 )
+
+// ActionType defines the type of action that can be performed in a decision node.
+type ActionType string
+
+const (
+	// ActionTypeView indicates that the action is a view type, requiring user selection.
+	ActionTypeView ActionType = "VIEW"
+	// ActionTypeUserInput indicates that the action requires user input to proceed.
+	ActionTypeUserInput ActionType = "USER_INPUT"
+)

--- a/backend/internal/flow/constants/errorconstants.go
+++ b/backend/internal/flow/constants/errorconstants.go
@@ -195,3 +195,11 @@ var ErrorInvalidAuthFlowConfiguredForApplication = serviceerror.ServiceError{
 	Error:            "Invalid configuration",
 	ErrorDescription: "The configured flow graph is not valid for the application authentication flow",
 }
+
+// ErrorNoActionsDefinedForNode defines the error response for nodes without any actions defined.
+var ErrorNoActionsDefinedForNode = serviceerror.ServiceError{
+	Code:             "FES-65017",
+	Type:             serviceerror.ServerErrorType,
+	Error:            "Invalid configuration",
+	ErrorDescription: "No actions defined for the node",
+}

--- a/backend/internal/flow/handler/flowexechandler.go
+++ b/backend/internal/flow/handler/flowexechandler.go
@@ -58,8 +58,14 @@ func (h *FlowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 		return
 	}
 
+	// Sanitize the input to prevent injection attacks
+	appID := sysutils.SanitizeString(flowR.ApplicationID)
+	flowID := sysutils.SanitizeString(flowR.FlowID)
+	actionID := sysutils.SanitizeString(flowR.ActionID)
+	inputs := sysutils.SanitizeStringMap(flowR.Inputs)
+
 	svc := flow.GetFlowService()
-	flowStep, flowErr := svc.Execute(flowR.ApplicationID, flowR.FlowID, flowR.ActionID, flowR.Inputs)
+	flowStep, flowErr := svc.Execute(appID, flowID, actionID, inputs)
 
 	if flowErr != nil {
 		handleFlowError(w, logger, flowErr)

--- a/backend/internal/flow/model/decisionnode.go
+++ b/backend/internal/flow/model/decisionnode.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"github.com/asgardeo/thunder/internal/flow/constants"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
+
+// DecisionNode represents a node that makes decisions based on input data.
+type DecisionNode struct {
+	*Node
+}
+
+// NewDecisionNode creates a new DecisionNode with the given details.
+func NewDecisionNode(id string, isStartNode bool, isFinalNode bool) NodeInterface {
+	return &DecisionNode{
+		Node: &Node{
+			id:               id,
+			_type:            constants.NodeTypeDecision,
+			isStartNode:      isStartNode,
+			isFinalNode:      isFinalNode,
+			nextNodeList:     []string{},
+			previousNodeList: []string{},
+			inputData:        []InputData{},
+			executorConfig:   nil,
+		},
+	}
+}
+
+// Execute executes the decision node logic based on the current context.
+func (n *DecisionNode) Execute(ctx *NodeContext) (*NodeResponse, *serviceerror.ServiceError) {
+	triggeredActionID := ctx.CurrentActionID
+	if triggeredActionID != "" {
+		return n.TriggerAction(ctx, triggeredActionID)
+	}
+
+	return n.PrepareActionInput(ctx, triggeredActionID)
+}
+
+// TriggerAction processes the action triggered by the user and determines the next node to transition to.
+func (n *DecisionNode) TriggerAction(ctx *NodeContext, actionID string) (*NodeResponse,
+	*serviceerror.ServiceError) {
+	nextNodeIDs := n.GetNextNodeList()
+	if len(nextNodeIDs) == 0 {
+		return &NodeResponse{
+			Status:        constants.NodeStatusFailure,
+			Type:          "",
+			FailureReason: "No next nodes defined for the decision node.",
+		}, nil
+	}
+
+	var nextNodeID string
+	for _, nextNodeIDCandidate := range nextNodeIDs {
+		if nextNodeIDCandidate == actionID {
+			nextNodeID = nextNodeIDCandidate
+			break
+		}
+	}
+	if nextNodeID == "" {
+		return &NodeResponse{
+			Status:        constants.NodeStatusFailure,
+			Type:          "",
+			FailureReason: "No matching next node found for the triggered action ID.",
+		}, nil
+	}
+
+	return &NodeResponse{
+		Status:     constants.NodeStatusComplete,
+		Type:       "",
+		NextNodeID: nextNodeID,
+	}, nil
+}
+
+// PrepareActionInput prepares the input for the action to be triggered by the user.
+func (n *DecisionNode) PrepareActionInput(ctx *NodeContext, actionID string) (*NodeResponse,
+	*serviceerror.ServiceError) {
+	actions := n.getActionsList()
+	if len(actions) == 0 {
+		svcErr := constants.ErrorNoActionsDefinedForNode
+		svcErr.ErrorDescription = "No outgoing edges defined for the decision node."
+		return nil, &svcErr
+	}
+
+	return &NodeResponse{
+		Status:        constants.NodeStatusIncomplete,
+		Type:          constants.NodeResponseTypeView,
+		Actions:       actions,
+		FailureReason: "",
+	}, nil
+}
+
+// getActionsList retrieves the list of actions available for the decision node.
+func (n *DecisionNode) getActionsList() []Action {
+	actions := []Action{}
+	for _, nextNodeID := range n.GetNextNodeList() {
+		action := Action{
+			Type: constants.ActionTypeView,
+			ID:   nextNodeID,
+		}
+		actions = append(actions, action)
+	}
+	return actions
+}

--- a/backend/internal/flow/model/flowmodel.go
+++ b/backend/internal/flow/model/flowmodel.go
@@ -41,8 +41,9 @@ type EngineContext struct {
 
 // NodeContext holds the context for a specific node in the flow execution.
 type NodeContext struct {
-	FlowID string
-	AppID  string
+	FlowID          string
+	AppID           string
+	CurrentActionID string
 
 	NodeInputData []InputData
 	UserInputData map[string]string
@@ -78,8 +79,9 @@ type InputData struct {
 
 // Action represents an action to be executed in a flow step
 type Action struct {
-	Type     string         `json:"type"`
-	Executor *ExecutorModel `json:"executor,omitempty"`
+	Type constants.ActionType `json:"type"`
+	ID   string               `json:"id"`
+	// Executor *ExecutorModel `json:"executor,omitempty"`
 }
 
 // ExecutorModel represents an executor configuration within an action

--- a/backend/internal/flow/model/graph.go
+++ b/backend/internal/flow/model/graph.go
@@ -134,14 +134,14 @@ func (g *Graph) ToJSON() (string, error) {
 	}
 
 	type JSONNode struct {
-		ID             string          `json:"id"`
-		Type           string          `json:"type"`
-		IsStartNode    bool            `json:"isStartNode,omitempty"`
-		IsFinalNode    bool            `json:"isFinalNode,omitempty"`
-		NextNodeID     string          `json:"nextNodeId,omitempty"`
-		PreviousNodeID string          `json:"previousNodeId,omitempty"`
-		InputData      []JSONInputData `json:"inputData,omitempty"`
-		Executor       string          `json:"executor,omitempty"`
+		ID                 string          `json:"id"`
+		Type               string          `json:"type"`
+		IsStartNode        bool            `json:"isStartNode,omitempty"`
+		IsFinalNode        bool            `json:"isFinalNode,omitempty"`
+		NextNodeIDList     []string        `json:"nextNodeIds"`
+		PreviousNodeIDList []string        `json:"previousNodeIds"`
+		InputData          []JSONInputData `json:"inputData,omitempty"`
+		Executor           string          `json:"executor,omitempty"`
 	}
 
 	type JSONGraph struct {
@@ -161,12 +161,12 @@ func (g *Graph) ToJSON() (string, error) {
 	// Convert nodes to JSONNode
 	for id, node := range g.nodes {
 		jsonNode := JSONNode{
-			ID:             id,
-			Type:           node.GetType(),
-			IsStartNode:    node.IsStartNode(),
-			IsFinalNode:    node.IsFinalNode(),
-			NextNodeID:     node.GetNextNodeID(),
-			PreviousNodeID: node.GetPreviousNodeID(),
+			ID:                 id,
+			Type:               string(node.GetType()),
+			IsStartNode:        node.IsStartNode(),
+			IsFinalNode:        node.IsFinalNode(),
+			NextNodeIDList:     node.GetNextNodeList(),
+			PreviousNodeIDList: node.GetPreviousNodeList(),
 		}
 
 		// Set executor if available

--- a/backend/internal/flow/model/taskexecutionnode.go
+++ b/backend/internal/flow/model/taskexecutionnode.go
@@ -32,14 +32,14 @@ type TaskExecutionNode struct {
 func NewTaskExecutionNode(id string, isStartNode bool, isFinalNode bool) NodeInterface {
 	return &TaskExecutionNode{
 		Node: &Node{
-			id:             id,
-			_type:          constants.NodeTypeTaskExecution,
-			isStartNode:    isStartNode,
-			isFinalNode:    isFinalNode,
-			nextNodeID:     "",
-			previousNodeID: "",
-			inputData:      []InputData{},
-			executorConfig: &ExecutorConfig{},
+			id:               id,
+			_type:            constants.NodeTypeTaskExecution,
+			isStartNode:      isStartNode,
+			isFinalNode:      isFinalNode,
+			nextNodeList:     []string{},
+			previousNodeList: []string{},
+			inputData:        []InputData{},
+			executorConfig:   &ExecutorConfig{},
 		},
 	}
 }

--- a/backend/internal/flow/utils/utils.go
+++ b/backend/internal/flow/utils/utils.go
@@ -121,39 +121,20 @@ func BuildGraphFromDefinition(definition *jsonmodel.GraphDefinition) (model.Grap
 		return nil, fmt.Errorf("failed to set start node ID: %w", err)
 	}
 
-	// Add all edges to the graph
+	// Set edges in the graph
 	for sourceID, targetIDs := range definition.Edges {
 		for _, targetID := range targetIDs {
 			err := g.AddEdge(sourceID, targetID)
 			if err != nil {
 				return nil, fmt.Errorf("failed to add edge from %s to %s: %w", sourceID, targetID, err)
 			}
-		}
-	}
 
-	// Set PreviousNodeID and NextNodeID based on edges
-	for fromNodeID, toNodeIDs := range g.GetEdges() {
-		if len(toNodeIDs) > 0 {
-			// Set the NextNodeID for the source node
-			if sourceNode, exists := g.GetNode(fromNodeID); exists {
-				sourceNode.SetNextNodeID(toNodeIDs[0])
-				// Update the source node in the graph
-				err := g.AddNode(sourceNode)
-				if err != nil {
-					return nil, fmt.Errorf("failed to update source node %s in the graph: %w", fromNodeID, err)
-				}
+			if sourceNode, exists := g.GetNode(sourceID); exists {
+				sourceNode.AddNextNodeID(targetID)
 			}
 
-			// Set the PreviousNodeID for each target node
-			for _, toNodeID := range toNodeIDs {
-				if targetNode, exists := g.GetNode(toNodeID); exists {
-					targetNode.SetPreviousNodeID(fromNodeID)
-					// Update the target node in the graph
-					err := g.AddNode(targetNode)
-					if err != nil {
-						return nil, fmt.Errorf("failed to update target node %s in the graph: %w", toNodeID, err)
-					}
-				}
+			if targetNode, exists := g.GetNode(targetID); exists {
+				targetNode.AddPreviousNodeID(sourceID)
 			}
 		}
 	}


### PR DESCRIPTION
## Purpose

This pull request introduces the decision node support for the flow engine. Key changes include the addition of a `DecisionNode` type, updates to the flow graph structure, and modifications to the flow engine's execution logic to support decision nodes and user actions.

### Flow Graph Definition:
* Introduces a new `auth_flow_config_basic_or_google` auth flow definition (json) to support login with Username/Password or Google login.

### Enhancements to Decision-Making and Flow Execution:
* Added a new `DecisionNode` type to represent nodes that make decisions based on user actions or input, including logic for handling triggered actions and prompting users when no action is taken.
* Updated the flow graph structure to support multiple next nodes (`NextNodeIDList`) and previous nodes (`PreviousNodeIDList`) for improved flexibility in flow transitions.
* Enhanced the flow engine's execution logic to resolve the next node dynamically based on the current node type and user actions, with specific handling for decision nodes.

### Context and Action Handling:
* Introduced a `CurrentActionID` field in `EngineContext` to track the currently triggered action, and updated context preparation to include this field.
* Added support for defining and processing actions in node responses, allowing decision nodes to prompt users for actions or proceed based on predefined configurations.

### Security and Input Validation:
* Added input sanitization in the flow execution handler to prevent injection attacks, ensuring all user-provided data is sanitized before processing.

These changes collectively enhance the flexibility, robustness, and security of the flow engine while introducing new capabilities for decision-making and user interaction.

## Auth Flow

1. Initiate authentication
    ```sh
    curl --location 'https://localhost:8090/flow/execute' \
    --header 'Accept: application/json' \
    --header 'Content-Type: application/json' \
    --data '{
        "applicationId": "550e8400-e29b-41d4-a716-446655440000"
    }
    '
    ```
    
    Response:
    ```json
    {
        "flowId": "f03e9ba7-217e-4e52-83bf-6a6cade0f9df",
        "flowStatus": "INCOMPLETE",
        "type": "VIEW",
        "data": {
            "actions": [
                {
                    "type": "VIEW",
                    "id": "basic_auth"
                },
                {
                    "type": "VIEW",
                    "id": "google_auth"
                }
            ]
        }
    }
    ```

2. Submit the user decision
    ```sh
    curl --location 'https://localhost:8090/flow/execute' \
    --header 'Content-Type: application/json' \
    --data '{
        "flowId": "f03e9ba7-217e-4e52-83bf-6a6cade0f9df",
        "actionId": "basic_auth"
    }
    '
    ```
    
    Response:
    ```json
    {
        "flowId": "f03e9ba7-217e-4e52-83bf-6a6cade0f9df",
        "flowStatus": "INCOMPLETE",
        "type": "VIEW",
        "data": {
            "inputs": [
                {
                    "name": "username",
                    "type": "string",
                    "required": true
                },
                {
                    "name": "password",
                    "type": "string",
                    "required": true
                }
            ]
        }
    }
    ```

3. Submit username/ password input
    ```sh
    curl --location 'https://localhost:8090/flow/execute' \
    --header 'Content-Type: application/json' \
    --data '{
        "flowId": "f03e9ba7-217e-4e52-83bf-6a6cade0f9df",
        "inputs": {
            "username": "thor",
            "password": "thor123"
        }
    }
    '
    ```
    
    Response:
    ```json
    {
        "flowId": "f03e9ba7-217e-4e52-83bf-6a6cade0f9df",
        "flowStatus": "COMPLETE",
        "data": {},
        "assertion": "<jwt>"
    }
    ```
    
    Alternative instead of two steps, user inputs can also be included in step 2 as well.
