### PR TITLE
Modify graph definition from the edge-based structure to a node-based structure

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
@@ -24,14 +24,14 @@
             ],
             "executor": {
                 "name": "BasicAuthExecutor"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "authenticated",
             "type": "AUTHENTICATION_SUCCESS"
         }
-    ],
-    "edges": {
-        "basic_auth": ["authenticated"]
-    }
+    ]
 }

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
@@ -4,7 +4,11 @@
     "nodes": [
         {
             "id": "choose_auth",
-            "type": "DECISION"
+            "type": "DECISION",
+            "nextNodes": [
+                "basic_auth",
+                "google_auth"
+            ]
         },
         {
             "id": "basic_auth",
@@ -23,7 +27,10 @@
             ],
             "executor": {
                 "name": "BasicAuthExecutor"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "google_auth",
@@ -43,16 +50,14 @@
             "executor": {
                 "name": "GoogleOIDCAuthExecutor",
                 "idpName": "Google"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "authenticated",
             "type": "AUTHENTICATION_SUCCESS"
         }
-    ],
-    "edges": {
-        "choose_auth": ["basic_auth", "google_auth"],
-        "basic_auth": ["authenticated"],
-        "google_auth": ["authenticated"]
-    }
+    ]
 }

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
@@ -4,7 +4,12 @@
     "nodes": [
         {
             "id": "choose_auth",
-            "type": "DECISION"
+            "type": "DECISION",
+            "nextNodes": [
+                "basic_auth",
+                "google_auth",
+                "github_auth"
+            ]
         },
         {
             "id": "basic_auth",
@@ -23,7 +28,10 @@
             ],
             "executor": {
                 "name": "BasicAuthExecutor"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "google_auth",
@@ -43,7 +51,10 @@
             "executor": {
                 "name": "GoogleOIDCAuthExecutor",
                 "idpName": "Google"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "github_auth",
@@ -58,17 +69,14 @@
             "executor": {
                 "name": "GithubOAuthExecutor",
                 "idpName": "Github"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "authenticated",
             "type": "AUTHENTICATION_SUCCESS"
         }
-    ],
-    "edges": {
-        "choose_auth": ["basic_auth", "google_auth", "github_auth"],
-        "basic_auth": ["authenticated"],
-        "google_auth": ["authenticated"],
-        "github_auth": ["authenticated"]
-    }
+    ]
 }

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
@@ -15,14 +15,14 @@
             "executor": {
                 "name": "GithubOAuthExecutor",
                 "idpName": "Github"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "authenticated",
             "type": "AUTHENTICATION_SUCCESS"
         }
-    ],
-    "edges": {
-        "github_auth": ["authenticated"]
-    }
+    ]
 }

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
@@ -20,14 +20,14 @@
             "executor": {
                 "name": "GoogleOIDCAuthExecutor",
                 "idpName": "Google"
-            }
+            },
+            "nextNodes": [
+                "authenticated"
+            ]
         },
         {
             "id": "authenticated",
             "type": "AUTHENTICATION_SUCCESS"
         }
-    ],
-    "edges": {
-        "google_auth": ["authenticated"]
-    }
+    ]
 }

--- a/backend/internal/flow/constants/constants.go
+++ b/backend/internal/flow/constants/constants.go
@@ -19,6 +19,14 @@
 // Package constants defines the constants used in the flow execution service and engine.
 package constants
 
+// GraphType defines the type of graph used in the flow execution.
+type GraphType string
+
+const (
+	// GraphTypeAuthentication represents a graph type for authentication flows.
+	GraphTypeAuthentication GraphType = "AUTHENTICATION"
+)
+
 // FlowStatus defines the status of a flow execution.
 type FlowStatus string
 

--- a/backend/internal/flow/engine/flowengine.go
+++ b/backend/internal/flow/engine/flowengine.go
@@ -119,10 +119,10 @@ func setCurrentExecutionNode(ctx *model.EngineContext, logger *log.Logger) (mode
 
 	currentNode := ctx.CurrentNode
 	if currentNode == nil {
-		logger.Debug("Current node is nil. Setting the start node as the current node.")
-		var ok bool
-		currentNode, ok = graph.GetNode(graph.GetStartNodeID())
-		if !ok {
+		logger.Debug("Current node is nil. Setting start node as the current node.")
+		var err error
+		currentNode, err = graph.GetStartNode()
+		if err != nil {
 			return nil, &constants.ErrorStartNodeNotFoundInGraph
 		}
 		ctx.CurrentNode = currentNode

--- a/backend/internal/flow/jsonmodel/model.go
+++ b/backend/internal/flow/jsonmodel/model.go
@@ -21,9 +21,9 @@ package jsonmodel
 
 // GraphDefinition represents the direct graph structure from JSON
 type GraphDefinition struct {
-	ID    string              `json:"id"`
-	Nodes []NodeDefinition    `json:"nodes"`
-	Edges map[string][]string `json:"edges"`
+	ID    string           `json:"id"`
+	Type  string           `json:"type"`
+	Nodes []NodeDefinition `json:"nodes"`
 }
 
 // NodeDefinition represents a node in the graph definition
@@ -32,6 +32,7 @@ type NodeDefinition struct {
 	Type      string             `json:"type"`
 	InputData []InputDefinition  `json:"inputData"`
 	Executor  ExecutorDefinition `json:"executor"`
+	NextNodes []string           `json:"nextNodes,omitempty"`
 }
 
 // InputDefinition represents an input parameter for a node


### PR DESCRIPTION
## Purpose

This pull request modifies the graph definition by transitioning from the edge-based structure to a node-based `nextNodes` structure. It also introduces a new `GraphType` to categorize graph types and updates the flow engine to accommodate these structural changes.

### Graph Model Updates:
* Replaced the `Edges` structure with a `NextNodes` property in `NodeDefinition`, simplifying the representation of graph connections.
* Updated graph definitions (`auth_flow_config_*.json`) to use `nextNodes` instead of `edges`, removing the `edges` section entirely.

### New Graph Type:
* Introduced a `GraphType` type and a constant `GraphTypeAuthentication` to categorize graphs.
* Added a `type` field to `GraphDefinition` and `_type` to the `Graph` struct to support the new graph type.

### Flow Engine Enhancements:
* Replaced `GetStartNodeID` with `GetStartNode` in the `GraphInterface`, improving error handling for missing start nodes. 
* Updated the flow engine to dynamically determine the start node based on nodes without incoming connections. 

These changes improve the flexibility and maintainability of the graph model while aligning it with the new `nextNodes` structure.