### PR TITLE
Rename next node key

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
@@ -25,7 +25,7 @@
             "executor": {
                 "name": "BasicAuthExecutor"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
@@ -5,7 +5,7 @@
         {
             "id": "choose_auth",
             "type": "DECISION",
-            "nextNodes": [
+            "next": [
                 "basic_auth",
                 "google_auth"
             ]
@@ -28,7 +28,7 @@
             "executor": {
                 "name": "BasicAuthExecutor"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },
@@ -51,7 +51,7 @@
                 "name": "GoogleOIDCAuthExecutor",
                 "idpName": "Google"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
@@ -5,7 +5,7 @@
         {
             "id": "choose_auth",
             "type": "DECISION",
-            "nextNodes": [
+            "next": [
                 "basic_auth",
                 "google_auth",
                 "github_auth"
@@ -29,7 +29,7 @@
             "executor": {
                 "name": "BasicAuthExecutor"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },
@@ -52,7 +52,7 @@
                 "name": "GoogleOIDCAuthExecutor",
                 "idpName": "Google"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },
@@ -70,7 +70,7 @@
                 "name": "GithubOAuthExecutor",
                 "idpName": "Github"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_with_prompt.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_with_prompt.json
@@ -12,7 +12,7 @@
                     "required": true
                 }
             ],
-            "nextNodes": [
+            "next": [
                 "basic_auth"
             ]
         },
@@ -29,7 +29,7 @@
             "executor": {
                 "name": "BasicAuthExecutor"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
@@ -16,7 +16,7 @@
                 "name": "GithubOAuthExecutor",
                 "idpName": "Github"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
@@ -21,7 +21,7 @@
                 "name": "GoogleOIDCAuthExecutor",
                 "idpName": "Google"
             },
-            "nextNodes": [
+            "next": [
                 "authenticated"
             ]
         },

--- a/backend/internal/flow/jsonmodel/model.go
+++ b/backend/internal/flow/jsonmodel/model.go
@@ -32,7 +32,7 @@ type NodeDefinition struct {
 	Type      string             `json:"type"`
 	InputData []InputDefinition  `json:"inputData"`
 	Executor  ExecutorDefinition `json:"executor"`
-	NextNodes []string           `json:"nextNodes,omitempty"`
+	Next      []string           `json:"next,omitempty"`
 }
 
 // InputDefinition represents an input parameter for a node

--- a/backend/internal/flow/utils/utils.go
+++ b/backend/internal/flow/utils/utils.go
@@ -49,7 +49,7 @@ func BuildGraphFromDefinition(definition *jsonmodel.GraphDefinition) (model.Grap
 	// Add all nodes to the graph
 	edges := make(map[string][]string)
 	for _, nodeDef := range definition.Nodes {
-		isFinalNode := len(nodeDef.NextNodes) == 0
+		isFinalNode := len(nodeDef.Next) == 0
 
 		// Construct a new node. Here we set isStartNode to false by default.
 		node, err := model.NewNode(nodeDef.ID, nodeDef.Type, false, isFinalNode)
@@ -58,15 +58,15 @@ func BuildGraphFromDefinition(definition *jsonmodel.GraphDefinition) (model.Grap
 		}
 
 		// Set next nodes if defined
-		if len(nodeDef.NextNodes) > 0 {
-			node.SetNextNodeList(nodeDef.NextNodes)
+		if len(nodeDef.Next) > 0 {
+			node.SetNextNodeList(nodeDef.Next)
 
 			// Store edges based on the node definition
 			_, exists := edges[nodeDef.ID]
 			if !exists {
 				edges[nodeDef.ID] = []string{}
 			}
-			edges[nodeDef.ID] = append(edges[nodeDef.ID], nodeDef.NextNodes...)
+			edges[nodeDef.ID] = append(edges[nodeDef.ID], nodeDef.Next...)
 		}
 
 		// Convert and set input data from definition


### PR DESCRIPTION
## Purpose

This pull request refactors the naming of the `nextNodes` field to `next` across JSON configuration files and backend code. This change ensures consistency and simplifies the field name for better readability and maintainability.
