### PR TITLE
Add support for storing IDP properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,28 @@ Open the sample app in your browser and enter the username and password you crea
       "id": "550e8400-e29b-41d4-a716-446655440001",
       "name": "Google",
       "description": "Login with Google",
-      "client_id": "<client_id>",
-      "client_secret": "<client_secret>",
-      "redirect_uri": "<app_callback_url>",
-      "scopes": [
-          "openid",
-          "email",
-          "profile"
-      ]
+      "properties": [
+        {
+            "name": "client_id",
+            "value": "<client_id>",
+            "is_secret": false
+        },
+        {
+            "name": "client_secret",
+            "value": "<client_secret>",
+            "is_secret": true
+        },
+        {
+            "name": "redirect_uri",
+            "value": "<app_callback_url>",
+            "is_secret": false
+        },
+        {
+            "name": "scopes",
+            "value": "openid,email,profile",
+            "is_secret": false
+        }
+    ]
   }'
   ```
 
@@ -196,13 +210,28 @@ Open the sample app in your browser and enter the username and password you crea
       "id": "550e8400-e29b-41d4-a716-446655440001",
       "name": "Github",
       "description": "Login with Github",
-      "client_id": "<client_id>",
-      "client_secret": "<client_secret>",
-      "redirect_uri": "<app_callback_url>",
-      "scopes": [
-          "user:email",
-          "read:user"
-      ]
+      "properties": [
+          {
+              "name": "client_id",
+              "value": "<client_id>",
+              "is_secret": false
+          },
+          {
+              "name": "client_secret",
+              "value": "<client_secret>",
+              "is_secret": true
+          },
+          {
+              "name": "redirect_uri",
+              "value": "<app_callback_url>",
+              "is_secret": false
+          },
+          {
+              "name": "scopes",
+              "value": "user:email,read:user",
+              "is_secret": false
+          }
+      ],
   }'
   ```
 
@@ -358,13 +387,27 @@ Open the sample app in your browser and enter the username and password you crea
       "id": "550e8400-e29b-41d4-a716-446655440001",
       "name": "Google",
       "description": "Login with Google",
-      "client_id": "<client_id>",
-      "client_secret": "<client_secret>",
-      "redirect_uri": "<app_callback_url>",
-      "scopes": [
-          "openid",
-          "email",
-          "profile"
+      "properties": [
+          {
+              "name": "client_id",
+              "value": "<client_id>",
+              "is_secret": false
+          },
+          {
+              "name": "client_secret",
+              "value": "<client_secret>",
+              "is_secret": true
+          },
+          {
+              "name": "redirect_uri",
+              "value": "<app_callback_url>",
+              "is_secret": false
+          },
+          {
+              "name": "scopes",
+              "value": "openid,email,profile",
+              "is_secret": false
+          }
       ]
   }'
   ```
@@ -465,12 +508,27 @@ Open the sample app in your browser and enter the username and password you crea
       "id": "550e8400-e29b-41d4-a716-446655440001",
       "name": "Github",
       "description": "Login with Github",
-      "client_id": "<client_id>",
-      "client_secret": "<client_secret>",
-      "redirect_uri": "<app_callback_url>",
-      "scopes": [
-          "user:email",
-          "read:user"
+      "properties": [
+          {
+              "name": "client_id",
+              "value": "<client_id>",
+              "is_secret": false
+          },
+          {
+              "name": "client_secret",
+              "value": "<client_secret>",
+              "is_secret": true
+          },
+          {
+              "name": "redirect_uri",
+              "value": "<app_callback_url>",
+              "is_secret": false
+          },
+          {
+              "name": "scopes",
+              "value": "user:email,read:user",
+              "is_secret": false
+          }
       ]
   }'
   ```

--- a/backend/dbscripts/thunderdb/postgress.sql
+++ b/backend/dbscripts/thunderdb/postgress.sql
@@ -89,12 +89,17 @@ CREATE TABLE IDP (
     IDP_ID VARCHAR(36) UNIQUE NOT NULL,
     NAME VARCHAR(255) NOT NULL,
     DESCRIPTION VARCHAR(500),
-    CLIENT_ID VARCHAR(255) NOT NULL,
-    CLIENT_SECRET VARCHAR(255) NOT NULL,
-    REDIRECT_URI VARCHAR(500) NOT NULL,
-    SCOPES VARCHAR(255),
     CREATED_AT TIMESTAMPTZ DEFAULT NOW(),
     UPDATED_AT TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Table to store identity provider properties
+CREATE TABLE IDP_PROPERTY (
+    IDP_ID VARCHAR(36) REFERENCES IDP(IDP_ID) ON DELETE CASCADE,
+    PROPERTY_NAME VARCHAR(255) NOT NULL,
+    PROPERTY_VALUE VARCHAR(500) NOT NULL,
+    IS_SECRET CHAR(1) DEFAULT '0',
+    PRIMARY KEY (IDP_ID, PROPERTY_NAME)
 );
 
 -- Insert sample data into the tables.
@@ -135,8 +140,19 @@ VALUES
 ('550e8400-e29b-41d4-a716-446655440000', '456e8400-e29b-41d4-a716-446655440001', 'person',
 '{"age": 30, "roles": ["admin", "user"], "address": {"city": "Colombo", "zip": "00100"}}');
 
-INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, SCOPES)
+INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION)
 VALUES
-('550e8400-e29b-41d4-a716-446655440000', 'Local', 'Local Identity Provider', '', '', '', '[]'),
-('550e8400-e29b-41d4-a716-446655440000', 'Github', 'Login with Github', 'client1', 'secret1', 'https://localhost:8090/flow/authn', '["user:email","read:user"]'),
-('550e8400-e29b-41d4-a716-446655440001', 'Google', 'Login with Google', 'client2', 'secret2', 'https://localhost:8090/flow/authn', '["user:email","read:user"]');
+('550e8400-e29b-41d4-a716-446655440000', 'Local', 'Local Identity Provider'),
+('550e8400-e29b-41d4-a716-446655440001', 'Github', 'Login with Github'),
+('550e8400-e29b-41d4-a716-446655440002', 'Google', 'Login with Google');
+
+INSERT INTO IDP_PROPERTY (IDP_ID, PROPERTY_NAME, PROPERTY_VALUE, IS_SECRET)
+VALUES
+('550e8400-e29b-41d4-a716-446655440001', 'client_id', 'client1', '0'),
+('550e8400-e29b-41d4-a716-446655440001', 'client_secret', 'secret1', '1'),
+('550e8400-e29b-41d4-a716-446655440001', 'redirect_uri', 'https://localhost:3000', '0'),
+('550e8400-e29b-41d4-a716-446655440001', 'scopes', 'user:email,read:user', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'client_id', 'client2', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'client_secret', 'secret2', '1'),
+('550e8400-e29b-41d4-a716-446655440002', 'redirect_uri', 'https://localhost:3000', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'scopes', 'openid,email,profile', '0');

--- a/backend/dbscripts/thunderdb/sqlite.sql
+++ b/backend/dbscripts/thunderdb/sqlite.sql
@@ -89,12 +89,16 @@ CREATE TABLE IDP (
     IDP_ID VARCHAR(36) UNIQUE NOT NULL,
     NAME VARCHAR(255) NOT NULL,
     DESCRIPTION VARCHAR(500),
-    CLIENT_ID TEXT NOT NULL,
-    CLIENT_SECRET TEXT NOT NULL,
-    REDIRECT_URI VARCHAR(500) NOT NULL,
-    SCOPES VARCHAR(255),
     CREATED_AT TEXT DEFAULT (datetime('now')),
     UPDATED_AT TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IDP_PROPERTY (
+    IDP_ID VARCHAR(36) REFERENCES IDP(IDP_ID) ON DELETE CASCADE,
+    PROPERTY_NAME VARCHAR(255) NOT NULL,
+    PROPERTY_VALUE VARCHAR(500) NOT NULL,
+    IS_SECRET CHAR(1) DEFAULT '0',
+    PRIMARY KEY (IDP_ID, PROPERTY_NAME)
 );
 
 -- Insert sample data into the tables.
@@ -137,8 +141,19 @@ VALUES (
 datetime('now'), datetime('now')
 );
 
-INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, SCOPES, CREATED_AT, UPDATED_AT)
+INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, CREATED_AT, UPDATED_AT)
 VALUES
-('550e8400-e29b-41d4-a716-446655440000', 'Local', 'Local Identity Provider', '', '', '', '[]', datetime('now'), datetime('now')),
-('550e8400-e29b-41d4-a716-446655440001', 'Github', 'Login with Github', 'client1', 'secret1', 'https://localhost:8090/flow/authn', '["user:email","read:user"]', datetime('now'), datetime('now')),
-('550e8400-e29b-41d4-a716-446655440002', 'Google', 'Login with Google', 'client2', 'secret2', 'https://localhost:8090/flow/authn', '["user:email","read:user"]', datetime('now'), datetime('now'));
+('550e8400-e29b-41d4-a716-446655440000', 'Local', 'Local Identity Provider', datetime('now'), datetime('now')),
+('550e8400-e29b-41d4-a716-446655440001', 'Github', 'Login with Github', datetime('now'), datetime('now')),
+('550e8400-e29b-41d4-a716-446655440002', 'Google', 'Login with Google', datetime('now'), datetime('now'));
+
+INSERT INTO IDP_PROPERTY (IDP_ID, PROPERTY_NAME, PROPERTY_VALUE, IS_SECRET)
+VALUES
+('550e8400-e29b-41d4-a716-446655440001', 'client_id', 'client1', '0'),
+('550e8400-e29b-41d4-a716-446655440001', 'client_secret', 'secret1', '1'),
+('550e8400-e29b-41d4-a716-446655440001', 'redirect_uri', 'https://localhost:3000', '0'),
+('550e8400-e29b-41d4-a716-446655440001', 'scopes', 'user:email,read:user', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'client_id', 'client2', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'client_secret', 'secret2', '1'),
+('550e8400-e29b-41d4-a716-446655440002', 'redirect_uri', 'https://localhost:3000', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'scopes', 'openid,email,profile', '0');

--- a/backend/internal/idp/model/idp.go
+++ b/backend/internal/idp/model/idp.go
@@ -25,13 +25,17 @@ import (
 
 // IDP represents an identity provider in the system.
 type IDP struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`                    // Display name
-	Description  string   `json:"description,omitempty"`   // Description shown in UI
-	ClientID     string   `json:"client_id"`               // OAuth client ID
-	ClientSecret string   `json:"client_secret,omitempty"` // OAuth client secret
-	RedirectURI  string   `json:"redirect_uri,omitempty"`  // OAuth redirect URI
-	Scopes       []string `json:"scopes,omitempty"`        // OAuth scopes
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`                  // Display name
+	Description string        `json:"description,omitempty"` // Description shown in UI
+	Properties  []IDPProperty `json:"properties,omitempty"`  // Properties of the IdP
+}
+
+// IDPProperty represents a property of an identity provider.
+type IDPProperty struct {
+	Name     string `json:"name"`      // Property name
+	Value    string `json:"value"`     // Property value
+	IsSecret bool   `json:"is_secret"` // Indicates if the property is a secret
 }
 
 // ErrIDPNotFound is returned when the IdP is not found in the system.

--- a/backend/internal/idp/store/constants.go
+++ b/backend/internal/idp/store/constants.go
@@ -24,27 +24,23 @@ import dbmodel "github.com/asgardeo/thunder/internal/system/database/model"
 var (
 	// QueryCreateIdentityProvider is the query to create a new IdP.
 	QueryCreateIdentityProvider = dbmodel.DBQuery{
-		ID: "IPQ-IDP_MGT-01",
-		Query: "INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, SCOPES) " +
-			"VALUES ($1, $2, $3, $4, $5, $6, $7)",
+		ID:    "IPQ-IDP_MGT-01",
+		Query: "INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION) VALUES ($1, $2, $3)",
 	}
-
 	// QueryGetIdentityProviderByID is the query to get a IdP by IdP ID.
 	QueryGetIdentityProviderByID = dbmodel.DBQuery{
-		ID: "IPQ-IDP_MGT-02",
-		Query: "SELECT IDP_ID, NAME, DESCRIPTION, CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, SCOPES FROM IDP " +
-			"WHERE IDP_ID = $1",
+		ID:    "IPQ-IDP_MGT-02",
+		Query: "SELECT IDP_ID, NAME, DESCRIPTION FROM IDP WHERE IDP_ID = $1",
 	}
 	// QueryGetIdentityProviderList is the query to get a list of IdPs.
 	QueryGetIdentityProviderList = dbmodel.DBQuery{
 		ID:    "IPQ-IDP_MGT-03",
-		Query: "SELECT IDP_ID, NAME, DESCRIPTION, CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, SCOPES FROM IDP",
+		Query: "SELECT IDP_ID, NAME, DESCRIPTION FROM IDP",
 	}
 	// QueryUpdateIdentityProviderByID is the query to update a IdP by IdP ID.
 	QueryUpdateIdentityProviderByID = dbmodel.DBQuery{
-		ID: "IPQ-IDP_MGT-04",
-		Query: "UPDATE IDP SET NAME = $2, DESCRIPTION = $3, CLIENT_ID = $4, CLIENT_SECRET = $5, " +
-			"REDIRECT_URI = $6, SCOPES = $7 WHERE IDP_ID = $1;",
+		ID:    "IPQ-IDP_MGT-04",
+		Query: "UPDATE IDP SET NAME = $2, DESCRIPTION = $3 WHERE IDP_ID = $1;",
 	}
 	// QueryDeleteIdentityProviderByID is the query to delete a IdP by IdP ID.
 	QueryDeleteIdentityProviderByID = dbmodel.DBQuery{
@@ -53,8 +49,22 @@ var (
 	}
 	// QueryGetIdentityProviderByName is the query to get a IdP by IdP name.
 	QueryGetIdentityProviderByName = dbmodel.DBQuery{
-		ID: "IPQ-IDP_MGT-06",
-		Query: "SELECT IDP_ID, NAME, DESCRIPTION, CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, SCOPES FROM IDP " +
-			"WHERE NAME = $1",
+		ID:    "IPQ-IDP_MGT-06",
+		Query: "SELECT IDP_ID, NAME, DESCRIPTION FROM IDP WHERE NAME = $1",
+	}
+	// QueryInsertIDPProperties is the query to insert properties for a specific IdP.
+	QueryInsertIDPProperties = dbmodel.DBQuery{
+		ID:    "IPQ-IDP_MGT-07",
+		Query: "INSERT INTO IDP_PROPERTY (IDP_ID, PROPERTY_NAME, PROPERTY_VALUE, IS_SECRET) VALUES %s",
+	}
+	// QueryGetIDPProperties is the query to get properties for a specific IdP.
+	QueryGetIDPProperties = dbmodel.DBQuery{
+		ID:    "IPQ-IDP_MGT-08",
+		Query: "SELECT PROPERTY_NAME, PROPERTY_VALUE, IS_SECRET FROM IDP_PROPERTY WHERE IDP_ID = $1",
+	}
+	// QueryDeleteIDPProperties is the query to delete all properties for a specific IdP.
+	QueryDeleteIDPProperties = dbmodel.DBQuery{
+		ID:    "IPQ-IDP_MGT-10",
+		Query: "DELETE FROM IDP_PROPERTY WHERE IDP_ID = $1",
 	}
 )

--- a/backend/internal/system/utils/stringutil.go
+++ b/backend/internal/system/utils/stringutil.go
@@ -103,3 +103,16 @@ func MergeStringMaps(dst, src map[string]string) map[string]string {
 	}
 	return dst
 }
+
+// BoolToNumString converts a boolean value to a numeric string representation.
+func BoolToNumString(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// NumStringToBool converts a numeric string representation to a boolean value.
+func NumStringToBool(s string) bool {
+	return s == "1"
+}

--- a/docs/apis/idp.yaml
+++ b/docs/apis/idp.yaml
@@ -203,13 +203,16 @@ components:
           type: string
         description:
           type: string
-        client_id:
-          type: string
-        client_secret:
-          type: string
-        redirect_uri:
-          type: string
-        scopes:
+        properties:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/model.IDPProperty'
+    model.IDPProperty:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+        is_secret:
+          type: boolean

--- a/tests/integration/idp/idpapi_test.go
+++ b/tests/integration/idp/idpapi_test.go
@@ -40,41 +40,116 @@ var (
 			ID:          "550e8400-e29b-41d4-a716-446655440000",
 			Name:        "Local",
 			Description: "Local Identity Provider",
-			ClientID:    "local",
-			Scopes:      json.RawMessage(`["local"]`),
+			Properties:  []IDPProperty{},
 		},
 		{
 			ID:          "550e8400-e29b-41d4-a716-446655440001",
 			Name:        "Github",
 			Description: "Login with Github",
-			ClientID:    "client1",
-			Scopes:      json.RawMessage(`["user:email","read:user"]`),
+			Properties: []IDPProperty{
+				{
+					Name:     "client_id",
+					Value:    "client1",
+					IsSecret: false,
+				},
+				{
+					Name:     "client_secret",
+					Value:    "secret1",
+					IsSecret: true,
+				},
+				{
+					Name:     "redirect_uri",
+					Value:    "https://localhost:3000",
+					IsSecret: false,
+				},
+				{
+					Name:     "scopes",
+					Value:    "user:email,read:user",
+					IsSecret: false,
+				},
+			},
 		},
 		{
 			ID:          "550e8400-e29b-41d4-a716-446655440002",
 			Name:        "Google",
 			Description: "Login with Google",
-			ClientID:    "client1",
-			Scopes:      json.RawMessage(`["openid","email","profile"]`),
+			Properties: []IDPProperty{
+				{
+					Name:     "client_id",
+					Value:    "client2",
+					IsSecret: false,
+				},
+				{
+					Name:     "client_secret",
+					Value:    "secret2",
+					IsSecret: true,
+				},
+				{
+					Name:     "redirect_uri",
+					Value:    "https://localhost:3000",
+					IsSecret: false,
+				},
+				{
+					Name:     "scopes",
+					Value:    "openid,email,profile",
+					IsSecret: false,
+				},
+			},
 		},
 	}
 
 	idpToCreate = IDP{
-		Name:         "Google 2",
-		Description:  "Google User Login",
-		ClientID:     "client2",
-		ClientSecret: "secret2",
-		RedirectURI:  "https://localhost:8090/flow/authn2",
-		Scopes:       json.RawMessage(`["openid","email","profile"]`),
+		Name:        "Google 2",
+		Description: "Google User Login",
+		Properties: []IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "client2",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "secret2",
+				IsSecret: true,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:3000",
+				IsSecret: false,
+			},
+			{
+				Name:     "scopes",
+				Value:    "openid,email,profile",
+				IsSecret: false,
+			},
+		},
 	}
 
 	idpToUpdate = IDP{
-		Name:         "Github 2",
-		Description:  "Github User Login",
-		ClientID:     "client3",
-		ClientSecret: "secret3",
-		RedirectURI:  "https://localhost:8090/flow/authn3",
-		Scopes:       json.RawMessage(`["user:email","read:user"]`),
+		Name:        "Github 2",
+		Description: "Github User Login",
+		Properties: []IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "client3",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "secret3",
+				IsSecret: true,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:3000",
+				IsSecret: false,
+			},
+			{
+				Name:     "scopes",
+				Value:    "user:email,read:user",
+				IsSecret: false,
+			},
+		},
 	}
 )
 
@@ -226,9 +301,7 @@ func (ts *IdpAPITestSuite) TestIdpUpdate() {
 		ID:          createdIdpID,
 		Name:        idpToUpdate.Name,
 		Description: idpToUpdate.Description,
-		ClientID:    idpToUpdate.ClientID,
-		RedirectURI: idpToUpdate.RedirectURI,
-		Scopes:      idpToUpdate.Scopes,
+		Properties:  idpToUpdate.Properties,
 	})
 }
 
@@ -349,9 +422,7 @@ func buildCreatedIdp() IDP {
 		ID:          createdIdpID,
 		Name:        idpToCreate.Name,
 		Description: idpToCreate.Description,
-		ClientID:    idpToCreate.ClientID,
-		RedirectURI: idpToCreate.RedirectURI,
-		Scopes:      idpToCreate.Scopes,
+		Properties:  idpToCreate.Properties,
 	}
 }
 
@@ -361,7 +432,6 @@ func buildCreatedIdpToList() IDP {
 		ID:          createdIdpID,
 		Name:        idpToCreate.Name,
 		Description: idpToCreate.Description,
-		ClientID:    idpToCreate.ClientID,
-		Scopes:      idpToCreate.Scopes,
+		Properties:  idpToCreate.Properties,
 	}
 }

--- a/tests/integration/idp/model.go
+++ b/tests/integration/idp/model.go
@@ -18,47 +18,43 @@
 
 package idp
 
-import (
-	"encoding/json"
-)
-
-type IDP struct {
-	ID           string          `json:"id"`
-	Name         string          `json:"name"`          // Display name
-	Description  string          `json:"description"`   // Description shown in UI
-	ClientID     string          `json:"client_id"`     // OAuth client ID
-	ClientSecret string          `json:"client_secret"` // OAuth client secret
-	RedirectURI  string          `json:"redirect_uri"`  // OAuth redirect URI
-	Scopes       json.RawMessage `json:"scopes"`        // JSON format scopes
+type IDPProperty struct {
+	Name     string `json:"name"`      // Name of the property
+	Value    string `json:"value"`     // Value of the property
+	IsSecret bool   `json:"is_secret"` // Whether the property is a secret
 }
 
-func compareStringSlices(a, b []string) bool {
-
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+type IDP struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`        // Display name
+	Description string        `json:"description"` // Description shown in UI
+	Properties  []IDPProperty `json:"properties"`  // Additional properties for the IDP
 }
 
 // compare and validate whether two IdPs have equal content
 func (idp *IDP) equals(expectedIdp IDP) bool {
-	if idp.ID != expectedIdp.ID || idp.Name != expectedIdp.Name || idp.Description != expectedIdp.Description || idp.ClientID != expectedIdp.ClientID || idp.ClientSecret != expectedIdp.ClientSecret || idp.RedirectURI != expectedIdp.RedirectURI {
+	if idp.ID != expectedIdp.ID || idp.Name != expectedIdp.Name || idp.Description != expectedIdp.Description {
 		return false
 	}
 
-	// Compare the Scopes JSON
-	var scopes1, scopes2 []string
-	if err := json.Unmarshal(idp.Scopes, &scopes1); err != nil {
-		return false
-	}
-	if err := json.Unmarshal(expectedIdp.Scopes, &scopes2); err != nil {
-		return false
+	// Compare the Properties
+	for _, expProp := range expectedIdp.Properties {
+		found := false
+		for _, p := range idp.Properties {
+			if p.Name == expProp.Name {
+				found = true
+				if !expProp.IsSecret {
+					if p.Value != expProp.Value {
+						return false
+					}
+				}
+				break
+			}
+		}
+		if !found {
+			return false
+		}
 	}
 
-	return compareStringSlices(scopes1, scopes2)
+	return true
 }

--- a/tests/integration/resources/dbscripts/thunderdb/sqlite.sql
+++ b/tests/integration/resources/dbscripts/thunderdb/sqlite.sql
@@ -89,12 +89,16 @@ CREATE TABLE IDP (
     IDP_ID VARCHAR(36) UNIQUE NOT NULL,
     NAME VARCHAR(255) NOT NULL,
     DESCRIPTION VARCHAR(500),
-    CLIENT_ID TEXT NOT NULL,
-    CLIENT_SECRET TEXT NOT NULL,
-    REDIRECT_URI VARCHAR(500) NOT NULL,
-    SCOPES VARCHAR(255),
     CREATED_AT TEXT DEFAULT (datetime('now')),
     UPDATED_AT TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IDP_PROPERTY (
+    IDP_ID VARCHAR(36) REFERENCES IDP(IDP_ID) ON DELETE CASCADE,
+    PROPERTY_NAME VARCHAR(255) NOT NULL,
+    PROPERTY_VALUE VARCHAR(500) NOT NULL,
+    IS_SECRET CHAR(1) DEFAULT '0',
+    PRIMARY KEY (IDP_ID, PROPERTY_NAME)
 );
 
 -- Insert sample data into the tables.
@@ -137,8 +141,19 @@ VALUES (
            datetime('now'), datetime('now')
        );
 
-INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, SCOPES, CREATED_AT, UPDATED_AT)
+INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, CREATED_AT, UPDATED_AT)
 VALUES
-('550e8400-e29b-41d4-a716-446655440000', 'Local', 'Local Identity Provider', 'local', 'local', 'https://localhost:8090', '["local"]', datetime('now'), datetime('now')),
-('550e8400-e29b-41d4-a716-446655440001', 'Github', 'Login with Github', 'client1', 'secret1', 'https://localhost:3000', '["user:email","read:user"]', datetime('now'), datetime('now')),
-('550e8400-e29b-41d4-a716-446655440002', 'Google', 'Login with Google', 'client1', 'secret1', 'https://localhost:3000', '["openid","email","profile"]', datetime('now'), datetime('now'));
+('550e8400-e29b-41d4-a716-446655440000', 'Local', 'Local Identity Provider', datetime('now'), datetime('now')),
+('550e8400-e29b-41d4-a716-446655440001', 'Github', 'Login with Github', datetime('now'), datetime('now')),
+('550e8400-e29b-41d4-a716-446655440002', 'Google', 'Login with Google', datetime('now'), datetime('now'));
+
+INSERT INTO IDP_PROPERTY (IDP_ID, PROPERTY_NAME, PROPERTY_VALUE, IS_SECRET)
+VALUES
+('550e8400-e29b-41d4-a716-446655440001', 'client_id', 'client1', '0'),
+('550e8400-e29b-41d4-a716-446655440001', 'client_secret', 'secret1', '1'),
+('550e8400-e29b-41d4-a716-446655440001', 'redirect_uri', 'https://localhost:3000', '0'),
+('550e8400-e29b-41d4-a716-446655440001', 'scopes', 'user:email,read:user', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'client_id', 'client2', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'client_secret', 'secret2', '1'),
+('550e8400-e29b-41d4-a716-446655440002', 'redirect_uri', 'https://localhost:3000', '0'),
+('550e8400-e29b-41d4-a716-446655440002', 'scopes', 'openid,email,profile', '0');


### PR DESCRIPTION
## Purpose

This pull request refactors the handling of identity provider (IdP) configurations by introducing a new `IDP_PROPERTY` table to store properties in a more flexible and extensible format. It also updates the codebase to align with this new structure, improving maintainability and security by masking sensitive data in API responses.

### Database Schema Changes:
* Introduced a new `IDP_PROPERTY` table in both PostgreSQL and SQLite schemas to store IdP properties (`client_id`, `client_secret`, etc.) as key-value pairs, with a flag to indicate if a property is secret. The original columns for these properties were removed from the `IDP` table.
* Updated sample data insertion queries to populate the new `IDP_PROPERTY` table with relevant IdP properties.

### Backend Code Changes:
* Modified the `IDP` struct in `idp.go` to replace individual fields (`client_id`, `client_secret`, etc.) with a `Properties` field, which is a slice of `IDPProperty` structs.
* Added a helper function `getIDPConfigs` in `utils.go` to extract specific properties from the `IDP_PROPERTY` table for executors. This ensures a clean separation of concerns and simplifies executor initialization.
* Updated the `IDPHandler` methods to mask secret properties in API responses and to handle the new `Properties` structure. This includes creating a utility function `getIDPResponse` to prepare responses with masked secrets.

### Query and Constants Updates:
* Updated database queries in `constants.go` to align with the new schema, removing references to the old `client_id`, `client_secret`, etc., and focusing on the new `IDP_PROPERTY` table.

### Documentation Updates:
* Updated examples in `README.md` to reflect the new `properties` structure for IdP configurations in JSON format.

These changes collectively enhance the flexibility, security, and maintainability of IdP configurations in the codebase.