### PR TITLE
Removing optional fields from the basic auth login

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
@@ -15,11 +15,6 @@
                     "name": "password",
                     "type": "string",
                     "required": true
-                },
-                {
-                    "name": "firstName",
-                    "type": "string",
-                    "required": false
                 }
             ],
             "executor": {


### PR DESCRIPTION
## Purpose
This pull request includes a small change to the `auth_flow_config_basic.json` file. The change removes the `firstName` field from the configuration, which was previously optional.