### PR TITLE
Update authenticated user and user ID handling logic

### DIFF
--- a/backend/internal/authn/model/model.go
+++ b/backend/internal/authn/model/model.go
@@ -26,12 +26,9 @@ import (
 
 // AuthenticatedUser represents the user information of an authenticated user.
 type AuthenticatedUser struct {
-	IsAuthenticated        bool
-	UserID                 string
-	Username               string
-	Domain                 string
-	AuthenticatedSubjectID string
-	Attributes             map[string]string
+	IsAuthenticated bool
+	UserID          string
+	Attributes      map[string]string
 }
 
 // AuthenticationContext represents the context of an authentication session.

--- a/backend/internal/executor/authassert/authassertexecutor.go
+++ b/backend/internal/executor/authassert/authassertexecutor.go
@@ -68,8 +68,8 @@ func (a *AuthAssertExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.Exe
 
 	if ctx.AuthenticatedUser.IsAuthenticated {
 		tokenSub := ""
-		if ctx.AuthenticatedUser.AuthenticatedSubjectID != "" {
-			tokenSub = ctx.AuthenticatedUser.AuthenticatedSubjectID
+		if ctx.AuthenticatedUser.UserID != "" {
+			tokenSub = ctx.AuthenticatedUser.UserID
 		}
 		token, err := jwt.GenerateJWT(tokenSub, ctx.AppID, ctx.AuthenticatedUser.Attributes)
 		if err != nil {

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -108,12 +108,12 @@ func (b *BasicAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.Exec
 		return execResp, nil
 	}
 
-	ctx.AuthenticatedUser = *authenticatedUser
+	execResp.AuthenticatedUser = *authenticatedUser
 	execResp.Status = flowconst.ExecComplete
 
 	logger.Debug("Basic authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
-		log.Bool("isAuthenticated", ctx.AuthenticatedUser.IsAuthenticated))
+		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
 	return execResp, nil
 }
@@ -195,10 +195,8 @@ func getAuthenticatedUser(username, password string, logger *log.Logger) (*authn
 		}
 
 		authenticatedUser = authnmodel.AuthenticatedUser{
-			IsAuthenticated:        true,
-			UserID:                 user.ID,
-			Username:               attrs["username"].(string),
-			AuthenticatedSubjectID: user.ID,
+			IsAuthenticated: true,
+			UserID:          user.ID,
 			Attributes: map[string]string{
 				"email":     email,
 				"firstName": firstName,

--- a/backend/internal/executor/oidcauth/oidcauthexecutor.go
+++ b/backend/internal/executor/oidcauth/oidcauthexecutor.go
@@ -152,7 +152,7 @@ func (o *OIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.Execu
 
 	logger.Debug("OIDC authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
-		log.Bool("isAuthenticated", ctx.AuthenticatedUser.IsAuthenticated))
+		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
 	return execResp, nil
 }
@@ -211,14 +211,14 @@ func (o *OIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
 		if authenticatedUser == nil {
 			return nil
 		}
-		ctx.AuthenticatedUser = *authenticatedUser
+		execResp.AuthenticatedUser = *authenticatedUser
 	} else {
-		ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
+		execResp.AuthenticatedUser = authnmodel.AuthenticatedUser{
 			IsAuthenticated: false,
 		}
 	}
 
-	if ctx.AuthenticatedUser.IsAuthenticated {
+	if execResp.AuthenticatedUser.IsAuthenticated {
 		execResp.Status = flowconst.ExecComplete
 	} else {
 		execResp.Status = flowconst.ExecFailure
@@ -344,23 +344,10 @@ func (o *OIDCAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.Nod
 		}
 	}
 
-	// Determine username from the user claims.
-	username := ""
-	if sub, ok := userClaims["sub"]; ok {
-		username = sub
-		delete(userClaims, "sub")
-	}
-	if email, ok := userClaims["email"]; ok && email != "" {
-		username = email
-	}
-
 	authenticatedUser := authnmodel.AuthenticatedUser{
-		IsAuthenticated:        true,
-		UserID:                 "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
-		Username:               username,
-		Domain:                 o.GetName(),
-		AuthenticatedSubjectID: username,
-		Attributes:             userClaims,
+		IsAuthenticated: true,
+		UserID:          "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
+		Attributes:      userClaims,
 	}
 
 	return &authenticatedUser, nil

--- a/backend/internal/flow/model/node.go
+++ b/backend/internal/flow/model/node.go
@@ -21,21 +21,24 @@ package model
 import (
 	"errors"
 
+	authnmodel "github.com/asgardeo/thunder/internal/authn/model"
 	"github.com/asgardeo/thunder/internal/flow/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
 
 // NodeResponse represents the response from a node execution
 type NodeResponse struct {
-	Status         constants.NodeStatus       `json:"status"`
-	Type           constants.NodeResponseType `json:"type"`
-	FailureReason  string                     `json:"failure_reason,omitempty"`
-	RequiredData   []InputData                `json:"required_data,omitempty"`
-	AdditionalData map[string]string          `json:"additional_data,omitempty"`
-	RedirectURL    string                     `json:"redirect_url,omitempty"`
-	Actions        []Action                   `json:"actions,omitempty"`
-	NextNodeID     string                     `json:"next_node_id,omitempty"`
-	Assertion      string                     `json:"assertion,omitempty"`
+	Status            constants.NodeStatus         `json:"status"`
+	Type              constants.NodeResponseType   `json:"type"`
+	FailureReason     string                       `json:"failure_reason,omitempty"`
+	RequiredData      []InputData                  `json:"required_data,omitempty"`
+	AdditionalData    map[string]string            `json:"additional_data,omitempty"`
+	RedirectURL       string                       `json:"redirect_url,omitempty"`
+	Actions           []Action                     `json:"actions,omitempty"`
+	NextNodeID        string                       `json:"next_node_id,omitempty"`
+	RuntimeData       map[string]string            `json:"runtime_data,omitempty"`
+	AuthenticatedUser authnmodel.AuthenticatedUser `json:"authenticated_user,omitempty"`
+	Assertion         string                       `json:"assertion,omitempty"`
 }
 
 // NodeInterface defines the interface for nodes in the graph

--- a/backend/internal/flow/model/taskexecutionnode.go
+++ b/backend/internal/flow/model/taskexecutionnode.go
@@ -76,11 +76,13 @@ func (n *TaskExecutionNode) triggerExecutor(ctx *NodeContext) (*ExecutorResponse
 // buildNodeResponse constructs a NodeResponse from the ExecutorResponse.
 func buildNodeResponse(execResp *ExecutorResponse) *NodeResponse {
 	nodeResp := &NodeResponse{
-		FailureReason:  execResp.FailureReason,
-		RequiredData:   execResp.RequiredData,
-		AdditionalData: execResp.AdditionalData,
-		RedirectURL:    execResp.RedirectURL,
-		Assertion:      execResp.Assertion,
+		FailureReason:     execResp.FailureReason,
+		RequiredData:      execResp.RequiredData,
+		AdditionalData:    execResp.AdditionalData,
+		RedirectURL:       execResp.RedirectURL,
+		RuntimeData:       execResp.RuntimeData,
+		AuthenticatedUser: execResp.AuthenticatedUser,
+		Assertion:         execResp.Assertion,
 	}
 
 	if execResp.Status == constants.ExecComplete {

--- a/backend/internal/outboundauth/basicauth/basicauthenticator.go
+++ b/backend/internal/outboundauth/basicauth/basicauthenticator.go
@@ -144,10 +144,8 @@ func getAuthenticatedUser(username, password string, logger *log.Logger) (*authn
 			return nil, err
 		}
 		authenticatedUser = authnmodel.AuthenticatedUser{
-			IsAuthenticated:        true,
-			UserID:                 user.ID,
-			Username:               attrs["username"].(string),
-			AuthenticatedSubjectID: attrs["email"].(string),
+			IsAuthenticated: true,
+			UserID:          user.ID,
 			Attributes: map[string]string{
 				"email":     attrs["email"].(string),
 				"firstName": attrs["firstName"].(string),

--- a/backend/internal/outboundauth/github/githubauthenticator.go
+++ b/backend/internal/outboundauth/github/githubauthenticator.go
@@ -163,13 +163,11 @@ func (ga *GithubAuthenticator) ProcessAuthenticationResponse(w http.ResponseWrit
 		logger.Error("Failed to fetch user info: ", log.Error(err))
 		return errors.New("failed to fetch user info: " + err.Error())
 	}
-	username := userAttributes["email"]
 
 	// Set the authenticated user in the context.
 	ctx.AuthenticatedUser = authnmodel.AuthenticatedUser{
 		IsAuthenticated: true,
 		UserID:          "143e87c1-ccfc-440d-b0a5-bb23c9a2f39e",
-		Username:        username,
 		Attributes:      userAttributes,
 	}
 	ctx.AuthTime = time.Now()


### PR DESCRIPTION
## Purpose

This pull request introduces significant changes to streamline the authentication model and improve the handling of authenticated user data across multiple executors. The focus is on removing redundant fields, consolidating user identification logic, and ensuring consistent use of `execResp` for authenticated user data instead of `ctx`. Below are the most important changes grouped by theme:

### Simplification of User Model:
* Removed redundant fields `Username`, `Domain`, and `AuthenticatedSubjectID` from the `AuthenticatedUser` struct in `backend/internal/authn/model/model.go`.

### Standardization of Authenticated User Handling:
* Updated all executors (e.g., `BasicAuthExecutor`, `GithubOAuthExecutor`, `GoogleOIDCAuthExecutor`, etc.) to use `execResp.AuthenticatedUser` instead of `ctx.AuthenticatedUser` for storing and accessing authenticated user data. This ensures a consistent pattern across executors.
* executors will add AuthenticatedUser to the ExecutorResponse and NodeResponse respectively. At the end, Engine will append it to the EngineContext. This way context will not be modified by downstream processes unintentionally.

### Removal of Username-Based User Identification:
* Removed logic for retrieving user IDs using usernames in the `getUserID` method of `AttributeCollector`. This simplifies the user identification process by relying solely on `userID`.
* Deleted the `getUsername` method and related username-based logic in `AttributeCollector`.

### Improvements to Attribute Handling:
* Updated the `CheckInputData` method in `AttributeCollector` to use `execResp.RuntimeData` instead of `ctx.RuntimeData` for managing runtime data. This change aligns with the standardization of response handling.
