### PR TITLE
Improve sms OTP executor with having userID as a prerequisite

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github_sms.json
@@ -9,7 +9,7 @@
                 "basic_auth",
                 "google_auth",
                 "github_auth",
-                "mobile_prompt_username"
+                "prompt_mobile"
             ]
         },
         {
@@ -76,11 +76,11 @@
             ]
         },
         {
-            "id": "mobile_prompt_username",
+            "id": "prompt_mobile",
             "type": "PROMPT_ONLY",
             "inputData": [
                 {
-                    "name": "username",
+                    "name": "mobileNumber",
                     "type": "string",
                     "required": true
                 }

--- a/backend/internal/executor/authassert/authassertexecutor.go
+++ b/backend/internal/executor/authassert/authassertexecutor.go
@@ -114,3 +114,13 @@ func (a *AuthAssertExecutor) ValidatePrerequisites(ctx *flowmodel.NodeContext,
 	execResp *flowmodel.ExecutorResponse) bool {
 	return a.internal.ValidatePrerequisites(ctx, execResp)
 }
+
+// GetUserIDFromContext retrieves the user ID from the context.
+func (a *AuthAssertExecutor) GetUserIDFromContext(ctx *flowmodel.NodeContext) (string, error) {
+	return a.internal.GetUserIDFromContext(ctx)
+}
+
+// GetRequiredData returns the required input data for the AuthAssertExecutor.
+func (a *AuthAssertExecutor) GetRequiredData(ctx *flowmodel.NodeContext) []flowmodel.InputData {
+	return a.internal.GetRequiredData(ctx)
+}

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -142,6 +142,16 @@ func (b *BasicAuthExecutor) ValidatePrerequisites(ctx *flowmodel.NodeContext,
 	return b.internal.ValidatePrerequisites(ctx, execResp)
 }
 
+// GetUserIDFromContext retrieves the user ID from the context.
+func (b *BasicAuthExecutor) GetUserIDFromContext(ctx *flowmodel.NodeContext) (string, error) {
+	return b.internal.GetUserIDFromContext(ctx)
+}
+
+// GetRequiredData returns the required input data for the BasicAuthExecutor.
+func (b *BasicAuthExecutor) GetRequiredData(ctx *flowmodel.NodeContext) []flowmodel.InputData {
+	return b.internal.GetRequiredData(ctx)
+}
+
 // getAuthenticatedUser perform authentication based on the provided username and password and return
 // authenticated user details.
 func getAuthenticatedUser(username, password string, logger *log.Logger) (*authnmodel.AuthenticatedUser, error) {

--- a/backend/internal/executor/oauth/oauthexecutor.go
+++ b/backend/internal/executor/oauth/oauthexecutor.go
@@ -279,6 +279,16 @@ func (o *OAuthExecutor) ValidatePrerequisites(ctx *flowmodel.NodeContext, execRe
 	return o.internal.ValidatePrerequisites(ctx, execResp)
 }
 
+// GetUserIDFromContext retrieves the user ID from the context.
+func (o *OAuthExecutor) GetUserIDFromContext(ctx *flowmodel.NodeContext) (string, error) {
+	return o.internal.GetUserIDFromContext(ctx)
+}
+
+// GetRequiredData returns the required input data for the OAuthExecutor.
+func (o *OAuthExecutor) GetRequiredData(ctx *flowmodel.NodeContext) []flowmodel.InputData {
+	return o.internal.GetRequiredData(ctx)
+}
+
 // ExchangeCodeForToken exchanges the authorization code for an access token.
 func (o *OAuthExecutor) ExchangeCodeForToken(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
 	code string) (*model.TokenResponse, error) {

--- a/backend/internal/executor/oidcauth/oidcauthexecutor.go
+++ b/backend/internal/executor/oidcauth/oidcauthexecutor.go
@@ -252,6 +252,16 @@ func (o *OIDCAuthExecutor) ValidatePrerequisites(ctx *flowmodel.NodeContext,
 	return o.internal.ValidatePrerequisites(ctx, execResp)
 }
 
+// GetUserIDFromContext retrieves the user ID from the context.
+func (o *OIDCAuthExecutor) GetUserIDFromContext(ctx *flowmodel.NodeContext) (string, error) {
+	return o.internal.GetUserIDFromContext(ctx)
+}
+
+// GetRequiredData returns the required input data for the OIDCAuthExecutor.
+func (o *OIDCAuthExecutor) GetRequiredData(ctx *flowmodel.NodeContext) []flowmodel.InputData {
+	return o.internal.GetRequiredData(ctx)
+}
+
 // ExchangeCodeForToken exchanges the authorization code for an access token.
 func (o *OIDCAuthExecutor) ExchangeCodeForToken(ctx *flowmodel.NodeContext, execResp *flowmodel.ExecutorResponse,
 	code string) (*model.TokenResponse, error) {

--- a/backend/internal/notification/message/service/clientservice.go
+++ b/backend/internal/notification/message/service/clientservice.go
@@ -65,6 +65,10 @@ func (mcs *MessageClientService) GetMessageClientByName(senderName string) (clie
 			log.Any("serviceError", svcErr))
 		return nil, svcErr
 	}
+	if sender == nil {
+		logger.Error("Sender not found", log.String("senderName", senderName))
+		return nil, &constants.ErrorSenderNotFound
+	}
 
 	client, err := getMessageClient(*sender)
 	if err != nil {


### PR DESCRIPTION
## Purpose

This pull request introduces significant updates to the authentication flow configuration and executor logic, focusing on improving user identification and input handling. Key changes include replacing the `username` attribute with `userID` and `mobileNumber` for better flexibility, centralizing user ID resolution logic, and enhancing the SMS OTP authentication flow.

### Authentication Flow Configuration Updates:
* Replaced `mobile_prompt_username` with `prompt_mobile` and updated its input attribute from `username` to `mobileNumber` in the `auth_flow_config_basic_google_github_sms.json` file. This aligns the configuration with the new user identification approach.

### Executor Enhancements:
* Introduced a new `GetUserIDFromContext` method across executors (`AttributeCollector`, `AuthAssertExecutor`, `BasicAuthExecutor`, `OAuthExecutor`, `OIDCAuthExecutor`, `SMSOTPAuthExecutor`) to centralize user ID retrieval logic. 
* Removed redundant `getUserID` logic from `AttributeCollector` and replaced its usage with the new `GetUserIDFromContext` method. 

### SMS OTP Authentication Flow Improvements:
* Enhanced the `SMSOTPAuthExecutor` to resolve `userID` dynamically from multiple attributes (`mobileNumber`, `username`, `email`) if not explicitly provided, ensuring greater flexibility.
* Updated OTP generation and validation logic to use `userID` instead of `username`, improving consistency and security.
* Added logic to prompt users for missing `mobileNumber` if it cannot be resolved from the context or user attributes.

These changes collectively improve the flexibility, maintainability, and security of the authentication flow.