### PR TITLE
Improve IdentifyUser to filter based on multiple attributes

### DIFF
--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -158,7 +158,8 @@ func getAuthenticatedUser(username, password string, logger *log.Logger) (*authn
 	userProvider := userprovider.NewUserProvider()
 	userService := userProvider.GetUserService()
 
-	userID, err := userService.IdentityUser("username", username)
+	filters := map[string]interface{}{"username": username}
+	userID, err := userService.IdentifyUser(filters)
 	if err != nil {
 		logger.Error("Failed to identify user by username",
 			log.String("username", log.MaskString(username)),

--- a/backend/internal/executor/smsauth/smsauthexecutor.go
+++ b/backend/internal/executor/smsauth/smsauthexecutor.go
@@ -313,7 +313,8 @@ func (s *SMSOTPAuthExecutor) resolveUserIDFromAttribute(ctx *flowmodel.NodeConte
 	if attributeValue != "" {
 		userProvider := userprovider.NewUserProvider()
 		userService := userProvider.GetUserService()
-		userID, err := userService.IdentityUser(attributeName, attributeValue)
+		filters := map[string]interface{}{attributeName: attributeValue}
+		userID, err := userService.IdentifyUser(filters)
 		if err != nil {
 			return false, fmt.Errorf("failed to identify user by %s: %w", attributeName, err)
 		}

--- a/backend/internal/outboundauth/basicauth/basicauthenticator.go
+++ b/backend/internal/outboundauth/basicauth/basicauthenticator.go
@@ -113,7 +113,8 @@ func getAuthenticatedUser(username, password string, logger *log.Logger) (*authn
 	userProvider := userprovider.NewUserProvider()
 	userService := userProvider.GetUserService()
 
-	userID, err := userService.IdentityUser("username", username)
+	filters := map[string]interface{}{"username": username}
+	userID, err := userService.IdentifyUser(filters)
 	if err != nil {
 		logger.Error("Failed to identify user by username",
 			log.String("username", log.MaskString(username)),

--- a/backend/internal/user/service/userservice.go
+++ b/backend/internal/user/service/userservice.go
@@ -36,7 +36,7 @@ type UserServiceInterface interface {
 	GetUser(userID string) (*model.User, error)
 	UpdateUser(userID string, user *model.User) (*model.User, error)
 	DeleteUser(userID string) error
-	IdentityUser(attrName, attrValue string) (*string, error)
+	IdentifyUser(filters map[string]interface{}) (*string, error)
 	VerifyUser(userID, credType, credValue string) (*model.User, error)
 }
 
@@ -162,17 +162,13 @@ func (as *UserService) DeleteUser(userID string) error {
 	return nil
 }
 
-// IdentityUser identify user with the given attributes.
-func (as *UserService) IdentityUser(attrName, attrValue string) (*string, error) {
-	if attrName == "" {
-		return nil, errors.New("attribute name is empty")
+// IdentifyUser identifies a user with the given filters.
+func (as *UserService) IdentifyUser(filters map[string]interface{}) (*string, error) {
+	if len(filters) == 0 {
+		return nil, errors.New("filters map is empty")
 	}
 
-	if attrValue == "" {
-		return nil, errors.New("attribute value is empty")
-	}
-
-	userID, err := store.IdentifyUser(attrName, attrValue)
+	userID, err := store.IdentifyUser(filters)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Purpose
This pull request refactors the user identification logic across multiple components to improve flexibility and security. The primary change replaces the use of individual attribute-based identification with a more generic filter-based approach, allowing for multiple attributes to be used in user lookups. Additionally, sensitive data handling has been improved by introducing a utility to mask sensitive values in logs.

### Refactoring user identification logic:

* Updated the `UserServiceInterface` in `backend/internal/user/service/userservice.go` to replace the `IdentityUser(attrName, attrValue string)` method with `IdentifyUser(filters map[string]interface{})` for more flexible user identification.
* Refactored the `IdentifyUser` implementation in `backend/internal/user/service/userservice.go` to use a `filters` map instead of individual attributes, ensuring better extensibility.
* Updated the `IdentifyUser` function in `backend/internal/user/store/store.go` to accept a `filters` map and removed the dependency on `attrName` and `attrValue`. [[1]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L228-R229) [[2]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L244)

### Enhanced logging for sensitive data:

* Introduced a new utility function `maskMapValues` in `backend/internal/user/store/store.go` to mask sensitive values in the `filters` map before logging, improving security and privacy.
* Updated error logging in `IdentifyUser` to use the `maskMapValues` function when logging filters, replacing direct logging of attribute names and values.

### Code updates in dependent components:

* Replaced calls to `IdentityUser` with `IdentifyUser` in `backend/internal/executor/basicauth/basicauthexecutor.go` and `backend/internal/outboundauth/basicauth/basicauthenticator.go`, adapting to the new filter-based method. [[1]](diffhunk://#diff-30649f0349d4fac2053a5338a4d4c25d63384d8b480080b85413323566d286e6L161-R162) [[2]](diffhunk://#diff-a997e392a9aa79bac305e0ffb00e43d6e50adb20e4740a464e6d9b4011efe91eL116-R117)
* Updated the `SMSOTPAuthExecutor` in `backend/internal/executor/smsauth/smsauthexecutor.go` to use the new `IdentifyUser(filters map[string]interface{})` method.