### PR TITLE
Implement the CLF Formatted Access Log Handler for HTTP Requests

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -125,6 +125,9 @@ func initFlowService(logger *log.Logger) {
 
 // startServer starts the HTTP server with the given configurations and multiplexer.
 func startServer(logger *log.Logger, cfg *config.Config, mux *http.ServeMux, thunderHome string) {
+	// Wrap the multiplexer with AccessLogHandler.
+	wrappedMux := log.AccessLogHandler(logger, mux)
+
 	// Get TLS configuration from the certificate and key files.
 	tlsConfig, err := cert.GetTLSConfig(cfg, thunderHome)
 	if err != nil {
@@ -142,7 +145,7 @@ func startServer(logger *log.Logger, cfg *config.Config, mux *http.ServeMux, thu
 	logger.Info("WSO2 Thunder server started...", log.String("address", serverAddr))
 
 	server := &http.Server{
-		Handler:           mux,
+		Handler:           wrappedMux,
 		ReadHeaderTimeout: 10 * time.Second, // Mitigate Slowloris attacks
 	}
 

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -21,10 +21,14 @@ package log
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/asgardeo/thunder/internal/system/constants"
 )
@@ -77,6 +81,51 @@ func initLogger() error {
 	}
 
 	return nil
+}
+
+// AccessLogHandler logs HTTP requests in Apache CLF.
+func AccessLogHandler(logger *Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Capture the status and size.
+		lrw := &loggingResponseWriter{ResponseWriter: w, statusCode: 200}
+		next.ServeHTTP(lrw, r)
+
+		host, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if host == "" {
+			host = r.RemoteAddr
+		}
+
+		logger.Info(fmt.Sprintf(
+			`%s - - [%s] "%s %s %s" %d %d`,
+			host,
+			start.Format("02/Jan/2006:15:04:05 -0700"),
+			r.Method,
+			r.RequestURI,
+			r.Proto,
+			lrw.statusCode,
+			lrw.size,
+		))
+	})
+}
+
+// loggingResponseWriter wraps http.ResponseWriter to capture status and size.
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	size       int
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(code int) {
+	lrw.statusCode = code
+	lrw.ResponseWriter.WriteHeader(code)
+}
+
+func (lrw *loggingResponseWriter) Write(b []byte) (int, error) {
+	size, err := lrw.ResponseWriter.Write(b)
+	lrw.size += size
+	return size, err
 }
 
 // With creates a new logger instance with additional fields.


### PR DESCRIPTION
## Description
This pull request introduces an access logging feature for HTTP requests in Apache Common Log Format (CLF) and integrates it into the server setup. The most important changes include the addition of the `AccessLogHandler` function, modifications to wrap the HTTP multiplexer for logging, and the creation of a custom response writer to capture HTTP status and size.

### Access Logging Feature:

* [`backend/internal/system/log/log.go`](diffhunk://#diff-591e719b99307a090a27bc9b241df79dc046c23513ff4f890306216c52a37cd9R86-R130): Added the `AccessLogHandler` function to log HTTP requests in Apache CLF format and created the `loggingResponseWriter` type to capture HTTP response status and size.
* [`backend/internal/system/log/log.go`](diffhunk://#diff-591e719b99307a090a27bc9b241df79dc046c23513ff4f890306216c52a37cd9R24-R31): Imported necessary packages (`net`, `http`, `time`, `fmt`) to support the access logging functionality.

### Integration into Server Setup:

* [`backend/cmd/server/main.go`](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408R128-R130): Wrapped the HTTP multiplexer (`mux`) with `AccessLogHandler` to enable logging of incoming HTTP requests.
* [`backend/cmd/server/main.go`](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408L145-R148): Updated the HTTP server configuration to use the wrapped multiplexer (`wrappedMux`) instead of the original `mux`.[Copilot is generating a summary...]

## Output
```
time=2025-06-20T06:37:09.649+05:30 level=INFO msg="127.0.0.1 - - [20/Jun/2025:06:37:09 +0530] \"POST /oauth2/token HTTP/1.1\" 200 639"
```
```
time=2025-06-20T06:37:12.513+05:30 level=INFO msg="127.0.0.1 - - [20/Jun/2025:06:37:12 +0530] \"POST /oauth2/token HTTP/1.1\" 401 76""
```