### PR TITLE
Refactor the server ops and API services to allow injecting providers

### DIFF
--- a/backend/internal/system/services/applicationservice.go
+++ b/backend/internal/system/services/applicationservice.go
@@ -27,12 +27,14 @@ import (
 
 // ApplicationService defines the service for handling application-related requests.
 type ApplicationService struct {
+	ServerOpsService   server.ServerOperationServiceInterface
 	applicationHandler *handler.ApplicationHandler
 }
 
 // NewApplicationService creates a new instance of ApplicationService.
-func NewApplicationService(mux *http.ServeMux) *ApplicationService {
+func NewApplicationService(mux *http.ServeMux) ServiceInterface {
 	instance := &ApplicationService{
+		ServerOpsService:   server.NewServerOperationService(),
 		applicationHandler: handler.NewApplicationHandler(),
 	}
 	instance.RegisterRoutes(mux)
@@ -51,11 +53,14 @@ func (s *ApplicationService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "POST /applications", &opts1, s.applicationHandler.HandleApplicationPostRequest)
-	server.WrapHandleFunction(mux, "GET /applications", &opts1, s.applicationHandler.HandleApplicationListRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /applications", &opts1, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /applications", &opts1,
+		s.applicationHandler.HandleApplicationPostRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /applications", &opts1,
+		s.applicationHandler.HandleApplicationListRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /applications", &opts1,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 
 	opts2 := server.RequestWrapOptions{
 		Cors: &server.Cors{
@@ -64,11 +69,14 @@ func (s *ApplicationService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "GET /applications/", &opts2, s.applicationHandler.HandleApplicationGetRequest)
-	server.WrapHandleFunction(mux, "PUT /applications/", &opts2, s.applicationHandler.HandleApplicationPutRequest)
-	server.WrapHandleFunction(mux, "DELETE /applications/", &opts2,
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /applications/", &opts2,
+		s.applicationHandler.HandleApplicationGetRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "PUT /applications/", &opts2,
+		s.applicationHandler.HandleApplicationPutRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "DELETE /applications/", &opts2,
 		s.applicationHandler.HandleApplicationDeleteRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /applications/", &opts2, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /applications/", &opts2,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 }

--- a/backend/internal/system/services/authnservice.go
+++ b/backend/internal/system/services/authnservice.go
@@ -27,13 +27,15 @@ import (
 
 // AuthenticationService defines the service for handling authentication requests.
 type AuthenticationService struct {
-	authHandler *authn.AuthenticationHandler
+	ServerOpsService server.ServerOperationServiceInterface
+	authHandler      *authn.AuthenticationHandler
 }
 
 // NewAuthenticationService creates a new instance of AuthenticationService.
-func NewAuthenticationService(mux *http.ServeMux) *AuthenticationService {
+func NewAuthenticationService(mux *http.ServeMux) ServiceInterface {
 	instance := &AuthenticationService{
-		authHandler: authn.NewAuthenticationHandler(),
+		ServerOpsService: server.NewServerOperationService(),
+		authHandler:      authn.NewAuthenticationHandler(),
 	}
 	instance.RegisterRoutes(mux)
 	return instance
@@ -48,9 +50,10 @@ func (s *AuthenticationService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "POST /flow/authn", &opts, s.authHandler.HandleAuthenticationRequest)
-	server.WrapHandleFunction(mux, "GET /flow/authn", &opts, s.authHandler.HandleAuthenticationRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /flow/authn", &opts, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /flow/authn", &opts, s.authHandler.HandleAuthenticationRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /flow/authn", &opts, s.authHandler.HandleAuthenticationRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /flow/authn", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 }

--- a/backend/internal/system/services/authorizationservice.go
+++ b/backend/internal/system/services/authorizationservice.go
@@ -27,13 +27,15 @@ import (
 
 // AuthorizationService defines the service for handling OAuth2 authorization requests.
 type AuthorizationService struct {
-	authHandler authz.AuthorizeHandlerInterface
+	ServerOpsService server.ServerOperationServiceInterface
+	authHandler      authz.AuthorizeHandlerInterface
 }
 
 // NewAuthorizationService creates a new instance of AuthorizationService.
-func NewAuthorizationService(mux *http.ServeMux) *AuthorizationService {
+func NewAuthorizationService(mux *http.ServeMux) ServiceInterface {
 	instance := &AuthorizationService{
-		authHandler: authz.NewAuthorizeHandler(),
+		ServerOpsService: server.NewServerOperationService(),
+		authHandler:      authz.NewAuthorizeHandler(),
 	}
 	instance.RegisterRoutes(mux)
 
@@ -42,5 +44,5 @@ func NewAuthorizationService(mux *http.ServeMux) *AuthorizationService {
 
 // RegisterRoutes registers the routes for the AuthorizationService.
 func (s *AuthorizationService) RegisterRoutes(mux *http.ServeMux) {
-	server.WrapHandleFunction(mux, "GET /oauth2/authorize", nil, s.authHandler.HandleAuthorizeRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /oauth2/authorize", nil, s.authHandler.HandleAuthorizeRequest)
 }

--- a/backend/internal/system/services/flowexecutionservice.go
+++ b/backend/internal/system/services/flowexecutionservice.go
@@ -27,12 +27,14 @@ import (
 
 // FlowExecutionService defines the service for handling flow execution requests.
 type FlowExecutionService struct {
+	ServerOpsService     server.ServerOperationServiceInterface
 	flowExecutionHandler *handler.FlowExecutionHandler
 }
 
 // NewFlowExecutionService creates a new instance of FlowExecutionService.
-func NewFlowExecutionService(mux *http.ServeMux) *FlowExecutionService {
+func NewFlowExecutionService(mux *http.ServeMux) ServiceInterface {
 	instance := &FlowExecutionService{
+		ServerOpsService:     server.NewServerOperationService(),
 		flowExecutionHandler: handler.NewFlowExecutionHandler(),
 	}
 	instance.RegisterRoutes(mux)
@@ -51,8 +53,10 @@ func (s *FlowExecutionService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "POST /flow/execute", &opts, s.flowExecutionHandler.HandleFlowExecutionRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /flow/execute", &opts, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /flow/execute", &opts,
+		s.flowExecutionHandler.HandleFlowExecutionRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /flow/execute", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 }

--- a/backend/internal/system/services/healthcheckservice.go
+++ b/backend/internal/system/services/healthcheckservice.go
@@ -27,12 +27,14 @@ import (
 
 // HealthCheckService defines the service for handling readiness and liveness checks.
 type HealthCheckService struct {
+	ServerOpsService   server.ServerOperationServiceInterface
 	healthCheckHandler *handler.HealthCheckHandler
 }
 
 // NewHealthCheckService creates a new instance of HealthCheckService.
-func NewHealthCheckService(mux *http.ServeMux) *HealthCheckService {
+func NewHealthCheckService(mux *http.ServeMux) ServiceInterface {
 	instance := &HealthCheckService{
+		ServerOpsService:   server.NewServerOperationService(),
 		healthCheckHandler: handler.NewHealthCheckHandler(),
 	}
 	instance.RegisterRoutes(mux)
@@ -52,13 +54,17 @@ func (h *HealthCheckService) RegisterRoutes(mux *http.ServeMux) {
 		},
 	}
 
-	server.WrapHandleFunction(mux, "OPTIONS /health/liveness", &opts1, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
-	server.WrapHandleFunction(mux, "GET /health/liveness", &opts1, h.healthCheckHandler.HandleLivenessRequest)
+	h.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /health/liveness", &opts1,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	h.ServerOpsService.WrapHandleFunction(mux, "GET /health/liveness", &opts1,
+		h.healthCheckHandler.HandleLivenessRequest)
 
-	server.WrapHandleFunction(mux, "OPTIONS /health/readiness", &opts1, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
-	server.WrapHandleFunction(mux, "GET /health/readiness", &opts1, h.healthCheckHandler.HandleReadinessRequest)
+	h.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /health/readiness", &opts1,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	h.ServerOpsService.WrapHandleFunction(mux, "GET /health/readiness", &opts1,
+		h.healthCheckHandler.HandleReadinessRequest)
 }

--- a/backend/internal/system/services/idpservice.go
+++ b/backend/internal/system/services/idpservice.go
@@ -30,13 +30,15 @@ import (
 
 // IDPService is the service for identity provider management operations.
 type IDPService struct {
-	idpHandler *handler.IDPHandler
+	ServerOpsService server.ServerOperationServiceInterface
+	idpHandler       *handler.IDPHandler
 }
 
 // NewIDPService creates a new instance of IDPService.
-func NewIDPService(mux *http.ServeMux) *IDPService {
+func NewIDPService(mux *http.ServeMux) ServiceInterface {
 	instance := &IDPService{
-		idpHandler: &handler.IDPHandler{},
+		ServerOpsService: server.NewServerOperationService(),
+		idpHandler:       &handler.IDPHandler{},
 	}
 	instance.RegisterRoutes(mux)
 
@@ -52,11 +54,12 @@ func (s *IDPService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "POST /identity-providers", &opts1, s.idpHandler.HandleIDPPostRequest)
-	server.WrapHandleFunction(mux, "GET /identity-providers", &opts1, s.idpHandler.HandleIDPListRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /identity-providers", &opts1, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /identity-providers", &opts1, s.idpHandler.HandleIDPPostRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /identity-providers", &opts1, s.idpHandler.HandleIDPListRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /identity-providers", &opts1,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 
 	opts2 := server.RequestWrapOptions{
 		Cors: &server.Cors{
@@ -65,10 +68,12 @@ func (s *IDPService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "GET /identity-providers/", &opts2, s.idpHandler.HandleIDPGetRequest)
-	server.WrapHandleFunction(mux, "PUT /identity-providers/", &opts2, s.idpHandler.HandleIDPPutRequest)
-	server.WrapHandleFunction(mux, "DELETE /identity-providers/", &opts2, s.idpHandler.HandleIDPDeleteRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /identity-providers/", &opts2, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /identity-providers/", &opts2, s.idpHandler.HandleIDPGetRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "PUT /identity-providers/", &opts2, s.idpHandler.HandleIDPPutRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "DELETE /identity-providers/", &opts2,
+		s.idpHandler.HandleIDPDeleteRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /identity-providers/", &opts2,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 }

--- a/backend/internal/system/services/notificationsenderservice.go
+++ b/backend/internal/system/services/notificationsenderservice.go
@@ -27,12 +27,14 @@ import (
 
 // NotificationSenderService provides HTTP endpoints for managing message notification senders.
 type NotificationSenderService struct {
+	ServerOpsService    server.ServerOperationServiceInterface
 	notificationHandler *handler.MessageNotificationHandler
 }
 
 // NewNotificationSenderService creates a new instance of NotificationSenderService.
-func NewNotificationSenderService(mux *http.ServeMux) *NotificationSenderService {
+func NewNotificationSenderService(mux *http.ServeMux) ServiceInterface {
 	instance := &NotificationSenderService{
+		ServerOpsService:    server.NewServerOperationService(),
 		notificationHandler: handler.NewMessageNotificationHandler(),
 	}
 	instance.RegisterRoutes(mux)
@@ -49,14 +51,14 @@ func (s *NotificationSenderService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "GET /notification-senders/message", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /notification-senders/message", &opts,
 		s.notificationHandler.HandleSenderListRequest)
-	server.WrapHandleFunction(mux, "POST /notification-senders/message", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /notification-senders/message", &opts,
 		s.notificationHandler.HandleSenderCreateRequest)
-	server.WrapHandleFunction(mux, "GET /notification-senders/message/{id}", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /notification-senders/message/{id}", &opts,
 		s.notificationHandler.HandleSenderGetRequest)
-	server.WrapHandleFunction(mux, "PUT /notification-senders/message/{id}", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "PUT /notification-senders/message/{id}", &opts,
 		s.notificationHandler.HandleSenderUpdateRequest)
-	server.WrapHandleFunction(mux, "DELETE /notification-senders/message/{id}", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "DELETE /notification-senders/message/{id}", &opts,
 		s.notificationHandler.HandleSenderDeleteRequest)
 }

--- a/backend/internal/system/services/service.go
+++ b/backend/internal/system/services/service.go
@@ -32,20 +32,3 @@ type Route struct {
 type ServiceInterface interface {
 	RegisterRoutes(mux *http.ServeMux)
 }
-
-// The AbstractService struct is an empty struct that can be embedded in other services.
-type AbstractService struct{}
-
-// RegisterRoutes is a method that can be overridden by concrete services to register their routes.
-func (s *AbstractService) RegisterRoutes(mux *http.ServeMux) {
-	// This method can be overridden by concrete services to register their routes.
-	// For example:
-	// opts := server.RequestWrapOptions{
-	// 	Cors: &server.Cors{
-	// 		AllowedMethods:   "GET, POST",
-	// 		AllowedHeaders:   "Content-Type, Authorization",
-	// 		AllowCredentials: true,
-	// 	},
-	// }
-	// server.WrapHandleFunction(mux, "GET /example", &opts, s.ExampleHandler)
-}

--- a/backend/internal/system/services/tokenservice.go
+++ b/backend/internal/system/services/tokenservice.go
@@ -27,13 +27,15 @@ import (
 
 // TokenService defines the service for handling OAuth2 token requests.
 type TokenService struct {
-	tokenHandler *token.TokenHandler
+	ServerOpsService server.ServerOperationServiceInterface
+	tokenHandler     *token.TokenHandler
 }
 
 // NewTokenService creates a new instance of TokenService.
-func NewTokenService(mux *http.ServeMux) *TokenService {
+func NewTokenService(mux *http.ServeMux) ServiceInterface {
 	instance := &TokenService{
-		tokenHandler: &token.TokenHandler{},
+		ServerOpsService: server.NewServerOperationService(),
+		tokenHandler:     &token.TokenHandler{},
 	}
 	instance.RegisterRoutes(mux)
 
@@ -49,5 +51,5 @@ func (s *TokenService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "POST /oauth2/token", &opts, s.tokenHandler.HandleTokenRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth2/token", &opts, s.tokenHandler.HandleTokenRequest)
 }

--- a/backend/internal/system/services/userservice.go
+++ b/backend/internal/system/services/userservice.go
@@ -30,13 +30,15 @@ import (
 
 // UserService is the service for user management operations.
 type UserService struct {
-	userHandler *handler.UserHandler
+	ServerOpsService server.ServerOperationServiceInterface
+	userHandler      *handler.UserHandler
 }
 
 // NewUserService creates a new instance of UserService.
-func NewUserService(mux *http.ServeMux) *UserService {
+func NewUserService(mux *http.ServeMux) ServiceInterface {
 	instance := &UserService{
-		userHandler: &handler.UserHandler{},
+		ServerOpsService: server.NewServerOperationService(),
+		userHandler:      &handler.UserHandler{},
 	}
 	instance.RegisterRoutes(mux)
 
@@ -52,11 +54,12 @@ func (s *UserService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "POST /users", &opts1, s.userHandler.HandleUserPostRequest)
-	server.WrapHandleFunction(mux, "GET /users", &opts1, s.userHandler.HandleUserListRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /users", &opts1, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /users", &opts1, s.userHandler.HandleUserPostRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /users", &opts1, s.userHandler.HandleUserListRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /users", &opts1,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 
 	opts2 := server.RequestWrapOptions{
 		Cors: &server.Cors{
@@ -65,10 +68,11 @@ func (s *UserService) RegisterRoutes(mux *http.ServeMux) {
 			AllowCredentials: true,
 		},
 	}
-	server.WrapHandleFunction(mux, "GET /users/", &opts2, s.userHandler.HandleUserGetRequest)
-	server.WrapHandleFunction(mux, "PUT /users/", &opts2, s.userHandler.HandleUserPutRequest)
-	server.WrapHandleFunction(mux, "DELETE /users/", &opts2, s.userHandler.HandleUserDeleteRequest)
-	server.WrapHandleFunction(mux, "OPTIONS /users/", &opts2, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
+	s.ServerOpsService.WrapHandleFunction(mux, "GET /users/", &opts2, s.userHandler.HandleUserGetRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "PUT /users/", &opts2, s.userHandler.HandleUserPutRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "DELETE /users/", &opts2, s.userHandler.HandleUserDeleteRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /users/", &opts2,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
 }


### PR DESCRIPTION
## Purpose

This pull requests moves the existing server operations functionality to a new `ServerOperationService`. The changes refactor all available API services to use this new service, improving code modularity and reducing duplication. 
This allows to inject mock services to the API and server operations services.

Additionally, the unused abstract service structure has been removed to simplify the codebase.
