### PR TITLE
Add support to run without tls

### DIFF
--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -32,6 +32,7 @@ import (
 type ServerConfig struct {
 	Hostname string `yaml:"hostname"`
 	Port     int    `yaml:"port"`
+	HTTPOnly bool   `yaml:"http_only"`
 }
 
 // GateClientConfig holds the client configuration details.


### PR DESCRIPTION
## Purpose
This pull request introduces support for running the server in HTTP-only mode, alongside the existing TLS-enabled mode. The changes include adding a configuration option for HTTP-only mode, implementing a new function to start an HTTP server, and updating the server initialization logic to handle both modes.

### HTTP-only mode support:

* [`backend/internal/system/config/config.go`](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR35): Added a new `HTTPOnly` field to the `ServerConfig` struct to allow configuration of HTTP-only mode.
* [`backend/cmd/server/main.go`](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408R57-R63): Updated the `main` function to check the `HTTPOnly` configuration and start the server without TLS if enabled.

### HTTP server implementation:

* [`backend/cmd/server/main.go`](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408R162-R178): Added a new `startHTTPServer` function to handle starting the server in HTTP-only mode. This function sets up an HTTP server with a specified address and logs relevant information.

### Adjustments to existing TLS server logic:

* [`backend/cmd/server/main.go`](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408R145): Modified the `startServer` function to include a fallback to `http.ListenAndServe` for non-TLS connections, ensuring compatibility.