### PR TITLE
Update executors to utilize executor properties

### DIFF
--- a/backend/internal/executor/attributecollect/attributecollector.go
+++ b/backend/internal/executor/attributecollect/attributecollector.go
@@ -46,7 +46,7 @@ type AttributeCollector struct {
 }
 
 // NewAttributeCollector creates a new instance of AttributeCollector.
-func NewAttributeCollector(id, name string) flowmodel.ExecutorInterface {
+func NewAttributeCollector(id, name string, properties map[string]string) *AttributeCollector {
 	prerequisites := []flowmodel.InputData{
 		{
 			Name:     "userID",
@@ -56,7 +56,7 @@ func NewAttributeCollector(id, name string) flowmodel.ExecutorInterface {
 	}
 
 	return &AttributeCollector{
-		internal: *flowmodel.NewExecutor(id, name, []flowmodel.InputData{}, prerequisites),
+		internal: *flowmodel.NewExecutor(id, name, []flowmodel.InputData{}, prerequisites, properties),
 	}
 }
 

--- a/backend/internal/executor/authassert/authassertexecutor.go
+++ b/backend/internal/executor/authassert/authassertexecutor.go
@@ -36,9 +36,9 @@ type AuthAssertExecutor struct {
 }
 
 // NewAuthAssertExecutor creates a new instance of AuthAssertExecutor.
-func NewAuthAssertExecutor(id, name string) flowmodel.ExecutorInterface {
+func NewAuthAssertExecutor(id, name string, properties map[string]string) *AuthAssertExecutor {
 	return &AuthAssertExecutor{
-		internal: *flowmodel.NewExecutor(id, name, []flowmodel.InputData{}, []flowmodel.InputData{}),
+		internal: *flowmodel.NewExecutor(id, name, []flowmodel.InputData{}, []flowmodel.InputData{}, properties),
 	}
 }
 

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -37,7 +37,7 @@ type BasicAuthExecutor struct {
 }
 
 // NewBasicAuthExecutor creates a new instance of BasicAuthExecutor.
-func NewBasicAuthExecutor(id, name string) flowmodel.ExecutorInterface {
+func NewBasicAuthExecutor(id, name string, properties map[string]string) *BasicAuthExecutor {
 	defaultInputs := []flowmodel.InputData{
 		{
 			Name:     "username",
@@ -51,7 +51,7 @@ func NewBasicAuthExecutor(id, name string) flowmodel.ExecutorInterface {
 		},
 	}
 	return &BasicAuthExecutor{
-		internal: *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}),
+		internal: *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}, properties),
 	}
 }
 

--- a/backend/internal/executor/githubauth/githubauthexecutor.go
+++ b/backend/internal/executor/githubauth/githubauthexecutor.go
@@ -60,7 +60,8 @@ func NewGithubOAuthExecutorFromProps(execProps flowmodel.ExecutorProperties,
 		AdditionalParams:      oAuthProps.AdditionalParams,
 	}
 
-	base := oauth.NewOAuthExecutor("github_oauth_executor", execProps.Name, []flowmodel.InputData{}, compOAuthProps)
+	base := oauth.NewOAuthExecutor("github_oauth_executor", execProps.Name, []flowmodel.InputData{},
+		execProps.Properties, compOAuthProps)
 	exec, ok := base.(*oauth.OAuthExecutor)
 	if !ok {
 		panic("failed to cast GithubOAuthExecutor to OAuthExecutor")
@@ -71,8 +72,9 @@ func NewGithubOAuthExecutorFromProps(execProps flowmodel.ExecutorProperties,
 }
 
 // NewGithubOAuthExecutor creates a new instance of GithubOAuthExecutor with the provided details.
-func NewGithubOAuthExecutor(id, name, clientID, clientSecret, redirectURI string,
-	scopes []string, additionalParams map[string]string) oauth.OAuthExecutorInterface {
+func NewGithubOAuthExecutor(id, name string, properties map[string]string,
+	clientID, clientSecret, redirectURI string, scopes []string,
+	additionalParams map[string]string) oauth.OAuthExecutorInterface {
 	// Prepare the OAuth properties for GitHub
 	oAuthProps := &model.OAuthExecProperties{
 		AuthorizationEndpoint: githubAuthorizeEndpoint,
@@ -85,7 +87,7 @@ func NewGithubOAuthExecutor(id, name, clientID, clientSecret, redirectURI string
 		AdditionalParams:      additionalParams,
 	}
 
-	base := oauth.NewOAuthExecutor(id, name, []flowmodel.InputData{}, oAuthProps)
+	base := oauth.NewOAuthExecutor(id, name, []flowmodel.InputData{}, properties, oAuthProps)
 	exec, ok := base.(*oauth.OAuthExecutor)
 	if !ok {
 		panic("failed to cast GithubOAuthExecutor to OAuthExecutor")

--- a/backend/internal/executor/googleauth/googleauthexecutor.go
+++ b/backend/internal/executor/googleauth/googleauthexecutor.go
@@ -59,7 +59,7 @@ func NewGoogleOIDCAuthExecutorFromProps(execProps flowmodel.ExecutorProperties,
 	}
 
 	base := oidcauth.NewOIDCAuthExecutor("google_oidc_auth_executor", execProps.Name,
-		[]flowmodel.InputData{}, compOAuthProps)
+		[]flowmodel.InputData{}, execProps.Properties, compOAuthProps)
 	exec, ok := base.(*oidcauth.OIDCAuthExecutor)
 	if !ok {
 		panic("failed to cast GoogleOIDCAuthExecutor to OIDCAuthExecutor")
@@ -70,8 +70,9 @@ func NewGoogleOIDCAuthExecutorFromProps(execProps flowmodel.ExecutorProperties,
 }
 
 // NewGoogleOIDCAuthExecutor creates a new instance of GoogleOIDCAuthExecutor with the provided details.
-func NewGoogleOIDCAuthExecutor(id, name, clientID, clientSecret, redirectURI string,
-	scopes []string, additionalParams map[string]string) oidcauth.OIDCAuthExecutorInterface {
+func NewGoogleOIDCAuthExecutor(id, name string, properties map[string]string,
+	clientID, clientSecret, redirectURI string, scopes []string,
+	additionalParams map[string]string) oidcauth.OIDCAuthExecutorInterface {
 	// Prepare the OAuth properties for Google
 	oAuthProps := &model.OAuthExecProperties{
 		AuthorizationEndpoint: googleAuthorizeEndpoint,
@@ -85,7 +86,7 @@ func NewGoogleOIDCAuthExecutor(id, name, clientID, clientSecret, redirectURI str
 		AdditionalParams:      additionalParams,
 	}
 
-	base := oidcauth.NewOIDCAuthExecutor(id, name, []flowmodel.InputData{}, oAuthProps)
+	base := oidcauth.NewOIDCAuthExecutor(id, name, []flowmodel.InputData{}, properties, oAuthProps)
 	exec, ok := base.(*oidcauth.OIDCAuthExecutor)
 	if !ok {
 		panic("failed to cast GoogleOIDCAuthExecutor to OIDCAuthExecutor")

--- a/backend/internal/executor/oauth/oauthexecutor.go
+++ b/backend/internal/executor/oauth/oauthexecutor.go
@@ -67,7 +67,7 @@ type OAuthExecutor struct {
 }
 
 // NewOAuthExecutor creates a new instance of OAuthExecutor.
-func NewOAuthExecutor(id, name string, defaultInputs []flowmodel.InputData,
+func NewOAuthExecutor(id, name string, defaultInputs []flowmodel.InputData, properties map[string]string,
 	oAuthProps *model.OAuthExecProperties) OAuthExecutorInterface {
 	if len(defaultInputs) == 0 {
 		defaultInputs = []flowmodel.InputData{
@@ -79,7 +79,7 @@ func NewOAuthExecutor(id, name string, defaultInputs []flowmodel.InputData,
 		}
 	}
 	return &OAuthExecutor{
-		internal:        *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}),
+		internal:        *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}, properties),
 		oAuthProperties: *oAuthProps,
 	}
 }

--- a/backend/internal/executor/oidcauth/oidcauthexecutor.go
+++ b/backend/internal/executor/oidcauth/oidcauthexecutor.go
@@ -50,7 +50,7 @@ type OIDCAuthExecutor struct {
 }
 
 // NewOIDCAuthExecutor creates a new instance of OIDCAuthExecutor.
-func NewOIDCAuthExecutor(id, name string, defaultInputs []flowmodel.InputData,
+func NewOIDCAuthExecutor(id, name string, defaultInputs []flowmodel.InputData, properties map[string]string,
 	oAuthProps *oauthmodel.OAuthExecProperties) OIDCAuthExecutorInterface {
 	scopes := oAuthProps.Scopes
 	if !slices.Contains(scopes, "openid") {
@@ -69,7 +69,7 @@ func NewOIDCAuthExecutor(id, name string, defaultInputs []flowmodel.InputData,
 		AdditionalParams:      oAuthProps.AdditionalParams,
 		Properties:            oAuthProps.Properties,
 	}
-	base := oauth.NewOAuthExecutor(id, name, defaultInputs, &compOAuthProps)
+	base := oauth.NewOAuthExecutor(id, name, defaultInputs, properties, &compOAuthProps)
 
 	return &OIDCAuthExecutor{
 		internal: base,

--- a/backend/internal/flow/model/executor.go
+++ b/backend/internal/flow/model/executor.go
@@ -80,11 +80,13 @@ type Executor struct {
 }
 
 // NewExecutor creates a new instance of Executor with the given properties.
-func NewExecutor(id, name string, defaultInputs []InputData, prerequisites []InputData) *Executor {
+func NewExecutor(id, name string, defaultInputs []InputData, prerequisites []InputData,
+	properties map[string]string) *Executor {
 	return &Executor{
 		Properties: ExecutorProperties{
-			ID:   id,
-			Name: name,
+			ID:         id,
+			Name:       name,
+			Properties: properties,
 		},
 		DefaultExecutorInputs: defaultInputs,
 		Prerequisites:         prerequisites,

--- a/backend/internal/flow/utils/utils.go
+++ b/backend/internal/flow/utils/utils.go
@@ -220,7 +220,7 @@ func GetExecutorByName(execConfig *model.ExecutorConfig) (model.ExecutorInterfac
 		if err != nil {
 			return nil, fmt.Errorf("error while getting IDP for BasicAuthExecutor: %w", err)
 		}
-		executor = basicauth.NewBasicAuthExecutor(idp.ID, idp.Name)
+		executor = basicauth.NewBasicAuthExecutor(idp.ID, idp.Name, execConfig.Properties)
 	case "SMSOTPAuthExecutor":
 		idp, err := getIDP("Local")
 		if err != nil {
@@ -232,9 +232,9 @@ func GetExecutorByName(execConfig *model.ExecutorConfig) (model.ExecutorInterfac
 		}
 		senderName, exists := execConfig.Properties["senderName"]
 		if !exists || senderName == "" {
-			return nil, fmt.Errorf("sender_name property is required for SMSOTPAuthExecutor")
+			return nil, fmt.Errorf("senderName property is required for SMSOTPAuthExecutor")
 		}
-		executor = smsauth.NewSMSOTPAuthExecutor(idp.ID, idp.Name, senderName)
+		executor = smsauth.NewSMSOTPAuthExecutor(idp.ID, idp.Name, execConfig.Properties)
 	case "GithubOAuthExecutor":
 		idp, err := getIDP(execConfig.IdpName)
 		if err != nil {
@@ -247,8 +247,8 @@ func GetExecutorByName(execConfig *model.ExecutorConfig) (model.ExecutorInterfac
 			return nil, err
 		}
 
-		executor = githubauth.NewGithubOAuthExecutor(idp.ID, idp.Name, clientID, clientSecret,
-			redirectURI, scopes, additionalParams)
+		executor = githubauth.NewGithubOAuthExecutor(idp.ID, idp.Name, execConfig.Properties,
+			clientID, clientSecret, redirectURI, scopes, additionalParams)
 	case "GoogleOIDCAuthExecutor":
 		idp, err := getIDP(execConfig.IdpName)
 		if err != nil {
@@ -261,12 +261,14 @@ func GetExecutorByName(execConfig *model.ExecutorConfig) (model.ExecutorInterfac
 			return nil, err
 		}
 
-		executor = googleauth.NewGoogleOIDCAuthExecutor(idp.ID, idp.Name, clientID, clientSecret,
-			redirectURI, scopes, additionalParams)
+		executor = googleauth.NewGoogleOIDCAuthExecutor(idp.ID, idp.Name, execConfig.Properties,
+			clientID, clientSecret, redirectURI, scopes, additionalParams)
 	case "AttributeCollector":
-		executor = attributecollect.NewAttributeCollector("attribute-collector", "AttributeCollector")
+		executor = attributecollect.NewAttributeCollector("attribute-collector", "AttributeCollector",
+			execConfig.Properties)
 	case "AuthAssertExecutor":
-		executor = authassert.NewAuthAssertExecutor("auth-assert-executor", "AuthAssertExecutor")
+		executor = authassert.NewAuthAssertExecutor("auth-assert-executor", "AuthAssertExecutor",
+			execConfig.Properties)
 	default:
 		return nil, fmt.Errorf("executor with name %s not found", execConfig.Name)
 	}


### PR DESCRIPTION
## Purpose
This pull request ensures that executors utilize the already existing executor properties map to configure the executor properties.

Currently this will be utilized in SMS OTP flow to configure the notification `senderName`.