### PR TITLE
Add user validation for federated authenticators with identifying executor

### DIFF
--- a/backend/internal/executor/attributecollect/attributecollector.go
+++ b/backend/internal/executor/attributecollect/attributecollector.go
@@ -45,6 +45,8 @@ type AttributeCollector struct {
 	internal flowmodel.Executor
 }
 
+var _ flowmodel.ExecutorInterface = (*AttributeCollector)(nil)
+
 // NewAttributeCollector creates a new instance of AttributeCollector.
 func NewAttributeCollector(id, name string, properties map[string]string) *AttributeCollector {
 	prerequisites := []flowmodel.InputData{

--- a/backend/internal/executor/authassert/authassertexecutor.go
+++ b/backend/internal/executor/authassert/authassertexecutor.go
@@ -35,6 +35,8 @@ type AuthAssertExecutor struct {
 	internal flowmodel.Executor
 }
 
+var _ flowmodel.ExecutorInterface = (*AuthAssertExecutor)(nil)
+
 // NewAuthAssertExecutor creates a new instance of AuthAssertExecutor.
 func NewAuthAssertExecutor(id, name string, properties map[string]string) *AuthAssertExecutor {
 	return &AuthAssertExecutor{

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -55,7 +55,8 @@ func NewBasicAuthExecutor(id, name string, properties map[string]string) *BasicA
 		},
 	}
 	return &BasicAuthExecutor{
-		internal: *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}, properties),
+		IdentifyingExecutor: identify.NewIdentifyingExecutor(id, name, properties),
+		internal:            *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}, properties),
 	}
 }
 

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 
 	authnmodel "github.com/asgardeo/thunder/internal/authn/model"
+	"github.com/asgardeo/thunder/internal/executor/identify"
 	flowconst "github.com/asgardeo/thunder/internal/flow/constants"
 	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -33,8 +34,11 @@ const loggerComponentName = "BasicAuthExecutor"
 
 // BasicAuthExecutor implements the ExecutorInterface for basic authentication.
 type BasicAuthExecutor struct {
+	*identify.IdentifyingExecutor
 	internal flowmodel.Executor
 }
+
+var _ flowmodel.ExecutorInterface = (*BasicAuthExecutor)(nil)
 
 // NewBasicAuthExecutor creates a new instance of BasicAuthExecutor.
 func NewBasicAuthExecutor(id, name string, properties map[string]string) *BasicAuthExecutor {
@@ -94,10 +98,13 @@ func (b *BasicAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.Exec
 	// TODO: Should handle client errors here. Service should return a ServiceError and
 	//  client errors should be appended as a failure.
 	//  For the moment handling returned error as a authentication failure.
-	authenticatedUser, err := getAuthenticatedUser(username, ctx.UserInputData["password"], logger)
+	authenticatedUser, err := b.getAuthenticatedUser(username, ctx.UserInputData["password"], execResp)
 	if err != nil {
 		execResp.Status = flowconst.ExecFailure
 		execResp.FailureReason = "Failed to authenticate user: " + err.Error()
+		return execResp, nil
+	}
+	if execResp.Status == flowconst.ExecFailure {
 		return execResp, nil
 	}
 	if authenticatedUser == nil {
@@ -154,23 +161,22 @@ func (b *BasicAuthExecutor) GetRequiredData(ctx *flowmodel.NodeContext) []flowmo
 
 // getAuthenticatedUser perform authentication based on the provided username and password and return
 // authenticated user details.
-func getAuthenticatedUser(username, password string, logger *log.Logger) (*authnmodel.AuthenticatedUser, error) {
-	userProvider := userprovider.NewUserProvider()
-	userService := userProvider.GetUserService()
+func (b *BasicAuthExecutor) getAuthenticatedUser(username, password string,
+	execResp *flowmodel.ExecutorResponse) (*authnmodel.AuthenticatedUser, error) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
+		log.String(log.LoggerKeyExecutorID, b.GetID()))
 
 	filters := map[string]interface{}{"username": username}
-	userID, err := userService.IdentifyUser(filters)
+	userID, err := b.IdentifyUser(filters, execResp)
 	if err != nil {
-		logger.Error("Failed to identify user by username",
-			log.String("username", log.MaskString(username)),
-			log.Error(err))
 		return nil, err
 	}
-	if *userID == "" {
-		logger.Error("User not found for the provided username",
-			log.String("username", log.MaskString(username)))
-		return nil, err
+	if execResp.Status == flowconst.ExecFailure {
+		return nil, nil
 	}
+
+	userProvider := userprovider.NewUserProvider()
+	userService := userProvider.GetUserService()
 
 	user, err := userService.VerifyUser(*userID, "password", password)
 	if err != nil {

--- a/backend/internal/executor/googleauth/constants.go
+++ b/backend/internal/executor/googleauth/constants.go
@@ -25,6 +25,3 @@ const (
 	googleUserInfoEndpoint  = "https://openidconnect.googleapis.com/v1/userinfo"
 	googleJwksEndpoint      = "https://www.googleapis.com/oauth2/v3/certs"
 )
-
-// idTokenNonUserAttributes contains the list of non-user attributes that are expected in the ID token.
-var idTokenNonUserAttributes = []string{"aud", "exp", "iat", "iss", "at_hash", "azp", "nonce", "sub"}

--- a/backend/internal/executor/googleauth/constants.go
+++ b/backend/internal/executor/googleauth/constants.go
@@ -27,4 +27,4 @@ const (
 )
 
 // idTokenNonUserAttributes contains the list of non-user attributes that are expected in the ID token.
-var idTokenNonUserAttributes = []string{"aud", "exp", "iat", "iss", "at_hash", "azp", "nonce"}
+var idTokenNonUserAttributes = []string{"aud", "exp", "iat", "iss", "at_hash", "azp", "nonce", "sub"}

--- a/backend/internal/executor/googleauth/googleauthexecutor.go
+++ b/backend/internal/executor/googleauth/googleauthexecutor.go
@@ -20,19 +20,15 @@
 package googleauth
 
 import (
-	"errors"
 	"fmt"
-	"slices"
 	"time"
 
-	authnmodel "github.com/asgardeo/thunder/internal/authn/model"
 	"github.com/asgardeo/thunder/internal/executor/oauth/model"
 	"github.com/asgardeo/thunder/internal/executor/oidcauth"
 	flowconst "github.com/asgardeo/thunder/internal/flow/constants"
 	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
 	jwtutils "github.com/asgardeo/thunder/internal/system/crypto/jwt/utils"
 	"github.com/asgardeo/thunder/internal/system/log"
-	systemutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 const loggerComponentName = "GoogleOIDCAuthExecutor"
@@ -132,62 +128,6 @@ func (g *GoogleOIDCAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel
 	return execResp, nil
 }
 
-// ProcessAuthFlowResponse processes the response from the Google OIDC authentication flow.
-func (g *GoogleOIDCAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
-	execResp *flowmodel.ExecutorResponse) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
-		log.String("executorID", g.GetID()), log.String("flowID", ctx.FlowID))
-	logger.Debug("Processing Google OIDC auth flow response")
-
-	code, okCode := ctx.UserInputData["code"]
-	if okCode && code != "" {
-		tokenResp, err := g.ExchangeCodeForToken(ctx, execResp, code)
-		if err != nil {
-			logger.Error("Failed to exchange authorization code for token", log.Error(err))
-			return fmt.Errorf("failed to exchange code for token: %w", err)
-		}
-		if execResp.Status == flowconst.ExecFailure {
-			return nil
-		}
-
-		err = g.validateTokenResponse(tokenResp)
-		if err != nil {
-			execResp.Status = flowconst.ExecFailure
-			execResp.FailureReason = err.Error()
-			return nil
-		}
-
-		if tokenResp.Scope == "" {
-			logger.Error("Scopes are empty in the token response")
-			execResp.AuthenticatedUser = authnmodel.AuthenticatedUser{
-				IsAuthenticated: false,
-			}
-		} else {
-			authenticatedUser, err := g.getAuthenticatedUserWithAttributes(ctx, execResp, tokenResp)
-			if err != nil {
-				return err
-			}
-			if authenticatedUser == nil {
-				return nil
-			}
-			execResp.AuthenticatedUser = *authenticatedUser
-		}
-	} else {
-		execResp.AuthenticatedUser = authnmodel.AuthenticatedUser{
-			IsAuthenticated: false,
-		}
-	}
-
-	if execResp.AuthenticatedUser.IsAuthenticated {
-		execResp.Status = flowconst.ExecComplete
-	} else {
-		execResp.Status = flowconst.ExecFailure
-		execResp.FailureReason = "Authentication failed. Authorization code not provided or invalid."
-	}
-
-	return nil
-}
-
 // ValidateIDToken validates the ID token received from Google.
 func (g *GoogleOIDCAuthExecutor) ValidateIDToken(execResp *flowmodel.ExecutorResponse, idToken string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
@@ -267,141 +207,4 @@ func (g *GoogleOIDCAuthExecutor) ValidateIDToken(execResp *flowmodel.ExecutorRes
 	}
 
 	return nil
-}
-
-// validateTokenResponse validates the token response received from Google.
-func (g *GoogleOIDCAuthExecutor) validateTokenResponse(tokenResp *model.TokenResponse) error {
-	if tokenResp == nil {
-		return errors.New("token response is nil")
-	}
-	if tokenResp.AccessToken == "" {
-		return errors.New("access token is empty in the token response")
-	}
-	return nil
-}
-
-// getAuthenticatedUserWithAttributes retrieves the authenticated user with attributes from the token response.
-func (g *GoogleOIDCAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.NodeContext,
-	execResp *flowmodel.ExecutorResponse, tokenResp *model.TokenResponse) (*authnmodel.AuthenticatedUser, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName),
-		log.String(log.LoggerKeyExecutorID, g.GetID()),
-		log.String(log.LoggerKeyFlowID, ctx.FlowID))
-
-	// If scopes contains openid, check if the id token is present.
-	if slices.Contains(g.GetOAuthProperties().Scopes, "openid") && tokenResp.IDToken == "" {
-		execResp.Status = flowconst.ExecFailure
-		execResp.FailureReason = "ID token is empty in the token response."
-		return nil, nil
-	}
-
-	userClaims := make(map[string]string)
-	userID := ""
-	if tokenResp.IDToken != "" {
-		if err := g.ValidateIDToken(execResp, tokenResp.IDToken); err != nil {
-			return nil, fmt.Errorf("failed to validate ID token: %w", err)
-		}
-		if execResp.Status == flowconst.ExecFailure {
-			return nil, nil
-		}
-
-		idTokenClaims, err := g.GetIDTokenClaims(execResp, tokenResp.IDToken)
-		if err != nil {
-			return nil, fmt.Errorf("failed to extract ID token claims: %w", err)
-		}
-		if execResp.Status == flowconst.ExecFailure {
-			return nil, nil
-		}
-		if len(idTokenClaims) != 0 {
-			// Validate nonce if configured.
-			if nonce, ok := ctx.UserInputData["nonce"]; ok && nonce != "" {
-				if idTokenClaims["nonce"] != nonce {
-					execResp.Status = flowconst.ExecFailure
-					execResp.FailureReason = "Nonce mismatch in ID token claims."
-					return nil, nil
-				}
-			}
-
-			// Resolve user with the sub claim if available.
-			// TODO: For now assume `sub` is the unique identifier for the user always.
-			sub, ok := idTokenClaims["sub"]
-			if ok {
-				if subStr, ok := sub.(string); ok && subStr != "" {
-					userID, err = g.resolveUser(subStr, execResp)
-					if err != nil {
-						return nil, err
-					}
-					if execResp.Status == flowconst.ExecFailure {
-						return nil, nil
-					}
-				}
-			}
-
-			// Filter non-user claims from the ID token claims.
-			for attr, val := range idTokenClaims {
-				if !slices.Contains(idTokenNonUserAttributes, attr) {
-					userClaims[attr] = systemutils.ConvertInterfaceValueToString(val)
-				}
-			}
-			logger.Debug("Extracted ID token claims", log.Any("claims", userClaims))
-		}
-	}
-
-	if len(g.GetOAuthProperties().Scopes) == 0 ||
-		(len(g.GetOAuthProperties().Scopes) == 1 && slices.Contains(g.GetOAuthProperties().Scopes, "openid")) {
-		logger.Debug("No additional scopes configured.")
-	} else {
-		userInfo, err := g.GetUserInfo(ctx, execResp, tokenResp.AccessToken)
-		if err != nil {
-			return nil, errors.New("failed to get user info: " + err.Error())
-		}
-		if execResp.Status == flowconst.ExecFailure {
-			return nil, nil
-		}
-
-		// If userID is still empty, try to resolve it using the sub claim from userInfo.
-		// TODO: For now assume `sub` is the unique identifier for the user always.
-		if userID == "" {
-			sub, ok := userInfo["sub"]
-			if !ok || sub == "" {
-				execResp.Status = flowconst.ExecFailure
-				execResp.FailureReason = "sub claim not found in the response."
-				return nil, nil
-			}
-			userID, err = g.resolveUser(sub, execResp)
-			if err != nil {
-				return nil, err
-			}
-			if execResp.Status == flowconst.ExecFailure {
-				return nil, nil
-			}
-		}
-
-		for key, value := range userInfo {
-			if key != "username" && key != "sub" && key != "id" {
-				userClaims[key] = value
-			}
-		}
-		userClaims["user_id"] = userID
-	}
-
-	authenticatedUser := authnmodel.AuthenticatedUser{
-		IsAuthenticated: true,
-		UserID:          userID,
-		Attributes:      userClaims,
-	}
-
-	return &authenticatedUser, nil
-}
-
-// resolveUser resolves the user based on the sub claim from user info.
-func (g *GoogleOIDCAuthExecutor) resolveUser(sub string, execResp *flowmodel.ExecutorResponse) (string, error) {
-	filters := map[string]interface{}{"sub": sub}
-	userID, err := g.IdentifyUser(filters, execResp)
-	if err != nil {
-		return "", fmt.Errorf("failed to identify user with sub claim: %w", err)
-	}
-	if execResp.Status == flowconst.ExecFailure {
-		return "", nil
-	}
-	return *userID, nil
 }

--- a/backend/internal/executor/identify/identifyingexecutor.go
+++ b/backend/internal/executor/identify/identifyingexecutor.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package identify provides the IdentifyingExecutor for identifying users based on provided attributes.
+package identify
+
+import (
+	"strings"
+
+	flowconst "github.com/asgardeo/thunder/internal/flow/constants"
+	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
+	"github.com/asgardeo/thunder/internal/system/log"
+	userprovider "github.com/asgardeo/thunder/internal/user/provider"
+)
+
+const loggerComponentName = "IdentifyingExecutor"
+
+// IdentifyingExecutor implements the ExecutorInterface for identifying users based on provided attributes.
+type IdentifyingExecutor struct {
+	internal flowmodel.Executor
+}
+
+// NewIdentifyingExecutor creates a new instance of IdentifyingExecutor.
+func NewIdentifyingExecutor(id, name string, properties map[string]string) *IdentifyingExecutor {
+	return &IdentifyingExecutor{
+		internal: *flowmodel.NewExecutor(id, name, []flowmodel.InputData{}, []flowmodel.InputData{}, properties),
+	}
+}
+
+// IdentifyUser identifies a user based on the provided attributes.
+func (i *IdentifyingExecutor) IdentifyUser(filters map[string]interface{},
+	execResp *flowmodel.ExecutorResponse) (*string, error) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	logger.Debug("Identifying user with filters")
+
+	userProvider := userprovider.NewUserProvider()
+	userService := userProvider.GetUserService()
+
+	userID, err := userService.IdentifyUser(filters)
+	if err != nil {
+		if strings.Contains(err.Error(), "user not found") {
+			logger.Debug("User not found for the provided filters")
+			execResp.Status = flowconst.ExecFailure
+			execResp.FailureReason = "User not found"
+			return nil, nil
+		}
+
+		logger.Error("Error identifying user", log.Error(err))
+		return nil, err
+	}
+	if userID == nil || *userID == "" {
+		logger.Debug("User not found for the provided filter")
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "User not found"
+		return nil, nil
+	}
+
+	return userID, nil
+}

--- a/backend/internal/executor/oauth/oauthexecutor.go
+++ b/backend/internal/executor/oauth/oauthexecutor.go
@@ -83,8 +83,9 @@ func NewOAuthExecutor(id, name string, defaultInputs []flowmodel.InputData, prop
 		}
 	}
 	return &OAuthExecutor{
-		internal:        *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}, properties),
-		oAuthProperties: *oAuthProps,
+		IdentifyingExecutor: identify.NewIdentifyingExecutor(id, name, properties),
+		internal:            *flowmodel.NewExecutor(id, name, defaultInputs, []flowmodel.InputData{}, properties),
+		oAuthProperties:     *oAuthProps,
 	}
 }
 

--- a/backend/internal/executor/oidcauth/constants.go
+++ b/backend/internal/executor/oidcauth/constants.go
@@ -19,4 +19,4 @@
 package oidcauth
 
 // idTokenNonUserAttributes contains the list of non-user attributes that are expected in the ID token.
-var idTokenNonUserAttributes = []string{"aud", "exp", "iat", "iss", "at_hash", "azp"}
+var idTokenNonUserAttributes = []string{"aud", "exp", "iat", "iss", "at_hash", "azp", "nonce", "sub"}

--- a/backend/internal/executor/oidcauth/oidcauthexecutor.go
+++ b/backend/internal/executor/oidcauth/oidcauthexecutor.go
@@ -47,8 +47,8 @@ type OIDCAuthExecutorInterface interface {
 
 // OIDCAuthExecutor implements the OIDCAuthExecutorInterface for handling generic OIDC authentication flows.
 type OIDCAuthExecutor struct {
-	internal oauth.OAuthExecutorInterface
 	*identify.IdentifyingExecutor
+	internal oauth.OAuthExecutorInterface
 }
 
 var _ flowmodel.ExecutorInterface = (*OIDCAuthExecutor)(nil)
@@ -76,7 +76,8 @@ func NewOIDCAuthExecutor(id, name string, defaultInputs []flowmodel.InputData, p
 	base := oauth.NewOAuthExecutor(id, name, defaultInputs, properties, &compOAuthProps)
 
 	return &OIDCAuthExecutor{
-		internal: base,
+		IdentifyingExecutor: identify.NewIdentifyingExecutor(id, name, properties),
+		internal:            base,
 	}
 }
 

--- a/backend/internal/executor/smsauth/smsauthexecutor.go
+++ b/backend/internal/executor/smsauth/smsauthexecutor.go
@@ -54,6 +54,8 @@ type SMSOTPAuthExecutor struct {
 	internal flowmodel.Executor
 }
 
+var _ flowmodel.ExecutorInterface = (*SMSOTPAuthExecutor)(nil)
+
 // NewSMSOTPAuthExecutor creates a new instance of SMSOTPAuthExecutor.
 func NewSMSOTPAuthExecutor(id, name string, properties map[string]string) *SMSOTPAuthExecutor {
 	defaultInputs := []flowmodel.InputData{


### PR DESCRIPTION
## Purpose

This pull request introduces enhancements to the executor framework by implementing user identification capabilities across various executors. A new `IdentifyingExecutor` is added to centralize user identification logic, and existing executors are updated to utilize this functionality. Additionally, error handling and user resolution mechanisms are improved for better reliability.

> :warning: **Note:** 
> With this change for federated login scenarios, always a unique user should be created in the local system with the matching unique identifier from the federated IDPs (`sub` claim for google/ oidc or `id` claim for github). Otherwise the authentication will fail with user not found error.

### User Identification Enhancements:
* [`backend/internal/executor/identify/identifyingexecutor.go`]: Added a new `IdentifyingExecutor` to encapsulate user identification logic, including methods to identify users based on attributes and handle errors gracefully.

### Integration of `IdentifyingExecutor`:
* [`backend/internal/executor/basicauth/basicauthexecutor.go`]: Integrated `IdentifyingExecutor` into `BasicAuthExecutor` for user identification and replaced the standalone `getAuthenticatedUser` function with an instance method.
* [`backend/internal/executor/oauth/oauthexecutor.go`]: Updated `OAuthExecutor` to use `IdentifyingExecutor` for resolving users based on the `sub` claim in OAuth responses.
* [`backend/internal/executor/oidcauth/oidcauthexecutor.go`]: Enhanced `OIDCAuthExecutor` to utilize `IdentifyingExecutor` for user identification using the `sub` claim in ID token claims.
* [`backend/internal/executor/githubauth/githubauthexecutor.go`]: Improved error handling for empty token scopes and added user resolution logic using the `id` claim from user info.
* [`backend/internal/executor/googleauth/googleauthexecutor.go`]: Enhanced error handling for missing `sub` claims and added fallback mechanisms for user resolution using ID tokens and user info.

### Refactor Google and OIDC Auth Executors:
* Refactor the Google and OIDC auth executors by moving the duplicated logic in the Google auth executor to the common OIDC auth executor.

### Miscellaneous Updates:
* Added interface assertions (`var _ flowmodel.ExecutorInterface = ...`) to ensure all executors conform to the `ExecutorInterface`.