### PR TITLE
Add user registration support for federated auth executors

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
@@ -1,0 +1,104 @@
+{
+    "id": "registration_flow_config_basic_google_github",
+    "type": "REGISTRATION",
+    "nodes": [
+        {
+            "id": "choose_auth",
+            "type": "DECISION",
+            "next": [
+                "basic_auth",
+                "google_auth",
+                "github_auth"
+            ]
+        },
+        {
+            "id": "basic_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "username",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "BasicAuthExecutor"
+            },
+            "next": [
+                "provisioning"
+            ]
+        },
+        {
+            "id": "google_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "code",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "nonce",
+                    "type": "string",
+                    "required": false
+                }
+            ],
+            "executor": {
+                "name": "GoogleOIDCAuthExecutor",
+                "idpName": "Google"
+            },
+            "next": [
+                "provisioning"
+            ]
+        },
+        {
+            "id": "github_auth",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "code",
+                    "type": "string",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "GithubOAuthExecutor",
+                "idpName": "Github"
+            },
+            "next": [
+                "provisioning"
+            ]
+        },
+        {
+            "id": "provisioning",
+            "type": "TASK_EXECUTION",
+            "inputData": [
+                {
+                    "name": "sub",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "email",
+                    "type": "string",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "ProvisioningExecutor"
+            },
+            "next": [
+                "authenticated"
+            ]
+        },
+        {
+            "id": "authenticated",
+            "type": "AUTHENTICATION_SUCCESS"
+        }
+    ]
+}

--- a/backend/internal/executor/oauth/oauthexecutor.go
+++ b/backend/internal/executor/oauth/oauthexecutor.go
@@ -252,7 +252,7 @@ func (o *OAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
 
 	if execResp.AuthenticatedUser.IsAuthenticated {
 		execResp.Status = flowconst.ExecComplete
-	} else {
+	} else if ctx.FlowType != flowconst.GraphTypeRegistration {
 		execResp.Status = flowconst.ExecFailure
 		execResp.FailureReason = "Authentication failed. Authorization code not provided or invalid."
 	}
@@ -479,24 +479,62 @@ func (o *OAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.NodeCo
 	if err != nil {
 		return nil, fmt.Errorf("failed to identify user with sub claim: %w", err)
 	}
+
+	// Handle registration flows.
+	if ctx.FlowType == flowconst.GraphTypeRegistration {
+		if execResp.Status == flowconst.ExecFailure {
+			if execResp.FailureReason == "User not found" {
+				logger.Debug("User not found for the provided sub claim. Proceeding with registration flow.")
+				execResp.Status = flowconst.ExecComplete
+				execResp.FailureReason = ""
+
+				if execResp.RuntimeData == nil {
+					execResp.RuntimeData = make(map[string]string)
+				}
+				execResp.RuntimeData["sub"] = sub
+
+				// TODO: Need to convert attributes as per the IDP to local attribute mapping
+				//  when the support is implemented.
+				return &authnmodel.AuthenticatedUser{
+					IsAuthenticated: false,
+					Attributes:      getUserAttributes(userInfo, ""),
+				}, nil
+			}
+			return nil, err
+		}
+
+		// At this point, a unique user is found in the system. Hence fail the execution.
+		execResp.Status = flowconst.ExecFailure
+		execResp.FailureReason = "User already exists with the provided sub claim."
+		return nil, nil
+	}
+
 	if execResp.Status == flowconst.ExecFailure {
 		return nil, nil
 	}
 
-	// Populate authenticated user from user info
+	// TODO: Need to convert attributes as per the IDP to local attribute mapping
+	//  when the support is implemented.
+	authenticatedUser := authnmodel.AuthenticatedUser{
+		IsAuthenticated: true,
+		UserID:          *userID,
+		Attributes:      getUserAttributes(userInfo, *userID),
+	}
+
+	return &authenticatedUser, nil
+}
+
+// getUserAttributes extracts user attributes from the user info map, excluding certain keys.
+func getUserAttributes(userInfo map[string]string, userID string) map[string]string {
 	attributes := make(map[string]string)
 	for key, value := range userInfo {
 		if key != "username" && key != "sub" {
 			attributes[key] = value
 		}
 	}
-	attributes["user_id"] = *userID
-
-	authenticatedUser := authnmodel.AuthenticatedUser{
-		IsAuthenticated: true,
-		UserID:          *userID,
-		Attributes:      attributes,
+	if userID != "" {
+		attributes["user_id"] = userID
 	}
 
-	return &authenticatedUser, nil
+	return attributes
 }

--- a/backend/internal/flow/engine/flowengine.go
+++ b/backend/internal/flow/engine/flowengine.go
@@ -178,7 +178,7 @@ func updateContextWithNodeResponse(engineCtx *model.EngineContext, nodeResp *mod
 	}
 
 	// Handle authenticated user from the node response
-	if nodeResp.AuthenticatedUser.IsAuthenticated {
+	if nodeResp.AuthenticatedUser.IsAuthenticated || engineCtx.FlowType == constants.GraphTypeRegistration {
 		prevAuthnUserAttrs := engineCtx.AuthenticatedUser.Attributes
 		engineCtx.AuthenticatedUser = nodeResp.AuthenticatedUser
 


### PR DESCRIPTION
## Purpose

This pull request refactors the OAuth and OIDC auth executors (i.e. Google and Github) to support user registration through the `ProvisioningExecutor`. Below is a summary of the most important changes grouped by theme.

### Support for User Registration:
* Added a JSON configuration file for registration with basic and social options: `registration_flow_config_basic_google_github.json`.

### Updates to Federated Auth Executors:
* Refactored `OAuthExecutor`, `OIDCAuthExecutor` and `GithubOAuthExecutor` to handle registration flows by checking `FlowType` and allowing user registration if the user does not exist.
* Adjusted logic in the `ProcessAuthFlowResponse` method to avoid authentication failure for registration flows when the user is not authenticated.

### Attribute Filtering in Provisioning Executor/ Flow Engine:
* Allow retrieving user attributes from the authenticated user during registration flows.

## Related Issues
- https://github.com/asgardeo/thunder/issues/178

## Related PRs
- https://github.com/asgardeo/thunder/pull/181 (#182 should be merged after this)