### PR TITLE
Fix go version format

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/asgardeo/thunder
 
-go 1.24.2
+go 1.24
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Purpose
This pull request makes a minor adjustment to the `go.mod` file by updating the Go version specification to remove the patch version, ensuring compatibility with a broader range of environments.

* [`backend/go.mod`](diffhunk://#diff-10e03f00c5bf8508d67e327c7a19879247498e8392ec699e9a05afcd36a8ed1fL3-R3): Changed `go 1.24.2` to `go 1.24` to specify the Go version without the patch version.