### PR TITLE
Fix SMS flow template inconsistency

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_sms_with_username.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_sms_with_username.json
@@ -1,13 +1,13 @@
 {
-    "id": "auth_flow_config_sms",
+    "id": "auth_flow_config_sms_with_username",
     "type": "AUTHENTICATION",
     "nodes": [
         {
-            "id": "prompt_mobile",
+            "id": "mobile_prompt_username",
             "type": "PROMPT_ONLY",
             "inputData": [
                 {
-                    "name": "mobileNumber",
+                    "name": "username",
                     "type": "string",
                     "required": true
                 }


### PR DESCRIPTION
## Purpose
This PR fixes the inconsistency between SMS OTP login auth and registration flow templates by modifying the existing sms auth flow template to use `mobileNumber` and move the existing username + OTP login to a new flow template.
