### PR TITLE
Fix password storing issue in user provisioning flow

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
@@ -77,18 +77,6 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "inputData": [
-                {
-                    "name": "sub",
-                    "type": "string",
-                    "required": true
-                },
-                {
-                    "name": "email",
-                    "type": "string",
-                    "required": true
-                }
-            ],
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/backend/internal/executor/provision/provisioningexecutor.go
+++ b/backend/internal/executor/provision/provisioningexecutor.go
@@ -127,6 +127,7 @@ func (p *ProvisioningExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.E
 	}
 
 	// Create the user in the store.
+	p.appendNonIdentifyingAttributes(ctx, &userAttributes)
 	createdUser, err := p.createUserInStore(ctx.FlowID, userAttributes)
 	if err != nil {
 		logger.Error("Failed to create user in the store", log.Error(err))
@@ -275,6 +276,16 @@ func (p *ProvisioningExecutor) getInputAttributes(ctx *flowmodel.NodeContext) ma
 	}
 
 	return attributesMap
+}
+
+// appendNonIdentifyingAttributes appends non-identifying attributes to the provided attributes map.
+func (p *ProvisioningExecutor) appendNonIdentifyingAttributes(ctx *flowmodel.NodeContext,
+	attributes *map[string]interface{}) {
+	if value, exists := ctx.UserInputData[passwordAttributeName]; exists {
+		(*attributes)[passwordAttributeName] = value
+	} else if runtimeValue, exists := ctx.RuntimeData[passwordAttributeName]; exists {
+		(*attributes)[passwordAttributeName] = runtimeValue
+	}
 }
 
 // createUserInStore creates a new user in the user store with the provided attributes.


### PR DESCRIPTION
## Purpose

This pull request fixes the issue of not provisioning user password during registration flows by adding support for storing non-identifying attributes during user creation. 

* **Configuration file update**: Removed the `inputData` section from `registration_flow_config_basic_google_github.json`, simplifying the task execution configuration for the provisioning step.
* **New helper method**: Added `appendNonIdentifyingAttributes` method in `ProvisioningExecutor` to handle non-identifying attributes, such as passwords, by checking both `UserInputData` and `RuntimeData`.
* **Integration of helper method**: Updated the `Execute` method in `ProvisioningExecutor` to call `appendNonIdentifyingAttributes` before creating the user in the store, ensuring non-identifying attributes are included.

## Related Issues
- https://github.com/asgardeo/thunder/issues/178