### PR TITLE
Update error codes of group API & simplify the 500 response

### DIFF
--- a/backend/internal/group/constants/errorconstants.go
+++ b/backend/internal/group/constants/errorconstants.go
@@ -26,49 +26,49 @@ var (
 	// ErrorInvalidRequestFormat is the error returned when the request format is invalid.
 	ErrorInvalidRequestFormat = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "GRP-60001",
+		Code:             "GRP-1001",
 		Error:            "Invalid request format",
 		ErrorDescription: "The request body is malformed or contains invalid data",
 	}
 	// ErrorMissingGroupID is the error returned when group ID is missing.
 	ErrorMissingGroupID = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "GRP-60002",
+		Code:             "GRP-1002",
 		Error:            "Invalid request format",
 		ErrorDescription: "Group ID is required",
 	}
 	// ErrorGroupNotFound is the error returned when a group is not found.
 	ErrorGroupNotFound = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "GRP-60003",
+		Code:             "GRP-1003",
 		Error:            "Group not found",
 		ErrorDescription: "The group with the specified id does not exist",
 	}
 	// ErrorGroupNameConflict is the error returned when a group name conflicts.
 	ErrorGroupNameConflict = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "GRP-60004",
+		Code:             "GRP-1004",
 		Error:            "Group name conflict",
 		ErrorDescription: "A group with the same name exists under the same parent",
 	}
 	// ErrorParentNotFound is the error returned when parent is not found.
 	ErrorParentNotFound = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "GRP-60005",
+		Code:             "GRP-1005",
 		Error:            "Parent not found",
 		ErrorDescription: "Parent group or organization unit not found",
 	}
 	// ErrorCannotDeleteGroup is the error returned when group cannot be deleted.
 	ErrorCannotDeleteGroup = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "GRP-60007",
+		Code:             "GRP-1006",
 		Error:            "Cannot delete group",
 		ErrorDescription: "Cannot delete group with child groups",
 	}
 	// ErrorInvalidUserID is the error returned when user ID is invalid.
 	ErrorInvalidUserID = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "GRP-60008",
+		Code:             "GRP-1007",
 		Error:            "Invalid user ID",
 		ErrorDescription: "One or more user IDs in the request do not exist",
 	}
@@ -79,7 +79,7 @@ var (
 	// ErrorInternalServerError is the error returned when an internal server error occurs.
 	ErrorInternalServerError = serviceerror.ServiceError{
 		Type:             serviceerror.ServerErrorType,
-		Code:             "GRP-65001",
+		Code:             "GRP-5000",
 		Error:            "Internal server error",
 		ErrorDescription: "An unexpected error occurred while processing the request",
 	}

--- a/docs/apis/group.yaml
+++ b/docs/apis/group.yaml
@@ -53,14 +53,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        "404":
-          description: Parent group not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+              examples:
+                invalid-request-format:
+                  summary: Invalid request format
+                  value:
+                    code: "GRP-1001"
+                    message: "Invalid request format"
+                    description: "The request body is malformed or contains invalid data"
         "500":
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: "Internal server error"
 
     post:
       tags:
@@ -131,14 +137,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+              examples:
+                invalid-request-format:
+                  summary: Invalid request format
+                  value:
+                    code: "GRP-1001"
+                    message: "Invalid request format"
+                    description: "The request body is malformed or contains invalid data"
+                invalid-user-id:
+                  summary: Invalid user ID
+                  value:
+                    code: "GRP-1007"
+                    message: "Invalid user ID"
+                    description: "One or more user IDs in the request do not exist"
+                parent-not-found:
+                  summary: Parent not found
+                  value:
+                    code: "GRP-1005"
+                    message: "Parent not found"
+                    description: "Parent group or organization unit not found"
         "409":
-          description: A group with the same name exists under the same parent
+          description: Conflict
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+              example:
+                code: "GRP-1004"
+                message: "Group name conflict"
+                description: "A group with the same name exists under the same parent"
         "500":
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: "Internal server error"
 
   /groups/{id}:
     get:
@@ -171,14 +205,33 @@ paths:
                   - "9f1e47d3-0347-4464-9f02-e0bfae02e896"
                 groups:
                   - "6b1e7b8d-7e19-41eb-8fa2-c0ee5bb67a94"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "GRP-1002"
+                message: "Invalid request format"
+                description: "Group ID is required"
         "404":
           description: Group not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+              example:
+                code: "GRP-1003"
+                message: "Group not found"
+                description: "The group with the specified id does not exist"
         "500":
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: "Internal server error"
 
     put:
       tags:
@@ -235,20 +288,58 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+              examples:
+                missing-group-id:
+                  summary: Missing group ID
+                  value:
+                    code: "GRP-1002"
+                    message: "Invalid request format"
+                    description: "Group ID is required"
+                invalid-request-format:
+                  summary: Invalid request format
+                  value:
+                    code: "GRP-1001"
+                    message: "Invalid request format"
+                    description: "The request body is malformed or contains invalid data"
+                invalid-user-id:
+                  summary: Invalid user ID
+                  value:
+                    code: "GRP-1007"
+                    message: "Invalid user ID"
+                    description: "One or more user IDs in the request do not exist"
+                parent-not-found:
+                  summary: Parent not found
+                  value:
+                    code: "GRP-1005"
+                    message: "Parent not found"
+                    description: "Parent group or organization unit not found"
         "404":
           description: Group not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+              example:
+                code: "GRP-1003"
+                message: "Group not found"
+                description: "The group with the specified id does not exist"
         "409":
-          description: A group with the same name exists under the same parent
+          description: Conflict
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+              example:
+                code: "GRP-1004"
+                message: "Group name conflict"
+                description: "A group with the same name exists under the same parent"
         "500":
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: "Internal server error"
 
     delete:
       tags:
@@ -265,13 +356,41 @@ paths:
         "204":
           description: Group deleted
         "400":
-          description: Cannot delete group with child groups
+          description: Bad request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+              examples:
+                missing-group-id:
+                  summary: Missing group ID
+                  value:
+                    code: "GRP-1002"
+                    message: "Invalid request format"
+                    description: "Group ID is required"
+                cannot-delete-group:
+                  summary: Cannot delete group
+                  value:
+                    code: "GRP-1006"
+                    message: "Cannot delete group"
+                    description: "Cannot delete group with child groups"
+        "404":
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "GRP-1003"
+                message: "Group not found"
+                description: "The group with the specified id does not exist"
         "500":
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: "Internal server error"
 
 components:
   schemas:
@@ -345,9 +464,14 @@ components:
       required: [code, message]
       properties:
         code:
-          type: integer
-          format: int64
+          type: string
+          description: Error code
+          example: "GRP-1001"
         message:
           type: string
+          description: Error message
+          example: "Invalid request format"
         description:
           type: string
+          description: Detailed error description
+          example: "The request body is malformed or contains invalid data"

--- a/tests/integration/group/groupapi_test.go
+++ b/tests/integration/group/groupapi_test.go
@@ -350,7 +350,7 @@ func (suite *GroupAPITestSuite) TestCreateGroupWithInvalidUserID() {
 	err = json.Unmarshal(body, &errorResp)
 	suite.Require().NoError(err)
 
-	suite.Equal("GRP-60008", errorResp["code"])
+	suite.Equal("GRP-1007", errorResp["code"])
 	suite.Equal("Invalid user ID", errorResp["message"])
 	suite.Contains(errorResp["description"], "One or more user IDs in the request do not exist")
 }
@@ -397,7 +397,7 @@ func (suite *GroupAPITestSuite) TestCreateGroupWithMixedValidInvalidUserIDs() {
 	err = json.Unmarshal(body, &errorResp)
 	suite.Require().NoError(err)
 
-	suite.Equal("GRP-60008", errorResp["code"])
+	suite.Equal("GRP-1007", errorResp["code"])
 	suite.Equal("Invalid user ID", errorResp["message"])
 }
 
@@ -484,7 +484,7 @@ func (suite *GroupAPITestSuite) TestUpdateGroupWithInvalidUserID() {
 	err = json.Unmarshal(body, &errorResp)
 	suite.Require().NoError(err)
 
-	suite.Equal("GRP-60008", errorResp["code"])
+	suite.Equal("GRP-1007", errorResp["code"])
 	suite.Equal("Invalid user ID", errorResp["message"])
 	suite.Contains(errorResp["description"], "One or more user IDs in the request do not exist")
 }
@@ -581,7 +581,7 @@ func (suite *GroupAPITestSuite) TestUpdateGroupWithMultipleInvalidUserIDs() {
 	err = json.Unmarshal(body, &errorResp)
 	suite.Require().NoError(err)
 
-	suite.Equal("GRP-60008", errorResp["code"])
+	suite.Equal("GRP-1007", errorResp["code"])
 	suite.Equal("Invalid user ID", errorResp["message"])
 }
 


### PR DESCRIPTION
## Purpose
This pull request introduces several updates to error handling, error codes, and API documentation for the group service. The main changes include refactoring error codes to a new format, improving error handling logic in the backend, updating API documentation to include examples for error responses, and aligning integration tests with the updated error codes.

### Error Code Refactoring:
* Updated error codes in `backend/internal/group/constants/errorconstants.go` to use a new format (e.g., `GRP-1001` instead of `GRP-60001`) for better readability and consistency. This includes client errors (e.g., `GRP-1001` for invalid request format) and server errors (e.g., `GRP-5000` for internal server errors). [[1]](diffhunk://#diff-9a59413761c1238217c81a23c820dcb4d682b6c18ce6a3061235dcd7b6b28af2L29-R71) [[2]](diffhunk://#diff-9a59413761c1238217c81a23c820dcb4d682b6c18ce6a3061235dcd7b6b28af2L82-R82)

### Backend Error Handling:
* Refactored the `handleError` method in `backend/internal/group/handler/grouphandler.go` to log internal server errors and return plain text responses for 500 errors. This ensures better debugging and user experience. [[1]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cL249-L256) [[2]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cR263-R276)

### API Documentation Updates:
* Enhanced `docs/apis/group.yaml` with detailed examples for error responses, including specific error codes, messages, and descriptions for scenarios like invalid request formats, missing group IDs, and group conflicts. Added plain text responses for internal server errors. [[1]](diffhunk://#diff-cb8dd21110695cef0e9da3afb382e0dbe7caa141bc21311f1077399ecbec695dL56-R69) [[2]](diffhunk://#diff-cb8dd21110695cef0e9da3afb382e0dbe7caa141bc21311f1077399ecbec695dR140-R175) [[3]](diffhunk://#diff-cb8dd21110695cef0e9da3afb382e0dbe7caa141bc21311f1077399ecbec695dR208-R234) [[4]](diffhunk://#diff-cb8dd21110695cef0e9da3afb382e0dbe7caa141bc21311f1077399ecbec695dR291-R342) [[5]](diffhunk://#diff-cb8dd21110695cef0e9da3afb382e0dbe7caa141bc21311f1077399ecbec695dL268-R393)
* Updated the `Error` schema in `docs/apis/group.yaml` to use string-based error codes with descriptive examples.

### Integration Test Updates:
* Adjusted integration tests in `tests/integration/group/groupapi_test.go` to validate the new error codes (e.g., `GRP-1007` for invalid user IDs) and ensure alignment with the refactored error handling logic. [[1]](diffhunk://#diff-2b206849ff7c4f3ee9f2414e29f1f445c23f9ca461e3d54d81cbd438d89ebc9eL353-R353) [[2]](diffhunk://#diff-2b206849ff7c4f3ee9f2414e29f1f445c23f9ca461e3d54d81cbd438d89ebc9eL400-R400) [[3]](diffhunk://#diff-2b206849ff7c4f3ee9f2414e29f1f445c23f9ca461e3d54d81cbd438d89ebc9eL487-R487) [[4]](diffhunk://#diff-2b206849ff7c4f3ee9f2414e29f1f445c23f9ca461e3d54d81cbd438d89ebc9eL584-R584)