### PR TITLE
Refactor grant handler validations

### DIFF
--- a/backend/internal/oauth/oauth2/authz/codepersistence.go
+++ b/backend/internal/oauth/oauth2/authz/codepersistence.go
@@ -104,7 +104,10 @@ func GetAuthorizationCode(clientID, authCode string) (model.AuthorizationCode, e
 
 	results, err := dbClient.Query(constants.QueryGetAuthorizationCode, clientID, authCode)
 	if err != nil {
-		return model.AuthorizationCode{}, errors.New("error while retrieving authorization code: " + err.Error())
+		return model.AuthorizationCode{}, fmt.Errorf("error while retrieving authorization code: %w", err)
+	}
+	if len(results) == 0 {
+		return model.AuthorizationCode{}, constants.ErrAuthorizationCodeNotFound
 	}
 	row := results[0]
 

--- a/backend/internal/oauth/oauth2/authz/constants/constants.go
+++ b/backend/internal/oauth/oauth2/authz/constants/constants.go
@@ -19,6 +19,8 @@
 // Package constants defines constants related to OAuth2 authorization.
 package constants
 
+import "errors"
+
 // Authorization code states.
 const (
 	AuthCodeStateActive   = "ACTIVE"
@@ -26,3 +28,6 @@ const (
 	AuthCodeStateExpired  = "EXPIRED"
 	AuthCodeStateRevoked  = "REVOKED"
 )
+
+// ErrAuthorizationCodeNotFound is returned when an authorization code is not found in the database.
+var ErrAuthorizationCodeNotFound = errors.New("authorization code not found")

--- a/backend/internal/oauth/oauth2/granthandlers/granthandler.go
+++ b/backend/internal/oauth/oauth2/granthandlers/granthandler.go
@@ -26,7 +26,7 @@ import (
 
 // GrantHandler defines the interface for handling OAuth 2.0 grants.
 type GrantHandler interface {
-	ValidateGrant(tokenRequest *model.TokenRequest) *model.ErrorResponse
-	HandleGrant(tokenRequest *model.TokenRequest,
-		oauthApp *appmodel.OAuthApplication) (*model.TokenResponse, *model.ErrorResponse)
+	ValidateGrant(tokenRequest *model.TokenRequest, oauthApp *appmodel.OAuthApplication) *model.ErrorResponse
+	HandleGrant(tokenRequest *model.TokenRequest, oauthApp *appmodel.OAuthApplication) (*model.TokenResponse,
+		*model.ErrorResponse)
 }

--- a/backend/internal/system/services/tokenservice.go
+++ b/backend/internal/system/services/tokenservice.go
@@ -28,14 +28,14 @@ import (
 // TokenService defines the service for handling OAuth2 token requests.
 type TokenService struct {
 	ServerOpsService server.ServerOperationServiceInterface
-	tokenHandler     *token.TokenHandler
+	tokenHandler     token.TokenHandlerInterface
 }
 
 // NewTokenService creates a new instance of TokenService.
 func NewTokenService(mux *http.ServeMux) ServiceInterface {
 	instance := &TokenService{
 		ServerOpsService: server.NewServerOperationService(),
-		tokenHandler:     &token.TokenHandler{},
+		tokenHandler:     token.NewTokenHandler(),
 	}
 	instance.RegisterRoutes(mux)
 


### PR DESCRIPTION
## Purpose

This pull request refactors the OAuth 2.0 grant handling logic by moving some validations done at `HandleGrant` to the `ValidateGrant` function. Additionally this fixed the runtime issue for invalid codes in token requests.

### Refactoring of Grant Handlers
* [`backend/internal/oauth/oauth2/granthandlers/granthandler.go`](diffhunk://#diff-59f7aa51179d30b9686236cd01ed54e74570d8e08090f9bf7c7c71131d7c8498L29-R31): Updated the `GrantHandler` interface to include the `oauthApp` parameter in both `ValidateGrant` and `HandleGrant` methods, enabling grant validation to incorporate application-specific logic.

### Error Handling Enhancements

* [`backend/internal/oauth/oauth2/authz/codepersistence.go`](diffhunk://#diff-2a6a5c76f53cb2d677962489c7062478f1f81ac754b5a49afae8e58fc3b3ec67R109-R111): Added a check to return an error when no authorization code is found, improving error handling during code retrieval.
