### PR TITLE
Add capability to fully build & test only the backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ $(TOOL_BIN):
 # Default target
 all: prepare clean test_unit build test_integration
 
+backend: prepare clean test_unit build_backend test_integration
+
 prepare:
 	chmod +x build.sh
 


### PR DESCRIPTION
## Purpose
This pull request introduces a new `backend` target to the `Makefile` to streamline the build and testing process for backend-specific tasks.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R37-R38): Added a `backend` target that runs `prepare`, `clean`, `test_unit`, `build_backend`, and `test_integration` in sequence.