### PR TITLE
Improve Group listing to support pagination

### DIFF
--- a/backend/internal/group/constants/errorconstants.go
+++ b/backend/internal/group/constants/errorconstants.go
@@ -72,6 +72,20 @@ var (
 		Error:            "Invalid user ID",
 		ErrorDescription: "One or more user IDs in the request do not exist",
 	}
+	// ErrorInvalidLimit is the error returned when limit parameter is invalid.
+	ErrorInvalidLimit = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "GRP-1011",
+		Error:            "Invalid limit parameter",
+		ErrorDescription: "The limit parameter must be a positive integer",
+	}
+	// ErrorInvalidOffset is the error returned when offset parameter is invalid.
+	ErrorInvalidOffset = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "GRP-1012",
+		Error:            "Invalid offset parameter",
+		ErrorDescription: "The offset parameter must be a non-negative integer",
+	}
 )
 
 // Server errors for group management operations.

--- a/backend/internal/group/model/group.go
+++ b/backend/internal/group/model/group.go
@@ -94,6 +94,21 @@ type UpdateGroupRequest struct {
 	Groups      []string `json:"groups,omitempty"`
 }
 
+// Link represents a pagination link.
+type Link struct {
+	Href string `json:"href"`
+	Rel  string `json:"rel"`
+}
+
+// GroupListResponse represents the response for listing groups with pagination.
+type GroupListResponse struct {
+	TotalResults int          `json:"totalResults"`
+	StartIndex   int          `json:"startIndex"`
+	Count        int          `json:"count"`
+	Groups       []GroupBasic `json:"groups"`
+	Links        []Link       `json:"links"`
+}
+
 // Error variables
 var (
 	// ErrGroupNotFound is returned when the group is not found in the system.

--- a/backend/internal/group/store/queries.go
+++ b/backend/internal/group/store/queries.go
@@ -24,10 +24,17 @@ import (
 )
 
 var (
-	// QueryGetGroupList is the query to get all root groups.
+	// QueryGetGroupListCount is the query to get total count of root groups.
+	QueryGetGroupListCount = dbmodel.DBQuery{
+		ID:    "GRQ-GROUP_MGT-00",
+		Query: `SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID IS NOT NULL AND PARENT_ID IS NULL`,
+	}
+
+	// QueryGetGroupList is the query to get root groups with pagination.
 	QueryGetGroupList = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-01",
-		Query: `SELECT GROUP_ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE OU_ID IS NOT NULL AND PARENT_ID IS NULL`,
+		ID: "GRQ-GROUP_MGT-01",
+		Query: `SELECT GROUP_ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE OU_ID IS NOT NULL AND PARENT_ID IS NULL ` +
+			`ORDER BY NAME LIMIT $1 OFFSET $2`,
 	}
 
 	// QueryCreateGroup is the query to create a new group.

--- a/tests/integration/group/model.go
+++ b/tests/integration/group/model.go
@@ -63,3 +63,18 @@ type UpdateGroupRequest struct {
 	Users       []string `json:"users,omitempty"`
 	Groups      []string `json:"groups,omitempty"`
 }
+
+// Link represents a pagination link.
+type Link struct {
+	Href string `json:"href"`
+	Rel  string `json:"rel"`
+}
+
+// GroupListResponse represents the response for listing groups with pagination.
+type GroupListResponse struct {
+	TotalResults int          `json:"totalResults"`
+	StartIndex   int          `json:"startIndex"`
+	Count        int          `json:"count"`
+	Groups       []GroupBasic `json:"groups"`
+	Links        []Link       `json:"links"`
+}


### PR DESCRIPTION
## Purpose
This pull request introduces pagination support for the group listing API, along with validation for pagination parameters and comprehensive test coverage. The changes span multiple files, including the addition of new error constants, updated service methods, and integration tests for the new functionality.

### Pagination Support

* [`backend/internal/group/handler/grouphandler.go`](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cR53-R65): Added logic to parse and validate `limit` and `offset` query parameters, with a default limit of 30. Updated the `HandleGroupListRequest` method to support pagination and return paginated responses. [[1]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cR53-R65) [[2]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cL61-R83) [[3]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cR350-R373)
* [`backend/internal/group/model/group.go`](diffhunk://#diff-2da7e5d6c9049c160de801c8a9623aebba03a9492083ba66b2481c892b3ff0a5R97-R111): Introduced the `GroupListResponse` type to represent paginated responses, including metadata like `TotalResults`, `StartIndex`, and `Links`.

### Validation and Error Handling

* [`backend/internal/group/constants/errorconstants.go`](diffhunk://#diff-9a59413761c1238217c81a23c820dcb4d682b6c18ce6a3061235dcd7b6b28af2R75-R88): Added new error constants `ErrorInvalidLimit` and `ErrorInvalidOffset` for invalid pagination parameters.
* [`backend/internal/group/service/groupservice.go`](diffhunk://#diff-c968c9fcf81977db22a427b042701414eb10548b606387f7e16ecf05adc6e706L53-R69): Implemented validation for pagination parameters and added helper functions to build pagination links in the response. [[1]](diffhunk://#diff-c968c9fcf81977db22a427b042701414eb10548b606387f7e16ecf05adc6e706L53-R69) [[2]](diffhunk://#diff-c968c9fcf81977db22a427b042701414eb10548b606387f7e16ecf05adc6e706R436-R487)

### Database Query Updates

* [`backend/internal/group/store/queries.go`](diffhunk://#diff-1aa52af79e1228b9c89735059149bb0fab70f9b698b47780099bded5cd1288ccL27-R37): Added a query to retrieve the total count of groups (`QueryGetGroupListCount`) and updated the `QueryGetGroupList` to support pagination using `LIMIT` and `OFFSET`.
* [`backend/internal/group/store/store.go`](diffhunk://#diff-637b6648954f02fec855bad351162b87625a1bec21ef23a90a3b0de3d9a50c5dL35-R84): Updated `GetGroupList` to accept pagination parameters and added a new method `GetGroupListCount` to fetch the total number of groups.

### Integration Tests

* [`tests/integration/group/groupapi_test.go`](diffhunk://#diff-2b206849ff7c4f3ee9f2414e29f1f445c23f9ca461e3d54d81cbd438d89ebc9eL142-R156): Added tests to verify pagination functionality, including valid and invalid parameter scenarios, and the default behavior when only `offset` is provided. [[1]](diffhunk://#diff-2b206849ff7c4f3ee9f2414e29f1f445c23f9ca461e3d54d81cbd438d89ebc9eL142-R156) [[2]](diffhunk://#diff-2b206849ff7c4f3ee9f2414e29f1f445c23f9ca461e3d54d81cbd438d89ebc9eR166-R313)
* [`tests/integration/group/model.go`](diffhunk://#diff-62a96cc2c665e66d3c9d9ef03537ab1968e17eda3c2b653f55ea515cf27220a7R66-R80): Added the `GroupListResponse` type to match the updated API response structure for testing purposes.