### PR TITLE
Fix HTTP client test

### DIFF
--- a/backend/internal/system/http/httpclient_test.go
+++ b/backend/internal/system/http/httpclient_test.go
@@ -161,13 +161,19 @@ func (suite *HTTPClientTestSuite) TestGet() {
 }
 
 func (suite *HTTPClientTestSuite) TestDoWithError() {
+	// Create a test server and immediately close it to ensure the
+	// connection attempt fails without relying on external network
+	// conditions.
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	testServer.Close()
+
 	client := NewHTTPClient()
 
-	// Create a request to invalid URL
-	req, err := http.NewRequest("GET", "http://invalid-url-that-does-not-exist", nil)
+	// Create a request to the closed server
+	req, err := http.NewRequest("GET", testServer.URL, nil)
 	assert.NoError(suite.T(), err)
 
-	// Execute the request - should fail
+	// Execute the request - should fail because the server is closed
 	resp, err := client.Do(req)
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), resp)


### PR DESCRIPTION
## Summary
- ensure `TestDoWithError` fails reliably without external network

## Testing
- `go test ./...` in `backend`
- `go test ./...` in `tests/integration` *(fails: dial tcp [::1]:8095: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687648f96c008321ad898de976aa61ce