### PR TITLE
Introduce name, handle conflict check in OU impl

### DIFF
--- a/backend/internal/ou/service/ouservice.go
+++ b/backend/internal/ou/service/ouservice.go
@@ -214,18 +214,10 @@ func (ous *OrganizationUnitService) UpdateOrganizationUnit(
 
 	var nameConflict bool
 	if existingOU.Parent != request.Parent || existingOU.Name != request.Name {
-		if request.Parent == nil {
-			nameConflict, err = store.CheckOrganizationUnitNameConflict(request.Name, request.Parent)
-			if err != nil {
-				logger.Error("Failed to check organization unit name conflict", log.Error(err))
-				return model.OrganizationUnit{}, &constants.ErrorInternalServerError
-			}
-		} else {
-			nameConflict, err = store.CheckOrganizationUnitNameConflictForUpdate(request.Name, request.Parent, id)
-			if err != nil {
-				logger.Error("Failed to check organization unit name conflict", log.Error(err))
-				return model.OrganizationUnit{}, &constants.ErrorInternalServerError
-			}
+		nameConflict, err = store.CheckOrganizationUnitNameConflict(request.Name, request.Parent)
+		if err != nil {
+			logger.Error("Failed to check organization unit name conflict", log.Error(err))
+			return model.OrganizationUnit{}, &constants.ErrorInternalServerError
 		}
 	}
 
@@ -235,18 +227,10 @@ func (ous *OrganizationUnitService) UpdateOrganizationUnit(
 
 	var handleConflict bool
 	if existingOU.Parent != request.Parent || existingOU.Handle != request.Handle {
-		if request.Parent == nil {
-			handleConflict, err = store.CheckOrganizationUnitHandleConflict(request.Handle, request.Parent)
-			if err != nil {
-				logger.Error("Failed to check organization unit handle conflict", log.Error(err))
-				return model.OrganizationUnit{}, &constants.ErrorInternalServerError
-			}
-		} else {
-			handleConflict, err = store.CheckOrganizationUnitHandleConflictForUpdate(request.Handle, request.Parent, id)
-			if err != nil {
-				logger.Error("Failed to check organization unit handle conflict", log.Error(err))
-				return model.OrganizationUnit{}, &constants.ErrorInternalServerError
-			}
+		handleConflict, err = store.CheckOrganizationUnitHandleConflict(request.Handle, request.Parent)
+		if err != nil {
+			logger.Error("Failed to check organization unit handle conflict", log.Error(err))
+			return model.OrganizationUnit{}, &constants.ErrorInternalServerError
 		}
 	}
 

--- a/backend/internal/ou/store/queries.go
+++ b/backend/internal/ou/store/queries.go
@@ -75,33 +75,32 @@ var (
 		Query: `SELECT GROUP_ID FROM "GROUP" WHERE OU_ID = $1 AND PARENT_ID IS NULL`,
 	}
 
+	// QueryCheckOrganizationUnitHandleConflict is the query to check if an organization
+	// unit handle conflicts under the same parent.
+	QueryCheckOrganizationUnitHandleConflict = dbmodel.DBQuery{
+		ID:    "OUQ-OU_MGT-10",
+		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE HANDLE = $1 AND PARENT_ID = $2`,
+	}
+
+	// QueryCheckOrganizationUnitHandleConflictRoot is the query to check if an organization
+	// unit handle conflicts at root level.
+	QueryCheckOrganizationUnitHandleConflictRoot = dbmodel.DBQuery{
+		ID:    "OUQ-OU_MGT-11",
+		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE HANDLE = $1 AND PARENT_ID IS NULL`,
+	}
+
 	// QueryCheckOrganizationUnitNameConflict is the query to check if an organization
 	// unit name conflicts under the same parent.
 	QueryCheckOrganizationUnitNameConflict = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-10",
+		ID:    "OUQ-OU_MGT-12",
 		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE NAME = $1 AND PARENT_ID = $2`,
-	}
-
-	// QueryCheckOrganizationUnitNameConflictForUpdate is the query to check name conflict during update.
-	QueryCheckOrganizationUnitNameConflictForUpdate = dbmodel.DBQuery{
-		ID: "OUQ-OU_MGT-11",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE NAME = $1 AND PARENT_ID = $2 ` +
-			`AND OU_ID != $3`,
 	}
 
 	// QueryCheckOrganizationUnitNameConflictRoot is the query to check if an organization
 	// unit name conflicts at root level.
 	QueryCheckOrganizationUnitNameConflictRoot = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-12",
+		ID:    "OUQ-OU_MGT-13",
 		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE NAME = $1 AND PARENT_ID IS NULL`,
-	}
-
-	// QueryCheckOrganizationUnitNameConflictRootForUpdate is the query to check name
-	// conflict at root level during update.
-	QueryCheckOrganizationUnitNameConflictRootForUpdate = dbmodel.DBQuery{
-		ID: "OUQ-OU_MGT-13",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE NAME = $1 AND PARENT_ID IS NULL ` +
-			`AND OU_ID != $2`,
 	}
 
 	// QueryCheckOrganizationUnitHasUsersOrGroups is the query to check if an organization unit has users or groups.
@@ -111,35 +110,6 @@ var (
 					(SELECT COUNT(*) FROM ORGANIZATION_UNIT WHERE PARENT_ID = $1) +
 					(SELECT COUNT(*) FROM "USER" WHERE OU_ID = $1) + 
 					(SELECT COUNT(*) FROM "GROUP" WHERE OU_ID = $1) as count`,
-	}
-
-	// QueryCheckOrganizationUnitHandleConflict is the query to check if an organization
-	// unit handle conflicts under the same parent.
-	QueryCheckOrganizationUnitHandleConflict = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-15",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE HANDLE = $1 AND PARENT_ID = $2`,
-	}
-
-	// QueryCheckOrganizationUnitHandleConflictForUpdate is the query to check handle conflict during update.
-	QueryCheckOrganizationUnitHandleConflictForUpdate = dbmodel.DBQuery{
-		ID: "OUQ-OU_MGT-16",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE HANDLE = $1 AND PARENT_ID = $2 ` +
-			`AND OU_ID != $3`,
-	}
-
-	// QueryCheckOrganizationUnitHandleConflictRoot is the query to check if an organization
-	// unit handle conflicts at root level.
-	QueryCheckOrganizationUnitHandleConflictRoot = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-17",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE HANDLE = $1 AND PARENT_ID IS NULL`,
-	}
-
-	// QueryCheckOrganizationUnitHandleConflictRootForUpdate is the query to check handle
-	// conflict at root level during update.
-	QueryCheckOrganizationUnitHandleConflictRootForUpdate = dbmodel.DBQuery{
-		ID: "OUQ-OU_MGT-18",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE HANDLE = $1 AND PARENT_ID IS NULL ` +
-			`AND OU_ID != $2`,
 	}
 )
 

--- a/backend/internal/ou/store/store.go
+++ b/backend/internal/ou/store/store.go
@@ -300,17 +300,6 @@ func CheckOrganizationUnitNameConflict(name string, parentID *string) (bool, err
 	)
 }
 
-// CheckOrganizationUnitNameConflictForUpdate checks if an organization unit name conflicts during update.
-func CheckOrganizationUnitNameConflictForUpdate(name string, parentID *string, ouID string) (bool, error) {
-	return checkConflict(
-		QueryCheckOrganizationUnitNameConflictForUpdate,
-		QueryCheckOrganizationUnitNameConflictRootForUpdate,
-		name,
-		parentID,
-		ouID,
-	)
-}
-
 // CheckOrganizationUnitHandleConflict checks if an organization unit handle conflicts under the same parent.
 func CheckOrganizationUnitHandleConflict(handle string, parentID *string) (bool, error) {
 	return checkConflict(
@@ -318,17 +307,6 @@ func CheckOrganizationUnitHandleConflict(handle string, parentID *string) (bool,
 		QueryCheckOrganizationUnitHandleConflictRoot,
 		handle,
 		parentID,
-	)
-}
-
-// CheckOrganizationUnitHandleConflictForUpdate checks if an organization unit handle conflicts during update.
-func CheckOrganizationUnitHandleConflictForUpdate(handle string, parentID *string, ouID string) (bool, error) {
-	return checkConflict(
-		QueryCheckOrganizationUnitHandleConflictForUpdate,
-		QueryCheckOrganizationUnitHandleConflictRootForUpdate,
-		handle,
-		parentID,
-		ouID,
 	)
 }
 


### PR DESCRIPTION
## Purpose
This pull request simplifies the handling of organization unit (OU) name and handle conflict checks by removing redundant methods and queries. The changes streamline the codebase and improve maintainability by consolidating conflict-checking logic.

### Conflict-checking logic simplification:

* Removed conditional logic in `UpdateOrganizationUnit` to use a single method for checking name and handle conflicts, regardless of whether the operation is an update or a new creation. (`backend/internal/ou/service/ouservice.go`) [[1]](diffhunk://#diff-a3f9ac4d3a59e9804a4ff0c0ebdcfc4233de31b9ee092cad8f3ff4117f303430L217-L229) [[2]](diffhunk://#diff-a3f9ac4d3a59e9804a4ff0c0ebdcfc4233de31b9ee092cad8f3ff4117f303430L238-L250)

* Deleted redundant queries for checking name and handle conflicts during updates, as they are no longer required. Consolidated conflict-checking queries for both root-level and parent-level scenarios. (`backend/internal/ou/store/queries.go`) [[1]](diffhunk://#diff-15dd481b97543fd8035acb0e3b9d79dfc31b41348dab761b4230dcc78704422dL78-R103) [[2]](diffhunk://#diff-15dd481b97543fd8035acb0e3b9d79dfc31b41348dab761b4230dcc78704422dL115-L143)

* Removed unused methods `CheckOrganizationUnitNameConflictForUpdate` and `CheckOrganizationUnitHandleConflictForUpdate` from the `store` package, as their functionality is now covered by the simplified logic. (`backend/internal/ou/store/store.go`) [[1]](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L303-L313) [[2]](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L324-L334)