### PR TITLE
Update OU Listing to retrieve only the root OUs

### DIFF
--- a/backend/internal/ou/model/ou.go
+++ b/backend/internal/ou/model/ou.go
@@ -25,7 +25,6 @@ type OrganizationUnitBasic struct {
 	Handle            string   `json:"handle"`
 	Name              string   `json:"name"`
 	Description       string   `json:"description,omitempty"`
-	Parent            *string  `json:"parent"`
 	OrganizationUnits []string `json:"organizationUnits"`
 }
 

--- a/backend/internal/ou/store/queries.go
+++ b/backend/internal/ou/store/queries.go
@@ -27,16 +27,17 @@ import (
 )
 
 var (
-	// QueryGetOrganizationUnitListCount is the query to get total count of organization units.
-	QueryGetOrganizationUnitListCount = dbmodel.DBQuery{
+	// QueryGetRootOrganizationUnitListCount is the query to get total count of organization units.
+	QueryGetRootOrganizationUnitListCount = dbmodel.DBQuery{
 		ID:    "OUQ-OU_MGT-00",
-		Query: `SELECT COUNT(*) as total FROM ORGANIZATION_UNIT`,
+		Query: `SELECT COUNT(*) as total FROM ORGANIZATION_UNIT WHERE PARENT_ID IS NULL`,
 	}
 
-	// QueryGetOrganizationUnitList is the query to get organization units with pagination.
-	QueryGetOrganizationUnitList = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-01",
-		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, PARENT_ID FROM ORGANIZATION_UNIT ORDER BY NAME LIMIT $1 OFFSET $2`,
+	// QueryGetRootOrganizationUnitList is the query to get organization units with pagination.
+	QueryGetRootOrganizationUnitList = dbmodel.DBQuery{
+		ID: "OUQ-OU_MGT-01",
+		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, PARENT_ID FROM ORGANIZATION_UNIT WHERE PARENT_ID IS NULL ` +
+			`ORDER BY NAME LIMIT $1 OFFSET $2`,
 	}
 
 	// QueryCreateOrganizationUnit is the query to create a new organization unit.

--- a/backend/internal/ou/store/store.go
+++ b/backend/internal/ou/store/store.go
@@ -45,7 +45,7 @@ func GetOrganizationUnitListCount() (int, error) {
 		}
 	}()
 
-	results, err := dbClient.Query(QueryGetOrganizationUnitListCount)
+	results, err := dbClient.Query(QueryGetRootOrganizationUnitListCount)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -76,7 +76,7 @@ func GetOrganizationUnitList(limit, offset int) ([]model.OrganizationUnitBasic, 
 		}
 	}()
 
-	results, err := dbClient.Query(QueryGetOrganizationUnitList, limit, offset)
+	results, err := dbClient.Query(QueryGetRootOrganizationUnitList, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -395,19 +395,11 @@ func buildOrganizationUnitBasicFromResultRow(
 		}
 	}
 
-	var parentID *string
-	if parent, ok := row["parent_id"]; ok && parent != nil {
-		if parentStr, ok := parent.(string); ok {
-			parentID = &parentStr
-		}
-	}
-
 	return model.OrganizationUnitBasic{
 		ID:                ouID,
 		Handle:            handle,
 		Name:              name,
 		Description:       description,
-		Parent:            parentID,
 		OrganizationUnits: make([]string, 0), // Will be populated by caller
 	}, nil
 }
@@ -421,12 +413,19 @@ func buildOrganizationUnitFromResultRow(
 		return model.OrganizationUnit{}, fmt.Errorf("failed to build organization unit: %w", err)
 	}
 
+	var parentID *string
+	if parent, ok := row["parent_id"]; ok && parent != nil {
+		if parentStr, ok := parent.(string); ok {
+			parentID = &parentStr
+		}
+	}
+
 	return model.OrganizationUnit{
 		ID:                ou.ID,
 		Handle:            ou.Handle,
 		Name:              ou.Name,
 		Description:       ou.Description,
-		Parent:            ou.Parent,
+		Parent:            parentID,
 		Users:             []string{},
 		Groups:            []string{},
 		OrganizationUnits: []string{},

--- a/tests/integration/ou/ouapi_test.go
+++ b/tests/integration/ou/ouapi_test.go
@@ -172,21 +172,14 @@ func (suite *OUAPITestSuite) TestListOrganizationUnits() {
 
 	// Verify the list contains our created OUs
 	foundParent := false
-	foundChild := false
 	for _, ou := range ouListResponse.OrganizationUnits {
 		if ou.ID == createdOUID {
 			foundParent = true
 			suite.Equal(ouToCreate.Name, ou.Name)
 			suite.Equal(ouToCreate.Description, ou.Description)
 		}
-		if ou.ID == createdChildOUID {
-			foundChild = true
-			suite.Equal(childOUToCreate.Name, ou.Name)
-			suite.Equal(*childOUToCreate.Parent, *ou.Parent)
-		}
 	}
 	suite.True(foundParent, "Created parent OU should be in the list")
-	suite.True(foundChild, "Created child OU should be in the list")
 }
 
 func (suite *OUAPITestSuite) TestListOrganizationUnitsWithPagination() {


### PR DESCRIPTION
## Purpose
This pull request refactors the handling of organization units by focusing on root-level units and removing the `Parent` field from the `OrganizationUnitBasic` struct. The changes simplify the queries and data structures to better align with the new requirements, while also updating related integration tests.

### Model and Data Structure Changes:
* Removed the `Parent` field from the `OrganizationUnitBasic` struct in `ou.go`. (`[backend/internal/ou/model/ou.goL28](diffhunk://#diff-4d4890f9a2e4d14375477c5efa691745371d6f826272f079611b463004a16c38L28)`)

### Query Updates:
* Renamed and updated queries in `queries.go` to focus on root-level organization units by adding a `WHERE PARENT_ID IS NULL` condition. (`[backend/internal/ou/store/queries.goL30-R40](diffhunk://#diff-15dd481b97543fd8035acb0e3b9d79dfc31b41348dab761b4230dcc78704422dL30-R40)`)

### Store Logic Adjustments:
* Updated the `GetOrganizationUnitListCount` and `GetOrganizationUnitList` functions in `store.go` to use the new root-level queries. (`[[1]](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L48-R48)`, `[[2]](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L79-R79)`)
* Removed the logic for handling the `Parent` field in `buildOrganizationUnitBasicFromResultRow` and adjusted `buildOrganizationUnitFromResultRow` to handle the `Parent` field only for the full `OrganizationUnit` model. (`[[1]](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L398-L410)`, `[[2]](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9R416-R428)`)

### Test Updates:
* Modified the `TestListOrganizationUnits` integration test in `ouapi_test.go` to remove assertions related to child organization units, reflecting the focus on root-level units. (`[tests/integration/ou/ouapi_test.goL175-L189](diffhunk://#diff-ab32c886355428cccc8093b5d19b30908453d73927245406f683be77da4db60dL175-L189)`)