### PR TITLE
Exclude child attribute from the OU list response

### DIFF
--- a/backend/internal/ou/model/ou.go
+++ b/backend/internal/ou/model/ou.go
@@ -21,11 +21,10 @@ package model
 
 // OrganizationUnitBasic represents the basic information of an organization unit.
 type OrganizationUnitBasic struct {
-	ID                string   `json:"id"`
-	Handle            string   `json:"handle"`
-	Name              string   `json:"name"`
-	Description       string   `json:"description,omitempty"`
-	OrganizationUnits []string `json:"organizationUnits"`
+	ID          string `json:"id"`
+	Handle      string `json:"handle"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }
 
 // OrganizationUnit represents a complete organization unit with users, groups, and sub organization units.

--- a/backend/internal/ou/service/ouservice.go
+++ b/backend/internal/ou/service/ouservice.go
@@ -77,22 +77,6 @@ func (ous *OrganizationUnitService) GetOrganizationUnitList(limit, offset int) (
 		return nil, &constants.ErrorInternalServerError
 	}
 
-	parentIDs := make([]string, len(ouList))
-	for i, ou := range ouList {
-		parentIDs[i] = ou.ID
-	}
-
-	subOUsMap, err := store.GetSubOrganizationUnitsByParentIDs(parentIDs)
-	if err != nil {
-		logger.Error("Failed to get sub organization units", log.Error(err))
-		return nil, &constants.ErrorInternalServerError
-	}
-
-	for i := range ouList {
-		if subOUs, exists := subOUsMap[ouList[i].ID]; exists {
-			ouList[i].OrganizationUnits = subOUs
-		}
-	}
 	response := &model.OrganizationUnitListResponse{
 		TotalResults:      totalCount,
 		OrganizationUnits: ouList,

--- a/backend/internal/ou/store/queries.go
+++ b/backend/internal/ou/store/queries.go
@@ -19,12 +19,7 @@
 // Package store provides the implementation for organization unit persistence operations.
 package store
 
-import (
-	"fmt"
-	"strings"
-
-	dbmodel "github.com/asgardeo/thunder/internal/system/database/model"
-)
+import dbmodel "github.com/asgardeo/thunder/internal/system/database/model"
 
 var (
 	// QueryGetRootOrganizationUnitListCount is the query to get total count of organization units.
@@ -119,34 +114,3 @@ var (
 					(SELECT COUNT(*) FROM "GROUP" WHERE OU_ID = $1) as count`,
 	}
 )
-
-// buildSubOrganizationUnitsQuery constructs a query to get sub organization units for multiple parent IDs.
-func buildSubOrganizationUnitsQuery(parentIDs []string) (dbmodel.DBQuery, []interface{}, error) {
-	if len(parentIDs) == 0 {
-		return dbmodel.DBQuery{}, nil, fmt.Errorf("parentIDs list cannot be empty")
-	}
-
-	args := make([]interface{}, len(parentIDs))
-
-	postgresPlaceholders := make([]string, len(parentIDs))
-	sqlitePlaceholders := make([]string, len(parentIDs))
-
-	for i, parentID := range parentIDs {
-		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+1)
-		sqlitePlaceholders[i] = "?"
-		args[i] = parentID
-	}
-
-	baseQuery := "SELECT OU_ID, PARENT_ID FROM ORGANIZATION_UNIT WHERE PARENT_ID IN (%s)"
-	postgresQuery := fmt.Sprintf(baseQuery, strings.Join(postgresPlaceholders, ","))
-	sqliteQuery := fmt.Sprintf(baseQuery, strings.Join(sqlitePlaceholders, ","))
-
-	query := dbmodel.DBQuery{
-		ID:            "OUQ-OU_MGT-02",
-		Query:         postgresQuery,
-		PostgresQuery: postgresQuery,
-		SQLiteQuery:   sqliteQuery,
-	}
-
-	return query, args, nil
-}


### PR DESCRIPTION
## Purpose
This pull request removes the handling of sub-organization units from the `OrganizationUnit` model and related services, simplifying the codebase. The most important changes include the removal of the `OrganizationUnits` field from the `OrganizationUnitBasic` struct, the deletion of methods and logic for retrieving sub-organization units, and the cleanup of unused fields in related functions.

### Removal of sub-organization unit handling:

* [`backend/internal/ou/model/ou.go`](diffhunk://#diff-4d4890f9a2e4d14375477c5efa691745371d6f826272f079611b463004a16c38L28): Removed the `OrganizationUnits` field from the `OrganizationUnitBasic` struct, as sub-organization units are no longer part of the model.

* [`backend/internal/ou/service/ouservice.go`](diffhunk://#diff-a3f9ac4d3a59e9804a4ff0c0ebdcfc4233de31b9ee092cad8f3ff4117f303430L80-L95): Removed logic for fetching and populating sub-organization units in the `GetOrganizationUnitList` method.

* [`backend/internal/ou/store/store.go`](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L225-L275): Deleted the `GetSubOrganizationUnitsByParentIDs` function, which was responsible for retrieving sub-organization units from the database.

### Code cleanup:

* [`backend/internal/ou/store/store.go`](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L403): Removed the initialization of the `OrganizationUnits` field in the `buildOrganizationUnitBasicFromResultRow` function, as it is no longer needed.

* [`backend/internal/ou/store/store.go`](diffhunk://#diff-e9a68657b4073f9ae7d6b5d37c5516579b80b8ab07d96061a03ca31d95440be9L429-L431): Removed unused fields (`Users`, `Groups`, and `OrganizationUnits`) from the `buildOrganizationUnitFromResultRow` function.