### PR TITLE
Introduce GET, POST by handle path for Group API

### DIFF
--- a/backend/internal/group/model/group.go
+++ b/backend/internal/group/model/group.go
@@ -108,3 +108,10 @@ type MemberListResponse struct {
 	Members      []Member `json:"members"`
 	Links        []Link   `json:"links"`
 }
+
+// CreateGroupByPathRequest represents the request body for creating a group under a specific OU path.
+type CreateGroupByPathRequest struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Members     []Member `json:"members,omitempty"`
+}

--- a/backend/internal/group/store/queries.go
+++ b/backend/internal/group/store/queries.go
@@ -39,64 +39,76 @@ var (
 		Query: `SELECT GROUP_ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" ORDER BY NAME LIMIT $1 OFFSET $2`,
 	}
 
+	// QueryGetGroupsByOrganizationUnitCount is the query to get total count of groups by organization unit.
+	QueryGetGroupsByOrganizationUnitCount = dbmodel.DBQuery{
+		ID:    "GRQ-GROUP_MGT-02",
+		Query: `SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID = $1`,
+	}
+
+	// QueryGetGroupsByOrganizationUnit is the query to get groups by organization unit with pagination.
+	QueryGetGroupsByOrganizationUnit = dbmodel.DBQuery{
+		ID:    "GRQ-GROUP_MGT-03",
+		Query: `SELECT GROUP_ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE OU_ID = $1 ORDER BY NAME LIMIT $2 OFFSET $3`,
+	}
+
 	// QueryCreateGroup is the query to create a new group.
 	QueryCreateGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-02",
+		ID:    "GRQ-GROUP_MGT-04",
 		Query: `INSERT INTO "GROUP" (GROUP_ID, OU_ID, NAME, DESCRIPTION) VALUES ($1, $2, $3, $4)`,
 	}
 
 	// QueryGetGroupByID is the query to get a group by id.
 	QueryGetGroupByID = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-03",
+		ID:    "GRQ-GROUP_MGT-05",
 		Query: `SELECT GROUP_ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE GROUP_ID = $1`,
 	}
 
 	// QueryUpdateGroup is the query to update a group.
 	QueryUpdateGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-04",
+		ID:    "GRQ-GROUP_MGT-06",
 		Query: `UPDATE "GROUP" SET OU_ID = $2, NAME = $3, DESCRIPTION = $4 WHERE GROUP_ID = $1`,
 	}
 
 	// QueryDeleteGroup is the query to delete a group.
 	QueryDeleteGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-05",
+		ID:    "GRQ-GROUP_MGT-07",
 		Query: `DELETE FROM "GROUP" WHERE GROUP_ID = $1`,
 	}
 
 	// QueryGetGroupMembers is the query to get members assigned to a group.
 	QueryGetGroupMembers = dbmodel.DBQuery{
-		ID: "GRQ-GROUP_MGT-06",
+		ID: "GRQ-GROUP_MGT-08",
 		Query: `SELECT MEMBER_ID, MEMBER_TYPE FROM GROUP_MEMBER_REFERENCE WHERE GROUP_ID = $1 ` +
 			`ORDER BY MEMBER_TYPE, MEMBER_ID LIMIT $2 OFFSET $3`,
 	}
 
 	// QueryGetGroupMemberCount is the query to get total count of members in a group.
 	QueryGetGroupMemberCount = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-07",
+		ID:    "GRQ-GROUP_MGT-09",
 		Query: `SELECT COUNT(*) as total FROM GROUP_MEMBER_REFERENCE WHERE GROUP_ID = $1`,
 	}
 
 	// QueryDeleteGroupMembers is the query to delete all members assigned to a group.
 	QueryDeleteGroupMembers = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-08",
+		ID:    "GRQ-GROUP_MGT-10",
 		Query: `DELETE FROM GROUP_MEMBER_REFERENCE WHERE GROUP_ID = $1`,
 	}
 
 	// QueryAddMemberToGroup is the query to assign member to a group.
 	QueryAddMemberToGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-09",
+		ID:    "GRQ-GROUP_MGT-11",
 		Query: `INSERT INTO GROUP_MEMBER_REFERENCE (GROUP_ID, MEMBER_TYPE, MEMBER_ID) VALUES ($1, $2, $3)`,
 	}
 
 	// QueryCheckGroupNameConflict is the query to check if a group name conflicts within the same organization unit.
 	QueryCheckGroupNameConflict = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-10",
+		ID:    "GRQ-GROUP_MGT-12",
 		Query: `SELECT COUNT(*) as count FROM "GROUP" WHERE NAME = $1 AND OU_ID = $2`,
 	}
 
 	// QueryCheckGroupNameConflictForUpdate is the query to check name conflict during update.
 	QueryCheckGroupNameConflictForUpdate = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-11",
+		ID:    "GRQ-GROUP_MGT-13",
 		Query: `SELECT COUNT(*) as count FROM "GROUP" WHERE NAME = $1 AND OU_ID = $2 AND GROUP_ID != $3`,
 	}
 )
@@ -122,7 +134,7 @@ func buildBulkGroupExistsQuery(groupIDs []string) (dbmodel.DBQuery, []interface{
 	sqliteQuery := fmt.Sprintf(baseQuery, strings.Join(sqlitePlaceholders, ","))
 
 	query := dbmodel.DBQuery{
-		ID:            "ASQ-GROUP_MGT-12",
+		ID:            "ASQ-GROUP_MGT-14",
 		Query:         postgresQuery,
 		PostgresQuery: postgresQuery,
 		SQLiteQuery:   sqliteQuery,

--- a/tests/integration/group/group_tree_api_test.go
+++ b/tests/integration/group/group_tree_api_test.go
@@ -1,0 +1,630 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package group
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+var (
+	pathTestOU = CreateOURequest{
+		Name:        "Test Engineering",
+		Handle:      "test-engineering",
+		Description: "Test Engineering Unit for Group Tests",
+		Parent:      nil,
+	}
+
+	pathTestGroup = CreateGroupByPathRequest{
+		Name:        "Frontend Team",
+		Description: "Frontend development team",
+		Members: []Member{
+			{
+				Id:   "550e8400-e29b-41d4-a716-446655440000",
+				Type: MemberTypeUser,
+			},
+		},
+	}
+)
+
+var pathTestOUID string
+var pathTestGroupID string
+
+// CreateOURequest represents the request body for creating an organization unit.
+type CreateOURequest struct {
+	Handle      string  `json:"handle"`
+	Name        string  `json:"name"`
+	Description string  `json:"description,omitempty"`
+	Parent      *string `json:"parent,omitempty"`
+}
+
+// OrganizationUnit represents an organization unit.
+type OrganizationUnit struct {
+	ID          string  `json:"id"`
+	Handle      string  `json:"handle"`
+	Name        string  `json:"name"`
+	Description string  `json:"description,omitempty"`
+	Parent      *string `json:"parent"`
+}
+
+type GroupTreeAPITestSuite struct {
+	suite.Suite
+}
+
+func TestGroupTreeAPITestSuite(t *testing.T) {
+	suite.Run(t, new(GroupTreeAPITestSuite))
+}
+
+func (suite *GroupTreeAPITestSuite) SetupSuite() {
+	// Create OU for testing
+	id, err := createOUForGroupTests(suite, pathTestOU)
+	suite.Require().NoError(err, "Failed to create OU during setup: %v", err)
+	pathTestOUID = id
+}
+
+func (suite *GroupTreeAPITestSuite) TearDownSuite() {
+	// Clean up created group if exists
+	if pathTestGroupID != "" {
+		err := deleteGroupByID(suite, pathTestGroupID)
+		if err != nil {
+			suite.T().Logf("Failed to delete group during teardown: %v", err)
+		}
+	}
+
+	// Clean up created OU
+	if pathTestOUID != "" {
+		err := deleteOUByID(suite, pathTestOUID)
+		if err != nil {
+			suite.T().Logf("Failed to delete OU during teardown: %v", err)
+		}
+	}
+}
+
+// TestGetGroupsByPath tests retrieving groups by organization unit handle path
+func (suite *GroupTreeAPITestSuite) TestGetGroupsByPath() {
+	if pathTestOUID == "" {
+		suite.T().Fatal("OU ID is not available for path-based group retrieval")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/tree/"+pathTestOU.Handle, nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err, "Failed to read response body: %v", err)
+
+	var groupListResponse GroupListResponse
+	err = json.Unmarshal(body, &groupListResponse)
+	suite.Require().NoError(err)
+
+	// Verify the response structure
+	suite.GreaterOrEqual(groupListResponse.TotalResults, 0)
+	suite.Equal(groupListResponse.StartIndex, 1)
+	suite.Equal(groupListResponse.Count, len(groupListResponse.Groups))
+}
+
+// TestGetGroupsByInvalidPath tests retrieving groups by invalid organization unit handle path
+func (suite *GroupTreeAPITestSuite) TestGetGroupsByInvalidPath() {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/tree/nonexistent-ou", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusNotFound, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	var errorResp ErrorResponse
+	err = json.Unmarshal(body, &errorResp)
+	suite.Require().NoError(err)
+
+	suite.Equal("GRP-1003", errorResp.Code)
+	suite.Equal("Group not found", errorResp.Message)
+}
+
+// TestGetGroupsByPathWithPagination tests retrieving groups by path with pagination parameters
+func (suite *GroupTreeAPITestSuite) TestGetGroupsByPathWithPagination() {
+	if pathTestOUID == "" {
+		suite.T().Fatal("OU ID is not available for pagination test")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/tree/"+pathTestOU.Handle+"?limit=5&offset=0", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	var groupListResponse GroupListResponse
+	err = json.Unmarshal(body, &groupListResponse)
+	suite.Require().NoError(err)
+
+	// Verify pagination parameters
+	suite.GreaterOrEqual(groupListResponse.TotalResults, 0)
+	suite.Equal(groupListResponse.StartIndex, 1)
+	suite.LessOrEqual(groupListResponse.Count, 5)
+}
+
+// TestCreateGroupByPath tests creating a group by organization unit handle path
+func (suite *GroupTreeAPITestSuite) TestCreateGroupByPath() {
+	if pathTestOUID == "" {
+		suite.T().Fatal("OU ID is not available for group creation by path")
+	}
+
+	jsonData, err := json.Marshal(pathTestGroup)
+	suite.Require().NoError(err)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/groups/tree/"+pathTestOU.Handle, bytes.NewBuffer(jsonData))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusCreated, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	var createdGroup Group
+	err = json.Unmarshal(body, &createdGroup)
+	suite.Require().NoError(err)
+
+	// Verify the created group
+	suite.Equal(pathTestGroup.Name, createdGroup.Name)
+	suite.Equal(pathTestGroup.Description, createdGroup.Description)
+	suite.Equal(pathTestOUID, createdGroup.OrganizationUnitId)
+	suite.Equal(len(pathTestGroup.Members), len(createdGroup.Members))
+
+	// Store the group ID for cleanup
+	pathTestGroupID = createdGroup.Id
+
+	suite.T().Logf("Created group with ID: %s", pathTestGroupID)
+}
+
+// TestCreateGroupByInvalidPath tests creating a group by invalid organization unit handle path
+func (suite *GroupTreeAPITestSuite) TestCreateGroupByInvalidPath() {
+	createRequest := CreateGroupByPathRequest{
+		Name:        "Invalid Path Group",
+		Description: "Group created with invalid path",
+		Members:     []Member{},
+	}
+
+	jsonData, err := json.Marshal(createRequest)
+	suite.Require().NoError(err)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/groups/tree/nonexistent-ou", bytes.NewBuffer(jsonData))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusNotFound, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	var errorResp ErrorResponse
+	err = json.Unmarshal(body, &errorResp)
+	suite.Require().NoError(err)
+
+	suite.Equal("GRP-1003", errorResp.Code)
+	suite.Equal("Group not found", errorResp.Message)
+}
+
+// TestCreateGroupByPathWithInvalidData tests creating a group by path with invalid data
+func (suite *GroupTreeAPITestSuite) TestCreateGroupByPathWithInvalidData() {
+	if pathTestOUID == "" {
+		suite.T().Fatal("OU ID is not available for invalid data test")
+	}
+
+	// Test with empty name
+	createRequest := CreateGroupByPathRequest{
+		Name:        "",
+		Description: "Group with empty name",
+		Members:     []Member{},
+	}
+
+	jsonData, err := json.Marshal(createRequest)
+	suite.Require().NoError(err)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/groups/tree/"+pathTestOU.Handle, bytes.NewBuffer(jsonData))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	var errorResp ErrorResponse
+	err = json.Unmarshal(body, &errorResp)
+	suite.Require().NoError(err)
+
+	suite.Equal("GRP-1001", errorResp.Code)
+	suite.Equal("Invalid request format", errorResp.Message)
+}
+
+// TestCreateGroupByPathWithInvalidMemberType tests creating a group by path with invalid member type
+func (suite *GroupTreeAPITestSuite) TestCreateGroupByPathWithInvalidMemberType() {
+	if pathTestOUID == "" {
+		suite.T().Fatal("OU ID is not available for invalid member type test")
+	}
+
+	// Create a request with invalid member type
+	requestBody := map[string]interface{}{
+		"name":        "Group with Invalid Member",
+		"description": "Group with invalid member type",
+		"members": []map[string]interface{}{
+			{
+				"id":   "550e8400-e29b-41d4-a716-446655440000",
+				"type": "invalid_type",
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(requestBody)
+	suite.Require().NoError(err)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/groups/tree/"+pathTestOU.Handle, bytes.NewBuffer(jsonData))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestCreateGroupByPathWithMalformedJSON tests creating a group by path with malformed JSON
+func (suite *GroupTreeAPITestSuite) TestCreateGroupByPathWithMalformedJSON() {
+	if pathTestOUID == "" {
+		suite.T().Fatal("OU ID is not available for malformed JSON test")
+	}
+
+	malformedJSON := `{"name": "Test Group", "description": "Malformed JSON",`
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/groups/tree/"+pathTestOU.Handle, bytes.NewBufferString(malformedJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestCreateGroupByPathWithEmptyPath tests creating a group with empty path
+func (suite *GroupTreeAPITestSuite) TestCreateGroupByPathWithEmptyPath() {
+	createRequest := CreateGroupByPathRequest{
+		Name:        "Group with Empty Path",
+		Description: "Group created with empty path",
+		Members:     []Member{},
+	}
+
+	jsonData, err := json.Marshal(createRequest)
+	suite.Require().NoError(err)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/groups/tree/", bytes.NewBuffer(jsonData))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestGroupTreeEndpointsWithNestedPaths tests the endpoints with nested organization unit paths
+func (suite *GroupTreeAPITestSuite) TestGroupTreeEndpointsWithNestedPaths() {
+	if pathTestOUID == "" {
+		suite.T().Fatal("OU ID is not available for nested path test")
+	}
+
+	// Create a child OU for testing nested paths
+	childOU := CreateOURequest{
+		Name:        "Backend Team",
+		Handle:      "backend",
+		Description: "Backend development team",
+		Parent:      &pathTestOUID,
+	}
+
+	childOUID, err := createOUForGroupTests(suite, childOU)
+	suite.Require().NoError(err, "Failed to create child OU for nested path testing")
+	defer func() {
+		if childOUID != "" {
+			if err := deleteOUByID(suite, childOUID); err != nil {
+				suite.T().Logf("Failed to delete child OU with ID %s: %v", childOUID, err)
+			}
+		}
+	}()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	// Test GET with nested path
+	nestedPath := pathTestOU.Handle + "/" + childOU.Handle
+	req, err := http.NewRequest("GET", testServerURL+"/groups/tree/"+nestedPath, nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	// Test POST with nested path
+	nestedGroupRequest := CreateGroupByPathRequest{
+		Name:        "Backend API Team",
+		Description: "Team responsible for backend APIs",
+		Members:     []Member{},
+	}
+
+	jsonData, err := json.Marshal(nestedGroupRequest)
+	suite.Require().NoError(err)
+
+	postReq, err := http.NewRequest("POST", testServerURL+"/groups/tree/"+nestedPath, bytes.NewBuffer(jsonData))
+	suite.Require().NoError(err)
+	postReq.Header.Set("Content-Type", "application/json")
+
+	postResp, err := client.Do(postReq)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := postResp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	suite.Equal(http.StatusCreated, postResp.StatusCode)
+
+	// Clean up the created group
+	postBody, err := io.ReadAll(postResp.Body)
+	suite.Require().NoError(err)
+
+	var createdGroup Group
+	err = json.Unmarshal(postBody, &createdGroup)
+	suite.Require().NoError(err)
+
+	err = deleteGroupByID(suite, createdGroup.Id)
+	if err != nil {
+		suite.T().Logf("Failed to delete nested group: %v", err)
+	}
+}
+
+// Helper functions
+
+// createOUForGroupTests creates an organization unit for group testing
+func createOUForGroupTests(suite *GroupTreeAPITestSuite, ouRequest CreateOURequest) (string, error) {
+	jsonData, err := json.Marshal(ouRequest)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/organization-units", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", err
+	}
+
+	var createdOU OrganizationUnit
+	err = json.NewDecoder(resp.Body).Decode(&createdOU)
+	if err != nil {
+		return "", err
+	}
+
+	return createdOU.ID, nil
+}
+
+// deleteOUByID deletes an organization unit by ID
+func deleteOUByID(suite *GroupTreeAPITestSuite, id string) error {
+	req, err := http.NewRequest("DELETE", testServerURL+"/organization-units/"+id, nil)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// deleteGroupByID deletes a group by ID
+func deleteGroupByID(suite *GroupTreeAPITestSuite, id string) error {
+	req, err := http.NewRequest("DELETE", testServerURL+"/groups/"+id, nil)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	return nil
+}

--- a/tests/integration/group/model.go
+++ b/tests/integration/group/model.go
@@ -85,3 +85,17 @@ type MemberListResponse struct {
 	Members      []Member `json:"members"`
 	Links        []Link   `json:"links"`
 }
+
+// CreateGroupByPathRequest represents the request body for creating a group under a specific OU path.
+type CreateGroupByPathRequest struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Members     []Member `json:"members,omitempty"`
+}
+
+// ErrorResponse represents an error response.
+type ErrorResponse struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Description string `json:"description,omitempty"`
+}


### PR DESCRIPTION
## Purpose
This pull request introduces functionality to manage groups based on organizational unit (OU) paths, including listing and creating groups under specific paths. The changes span across the handler, service, and database layers, and include updates to API routes and integration tests. Below is a summary of the most significant changes:

### Handler Enhancements:
* Added `HandleGroupListByPathRequest` and `HandleGroupPostByPathRequest` methods in `GroupHandler` to handle listing and creating groups by OU paths. These methods include path validation, pagination, and error handling. [[1]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cR82-R119) [[2]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cR164-R210)
* Introduced `extractAndValidatePath` utility to validate and extract the `path` parameter from requests.

### Service Layer Additions:
* Added `GetGroupsByPath` and `CreateGroupByPath` methods in `GroupService` to support group operations by hierarchical paths. These methods validate paths, interact with the OU service, and handle pagination. [[1]](diffhunk://#diff-c968c9fcf81977db22a427b042701414eb10548b606387f7e16ecf05adc6e706R97-R155) [[2]](diffhunk://#diff-c968c9fcf81977db22a427b042701414eb10548b606387f7e16ecf05adc6e706R215-R251)
* Implemented `validateAndProcessHandlePath` to ensure the handle path is valid and properly formatted.

### Database Layer Updates:
* Added queries `QueryGetGroupsByOrganizationUnitCount` and `QueryGetGroupsByOrganizationUnit` for retrieving group counts and paginated group lists by organization unit.
* Introduced `GetGroupsByOrganizationUnitCount` and `GetGroupsByOrganizationUnit` functions to execute the above queries and return results.

### API Route Modifications:
* Updated routes to support the new endpoints for listing and creating groups by paths (`GET /groups/tree/{path...}` and `POST /groups/tree/{path...}`). [[1]](diffhunk://#diff-d3b830704ff9c7eca276e53cff2b7c37a6dc6f6067d0bcd9e886594e5bb0194cL70-R84) [[2]](diffhunk://#diff-d3b830704ff9c7eca276e53cff2b7c37a6dc6f6067d0bcd9e886594e5bb0194cL84-R109)

### Model and Test Additions:
* Added `CreateGroupByPathRequest` model to represent the request body for creating groups under specific OU paths. [[1]](diffhunk://#diff-2da7e5d6c9049c160de801c8a9623aebba03a9492083ba66b2481c892b3ff0a5R111-R117) [[2]](diffhunk://#diff-62a96cc2c665e66d3c9d9ef03537ab1968e17eda3c2b653f55ea515cf27220a7R88-R101)
* Updated integration tests with the new request model and error response structure.