### PR TITLE
Disable test caching for the integration test suite

### DIFF
--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -88,7 +88,18 @@ func initTests() {
 }
 
 func runTests() error {
-	cmd := exec.Command("go", "test", "-p=1", "-v", "./...")
+	// Clean the test cache to avoid getting results from previous runs.
+	// This is important to avoid false positives in test results as the
+	// server and integration test suite are two separate applications.
+	cmd := exec.Command("go", "clean", "-testcache")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to clean test cache: %w", err)
+	}
+
+	cmd = exec.Command("go", "test", "-p=1", "-v", "./...")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
## Purpose

The Thunder integration test suite is implemented as a separate Go application located in the tests/integration directory. It is responsible for unpacking the backend server zip, starting the server, and executing the go test command via the os/exec module.

The backend server resides in the backend directory and is built into a zip file containing the server executable and its required resources.

However, Go's test caching mechanism can interfere with this setup. By default, go test caches results based on input files and environment variables. Since the backend and integration test suites are independent Go modules, changes to the backend source code may not be detected by the integration tests, allowing outdated cached test results to be reused.

This can lead to false positives — cases where tests appear to pass locally even though the backend has breaking changes. This issue has been observed in local builds, where integration tests report success, but CI (e.g., GitHub Actions) correctly flags the failures.

This PR addresses that issue by explicitly disabling the Go test cache for integration tests, ensuring the tests are always executed against the latest backend server build.

Quoted from Go 1.10 release notes;
```
The go test command now caches test results: if the test executable and command line match a previous run and the files and environment variables consulted by that run have not changed either, go test will print the previous test output, replacing the elapsed time with the string “(cached).”
```

[1] https://go.dev/doc/go1.10#test
