### PR TITLE
Restructure Access Log and Add Elapsed Time

### DIFF
--- a/backend/internal/system/log/accesslog.go
+++ b/backend/internal/system/log/accesslog.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package log
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// AccessLogHandler logs HTTP requests in Apache CLF with response time.
+func AccessLogHandler(logger *Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Capture the status and size.
+		lrw := &loggingResponseWriter{ResponseWriter: w, statusCode: 200}
+		next.ServeHTTP(lrw, r)
+
+		// Calculate elapsed time in milliseconds
+		elapsedMs := time.Since(start).Milliseconds()
+
+		host, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if host == "" {
+			host = r.RemoteAddr
+		}
+
+		// Standard CLF format with additional fields. Last %d is the response time in milliseconds.
+		logger.Info(fmt.Sprintf(
+			`%s - - [%s] "%s %s %s" %d %d %d`,
+			host,
+			start.Format("02/Jan/2006:15:04:05 -0700"),
+			r.Method,
+			r.RequestURI,
+			r.Proto,
+			lrw.statusCode,
+			lrw.size,
+			elapsedMs,
+		))
+	})
+}
+
+// loggingResponseWriter wraps http.ResponseWriter to capture status and size.
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	size       int
+}
+
+// WriteHeader captures the status code and delegates to the original ResponseWriter.
+func (lrw *loggingResponseWriter) WriteHeader(code int) {
+	lrw.statusCode = code
+	lrw.ResponseWriter.WriteHeader(code)
+}
+
+// Write captures the size of the response and delegates to the original ResponseWriter.
+func (lrw *loggingResponseWriter) Write(b []byte) (int, error) {
+	size, err := lrw.ResponseWriter.Write(b)
+	lrw.size += size
+	return size, err
+}

--- a/backend/internal/system/log/accesslog_test.go
+++ b/backend/internal/system/log/accesslog_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package log
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type AccessLogTestSuite struct {
+	suite.Suite
+}
+
+func TestAccessLogSuite(t *testing.T) {
+	suite.Run(t, new(AccessLogTestSuite))
+}
+
+func (suite *AccessLogTestSuite) TestAccessLogHandler() {
+	var buf bytes.Buffer
+
+	logger = nil
+	once = sync.Once{}
+
+	handlerOptions := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	logHandler := slog.NewTextHandler(&buf, handlerOptions)
+	log := &Logger{
+		internal: slog.New(logHandler),
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("OK"))
+		if err != nil {
+			suite.T().Errorf("Failed to write response: %v", err)
+		}
+	})
+
+	handler := AccessLogHandler(log, testHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+
+	rr := httptest.NewRecorder()
+
+	// Call the handler
+	handler.ServeHTTP(rr, req)
+
+	// Verify response
+	assert.Equal(suite.T(), http.StatusOK, rr.Code)
+	assert.Equal(suite.T(), "OK", rr.Body.String())
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "192.168.1.1")
+	assert.Contains(suite.T(), output, "GET /test")
+	assert.Contains(suite.T(), output, "200")
+}
+
+func (suite *AccessLogTestSuite) TestLoggingResponseWriter() {
+	rec := httptest.NewRecorder()
+	lrw := &loggingResponseWriter{
+		ResponseWriter: rec,
+		statusCode:     http.StatusOK,
+		size:           0,
+	}
+
+	// Test writing headers
+	lrw.WriteHeader(http.StatusNotFound)
+	assert.Equal(suite.T(), http.StatusNotFound, lrw.statusCode)
+
+	// Test writing content
+	n, err := lrw.Write([]byte("test content"))
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 12, n)
+	assert.Equal(suite.T(), 12, lrw.size)
+
+	// Write more content
+	n, err = lrw.Write([]byte(" more"))
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 5, n)
+	assert.Equal(suite.T(), 17, lrw.size) // 12 + 5
+
+	// Verify the actual content was written to the underlying ResponseWriter
+	assert.Equal(suite.T(), "test content more", rec.Body.String())
+}

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -22,8 +22,6 @@ import (
 	"bytes"
 	"io"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
@@ -206,48 +204,6 @@ func (suite *LogTestSuite) TestLoggerWith() {
 	assert.Contains(suite.T(), output, "Context log message")
 }
 
-func (suite *LogTestSuite) TestAccessLogHandler() {
-	var buf bytes.Buffer
-
-	logger = nil
-	once = sync.Once{}
-
-	handlerOptions := &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}
-	logHandler := slog.NewTextHandler(&buf, handlerOptions)
-	log := &Logger{
-		internal: slog.New(logHandler),
-	}
-
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("OK"))
-		if err != nil {
-			suite.T().Errorf("Failed to write response: %v", err)
-		}
-	})
-
-	handler := AccessLogHandler(log, testHandler)
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	req.RemoteAddr = "192.168.1.1:12345"
-
-	rr := httptest.NewRecorder()
-
-	// Call the handler
-	handler.ServeHTTP(rr, req)
-
-	// Verify response
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	assert.Equal(suite.T(), "OK", rr.Body.String())
-
-	output := buf.String()
-	assert.Contains(suite.T(), output, "192.168.1.1")
-	assert.Contains(suite.T(), output, "GET /test")
-	assert.Contains(suite.T(), output, "200")
-}
-
 func (suite *LogTestSuite) TestMaskString() {
 	testCases := []struct {
 		name     string
@@ -302,32 +258,4 @@ func (suite *LogTestSuite) TestConvertFields() {
 	assert.Contains(suite.T(), output, "string=value")
 	assert.Contains(suite.T(), output, "int=42")
 	assert.Contains(suite.T(), output, "bool=true")
-}
-
-func (suite *LogTestSuite) TestLoggingResponseWriter() {
-	rec := httptest.NewRecorder()
-	lrw := &loggingResponseWriter{
-		ResponseWriter: rec,
-		statusCode:     http.StatusOK,
-		size:           0,
-	}
-
-	// Test writing headers
-	lrw.WriteHeader(http.StatusNotFound)
-	assert.Equal(suite.T(), http.StatusNotFound, lrw.statusCode)
-
-	// Test writing content
-	n, err := lrw.Write([]byte("test content"))
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), 12, n)
-	assert.Equal(suite.T(), 12, lrw.size)
-
-	// Write more content
-	n, err = lrw.Write([]byte(" more"))
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), 5, n)
-	assert.Equal(suite.T(), 17, lrw.size) // 12 + 5
-
-	// Verify the actual content was written to the underlying ResponseWriter
-	assert.Equal(suite.T(), "test content more", rec.Body.String())
 }


### PR DESCRIPTION
## Purpose

- This PR refactors the HTTP access logging by extracting it from `log.go` file into a dedicated `accesslog.go` file.
- Also enhances the access logs by including **elapsed time** while being aligned with the Apache's Combined Log Format (CLF).