### PR TITLE
Introduce system constants for pagination page default and limit.

### DIFF
--- a/backend/internal/group/handler/grouphandler.go
+++ b/backend/internal/group/handler/grouphandler.go
@@ -36,7 +36,6 @@ import (
 )
 
 const loggerComponentName = "GroupHandler"
-const limitDefault = 30
 
 // GroupHandler is the handler for group management operations.
 type GroupHandler struct{}
@@ -493,7 +492,7 @@ func parsePaginationParams(query url.Values) (int, int, *serviceerror.ServiceErr
 	}
 
 	if limit == 0 {
-		limit = limitDefault
+		limit = serverconst.DefaultPageSize
 	}
 
 	return limit, offset, nil

--- a/backend/internal/group/service/groupservice.go
+++ b/backend/internal/group/service/groupservice.go
@@ -29,6 +29,7 @@ import (
 	"github.com/asgardeo/thunder/internal/group/store"
 	ouconstants "github.com/asgardeo/thunder/internal/ou/constants"
 	ouservice "github.com/asgardeo/thunder/internal/ou/service"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
@@ -538,7 +539,7 @@ func buildGroupBasic(groupDAO model.GroupBasicDAO) model.GroupBasic {
 
 // validatePaginationParams validates pagination parameters.
 func validatePaginationParams(limit, offset int) *serviceerror.ServiceError {
-	if limit < 1 || limit > 100 {
+	if limit < 1 || limit > serverconst.MaxPageSize {
 		return &constants.ErrorInvalidLimit
 	}
 	if offset < 0 {

--- a/backend/internal/ou/handler/ouhandler.go
+++ b/backend/internal/ou/handler/ouhandler.go
@@ -36,7 +36,6 @@ import (
 )
 
 const loggerComponentName = "OrganizationUnitHandler"
-const limitDefault = 30
 
 // OrganizationUnitHandler is the handler for organization unit management operations.
 type OrganizationUnitHandler struct {
@@ -61,7 +60,7 @@ func (ouh *OrganizationUnitHandler) HandleOUListRequest(w http.ResponseWriter, r
 	}
 
 	if limit == 0 {
-		limit = limitDefault
+		limit = serverconst.DefaultPageSize
 	}
 
 	ouListResponse, svcErr := ouh.service.GetOrganizationUnitList(limit, offset)
@@ -367,7 +366,7 @@ func (ouh *OrganizationUnitHandler) handleResourceListRequest(
 	}
 
 	if limit == 0 {
-		limit = limitDefault
+		limit = serverconst.DefaultPageSize
 	}
 
 	response, svcErr := serviceFunc(id, limit, offset)
@@ -492,7 +491,7 @@ func (ouh *OrganizationUnitHandler) handleResourceListByPathRequest(
 	}
 
 	if limit == 0 {
-		limit = limitDefault
+		limit = serverconst.DefaultPageSize
 	}
 
 	response, svcErr := serviceFunc(path, limit, offset)

--- a/backend/internal/ou/service/ouservice.go
+++ b/backend/internal/ou/service/ouservice.go
@@ -27,6 +27,7 @@ import (
 	"github.com/asgardeo/thunder/internal/ou/constants"
 	"github.com/asgardeo/thunder/internal/ou/model"
 	"github.com/asgardeo/thunder/internal/ou/store"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
@@ -665,7 +666,7 @@ func validateAndProcessHandlePath(handlePath string) ([]string, *serviceerror.Se
 
 // validatePaginationParams validates pagination parameters.
 func validatePaginationParams(limit, offset int) *serviceerror.ServiceError {
-	if limit < 1 || limit > 100 {
+	if limit < 1 || limit > serverconst.MaxPageSize {
 		return &constants.ErrorInvalidLimit
 	}
 	if offset < 0 {

--- a/backend/internal/system/constants/serverconstants.go
+++ b/backend/internal/system/constants/serverconstants.go
@@ -43,3 +43,9 @@ const ContentTypeJSON = "application/json"
 
 // ContentTypeFormURLEncoded is the content type for form-urlencoded data.
 const ContentTypeFormURLEncoded = "application/x-www-form-urlencoded"
+
+// DefaultPageSize is the default limit for pagination when not specified.
+const DefaultPageSize = 30
+
+// MaxPageSize is the maximum allowed limit for pagination.
+const MaxPageSize = 100

--- a/backend/internal/user/handler/userhandler.go
+++ b/backend/internal/user/handler/userhandler.go
@@ -36,7 +36,6 @@ import (
 )
 
 const loggerComponentName = "UserHandler"
-const limitDefault = 30
 
 // UserHandler is the handler for user management operations.
 type UserHandler struct {
@@ -85,7 +84,7 @@ func (ah *UserHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 	}
 
 	if limit == 0 {
-		limit = limitDefault
+		limit = serverconst.DefaultPageSize
 	}
 
 	// Get the user list using the user service.

--- a/backend/internal/user/service/userservice.go
+++ b/backend/internal/user/service/userservice.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/crypto/hash"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -314,7 +315,7 @@ func (as *UserService) ValidateUserIDs(userIDs []string) ([]string, *serviceerro
 
 // validatePaginationParams validates pagination parameters.
 func validatePaginationParams(limit, offset int) *serviceerror.ServiceError {
-	if limit < 1 || limit > 100 {
+	if limit < 1 || limit > serverconst.MaxPageSize {
 		return &constants.ErrorInvalidLimit
 	}
 	if offset < 0 {


### PR DESCRIPTION
## Purpose
This pull request standardizes pagination limit constants across the codebase by introducing `DefaultPaginationLimit` and `MaxPaginationLimit` in `serverconstants.go`, and updating all relevant handlers and services to use these shared values. This improves maintainability and consistency for pagination logic in group, organization unit, and user management operations.

**Pagination Limit Standardization**

* Added `DefaultPaginationLimit` and `MaxPaginationLimit` constants to `backend/internal/system/constants/serverconstants.go` for centralized pagination configuration.
* Updated group, organization unit, and user handlers (`grouphandler.go`, `ouhandler.go`, `userhandler.go`) to use `serverconst.DefaultPaginationLimit` instead of local `limitDefault` constants when the pagination limit is not specified. [[1]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cL39) [[2]](diffhunk://#diff-cb150916dc3c5f592f9048103e47b3a410c1addf6b3cfc9a16be7fc77d03776cL496-R495) [[3]](diffhunk://#diff-27934dab93829cc822194e2f6d0d85d4b987671beb57ac2937da0a965680e32aL39) [[4]](diffhunk://#diff-27934dab93829cc822194e2f6d0d85d4b987671beb57ac2937da0a965680e32aL64-R63) [[5]](diffhunk://#diff-27934dab93829cc822194e2f6d0d85d4b987671beb57ac2937da0a965680e32aL370-R369) [[6]](diffhunk://#diff-27934dab93829cc822194e2f6d0d85d4b987671beb57ac2937da0a965680e32aL495-R494) [[7]](diffhunk://#diff-a835c982b85fd7017f2332cf2ed0a2c4297f043cbf59b7ff9ce4764da0b9afbeL39) [[8]](diffhunk://#diff-a835c982b85fd7017f2332cf2ed0a2c4297f043cbf59b7ff9ce4764da0b9afbeL88-R87)
* Updated service-level pagination validation in `groupservice.go`, `ouservice.go`, and `userservice.go` to use `serverconst.MaxPaginationLimit` instead of hardcoded values, ensuring all limits are validated against the shared constant. [[1]](diffhunk://#diff-c968c9fcf81977db22a427b042701414eb10548b606387f7e16ecf05adc6e706R32) [[2]](diffhunk://#diff-c968c9fcf81977db22a427b042701414eb10548b606387f7e16ecf05adc6e706L541-R542) [[3]](diffhunk://#diff-a3f9ac4d3a59e9804a4ff0c0ebdcfc4233de31b9ee092cad8f3ff4117f303430R30) [[4]](diffhunk://#diff-a3f9ac4d3a59e9804a4ff0c0ebdcfc4233de31b9ee092cad8f3ff4117f303430L668-R669) [[5]](diffhunk://#diff-9c4f35acdc7d776283e1d68652ae58442b48d74b6b6050c6f98341359b87a820R27) [[6]](diffhunk://#diff-9c4f35acdc7d776283e1d68652ae58442b48d74b6b6050c6f98341359b87a820L317-R318)