### PR TITLE
Integrate caching to the cert service

### DIFF
--- a/backend/internal/cert/certservice.go
+++ b/backend/internal/cert/certservice.go
@@ -47,7 +47,7 @@ type CertificateServiceInterface interface {
 
 // CertificateService implements the CertificateServiceInterface for managing certificates.
 type CertificateService struct {
-	Store store.CachedBackedCertificateStoreInterface
+	Store store.CertificateStoreInterface
 }
 
 // NewCertificateService creates a new instance of CertificateService.

--- a/backend/internal/cert/constants/errorconstants.go
+++ b/backend/internal/cert/constants/errorconstants.go
@@ -64,6 +64,20 @@ var (
 		Error:            "Certificate not found",
 		ErrorDescription: "The requested certificate could not be found",
 	}
+	// ErrorCertificateAlreadyExists is the error when a certificate already exists.
+	ErrorCertificateAlreadyExists = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "CES-1007",
+		Error:            "Certificate already exists",
+		ErrorDescription: "A certificate with the same reference type and ID already exists",
+	}
+	// ErrorReferenceUpdateIsNotAllowed is the error when trying to update a certificate's reference type or ID.
+	ErrorReferenceUpdateIsNotAllowed = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "CES-1008",
+		Error:            "Reference update is not allowed",
+		ErrorDescription: "Updating the reference type or ID of an existing certificate is not allowed",
+	}
 )
 
 // Server errors for the certificate service.

--- a/backend/internal/cert/store/cachedbackedstore.go
+++ b/backend/internal/cert/store/cachedbackedstore.go
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package store
+
+import (
+	"errors"
+
+	"github.com/asgardeo/thunder/internal/cert/constants"
+	"github.com/asgardeo/thunder/internal/cert/model"
+	"github.com/asgardeo/thunder/internal/system/cache"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+const cachedStoreLoggerComponentName = "CachedBackedCertificateStore"
+
+// CachedBackedCertificateStoreInterface defines the interface for the cached backed certificate store
+// which provides methods to manage certificates with caching capabilities.
+type CachedBackedCertificateStoreInterface interface {
+	GetCertificateByID(id string) (*model.Certificate, error)
+	GetCertificateByReference(refType constants.CertificateReferenceType, refID string) (*model.Certificate, error)
+	CreateCertificate(cert *model.Certificate) error
+	UpdateCertificateByID(existingCert, updatedCert *model.Certificate) error
+	UpdateCertificateByReference(existingCert, updatedCert *model.Certificate) error
+	DeleteCertificateByID(id string) error
+	DeleteCertificateByReference(refType constants.CertificateReferenceType, refID string) error
+}
+
+// CachedBackedCertificateStore is the implementation of CachedBackedCertificateStoreInterface.
+type CachedBackedCertificateStore struct {
+	CertByIDCacheManager        cache.CacheManagerInterface[*model.Certificate]
+	CertByReferenceCacheManager cache.CacheManagerInterface[*model.Certificate]
+	Store                       CertificateStoreInterface
+}
+
+// NewCachedBackedCertificateStore creates a new instance of CachedBackedCertificateStore.
+func NewCachedBackedCertificateStore() CachedBackedCertificateStoreInterface {
+	return &CachedBackedCertificateStore{
+		CertByIDCacheManager:        cache.GetCacheManager[*model.Certificate]("CertificateByIDCache"),
+		CertByReferenceCacheManager: cache.GetCacheManager[*model.Certificate]("CertificateByReferenceCache"),
+		Store:                       NewCertificateStore(),
+	}
+}
+
+// GetCertificateByID retrieves a certificate by its ID, using cache if available.
+func (s *CachedBackedCertificateStore) GetCertificateByID(id string) (*model.Certificate, error) {
+	cacheKey := cache.CacheKey{
+		Key: id,
+	}
+	cachedCert, ok := s.CertByIDCacheManager.Get(cacheKey)
+	if ok {
+		return cachedCert, nil
+	}
+
+	cert, err := s.Store.GetCertificateByID(id)
+	if err != nil || cert == nil {
+		return cert, err
+	}
+	s.cacheCertificate(cert)
+
+	return cert, nil
+}
+
+// GetCertificateByReference retrieves a certificate by its reference type and ID, using cache if available.
+func (s *CachedBackedCertificateStore) GetCertificateByReference(refType constants.CertificateReferenceType,
+	refID string) (*model.Certificate, error) {
+	cacheKey := getCertByReferenceCacheKey(refType, refID)
+	cachedCert, ok := s.CertByReferenceCacheManager.Get(cacheKey)
+	if ok {
+		return cachedCert, nil
+	}
+
+	cert, err := s.Store.GetCertificateByReference(refType, refID)
+	if err != nil || cert == nil {
+		return cert, err
+	}
+	s.cacheCertificate(cert)
+
+	return cert, nil
+}
+
+// CreateCertificate creates a new certificate and caches it.
+func (s *CachedBackedCertificateStore) CreateCertificate(cert *model.Certificate) error {
+	if err := s.Store.CreateCertificate(cert); err != nil {
+		return err
+	}
+	s.cacheCertificate(cert)
+	return nil
+}
+
+// UpdateCertificateByID updates an existing certificate by its ID and refreshes the cache.
+func (s *CachedBackedCertificateStore) UpdateCertificateByID(existingCert, updatedCert *model.Certificate) error {
+	if err := s.Store.UpdateCertificateByID(existingCert.ID, updatedCert); err != nil {
+		return err
+	}
+
+	// Invalidate old caches and cache the updated certificate
+	s.invalidateCertificateCache(existingCert.ID, existingCert.RefType, existingCert.RefID)
+	s.cacheCertificate(updatedCert)
+
+	return nil
+}
+
+// UpdateCertificateByReference updates an existing certificate by its reference type and ID and refreshes the cache.
+func (s *CachedBackedCertificateStore) UpdateCertificateByReference(existingCert,
+	updatedCert *model.Certificate) error {
+	if err := s.Store.UpdateCertificateByReference(existingCert.RefType, existingCert.RefID, updatedCert); err != nil {
+		return err
+	}
+
+	// Invalidate old caches and cache the updated certificate
+	s.invalidateCertificateCache(existingCert.ID, existingCert.RefType, existingCert.RefID)
+	s.cacheCertificate(updatedCert)
+
+	return nil
+}
+
+// DeleteCertificateByID deletes a certificate by its ID and invalidates the caches.
+func (s *CachedBackedCertificateStore) DeleteCertificateByID(id string) error {
+	cacheKey := cache.CacheKey{
+		Key: id,
+	}
+	existingCert, ok := s.CertByIDCacheManager.Get(cacheKey)
+	if !ok {
+		var err error
+		existingCert, err = s.Store.GetCertificateByID(id)
+		if err != nil {
+			if errors.Is(err, constants.ErrCertificateNotFound) {
+				return nil
+			}
+			return err
+		}
+	}
+	if existingCert == nil {
+		return nil
+	}
+
+	if err := s.Store.DeleteCertificateByID(id); err != nil {
+		return err
+	}
+	s.invalidateCertificateCache(existingCert.ID, existingCert.RefType, existingCert.RefID)
+
+	return nil
+}
+
+// DeleteCertificateByReference deletes a certificate by its reference type and ID and invalidates the caches.
+func (s *CachedBackedCertificateStore) DeleteCertificateByReference(refType constants.CertificateReferenceType,
+	refID string) error {
+	cacheKey := getCertByReferenceCacheKey(refType, refID)
+	existingCert, ok := s.CertByReferenceCacheManager.Get(cacheKey)
+	if !ok {
+		var err error
+		existingCert, err = s.Store.GetCertificateByReference(refType, refID)
+		if err != nil {
+			if errors.Is(err, constants.ErrCertificateNotFound) {
+				return nil
+			}
+			return err
+		}
+	}
+	if existingCert == nil {
+		return nil
+	}
+
+	if err := s.Store.DeleteCertificateByReference(refType, refID); err != nil {
+		return err
+	}
+	s.invalidateCertificateCache(existingCert.ID, existingCert.RefType, existingCert.RefID)
+
+	return nil
+}
+
+// cacheCertificate caches the certificate by ID and reference.
+func (s *CachedBackedCertificateStore) cacheCertificate(cert *model.Certificate) {
+	if cert == nil {
+		return
+	}
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, cachedStoreLoggerComponentName))
+
+	// Cache by ID
+	if cert.ID != "" {
+		idCacheKey := cache.CacheKey{
+			Key: cert.ID,
+		}
+		if err := s.CertByIDCacheManager.Set(idCacheKey, cert); err != nil {
+			logger.Error("Failed to cache certificate by ID", log.Error(err),
+				log.String("certID", cert.ID))
+		} else {
+			logger.Debug("Certificate cached by ID", log.String("certID", cert.ID))
+		}
+	}
+
+	// Cache by reference type and ID
+	if cert.RefType != "" && cert.RefID != "" {
+		refCacheKey := getCertByReferenceCacheKey(cert.RefType, cert.RefID)
+		if err := s.CertByReferenceCacheManager.Set(refCacheKey, cert); err != nil {
+			logger.Error("Failed to cache certificate by reference", log.Error(err),
+				log.String("refType", string(cert.RefType)), log.String("refID", cert.RefID))
+		} else {
+			logger.Debug("Certificate cached by reference", log.String("refType", string(cert.RefType)),
+				log.String("refID", cert.RefID))
+		}
+	}
+}
+
+// invalidateCertificateCache invalidates all certificate caches for the given ID and reference.
+func (s *CachedBackedCertificateStore) invalidateCertificateCache(id string,
+	refType constants.CertificateReferenceType, refID string) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, cachedStoreLoggerComponentName))
+
+	// Invalidate ID cache
+	if id != "" {
+		idCacheKey := cache.CacheKey{
+			Key: id,
+		}
+		if err := s.CertByIDCacheManager.Delete(idCacheKey); err != nil {
+			logger.Error("Failed to invalidate certificate cache by ID", log.Error(err),
+				log.String("certID", id))
+		} else {
+			logger.Debug("Certificate cache invalidated by ID", log.String("certID", id))
+		}
+	}
+
+	// Invalidate reference cache
+	if refType != "" && refID != "" {
+		refCacheKey := getCertByReferenceCacheKey(refType, refID)
+		if err := s.CertByReferenceCacheManager.Delete(refCacheKey); err != nil {
+			logger.Error("Failed to invalidate certificate cache by reference", log.Error(err),
+				log.String("refType", string(refType)), log.String("refID", refID))
+		} else {
+			logger.Debug("Certificate cache invalidated by reference", log.String("refType", string(refType)),
+				log.String("refID", refID))
+		}
+	}
+}
+
+// getCertByReferenceCacheKey generates a cache key for a certificate based on its reference type and ID.
+func getCertByReferenceCacheKey(refType constants.CertificateReferenceType, refID string) cache.CacheKey {
+	return cache.CacheKey{
+		Key: string(refType) + ":" + refID,
+	}
+}

--- a/backend/internal/cert/store/cachedbackedstore.go
+++ b/backend/internal/cert/store/cachedbackedstore.go
@@ -29,19 +29,7 @@ import (
 
 const cachedStoreLoggerComponentName = "CachedBackedCertificateStore"
 
-// CachedBackedCertificateStoreInterface defines the interface for the cached backed certificate store
-// which provides methods to manage certificates with caching capabilities.
-type CachedBackedCertificateStoreInterface interface {
-	GetCertificateByID(id string) (*model.Certificate, error)
-	GetCertificateByReference(refType constants.CertificateReferenceType, refID string) (*model.Certificate, error)
-	CreateCertificate(cert *model.Certificate) error
-	UpdateCertificateByID(existingCert, updatedCert *model.Certificate) error
-	UpdateCertificateByReference(existingCert, updatedCert *model.Certificate) error
-	DeleteCertificateByID(id string) error
-	DeleteCertificateByReference(refType constants.CertificateReferenceType, refID string) error
-}
-
-// CachedBackedCertificateStore is the implementation of CachedBackedCertificateStoreInterface.
+// CachedBackedCertificateStore is the implementation of CertificateStoreInterface that uses caching.
 type CachedBackedCertificateStore struct {
 	CertByIDCacheManager        cache.CacheManagerInterface[*model.Certificate]
 	CertByReferenceCacheManager cache.CacheManagerInterface[*model.Certificate]
@@ -49,7 +37,7 @@ type CachedBackedCertificateStore struct {
 }
 
 // NewCachedBackedCertificateStore creates a new instance of CachedBackedCertificateStore.
-func NewCachedBackedCertificateStore() CachedBackedCertificateStoreInterface {
+func NewCachedBackedCertificateStore() CertificateStoreInterface {
 	return &CachedBackedCertificateStore{
 		CertByIDCacheManager:        cache.GetCacheManager[*model.Certificate]("CertificateByIDCache"),
 		CertByReferenceCacheManager: cache.GetCacheManager[*model.Certificate]("CertificateByReferenceCache"),
@@ -105,7 +93,7 @@ func (s *CachedBackedCertificateStore) CreateCertificate(cert *model.Certificate
 
 // UpdateCertificateByID updates an existing certificate by its ID and refreshes the cache.
 func (s *CachedBackedCertificateStore) UpdateCertificateByID(existingCert, updatedCert *model.Certificate) error {
-	if err := s.Store.UpdateCertificateByID(existingCert.ID, updatedCert); err != nil {
+	if err := s.Store.UpdateCertificateByID(existingCert, updatedCert); err != nil {
 		return err
 	}
 
@@ -119,7 +107,7 @@ func (s *CachedBackedCertificateStore) UpdateCertificateByID(existingCert, updat
 // UpdateCertificateByReference updates an existing certificate by its reference type and ID and refreshes the cache.
 func (s *CachedBackedCertificateStore) UpdateCertificateByReference(existingCert,
 	updatedCert *model.Certificate) error {
-	if err := s.Store.UpdateCertificateByReference(existingCert.RefType, existingCert.RefID, updatedCert); err != nil {
+	if err := s.Store.UpdateCertificateByReference(existingCert, updatedCert); err != nil {
 		return err
 	}
 

--- a/backend/internal/cert/store/store.go
+++ b/backend/internal/cert/store/store.go
@@ -37,9 +37,8 @@ type CertificateStoreInterface interface {
 	GetCertificateByID(id string) (*model.Certificate, error)
 	GetCertificateByReference(refType constants.CertificateReferenceType, refID string) (*model.Certificate, error)
 	CreateCertificate(cert *model.Certificate) error
-	UpdateCertificateByID(id string, cert *model.Certificate) error
-	UpdateCertificateByReference(refType constants.CertificateReferenceType, refID string,
-		cert *model.Certificate) error
+	UpdateCertificateByID(existingCert, updatedCert *model.Certificate) error
+	UpdateCertificateByReference(existingCert, updatedCert *model.Certificate) error
 	DeleteCertificateByID(id string) error
 	DeleteCertificateByReference(refType constants.CertificateReferenceType, refID string) error
 }
@@ -163,14 +162,14 @@ func (s *CertificateStore) CreateCertificate(cert *model.Certificate) error {
 }
 
 // UpdateCertificateByID updates a certificate by its ID.
-func (s *CertificateStore) UpdateCertificateByID(id string, cert *model.Certificate) error {
-	return s.updateCertificate(QueryUpdateCertificateByID, id, cert.Type, cert.Value)
+func (s *CertificateStore) UpdateCertificateByID(existingCert, updatedCert *model.Certificate) error {
+	return s.updateCertificate(QueryUpdateCertificateByID, existingCert.ID, updatedCert.Type, updatedCert.Value)
 }
 
 // UpdateCertificateByReference updates a certificate by its reference type and ID.
-func (s *CertificateStore) UpdateCertificateByReference(refType constants.CertificateReferenceType,
-	refID string, cert *model.Certificate) error {
-	return s.updateCertificate(QueryUpdateCertificateByReference, refType, refID, cert.Type, cert.Value)
+func (s *CertificateStore) UpdateCertificateByReference(existingCert, updatedCert *model.Certificate) error {
+	return s.updateCertificate(QueryUpdateCertificateByReference, existingCert.RefType, existingCert.RefID,
+		updatedCert.Type, updatedCert.Value)
 }
 
 // updateCertificate updates a certificate based on a query and its arguments.


### PR DESCRIPTION
## Purpose

This pull request introduces a caching layer for certificate management and improves error handling and validation in certificate CRUD operations. The main changes include switching to a cached certificate store, adding new error types, and enforcing stricter validation when creating and updating certificates to prevent duplicate entries and reference changes.

**Caching and Store Refactoring:**

* Introduced a new `CachedBackedCertificateStoreInterface` and its implementation in `backend/internal/cert/store/cachedbackedstore.go`, providing caching for certificate retrieval, creation, update, and deletion operations. This improves performance by reducing direct store access and ensures cache consistency.
* Updated `CertificateService` in `backend/internal/cert/certservice.go` to use `CachedBackedCertificateStoreInterface` instead of the previous store interface, and switched instantiation to use the cached store.

**Error Handling and Validation Enhancements:**

* Added new error constants in `backend/internal/cert/constants/errorconstants.go` for "certificate already exists" and "reference update is not allowed," enabling more precise client error responses.
* Improved error handling in certificate retrieval methods (`GetCertificateByID`, `GetCertificateByReference`) to return a specific "certificate not found" error when appropriate, and to log debug information when a certificate is missing. [[1]](diffhunk://#diff-ea71a3b6a96c803a472aae959f9c4b81d09cc8834954ba29881bb2cbd6993bceR76-R79) [[2]](diffhunk://#diff-ea71a3b6a96c803a472aae959f9c4b81d09cc8834954ba29881bb2cbd6993bceR105-R109)
* Added validation in `CreateCertificate` to prevent creating certificates with duplicate references, returning the new "already exists" error if a duplicate is found.
* Enhanced update methods (`UpdateCertificateByID`, `UpdateCertificateByReference`) to ensure that certificate references cannot be changed during updates, returning the new "reference update is not allowed" error if attempted, and to check for existence before updating. [[1]](diffhunk://#diff-ea71a3b6a96c803a472aae959f9c4b81d09cc8834954ba29881bb2cbd6993bceL136-R175) [[2]](diffhunk://#diff-ea71a3b6a96c803a472aae959f9c4b81d09cc8834954ba29881bb2cbd6993bceL163-R224)

## Related Issue
- https://github.com/asgardeo/thunder/issues/296
