### PR TITLE
Add registration flow enabled validation to the flow service

### DIFF
--- a/backend/internal/flow/constants/errorconstants.go
+++ b/backend/internal/flow/constants/errorconstants.go
@@ -64,6 +64,14 @@ var ErrorInvalidFlowType = serviceerror.ServiceError{
 	ErrorDescription: "Invalid flow type provided in the request",
 }
 
+// ErrorRegistrationFlowDisabled defines the error response for registration flow disabled errors.
+var ErrorRegistrationFlowDisabled = serviceerror.ServiceError{
+	Code:             "FES-1006",
+	Type:             serviceerror.ClientErrorType,
+	Error:            "Registration not allowed",
+	ErrorDescription: "Registration flow is disabled for the application",
+}
+
 // Server error structs
 
 // ErrorFlowGraphNotInitialized defines the error response for uninitialized flow graph errors.

--- a/backend/internal/flow/flowexecservice.go
+++ b/backend/internal/flow/flowexecservice.go
@@ -350,6 +350,8 @@ func getFlowGraph(appID string, flowType constants.FlowType) (string, *serviceer
 	if flowType == constants.FlowTypeRegistration {
 		if app.RegistrationFlowGraphID == "" {
 			return "", &constants.ErrorRegisFlowNotConfiguredForApplication
+		} else if !app.IsRegistrationFlowEnabled {
+			return "", &constants.ErrorRegistrationFlowDisabled
 		}
 		return app.RegistrationFlowGraphID, nil
 	}


### PR DESCRIPTION
## Purpose

This pull request introduces an additional error handling mechanism for the registration flow in the backend service. The main change is the introduction of a new error type to handle cases where the registration flow is disabled for an application, and its integration into the flow graph retrieval logic.
