### PR TITLE
Improve code clarity

### DIFF
--- a/backend/internal/system/utils/uuidutil.go
+++ b/backend/internal/system/utils/uuidutil.go
@@ -21,14 +21,13 @@ package utils
 import (
 	"crypto/rand"
 	"fmt"
-	"io"
 )
 
 // GenerateUUID returns a UUID string in lowercase hexadecimal, following the canonical textual representation
 // as specified in RFC 9562.
 func GenerateUUID() string {
 	var uuid [16]byte
-	_, err := io.ReadFull(rand.Reader, uuid[:])
+	_, err := rand.Read(uuid[:])
 	if err != nil {
 		panic(fmt.Errorf("failed to generate random bytes: %w", err))
 	}


### PR DESCRIPTION
This pull request makes a small change to the `GenerateUUID` function in `uuidutil.go` to simplify random byte generation by replacing `io.ReadFull` with `rand.Read`. This improves code clarity and removes an unnecessary import.