### PR TITLE
Include mail attribute in the authenticated assertion

### DIFF
--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -37,6 +37,7 @@ const (
 	userAttributeUsername  = "username"
 	userAttributePassword  = "password"
 	userAttributeEmail     = "email"
+	userAttributeMail      = "mail"
 	userAttributeFirstName = "firstName"
 	userAttributeLastName  = "lastName"
 )
@@ -242,6 +243,12 @@ func (b *BasicAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 			email = emailAttr.(string)
 		}
 
+		mail := ""
+		mailAttr := attrs[userAttributeMail]
+		if mailAttr != nil {
+			mail = mailAttr.(string)
+		}
+
 		firstName := ""
 		firstNameAttr := attrs[userAttributeFirstName]
 		if firstNameAttr != nil {
@@ -267,6 +274,9 @@ func (b *BasicAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 		}
 		if email != "" {
 			authenticatedUser.Attributes[userAttributeEmail] = email
+		}
+		if mail != "" {
+			authenticatedUser.Attributes[userAttributeMail] = mail
 		}
 	}
 	return &authenticatedUser, nil


### PR DESCRIPTION
## Purpose
This pull request adds support for handling a new user attribute, `mail`, in the BasicAuth executor. The changes ensure that the `mail` attribute is extracted from user attributes and included in the authenticated user data if present.

**User attribute handling:**
* Added `userAttributeMail` constant and logic to extract and store the `mail` attribute from user attributes in `basicauthexecutor.go`. [[1]](diffhunk://#diff-30649f0349d4fac2053a5338a4d4c25d63384d8b480080b85413323566d286e6R40) [[2]](diffhunk://#diff-30649f0349d4fac2053a5338a4d4c25d63384d8b480080b85413323566d286e6R246-R251) [[3]](diffhunk://#diff-30649f0349d4fac2053a5338a4d4c25d63384d8b480080b85413323566d286e6R278-R280)