### PR TITLE
Fix improper error response for token request

### DIFF
--- a/backend/internal/oauth/oauth2/token/tokenhandler_test.go
+++ b/backend/internal/oauth/oauth2/token/tokenhandler_test.go
@@ -142,13 +142,35 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_MissingClientID() {
 
 	handler.HandleTokenRequest(rr, req)
 
-	assert.Equal(suite.T(), http.StatusBadRequest, rr.Code)
+	assert.Equal(suite.T(), http.StatusUnauthorized, rr.Code)
 
 	var response map[string]interface{}
 	err := json.Unmarshal(rr.Body.Bytes(), &response)
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "invalid_request", response["error"])
+	assert.Equal(suite.T(), "invalid_client", response["error"])
 	assert.Equal(suite.T(), "Missing client_id parameter", response["error_description"])
+}
+
+func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_MissingClientSecret() {
+	handler := NewTokenHandler()
+	formData := url.Values{}
+	formData.Set("grant_type", "authorization_code")
+	formData.Set("client_id", "test-client-id")
+
+	req, _ := http.NewRequest("POST", "/token", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+
+	handler.HandleTokenRequest(rr, req)
+
+	assert.Equal(suite.T(), http.StatusUnauthorized, rr.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "invalid_client", response["error"])
+	assert.Equal(suite.T(), "Missing client_secret parameter", response["error_description"])
 }
 
 func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_InvalidClient() {

--- a/tests/integration/identity/oauth2/token/token_test.go
+++ b/tests/integration/identity/oauth2/token/token_test.go
@@ -340,8 +340,8 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantNegativeCases() {
 			testName:       "MissingCredentialsInBody",
 			requestBody:    "grant_type=client_credentials",
 			authHeader:     "",
-			expectedStatus: http.StatusBadRequest,
-			expectedError:  "invalid_request",
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "invalid_client",
 		},
 		{
 			testName:       "InvalidGrantType",


### PR DESCRIPTION
## Purpose
Fix improper error responses for invalid token requests to `/oauth2/token` when using authorization code grant, adhering to RFC 6749.

## Related Issue
- https://github.com/asgardeo/thunder/issues/346
