### PR TITLE
Add support for run tests using gotestsum

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -368,9 +368,18 @@ function package_sample_app() {
 
 function test_unit() {
     echo "================================================================"
-    echo "Running unit tests..."
+    echo "Preparing to run unit tests..."
     cd "$BACKEND_BASE_DIR" || exit 1
-    go test -v -cover ./... || { echo "There are unit test failures."; exit 1; }
+    
+    # Use gotestsum if available, otherwise fall back to go test
+    if command -v gotestsum &> /dev/null; then
+        echo "Running unit tests using gotestsum..."
+        gotestsum -- -v -cover ./... || { echo "There are unit test failures."; exit 1; }
+    else
+        echo "Running unit tests using go test..."
+        go test -v -cover ./... || { echo "There are unit test failures."; exit 1; }
+    fi
+    
     echo "================================================================"
 }
 

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -99,7 +99,15 @@ func runTests() error {
 		return fmt.Errorf("failed to clean test cache: %w", err)
 	}
 
-	cmd = exec.Command("go", "test", "-p=1", "-v", "./...")
+	_, err = exec.LookPath("gotestsum")
+	if err == nil {
+		fmt.Println("Running integration tests using gotestsum...")
+		cmd = exec.Command("gotestsum", "--format", "testname", "--", "-p=1", "./...")
+	} else {
+		fmt.Println("Running integration tests using go test...")
+		cmd = exec.Command("go", "test", "-p=1", "-v", "./...")
+	}
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
## Purpose
This pull request improves how tests are executed by preferring the use of `gotestsum` for both unit and integration tests if it is available, while still falling back to `go test` when necessary. This enhances test output readability and consistency across environments.

**Test execution improvements:**

* Updated the `test_unit` function in `build.sh` to check for `gotestsum` and use it for running unit tests if available, otherwise defaults to `go test`.
* Modified the `runTests` function in `tests/integration/main.go` to similarly prefer `gotestsum` for integration tests, falling back to `go test` if `gotestsum` is not installed.