### PR TITLE
Remove invalid tests

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/refreshtoken_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refreshtoken_test.go
@@ -146,11 +146,6 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateGrant_MissingClientI
 	assert.Equal(suite.T(), "Client ID is required", err.ErrorDescription)
 }
 
-func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success() {
-	// Skip this test as it requires complex mocking of JWT utils functions that are not easily mockable
-	suite.T().Skip("Complex integration test - requires mocking JWT utils functions")
-}
-
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_InvalidSignature() {
 	// Mock JWT service to return nil public key (simulating signature verification failure)
 	suite.mockJWTService.On("GetPublicKey").Return(nil)
@@ -165,11 +160,6 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_InvalidSignature
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
 	assert.Equal(suite.T(), "Server public key not available", err.ErrorDescription)
-}
-
-func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_JWTGenerationError() {
-	// Skip this test as it requires complex mocking of JWT utils functions that are not easily mockable
-	suite.T().Skip("Complex integration test - requires mocking JWT utils functions")
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() {


### PR DESCRIPTION
## Purpose
This pull request simplifies the test suite for the refresh token grant handler by removing two test stubs that were previously skipped due to the complexity of mocking JWT utility functions. These tests were not providing value in their skipped state and their removal helps keep the test suite clean and maintainable.

Test suite cleanup:

* Removed the skipped test `TestHandleGrant_Success` from `refresh_token_test.go` that was previously marked as requiring complex mocking of JWT utilities.
* Removed the skipped test `TestHandleGrant_JWTGenerationError` from `refresh_token_test.go` for the same reason.