### PR TITLE
Refactor hashing logic to use new util methods

### DIFF
--- a/backend/internal/application/service/applicationservice.go
+++ b/backend/internal/application/service/applicationservice.go
@@ -139,7 +139,7 @@ func (as *ApplicationService) CreateApplication(app *model.ApplicationDTO) (*mod
 			OAuthAppConfig: &model.OAuthAppConfigProcessedDTO{
 				AppID:                   appID,
 				ClientID:                inboundAuthConfig.OAuthAppConfig.ClientID,
-				HashedClientSecret:      hash.HashString(inboundAuthConfig.OAuthAppConfig.ClientSecret),
+				HashedClientSecret:      hash.GenerateThumbprintFromString(inboundAuthConfig.OAuthAppConfig.ClientSecret),
 				RedirectURIs:            inboundAuthConfig.OAuthAppConfig.RedirectURIs,
 				GrantTypes:              inboundAuthConfig.OAuthAppConfig.GrantTypes,
 				ResponseTypes:           inboundAuthConfig.OAuthAppConfig.ResponseTypes,
@@ -408,7 +408,7 @@ func (as *ApplicationService) UpdateApplication(appID string, app *model.Applica
 			OAuthAppConfig: &model.OAuthAppConfigProcessedDTO{
 				AppID:                   appID,
 				ClientID:                inboundAuthConfig.OAuthAppConfig.ClientID,
-				HashedClientSecret:      hash.HashString(inboundAuthConfig.OAuthAppConfig.ClientSecret),
+				HashedClientSecret:      hash.GenerateThumbprintFromString(inboundAuthConfig.OAuthAppConfig.ClientSecret),
 				RedirectURIs:            inboundAuthConfig.OAuthAppConfig.RedirectURIs,
 				GrantTypes:              inboundAuthConfig.OAuthAppConfig.GrantTypes,
 				ResponseTypes:           inboundAuthConfig.OAuthAppConfig.ResponseTypes,

--- a/backend/internal/cert/systemcertservice.go
+++ b/backend/internal/cert/systemcertservice.go
@@ -19,15 +19,14 @@
 package cert
 
 import (
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
 	"errors"
 	"os"
 	"path"
 
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/crypto/hash"
 )
 
 // SystemCertificateServiceInterface defines the interface for system certificate operations.
@@ -88,10 +87,6 @@ func (c *SystemCertificateService) GetCertificateKid() (string, error) {
 		return "", err
 	}
 
-	// Calculate SHA-256 thumbprint and use it as kid
-	h := sha256.New()
-	h.Write(parsedCert.Raw)
-	x5tS256 := base64.StdEncoding.EncodeToString(h.Sum(nil))
-
+	x5tS256 := hash.GenerateThumbprint(parsedCert.Raw)
 	return x5tS256, nil
 }

--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -22,11 +22,9 @@ package jwks
 import (
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"strings"
-
-	"crypto/x509"
 
 	// Use crypto/sha1 only for JWKS x5t as required by spec for thumbprint.
 	"crypto/sha1" //nolint:gosec
@@ -35,6 +33,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/jwks/constants"
 	"github.com/asgardeo/thunder/internal/oauth/jwks/model"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/crypto/hash"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
 
@@ -92,9 +91,7 @@ func (s *JWKSService) GetJWKS() (*model.JWKSResponse, *serviceerror.ServiceError
 	// x5t: SHA-1 thumbprint, x5t#S256: SHA-256 thumbprint
 	sha1Sum := sha1.Sum(parsedCert.Raw) //nolint:gosec // x5t (SHA-1 thumbprint) is required by spec
 	x5t := base64.StdEncoding.EncodeToString(sha1Sum[:])
-	h := sha256.New()
-	h.Write(parsedCert.Raw)
-	x5tS256 := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	x5tS256 := hash.GenerateThumbprint(parsedCert.Raw)
 
 	var jwks model.JWKS
 	switch pub := parsedCert.PublicKey.(type) {

--- a/backend/internal/oauth/oauth2/token/tokenhandler.go
+++ b/backend/internal/oauth/oauth2/token/tokenhandler.go
@@ -119,7 +119,7 @@ func (th *TokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Validate the client credentials.
-	hashedClientSecret := hash.HashString(clientSecret)
+	hashedClientSecret := hash.GenerateThumbprintFromString(clientSecret)
 	if tokenAuthMethod != constants.TokenEndpointAuthMethodNone {
 		if clientID != oauthApp.ClientID || hashedClientSecret != oauthApp.HashedClientSecret {
 			utils.WriteJSONError(w, constants.ErrorInvalidClient,

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -130,6 +130,11 @@ type CORSConfig struct {
 	AllowedOrigins []string `yaml:"allowed_origins" json:"allowed_origins"`
 }
 
+// HashConfig holds the hashing configuration details.
+type HashConfig struct {
+	Algorithm string `yaml:"algorithm"`
+}
+
 // Config holds the complete configuration details of the server.
 type Config struct {
 	Server     ServerConfig     `yaml:"server" json:"server"`
@@ -140,6 +145,7 @@ type Config struct {
 	OAuth      OAuthConfig      `yaml:"oauth" json:"oauth"`
 	Flow       FlowConfig       `yaml:"flow" json:"flow"`
 	Crypto     CryptoConfig     `yaml:"crypto" json:"crypto"`
+	Hash       HashConfig       `yaml:"hash"`
 	CORS       CORSConfig       `yaml:"cors" json:"cors"`
 }
 

--- a/backend/internal/system/crypto/cryptoservice.go
+++ b/backend/internal/system/crypto/cryptoservice.go
@@ -157,5 +157,5 @@ func (cs *CryptoService) DecryptString(ciphertext string) (string, error) {
 
 // getKeyID generates a unique identifier for the key.
 func getKeyID(key []byte) string {
-	return hash.Hash(key)
+	return hash.GenerateThumbprint(key)
 }

--- a/backend/internal/system/crypto/hash/hash.go
+++ b/backend/internal/system/crypto/hash/hash.go
@@ -20,40 +20,132 @@
 package hash
 
 import (
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/log"
 )
 
-// Hash returns a SHA-256 hash of the input byte array.
-func Hash(input []byte) string {
-	h := sha256.New()
-	h.Write(input)
-	return hex.EncodeToString(h.Sum(nil))
-}
+const (
+	sha256Algorithm = "SHA256"
+	pbkdf2Algorithm = "PBKDF2"
 
-// HashString returns a SHA-256 hash of the input string.
-func HashString(input string) string {
-	return Hash([]byte(input))
-}
+	defaultPBKDF2Iterations = 600000
+	defaultPBKDF2KeyLength  = 32
+)
 
-// HashStringWithSalt hashes the input string with the given salt and returns the hex-encoded hash.
-func HashStringWithSalt(input, salt string) (string, error) {
-	hasher := sha256.New()
-	_, err := hasher.Write([]byte(input + salt))
-	if err != nil {
-		return "", err
+// NewCredential creates a credential using the configured hash provider.
+func NewCredential(credentialValue []byte) Credential {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HashProvider"))
+	algorithm := config.GetThunderRuntime().Config.Hash.Algorithm
+
+	switch algorithm {
+	case sha256Algorithm:
+		logger.Debug("Using SHA256 hash provider as per configuration.")
+		return newSHA256Credential(credentialValue)
+	default:
+		logger.Debug("Using PBKDF2 hash provider as per configuration.")
+		return newPBKDF2Credential(credentialValue)
 	}
-	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
-// GenerateSalt generates a random salt string.
-func GenerateSalt() (string, error) {
+// Verify verifies a credential by selecting the appropriate hash provider
+// based on the reference credential's algorithm.
+func Verify(credentialValueToVerify []byte, referenceCredential Credential) bool {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HashProvider"))
+	algorithm := referenceCredential.Algorithm
+
+	switch algorithm {
+	case sha256Algorithm:
+		logger.Debug("Using SHA256 hash provider for verification as per credential algorithm.")
+		return verifySHA256Credential(credentialValueToVerify, referenceCredential)
+	case pbkdf2Algorithm:
+		logger.Debug("Using PBKDF2 hash provider for verification as per credential algorithm.")
+		return verifyPBKDF2Credential(credentialValueToVerify, referenceCredential)
+	default:
+		logger.Error("Unsupported hash algorithm in credential", log.String("algorithm", referenceCredential.Algorithm))
+		return false
+	}
+}
+
+// newSHA256Credential generates a SHA256 hash of the input data combined with salt.
+func newSHA256Credential(credentialValue []byte) Credential {
+	credSalt, _ := generateSalt()
+	credentialValue = append(credentialValue, credSalt...)
+	hash := sha256.Sum256(credentialValue)
+
+	return Credential{
+		Algorithm: sha256Algorithm,
+		Hash:      hex.EncodeToString(hash[:]),
+		Salt:      hex.EncodeToString(credSalt),
+	}
+}
+
+// verifySHA256Credential checks if the SHA256 hash of the input data and salt matches the expected hash.
+func verifySHA256Credential(credentialValueToVerify []byte, referenceCredential Credential) bool {
+	saltBytes, err := hex.DecodeString(referenceCredential.Salt)
+	if err != nil {
+		return false
+	}
+	credentialValueToVerify = append(credentialValueToVerify, saltBytes...)
+	hashedData := sha256.Sum256(credentialValueToVerify)
+	return referenceCredential.Hash == hex.EncodeToString(hashedData[:])
+}
+
+// newPBKDF2Credential generates a PBKDF2 hash of the input data using the provided salt.
+func newPBKDF2Credential(credentialValue []byte) Credential {
+	credSalt, _ := generateSalt()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "PBKDF2HashProvider"))
+	hash, err := pbkdf2.Key(sha256.New, string(credentialValue), credSalt, defaultPBKDF2Iterations, defaultPBKDF2KeyLength)
+	if err != nil {
+		logger.Error("Error hashing data with PBKDF2: %v", log.Error(err))
+		return Credential{}
+	}
+	return Credential{
+		Algorithm: pbkdf2Algorithm,
+		Hash:      hex.EncodeToString(hash),
+		Salt:      hex.EncodeToString(credSalt),
+	}
+}
+
+// verifyPBKDF2Credential checks if the PBKDF2 hash of the input data and salt matches the expected hash.
+func verifyPBKDF2Credential(credentialValueToVerify []byte, referenceCredential Credential) bool {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "PBKDF2HashProvider"))
+	saltBytes, err := hex.DecodeString(referenceCredential.Salt)
+	if err != nil {
+		logger.Error("Error decoding salt: %v", log.Error(err))
+		return false
+	}
+	hash, err := pbkdf2.Key(sha256.New,
+		string(credentialValueToVerify), saltBytes, defaultPBKDF2Iterations, defaultPBKDF2KeyLength)
+	if err != nil {
+		logger.Error("Error hashing data with PBKDF2: %v", log.Error(err))
+		return false
+	}
+	return hex.EncodeToString(hash) == referenceCredential.Hash
+}
+
+// generateSalt generates a random salt string.
+func generateSalt() ([]byte, error) {
 	salt := make([]byte, 16)
 	_, err := rand.Read(salt)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return base64.StdEncoding.EncodeToString(salt), nil
+	return salt, nil
+}
+
+// GenerateThumbprint generates a SHA-256 thumbprint for the given data.
+func GenerateThumbprint(data []byte) string {
+	hash := sha256.Sum256(data)
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+// GenerateThumbprintFromString generates a SHA-256 thumbprint for the given string data.
+func GenerateThumbprintFromString(data string) string {
+	return GenerateThumbprint([]byte(data))
 }

--- a/backend/internal/system/crypto/hash/model.go
+++ b/backend/internal/system/crypto/hash/model.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package hash provides generic hashing utilities for sensitive data.
+package hash
+
+// Credential represents the credentials of a hashed value.
+type Credential struct {
+	Algorithm string
+	Hash      string
+	Salt      string
+}


### PR DESCRIPTION
This pull request introduces a major refactor and enhancement of the hashing utilities used throughout the backend, focusing on improved security, configurability, and code maintainability. The core changes include replacing direct SHA-256 hashing with a configurable hash provider supporting both SHA-256 and PBKDF2, updating all usages to leverage the new provider, and adding robust test coverage. Additionally, thumbprint generation is now standardized and centralized.

**Hashing and Credential Management Improvements:**

* Introduced a configurable hash provider in `backend/internal/system/crypto/hash/hash.go`, supporting both SHA-256 and PBKDF2 algorithms, and added a `Credential` model to encapsulate algorithm, hash, and salt. Verification logic now selects the appropriate provider based on configuration or credential algorithm. [[1]](diffhunk://#diff-ea7025d52e3a7cc8eaa819e156081ba02be43b1b042f2c997ad5ddf0997f7a50R23-R150) [[2]](diffhunk://#diff-58e11e6836b3b5e919acb9c04e01b94a8b34909873dcae945b64cca33043df84R1-R27)
* Updated all usages of hashing (e.g., client secrets, key IDs, user credentials) to use the new provider via `NewCredential`, `Verify`, and `GenerateThumbprint` functions, replacing previous direct SHA-256 hash calls. [[1]](diffhunk://#diff-184bf5335b299c8ffcabe997d2252f1818e2a249d828d4fd2f2aafa891589fb5L142-R142) [[2]](diffhunk://#diff-184bf5335b299c8ffcabe997d2252f1818e2a249d828d4fd2f2aafa891589fb5L411-R411) [[3]](diffhunk://#diff-f5f7212acd7b6df69538926d1014f93a5472cddedfa16a027c70b902eaa8b219L122-R122) [[4]](diffhunk://#diff-8426fa5a37775a58777d4f6a51ffaa7f98ecd5072a5278fec8e9f9915ebbbc9bL160-R160) [[5]](diffhunk://#diff-9c4f35acdc7d776283e1d68652ae58442b48d74b6b6050c6f98341359b87a820L240-R249) [[6]](diffhunk://#diff-e3e0a0fd35744f9376521f3137b86e5a794b573f4a680def6ade9b3b366633dcL91-R90) [[7]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L95-R94)
* Added `HashConfig` to the main configuration struct in `backend/internal/system/config/config.go` to allow runtime selection of the hash algorithm. [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR133-R137) [[2]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR148)

**Thumbprint Generation Standardization:**

* Centralized thumbprint generation for certificates and client secrets using the new `GenerateThumbprint` and `GenerateThumbprintFromString` functions, ensuring consistent encoding and algorithm usage across the codebase. [[1]](diffhunk://#diff-e3e0a0fd35744f9376521f3137b86e5a794b573f4a680def6ade9b3b366633dcL91-R90) [[2]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L95-R94) [[3]](diffhunk://#diff-184bf5335b299c8ffcabe997d2252f1818e2a249d828d4fd2f2aafa891589fb5L142-R142) [[4]](diffhunk://#diff-184bf5335b299c8ffcabe997d2252f1818e2a249d828d4fd2f2aafa891589fb5L411-R411) [[5]](diffhunk://#diff-f5f7212acd7b6df69538926d1014f93a5472cddedfa16a027c70b902eaa8b219L122-R122)

**Testing and Reliability:**

* Refactored and expanded the test suite in `backend/internal/system/crypto/hash/hash_test.go` to cover all hash provider functionalities, including SHA-256 and PBKDF2 hashing, verification, salt generation, and thumbprint computation.

**General Codebase Cleanup:**

* Removed redundant imports and legacy hash functions, and updated references to use the new hash provider and credential model. [[1]](diffhunk://#diff-e3e0a0fd35744f9376521f3137b86e5a794b573f4a680def6ade9b3b366633dcL22-R29) [[2]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L25-R36)

These changes collectively improve security by supporting stronger hash algorithms, enhance flexibility via configuration, and make the codebase easier to maintain and extend.