### PR TITLE
Improve auth assertion to use application token configurations

### DIFF
--- a/backend/internal/authn/dto/dto.go
+++ b/backend/internal/authn/dto/dto.go
@@ -28,7 +28,7 @@ import (
 type AuthenticatedUser struct {
 	IsAuthenticated bool
 	UserID          string
-	Attributes      map[string]string
+	Attributes      map[string]interface{}
 }
 
 // AuthenticationContext represents the context of an authentication session.

--- a/backend/internal/executor/attributecollect/attributecollector.go
+++ b/backend/internal/executor/attributecollect/attributecollector.go
@@ -183,12 +183,13 @@ func (a *AttributeCollector) CheckInputData(ctx *flowmodel.NodeContext, execResp
 				if inputData.Name == userAttributePassword {
 					continue
 				}
-				logger.Debug("Attribute exists in authenticated user attributes, adding to runtime data",
-					log.String("attributeName", inputData.Name))
 
-				// TODO: This should be modified according to the storage mechanism of the
-				//  user store implementation.
-				execResp.RuntimeData[inputData.Name] = attribute
+				attributeStr, ok := attribute.(string)
+				if ok {
+					logger.Debug("Attribute exists in authenticated user attributes, adding to runtime data",
+						log.String("attributeName", inputData.Name))
+					execResp.RuntimeData[inputData.Name] = attributeStr
+				}
 			} else {
 				logger.Debug("Attribute does not exist in authenticated user attributes, adding to required data",
 					log.String("attributeName", inputData.Name))

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -32,13 +32,9 @@ import (
 )
 
 const (
-	loggerComponentName    = "BasicAuthExecutor"
-	userAttributeUserID    = "userID"
-	userAttributeUsername  = "username"
-	userAttributePassword  = "password"
-	userAttributeEmail     = "email"
-	userAttributeFirstName = "firstName"
-	userAttributeLastName  = "lastName"
+	loggerComponentName   = "BasicAuthExecutor"
+	userAttributeUsername = "username"
+	userAttributePassword = "password"
 )
 
 // BasicAuthExecutor implements the ExecutorInterface for basic authentication.
@@ -193,7 +189,7 @@ func (b *BasicAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 
 				return &authndto.AuthenticatedUser{
 					IsAuthenticated: false,
-					Attributes: map[string]string{
+					Attributes: map[string]interface{}{
 						userAttributeUsername: username,
 					},
 				}, nil
@@ -236,37 +232,10 @@ func (b *BasicAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 			return nil, err
 		}
 
-		email := ""
-		emailAttr := attrs[userAttributeEmail]
-		if emailAttr != nil {
-			email = emailAttr.(string)
-		}
-
-		firstName := ""
-		firstNameAttr := attrs[userAttributeFirstName]
-		if firstNameAttr != nil {
-			firstName = firstNameAttr.(string)
-		}
-
-		lastName := ""
-		lastNameAttr := attrs[userAttributeLastName]
-		if lastNameAttr != nil {
-			lastName = lastNameAttr.(string)
-		}
-
 		authenticatedUser = authndto.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          user.ID,
-			Attributes:      map[string]string{},
-		}
-		if firstName != "" {
-			authenticatedUser.Attributes[userAttributeFirstName] = firstName
-		}
-		if lastName != "" {
-			authenticatedUser.Attributes[userAttributeLastName] = lastName
-		}
-		if email != "" {
-			authenticatedUser.Attributes[userAttributeEmail] = email
+			Attributes:      attrs,
 		}
 	}
 	return &authenticatedUser, nil

--- a/backend/internal/executor/githubauth/githubauthexecutor.go
+++ b/backend/internal/executor/githubauth/githubauthexecutor.go
@@ -393,8 +393,8 @@ func (o *GithubOAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.
 }
 
 // getUserAttributes extracts user attributes from the user info map, excluding certain keys.
-func getUserAttributes(userInfo map[string]string, userID string) map[string]string {
-	attributes := make(map[string]string)
+func getUserAttributes(userInfo map[string]string, userID string) map[string]interface{} {
+	attributes := make(map[string]interface{})
 	for key, value := range userInfo {
 		if key != "username" && key != "sub" && key != "id" {
 			attributes[key] = value

--- a/backend/internal/executor/oauth/oauthexecutor.go
+++ b/backend/internal/executor/oauth/oauthexecutor.go
@@ -525,8 +525,8 @@ func (o *OAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.NodeCo
 }
 
 // getUserAttributes extracts user attributes from the user info map, excluding certain keys.
-func getUserAttributes(userInfo map[string]string, userID string) map[string]string {
-	attributes := make(map[string]string)
+func getUserAttributes(userInfo map[string]string, userID string) map[string]interface{} {
+	attributes := make(map[string]interface{})
 	for key, value := range userInfo {
 		if key != "username" && key != "sub" {
 			attributes[key] = value

--- a/backend/internal/executor/oidcauth/oidcauthexecutor.go
+++ b/backend/internal/executor/oidcauth/oidcauthexecutor.go
@@ -33,7 +33,6 @@ import (
 	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
-	systemutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 const loggerComponentName = "OIDCAuthExecutor"
@@ -362,12 +361,12 @@ func (o *OIDCAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.Nod
 		log.String(log.LoggerKeyExecutorID, o.GetID()),
 		log.String(log.LoggerKeyFlowID, ctx.FlowID))
 
-	userClaims := make(map[string]string)
+	userClaims := make(map[string]interface{})
 	if len(idTokenClaims) != 0 {
 		// Filter non-user claims from the ID token claims.
 		for attr, val := range idTokenClaims {
 			if !slices.Contains(idTokenNonUserAttributes, attr) {
-				userClaims[attr] = systemutils.ConvertInterfaceValueToString(val)
+				userClaims[attr] = val
 			}
 		}
 		logger.Debug("Extracted ID token claims", log.Int("noOfClaims", len(idTokenClaims)))

--- a/backend/internal/executor/provision/provisioningexecutor.go
+++ b/backend/internal/executor/provision/provisioningexecutor.go
@@ -29,7 +29,6 @@ import (
 	flowconst "github.com/asgardeo/thunder/internal/flow/constants"
 	flowmodel "github.com/asgardeo/thunder/internal/flow/model"
 	"github.com/asgardeo/thunder/internal/system/log"
-	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 	usermodel "github.com/asgardeo/thunder/internal/user/model"
 	"github.com/asgardeo/thunder/internal/user/service"
 )
@@ -156,7 +155,7 @@ func (p *ProvisioningExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.E
 	authenticatedUser := authndto.AuthenticatedUser{
 		IsAuthenticated: true,
 		UserID:          createdUser.ID,
-		Attributes:      sysutils.ConvertInterfaceMapToStringMap(retAttributes),
+		Attributes:      retAttributes,
 	}
 	execResp.AuthenticatedUser = authenticatedUser
 	execResp.Status = flowconst.ExecComplete
@@ -205,12 +204,12 @@ func (p *ProvisioningExecutor) CheckInputData(ctx *flowmodel.NodeContext, execRe
 		for _, inputData := range missingAttributes {
 			attribute, exists := authnUserAttrs[inputData.Name]
 			if exists {
-				logger.Debug("Attribute exists in authenticated user attributes, adding to runtime data",
-					log.String("attributeName", inputData.Name))
-
-				// TODO: This should be modified according to the storage mechanism of the
-				//  user store implementation.
-				execResp.RuntimeData[inputData.Name] = attribute
+				attributeStr, ok := attribute.(string)
+				if ok {
+					logger.Debug("Attribute exists in authenticated user attributes, adding to runtime data",
+						log.String("attributeName", inputData.Name))
+					execResp.RuntimeData[inputData.Name] = attributeStr
+				}
 			} else {
 				logger.Debug("Attribute does not exist in authenticated user attributes, adding to required data",
 					log.String("attributeName", inputData.Name))

--- a/backend/internal/executor/smsauth/smsauthexecutor.go
+++ b/backend/internal/executor/smsauth/smsauthexecutor.go
@@ -44,8 +44,6 @@ const (
 	userAttributeUsername     = "username"
 	userAttributeMobileNumber = "mobileNumber"
 	userAttributeEmail        = "email"
-	userAttributeFirstName    = "firstName"
-	userAttributeLastName     = "lastName"
 	userInputOTP              = "otp"
 	errorInvalidOTP           = "invalid OTP provided"
 )
@@ -721,7 +719,7 @@ func (s *SMSOTPAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 		execResp.FailureReason = ""
 		return &authndto.AuthenticatedUser{
 			IsAuthenticated: false,
-			Attributes: map[string]string{
+			Attributes: map[string]interface{}{
 				userAttributeMobileNumber: mobileNumber,
 			},
 		}, nil
@@ -743,40 +741,10 @@ func (s *SMSOTPAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 		return nil, fmt.Errorf("failed to unmarshal user attributes: %w", err)
 	}
 
-	// Create the authenticated user object
-	email := ""
-	emailAttr := attrs[userAttributeEmail]
-	if emailAttr != nil {
-		email = emailAttr.(string)
-	}
-
-	firstName := ""
-	firstNameAttr := attrs[userAttributeFirstName]
-	if firstNameAttr != nil {
-		firstName = firstNameAttr.(string)
-	}
-
-	lastName := ""
-	lastNameAttr := attrs[userAttributeLastName]
-	if lastNameAttr != nil {
-		lastName = lastNameAttr.(string)
-	}
-
 	authenticatedUser := &authndto.AuthenticatedUser{
 		IsAuthenticated: true,
 		UserID:          user.ID,
-		Attributes: map[string]string{
-			userAttributeMobileNumber: mobileNumber,
-		},
-	}
-	if email != "" {
-		authenticatedUser.Attributes[userAttributeEmail] = email
-	}
-	if firstName != "" {
-		authenticatedUser.Attributes[userAttributeFirstName] = firstName
-	}
-	if lastName != "" {
-		authenticatedUser.Attributes[userAttributeLastName] = lastName
+		Attributes:      attrs,
 	}
 
 	return authenticatedUser, nil

--- a/backend/internal/flow/constants/errorconstants.go
+++ b/backend/internal/flow/constants/errorconstants.go
@@ -72,6 +72,14 @@ var ErrorRegistrationFlowDisabled = serviceerror.ServiceError{
 	ErrorDescription: "Registration flow is disabled for the application",
 }
 
+// ErrorApplicationRetrievalClientError defines the error response for application retrieval client errors.
+var ErrorApplicationRetrievalClientError = serviceerror.ServiceError{
+	Code:             "FES-1007",
+	Type:             serviceerror.ClientErrorType,
+	Error:            "Application retrieval error",
+	ErrorDescription: "Error while retrieving application details",
+}
+
 // Server error structs
 
 // ErrorFlowGraphNotInitialized defines the error response for uninitialized flow graph errors.
@@ -227,4 +235,12 @@ var ErrorFlowContextConversionFailed = serviceerror.ServiceError{
 	Type:             serviceerror.ServerErrorType,
 	Error:            "Something went wrong",
 	ErrorDescription: "Failed to convert flow context from database format",
+}
+
+// ErrorApplicationRetrievalServerError defines the error response for application retrieval server errors.
+var ErrorApplicationRetrievalServerError = serviceerror.ServiceError{
+	Code:             "FES-5020",
+	Type:             serviceerror.ServerErrorType,
+	Error:            "Application retrieval error",
+	ErrorDescription: "Server error while retrieving application details",
 }

--- a/backend/internal/flow/engine/flowengine.go
+++ b/backend/internal/flow/engine/flowengine.go
@@ -83,6 +83,7 @@ func (fe *FlowEngine) Execute(ctx *model.EngineContext) (model.FlowStep, *servic
 			NodeInputData:     ctx.CurrentNode.GetInputData(),
 			UserInputData:     ctx.UserInputData,
 			RuntimeData:       ctx.RuntimeData,
+			Application:       ctx.Application,
 			AuthenticatedUser: ctx.AuthenticatedUser,
 		}
 		if nodeCtx.NodeInputData == nil {
@@ -188,7 +189,7 @@ func updateContextWithNodeResponse(engineCtx *model.EngineContext, nodeResp *mod
 			if engineCtx.AuthenticatedUser.Attributes == nil {
 				engineCtx.AuthenticatedUser.Attributes = prevAuthnUserAttrs
 			} else {
-				engineCtx.AuthenticatedUser.Attributes = sysutils.MergeStringMaps(
+				engineCtx.AuthenticatedUser.Attributes = sysutils.MergeInterfaceMaps(
 					prevAuthnUserAttrs, engineCtx.AuthenticatedUser.Attributes)
 			}
 		}

--- a/backend/internal/flow/model/flowmodel.go
+++ b/backend/internal/flow/model/flowmodel.go
@@ -20,6 +20,7 @@
 package model
 
 import (
+	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	authndto "github.com/asgardeo/thunder/internal/authn/dto"
 	"github.com/asgardeo/thunder/internal/flow/constants"
 )
@@ -36,7 +37,8 @@ type EngineContext struct {
 	CurrentNodeResponse *NodeResponse
 	CurrentActionID     string
 
-	Graph GraphInterface
+	Graph       GraphInterface
+	Application appmodel.ApplicationProcessedDTO
 
 	AuthenticatedUser authndto.AuthenticatedUser
 }
@@ -52,6 +54,7 @@ type NodeContext struct {
 	UserInputData map[string]string
 	RuntimeData   map[string]string
 
+	Application       appmodel.ApplicationProcessedDTO
 	AuthenticatedUser authndto.AuthenticatedUser
 }
 

--- a/backend/internal/flow/store/model.go
+++ b/backend/internal/flow/store/model.go
@@ -66,13 +66,13 @@ func (f *FlowContextWithUserDataDB) ToEngineContext(graph model.GraphInterface) 
 	}
 
 	// Parse authenticated user attributes
-	var userAttributes map[string]string
+	var userAttributes map[string]interface{}
 	if f.UserAttributes != nil {
 		if err := json.Unmarshal([]byte(*f.UserAttributes), &userAttributes); err != nil {
 			return model.EngineContext{}, err
 		}
 	} else {
-		userAttributes = make(map[string]string)
+		userAttributes = make(map[string]interface{})
 	}
 
 	// Build authenticated user

--- a/backend/internal/oauth/session/store/sessiondatastore_test.go
+++ b/backend/internal/oauth/session/store/sessiondatastore_test.go
@@ -84,7 +84,7 @@ func (suite *SessionDataStoreTestSuite) TestAddSession() {
 		AuthenticatedUser: authndto.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
-			Attributes: map[string]string{
+			Attributes: map[string]interface{}{
 				"username": "testuser",
 				"email":    "test@example.com",
 			},

--- a/backend/internal/system/utils/sliceutil.go
+++ b/backend/internal/system/utils/sliceutil.go
@@ -68,3 +68,14 @@ func DeepCopyMapOfClonables[T ClonableInterface](src map[string]T) (map[string]T
 	}
 	return dst, nil
 }
+
+// MergeInterfaceMaps merges two maps of interface{} and returns the result.
+func MergeInterfaceMaps(dst, src map[string]interface{}) map[string]interface{} {
+	if dst == nil {
+		dst = make(map[string]interface{})
+	}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}


### PR DESCRIPTION
## Important
Should be rebased and merged after https://github.com/asgardeo/thunder/pull/351 & https://github.com/asgardeo/thunder/pull/353

## Purpose
This pull request improves the auth assertion JWT token issuance logic to use the token configurations configured for the authenticating application. With this following changes will be introduced to the auth assertion.
- Utilize application's issuer and validity period
- Will include user attributes configured for the application in the jwt token

In order to support the above requirement, this pull request also adds the Application struct to the flow contexts (`EngineContext` and `NodeContext`). With this, the server requires to retrieve and add the application to the context on each flow execution request.

## Related Issues
- https://github.com/asgardeo/thunder/issues/345

## Related PRs
- https://github.com/asgardeo/thunder/pull/347
- https://github.com/asgardeo/thunder/pull/353