### PR TITLE
Improve caching in 'allowed origins'

### DIFF
--- a/backend/internal/system/server/serveroperation.go
+++ b/backend/internal/system/server/serveroperation.go
@@ -92,16 +92,16 @@ func (ops *ServerOperationService) getAllowedOrigins() ([]string, error) {
 		}
 		if len(results) == 0 {
 			logger.Debug("No allowed origins found")
-			return []string{}, nil
+			originList = []string{}
+		} else {
+			row := results[0]
+			allowedOrigins, ok := row["allowed_origins"].(string)
+			if !ok {
+				logger.Error("Failed to parse allowed_origins as string")
+				return nil, errors.New("failed to parse allowed_origins as string")
+			}
+			originList = utils.ParseStringArray(allowedOrigins, ",")
 		}
-
-		row := results[0]
-		allowedOrigins, ok := row["allowed_origins"].(string)
-		if !ok {
-			logger.Error("Failed to parse allowed_origins as string")
-			return nil, err
-		}
-		originList = utils.ParseStringArray(allowedOrigins, ",")
 
 		if err := ops.OriginCache.Set(cacheKey, originList); err != nil {
 			logger.Error("Failed to cache allowed origins", log.Error(err))


### PR DESCRIPTION
## Purpose
This pull request refactors the logic for handling cases where no allowed origins are found in the `getAllowedOrigins` method. The main change is to set `originList` to an empty slice instead of returning early, ensuring consistent flow and caching behavior.

Error handling and control flow improvements:

* Refactored the handling of empty results in `getAllowedOrigins` to set `originList` to an empty slice and continue execution, rather than returning early. This ensures that the empty list is still cached, improving consistency and avoiding potential cache misses.