### PR TITLE
Improve user schema api update test

### DIFF
--- a/tests/integration/userschema/userschema_api_update_test.go
+++ b/tests/integration/userschema/userschema_api_update_test.go
@@ -379,14 +379,13 @@ func (ts *UpdateUserSchemaTestSuite) createTestSchema(schema CreateUserSchemaReq
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		ts.T().Fatalf("Expected status 201, got %d. Response: %s", resp.StatusCode, string(body))
-	}
-
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		ts.T().Fatalf("Failed to read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		ts.T().Fatalf("Expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var createdSchema UserSchema


### PR DESCRIPTION
## Purpose
This pull request includes a minor improvement to the error handling in the `createTestSchema` helper within the user schema integration tests. The change ensures the response body is always fully read before checking and reporting errors, which can help with debugging and resource management.

* Testing improvement:
  * [`tests/integration/userschema/userschema_api_update_test.go`](diffhunk://#diff-394959b678904ccb300fa0780dfc70ae69cfe3c1a447b7cd887fa8cfa8f14852L382-R390): Refactored error handling in `createTestSchema` to read the response body before checking the status code, ensuring more informative error messages and proper resource usage.