### PR TITLE
Fix sample app's runtime.json resolution

### DIFF
--- a/samples/apps/oauth/server/package.json
+++ b/samples/apps/oauth/server/package.json
@@ -6,7 +6,6 @@
     "main": "server.js",
     "pkg": {
         "assets": [
-            "app/**/*",
             "server.key",
             "server.cert"
         ],

--- a/samples/apps/oauth/server/server.js
+++ b/samples/apps/oauth/server/server.js
@@ -34,11 +34,12 @@ const keyPath = path.join(certDir, 'server.key');
 const certPath = path.join(certDir, 'server.cert');
 
 // Serve static files from the 'dist' directory
-app.use(express.static(path.join(__dirname, 'app')));
+const appDir = path.join(certDir, 'app');
+app.use(express.static(appDir));
 
 // Handle SPA routing
 app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'app', 'index.html'));
+  res.sendFile(path.join(appDir, 'index.html'));
 });
 
 if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {


### PR DESCRIPTION
## Purpose
Update `server.js` of sample app to use the `runtime.json` from the thunder distribution pack instead of the embedded one.

##Related issue
- https://github.com/asgardeo/thunder/issues/373