### PR TITLE
Add Helm Chart for Thunder Kubernetes Deployment

### DIFF
--- a/install/helm/.helmignore
+++ b/install/helm/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+*.md
+*.png

--- a/install/helm/Chart.yaml
+++ b/install/helm/Chart.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v2
+name: thunder
+description: A Helm chart for WSO2 Thunder - Lightweight user and identity management system
+type: application
+version: 0.0.1
+appVersion: "0.7.0"

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -1,0 +1,207 @@
+# Thunder Helm Chart
+
+This repository contains the Helm chart for WSO2 Thunder, a lightweight user and identity management system designed for modern application development.
+
+## Prerequisites
+
+### Infrastructure
+- Running Kubernetes cluster ([minikube](https://kubernetes.io/docs/tasks/tools/#minikube) or an alternative cluster)
+- Kubernetes ingress controller ([NGINX Ingress](https://github.com/kubernetes/ingress-nginx) recommended)
+
+### Tools
+| Tool          | Installation Guide | Version Check Command |
+|---------------|--------------------|-----------------------|
+| Git           | [Install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) | `git --version` |
+| Helm          | [Install Helm](https://helm.sh/docs/intro/install/) | `helm version` |
+| Docker        | [Install Docker](https://docs.docker.com/engine/install/) | `docker --version` |
+| kubectl       | [Install kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) | `kubectl version` |
+
+## Quick Start Guide
+
+Follow these steps to deploy Thunder in your Kubernetes cluster:
+
+### 1. Clone the Thunder repository
+
+```bash
+git clone https://github.com/asgardeo/thunder.git
+cd thunder/install/helm
+```
+
+### 2. Install the Thunder Helm chart
+
+You can install the Thunder Helm chart with the release name `my-thunder` as follows:
+
+```bash
+helm install my-thunder .
+```
+
+If you want to customize the installation, create a `custom-values.yaml` file with your configurations and use:
+
+```bash
+helm install my-thunder . -f custom-values.yaml
+```
+
+The command deploys Thunder on the Kubernetes cluster with the default configuration. The [Parameters](#parameters) section lists the available parameters that can be configured during installation.
+
+### 3. Access Thunder
+
+### 4. Obtain the External IP
+
+After deploying WSO2 Identity Server, you need to find its external IP address to access it outside the cluster. Run the following command to list the Ingress resources:
+
+```bash
+kubectl get ingress
+```
+**Output Fields:**
+
+- **HOSTS** – Hostname (e.g., `thunder.local`)
+- **ADDRESS** – External IP
+- **PORTS** – Exposed ports (usually 80, 443)
+
+After the installation is complete, you can access Thunder via the Ingress hostname.
+
+By default, Thunder will be available at `http://thunder.local`. You may need to add this hostname to your local hosts file or configure your DNS accordingly.
+
+### Uninstalling the Chart
+
+To uninstall/delete the `my-thunder` deployment:
+
+```bash
+helm uninstall my-thunder
+```
+
+This command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following table lists the configurable parameters of the Thunder chart and their default values.
+
+### Global Parameters
+
+| Name                      | Description                                     | Default                                                 |
+| ------------------------- | ----------------------------------------------- | ------------------------------------------------------- |
+| `nameOverride`            | String to partially override common.names.fullname | `""`                                                  |
+| `fullnameOverride`        | String to fully override common.names.fullname  | `""`                                                    |
+
+### Deployment Parameters
+
+| Name                                    | Description                                                                             | Default                        |
+| --------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------ |
+| `deployment.replicaCount`               | Number of Thunder replicas                                                              | `2`                            |
+| `deployment.strategy.rollingUpdate.maxSurge` | Maximum number of pods that can be created over the desired number during an update | `1`                           |
+| `deployment.strategy.rollingUpdate.maxUnavailable` | Maximum number of pods that can be unavailable during an update              | `0`                           |
+| `deployment.image.registry`             | Thunder image registry                                                                  | `ghcr.io/asgardeo`             |
+| `deployment.image.repository`           | Thunder image repository                                                                | `thunder`                      |
+| `deployment.image.tag`                  | Thunder image tag                                                                       | `0.7.0`                        |
+| `deployment.image.digest`               | Thunder image digest (use either tag or digest)                                         | `""`                           |
+| `deployment.image.pullPolicy`           | Thunder image pull policy                                                               | `Always`                       |
+| `deployment.terminationGracePeriodSeconds` | Pod termination grace period in seconds                                              | `10`                           |
+| `deployment.container.port`             | Thunder container port                                                                  | `8090`                         |
+| `deployment.startupProbe.initialDelaySeconds` | Startup probe initial delay seconds                                               | `1`                            |
+| `deployment.startupProbe.periodSeconds` | Startup probe period seconds                                                            | `2`                            |
+| `deployment.startupProbe.failureThreshold` | Startup probe failure threshold                                                      | `30`                           |
+| `deployment.livenessProbe.periodSeconds` | Liveness probe period seconds                                                          | `10`                           |
+| `deployment.readinessProbe.initialDelaySeconds` | Readiness probe initial delay seconds                                           | `1`                            |
+| `deployment.readinessProbe.periodSeconds` | Readiness probe period seconds                                                        | `10`                           |
+| `deployment.resources.limits.cpu`       | CPU resource limits                                                                     | `1.5`                          |
+| `deployment.resources.limits.memory`    | Memory resource limits                                                                  | `512Mi`                        |
+| `deployment.resources.requests.cpu`     | CPU resource requests                                                                   | `1`                            |
+| `deployment.resources.requests.memory`  | Memory resource requests                                                                | `256Mi`                        |
+| `deployment.securityContext.enableRunAsUser` | Enable running as non-root user                                                    | `true`                         |
+| `deployment.securityContext.runAsUser`  | User ID to run the container                                                            | `802`                          |
+| `deployment.securityContext.seccompProfile.enabled` | Enable seccomp profile                                                      | `false`                        |
+| `deployment.securityContext.seccompProfile.type` | Seccomp profile type                                                           | `RuntimeDefault`               |
+
+### HPA Parameters
+
+| Name                              | Description                                                      | Default                       |
+| --------------------------------- | ---------------------------------------------------------------- | ----------------------------- |
+| `hpa.enabled`                     | Enable Horizontal Pod Autoscaler                                 | `true`                        |
+| `hpa.maxReplicas`                 | Maximum number of replicas                                       | `10`                          |
+| `hpa.averageUtilizationCPU`       | Target CPU utilization percentage                                | `65`                          |
+| `hpa.averageUtilizationMemory`    | Target Memory utilization percentage                             | `75`                          |
+
+### Service Parameters
+
+| Name                             | Description                                                       | Default                      |
+| -------------------------------- | ----------------------------------------------------------------- | ---------------------------- |
+| `service.port`                   | Thunder service port                                              | `8090`                       |
+
+### Service Account Parameters
+
+| Name                         | Description                                                | Default                       |
+| ---------------------------- | ---------------------------------------------------------- | ----------------------------- |
+| `serviceAccount.create`      | Enable creation of ServiceAccount                          | `true`                        |
+| `serviceAccount.name`        | Name of the service account to use                         | `thunder-service-account`     |
+
+### PDB Parameters
+
+| Name                        | Description                                                 | Default                       |
+| --------------------------- | ----------------------------------------------------------- | ----------------------------- |
+| `pdb.minAvailable`          | Minimum number of pods that must be available               | `50%`                         |
+
+### Ingress Parameters
+
+| Name                                  | Description                                                     | Default                      |
+| ------------------------------------- | --------------------------------------------------------------- | ---------------------------- |
+| `ingress.className`                   | Ingress controller class                                        | `nginx`                      |
+| `ingress.hostname`                    | Default host for the ingress resource                           | `thunder.local`              |
+| `ingress.paths[0].path`               | Path for the ingress resource                                   | `/`                          |
+| `ingress.paths[0].pathType`           | Path type for the ingress resource                              | `Prefix`                     |
+| `ingress.tlsSecretsName`              | TLS secret name for HTTPS                                       | `thunder-tls`                |
+| `ingress.commonAnnotations`           | Common annotations for ingress                                  | See values.yaml              |
+| `ingress.customAnnotations`           | Custom annotations for ingress                                  | `{}`                         |
+
+### Thunder Configuration Parameters
+
+| Name                                   | Description                                                     | Default                      |
+| -------------------------------------- | --------------------------------------------------------------- | ---------------------------- |
+| `configuration.server.hostname`        | Thunder server hostname                                         | `0.0.0.0`                    |
+| `configuration.server.port`            | Thunder server port                                             | `8090`                       |
+| `configuration.gateClient.hostname`    | Gate client hostname                                            | `0.0.0.0`                    |
+| `configuration.gateClient.port`        | Gate client port                                                | `9090`                       |
+| `configuration.gateClient.scheme`      | Gate client scheme                                              | `https`                      |
+| `configuration.gateClient.loginPath`   | Gate client login path                                          | `/login`                     |
+| `configuration.gateClient.errorPath`   | Gate client error path                                          | `/error`                     |
+| `configuration.security.certFile`      | Server certificate file path                                    | `repository/resources/security/server.cert` |
+| `configuration.security.keyFile`       | Server key file path                                            | `repository/resources/security/server.key`  |
+| `configuration.database.identity.type` | Identity database type (postgres or sqlite)                     | `postgres`                   |
+| `configuration.database.identity.sqlitePath` | SQLite database path (for sqlite only)                    | `repository/database/thunderdb.db` |
+| `configuration.database.identity.sqliteOptions` | SQLite options (for sqlite only)                       | `_journal_mode=WAL&_busy_timeout=5000` |
+| `configuration.database.identity.name` | Postgres database name (for postgres only)                      | `thunderdb`                  |
+| `configuration.database.identity.host` | Postgres host (for postgres only)                               | `wso2-thunder.postgres.database.azure.com` |
+| `configuration.database.identity.port` | Postgres port (for postgres only)                               | `5432`                       |
+| `configuration.database.identity.username` | Postgres username (for postgres only)                       | `sqladmin`                   |
+| `configuration.database.identity.password` | Postgres password (for postgres only)                       | `sdfds#4J2knc`              |
+| `configuration.database.identity.sslmode` | Postgres SSL mode (for postgres only)                        | `require`                    |
+| `configuration.database.runtime.type`  | Runtime database type (postgres or sqlite)                      | `postgres`                   |
+| `configuration.database.runtime.sqlitePath` | SQLite database path (for sqlite only)                     | `repository/database/runtimedb.db` |
+| `configuration.database.runtime.sqliteOptions` | SQLite options (for sqlite only)                        | `_journal_mode=WAL&_busy_timeout=5000` |
+| `configuration.database.runtime.name`  | Postgres database name (for postgres only)                      | `runtimedb`                  |
+| `configuration.database.runtime.host`  | Postgres host (for postgres only)                               | `wso2-thunder.postgres.database.azure.com` |
+| `configuration.database.runtime.port`  | Postgres port (for postgres only)                               | `5432`                       |
+| `configuration.database.runtime.username` | Postgres username (for postgres only)                        | `sqladmin`                   |
+| `configuration.database.runtime.password` | Postgres password (for postgres only)                        | `sdfds#4J2knc`              |
+| `configuration.database.runtime.sslmode` | Postgres SSL mode (for postgres only)                         | `require`                    |
+| `configuration.cache.disabled`         | Disable cache                                                   | `false`                      |
+| `configuration.cache.type`             | Cache type                                                      | `inmemory`                   |
+| `configuration.cache.size`             | Cache size                                                      | `1000`                       |
+| `configuration.cache.ttl`              | Cache TTL in seconds                                            | `3600`                       |
+| `configuration.cache.evictionPolicy`   | Cache eviction policy                                           | `LRU`                        |
+| `configuration.cache.cleanupInterval`  | Cache cleanup interval in seconds                               | `300`                        |
+| `configuration.oauth.jwt.issuer`       | JWT issuer                                                      | `thunder`                    |
+| `configuration.oauth.jwt.validityPeriod` | JWT validity period in seconds                                | `3600`                       |
+| `configuration.oauth.refreshToken.renewOnGrant` | Renew refresh token on grant                           | `false`                      |
+| `configuration.oauth.refreshToken.validityPeriod` | Refresh token validity period in seconds             | `86400`                      |
+| `configuration.flow.graphDirectory`    | Flow graph directory                                            | `repository/resources/graphs/` |
+| `configuration.flow.authn.defaultFlow` | Default authentication flow                                     | `auth_flow_config_basic`     |
+| `configuration.cors.allowedOrigins`    | CORS allowed origins                                            | See values.yaml              |
+
+### Custom Configuration
+
+The Thunder configuration file (deployment.yaml) can be customized by overriding the default values in the values.yaml file.
+Alternatively, you can directly update the values in conf/deployment.yaml before deploying the Helm chart.
+
+### Database Configuration
+
+Thunder supports both sqlite and postgres databases. By default, sqlite is configured. You can configure the database connection by overriding the database configuration in the values.yaml file.

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -1,0 +1,85 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+server:
+  hostname: {{ .Values.configuration.server.hostname | quote }}
+  port: {{ .Values.configuration.server.port }}
+
+gate_client:
+  hostname: {{ .Values.configuration.gateClient.hostname | quote }}
+  port: {{ .Values.configuration.gateClient.port }}
+  scheme: {{ .Values.configuration.gateClient.scheme | quote }}
+  login_path: {{ .Values.configuration.gateClient.loginPath | quote }}
+  error_path: {{ .Values.configuration.gateClient.errorPath | quote }}
+
+security:
+  cert_file: {{ .Values.configuration.security.certFile | quote }}
+  key_file: {{ .Values.configuration.security.keyFile | quote }}
+
+database:
+  identity:
+    type: {{ .Values.configuration.database.identity.type | quote }}
+    {{- if eq .Values.configuration.database.identity.type "sqlite" }}
+    path: {{ .Values.configuration.database.identity.sqlitePath | quote }}
+    options: {{ .Values.configuration.database.identity.sqliteOptions | quote }}
+    {{- else }}
+    hostname: {{ .Values.configuration.database.identity.host | quote }}
+    port: {{ .Values.configuration.database.identity.port }}
+    name: {{ .Values.configuration.database.identity.name | quote }}
+    username: {{ .Values.configuration.database.identity.username | quote }}
+    password: {{ .Values.configuration.database.identity.password | quote }}
+    sslmode: {{ .Values.configuration.database.identity.sslmode | quote }}
+    {{- end }}
+  runtime:
+    type: {{ .Values.configuration.database.runtime.type | quote }}
+    {{- if eq .Values.configuration.database.runtime.type "sqlite" }}
+    path: {{ .Values.configuration.database.runtime.sqlitePath | quote }}
+    options: {{ .Values.configuration.database.runtime.sqliteOptions | quote }}
+    {{- else }}
+    hostname: {{ .Values.configuration.database.runtime.host | quote }}
+    port: {{ .Values.configuration.database.runtime.port }}
+    name: {{ .Values.configuration.database.runtime.name | quote }}
+    username: {{ .Values.configuration.database.runtime.username | quote }}
+    password: {{ .Values.configuration.database.runtime.password | quote }}
+    sslmode: {{ .Values.configuration.database.runtime.sslmode | quote }}
+    {{- end }}
+
+cache:
+  disabled: {{ .Values.configuration.cache.disabled }}
+  type: {{ .Values.configuration.cache.type | quote }}
+  size: {{ .Values.configuration.cache.size }}
+  ttl: {{ .Values.configuration.cache.ttl }}
+  eviction_policy: {{ .Values.configuration.cache.evictionPolicy | quote }}
+  cleanup_interval: {{ .Values.configuration.cache.cleanupInterval }}
+
+oauth:
+  jwt:
+    issuer: {{ .Values.configuration.oauth.jwt.issuer | quote }}
+    validity_period: {{ .Values.configuration.oauth.jwt.validityPeriod }}
+  refresh_token:
+    renew_on_grant: {{ .Values.configuration.oauth.refreshToken.renewOnGrant }}
+    validity_period: {{ .Values.configuration.oauth.refreshToken.validityPeriod }}
+
+flow:
+  graph_directory: {{ .Values.configuration.flow.graphDirectory | quote }}
+  authn:
+    default_flow: {{ .Values.configuration.flow.authn.defaultFlow | quote }}
+
+cors:
+  allowed_origins:
+  {{- range .Values.configuration.cors.allowedOrigins }}
+    - {{ . | quote }}
+  {{- end }}

--- a/install/helm/templates/_helpers.tpl
+++ b/install/helm/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/*
+Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+
+WSO2 LLC. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+
+{{- define "thunder.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "thunder.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "thunder.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "thunder.labels" -}}
+helm.sh/chart: {{ include "thunder.chart" . }}
+{{ include "thunder.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "thunder.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "thunder.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "thunder.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "thunder.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/install/helm/templates/config-map.yaml
+++ b/install/helm/templates/config-map.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "thunder.fullname" . }}-cm-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}
+data:
+  deployment.yaml: {{ tpl (.Files.Get "conf/deployment.yaml") . | quote }}

--- a/install/helm/templates/hpa.yaml
+++ b/install/helm/templates/hpa.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "thunder.fullname" . }}-hpa
+spec:
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  minReplicas: {{ .Values.deployment.replicaCount }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "thunder.fullname" . }}-deployment
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.averageUtilizationCPU }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.averageUtilizationMemory }}
+{{- end }}

--- a/install/helm/templates/ingress.yaml
+++ b/install/helm/templates/ingress.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    {{- toYaml .Values.ingress.combinedAnnotations | nindent 4 }}
+  name: {{ include "thunder.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "thunder.fullname" .  }}-service
+                port:
+                  number: {{ .Values.service.port }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.hostname | quote }}
+    secretName: {{ .Values.ingress.tlsSecretsName  }}

--- a/install/helm/templates/pdb.yaml
+++ b/install/helm/templates/pdb.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{ $replicas:= int .Values.deployment.replicaCount }}
+{{- if gt $replicas 1 }}
+apiVersion: "policy/v1"
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "thunder.fullname" . }}-pdb
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable | quote }}
+  selector:
+    matchLabels:
+      {{- include "thunder.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/install/helm/templates/rbac.yaml
+++ b/install/helm/templates/rbac.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "thunder.fullname" . }}-endpoints-reader-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    verbs: ["get", "list"]
+    resources: ["endpoints"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "thunder.fullname" . }}-endpoints-reader-role-binding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "thunder.fullname" . }}-endpoints-reader-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "thunder.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/install/helm/templates/service-account.yaml
+++ b/install/helm/templates/service-account.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thunder.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}

--- a/install/helm/templates/service.yaml
+++ b/install/helm/templates/service.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thunder.fullname" . }}-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "thunder.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: servlet-https
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.deployment.container.port }}
+      protocol: TCP

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -81,7 +81,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - nc -z localhost 8090
+                - nc -z localhost {{ .Values.deployment.container.port }}
             initialDelaySeconds: {{ .Values.deployment.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.deployment.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.deployment.startupProbe.failureThreshold }}

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -1,0 +1,128 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "thunder.fullname" . }}-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.deployment.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.deployment.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.deployment.strategy.rollingUpdate.maxUnavailable }}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "thunder.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "thunder.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum.deployment.yaml: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "thunder.serviceAccountName" . }}
+      securityContext:
+        {{- if .Values.deployment.securityContext.enableRunAsUser }}
+        runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
+        {{- end }}
+        {{- if .Values.deployment.securityContext.seccompProfile.enabled }}
+        seccompProfile:
+          type: {{ .Values.deployment.securityContext.seccompProfile.type }}
+        {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - {{ include "thunder.name" . }}
+                    - key: app.kubernetes.io/instance
+                      operator: In
+                      values:
+                        - {{ .Release.Name }}
+                topologyKey: topology.kubernetes.io/zone
+      {{- if .Values.deployment.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.deployment.image.imagePullSecret }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+      containers:
+        - name: thunder
+          {{- if .Values.deployment.image.digest }}
+          image: {{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}@{{ .Values.deployment.image.digest }}
+          {{- else }}
+          image: {{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ default "latest" .Values.deployment.image.tag }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - nc -z localhost 8090
+            initialDelaySeconds: {{ .Values.deployment.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.deployment.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.deployment.startupProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: {{ .Values.deployment.container.port }}
+              scheme: HTTPS
+            periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: {{ .Values.deployment.container.port }}
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
+          resources:
+            requests:
+              memory: {{ .Values.deployment.resources.requests.memory }}
+              cpu: {{ .Values.deployment.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.deployment.resources.limits.memory }}
+              cpu: {{ .Values.deployment.resources.limits.cpu }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            {{- if .Values.deployment.securityContext.enableRunAsUser }}
+            runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
+            {{- end }}
+            capabilities:
+              drop:
+                - all
+          ports:
+            - containerPort: {{ .Values.deployment.container.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: deployment-yaml-volume
+              mountPath: /opt/thunder/repository/conf/deployment.yaml
+              subPath: deployment.yaml
+      volumes:
+        - name: deployment-yaml-volume
+          configMap:
+            name: {{ include "thunder.fullname" . }}-cm-deployment

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -107,7 +107,7 @@ spec:
               cpu: {{ .Values.deployment.resources.limits.cpu }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             {{- if .Values.deployment.securityContext.enableRunAsUser }}
             runAsUser: {{ .Values.deployment.securityContext.runAsUser }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -134,8 +134,8 @@ configuration:
       name: "thunderdb" 
       host: "localhost" 
       port: "5432" 
-      username: "asgthunder>" 
-      password: "asgthunder" 
+      username: "asgthunder"
+      password: "asgthunder"
       sslmode: "require" 
     # Runtime database configuration
     runtime:
@@ -147,7 +147,7 @@ configuration:
       name: "runtimedb" 
       host: "localhost" 
       port: "5432" 
-      username: "asgthunder>" 
+      username: "asgthunder"
       password: "asgthunder" 
       sslmode: "require" 
 

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -126,30 +126,26 @@ configuration:
   # Database configuration
   database:
     identity:
-      type: "sqlite" # postgres or sqlite
-      # Below two parameters are only required for sqlite
-      sqlitePath: "repository/database/thunderdb.db" # Only required for sqlite
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
-      # Below parameters are only required for Postgres
-      name: "thunderdb" 
-      host: "<DB_HOSTNAME>" 
-      port: "<DB_PORT>" 
-      username: "<DB_USERNAME>" 
-      password: "<DB_PASSWORD>" 
-      sslmode: "require" 
+      type: "postgres" # postgres or sqlite
+      host: "wso2-thunder.postgres.database.azure.com"
+      port: 5432
+      name: "thunderdb"
+      username: "sqladmin"
+      password: "sdfds#4J2knc"
+      sqlitePath: "repository/database/thunderdb.db"
+      options: "_journal_mode=WAL&_busy_timeout=5000"
+      sslmode: "require"
     # Runtime database configuration
     runtime:
-      type: "sqlite" # postgres or sqlite
-      # Below two parameters are only required for sqlite
-      sqlitePath: "repository/database/runtimedb.db" # Only required for sqlite
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
-      # Below parameters are only required for Postgres
-      name: "runtimedb" 
-      host: "<DB_HOSTNAME>" 
-      port: "<DB_PORT>" 
-      username: "<DB_USERNAME>" 
-      password: "<DB_PASSWORD>" 
-      sslmode: "require" 
+      type: "postgres" # postgres or sqlite
+      host: "wso2-thunder.postgres.database.azure.com"
+      port: 5432
+      name: "runtimedb"
+      username: "sqladmin"
+      password: "sdfds#4J2knc"
+      sqlitePath: "repository/database/runtimedb.db"
+      options: "_journal_mode=WAL&_busy_timeout=5000"
+      sslmode: "require"
 
   # Cache configuration
   cache:

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -1,0 +1,183 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+deployment:
+  replicaCount: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  securityContext:
+    enableRunAsUser: true
+    runAsUser: 802
+    seccompProfile:
+      enabled: true
+      type: "RuntimeDefault"
+  # Pod termination grace period. K8s API server waits this period after pre stop hook and sending TERM signal
+  terminationGracePeriodSeconds: 10
+  image:
+    # -- Container image registry host name
+    registry: "ghcr.io/asgardeo"
+    # -- Container image repository name
+    repository: "thunder"
+    # -- Container image digest
+    digest: ""
+    # -- Container image tag. Either "tag" or "digest" should be defined
+    tag: "0.7.0"
+    pullPolicy: "Always"
+  startupProbe:
+    initialDelaySeconds: 1
+    periodSeconds: 2
+    failureThreshold: 30
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 1
+    periodSeconds: 10
+  container:
+    port: 8090
+  resources:
+    limits:
+      cpu: 1.5
+      memory: 512Mi
+    requests:
+      cpu: 1
+      memory: 256Mi
+
+hpa:
+  enabled: true
+  maxReplicas: 10
+  averageUtilizationCPU: 65
+  averageUtilizationMemory: 75
+
+pdb:
+  minAvailable: "50%"
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "thunder-service-account"
+  create: true
+
+service:
+  port: 8090
+
+ingress:
+  className: "nginx"
+  commonAnnotations: &commonAnnotations
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/session-cookie-conditional-samesite-none: "true"
+    nginx.ingress.kubernetes.io/session-cookie-hash: sha1
+    nginx.ingress.kubernetes.io/session-cookie-name: paf
+    nginx.ingress.kubernetes.io/session-cookie-path: /
+    nginx.ingress.kubernetes.io/session-cookie-samesite: None
+  customAnnotations: &customAnnotations
+    {}
+  combinedAnnotations:
+    !!merge <<: *commonAnnotations
+    !!merge <<: *customAnnotations
+  hostname: thunder.local
+  paths:
+    - path: /
+      pathType: Prefix
+  tlsSecretsName: "thunder-tls"
+
+# Thunder specific configurations
+configuration:
+  # Server configuration
+  server:
+    hostname: "0.0.0.0"
+    port: 8090
+
+  # Gate client configuration
+  gateClient:
+    hostname: "0.0.0.0"
+    port: 9090
+    scheme: "https"
+    loginPath: "/login"
+    errorPath: "/error"
+
+  # Security configuration
+  security:
+    certFile: "repository/resources/security/server.cert"
+    keyFile: "repository/resources/security/server.key"
+
+  # Database configuration
+  database:
+    identity:
+      type: "sqlite" # postgres or sqlite
+      # Below two parameters are only required for sqlite
+      sqlitePath: "repository/database/thunderdb.db" # Only required for sqlite
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
+      # Below parameters are only required for Postgres
+      name: "thunderdb" 
+      host: "<DB_HOSTNAME>" 
+      port: "<DB_PORT>" 
+      username: "<DB_USERNAME>" 
+      password: "<DB_PASSWORD>" 
+      sslmode: "require" 
+    # Runtime database configuration
+    runtime:
+      type: "sqlite" # postgres or sqlite
+      # Below two parameters are only required for sqlite
+      sqlitePath: "repository/database/runtimedb.db" # Only required for sqlite
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
+      # Below parameters are only required for Postgres
+      name: "runtimedb" 
+      host: "<DB_HOSTNAME>" 
+      port: "<DB_PORT>" 
+      username: "<DB_USERNAME>" 
+      password: "<DB_PASSWORD>" 
+      sslmode: "require" 
+
+  # Cache configuration
+  cache:
+    disabled: false
+    type: "inmemory"
+    size: 1000
+    ttl: 3600
+    evictionPolicy: "LRU"
+    cleanupInterval: 300
+
+  # OAuth configuration
+  oauth:
+    jwt:
+      issuer: "thunder"
+      validityPeriod: 3600
+    refreshToken:
+      renewOnGrant: false
+      validityPeriod: 86400
+
+  # Flow configuration
+  flow:
+    graphDirectory: "repository/resources/graphs/"
+    authn:
+      defaultFlow: "auth_flow_config_basic"
+
+  # CORS configuration
+  cors:
+    allowedOrigins:
+      - "https://localhost:3000"
+      - "https://localhost:9001"
+      - "https://localhost:9090"


### PR DESCRIPTION
## Purpose
This PR introduces a Helm chart to deploy Thunder in a Kubernetes environments.

This PR includes;
- Deployment definition for deploying Thunder pods
- Configurable deployment parameters including replica count, rolling update strategy, and security contexts
- Pre-configured health checks (startup, liveness, and readiness probes)
- Service definition for exposing Thunder API
- Ingress configuration for external access
- Horizontal Pod Autoscaler for automatic scaling
- Pod Disruption Budget for high availability during cluster maintenance
- RBAC and Service Account setup for proper Kubernetes permissions
- ConfigMap for deployment configurations