### PR TITLE
Update README to indicate Go version requirement as 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,7 +1671,7 @@ curl -kL https://localhost:8090/oauth2/jwks
 
 ### Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - Node.js 20+
 
 ---


### PR DESCRIPTION
## Purpose
This pull request updates the documentation to reflect the minimum required Go version for the project.

Documentation update:

* Updated the prerequisite in `README.md` to require Go 1.25+ instead of Go 1.24+.