### PR TITLE
Fix redundant file reads on tls config and cert kid handling

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -153,6 +153,18 @@ func startTLSServer(logger *log.Logger, cfg *config.Config, mux *http.ServeMux, 
 		logger.Fatal("Failed to load TLS configuration", log.Error(err))
 	}
 
+	// Extract and set the certificate Key ID (kid).
+	kid, err := sysCertSvc.GetCertificateKid(tlsConfig)
+	if err != nil {
+		logger.Fatal("Failed to extract certificate kid", log.Error(err))
+	}
+
+	certConfig := config.CertConfig{
+		TLSConfig: tlsConfig,
+		CertKid:   kid,
+	}
+	config.GetThunderRuntime().SetCertConfig(certConfig)
+
 	ln, err := tls.Listen("tcp", serverAddr, tlsConfig)
 	if err != nil {
 		logger.Fatal("Failed to start TLS listener", log.Error(err))

--- a/backend/internal/cert/systemcertservice.go
+++ b/backend/internal/cert/systemcertservice.go
@@ -33,7 +33,7 @@ import (
 // SystemCertificateServiceInterface defines the interface for system certificate operations.
 type SystemCertificateServiceInterface interface {
 	GetTLSConfig(cfg *config.Config, currentDirectory string) (*tls.Config, error)
-	GetCertificateKid() (string, error)
+	GetCertificateKid(tlsConfig *tls.Config) (string, error)
 }
 
 // SystemCertificateService implements the SystemCertificateServiceInterface for managing system certificates.
@@ -71,13 +71,10 @@ func (c *SystemCertificateService) GetTLSConfig(cfg *config.Config, currentDirec
 }
 
 // GetCertificateKid extracts the Key ID (kid) from the TLS certificate using SHA-256 thumbprint.
-func (c *SystemCertificateService) GetCertificateKid() (string, error) {
-	thunderRuntime := config.GetThunderRuntime()
-	tlsConfig, err := c.GetTLSConfig(&thunderRuntime.Config, thunderRuntime.ThunderHome)
-	if err != nil {
-		return "", err
+func (c *SystemCertificateService) GetCertificateKid(tlsConfig *tls.Config) (string, error) {
+	if tlsConfig == nil {
+		return "", errors.New("TLS configuration is not set")
 	}
-
 	if len(tlsConfig.Certificates) == 0 || len(tlsConfig.Certificates[0].Certificate) == 0 {
 		return "", errors.New("no certificate found in TLS config")
 	}

--- a/backend/internal/oauth/jwks/constants/constants.go
+++ b/backend/internal/oauth/jwks/constants/constants.go
@@ -21,12 +21,12 @@ package constants
 
 import "github.com/asgardeo/thunder/internal/system/error/serviceerror"
 
-// ErrorWhileRetrievingTLSConfig is returned when there is an error retrieving the TLS configuration.
-var ErrorWhileRetrievingTLSConfig = &serviceerror.ServiceError{
+// ErrorTLSConfigNotFound is returned when the TLS configuration is not set.
+var ErrorTLSConfigNotFound = &serviceerror.ServiceError{
 	Code:             "JWKS-5001",
 	Type:             serviceerror.ServerErrorType,
-	Error:            "Error while retrieving TLS configuration.",
-	ErrorDescription: "An error occurred while retrieving server TLS configurations",
+	Error:            "Error retrieving TLS configuration.",
+	ErrorDescription: "TLS configuration is not set.",
 }
 
 // ErrorWhileParsingCertificate is returned when there is an error parsing the server certificate.
@@ -53,10 +53,10 @@ var ErrorUnsupportedPublicKeyType = &serviceerror.ServiceError{
 	ErrorDescription: "The certificate public key type is not supported for JWKS.",
 }
 
-// ErrorWhileRetrievingCertificateKid is returned when there is an error retrieving the certificate kid.
-var ErrorWhileRetrievingCertificateKid = &serviceerror.ServiceError{
+// ErrorCertificateKidNotFound is returned when the certificate Key ID (kid) is not found.
+var ErrorCertificateKidNotFound = &serviceerror.ServiceError{
 	Code:             "JWKS-5005",
 	Type:             serviceerror.ServerErrorType,
-	Error:            "Error while retrieving certificate kid.",
-	ErrorDescription: "An error occurred while retrieving the certificate Key ID (kid).",
+	Error:            "Error while retrieving certificate Key ID (kid).",
+	ErrorDescription: "Certificate Key ID (kid) not found.",
 }

--- a/backend/internal/system/config/runtimeconfig.go
+++ b/backend/internal/system/config/runtimeconfig.go
@@ -18,12 +18,22 @@
 
 package config
 
-import "sync"
+import (
+	"crypto/tls"
+	"sync"
+)
+
+// CertConfig holds the server certificate configuration.
+type CertConfig struct {
+	TLSConfig *tls.Config
+	CertKid   string
+}
 
 // ThunderRuntime holds the runtime configuration for the Thunder server.
 type ThunderRuntime struct {
 	ThunderHome string `yaml:"thunder_home"`
 	Config      Config `yaml:"config"`
+	CertConfig  CertConfig
 }
 
 var (
@@ -56,4 +66,9 @@ func GetThunderRuntime() *ThunderRuntime {
 func ResetThunderRuntime() {
 	runtimeConfig = nil
 	once = sync.Once{}
+}
+
+// SetCertConfig sets the CertConfig in ThunderRuntime.
+func (tr *ThunderRuntime) SetCertConfig(certConfig CertConfig) {
+	tr.CertConfig = certConfig
 }

--- a/backend/internal/system/jwt/service.go
+++ b/backend/internal/system/jwt/service.go
@@ -139,9 +139,9 @@ func (js *JWTService) GenerateJWT(sub, aud, iss string, validityPeriod int64, cl
 	thunderRuntime := config.GetThunderRuntime()
 
 	// Get the certificate kid (Key ID) for the JWT header.
-	kid, err := js.SystemCertificateService.GetCertificateKid()
-	if err != nil {
-		return "", 0, err
+	kid := thunderRuntime.CertConfig.CertKid
+	if kid == "" {
+		return "", 0, errors.New("certificate Key ID (kid) not found")
 	}
 
 	// Create the JWT header.

--- a/backend/tests/mocks/certmock/SystemCertificateServiceInterface_mock.go
+++ b/backend/tests/mocks/certmock/SystemCertificateServiceInterface_mock.go
@@ -39,8 +39,8 @@ func (_m *SystemCertificateServiceInterfaceMock) EXPECT() *SystemCertificateServ
 }
 
 // GetCertificateKid provides a mock function for the type SystemCertificateServiceInterfaceMock
-func (_mock *SystemCertificateServiceInterfaceMock) GetCertificateKid() (string, error) {
-	ret := _mock.Called()
+func (_mock *SystemCertificateServiceInterfaceMock) GetCertificateKid(tlsConfig *tls.Config) (string, error) {
+	ret := _mock.Called(tlsConfig)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateKid")
@@ -48,16 +48,16 @@ func (_mock *SystemCertificateServiceInterfaceMock) GetCertificateKid() (string,
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (string, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(*tls.Config) (string, error)); ok {
+		return returnFunc(tlsConfig)
 	}
-	if returnFunc, ok := ret.Get(0).(func() string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(*tls.Config) string); ok {
+		r0 = returnFunc(tlsConfig)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(*tls.Config) error); ok {
+		r1 = returnFunc(tlsConfig)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -70,13 +70,20 @@ type SystemCertificateServiceInterfaceMock_GetCertificateKid_Call struct {
 }
 
 // GetCertificateKid is a helper method to define mock.On call
-func (_e *SystemCertificateServiceInterfaceMock_Expecter) GetCertificateKid() *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call {
-	return &SystemCertificateServiceInterfaceMock_GetCertificateKid_Call{Call: _e.mock.On("GetCertificateKid")}
+//   - tlsConfig *tls.Config
+func (_e *SystemCertificateServiceInterfaceMock_Expecter) GetCertificateKid(tlsConfig interface{}) *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call {
+	return &SystemCertificateServiceInterfaceMock_GetCertificateKid_Call{Call: _e.mock.On("GetCertificateKid", tlsConfig)}
 }
 
-func (_c *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call) Run(run func()) *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call {
+func (_c *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call) Run(run func(tlsConfig *tls.Config)) *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 *tls.Config
+		if args[0] != nil {
+			arg0 = args[0].(*tls.Config)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -86,7 +93,7 @@ func (_c *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call) Return(s
 	return _c
 }
 
-func (_c *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call) RunAndReturn(run func() (string, error)) *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call {
+func (_c *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call) RunAndReturn(run func(tlsConfig *tls.Config) (string, error)) *SystemCertificateServiceInterfaceMock_GetCertificateKid_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Purpose

This pull request refactors how TLS certificate configuration and Key ID (kid) management are handled throughout the backend. The main change is the introduction of a centralized `CertConfig` struct in the runtime config, which stores both the TLS configuration and the certificate kid. This approach replaces previous patterns of repeatedly fetching or calculating the kid and TLS config through file reads, streamlining access and reducing redundant operations. The JWKS and JWT services, as well as their tests, are updated to use this new pattern, and error handling is improved and made more explicit.
