### PR TITLE
Centralizing DB Client creation and closing & Introduce database connection pooling

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -25,13 +25,16 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
+	"syscall"
 	"time"
 
 	"github.com/asgardeo/thunder/internal/cert"
 	"github.com/asgardeo/thunder/internal/flow"
 	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/managers"
@@ -53,6 +56,8 @@ func main() {
 	}
 
 	initFlowService(logger)
+
+	closeDBConnections(logger)
 
 	if cfg.Server.HTTPOnly {
 		logger.Info("TLS is not enabled, starting server without TLS")
@@ -193,4 +198,19 @@ func createHTTPServer(logger *log.Logger, cfg *config.Config, mux *http.ServeMux
 	}
 
 	return server, serverAddr
+}
+
+// closeDBConnections sets up signal handling for graceful shutdown
+func closeDBConnections(logger *log.Logger) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-c
+		dbProvider := provider.GetDBProvider()
+		if err := dbProvider.Close(); err != nil {
+			logger.Error("Error closing database connections", log.Error(err))
+		}
+		logger.Info("Database connections closed successfully")
+	}()
 }

--- a/backend/cmd/server/repository/conf/deployment.yaml
+++ b/backend/cmd/server/repository/conf/deployment.yaml
@@ -19,10 +19,17 @@ database:
     type: "sqlite"
     path: "repository/database/thunderdb.db"
     options: "_journal_mode=WAL&_busy_timeout=5000"
+    max_open_conns: 500
+    max_idle_conns: 100
+    conn_max_lifetime: 3600
+
   runtime:
     type: "sqlite"
     path: "repository/database/runtimedb.db"
     options: "_journal_mode=WAL&_busy_timeout=5000"
+    max_open_conns: 500
+    max_idle_conns: 100
+    conn_max_lifetime: 3600
 
 cache:
   disabled: false

--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -25,7 +25,10 @@
       "password": "",
       "sslmode": "",
       "path": "repository/database/thunderdb.db",
-      "options": "_journal_mode=WAL&_busy_timeout=5000"
+      "options": "_journal_mode=WAL&_busy_timeout=5000",
+      "max_open_conns": 500,
+      "max_idle_conns": 100,
+      "conn_max_lifetime": 3600
     },
     "runtime": {
       "type": "sqlite",
@@ -36,7 +39,10 @@
       "password": "",
       "sslmode": "",
       "path": "repository/database/runtimedb.db",
-      "options": "_journal_mode=WAL&_busy_timeout=5000"
+      "options": "_journal_mode=WAL&_busy_timeout=5000",
+      "max_open_conns": 500,
+      "max_idle_conns": 100,
+      "conn_max_lifetime": 3600
     }
   },
   "cache": {

--- a/backend/internal/cert/store/store.go
+++ b/backend/internal/cert/store/store.go
@@ -27,10 +27,7 @@ import (
 	"github.com/asgardeo/thunder/internal/cert/model"
 	dbmodel "github.com/asgardeo/thunder/internal/system/database/model"
 	dbprovider "github.com/asgardeo/thunder/internal/system/database/provider"
-	"github.com/asgardeo/thunder/internal/system/log"
 )
-
-const loggerComponentName = "CertificateStore"
 
 // CertificateStoreInterface defines the methods for certificate storage operations.
 type CertificateStoreInterface interface {
@@ -51,7 +48,7 @@ type CertificateStore struct {
 // NewCertificateStore creates a new instance of CertificateStore.
 func NewCertificateStore() CertificateStoreInterface {
 	return &CertificateStore{
-		DBProvider: dbprovider.NewDBProvider(),
+		DBProvider: dbprovider.GetDBProvider(),
 	}
 }
 
@@ -68,17 +65,10 @@ func (s *CertificateStore) GetCertificateByReference(refType constants.Certifica
 
 // getCertificate retrieves a certificate based on a query and its arguments.
 func (s *CertificateStore) getCertificate(query dbmodel.DBQuery, args ...interface{}) (*model.Certificate, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
 	dbClient, err := s.DBProvider.GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(query, args...)
 	if err != nil {
@@ -138,17 +128,10 @@ func (s *CertificateStore) buildCertificateFromResultRow(row map[string]interfac
 
 // CreateCertificate creates a new certificate in the database.
 func (s *CertificateStore) CreateCertificate(cert *model.Certificate) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
 	dbClient, err := s.DBProvider.GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	rows, err := dbClient.Execute(QueryInsertCertificate, cert.ID, cert.RefType, cert.RefID, cert.Type, cert.Value)
 	if err != nil {
@@ -174,17 +157,10 @@ func (s *CertificateStore) UpdateCertificateByReference(existingCert, updatedCer
 
 // updateCertificate updates a certificate based on a query and its arguments.
 func (s *CertificateStore) updateCertificate(query dbmodel.DBQuery, args ...interface{}) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
 	dbClient, err := s.DBProvider.GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	rows, err := dbClient.Execute(query, args...)
 	if err != nil {
@@ -210,17 +186,10 @@ func (s *CertificateStore) DeleteCertificateByReference(refType constants.Certif
 
 // deleteCertificate deletes a certificate based on a query and its arguments.
 func (s *CertificateStore) deleteCertificate(query dbmodel.DBQuery, args ...interface{}) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
 	dbClient, err := s.DBProvider.GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	_, err = dbClient.Execute(query, args...)
 	if err != nil {

--- a/backend/internal/group/store/store.go
+++ b/backend/internal/group/store/store.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/asgardeo/thunder/internal/group/constants"
 	"github.com/asgardeo/thunder/internal/group/model"
-	"github.com/asgardeo/thunder/internal/system/database/client"
 	dbmodel "github.com/asgardeo/thunder/internal/system/database/model"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -436,7 +435,7 @@ func CheckGroupNameConflictForUpdate(name string, organizationUnitID string, gro
 // checkGroupNameConflictForCreate checks if the new group name conflicts with existing groups
 // in the same organization unit.
 func checkGroupNameConflictForCreate(
-	dbClient client.DBClientInterface,
+	dbClient provider.DBClientInterface,
 	name string,
 	organizationUnitID string,
 ) error {
@@ -461,7 +460,7 @@ func checkGroupNameConflictForCreate(
 // checkGroupNameConflictForUpdate checks if the new group name conflicts with other groups
 // in the same organization unit.
 func checkGroupNameConflictForUpdate(
-	dbClient client.DBClientInterface,
+	dbClient provider.DBClientInterface,
 	name string,
 	organizationUnitID string,
 	groupID string,

--- a/backend/internal/group/store/store.go
+++ b/backend/internal/group/store/store.go
@@ -35,17 +35,10 @@ const loggerComponentName = "GroupStore"
 
 // GetGroupListCount retrieves the total count of root groups.
 func GetGroupListCount() (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	countResults, err := dbClient.Query(QueryGetGroupListCount)
 	if err != nil {
@@ -64,17 +57,10 @@ func GetGroupListCount() (int, error) {
 
 // GetGroupList retrieves root groups.
 func GetGroupList(limit, offset int) ([]model.GroupBasicDAO, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetGroupList, limit, offset)
 	if err != nil {
@@ -103,17 +89,10 @@ func GetGroupList(limit, offset int) ([]model.GroupBasicDAO, error) {
 
 // CreateGroup creates a new group in the database.
 func CreateGroup(group model.GroupDAO) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	tx, err := dbClient.BeginTx()
 	if err != nil {
@@ -151,17 +130,10 @@ func CreateGroup(group model.GroupDAO) error {
 
 // GetGroup retrieves a group by its id.
 func GetGroup(id string) (model.GroupDAO, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return model.GroupDAO{}, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetGroupByID, id)
 	if err != nil {
@@ -187,17 +159,10 @@ func GetGroup(id string) (model.GroupDAO, error) {
 
 // GetGroupMembers retrieves members of a group with pagination.
 func GetGroupMembers(groupID string, limit, offset int) ([]model.Member, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetGroupMembers, groupID, limit, offset)
 	if err != nil {
@@ -221,17 +186,10 @@ func GetGroupMembers(groupID string, limit, offset int) ([]model.Member, error) 
 
 // GetGroupMemberCount retrieves the total count of members in a group.
 func GetGroupMemberCount(groupID string) (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	countResults, err := dbClient.Query(QueryGetGroupMemberCount, groupID)
 	if err != nil {
@@ -251,17 +209,10 @@ func GetGroupMemberCount(groupID string) (int, error) {
 
 // UpdateGroup updates an existing group.
 func UpdateGroup(group model.GroupDAO) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	tx, err := dbClient.BeginTx()
 	if err != nil {
@@ -316,15 +267,10 @@ func UpdateGroup(group model.GroupDAO) error {
 func DeleteGroup(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	tx, err := dbClient.BeginTx()
 	if err != nil {
@@ -367,17 +313,10 @@ func ValidateGroupIDs(groupIDs []string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	query, args, err := buildBulkGroupExistsQuery(groupIDs)
 	if err != nil {
@@ -475,17 +414,10 @@ func updateGroupMembers(
 // CheckGroupNameConflictForCreate checks if the new group name conflicts with existing groups
 // in the same organization unit.
 func CheckGroupNameConflictForCreate(name string, organizationUnitID string) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	return checkGroupNameConflictForCreate(dbClient, name, organizationUnitID)
 }
@@ -493,17 +425,10 @@ func CheckGroupNameConflictForCreate(name string, organizationUnitID string) err
 // CheckGroupNameConflictForUpdate checks if the new group name conflicts with other groups
 // in the same organization unit.
 func CheckGroupNameConflictForUpdate(name string, organizationUnitID string, groupID string) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	return checkGroupNameConflictForUpdate(dbClient, name, organizationUnitID, groupID)
 }
@@ -561,17 +486,10 @@ func checkGroupNameConflictForUpdate(
 
 // GetGroupsByOrganizationUnitCount retrieves the total count of groups in a specific organization unit.
 func GetGroupsByOrganizationUnitCount(organizationUnitID string) (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	countResults, err := dbClient.Query(QueryGetGroupsByOrganizationUnitCount, organizationUnitID)
 	if err != nil {
@@ -591,17 +509,10 @@ func GetGroupsByOrganizationUnitCount(organizationUnitID string) (int, error) {
 
 // GetGroupsByOrganizationUnit retrieves a list of groups in a specific organization unit with pagination.
 func GetGroupsByOrganizationUnit(organizationUnitID string, limit, offset int) ([]model.GroupBasicDAO, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetGroupsByOrganizationUnit, organizationUnitID, limit, offset)
 	if err != nil {

--- a/backend/internal/idp/store/store.go
+++ b/backend/internal/idp/store/store.go
@@ -52,17 +52,10 @@ func NewIDPStore() IDPStoreInterface {
 
 // CreateIdentityProvider handles the IdP creation in the database.
 func (s *IDPStore) CreateIdentityProvider(idp model.IdpDTO) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	tx, err := dbClient.BeginTx()
 	if err != nil {
@@ -115,17 +108,10 @@ func (s *IDPStore) CreateIdentityProvider(idp model.IdpDTO) error {
 
 // GetIdentityProviderList retrieves a list of IdPs from the database.
 func (s *IDPStore) GetIdentityProviderList() ([]model.BasicIdpDTO, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetIdentityProviderList)
 	if err != nil {
@@ -146,17 +132,10 @@ func (s *IDPStore) GetIdentityProviderList() ([]model.BasicIdpDTO, error) {
 
 // getIDPProperties retrieves the properties of a specific IdP by its ID.
 func (s *IDPStore) getIDPProperties(idpID string) ([]model.IdpProperty, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPStore"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetIDPProperties, idpID)
 	if err != nil {
@@ -178,17 +157,10 @@ func (s *IDPStore) GetIdentityProviderByName(name string) (*model.IdpDTO, error)
 
 // getIDP retrieves an IDP based on the provided query and identifier.
 func (s *IDPStore) getIDP(query dbmodel.DBQuery, identifier string) (*model.IdpDTO, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPStore"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(query, identifier)
 	if err != nil {
@@ -226,17 +198,10 @@ func (s *IDPStore) getIDP(query dbmodel.DBQuery, identifier string) (*model.IdpD
 
 // UpdateIdentityProvider updates the idp in the database.
 func (s *IDPStore) UpdateIdentityProvider(idp *model.IdpDTO) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPStore"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	tx, err := dbClient.BeginTx()
 	if err != nil {
@@ -301,15 +266,10 @@ func (s *IDPStore) UpdateIdentityProvider(idp *model.IdpDTO) error {
 func (s *IDPStore) DeleteIdentityProvider(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPStore"))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	rowsAffected, err := dbClient.Execute(QueryDeleteIdentityProviderByID, id)
 	if err != nil {

--- a/backend/internal/notification/message/store/store.go
+++ b/backend/internal/notification/message/store/store.go
@@ -88,17 +88,10 @@ func (s *MessageNotificationStore) CreateSender(sender model.MessageNotification
 
 // ListSenders retrieves all message notification senders
 func (s *MessageNotificationStore) ListSenders() ([]model.MessageNotificationSender, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetAllNotificationSenders)
 	if err != nil {
@@ -127,17 +120,10 @@ func (s *MessageNotificationStore) ListSenders() ([]model.MessageNotificationSen
 
 // GetSenderProperties retrieves all properties of a message notification sender by ID.
 func (s *MessageNotificationStore) GetSenderProperties(id string) ([]model.SenderProperty, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetNotificationSenderProperties, id)
 	if err != nil {
@@ -166,15 +152,10 @@ func (s *MessageNotificationStore) getSender(query dbmodel.DBQuery,
 	identifier string) (*model.MessageNotificationSender, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(query, identifier)
 	if err != nil {
@@ -235,15 +216,10 @@ func (s *MessageNotificationStore) UpdateSender(id string, sender model.MessageN
 func (s *MessageNotificationStore) DeleteSender(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	rowsAffected, err := dbClient.Execute(QueryDeleteNotificationSender, id)
 	if err != nil {
@@ -258,17 +234,10 @@ func (s *MessageNotificationStore) DeleteSender(id string) error {
 
 // executeTransaction is a helper function to handle database transactions.
 func executeTransaction(queries []func(tx dbmodel.TxInterface) error) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	tx, err := dbClient.BeginTx()
 	if err != nil {

--- a/backend/internal/oauth/oauth2/authz/store/store.go
+++ b/backend/internal/oauth/oauth2/authz/store/store.go
@@ -50,7 +50,7 @@ type AuthorizationCodeStore struct {
 // NewAuthorizationCodeStore creates a new instance of AuthorizationCodeStore.
 func NewAuthorizationCodeStore() AuthorizationCodeStoreInterface {
 	return &AuthorizationCodeStore{
-		DBProvider: provider.NewDBProvider(),
+		DBProvider: provider.GetDBProvider(),
 	}
 }
 
@@ -63,12 +63,6 @@ func (acs *AuthorizationCodeStore) InsertAuthorizationCode(authzCode model.Autho
 		logger.Error("Failed to get database client", log.Error(err))
 		return err
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	tx, err := dbClient.BeginTx()
 	if err != nil {
@@ -119,12 +113,6 @@ func (acs *AuthorizationCodeStore) GetAuthorizationCode(clientID, authCode strin
 		logger.Error("Failed to get database client", log.Error(err))
 		return model.AuthorizationCode{}, err
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	results, err := dbClient.Query(constants.QueryGetAuthorizationCode, clientID, authCode)
 	if err != nil {
@@ -200,12 +188,6 @@ func (acs *AuthorizationCodeStore) updateAuthorizationCodeState(authzCode model.
 		logger.Error("Failed to get database client", log.Error(err))
 		return err
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	_, err = dbClient.Execute(constants.QueryUpdateAuthorizationCodeState, newState, authzCode.CodeID)
 	return err

--- a/backend/internal/ou/store/store.go
+++ b/backend/internal/ou/store/store.go
@@ -33,17 +33,10 @@ const loggerComponentName = "OrganizationUnitStore"
 
 // GetOrganizationUnitListCount retrieves the total count of organization units.
 func GetOrganizationUnitListCount() (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetRootOrganizationUnitListCount)
 	if err != nil {
@@ -64,17 +57,10 @@ func GetOrganizationUnitListCount() (int, error) {
 
 // GetOrganizationUnitList retrieves organization units with pagination.
 func GetOrganizationUnitList(limit, offset int) ([]model.OrganizationUnitBasic, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetRootOrganizationUnitList, limit, offset)
 	if err != nil {
@@ -95,17 +81,10 @@ func GetOrganizationUnitList(limit, offset int) ([]model.OrganizationUnitBasic, 
 
 // CreateOrganizationUnit creates a new organization unit in the database.
 func CreateOrganizationUnit(ou model.OrganizationUnit) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	_, err = dbClient.Execute(
 		QueryCreateOrganizationUnit,
@@ -124,17 +103,10 @@ func CreateOrganizationUnit(ou model.OrganizationUnit) error {
 
 // GetOrganizationUnit retrieves an organization unit by its id.
 func GetOrganizationUnit(id string) (model.OrganizationUnit, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return model.OrganizationUnit{}, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetOrganizationUnitByID, id)
 	if err != nil {
@@ -161,15 +133,10 @@ func GetOrganizationUnitByPath(handlePath []string) (model.OrganizationUnit, err
 		return model.OrganizationUnit{}, constants.ErrOrganizationUnitNotFound
 	}
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return model.OrganizationUnit{}, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	var currentOU model.OrganizationUnit
 	var parentID *string
@@ -210,17 +177,10 @@ func GetOrganizationUnitByPath(handlePath []string) (model.OrganizationUnit, err
 
 // IsOrganizationUnitExists checks if an organization unit exists by ID.
 func IsOrganizationUnitExists(id string) (bool, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryCheckOrganizationUnitExists, id)
 	if err != nil {
@@ -242,17 +202,10 @@ func IsOrganizationUnitExists(id string) (bool, error) {
 
 // UpdateOrganizationUnit updates an existing organization unit.
 func UpdateOrganizationUnit(ou model.OrganizationUnit) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	_, err = dbClient.Execute(
 		QueryUpdateOrganizationUnit,
@@ -271,17 +224,10 @@ func UpdateOrganizationUnit(ou model.OrganizationUnit) error {
 
 // DeleteOrganizationUnit deletes an organization unit.
 func DeleteOrganizationUnit(id string) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	_, err = dbClient.Execute(QueryDeleteOrganizationUnit, id)
 	if err != nil {
@@ -293,17 +239,10 @@ func DeleteOrganizationUnit(id string) error {
 
 // GetOrganizationUnitChildrenCount retrieves the total count of child organization units for a given parent ID.
 func GetOrganizationUnitChildrenCount(parentID string) (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetOrganizationUnitChildrenCount, parentID)
 	if err != nil {
@@ -325,17 +264,10 @@ func GetOrganizationUnitChildrenCount(parentID string) (int, error) {
 
 // GetOrganizationUnitChildrenList retrieves a paginated list of child organization units for a given parent ID.
 func GetOrganizationUnitChildrenList(parentID string, limit, offset int) ([]model.OrganizationUnitBasic, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetOrganizationUnitChildrenList, parentID, limit, offset)
 	if err != nil {
@@ -356,17 +288,10 @@ func GetOrganizationUnitChildrenList(parentID string, limit, offset int) ([]mode
 
 // GetOrganizationUnitUsersCount retrieves the total count of users in a given organization unit.
 func GetOrganizationUnitUsersCount(ouID string) (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetOrganizationUnitUsersCount, ouID)
 	if err != nil {
@@ -388,17 +313,10 @@ func GetOrganizationUnitUsersCount(ouID string) (int, error) {
 
 // GetOrganizationUnitUsersList retrieves a paginated list of users in a given organization unit.
 func GetOrganizationUnitUsersList(ouID string, limit, offset int) ([]model.User, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetOrganizationUnitUsersList, ouID, limit, offset)
 	if err != nil {
@@ -421,17 +339,10 @@ func GetOrganizationUnitUsersList(ouID string, limit, offset int) ([]model.User,
 
 // GetOrganizationUnitGroupsCount retrieves the total count of groups in a given organization unit.
 func GetOrganizationUnitGroupsCount(ouID string) (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetOrganizationUnitGroupsCount, ouID)
 	if err != nil {
@@ -453,17 +364,10 @@ func GetOrganizationUnitGroupsCount(ouID string) (int, error) {
 
 // GetOrganizationUnitGroupsList retrieves a paginated list of groups in a given organization unit.
 func GetOrganizationUnitGroupsList(ouID string, limit, offset int) ([]model.Group, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetOrganizationUnitGroupsList, ouID, limit, offset)
 	if err != nil {
@@ -518,17 +422,10 @@ func CheckOrganizationUnitHandleConflict(handle string, parentID *string) (bool,
 
 // CheckOrganizationUnitHasChildResources checks if an organization unit has users groups or sub-ous.
 func CheckOrganizationUnitHasChildResources(ouID string) (bool, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryCheckOrganizationUnitHasUsersOrGroups, ouID)
 	if err != nil {
@@ -610,17 +507,10 @@ func checkConflict(
 	parentID *string,
 	extraArgs ...interface{},
 ) (bool, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	var results []map[string]interface{}
 

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -54,15 +54,18 @@ type SecurityConfig struct {
 
 // DataSource holds the individual database connection details.
 type DataSource struct {
-	Type     string `yaml:"type" json:"type"`
-	Hostname string `yaml:"hostname" json:"hostname"`
-	Port     int    `yaml:"port" json:"port"`
-	Name     string `yaml:"name" json:"name"`
-	Username string `yaml:"username" json:"username"`
-	Password string `yaml:"password" json:"password"`
-	SSLMode  string `yaml:"sslmode" json:"sslmode"`
-	Path     string `yaml:"path" json:"path"`
-	Options  string `yaml:"options" json:"options"`
+	Type            string `yaml:"type" json:"type"`
+	Hostname        string `yaml:"hostname" json:"hostname"`
+	Port            int    `yaml:"port" json:"port"`
+	Name            string `yaml:"name" json:"name"`
+	Username        string `yaml:"username" json:"username"`
+	Password        string `yaml:"password" json:"password"`
+	SSLMode         string `yaml:"sslmode" json:"sslmode"`
+	Path            string `yaml:"path" json:"path"`
+	Options         string `yaml:"options" json:"options"`
+	MaxOpenConns    int    `yaml:"max_open_conns" json:"max_open_conns"`
+	MaxIdleConns    int    `yaml:"max_idle_conns" json:"max_idle_conns"`
+	ConnMaxLifetime int    `yaml:"conn_max_lifetime" json:"conn_max_lifetime"`
 }
 
 // DatabaseConfig holds the different database configuration details.

--- a/backend/internal/system/database/provider/dbclient.go
+++ b/backend/internal/system/database/provider/dbclient.go
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-// Package client provides database client implementations for executing queries and managing transactions.
-package client
+// Package provider provides database client implementations for executing queries and managing transactions.
+package provider
 
 import (
 	"strings"
@@ -37,8 +37,6 @@ type DBClientInterface interface {
 	Execute(query model.DBQuery, args ...interface{}) (int64, error)
 	// BeginTx starts a new database transaction.
 	BeginTx() (model.TxInterface, error)
-	// Close closes the database connection.
-	Close() error
 }
 
 // DBClient is the implementation of DBClientInterface.
@@ -132,6 +130,6 @@ func (client *DBClient) BeginTx() (model.TxInterface, error) {
 }
 
 // Close closes the database connection.
-func (client *DBClient) Close() error {
+func (client *DBClient) close() error {
 	return client.db.Close()
 }

--- a/backend/internal/system/database/provider/dbclient_test.go
+++ b/backend/internal/system/database/provider/dbclient_test.go
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package client
+package provider
 
 import (
 	"database/sql"
@@ -253,15 +253,5 @@ func (suite *DBClientTestSuite) TestBeginTxError() {
 	assert.Error(suite.T(), err)
 	assert.Equal(suite.T(), expectedErr, err)
 	assert.Nil(suite.T(), tx)
-	assert.NoError(suite.T(), suite.mock.ExpectationsWereMet())
-}
-
-func (suite *DBClientTestSuite) TestCloseSuccess() {
-	// Setup expectation for closing the database
-	suite.mock.ExpectClose()
-
-	err := suite.dbClient.Close()
-
-	assert.NoError(suite.T(), err)
 	assert.NoError(suite.T(), suite.mock.ExpectationsWereMet())
 }

--- a/backend/internal/system/healthcheck/service/healthcheckservice.go
+++ b/backend/internal/system/healthcheck/service/healthcheckservice.go
@@ -47,7 +47,7 @@ type HealthCheckService struct {
 func GetHealthCheckService() HealthCheckServiceInterface {
 	once.Do(func() {
 		instance = &HealthCheckService{
-			DBProvider: provider.NewDBProvider(),
+			DBProvider: provider.GetDBProvider(),
 		}
 	})
 	return instance
@@ -87,13 +87,6 @@ func (hcs *HealthCheckService) checkDatabaseStatus(dbname string, query dbmodel.
 		logger.Error("Failed to get database client", log.Error(err))
 		return model.StatusDown
 	}
-	defer func() {
-		if dbClient != nil {
-			if closeErr := dbClient.Close(); closeErr != nil {
-				logger.Error("Error closing database client", log.Error(closeErr))
-			}
-		}
-	}()
 
 	_, err = dbClient.Query(query)
 	if err != nil {

--- a/backend/internal/system/healthcheck/service/healthcheckservice_test.go
+++ b/backend/internal/system/healthcheck/service/healthcheckservice_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/healthcheck/model"
 	"github.com/asgardeo/thunder/tests/mocks/database/clientmock"
 	dbprovidermock "github.com/asgardeo/thunder/tests/mocks/database/providermock"
@@ -44,6 +45,20 @@ func TestHealthCheckServiceSuite(t *testing.T) {
 }
 
 func (suite *HealthCheckServiceTestSuite) SetupTest() {
+	testConfig := &config.Config{
+		Database: config.DatabaseConfig{
+			Identity: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+			Runtime: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+		},
+	}
+	_ = config.InitializeThunderRuntime("test", testConfig)
+
 	instance = nil
 	once = sync.Once{}
 	suite.service = GetHealthCheckService()
@@ -126,8 +141,6 @@ func (suite *HealthCheckServiceTestSuite) TestCheckReadiness() {
 			// Reset mock expectations
 			suite.mockIdentityDB.ExpectedCalls = nil
 			suite.mockRuntimeDB.ExpectedCalls = nil
-			suite.mockIdentityDB.On("Close").Return(nil)
-			suite.mockRuntimeDB.On("Close").Return(nil)
 
 			// Setup database mocks
 			if tc.setupIdentityDB != nil {

--- a/backend/internal/user/store/store.go
+++ b/backend/internal/user/store/store.go
@@ -30,17 +30,10 @@ import (
 
 // GetUserListCount retrieves the total count of users.
 func GetUserListCount(filters map[string]interface{}) (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	countQuery, args, err := buildUserCountQuery(filters)
 	if err != nil {
@@ -66,18 +59,10 @@ func GetUserListCount(filters map[string]interface{}) (int, error) {
 
 // GetUserList retrieves a list of users from the database.
 func GetUserList(limit, offset int, filters map[string]interface{}) ([]model.User, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	listQuery, args, err := buildUserListQuery(filters, limit, offset)
 	if err != nil {
@@ -104,18 +89,10 @@ func GetUserList(limit, offset int, filters map[string]interface{}) ([]model.Use
 
 // CreateUser handles the user creation in the database.
 func CreateUser(user model.User, credentials []model.Credential) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	// Convert attributes to JSON string
 	attributes, err := json.Marshal(user.Attributes)
@@ -152,18 +129,10 @@ func CreateUser(user model.User, credentials []model.Credential) error {
 
 // GetUser retrieves a specific user by its ID from the database.
 func GetUser(id string) (model.User, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return model.User{}, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetUserByUserID, id)
 	if err != nil {
@@ -189,18 +158,10 @@ func GetUser(id string) (model.User, error) {
 
 // UpdateUser updates the user in the database.
 func UpdateUser(user *model.User) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	// Convert attributes to JSON string
 	attributes, err := json.Marshal(user.Attributes)
@@ -225,16 +186,10 @@ func UpdateUser(user *model.User) error {
 func DeleteUser(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	rowsAffected, err := dbClient.Execute(QueryDeleteUserByUserID, id)
 	if err != nil {
@@ -252,16 +207,10 @@ func DeleteUser(id string) error {
 func IdentifyUser(filters map[string]interface{}) (*string, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	identifyUserQuery, args, err := buildIdentifyQuery(filters)
 	if err != nil {
@@ -304,18 +253,10 @@ func IdentifyUser(filters map[string]interface{}) (*string, error) {
 
 // VerifyUser validate the user specified user using the given credentials from the database.
 func VerifyUser(id string) (model.User, []model.Credential, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return model.User{}, []model.Credential{}, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-			err = fmt.Errorf("failed to close database client: %w", closeErr)
-		}
-	}()
 
 	results, err := dbClient.Query(QueryValidateUserWithCredentials, id)
 	if err != nil {
@@ -362,17 +303,10 @@ func ValidateUserIDs(userIDs []string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	query, args, err := buildBulkUserExistsQuery(userIDs)
 	if err != nil {

--- a/backend/internal/userschema/store/store.go
+++ b/backend/internal/userschema/store/store.go
@@ -31,17 +31,10 @@ import (
 
 // GetUserSchemaListCount retrieves the total count of user schemas.
 func GetUserSchemaListCount() (int, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	countResults, err := dbClient.Query(QueryGetUserSchemaCount)
 	if err != nil {
@@ -64,15 +57,10 @@ func GetUserSchemaListCount() (int, error) {
 func GetUserSchemaList(limit, offset int) ([]model.UserSchemaListItem, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetUserSchemaList, limit, offset)
 	if err != nil {
@@ -94,17 +82,10 @@ func GetUserSchemaList(limit, offset int) ([]model.UserSchemaListItem, error) {
 
 // CreateUserSchema creates a new user schema.
 func CreateUserSchema(userSchema model.UserSchema) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	_, err = dbClient.Query(QueryCreateUserSchema, userSchema.ID, userSchema.Name, string(userSchema.Schema))
 	if err != nil {
@@ -116,17 +97,10 @@ func CreateUserSchema(userSchema model.UserSchema) error {
 
 // GetUserSchemaByID retrieves a user schema by its ID.
 func GetUserSchemaByID(schemaID string) (model.UserSchema, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return model.UserSchema{}, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetUserSchemaByID, schemaID)
 	if err != nil {
@@ -142,17 +116,10 @@ func GetUserSchemaByID(schemaID string) (model.UserSchema, error) {
 
 // GetUserSchemaByName retrieves a user schema by its name.
 func GetUserSchemaByName(name string) (model.UserSchema, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return model.UserSchema{}, fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	results, err := dbClient.Query(QueryGetUserSchemaByName, name)
 	if err != nil {
@@ -168,17 +135,10 @@ func GetUserSchemaByName(name string) (model.UserSchema, error) {
 
 // UpdateUserSchemaByID updates a user schema by its ID.
 func UpdateUserSchemaByID(schemaID string, userSchema model.UserSchema) error {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
-
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	_, err = dbClient.Query(QueryUpdateUserSchemaByID, userSchema.Name, string(userSchema.Schema), schemaID)
 	if err != nil {
@@ -192,15 +152,10 @@ func UpdateUserSchemaByID(schemaID string, userSchema model.UserSchema) error {
 func DeleteUserSchemaByID(schemaID string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
 
-	dbClient, err := provider.NewDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
-	defer func() {
-		if closeErr := dbClient.Close(); closeErr != nil {
-			logger.Error("Failed to close database client", log.Error(closeErr))
-		}
-	}()
 
 	rowsAffected, err := dbClient.Execute(QueryDeleteUserSchemaByID, schemaID)
 	if err != nil {

--- a/backend/tests/mocks/database/providermock/DBProviderInterface_mock.go
+++ b/backend/tests/mocks/database/providermock/DBProviderInterface_mock.go
@@ -5,7 +5,7 @@
 package providermock
 
 import (
-	"github.com/asgardeo/thunder/internal/system/database/client"
+	"github.com/asgardeo/thunder/internal/system/database/provider"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -37,23 +37,23 @@ func (_m *DBProviderInterfaceMock) EXPECT() *DBProviderInterfaceMock_Expecter {
 }
 
 // GetDBClient provides a mock function for the type DBProviderInterfaceMock
-func (_mock *DBProviderInterfaceMock) GetDBClient(dbName string) (client.DBClientInterface, error) {
+func (_mock *DBProviderInterfaceMock) GetDBClient(dbName string) (provider.DBClientInterface, error) {
 	ret := _mock.Called(dbName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDBClient")
 	}
 
-	var r0 client.DBClientInterface
+	var r0 provider.DBClientInterface
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (client.DBClientInterface, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) (provider.DBClientInterface, error)); ok {
 		return returnFunc(dbName)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) client.DBClientInterface); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) provider.DBClientInterface); ok {
 		r0 = returnFunc(dbName)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.DBClientInterface)
+			r0 = ret.Get(0).(provider.DBClientInterface)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
@@ -88,55 +88,12 @@ func (_c *DBProviderInterfaceMock_GetDBClient_Call) Run(run func(dbName string))
 	return _c
 }
 
-func (_c *DBProviderInterfaceMock_GetDBClient_Call) Return(dBClientInterface client.DBClientInterface, err error) *DBProviderInterfaceMock_GetDBClient_Call {
+func (_c *DBProviderInterfaceMock_GetDBClient_Call) Return(dBClientInterface provider.DBClientInterface, err error) *DBProviderInterfaceMock_GetDBClient_Call {
 	_c.Call.Return(dBClientInterface, err)
 	return _c
 }
 
-func (_c *DBProviderInterfaceMock_GetDBClient_Call) RunAndReturn(run func(dbName string) (client.DBClientInterface, error)) *DBProviderInterfaceMock_GetDBClient_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// Close provides a mock function for the type DBProviderInterfaceMock
-func (_mock *DBProviderInterfaceMock) Close() error {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Close")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func() error); ok {
-		return returnFunc()
-	}
-	r0 = ret.Error(0)
-	return r0
-}
-
-// DBProviderInterfaceMock_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
-type DBProviderInterfaceMock_Close_Call struct {
-	*mock.Call
-}
-
-// Close is a helper method to define mock.On call
-func (_e *DBProviderInterfaceMock_Expecter) Close() *DBProviderInterfaceMock_Close_Call {
-	return &DBProviderInterfaceMock_Close_Call{Call: _e.mock.On("Close")}
-}
-
-func (_c *DBProviderInterfaceMock_Close_Call) Run(run func()) *DBProviderInterfaceMock_Close_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *DBProviderInterfaceMock_Close_Call) Return(err error) *DBProviderInterfaceMock_Close_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *DBProviderInterfaceMock_Close_Call) RunAndReturn(run func() error) *DBProviderInterfaceMock_Close_Call {
+func (_c *DBProviderInterfaceMock_GetDBClient_Call) RunAndReturn(run func(dbName string) (provider.DBClientInterface, error)) *DBProviderInterfaceMock_GetDBClient_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/database/providermock/DBProviderInterface_mock.go
+++ b/backend/tests/mocks/database/providermock/DBProviderInterface_mock.go
@@ -9,9 +9,9 @@ import (
 	mock "github.com/stretchr/testify/mock"
 )
 
-// NewDBProviderInterfaceMock creates a new instance of DBProviderInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// GetDBProviderInterfaceMock creates a new instance of DBProviderInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
-func NewDBProviderInterfaceMock(t interface {
+func GetDBProviderInterfaceMock(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *DBProviderInterfaceMock {
@@ -94,6 +94,49 @@ func (_c *DBProviderInterfaceMock_GetDBClient_Call) Return(dBClientInterface cli
 }
 
 func (_c *DBProviderInterfaceMock_GetDBClient_Call) RunAndReturn(run func(dbName string) (client.DBClientInterface, error)) *DBProviderInterfaceMock_GetDBClient_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Close provides a mock function for the type DBProviderInterfaceMock
+func (_mock *DBProviderInterfaceMock) Close() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Close")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		return returnFunc()
+	}
+	r0 = ret.Error(0)
+	return r0
+}
+
+// DBProviderInterfaceMock_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type DBProviderInterfaceMock_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *DBProviderInterfaceMock_Expecter) Close() *DBProviderInterfaceMock_Close_Call {
+	return &DBProviderInterfaceMock_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *DBProviderInterfaceMock_Close_Call) Run(run func()) *DBProviderInterfaceMock_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *DBProviderInterfaceMock_Close_Call) Return(err error) *DBProviderInterfaceMock_Close_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *DBProviderInterfaceMock_Close_Call) RunAndReturn(run func() error) *DBProviderInterfaceMock_Close_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -136,7 +136,10 @@ configuration:
       port: "5432" 
       username: "asgthunder"
       password: "asgthunder"
-      sslmode: "require" 
+      sslmode: "require"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600
     # Runtime database configuration
     runtime:
       type: "sqlite" # postgres or sqlite
@@ -149,7 +152,10 @@ configuration:
       port: "5432" 
       username: "asgthunder"
       password: "asgthunder" 
-      sslmode: "require" 
+      sslmode: "require"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600 
 
   # Cache configuration
   cache:


### PR DESCRIPTION
## Purpose

1. Improve to use a singleton instance of DBProvider that returns identity and runtime DBClients with configured connection pooling.
2. Stop closing DBClients at each store-level and close only during shutting down of server.

## Related issue
- https://github.com/asgardeo/thunder/issues/324