### PR TITLE
Parameterize readOnlyRootFilesystem and update readme

### DIFF
--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -169,19 +169,19 @@ The following table lists the configurable parameters of the Thunder chart and t
 | `configuration.database.identity.sqlitePath` | SQLite database path (for sqlite only)                    | `repository/database/thunderdb.db` |
 | `configuration.database.identity.sqliteOptions` | SQLite options (for sqlite only)                       | `_journal_mode=WAL&_busy_timeout=5000` |
 | `configuration.database.identity.name` | Postgres database name (for postgres only)                      | `thunderdb`                  |
-| `configuration.database.identity.host` | Postgres host (for postgres only)                               | `wso2-thunder.postgres.database.azure.com` |
+| `configuration.database.identity.host` | Postgres host (for postgres only)                               | `localhost` |
 | `configuration.database.identity.port` | Postgres port (for postgres only)                               | `5432`                       |
-| `configuration.database.identity.username` | Postgres username (for postgres only)                       | `sqladmin`                   |
-| `configuration.database.identity.password` | Postgres password (for postgres only)                       | `sdfds#4J2knc`              |
+| `configuration.database.identity.username` | Postgres username (for postgres only)                       | `asgthunder`                   |
+| `configuration.database.identity.password` | Postgres password (for postgres only)                       | `asgthunder`              |
 | `configuration.database.identity.sslmode` | Postgres SSL mode (for postgres only)                        | `require`                    |
 | `configuration.database.runtime.type`  | Runtime database type (postgres or sqlite)                      | `postgres`                   |
 | `configuration.database.runtime.sqlitePath` | SQLite database path (for sqlite only)                     | `repository/database/runtimedb.db` |
 | `configuration.database.runtime.sqliteOptions` | SQLite options (for sqlite only)                        | `_journal_mode=WAL&_busy_timeout=5000` |
 | `configuration.database.runtime.name`  | Postgres database name (for postgres only)                      | `runtimedb`                  |
-| `configuration.database.runtime.host`  | Postgres host (for postgres only)                               | `wso2-thunder.postgres.database.azure.com` |
+| `configuration.database.runtime.host`  | Postgres host (for postgres only)                               | `localhost` |
 | `configuration.database.runtime.port`  | Postgres port (for postgres only)                               | `5432`                       |
-| `configuration.database.runtime.username` | Postgres username (for postgres only)                        | `sqladmin`                   |
-| `configuration.database.runtime.password` | Postgres password (for postgres only)                        | `sdfds#4J2knc`              |
+| `configuration.database.runtime.username` | Postgres username (for postgres only)                        | `asgthunder`                   |
+| `configuration.database.runtime.password` | Postgres password (for postgres only)                        | `asgthunder`              |
 | `configuration.database.runtime.sslmode` | Postgres SSL mode (for postgres only)                         | `require`                    |
 | `configuration.cache.disabled`         | Disable cache                                                   | `false`                      |
 | `configuration.cache.type`             | Cache type                                                      | `inmemory`                   |
@@ -204,4 +204,8 @@ Alternatively, you can directly update the values in conf/deployment.yaml before
 
 ### Database Configuration
 
-Thunder supports both sqlite and postgres databases. By default, sqlite is configured. You can configure the database connection by overriding the database configuration in the values.yaml file.
+Thunder supports both sqlite and postgres databases. By default, postgres is configured.
+
+Make sure to create the necessary databases and users in your Postgres instance before deploying Thunder. The values.yaml should be overridden with the required database configurations for the DB created.
+
+Note: Use sqlite only if you are running a single pod.

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -107,7 +107,7 @@ spec:
               cpu: {{ .Values.deployment.resources.limits.cpu }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ .Values.deployment.securityContext.readOnlyRootFilesystem }}
             runAsNonRoot: true
             {{- if .Values.deployment.securityContext.enableRunAsUser }}
             runAsUser: {{ .Values.deployment.securityContext.runAsUser }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -21,6 +21,7 @@ deployment:
       maxSurge: 1
       maxUnavailable: 0
   securityContext:
+    readOnlyRootFilesystem: true # This must be false if sqlite is used as the database
     enableRunAsUser: true
     runAsUser: 802
     seccompProfile:
@@ -126,7 +127,8 @@ configuration:
   # Database configuration
   database:
     identity:
-      type: "sqlite" # postgres or sqlite
+      # WARNING: Use sqlite only if you are running a single pod.
+      type: "postgres" # postgres or sqlite
       # Below two parameters are only required for sqlite
       sqlitePath: "repository/database/thunderdb.db" # Only required for sqlite
       sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
@@ -139,7 +141,8 @@ configuration:
       sslmode: "require" 
     # Runtime database configuration
     runtime:
-      type: "sqlite" # postgres or sqlite
+      # WARNING: Use sqlite only if you are running a single pod.
+      type: "postgres" # postgres or sqlite
       # Below two parameters are only required for sqlite
       sqlitePath: "repository/database/runtimedb.db" # Only required for sqlite
       sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite


### PR DESCRIPTION
## Purpose
This PR is to parameterize readOnlyRootFilesystem with default as false to facilitate sqlite DB.
The file system is required to have write access if SQLite DB is used as the DB stores data in the file system.