### PR TITLE
Restructure schema compilation & user validation

### DIFF
--- a/backend/internal/userschema/model/array.go
+++ b/backend/internal/userschema/model/array.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+type array struct {
+	required bool
+	items    property
+}
+
+func (p *array) isRequired() bool {
+	return p.required
+}
+
+func (p *array) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
+	arrayValue, ok := value.([]interface{})
+	if !ok {
+		logger.Debug("Expected array but got different type",
+			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+		return false, nil
+	}
+
+	if p.required && len(arrayValue) == 0 {
+		logger.Debug("Array property is required but empty", log.String("property", path))
+		return false, nil
+	}
+
+	if p.items == nil {
+		return true, nil
+	}
+
+	for index, item := range arrayValue {
+		itemPath := fmt.Sprintf("%s[%d]", path, index)
+		isValid, err := p.items.validateValue(item, itemPath, logger)
+		if err != nil {
+			return false, err
+		}
+		if !isValid {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (p *array) validateUniqueness(
+	value interface{},
+	path string,
+	identifyUser func(map[string]interface{}) (*string, error),
+	logger *log.Logger,
+) (bool, error) {
+	// Arrays are not supported for uniqueness validation
+	return true, nil
+}
+
+func compileArrayProperty(propName string, propMap map[string]json.RawMessage) (property, error) {
+	allowedFields := map[string]struct{}{
+		"type":     {},
+		"items":    {},
+		"required": {},
+	}
+
+	for field := range propMap {
+		if _, ok := allowedFields[field]; !ok {
+			return nil, fmt.Errorf("invalid field '%s' for array property", field)
+		}
+	}
+
+	prop := &array{}
+
+	if raw, exists := propMap["required"]; exists {
+		if err := json.Unmarshal(raw, &prop.required); err != nil {
+			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	itemsRaw, exists := propMap["items"]
+	if !exists {
+		return nil, fmt.Errorf("missing required 'items' field for array type")
+	}
+
+	compiledItems, err := compileProperty(propName, itemsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid 'items' definition: %w", err)
+	}
+
+	prop.items = compiledItems
+	return prop, nil
+}

--- a/backend/internal/userschema/model/boolean.go
+++ b/backend/internal/userschema/model/boolean.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+// boolean represents a boolean property in the user schema.
+type boolean struct {
+	required bool
+}
+
+func (p *boolean) isRequired() bool {
+	return p.required
+}
+
+func (p *boolean) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
+	_, ok := value.(bool)
+	if !ok {
+		logger.Debug("Expected boolean but got different type",
+			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+		return false, nil
+	}
+	return true, nil
+}
+
+func (p *boolean) validateUniqueness(
+	value interface{},
+	path string,
+	identifyUser func(map[string]interface{}) (*string, error),
+	logger *log.Logger,
+) (bool, error) {
+	return true, nil
+}
+
+func compileBooleanProperty(propMap map[string]json.RawMessage) (property, error) {
+	allowedFields := map[string]struct{}{
+		"type":     {},
+		"required": {},
+	}
+
+	for field := range propMap {
+		if _, ok := allowedFields[field]; !ok {
+			return nil, fmt.Errorf("invalid field '%s' for leaf property", field)
+		}
+	}
+
+	prop := &boolean{}
+
+	if raw, exists := propMap["required"]; exists {
+		if err := json.Unmarshal(raw, &prop.required); err != nil {
+			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	return prop, nil
+}

--- a/backend/internal/userschema/model/number.go
+++ b/backend/internal/userschema/model/number.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+type number struct {
+	required bool
+	unique   bool
+	enum     map[float64]struct{}
+}
+
+func (p *number) isRequired() bool {
+	return p.required
+}
+
+func (p *number) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
+	numberValue, ok := convertToFloat64(value)
+	if !ok {
+		logger.Debug("Expected number but got different type",
+			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+		return false, nil
+	}
+
+	if p.enum != nil {
+		if _, exists := p.enum[numberValue]; !exists {
+			logger.Debug("Value not in enum", log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (p *number) validateUniqueness(
+	value interface{},
+	path string,
+	identifyUser func(map[string]interface{}) (*string, error),
+	logger *log.Logger,
+) (bool, error) {
+	if !p.unique {
+		return true, nil
+	}
+
+	filter := map[string]interface{}{path: value}
+	existingUserID, err := identifyUser(filter)
+	if err != nil {
+		return false, err
+	}
+
+	return existingUserID == nil, nil
+}
+
+func compileNumberProperty(propMap map[string]json.RawMessage) (property, error) {
+	allowedFields := map[string]struct{}{
+		"type":     {},
+		"required": {},
+		"unique":   {},
+		"enum":     {},
+	}
+
+	for field := range propMap {
+		if _, ok := allowedFields[field]; !ok {
+			return nil, fmt.Errorf("invalid field '%s' for leaf property", field)
+		}
+	}
+
+	prop := &number{}
+
+	if raw, exists := propMap["required"]; exists {
+		if err := json.Unmarshal(raw, &prop.required); err != nil {
+			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["unique"]; exists {
+		if err := json.Unmarshal(raw, &prop.unique); err != nil {
+			return nil, fmt.Errorf("'unique' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["enum"]; exists {
+		var enumRaw []json.RawMessage
+		if err := json.Unmarshal(raw, &enumRaw); err != nil {
+			return nil, fmt.Errorf("'enum' field must be an array")
+		}
+		if len(enumRaw) == 0 {
+			return nil, fmt.Errorf("'enum' array cannot be empty")
+		}
+
+		prop.enum = make(map[float64]struct{}, len(enumRaw))
+		for i, itemRaw := range enumRaw {
+			var value float64
+			if err := json.Unmarshal(itemRaw, &value); err != nil {
+				return nil, fmt.Errorf("'enum' array item at index %d must be a number to match property type", i)
+			}
+			prop.enum[value] = struct{}{}
+		}
+	}
+
+	return prop, nil
+}

--- a/backend/internal/userschema/model/object.go
+++ b/backend/internal/userschema/model/object.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+type object struct {
+	required   bool
+	properties map[string]property
+}
+
+func (p *object) isRequired() bool {
+	return p.required
+}
+
+func (p *object) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
+	valueMap, ok := value.(map[string]interface{})
+	if !ok {
+		logger.Debug("Expected object but got different type",
+			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+		return false, nil
+	}
+
+	for nestedName, nestedProp := range p.properties {
+		nestedValue, exists := valueMap[nestedName]
+		nestedPath := path + "." + nestedName
+
+		if !exists {
+			if nestedProp.isRequired() {
+				return false, nil
+			}
+			continue
+		}
+
+		if nestedValue == nil {
+			continue
+		}
+
+		isValid, err := nestedProp.validateValue(nestedValue, nestedPath, logger)
+		if err != nil {
+			return false, err
+		}
+		if !isValid {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (p *object) validateUniqueness(
+	value interface{},
+	path string,
+	identifyUser func(map[string]interface{}) (*string, error),
+	logger *log.Logger,
+) (bool, error) {
+	valueMap, ok := value.(map[string]interface{})
+	if !ok {
+		logger.Debug("Expected object but got different type",
+			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+		return false, nil
+	}
+
+	for nestedName, nestedProp := range p.properties {
+		nestedValue, exists := valueMap[nestedName]
+		if !exists {
+			continue
+		}
+
+		nestedPath := path + "." + nestedName
+		isValid, err := nestedProp.validateUniqueness(nestedValue, nestedPath, identifyUser, logger)
+		if err != nil {
+			return false, err
+		}
+		if !isValid {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func compileObjectProperty(propMap map[string]json.RawMessage) (property, error) {
+	allowedFields := map[string]struct{}{
+		"type":       {},
+		"properties": {},
+		"required":   {},
+	}
+
+	for field := range propMap {
+		if _, ok := allowedFields[field]; !ok {
+			return nil, fmt.Errorf("invalid field '%s' for object property", field)
+		}
+	}
+
+	prop := &object{
+		properties: make(map[string]property),
+	}
+
+	if raw, exists := propMap["required"]; exists {
+		if err := json.Unmarshal(raw, &prop.required); err != nil {
+			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	propertiesRaw, exists := propMap["properties"]
+	if !exists {
+		return nil, fmt.Errorf("missing required 'properties' field for object type")
+	}
+
+	var nestedProps map[string]json.RawMessage
+	if err := json.Unmarshal(propertiesRaw, &nestedProps); err != nil {
+		return nil, fmt.Errorf("'properties' field must be an object")
+	}
+
+	for nestedName, nestedRaw := range nestedProps {
+		compiledNested, err := compileProperty(nestedName, nestedRaw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid nested property '%s': %w", nestedName, err)
+		}
+		prop.properties[nestedName] = compiledNested
+	}
+
+	return prop, nil
+}

--- a/backend/internal/userschema/model/schema.go
+++ b/backend/internal/userschema/model/schema.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+type property interface {
+	isRequired() bool
+	validateValue(value interface{}, path string, logger *log.Logger) (bool, error)
+	validateUniqueness(value interface{}, path string,
+		identifyUser func(map[string]interface{}) (*string, error), logger *log.Logger) (bool, error)
+}
+
+// Schema represents a user schema with a set of properties.
+type Schema struct {
+	properties map[string]property
+}
+
+// Validate validates the user attributes against the schema.
+func (cs *Schema) Validate(attributes json.RawMessage, logger *log.Logger) (bool, error) {
+	if len(attributes) == 0 {
+		logger.Debug("User has no attributes to validate")
+		return true, nil
+	}
+
+	var userAttrs map[string]interface{}
+	if err := json.Unmarshal(attributes, &userAttrs); err != nil {
+		return false, fmt.Errorf("failed to unmarshal user attributes: %w", err)
+	}
+
+	if len(cs.properties) == 0 {
+		return true, nil
+	}
+
+	for propName, prop := range cs.properties {
+		value, exists := userAttrs[propName]
+		if !exists {
+			if prop.isRequired() {
+				return false, nil
+			}
+			continue
+		}
+
+		isValid, err := prop.validateValue(value, propName, logger)
+		if err != nil {
+			return false, err
+		}
+		if !isValid {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// ValidateUniqueness checks uniqueness constraints for the schema properties.
+func (cs *Schema) ValidateUniqueness(
+	attrs map[string]interface{},
+	identifyUser func(map[string]interface{}) (*string, error),
+	logger *log.Logger,
+) (bool, error) {
+	if len(cs.properties) == 0 {
+		return true, nil
+	}
+
+	for propName, prop := range cs.properties {
+		value, exists := attrs[propName]
+		if !exists {
+			continue
+		}
+
+		isValid, err := prop.validateUniqueness(value, propName, identifyUser, logger)
+		if err != nil {
+			return false, err
+		}
+		if !isValid {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func convertToFloat64(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+// CompileUserSchema compiles a user schema from the provided JSON.
+func CompileUserSchema(schema json.RawMessage) (*Schema, error) {
+	var schemaMap map[string]json.RawMessage
+	if err := json.Unmarshal(schema, &schemaMap); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	if len(schemaMap) == 0 {
+		return nil, fmt.Errorf("schema cannot be empty - must contain at least one property definition")
+	}
+
+	compiled := &Schema{
+		properties: make(map[string]property, len(schemaMap)),
+	}
+
+	for propName, propRaw := range schemaMap {
+		compiledProp, err := compileProperty(propName, propRaw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid property '%s': %w", propName, err)
+		}
+		compiled.properties[propName] = compiledProp
+	}
+
+	return compiled, nil
+}
+
+func compileProperty(propName string, propRaw json.RawMessage) (property, error) {
+	var propMap map[string]json.RawMessage
+	if err := json.Unmarshal(propRaw, &propMap); err != nil {
+		return nil, fmt.Errorf("property definition must be an object")
+	}
+
+	typeRaw, exists := propMap["type"]
+	if !exists {
+		return nil, fmt.Errorf("missing required 'type' field")
+	}
+
+	var typeStr string
+	if err := json.Unmarshal(typeRaw, &typeStr); err != nil {
+		return nil, fmt.Errorf("'type' field must be a string")
+	}
+
+	switch typeStr {
+	case TypeString:
+		return compileStringProperty(propMap)
+	case TypeNumber:
+		return compileNumberProperty(propMap)
+	case TypeBoolean:
+		return compileBooleanProperty(propMap)
+	case TypeObject:
+		return compileObjectProperty(propMap)
+	case TypeArray:
+		return compileArrayProperty(propName, propMap)
+	default:
+		return nil, fmt.Errorf("invalid type '%s', must be one of: string, number, boolean, object, array", typeStr)
+	}
+}

--- a/backend/internal/userschema/model/string.go
+++ b/backend/internal/userschema/model/string.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+type str struct {
+	required bool
+	unique   bool
+	enum     map[string]struct{}
+	pattern  *regexp.Regexp
+}
+
+func (p *str) isRequired() bool {
+	return p.required
+}
+
+func (p *str) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
+	strValue, ok := value.(string)
+	if !ok {
+		logger.Debug("Expected string but got different type",
+			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+		return false, nil
+	}
+
+	if p.enum != nil {
+		if _, exists := p.enum[strValue]; !exists {
+			logger.Debug("Value not in enum", log.String("property", path), log.String("value", strValue))
+			return false, nil
+		}
+	}
+
+	if p.pattern != nil && !p.pattern.MatchString(strValue) {
+		logger.Debug("Regex pattern mismatch", log.String("property", path), log.String("value", strValue))
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (p *str) validateUniqueness(
+	value interface{},
+	path string,
+	identifyUser func(map[string]interface{}) (*string, error),
+	logger *log.Logger,
+) (bool, error) {
+	if !p.unique {
+		return true, nil
+	}
+
+	filter := map[string]interface{}{path: value}
+	existingUserID, err := identifyUser(filter)
+	if err != nil {
+		return false, err
+	}
+
+	return existingUserID == nil, nil
+}
+
+func compileStringProperty(propMap map[string]json.RawMessage) (property, error) {
+	allowedFields := map[string]struct{}{
+		"type":     {},
+		"required": {},
+		"unique":   {},
+		"enum":     {},
+		"regex":    {},
+		"pattern":  {},
+	}
+
+	for field := range propMap {
+		if _, ok := allowedFields[field]; !ok {
+			return nil, fmt.Errorf("invalid field '%s' for leaf property", field)
+		}
+	}
+
+	prop := &str{}
+
+	if raw, exists := propMap["required"]; exists {
+		if err := json.Unmarshal(raw, &prop.required); err != nil {
+			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["unique"]; exists {
+		if err := json.Unmarshal(raw, &prop.unique); err != nil {
+			return nil, fmt.Errorf("'unique' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["enum"]; exists {
+		var enumRaw []json.RawMessage
+		if err := json.Unmarshal(raw, &enumRaw); err != nil {
+			return nil, fmt.Errorf("'enum' field must be an array")
+		}
+		if len(enumRaw) == 0 {
+			return nil, fmt.Errorf("'enum' array cannot be empty")
+		}
+
+		prop.enum = make(map[string]struct{}, len(enumRaw))
+		for i, itemRaw := range enumRaw {
+			var value string
+			if err := json.Unmarshal(itemRaw, &value); err != nil {
+				return nil, fmt.Errorf("'enum' array item at index %d must be a string to match property type", i)
+			}
+			prop.enum[value] = struct{}{}
+		}
+	}
+
+	pattern, err := compilePattern(propMap)
+	if err != nil {
+		return nil, err
+	}
+	prop.pattern = pattern
+
+	return prop, nil
+}
+
+func compilePattern(propMap map[string]json.RawMessage) (*regexp.Regexp, error) {
+	var patternStr string
+	if raw, exists := propMap["regex"]; exists {
+		if _, dup := propMap["pattern"]; dup {
+			return nil, fmt.Errorf("cannot define both 'regex' and 'pattern' fields for the same property")
+		}
+		if err := json.Unmarshal(raw, &patternStr); err != nil {
+			return nil, fmt.Errorf("'regex' field must be a string")
+		}
+	} else if raw, exists := propMap["pattern"]; exists {
+		if err := json.Unmarshal(raw, &patternStr); err != nil {
+			return nil, fmt.Errorf("'pattern' field must be a string")
+		}
+	}
+
+	if patternStr == "" {
+		return nil, nil
+	}
+
+	compiled, err := regexp.Compile(patternStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex pattern: %w", err)
+	}
+
+	return compiled, nil
+}


### PR DESCRIPTION
## Purpose
This pull request introduces a comprehensive, extensible user schema validation system to the backend, supporting complex property types and validation rules. The main changes include the addition of core schema interfaces and implementations for string, number, boolean, object, and array property types, each with their own validation logic for value correctness and uniqueness constraints.

**Core schema infrastructure:**

* Introduced the `Property` interface and the main `Schema` struct in `schema.go`, providing methods for validating user attributes and enforcing uniqueness, as well as a function to compile a schema from JSON definitions.
* Implemented the central property compilation logic, supporting dynamic dispatch to appropriate property handlers based on type.

**Property type implementations:**

* Added `String`, `Number`, and `Boolean` property types with support for required, unique, enum, and pattern (for strings) constraints, including their compilation from JSON and validation logic. [[1]](diffhunk://#diff-0de0c8cdc4da84f3dbd952c15fba59f8abb0af0c4b9422fb47d4a8c8fe9acb45R1-R171) [[2]](diffhunk://#diff-4818559bf72a626d7d38f08a819042fa4eee3ea9d6a51eb279e1b59f173c9d33R1-R127) [[3]](diffhunk://#diff-0d72bba972237a85ef9ec9348f0ef2749ceeb2251bc6e873a6de44861ea1645cR1-R100)
* Added support for `Object` and `Array` property types, enabling nested schemas and recursive validation of complex attribute structures. [[1]](diffhunk://#diff-1c5cfba20aa31e726f71789c0027ac3a224330236f0c83bad03a447e999fa0b3R1-R150) [[2]](diffhunk://#diff-d5461f917076db6e798b20492cf73e9a5d30d66e932523962a230d23f71a7f9fR1-R115)

**Validation and extensibility:**

* Each property type provides value validation and uniqueness checking, with detailed error reporting and logging, making the schema system robust and extensible for future requirements. [[1]](diffhunk://#diff-0de0c8cdc4da84f3dbd952c15fba59f8abb0af0c4b9422fb47d4a8c8fe9acb45R1-R171) [[2]](diffhunk://#diff-4818559bf72a626d7d38f08a819042fa4eee3ea9d6a51eb279e1b59f173c9d33R1-R127) [[3]](diffhunk://#diff-0d72bba972237a85ef9ec9348f0ef2749ceeb2251bc6e873a6de44861ea1645cR1-R100) [[4]](diffhunk://#diff-1c5cfba20aa31e726f71789c0027ac3a224330236f0c83bad03a447e999fa0b3R1-R150) [[5]](diffhunk://#diff-d5461f917076db6e798b20492cf73e9a5d30d66e932523962a230d23f71a7f9fR1-R115) [[6]](diffhunk://#diff-f5f09d406cb757c788849aa66806f00db452399b22918c1d6000c5ca69476ef0R1-R179)