### PR TITLE
Update go lint template

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -19,8 +19,6 @@
 run:
   timeout: 5m
   allow-parallel-runners: true
-  skip-dirs:
-    - tests/mocks
 
 linters:
   disable-all: true
@@ -95,6 +93,8 @@ issues:
   max-same-issues: 0
   max-issues-per-linter: 0
   exclude-use-default: false
+  exclude-dirs:
+    - tests/mocks
 
 output:
   show-stats: true


### PR DESCRIPTION
## Purpose

This pull request updates the `.golangci.yml` configuration by replacing the deprecated `run.skip-dirs` config with the `issues.exclude-dirs` config.

```
level=warning msg="[config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`."
```