### PR TITLE
Add federated IDP authentication API and service implementation

### DIFF
--- a/backend/internal/authn/common/model.go
+++ b/backend/internal/authn/common/model.go
@@ -39,3 +39,17 @@ type AuthenticationContext struct {
 	AuthenticatedUser  AuthenticatedUser
 	AuthTime           time.Time
 }
+
+// AuthenticationResponse represents the response after successful authentication.
+type AuthenticationResponse struct {
+	ID               string
+	Type             string
+	OrganizationUnit string
+}
+
+// AuthenticationResponseDTO represents the data transfer object for the authentication response.
+type AuthenticationResponseDTO struct {
+	ID               string `json:"id"`
+	Type             string `json:"type,omitempty"`
+	OrganizationUnit string `json:"organization_unit,omitempty"`
+}

--- a/backend/internal/authn/errorconstants.go
+++ b/backend/internal/authn/errorconstants.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"github.com/asgardeo/thunder/internal/system/error/apierror"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
+
+// API errors
+
+// APIErrorInvalidRequestFormat is returned when the request body is malformed.
+var APIErrorInvalidRequestFormat = apierror.ErrorResponse{
+	Code:        "AUTHN-1000",
+	Message:     "Invalid request format",
+	Description: "The request body is malformed or contains invalid data",
+}
+
+// Client errors for the service
+var (
+	// ErrorInvalidIDPID is the error returned when the provided IDP ID is invalid.
+	ErrorInvalidIDPID = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1001",
+		Error:            "Invalid identity provider ID",
+		ErrorDescription: "The provided identity provider ID is invalid or empty",
+	}
+	// ErrorClientErrorWhileRetrievingIDP is the error returned when there is a client error while retrieving the IDP.
+	ErrorClientErrorWhileRetrievingIDP = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1002",
+		Error:            "Error retrieving identity provider",
+		ErrorDescription: "An error occurred while retrieving the identity provider",
+	}
+	// ErrorInvalidIDPType is the error returned when the provided IDP type is invalid.
+	ErrorInvalidIDPType = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1003",
+		Error:            "Invalid identity provider type",
+		ErrorDescription: "The requested identity provider type is invalid",
+	}
+	// ErrorEmptySessionToken is the error returned when the provided session token is invalid.
+	ErrorEmptySessionToken = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1004",
+		Error:            "Empty session token",
+		ErrorDescription: "The provided session token is empty",
+	}
+	// ErrorEmptyAuthCode is the error returned when the provided authorization code is empty.
+	ErrorEmptyAuthCode = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1005",
+		Error:            "Empty authorization code",
+		ErrorDescription: "The provided authorization code is empty",
+	}
+	// ErrorInvalidSessionToken is the error returned when the provided session token is invalid.
+	ErrorInvalidSessionToken = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1006",
+		Error:            "Invalid session token",
+		ErrorDescription: "The provided session token is invalid or has expired",
+	}
+	// ErrorSubClaimNotFound is the error returned when the 'sub' claim is not found in the ID token.
+	ErrorSubClaimNotFound = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1007",
+		Error:            "user subject not found",
+		ErrorDescription: "The 'sub' claim is not found in the ID token claims",
+	}
+)
+
+// Server errors for the service
+
+// ErrorInternalServerError is returned when an unexpected error occurs on the server.
+var ErrorInternalServerError = serviceerror.ServiceError{
+	Type:             serviceerror.ServerErrorType,
+	Code:             "AUTHN-5000",
+	Error:            "Internal server error",
+	ErrorDescription: "An unexpected error occurred while processing the request",
+}

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/asgardeo/thunder/internal/authn/common"
+	"github.com/asgardeo/thunder/internal/idp"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/error/apierror"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
+)
+
+// AuthenticationHandler defines the handler for managing authentication API requests.
+type AuthenticationHandler struct {
+	authService AuthenticationServiceInterface
+}
+
+// NewAuthenticationHandler creates a new instance of AuthenticationHandler.
+func NewAuthenticationHandler() *AuthenticationHandler {
+	return &AuthenticationHandler{
+		authService: NewAuthenticationService(),
+	}
+}
+
+// HandleGoogleAuthStartRequest handles the Google OAuth start authentication request.
+func (ah *AuthenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	authResponse, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGoogle, authRequest.IDPID)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	response := IDPAuthInitResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, response)
+}
+
+// HandleGoogleAuthFinishRequest handles the Google OAuth finish authentication request.
+func (ah *AuthenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	authResponse, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGoogle,
+		authRequest.SessionToken, authRequest.Code)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	responseDTO := common.AuthenticationResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
+}
+
+// HandleGithubAuthStartRequest handles the GitHub OAuth start authentication request.
+func (ah *AuthenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	authResponse, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGitHub, authRequest.IDPID)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	responseDTO := IDPAuthInitResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
+}
+
+// HandleGithubAuthFinishRequest handles the GitHub OAuth finish authentication request.
+func (ah *AuthenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	authResponse, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGitHub,
+		authRequest.SessionToken, authRequest.Code)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	responseDTO := common.AuthenticationResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
+}
+
+// HandleStandardOAuthStartRequest handles the standard OAuth start authentication request.
+func (ah *AuthenticationHandler) HandleStandardOAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	authResponse, svcErr := ah.authService.StartAuthentication(idp.IDPTypeOAuth, authRequest.IDPID)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	responseDTO := IDPAuthInitResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
+}
+
+// HandleStandardOAuthFinishRequest handles the standard OAuth finish authentication request.
+func (ah *AuthenticationHandler) HandleStandardOAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	authResponse, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeOAuth,
+		authRequest.SessionToken, authRequest.Code)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	responseDTO := common.AuthenticationResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
+}
+
+// handleServiceError converts service errors to appropriate HTTP responses.
+func (ah *AuthenticationHandler) handleServiceError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+	status := http.StatusBadRequest
+	if svcErr.Type == serviceerror.ServerErrorType {
+		status = http.StatusInternalServerError
+	}
+
+	errorResp := apierror.ErrorResponse{
+		Code:        svcErr.Code,
+		Message:     svcErr.Error,
+		Description: svcErr.ErrorDescription,
+	}
+	ah.writeErrorResponse(w, status, errorResp)
+}
+
+// writeSuccessResponse writes a successful JSON response.
+func (ah *AuthenticationHandler) writeSuccessResponse(w http.ResponseWriter, data interface{}) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthenticationHandler"))
+
+	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		logger.Error("Failed to encode response", log.Error(err))
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// writeErrorResponse writes an error response.
+func (ah *AuthenticationHandler) writeErrorResponse(w http.ResponseWriter,
+	statusCode int, errorResp apierror.ErrorResponse) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthenticationHandler"))
+
+	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(errorResp); err != nil {
+		logger.Error("Failed to encode error response", log.Error(err))
+		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
+	}
+}

--- a/backend/internal/authn/model.go
+++ b/backend/internal/authn/model.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import "github.com/asgardeo/thunder/internal/idp"
+
+// IDPAuthInitData represents the data returned when initiating IDP authentication.
+type IDPAuthInitData struct {
+	RedirectURL  string
+	SessionToken string
+}
+
+// AuthSessionData represents the data stored in the authentication session token.
+type AuthSessionData struct {
+	IDPID   string      `json:"idp_id"`
+	IDPType idp.IDPType `json:"idp_type"`
+}
+
+// IDPAuthInitRequestDTO is the request to initiate IDP authentication.
+type IDPAuthInitRequestDTO struct {
+	IDPID string `json:"idp_id"`
+}
+
+// IDPAuthInitResponseDTO is the response after initiating IDP authentication.
+type IDPAuthInitResponseDTO struct {
+	RedirectURL  string `json:"redirect_url,omitempty"`
+	SessionToken string `json:"session_token"`
+}
+
+// IDPAuthFinishRequestDTO is the request to complete IDP authentication.
+type IDPAuthFinishRequestDTO struct {
+	SessionToken string `json:"session_token"`
+	Code         string `json:"code"`
+}

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -168,6 +168,7 @@ func (s *oidcAuthnService) ValidateIDToken(idpID, idToken string) *serviceerror.
 	if oAuthClientConfig.OAuthEndpoints.JwksEndpoint != "" {
 		err := s.jwtService.VerifyJWTWithJWKS(idToken, oAuthClientConfig.OAuthEndpoints.JwksEndpoint, "", "")
 		if err != nil {
+			logger.Debug("ID token signature validation failed", log.Error(err))
 			return &ErrorInvalidIDTokenSignature
 		}
 	} else {

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package authn implements the authentication service for authenticating users against different methods.
+package authn
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/asgardeo/thunder/internal/authn/common"
+	"github.com/asgardeo/thunder/internal/authn/github"
+	"github.com/asgardeo/thunder/internal/authn/google"
+	"github.com/asgardeo/thunder/internal/authn/oauth"
+	"github.com/asgardeo/thunder/internal/authn/oidc"
+	"github.com/asgardeo/thunder/internal/idp"
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/jwt"
+	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
+	usermodel "github.com/asgardeo/thunder/internal/user/model"
+)
+
+const svcLoggerComponentName = "AuthenticationService"
+
+// crossAllowedTypes is the list of IDP types that allow cross-type authentication.
+var crossAllowedTypes = []idp.IDPType{idp.IDPTypeOAuth, idp.IDPTypeOIDC}
+
+// AuthenticationServiceInterface defines the interface for the authentication service.
+type AuthenticationServiceInterface interface {
+	StartAuthentication(requestedType idp.IDPType, idpID string) (
+		*IDPAuthInitData, *serviceerror.ServiceError)
+	FinishAuthentication(requestedType idp.IDPType, sessionToken, code string) (
+		*common.AuthenticationResponse, *serviceerror.ServiceError)
+}
+
+// authenticationService is the default implementation of the AuthenticationServiceInterface.
+type authenticationService struct {
+	idpService    idp.IDPServiceInterface
+	jwtService    jwt.JWTServiceInterface
+	oauthService  oauth.OAuthAuthnServiceInterface
+	oidcService   oidc.OIDCAuthnServiceInterface
+	googleService google.GoogleOIDCAuthnServiceInterface
+	githubService github.GithubOAuthAuthnServiceInterface
+}
+
+// NewAuthenticationService creates a new instance of AuthenticationService.
+func NewAuthenticationService() AuthenticationServiceInterface {
+	return &authenticationService{
+		idpService:    idp.NewIDPService(),
+		jwtService:    jwt.GetJWTService(),
+		oauthService:  oauth.NewOAuthAuthnService(nil, nil, oauth.OAuthEndpoints{}),
+		oidcService:   oidc.NewOIDCAuthnService(nil, nil),
+		googleService: google.NewGoogleOIDCAuthnService(nil),
+		githubService: github.NewGithubOAuthAuthnService(nil, nil),
+	}
+}
+
+// StartAuthentication initiates authentication against an IDP.
+func (as *authenticationService) StartAuthentication(requestedType idp.IDPType, idpID string) (
+	*IDPAuthInitData, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
+	logger.Debug("Starting IDP authentication", log.String("idpId", idpID))
+
+	if strings.TrimSpace(idpID) == "" {
+		return nil, &ErrorInvalidIDPID
+	}
+
+	identityProvider, svcErr := as.idpService.GetIdentityProvider(idpID)
+	if svcErr != nil {
+		return nil, as.handleIDPServiceError(idpID, svcErr, logger)
+	}
+
+	if svcErr := as.validateIDPType(requestedType, identityProvider.Type, logger); svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Route to appropriate service based on IDP type
+	var redirectURL string
+	switch identityProvider.Type {
+	case idp.IDPTypeOAuth:
+		redirectURL, svcErr = as.oauthService.BuildAuthorizeURL(idpID)
+	case idp.IDPTypeOIDC:
+		redirectURL, svcErr = as.oidcService.BuildAuthorizeURL(idpID)
+	case idp.IDPTypeGoogle:
+		redirectURL, svcErr = as.googleService.BuildAuthorizeURL(idpID)
+	case idp.IDPTypeGitHub:
+		redirectURL, svcErr = as.githubService.BuildAuthorizeURL(idpID)
+	default:
+		logger.Error("Unsupported IDP type", log.String("idpId", idpID),
+			log.String("type", string(identityProvider.Type)))
+		return nil, &ErrorInternalServerError
+	}
+
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Generate session token
+	sessionToken, err := as.createSessionToken(idpID, identityProvider.Type)
+	if err != nil {
+		logger.Error("Failed to create session token", log.String("idpId", idpID), log.Error(err))
+		return nil, &ErrorInternalServerError
+	}
+
+	return &IDPAuthInitData{
+		RedirectURL:  redirectURL,
+		SessionToken: sessionToken,
+	}, nil
+}
+
+// FinishAuthentication completes authentication against an IDP.
+func (as *authenticationService) FinishAuthentication(requestedType idp.IDPType, sessionToken, code string) (
+	*common.AuthenticationResponse, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
+	logger.Debug("Finishing IDP authentication")
+
+	if strings.TrimSpace(sessionToken) == "" {
+		return nil, &ErrorEmptySessionToken
+	}
+	if strings.TrimSpace(code) == "" {
+		return nil, &ErrorEmptyAuthCode
+	}
+
+	// Verify and decode session token
+	sessionData, svcErr := as.verifyAndDecodeSessionToken(sessionToken, logger)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	if svcErr := as.validateIDPType(requestedType, sessionData.IDPType, logger); svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Route to appropriate service based on IDP type from session
+	var user *usermodel.User
+	switch sessionData.IDPType {
+	case idp.IDPTypeOAuth:
+		_, user, svcErr = as.finishOAuthAuthentication(sessionData.IDPID, code, logger)
+	case idp.IDPTypeOIDC:
+		_, user, svcErr = as.finishOIDCAuthentication(sessionData.IDPID, code, logger)
+	case idp.IDPTypeGoogle:
+		_, user, svcErr = as.finishGoogleAuthentication(sessionData.IDPID, code, logger)
+	case idp.IDPTypeGitHub:
+		_, user, svcErr = as.finishGithubAuthentication(sessionData.IDPID, code, logger)
+	default:
+		logger.Error("Unsupported IDP type in session", log.String("idpId", sessionData.IDPID),
+			log.String("type", string(sessionData.IDPType)))
+		return nil, &ErrorInternalServerError
+	}
+
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	return &common.AuthenticationResponse{
+		ID:               user.ID,
+		Type:             user.Type,
+		OrganizationUnit: user.OrganizationUnit,
+	}, nil
+}
+
+// finishOAuthAuthentication handles OAuth authentication completion.
+func (as *authenticationService) finishOAuthAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.oauthService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	userInfo, svcErr := as.oauthService.FetchUserInfo(idpID, tokenResp.AccessToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	sub, svcErr := as.getSubClaim(userInfo, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.oauthService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// finishOIDCAuthentication handles OIDC authentication completion.
+func (as *authenticationService) finishOIDCAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.oidcService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	claims, svcErr := as.oidcService.GetIDTokenClaims(tokenResp.IDToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	// TODO: Fetch user info if more claims are needed. Implement when the IDP requested attribute
+	//  support is added
+
+	sub, svcErr := as.getSubClaim(claims, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.oidcService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// finishGoogleAuthentication handles Google authentication completion.
+func (as *authenticationService) finishGoogleAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.googleService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	claims, svcErr := as.googleService.GetIDTokenClaims(tokenResp.IDToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	// TODO: Fetch user info if more claims are needed. Implement when the IDP requested attribute
+	//  support is added
+
+	sub, svcErr := as.getSubClaim(claims, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.googleService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// finishGithubAuthentication handles GitHub authentication completion.
+func (as *authenticationService) finishGithubAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.githubService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	userInfo, svcErr := as.githubService.FetchUserInfo(idpID, tokenResp.AccessToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	sub, svcErr := as.getSubClaim(userInfo, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.githubService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// handleIDPServiceError handles errors from IDP service.
+func (as *authenticationService) handleIDPServiceError(idpID string, svcErr *serviceerror.ServiceError,
+	logger *log.Logger) *serviceerror.ServiceError {
+	if svcErr.Type == serviceerror.ClientErrorType {
+		return serviceerror.CustomServiceError(ErrorClientErrorWhileRetrievingIDP,
+			fmt.Sprintf("An error occurred while retrieving the identity provider with ID %s: %s",
+				idpID, svcErr.ErrorDescription))
+	}
+
+	logger.Error("Error occurred while retrieving IDP", log.String("idpId", idpID), log.Any("error", svcErr))
+	return &ErrorInternalServerError
+}
+
+// validateIDPType validates that the requested IDP type matches the actual IDP type.
+func (as *authenticationService) validateIDPType(requestedType, actualType idp.IDPType,
+	logger *log.Logger) *serviceerror.ServiceError {
+	if requestedType != "" && requestedType != actualType {
+		// Allow cross-type authentication for certain types
+		if slices.Contains(crossAllowedTypes, requestedType) &&
+			slices.Contains(crossAllowedTypes, actualType) {
+			return nil
+		}
+
+		logger.Debug("IDP type mismatch", log.String("requested", string(requestedType)),
+			log.String("actual", string(actualType)))
+		return &ErrorInvalidIDPType
+	}
+
+	return nil
+}
+
+// createSessionToken creates a JWT session token with authentication session data.
+func (as *authenticationService) createSessionToken(idpID string, idpType idp.IDPType) (string, error) {
+	sessionData := AuthSessionData{
+		IDPID:   idpID,
+		IDPType: idpType,
+	}
+	claims := map[string]interface{}{
+		"auth_data": sessionData,
+	}
+
+	jwtConfig := config.GetThunderRuntime().Config.OAuth.JWT
+	token, _, err := as.jwtService.GenerateJWT("auth-svc", "auth-svc", jwtConfig.Issuer, 600, claims)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+// verifyAndDecodeSessionToken verifies the JWT signature and decodes the auth session data.
+func (as *authenticationService) verifyAndDecodeSessionToken(token string, logger *log.Logger) (
+	*AuthSessionData, *serviceerror.ServiceError) {
+	// Verify JWT signature and claims
+	jwtConfig := config.GetThunderRuntime().Config.OAuth.JWT
+	err := as.jwtService.VerifyJWT(token, "auth-svc", jwtConfig.Issuer)
+	if err != nil {
+		logger.Debug("Error verifying session token", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	// Parse and extract authentication session data
+	payload, err := jwt.DecodeJWTPayload(token)
+	if err != nil {
+		logger.Debug("Error decoding session token payload", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	authDataClaim, ok := payload["auth_data"]
+	if !ok {
+		logger.Debug("auth_data claim not found in session token")
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	authDataBytes, err := json.Marshal(authDataClaim)
+	if err != nil {
+		logger.Debug("Error marshaling auth_data claim", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	var sessionData AuthSessionData
+	err = json.Unmarshal(authDataBytes, &sessionData)
+	if err != nil {
+		logger.Debug("Error marshaling auth_data claim", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	return &sessionData, nil
+}
+
+// getSubClaim extracts the 'sub' claim from user info claims.
+func (as *authenticationService) getSubClaim(userClaims map[string]interface{}, logger *log.Logger) (
+	string, *serviceerror.ServiceError) {
+	sub, ok := userClaims["sub"]
+	if ok && sub != nil {
+		if subStr, ok := sub.(string); ok && subStr != "" {
+			return subStr, nil
+		}
+	}
+
+	// Try 'id' field as fallback
+	id, ok := userClaims["id"]
+	if ok && id != nil {
+		if idStr := sysutils.ConvertInterfaceValueToString(id); idStr != "" {
+			return idStr, nil
+		}
+	}
+
+	logger.Debug("sub claim not found in user info claims")
+	return "", &ErrorSubClaimNotFound
+}

--- a/backend/internal/system/managers/servicemanager.go
+++ b/backend/internal/system/managers/servicemanager.go
@@ -83,5 +83,8 @@ func (sm *ServiceManager) RegisterServices() error {
 	// Register the notification sender service.
 	services.NewNotificationSenderService(sm.mux)
 
+	// Register the authentication service.
+	services.NewAuthenticationService(sm.mux)
+
 	return nil
 }

--- a/backend/internal/system/services/authenticationservice.go
+++ b/backend/internal/system/services/authenticationservice.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package services
+
+import (
+	"net/http"
+
+	"github.com/asgardeo/thunder/internal/authn"
+	"github.com/asgardeo/thunder/internal/system/server"
+)
+
+// AuthenticationService defines the service for handling authentication-related requests.
+type AuthenticationService struct {
+	ServerOpsService server.ServerOperationServiceInterface
+	authHandler      *authn.AuthenticationHandler
+}
+
+// NewAuthenticationService creates a new instance of AuthenticationService.
+func NewAuthenticationService(mux *http.ServeMux) ServiceInterface {
+	instance := &AuthenticationService{
+		ServerOpsService: server.NewServerOperationService(),
+		authHandler:      authn.NewAuthenticationHandler(),
+	}
+	instance.RegisterRoutes(mux)
+
+	return instance
+}
+
+// RegisterRoutes registers the routes for the AuthenticationService.
+func (s *AuthenticationService) RegisterRoutes(mux *http.ServeMux) {
+	opts := server.RequestWrapOptions{
+		Cors: &server.Cors{
+			AllowedMethods:   "POST",
+			AllowedHeaders:   "Content-Type, Authorization",
+			AllowCredentials: true,
+		},
+	}
+
+	// Google OAuth routes
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/google/start", &opts,
+		s.authHandler.HandleGoogleAuthStartRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/google/finish", &opts,
+		s.authHandler.HandleGoogleAuthFinishRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/google/start", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/google/finish", &opts,
+		optionsNoContentHandler)
+
+	// GitHub OAuth routes
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/github/start", &opts,
+		s.authHandler.HandleGithubAuthStartRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/github/finish", &opts,
+		s.authHandler.HandleGithubAuthFinishRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/github/start", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/github/finish", &opts,
+		optionsNoContentHandler)
+
+	// Standard OAuth routes
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/standard/start", &opts,
+		s.authHandler.HandleStandardOAuthStartRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/standard/finish", &opts,
+		s.authHandler.HandleStandardOAuthFinishRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/standard/start", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/standard/finish", &opts,
+		optionsNoContentHandler)
+}
+
+// optionsNoContentHandler handles OPTIONS requests by responding with 204 No Content.
+func optionsNoContentHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/docs/apis/authentication.yaml
+++ b/docs/apis/authentication.yaml
@@ -1,0 +1,332 @@
+openapi: 3.0.3
+
+info:
+  title: Authentication API
+  description: This API is used to authenticate users.
+  version: "1.0"
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://{host}:{port}
+    variables:
+      host:
+        default: "localhost"
+      port:
+        default: "8090"
+
+paths:
+  /auth/oauth/google/start:
+    post:
+      summary: Start Google authentication
+      description: Start OAuth authentication flow with a Google identity provider.
+      tags:
+      - Google
+      requestBody:
+        description: Google authentication initiation data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthInitRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthInitResponse'
+              example:
+                redirect_url: "https://accounts.google.com/o/oauth2/auth?client_id=your-client-id&response_type=code&scope=openid%20email%20profile&redirect_uri=https://yourapp.com/callback"
+                session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1001"
+                message: "Invalid identity provider ID"
+                description: "The provided identity provider ID is invalid or empty"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
+  /auth/oauth/google/finish:
+    post:
+      summary: Finish Google authentication
+      description: Complete oauth authentication flow with a Google identity provider.
+      tags:
+      - Google
+      requestBody:
+        description: Google authentication completion data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthFinishRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1003"
+                message: "Authorization code is required"
+                description: "The authorization code must be provided to complete authentication"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
+  /auth/oauth/github/start:
+    post:
+      summary: Start Github authentication
+      description: Start OAuth authentication flow with a Github identity provider.
+      tags:
+      - Github
+      requestBody:
+        description: Github authentication initiation data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthInitRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthInitResponse'
+              example:
+                redirect_url: "https://github.com/login/oauth/authorize?client_id=your-client-id&redirect_uri=https://yourapp.com/callback&scope=user"
+                session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1001"
+                message: "Invalid identity provider ID"
+                description: "The provided identity provider ID is invalid or empty"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
+  /auth/oauth/github/finish:
+    post:
+      summary: Finish Github authentication
+      description: Complete oauth authentication flow with a Github identity provider.
+      tags:
+      - Github
+      requestBody:
+        description: Github authentication completion data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthFinishRequest'
+            example:
+              session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+              code: "authorization-code"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1003"
+                message: "Authorization code is required"
+                description: "The authorization code must be provided to complete authentication"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
+  /auth/oauth/standard/start:
+    post:
+      summary: Start standard OAuth authentication
+      description: Start OAuth authentication flow with a standard identity provider.
+      tags:
+      - Standard
+      requestBody:
+        description: Standard OAuth IDP authentication initiation data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthInitRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthInitResponse'
+              example:
+                redirect_url: "https://your-idp.com/oauth2/authorize?client_id=your-client-id&response_type=code&scope=openid%20email%20profile&redirect_uri=https://yourapp.com/callback"
+                session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1001"
+                message: "Invalid identity provider ID"
+                description: "The provided identity provider ID is invalid or empty"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
+  /auth/oauth/standard/finish:
+    post:
+      summary: Finish standard OAuth authentication
+      description: Complete oauth authentication flow with a standard identity provider.
+      tags:
+      - Standard
+      requestBody:
+        description: Standard OAuth IDP authentication completion data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthFinishRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1003"
+                message: "Authorization code is required"
+                description: "The authorization code must be provided to complete authentication"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
+components:
+  schemas:
+    AuthenticationResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: "The unique identifier of the authenticated user"
+        type:
+          type: string
+          description: "The type of the authenticated user"
+        organization_unit:
+          type: string
+          format: uuid
+          description: "The organization unit ID of the authenticated user"
+
+    IDPAuthInitRequest:
+      type: object
+      required:
+        - idp_id
+      properties:
+        idp_id:
+          type: string
+          description: Identity provider ID
+          example: "550e8400-e29b-41d4-a716-446655440000"
+    
+    IDPAuthInitResponse:
+      type: object
+      properties:
+        redirect_url:
+          type: string
+          description: URL to redirect the user for authentication
+          example: "https://accounts.google.com/o/oauth2/auth?client_id=your-client-id&response_type=code&scope=openid%20email%20profile&redirect_uri=https://yourapp.com/callback"
+        session_token:
+          type: string
+          description: JWT token for the authentication session
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    
+    IDPAuthFinishRequest:
+      type: object
+      required:
+        - session_token
+        - code
+      properties:
+        session_token:
+          type: string
+          description: JWT token for the authentication session
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        code:
+          type: string
+          description: Authorization code received from the identity provider
+
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Error code
+        message:
+          type: string
+          description: Error message
+        description:
+          type: string
+          description: Detailed error description
+
+    ClientErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+
+    ServerErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+      example:
+        code: "AUTHN-5000"
+        message: "Internal server error"
+        description: "An unexpected error occurred while processing the request"


### PR DESCRIPTION
## Purpose

This pull request introduces 3 new authentication API endpoints for authenticating users against a federated IDP. With this support will be added to authenticate with a Google OIDC, Github OAuth and any other standard OAuth/ OIDC federated identity provider.

Additionally, this improves the ID token validation logic for Google authentication.

The most important changes are:

**Authentication API Layer Implementation:**

* Added a new `AuthenticationHandler` in `backend/internal/authn/handler.go` to handle authentication API requests for Google, GitHub, and standard OAuth flows, including request parsing, response formatting, and error handling.
* Introduced request/response and DTO models for authentication flows in `backend/internal/authn/model.go`, standardizing the data structures used for API communication.
* Added authentication-related error constants in `backend/internal/authn/errorconstants.go` for consistent error reporting across the authentication service.

**Service Registration and Routing:**

* Implemented `AuthenticationService` in `backend/internal/system/services/authenticationservice.go`, registering new API endpoints for starting and finishing authentication for Google, GitHub, and standard OAuth, with appropriate CORS and HTTP method handling.
* Registered the new authentication service in the service manager (`backend/internal/system/managers/servicemanager.go`) to ensure it is available in the application's HTTP server.

**Improvements to Google ID Token Validation:**

* Enhanced Google OIDC authentication logic in `backend/internal/authn/google/service.go` to explicitly check for empty ID tokens, verify signatures using JWKS endpoints, and provide more robust error handling and logging. [[1]](diffhunk://#diff-a5b044241b22c362b38508dd09ad0b565ec9b55d5e87e3871a4283fb03b37dc0R23) [[2]](diffhunk://#diff-a5b044241b22c362b38508dd09ad0b565ec9b55d5e87e3871a4283fb03b37dc0R46-R64) [[3]](diffhunk://#diff-a5b044241b22c362b38508dd09ad0b565ec9b55d5e87e3871a4283fb03b37dc0L110-R135)
* Improved debug logging for ID token signature validation failures in the OIDC service (`backend/internal/authn/oidc/service.go`).

## API endpoints
<img width="936" height="473" alt="Screenshot 2025-10-03 at 9 36 45 AM" src="https://github.com/user-attachments/assets/77dd0291-7d51-4b53-995e-686f249d8579" />

## Related Issues
- https://github.com/asgardeo/thunder/issues/413
- https://github.com/asgardeo/thunder/issues/414
