### PR TITLE
Add SMS OTP authentication API and service implementation

### DIFF
--- a/backend/internal/authn/common/model.go
+++ b/backend/internal/authn/common/model.go
@@ -39,3 +39,17 @@ type AuthenticationContext struct {
 	AuthenticatedUser  AuthenticatedUser
 	AuthTime           time.Time
 }
+
+// AuthenticationResponse represents the response after successful authentication.
+type AuthenticationResponse struct {
+	ID               string
+	Type             string
+	OrganizationUnit string
+}
+
+// AuthenticationResponseDTO represents the data transfer object for the authentication response.
+type AuthenticationResponseDTO struct {
+	ID               string `json:"id"`
+	Type             string `json:"type,omitempty"`
+	OrganizationUnit string `json:"organization_unit,omitempty"`
+}

--- a/backend/internal/authn/common/model.go
+++ b/backend/internal/authn/common/model.go
@@ -46,10 +46,3 @@ type AuthenticationResponse struct {
 	Type             string
 	OrganizationUnit string
 }
-
-// AuthenticationResponseDTO represents the data transfer object for the authentication response.
-type AuthenticationResponseDTO struct {
-	ID               string `json:"id"`
-	Type             string `json:"type,omitempty"`
-	OrganizationUnit string `json:"organization_unit,omitempty"`
-}

--- a/backend/internal/authn/errorconstants.go
+++ b/backend/internal/authn/errorconstants.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"github.com/asgardeo/thunder/internal/system/error/apierror"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
+
+// API errors
+
+// APIErrorInvalidRequestFormat is returned when the request body is malformed.
+var APIErrorInvalidRequestFormat = apierror.ErrorResponse{
+	Code:        "AUTHN-1000",
+	Message:     "Invalid request format",
+	Description: "The request body is malformed or contains invalid data",
+}
+
+// Client errors for the service
+var (
+	// ErrorInvalidIDPID is the error returned when the provided IDP ID is invalid.
+	ErrorInvalidIDPID = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1001",
+		Error:            "Invalid identity provider ID",
+		ErrorDescription: "The provided identity provider ID is invalid or empty",
+	}
+	// ErrorClientErrorWhileRetrievingIDP is the error returned when there is a client error while retrieving the IDP.
+	ErrorClientErrorWhileRetrievingIDP = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1002",
+		Error:            "Error retrieving identity provider",
+		ErrorDescription: "An error occurred while retrieving the identity provider",
+	}
+	// ErrorInvalidIDPType is the error returned when the provided IDP type is invalid.
+	ErrorInvalidIDPType = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1003",
+		Error:            "Invalid identity provider type",
+		ErrorDescription: "The requested identity provider type is invalid",
+	}
+	// ErrorEmptySessionToken is the error returned when the provided session token is invalid.
+	ErrorEmptySessionToken = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1004",
+		Error:            "Empty session token",
+		ErrorDescription: "The provided session token is empty",
+	}
+	// ErrorEmptyAuthCode is the error returned when the provided authorization code is empty.
+	ErrorEmptyAuthCode = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1005",
+		Error:            "Empty authorization code",
+		ErrorDescription: "The provided authorization code is empty",
+	}
+	// ErrorInvalidSessionToken is the error returned when the provided session token is invalid.
+	ErrorInvalidSessionToken = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1006",
+		Error:            "Invalid session token",
+		ErrorDescription: "The provided session token is invalid or has expired",
+	}
+	// ErrorSubClaimNotFound is the error returned when the 'sub' claim is not found in the ID token.
+	ErrorSubClaimNotFound = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-1007",
+		Error:            "user subject not found",
+		ErrorDescription: "The 'sub' claim is not found in the ID token claims",
+	}
+)
+
+// Server errors for the service
+
+// ErrorInternalServerError is returned when an unexpected error occurs on the server.
+var ErrorInternalServerError = serviceerror.ServiceError{
+	Type:             serviceerror.ServerErrorType,
+	Code:             "AUTHN-5000",
+	Error:            "Internal server error",
+	ErrorDescription: "An unexpected error occurred while processing the request",
+}

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/asgardeo/thunder/internal/idp"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/error/apierror"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
+)
+
+// AuthenticationHandler defines the handler for managing authentication API requests.
+type AuthenticationHandler struct {
+	authService AuthenticationServiceInterface
+}
+
+// NewAuthenticationHandler creates a new instance of AuthenticationHandler.
+func NewAuthenticationHandler() *AuthenticationHandler {
+	return &AuthenticationHandler{
+		authService: NewAuthenticationService(),
+	}
+}
+
+// HandleGoogleAuthStartRequest handles the Google OAuth start authentication request.
+func (ah *AuthenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequest](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	responseDTO, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGoogle, authRequest.IDPID)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	response := IDPAuthInitResponse(*responseDTO)
+	ah.writeSuccessResponse(w, response)
+}
+
+// HandleGoogleAuthFinishRequest handles the Google OAuth finish authentication request.
+func (ah *AuthenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequest](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	responseDTO, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGoogle,
+		authRequest.SessionToken, authRequest.Code)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	response := IDPAuthFinishResponse(*responseDTO)
+	ah.writeSuccessResponse(w, response)
+}
+
+// HandleGithubAuthStartRequest handles the GitHub OAuth start authentication request.
+func (ah *AuthenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequest](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	responseDTO, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGitHub, authRequest.IDPID)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	response := IDPAuthInitResponse(*responseDTO)
+	ah.writeSuccessResponse(w, response)
+}
+
+// HandleGithubAuthFinishRequest handles the GitHub OAuth finish authentication request.
+func (ah *AuthenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequest](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	responseDTO, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGitHub,
+		authRequest.SessionToken, authRequest.Code)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	response := IDPAuthFinishResponse(*responseDTO)
+	ah.writeSuccessResponse(w, response)
+}
+
+// HandleStandardOAuthStartRequest handles the standard OAuth start authentication request.
+func (ah *AuthenticationHandler) HandleStandardOAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequest](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	responseDTO, svcErr := ah.authService.StartAuthentication(idp.IDPTypeOAuth, authRequest.IDPID)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	response := IDPAuthInitResponse(*responseDTO)
+	ah.writeSuccessResponse(w, response)
+}
+
+// HandleStandardOAuthFinishRequest handles the standard OAuth finish authentication request.
+func (ah *AuthenticationHandler) HandleStandardOAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequest](r)
+	if err != nil {
+		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
+		return
+	}
+
+	responseDTO, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeOAuth,
+		authRequest.SessionToken, authRequest.Code)
+	if svcErr != nil {
+		ah.handleServiceError(w, svcErr)
+		return
+	}
+
+	response := IDPAuthFinishResponse(*responseDTO)
+	ah.writeSuccessResponse(w, response)
+}
+
+// handleServiceError converts service errors to appropriate HTTP responses.
+func (ah *AuthenticationHandler) handleServiceError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+	status := http.StatusBadRequest
+	if svcErr.Type == serviceerror.ServerErrorType {
+		status = http.StatusInternalServerError
+	}
+
+	errorResp := apierror.ErrorResponse{
+		Code:        svcErr.Code,
+		Message:     svcErr.Error,
+		Description: svcErr.ErrorDescription,
+	}
+	ah.writeErrorResponse(w, status, errorResp)
+}
+
+// writeSuccessResponse writes a successful JSON response.
+func (ah *AuthenticationHandler) writeSuccessResponse(w http.ResponseWriter, data interface{}) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthenticationHandler"))
+
+	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		logger.Error("Failed to encode response", log.Error(err))
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// writeErrorResponse writes an error response.
+func (ah *AuthenticationHandler) writeErrorResponse(w http.ResponseWriter,
+	statusCode int, errorResp apierror.ErrorResponse) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthenticationHandler"))
+
+	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(errorResp); err != nil {
+		logger.Error("Failed to encode error response", log.Error(err))
+		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
+	}
+}

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/idp"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/apierror"
@@ -44,113 +45,113 @@ func NewAuthenticationHandler() *AuthenticationHandler {
 
 // HandleGoogleAuthStartRequest handles the Google OAuth start authentication request.
 func (ah *AuthenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWriter, r *http.Request) {
-	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequest](r)
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
 		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
 		return
 	}
 
-	responseDTO, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGoogle, authRequest.IDPID)
+	authResponse, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGoogle, authRequest.IDPID)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
 	}
 
-	response := IDPAuthInitResponse(*responseDTO)
+	response := IDPAuthInitResponseDTO(*authResponse)
 	ah.writeSuccessResponse(w, response)
 }
 
 // HandleGoogleAuthFinishRequest handles the Google OAuth finish authentication request.
 func (ah *AuthenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
-	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequest](r)
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
 		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
 		return
 	}
 
-	responseDTO, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGoogle,
+	authResponse, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGoogle,
 		authRequest.SessionToken, authRequest.Code)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
 	}
 
-	response := IDPAuthFinishResponse(*responseDTO)
-	ah.writeSuccessResponse(w, response)
+	responseDTO := common.AuthenticationResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
 }
 
 // HandleGithubAuthStartRequest handles the GitHub OAuth start authentication request.
 func (ah *AuthenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWriter, r *http.Request) {
-	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequest](r)
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
 		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
 		return
 	}
 
-	responseDTO, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGitHub, authRequest.IDPID)
+	authResponse, svcErr := ah.authService.StartAuthentication(idp.IDPTypeGitHub, authRequest.IDPID)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
 	}
 
-	response := IDPAuthInitResponse(*responseDTO)
-	ah.writeSuccessResponse(w, response)
+	responseDTO := IDPAuthInitResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
 }
 
 // HandleGithubAuthFinishRequest handles the GitHub OAuth finish authentication request.
 func (ah *AuthenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
-	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequest](r)
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
 		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
 		return
 	}
 
-	responseDTO, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGitHub,
+	authResponse, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeGitHub,
 		authRequest.SessionToken, authRequest.Code)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
 	}
 
-	response := IDPAuthFinishResponse(*responseDTO)
-	ah.writeSuccessResponse(w, response)
+	responseDTO := common.AuthenticationResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
 }
 
 // HandleStandardOAuthStartRequest handles the standard OAuth start authentication request.
 func (ah *AuthenticationHandler) HandleStandardOAuthStartRequest(w http.ResponseWriter, r *http.Request) {
-	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequest](r)
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
 		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
 		return
 	}
 
-	responseDTO, svcErr := ah.authService.StartAuthentication(idp.IDPTypeOAuth, authRequest.IDPID)
+	authResponse, svcErr := ah.authService.StartAuthentication(idp.IDPTypeOAuth, authRequest.IDPID)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
 	}
 
-	response := IDPAuthInitResponse(*responseDTO)
-	ah.writeSuccessResponse(w, response)
+	responseDTO := IDPAuthInitResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
 }
 
 // HandleStandardOAuthFinishRequest handles the standard OAuth finish authentication request.
 func (ah *AuthenticationHandler) HandleStandardOAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
-	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequest](r)
+	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
 		ah.writeErrorResponse(w, http.StatusBadRequest, APIErrorInvalidRequestFormat)
 		return
 	}
 
-	responseDTO, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeOAuth,
+	authResponse, svcErr := ah.authService.FinishAuthentication(idp.IDPTypeOAuth,
 		authRequest.SessionToken, authRequest.Code)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
 	}
 
-	response := IDPAuthFinishResponse(*responseDTO)
-	ah.writeSuccessResponse(w, response)
+	responseDTO := common.AuthenticationResponseDTO(*authResponse)
+	ah.writeSuccessResponse(w, responseDTO)
 }
 
 // handleServiceError converts service errors to appropriate HTTP responses.

--- a/backend/internal/authn/model.go
+++ b/backend/internal/authn/model.go
@@ -32,6 +32,13 @@ type AuthSessionData struct {
 	IDPType idp.IDPType `json:"idp_type"`
 }
 
+// AuthenticationResponseDTO represents the data transfer object for the authentication response.
+type AuthenticationResponseDTO struct {
+	ID               string `json:"id"`
+	Type             string `json:"type,omitempty"`
+	OrganizationUnit string `json:"organization_unit,omitempty"`
+}
+
 // IDPAuthInitRequestDTO is the request to initiate IDP authentication.
 type IDPAuthInitRequestDTO struct {
 	IDPID string `json:"idp_id"`
@@ -47,4 +54,22 @@ type IDPAuthInitResponseDTO struct {
 type IDPAuthFinishRequestDTO struct {
 	SessionToken string `json:"session_token"`
 	Code         string `json:"code"`
+}
+
+// SendOTPAuthRequestDTO is the request to send an OTP for authentication.
+type SendOTPAuthRequestDTO struct {
+	SenderID  string `json:"sender_id"`
+	Recipient string `json:"recipient"`
+}
+
+// SendOTPAuthResponseDTO is the response after sending an OTP for authentication.
+type SendOTPAuthResponseDTO struct {
+	Status       string `json:"status"`
+	SessionToken string `json:"session_token"`
+}
+
+// VerifyOTPAuthRequestDTO is the request to verify an OTP for authentication.
+type VerifyOTPAuthRequestDTO struct {
+	SessionToken string `json:"session_token"`
+	OTP          string `json:"otp"`
 }

--- a/backend/internal/authn/model.go
+++ b/backend/internal/authn/model.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import "github.com/asgardeo/thunder/internal/idp"
+
+// IDPAuthInitDTO represents the data transfer object for initiating IDP authentication.
+type IDPAuthInitDTO struct {
+	RedirectURL  string
+	SessionToken string
+}
+
+// IDPAuthFinishDTO represents the data transfer object for completing IDP authentication.
+type IDPAuthFinishDTO struct {
+	ID               string
+	Type             string
+	OrganizationUnit string
+}
+
+// AuthSessionData represents the data stored in the authentication session token.
+type AuthSessionData struct {
+	IDPID   string      `json:"idp_id"`
+	IDPType idp.IDPType `json:"idp_type"`
+}
+
+// IDPAuthInitRequest is the request to initiate IDP authentication.
+type IDPAuthInitRequest struct {
+	IDPID string `json:"idp_id"`
+}
+
+// IDPAuthInitResponse is the response for IDP authentication initiation.
+type IDPAuthInitResponse struct {
+	RedirectURL  string `json:"redirect_url,omitempty"`
+	SessionToken string `json:"session_token"`
+}
+
+// IDPAuthFinishRequest is the request to complete IDP authentication.
+type IDPAuthFinishRequest struct {
+	SessionToken string `json:"session_token"`
+	Code         string `json:"code"`
+}
+
+// IDPAuthFinishResponse is the response for completed IDP authentication.
+type IDPAuthFinishResponse struct {
+	ID               string `json:"id"`
+	Type             string `json:"type,omitempty"`
+	OrganizationUnit string `json:"organization_unit,omitempty"`
+}

--- a/backend/internal/authn/model.go
+++ b/backend/internal/authn/model.go
@@ -20,17 +20,10 @@ package authn
 
 import "github.com/asgardeo/thunder/internal/idp"
 
-// IDPAuthInitDTO represents the data transfer object for initiating IDP authentication.
-type IDPAuthInitDTO struct {
+// IDPAuthInitData represents the data returned when initiating IDP authentication.
+type IDPAuthInitData struct {
 	RedirectURL  string
 	SessionToken string
-}
-
-// IDPAuthFinishDTO represents the data transfer object for completing IDP authentication.
-type IDPAuthFinishDTO struct {
-	ID               string
-	Type             string
-	OrganizationUnit string
 }
 
 // AuthSessionData represents the data stored in the authentication session token.
@@ -39,26 +32,19 @@ type AuthSessionData struct {
 	IDPType idp.IDPType `json:"idp_type"`
 }
 
-// IDPAuthInitRequest is the request to initiate IDP authentication.
-type IDPAuthInitRequest struct {
+// IDPAuthInitRequestDTO is the request to initiate IDP authentication.
+type IDPAuthInitRequestDTO struct {
 	IDPID string `json:"idp_id"`
 }
 
-// IDPAuthInitResponse is the response for IDP authentication initiation.
-type IDPAuthInitResponse struct {
+// IDPAuthInitResponseDTO is the response after initiating IDP authentication.
+type IDPAuthInitResponseDTO struct {
 	RedirectURL  string `json:"redirect_url,omitempty"`
 	SessionToken string `json:"session_token"`
 }
 
-// IDPAuthFinishRequest is the request to complete IDP authentication.
-type IDPAuthFinishRequest struct {
+// IDPAuthFinishRequestDTO is the request to complete IDP authentication.
+type IDPAuthFinishRequestDTO struct {
 	SessionToken string `json:"session_token"`
 	Code         string `json:"code"`
-}
-
-// IDPAuthFinishResponse is the response for completed IDP authentication.
-type IDPAuthFinishResponse struct {
-	ID               string `json:"id"`
-	Type             string `json:"type,omitempty"`
-	OrganizationUnit string `json:"organization_unit,omitempty"`
 }

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -168,6 +168,7 @@ func (s *oidcAuthnService) ValidateIDToken(idpID, idToken string) *serviceerror.
 	if oAuthClientConfig.OAuthEndpoints.JwksEndpoint != "" {
 		err := s.jwtService.VerifyJWTWithJWKS(idToken, oAuthClientConfig.OAuthEndpoints.JwksEndpoint, "", "")
 		if err != nil {
+			logger.Debug("ID token signature validation failed", log.Error(err))
 			return &ErrorInvalidIDTokenSignature
 		}
 	} else {

--- a/backend/internal/authn/otp/errorconstants.go
+++ b/backend/internal/authn/otp/errorconstants.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package otp
+
+import "github.com/asgardeo/thunder/internal/system/error/serviceerror"
+
+// Client errors for OTP authentication service
+var (
+	// ErrorInvalidSenderID is the error returned when the provided sender ID is invalid.
+	ErrorInvalidSenderID = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1001",
+		Error:            "Invalid sender ID",
+		ErrorDescription: "The provided sender ID is invalid or empty",
+	}
+	// ErrorInvalidRecipient is the error returned when the provided recipient is invalid.
+	ErrorInvalidRecipient = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1002",
+		Error:            "Invalid recipient",
+		ErrorDescription: "The provided recipient is invalid or empty",
+	}
+	// ErrorUnsupportedChannel is the error returned when the provided channel is not supported.
+	ErrorUnsupportedChannel = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1003",
+		Error:            "Unsupported channel",
+		ErrorDescription: "The provided channel is not supported for OTP authentication",
+	}
+	// ErrorInvalidSessionToken is the error returned when the provided session token is invalid.
+	ErrorInvalidSessionToken = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1004",
+		Error:            "Invalid session token",
+		ErrorDescription: "The provided session token is invalid or empty",
+	}
+	// ErrorInvalidOTP is the error returned when the provided OTP is invalid.
+	ErrorInvalidOTP = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1005",
+		Error:            "Invalid OTP",
+		ErrorDescription: "The provided OTP is invalid or empty",
+	}
+	// ErrorUserNotFound is the error returned when no user is found for the recipient.
+	ErrorUserNotFound = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1006",
+		Error:            "User not found",
+		ErrorDescription: "No user found for the provided recipient",
+	}
+	// ErrorClientErrorWhileSendingOTP is the error returned when there is a client error while sending OTP.
+	ErrorClientErrorWhileSendingOTP = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1007",
+		Error:            "Error processing OTP",
+		ErrorDescription: "An error occurred while processing the OTP request",
+	}
+	// ErrorClientErrorWhileResolvingUser is the error returned when there is a client error while resolving the user.
+	ErrorClientErrorWhileResolvingUser = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "AUTHN-OTP-1008",
+		Error:            "Error resolving user",
+		ErrorDescription: "An error occurred while resolving the user for the receipient",
+	}
+)
+
+// Server errors for OTP authentication service
+var (
+	// ErrorInternalServerError is returned when an unexpected error occurs on the server.
+	ErrorInternalServerError = serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "AUTHN-OTP-5000",
+		Error:            "Internal server error",
+		ErrorDescription: "An unexpected error occurred while processing the request",
+	}
+)

--- a/backend/internal/authn/otp/service.go
+++ b/backend/internal/authn/otp/service.go
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package otp implements the OTP authentication service.
+package otp
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/asgardeo/thunder/internal/notification"
+	notifcommon "github.com/asgardeo/thunder/internal/notification/common"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+	userconst "github.com/asgardeo/thunder/internal/user/constants"
+	usermodel "github.com/asgardeo/thunder/internal/user/model"
+	userservice "github.com/asgardeo/thunder/internal/user/service"
+)
+
+const (
+	loggerComponentName       = "OTPAuthnService"
+	userAttributeMobileNumber = "mobileNumber"
+)
+
+var supportedChannels = []notifcommon.ChannelType{notifcommon.ChannelTypeSMS}
+
+// OTPAuthnServiceInterface defines the interface for OTP authentication operations.
+// This is a wrapper over the notification.OTPServiceInterface to perform user authentication.
+type OTPAuthnServiceInterface interface {
+	SendOTP(senderID string, channel notifcommon.ChannelType, recipient string) (string, *serviceerror.ServiceError)
+	VerifyOTP(sessionToken, otp string) (*usermodel.User, *serviceerror.ServiceError)
+}
+
+// otpAuthnService is the default implementation of OTPAuthnServiceInterface.
+type otpAuthnService struct {
+	otpService  notification.OTPServiceInterface
+	userService userservice.UserServiceInterface
+}
+
+// NewOTPAuthnService creates a new instance of OTPAuthnService.
+func NewOTPAuthnService(otpSvc notification.OTPServiceInterface,
+	userSvc userservice.UserServiceInterface) OTPAuthnServiceInterface {
+	if otpSvc == nil {
+		otpSvc = notification.NewNotificationSenderServiceProvider().GetOTPService()
+	}
+	if userSvc == nil {
+		userSvc = userservice.GetUserService()
+	}
+	return &otpAuthnService{
+		otpService:  otpSvc,
+		userService: userSvc,
+	}
+}
+
+// SendOTP sends an OTP to the specified recipient using the provided sender.
+func (s *otpAuthnService) SendOTP(senderID string, channel notifcommon.ChannelType,
+	recipient string) (string, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	logger.Debug("Sending OTP for authentication", log.String("recipient", log.MaskString(recipient)),
+		log.String("channel", string(channel)))
+
+	if svcErr := s.validateOTPSendRequest(senderID, channel, recipient); svcErr != nil {
+		return "", svcErr
+	}
+
+	otpData := notifcommon.SendOTPDTO{
+		SenderID:  senderID,
+		Channel:   string(channel),
+		Recipient: recipient,
+	}
+	result, svcErr := s.otpService.SendOTP(otpData)
+	if svcErr != nil {
+		return "", s.handleOTPServiceError(svcErr, false, logger)
+	}
+
+	logger.Debug("OTP sent successfully, session token generated")
+	return result.SessionToken, nil
+}
+
+// VerifyOTP verifies the provided OTP against the session token and returns the authenticated user.
+func (s *otpAuthnService) VerifyOTP(sessionToken, otp string) (*usermodel.User, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	logger.Debug("Verifying OTP for authentication")
+
+	if svcErr := s.validateOTPVerifyRequest(sessionToken, otp); svcErr != nil {
+		return nil, svcErr
+	}
+
+	verifyData := notifcommon.VerifyOTPDTO{
+		SessionToken: sessionToken,
+		OTPCode:      otp,
+	}
+	result, svcErr := s.otpService.VerifyOTP(verifyData)
+	if svcErr != nil {
+		return nil, s.handleOTPServiceError(svcErr, true, logger)
+	}
+
+	return s.handleVerifyOTPResponse(result, logger)
+}
+
+// validateOTPSendRequest validates the parameters for sending an OTP.
+func (s *otpAuthnService) validateOTPSendRequest(senderID string, channel notifcommon.ChannelType,
+	recipient string) *serviceerror.ServiceError {
+	if strings.TrimSpace(senderID) == "" {
+		return &ErrorInvalidSenderID
+	}
+	if strings.TrimSpace(recipient) == "" {
+		return &ErrorInvalidRecipient
+	}
+	if !slices.Contains(supportedChannels, channel) {
+		return &ErrorUnsupportedChannel
+	}
+	return nil
+}
+
+// handleOTPServiceError handles errors from the OTP service.
+func (s *otpAuthnService) handleOTPServiceError(svcErr *serviceerror.ServiceError, isVerify bool,
+	logger *log.Logger) *serviceerror.ServiceError {
+	if svcErr.Type == serviceerror.ClientErrorType {
+		if isVerify {
+			return serviceerror.CustomServiceError(ErrorClientErrorWhileSendingOTP,
+				fmt.Sprintf("Error verifying OTP: %s", svcErr.ErrorDescription))
+		} else {
+			return serviceerror.CustomServiceError(ErrorClientErrorWhileSendingOTP,
+				fmt.Sprintf("Error sending OTP: %s", svcErr.ErrorDescription))
+		}
+	}
+
+	if isVerify {
+		logger.Error("Error occurred while verifying OTP", log.Any("error", svcErr))
+	} else {
+		logger.Error("Error occurred while sending OTP", log.Any("error", svcErr))
+	}
+	return &ErrorInternalServerError
+}
+
+// validateOTPVerifyRequest validates the parameters for verifying an OTP.
+func (s *otpAuthnService) validateOTPVerifyRequest(sessionToken, otp string) *serviceerror.ServiceError {
+	if strings.TrimSpace(sessionToken) == "" {
+		return &ErrorInvalidSessionToken
+	}
+	if strings.TrimSpace(otp) == "" {
+		return &ErrorInvalidOTP
+	}
+	return nil
+}
+
+// handleVerifyOTPResponse processes the OTP verification result and resolves the user.
+func (s *otpAuthnService) handleVerifyOTPResponse(result *notifcommon.VerifyOTPResultDTO,
+	logger *log.Logger) (*usermodel.User, *serviceerror.ServiceError) {
+	if result.Status != notifcommon.OTPVerifyStatusVerified {
+		return nil, &ErrorInvalidOTP
+	}
+
+	if result.Recipient == "" {
+		logger.Error("Recipient not found in OTP verification result")
+		return nil, &ErrorInternalServerError
+	}
+
+	user, svcErr := s.resolveUser(result.Recipient, notifcommon.ChannelTypeSMS, logger)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	return user, nil
+}
+
+// resolveUser retrieves a user by their recipient identifier (e.g., mobile number).
+func (s *otpAuthnService) resolveUser(recipient string, channel notifcommon.ChannelType,
+	logger *log.Logger) (*usermodel.User, *serviceerror.ServiceError) {
+	logger.Debug("Resolving user from recipient", log.String("recipient", log.MaskString(recipient)),
+		log.String("channel", string(channel)))
+
+	// Build filter based on channel type
+	filters := make(map[string]interface{})
+	switch channel {
+	case notifcommon.ChannelTypeSMS:
+		filters[userAttributeMobileNumber] = recipient
+	default:
+		return nil, &ErrorUnsupportedChannel
+	}
+
+	userID, svcErr := s.userService.IdentifyUser(filters)
+	if svcErr != nil {
+		return nil, s.handleUserServiceError(svcErr, logger)
+	}
+	if userID == nil || *userID == "" {
+		logger.Debug("No user found for recipient", log.String("recipient", log.MaskString(recipient)))
+		return nil, &ErrorUserNotFound
+	}
+
+	user, svcErr := s.userService.GetUser(*userID)
+	if svcErr != nil {
+		return nil, s.handleUserServiceError(svcErr, logger)
+	}
+
+	logger.Debug("User resolved from recipient", log.String("userId", user.ID))
+	return user, nil
+}
+
+// handleUserServiceError handles errors from the user service.
+func (s *otpAuthnService) handleUserServiceError(svcErr *serviceerror.ServiceError,
+	logger *log.Logger) *serviceerror.ServiceError {
+	if svcErr.Type == serviceerror.ClientErrorType {
+		if svcErr.Code == userconst.ErrorUserNotFound.Code {
+			return &ErrorUserNotFound
+		}
+		return serviceerror.CustomServiceError(ErrorClientErrorWhileResolvingUser,
+			fmt.Sprintf("An error occurred while retrieving user: %s", svcErr.ErrorDescription))
+	}
+
+	logger.Error("Error occurred while retrieving user", log.Any("error", svcErr))
+	return &ErrorInternalServerError
+}

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package authn implements the authentication service for authenticating users against different methods.
+package authn
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/asgardeo/thunder/internal/authn/github"
+	"github.com/asgardeo/thunder/internal/authn/google"
+	"github.com/asgardeo/thunder/internal/authn/oauth"
+	"github.com/asgardeo/thunder/internal/authn/oidc"
+	"github.com/asgardeo/thunder/internal/idp"
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/jwt"
+	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
+	usermodel "github.com/asgardeo/thunder/internal/user/model"
+)
+
+const svcLoggerComponentName = "AuthenticationService"
+
+// crossAllowedTypes is the list of IDP types that allow cross-type authentication.
+var crossAllowedTypes = []idp.IDPType{idp.IDPTypeOAuth, idp.IDPTypeOIDC}
+
+// AuthenticationServiceInterface defines the interface for the authentication service.
+type AuthenticationServiceInterface interface {
+	StartAuthentication(requestedType idp.IDPType, idpID string) (
+		*IDPAuthInitDTO, *serviceerror.ServiceError)
+	FinishAuthentication(requestedType idp.IDPType, sessionToken, code string) (
+		*IDPAuthFinishDTO, *serviceerror.ServiceError)
+}
+
+// authenticationService is the default implementation of the AuthenticationServiceInterface.
+type authenticationService struct {
+	idpService    idp.IDPServiceInterface
+	jwtService    jwt.JWTServiceInterface
+	oauthService  oauth.OAuthAuthnServiceInterface
+	oidcService   oidc.OIDCAuthnServiceInterface
+	googleService google.GoogleOIDCAuthnServiceInterface
+	githubService github.GithubOAuthAuthnServiceInterface
+}
+
+// NewAuthenticationService creates a new instance of AuthenticationService.
+func NewAuthenticationService() AuthenticationServiceInterface {
+	return &authenticationService{
+		idpService:    idp.NewIDPService(),
+		jwtService:    jwt.GetJWTService(),
+		oauthService:  oauth.NewOAuthAuthnService(nil, nil, oauth.OAuthEndpoints{}),
+		oidcService:   oidc.NewOIDCAuthnService(nil, nil),
+		googleService: google.NewGoogleOIDCAuthnService(nil),
+		githubService: github.NewGithubOAuthAuthnService(nil, nil),
+	}
+}
+
+// StartAuthentication initiates authentication against an IDP.
+func (as *authenticationService) StartAuthentication(requestedType idp.IDPType, idpID string) (
+	*IDPAuthInitDTO, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
+	logger.Debug("Starting IDP authentication", log.String("idpId", idpID))
+
+	if strings.TrimSpace(idpID) == "" {
+		return nil, &ErrorInvalidIDPID
+	}
+
+	identityProvider, svcErr := as.idpService.GetIdentityProvider(idpID)
+	if svcErr != nil {
+		return nil, as.handleIDPServiceError(idpID, svcErr, logger)
+	}
+
+	if svcErr := as.validateIDPType(requestedType, identityProvider.Type, logger); svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Route to appropriate service based on IDP type
+	var redirectURL string
+	switch identityProvider.Type {
+	case idp.IDPTypeOAuth:
+		redirectURL, svcErr = as.oauthService.BuildAuthorizeURL(idpID)
+	case idp.IDPTypeOIDC:
+		redirectURL, svcErr = as.oidcService.BuildAuthorizeURL(idpID)
+	case idp.IDPTypeGoogle:
+		redirectURL, svcErr = as.googleService.BuildAuthorizeURL(idpID)
+	case idp.IDPTypeGitHub:
+		redirectURL, svcErr = as.githubService.BuildAuthorizeURL(idpID)
+	default:
+		logger.Error("Unsupported IDP type", log.String("idpId", idpID),
+			log.String("type", string(identityProvider.Type)))
+		return nil, &ErrorInternalServerError
+	}
+
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Generate session token
+	sessionToken, err := as.createSessionToken(idpID, identityProvider.Type)
+	if err != nil {
+		logger.Error("Failed to create session token", log.String("idpId", idpID), log.Error(err))
+		return nil, &ErrorInternalServerError
+	}
+
+	return &IDPAuthInitDTO{
+		RedirectURL:  redirectURL,
+		SessionToken: sessionToken,
+	}, nil
+}
+
+// FinishAuthentication completes authentication against an IDP.
+func (as *authenticationService) FinishAuthentication(requestedType idp.IDPType, sessionToken, code string) (
+	*IDPAuthFinishDTO, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
+	logger.Debug("Finishing IDP authentication")
+
+	if strings.TrimSpace(sessionToken) == "" {
+		return nil, &ErrorEmptySessionToken
+	}
+	if strings.TrimSpace(code) == "" {
+		return nil, &ErrorEmptyAuthCode
+	}
+
+	// Verify and decode session token
+	sessionData, svcErr := as.verifyAndDecodeSessionToken(sessionToken, logger)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	if svcErr := as.validateIDPType(requestedType, sessionData.IDPType, logger); svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Route to appropriate service based on IDP type from session
+	var user *usermodel.User
+	switch sessionData.IDPType {
+	case idp.IDPTypeOAuth:
+		_, user, svcErr = as.finishOAuthAuthentication(sessionData.IDPID, code, logger)
+	case idp.IDPTypeOIDC:
+		_, user, svcErr = as.finishOIDCAuthentication(sessionData.IDPID, code, logger)
+	case idp.IDPTypeGoogle:
+		_, user, svcErr = as.finishGoogleAuthentication(sessionData.IDPID, code, logger)
+	case idp.IDPTypeGitHub:
+		_, user, svcErr = as.finishGithubAuthentication(sessionData.IDPID, code, logger)
+	default:
+		logger.Error("Unsupported IDP type in session", log.String("idpId", sessionData.IDPID),
+			log.String("type", string(sessionData.IDPType)))
+		return nil, &ErrorInternalServerError
+	}
+
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	return &IDPAuthFinishDTO{
+		ID:               user.ID,
+		Type:             user.Type,
+		OrganizationUnit: user.OrganizationUnit,
+	}, nil
+}
+
+// finishOAuthAuthentication handles OAuth authentication completion.
+func (as *authenticationService) finishOAuthAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.oauthService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	userInfo, svcErr := as.oauthService.FetchUserInfo(idpID, tokenResp.AccessToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	sub, svcErr := as.getSubClaim(userInfo, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.oauthService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// finishOIDCAuthentication handles OIDC authentication completion.
+func (as *authenticationService) finishOIDCAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.oidcService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	claims, svcErr := as.oidcService.GetIDTokenClaims(tokenResp.IDToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	// TODO: Fetch user info if more claims are needed. Implement when the IDP requested attribute
+	//  support is added
+
+	sub, svcErr := as.getSubClaim(claims, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.oidcService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// finishGoogleAuthentication handles Google authentication completion.
+func (as *authenticationService) finishGoogleAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.googleService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	claims, svcErr := as.googleService.GetIDTokenClaims(tokenResp.IDToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	// TODO: Fetch user info if more claims are needed. Implement when the IDP requested attribute
+	//  support is added
+
+	sub, svcErr := as.getSubClaim(claims, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.googleService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// finishGithubAuthentication handles GitHub authentication completion.
+func (as *authenticationService) finishGithubAuthentication(idpID, code string, logger *log.Logger) (
+	string, *usermodel.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.githubService.ExchangeCodeForToken(idpID, code, true)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	userInfo, svcErr := as.githubService.FetchUserInfo(idpID, tokenResp.AccessToken)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	sub, svcErr := as.getSubClaim(userInfo, logger)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	user, svcErr := as.githubService.GetInternalUser(sub)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	return sub, user, nil
+}
+
+// handleIDPServiceError handles errors from IDP service.
+func (as *authenticationService) handleIDPServiceError(idpID string, svcErr *serviceerror.ServiceError,
+	logger *log.Logger) *serviceerror.ServiceError {
+	if svcErr.Type == serviceerror.ClientErrorType {
+		return serviceerror.CustomServiceError(ErrorClientErrorWhileRetrievingIDP,
+			fmt.Sprintf("An error occurred while retrieving the identity provider with ID %s: %s",
+				idpID, svcErr.ErrorDescription))
+	}
+
+	logger.Error("Error occurred while retrieving IDP", log.String("idpId", idpID), log.Any("error", svcErr))
+	return &ErrorInternalServerError
+}
+
+// validateIDPType validates that the requested IDP type matches the actual IDP type.
+func (as *authenticationService) validateIDPType(requestedType, actualType idp.IDPType,
+	logger *log.Logger) *serviceerror.ServiceError {
+	if requestedType != "" && requestedType != actualType {
+		// Allow cross-type authentication for certain types
+		if slices.Contains(crossAllowedTypes, requestedType) &&
+			slices.Contains(crossAllowedTypes, actualType) {
+			return nil
+		}
+
+		logger.Debug("IDP type mismatch", log.String("requested", string(requestedType)),
+			log.String("actual", string(actualType)))
+		return &ErrorInvalidIDPType
+	}
+
+	return nil
+}
+
+// createSessionToken creates a JWT session token with authentication session data.
+func (as *authenticationService) createSessionToken(idpID string, idpType idp.IDPType) (string, error) {
+	sessionData := AuthSessionData{
+		IDPID:   idpID,
+		IDPType: idpType,
+	}
+	claims := map[string]interface{}{
+		"auth_data": sessionData,
+	}
+
+	jwtConfig := config.GetThunderRuntime().Config.OAuth.JWT
+	token, _, err := as.jwtService.GenerateJWT("auth-svc", "auth-svc", jwtConfig.Issuer, 600, claims)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+// verifyAndDecodeSessionToken verifies the JWT signature and decodes the auth session data.
+func (as *authenticationService) verifyAndDecodeSessionToken(token string, logger *log.Logger) (
+	*AuthSessionData, *serviceerror.ServiceError) {
+	publicKey := as.jwtService.GetPublicKey()
+	if publicKey == nil {
+		logger.Error("Error verifying session token: JWT public key is not available")
+		return nil, &ErrorInternalServerError
+	}
+
+	// Verify JWT signature and claims
+	jwtConfig := config.GetThunderRuntime().Config.OAuth.JWT
+	err := as.jwtService.VerifyJWT(token, publicKey, "auth-svc", jwtConfig.Issuer)
+	if err != nil {
+		logger.Debug("Error verifying session token", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	// Parse and extract authentication session data
+	payload, err := jwt.DecodeJWTPayload(token)
+	if err != nil {
+		logger.Debug("Error decoding session token payload", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	authDataClaim, ok := payload["auth_data"]
+	if !ok {
+		logger.Debug("auth_data claim not found in session token")
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	authDataBytes, err := json.Marshal(authDataClaim)
+	if err != nil {
+		logger.Debug("Error marshaling auth_data claim", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	var sessionData AuthSessionData
+	err = json.Unmarshal(authDataBytes, &sessionData)
+	if err != nil {
+		logger.Debug("Error marshaling auth_data claim", log.Error(err))
+		return nil, &ErrorInvalidSessionToken
+	}
+
+	return &sessionData, nil
+}
+
+// getSubClaim extracts the 'sub' claim from user info claims.
+func (as *authenticationService) getSubClaim(userClaims map[string]interface{}, logger *log.Logger) (
+	string, *serviceerror.ServiceError) {
+	sub, ok := userClaims["sub"]
+	if ok && sub != nil {
+		if subStr, ok := sub.(string); ok && subStr != "" {
+			return subStr, nil
+		}
+	}
+
+	// Try 'id' field as fallback
+	id, ok := userClaims["id"]
+	if ok && id != nil {
+		if idStr := sysutils.ConvertInterfaceValueToString(id); idStr != "" {
+			return idStr, nil
+		}
+	}
+
+	logger.Debug("sub claim not found in user info claims")
+	return "", &ErrorSubClaimNotFound
+}

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/github"
 	"github.com/asgardeo/thunder/internal/authn/google"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
@@ -46,9 +47,9 @@ var crossAllowedTypes = []idp.IDPType{idp.IDPTypeOAuth, idp.IDPTypeOIDC}
 // AuthenticationServiceInterface defines the interface for the authentication service.
 type AuthenticationServiceInterface interface {
 	StartAuthentication(requestedType idp.IDPType, idpID string) (
-		*IDPAuthInitDTO, *serviceerror.ServiceError)
+		*IDPAuthInitData, *serviceerror.ServiceError)
 	FinishAuthentication(requestedType idp.IDPType, sessionToken, code string) (
-		*IDPAuthFinishDTO, *serviceerror.ServiceError)
+		*common.AuthenticationResponse, *serviceerror.ServiceError)
 }
 
 // authenticationService is the default implementation of the AuthenticationServiceInterface.
@@ -75,7 +76,7 @@ func NewAuthenticationService() AuthenticationServiceInterface {
 
 // StartAuthentication initiates authentication against an IDP.
 func (as *authenticationService) StartAuthentication(requestedType idp.IDPType, idpID string) (
-	*IDPAuthInitDTO, *serviceerror.ServiceError) {
+	*IDPAuthInitData, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
 	logger.Debug("Starting IDP authentication", log.String("idpId", idpID))
 
@@ -120,7 +121,7 @@ func (as *authenticationService) StartAuthentication(requestedType idp.IDPType, 
 		return nil, &ErrorInternalServerError
 	}
 
-	return &IDPAuthInitDTO{
+	return &IDPAuthInitData{
 		RedirectURL:  redirectURL,
 		SessionToken: sessionToken,
 	}, nil
@@ -128,7 +129,7 @@ func (as *authenticationService) StartAuthentication(requestedType idp.IDPType, 
 
 // FinishAuthentication completes authentication against an IDP.
 func (as *authenticationService) FinishAuthentication(requestedType idp.IDPType, sessionToken, code string) (
-	*IDPAuthFinishDTO, *serviceerror.ServiceError) {
+	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
 	logger.Debug("Finishing IDP authentication")
 
@@ -170,7 +171,7 @@ func (as *authenticationService) FinishAuthentication(requestedType idp.IDPType,
 		return nil, svcErr
 	}
 
-	return &IDPAuthFinishDTO{
+	return &common.AuthenticationResponse{
 		ID:               user.ID,
 		Type:             user.Type,
 		OrganizationUnit: user.OrganizationUnit,

--- a/backend/internal/notification/common/model.go
+++ b/backend/internal/notification/common/model.go
@@ -107,7 +107,8 @@ type VerifyOTPDTO struct {
 
 // VerifyOTPResultDTO represents the service layer result for OTP verify operation.
 type VerifyOTPResultDTO struct {
-	Status OTPVerifyStatus
+	Status    OTPVerifyStatus
+	Recipient string
 }
 
 // OTPSessionData represents the data stored in the OTP session token.

--- a/backend/internal/notification/otpservice.go
+++ b/backend/internal/notification/otpservice.go
@@ -134,7 +134,8 @@ func (s *otpService) VerifyOTP(otpDTO common.VerifyOTPDTO) (*common.VerifyOTPRes
 	if currentTime > sessionData.ExpiryTime {
 		logger.Debug("OTP has expired")
 		return &common.VerifyOTPResultDTO{
-			Status: common.OTPVerifyStatusInvalid,
+			Status:    common.OTPVerifyStatusInvalid,
+			Recipient: sessionData.Recipient,
 		}, nil
 	}
 
@@ -143,12 +144,14 @@ func (s *otpService) VerifyOTP(otpDTO common.VerifyOTPDTO) (*common.VerifyOTPRes
 	if providedOTPHash != sessionData.OTPValue {
 		logger.Debug("Invalid OTP provided")
 		return &common.VerifyOTPResultDTO{
-			Status: common.OTPVerifyStatusInvalid,
+			Status:    common.OTPVerifyStatusInvalid,
+			Recipient: sessionData.Recipient,
 		}, nil
 	}
 
 	return &common.VerifyOTPResultDTO{
-		Status: common.OTPVerifyStatusVerified,
+		Status:    common.OTPVerifyStatusVerified,
+		Recipient: sessionData.Recipient,
 	}, nil
 }
 

--- a/backend/internal/system/managers/servicemanager.go
+++ b/backend/internal/system/managers/servicemanager.go
@@ -83,5 +83,8 @@ func (sm *ServiceManager) RegisterServices() error {
 	// Register the notification sender service.
 	services.NewNotificationSenderService(sm.mux)
 
+	// Register the authentication service.
+	services.NewAuthenticationService(sm.mux)
+
 	return nil
 }

--- a/backend/internal/system/services/authenticationservice.go
+++ b/backend/internal/system/services/authenticationservice.go
@@ -52,6 +52,16 @@ func (s *AuthenticationService) RegisterRoutes(mux *http.ServeMux) {
 		},
 	}
 
+	// SMS OTP routes
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/otp/sms/send", &opts,
+		s.authHandler.HandleSendSMSOTPRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/otp/sms/verify", &opts,
+		s.authHandler.HandleVerifySMSOTPRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/otp/sms/send", &opts,
+		optionsNoContentHandler)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/otp/sms/verify", &opts,
+		optionsNoContentHandler)
+
 	// Google OAuth routes
 	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/google/start", &opts,
 		s.authHandler.HandleGoogleAuthStartRequest)

--- a/backend/internal/system/services/authenticationservice.go
+++ b/backend/internal/system/services/authenticationservice.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package services
+
+import (
+	"net/http"
+
+	"github.com/asgardeo/thunder/internal/authn"
+	"github.com/asgardeo/thunder/internal/system/server"
+)
+
+// AuthenticationService defines the service for handling authentication-related requests.
+type AuthenticationService struct {
+	ServerOpsService server.ServerOperationServiceInterface
+	authHandler      *authn.AuthenticationHandler
+}
+
+// NewAuthenticationService creates a new instance of AuthenticationService.
+func NewAuthenticationService(mux *http.ServeMux) ServiceInterface {
+	instance := &AuthenticationService{
+		ServerOpsService: server.NewServerOperationService(),
+		authHandler:      authn.NewAuthenticationHandler(),
+	}
+	instance.RegisterRoutes(mux)
+
+	return instance
+}
+
+// RegisterRoutes registers the routes for the AuthenticationService.
+func (s *AuthenticationService) RegisterRoutes(mux *http.ServeMux) {
+	opts := server.RequestWrapOptions{
+		Cors: &server.Cors{
+			AllowedMethods:   "POST",
+			AllowedHeaders:   "Content-Type, Authorization",
+			AllowCredentials: true,
+		},
+	}
+
+	// Google OAuth routes
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/google/authenticate/start", &opts,
+		s.authHandler.HandleGoogleAuthStartRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/google/authenticate/finish", &opts,
+		s.authHandler.HandleGoogleAuthFinishRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/google/authenticate/start", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/google/authenticate/finish", &opts,
+		optionsNoContentHandler)
+
+	// GitHub OAuth routes
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/github/authenticate/start", &opts,
+		s.authHandler.HandleGithubAuthStartRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/github/authenticate/finish", &opts,
+		s.authHandler.HandleGithubAuthFinishRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/github/authenticate/start", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/github/authenticate/finish", &opts,
+		optionsNoContentHandler)
+
+	// Standard OAuth routes
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/standard/authenticate/start", &opts,
+		s.authHandler.HandleStandardOAuthStartRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/standard/authenticate/finish", &opts,
+		s.authHandler.HandleStandardOAuthFinishRequest)
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/standard/authenticate/start", &opts,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/standard/authenticate/finish", &opts,
+		optionsNoContentHandler)
+}
+
+// optionsNoContentHandler handles OPTIONS requests by responding with 204 No Content.
+func optionsNoContentHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/system/services/authenticationservice.go
+++ b/backend/internal/system/services/authenticationservice.go
@@ -53,39 +53,39 @@ func (s *AuthenticationService) RegisterRoutes(mux *http.ServeMux) {
 	}
 
 	// Google OAuth routes
-	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/google/authenticate/start", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/google/start", &opts,
 		s.authHandler.HandleGoogleAuthStartRequest)
-	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/google/authenticate/finish", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/google/finish", &opts,
 		s.authHandler.HandleGoogleAuthFinishRequest)
-	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/google/authenticate/start", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/google/start", &opts,
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		})
-	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/google/authenticate/finish", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/google/finish", &opts,
 		optionsNoContentHandler)
 
 	// GitHub OAuth routes
-	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/github/authenticate/start", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/github/start", &opts,
 		s.authHandler.HandleGithubAuthStartRequest)
-	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/github/authenticate/finish", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/github/finish", &opts,
 		s.authHandler.HandleGithubAuthFinishRequest)
-	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/github/authenticate/start", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/github/start", &opts,
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		})
-	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/github/authenticate/finish", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/github/finish", &opts,
 		optionsNoContentHandler)
 
 	// Standard OAuth routes
-	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/standard/authenticate/start", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/standard/start", &opts,
 		s.authHandler.HandleStandardOAuthStartRequest)
-	s.ServerOpsService.WrapHandleFunction(mux, "POST /oauth/standard/authenticate/finish", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "POST /auth/oauth/standard/finish", &opts,
 		s.authHandler.HandleStandardOAuthFinishRequest)
-	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/standard/authenticate/start", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/standard/start", &opts,
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		})
-	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /oauth/standard/authenticate/finish", &opts,
+	s.ServerOpsService.WrapHandleFunction(mux, "OPTIONS /auth/oauth/standard/finish", &opts,
 		optionsNoContentHandler)
 }
 

--- a/docs/apis/authentication.yaml
+++ b/docs/apis/authentication.yaml
@@ -17,6 +17,80 @@ servers:
         default: "8090"
 
 paths:
+  /auth/otp/sms/send:
+    post:
+      summary: Send a SMS OTP
+      description: Send a One Time Password (OTP) to a user's mobile number via SMS for authentication.
+      tags:
+        - SMS OTP
+      requestBody:
+        description: OTP send request data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendOtpAuthRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendOtpAuthResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-OTP-1002"
+                message: "Invalid recipient"
+                description: "The provided recipient is invalid or empty"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
+  /auth/otp/sms/verify:
+    post:
+      summary: Verify a SMS OTP
+      description: Verify a One Time Password (OTP) sent to a user's mobile number via SMS for authentication.
+      tags:
+        - SMS OTP
+      requestBody:
+        description: OTP verify request data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyOtpAuthRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-OTP-1005"
+                message: "Invalid OTP"
+                description: "The provided OTP is invalid or empty"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+
   /auth/oauth/google/start:
     post:
       summary: Start Google authentication
@@ -253,6 +327,48 @@ paths:
 
 components:
   schemas:
+    SendOtpAuthRequest:
+      type: object
+      properties:
+        sender_id:
+          type: string
+          description: ID of the message notification sender to use
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        recipient:
+          type: string
+          description: Recipient's mobile number
+          example: "+1234567890"
+      required:
+        - sender_id
+        - recipient
+
+    SendOtpAuthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Status of the OTP send request
+          example: "SUCCESS"
+        session_token:
+          type: string
+          description: JWT token for the authentication session
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+
+    VerifyOtpAuthRequest:
+      type: object
+      properties:
+        session_token:
+          type: string
+          description: JWT token for the OTP session
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        otp:
+          type: string
+          description: The OTP code received by the user
+          example: "123456"
+      required:
+        - session_token
+        - otp
+    
     AuthenticationResponse:
       type: object
       properties:

--- a/docs/apis/authentication.yaml
+++ b/docs/apis/authentication.yaml
@@ -17,7 +17,7 @@ servers:
         default: "8090"
 
 paths:
-  /oauth/google/authenticate/start:
+  /auth/oauth/google/start:
     post:
       summary: Start Google authentication
       description: Start OAuth authentication flow with a Google identity provider.
@@ -61,7 +61,7 @@ paths:
                 message: "Internal server error"
                 description: "An unexpected error occurred while processing the request"
 
-  /oauth/google/authenticate/finish:
+  /auth/oauth/google/finish:
     post:
       summary: Finish Google authentication
       description: Complete oauth authentication flow with a Google identity provider.
@@ -102,7 +102,7 @@ paths:
                 message: "Internal server error"
                 description: "An unexpected error occurred while processing the request"
 
-  /oauth/github/authenticate/start:
+  /auth/oauth/github/start:
     post:
       summary: Start Github authentication
       description: Start OAuth authentication flow with a Github identity provider.
@@ -146,7 +146,7 @@ paths:
                 message: "Internal server error"
                 description: "An unexpected error occurred while processing the request"
 
-  /oauth/github/authenticate/finish:
+  /auth/oauth/github/finish:
     post:
       summary: Finish Github authentication
       description: Complete oauth authentication flow with a Github identity provider.
@@ -190,7 +190,7 @@ paths:
                 message: "Internal server error"
                 description: "An unexpected error occurred while processing the request"
 
-  /oauth/standard/authenticate/start:
+  /auth/oauth/standard/start:
     post:
       summary: Start standard OAuth authentication
       description: Start OAuth authentication flow with a standard identity provider.
@@ -234,7 +234,7 @@ paths:
                 message: "Internal server error"
                 description: "An unexpected error occurred while processing the request"
 
-  /oauth/standard/authenticate/finish:
+  /auth/oauth/standard/finish:
     post:
       summary: Finish standard OAuth authentication
       description: Complete oauth authentication flow with a standard identity provider.

--- a/docs/apis/authentication.yaml
+++ b/docs/apis/authentication.yaml
@@ -1,0 +1,423 @@
+openapi: 3.0.3
+
+info:
+  title: Authentication API
+  description: This API is used to authenticate users.
+  version: "1.0"
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://{host}:{port}
+    variables:
+      host:
+        default: "localhost"
+      port:
+        default: "8090"
+
+paths:
+  /oauth/google/authenticate/start:
+    post:
+      summary: Start Google authentication
+      description: Start OAuth authentication flow with a Google identity provider.
+      tags:
+      - Google
+      requestBody:
+        description: Google authentication initiation data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthInitRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthInitResponse'
+              example:
+                redirect_url: "https://accounts.google.com/o/oauth2/auth?client_id=your-client-id&response_type=code&scope=openid%20email%20profile&redirect_uri=https://yourapp.com/callback"
+                session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1001"
+                message: "Invalid identity provider ID"
+                description: "The provided identity provider ID is invalid or empty"
+        "404":
+          description: 'Not Found: The identity provider with the specified ID does not exist.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1002"
+                message: "Identity provider not found"
+                description: "The requested identity provider could not be found"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+              example:
+                code: "AUTHN-5000"
+                message: "Internal server error"
+                description: "An unexpected error occurred while processing the request"
+
+  /oauth/google/authenticate/finish:
+    post:
+      summary: Finish Google authentication
+      description: Complete oauth authentication flow with a Google identity provider.
+      tags:
+      - Google
+      requestBody:
+        description: Google authentication completion data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthFinishRequest'
+            example:
+              session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+              code: "authorization-code"
+              nonce: "random-nonce-value"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthFinishResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1003"
+                message: "Authorization code is required"
+                description: "The authorization code must be provided to complete authentication"
+        "401":
+          description: 'Unauthorized'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1004"
+                message: "Invalid authorization code"
+                description: "The provided authorization code is invalid or has expired"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+              example:
+                code: "AUTHN-5000"
+                message: "Internal server error"
+                description: "An unexpected error occurred while processing the request"
+
+  /oauth/github/authenticate/start:
+    post:
+      summary: Start Github authentication
+      description: Start OAuth authentication flow with a Github identity provider.
+      tags:
+      - Github
+      requestBody:
+        description: Github authentication initiation data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthInitRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthInitResponse'
+              example:
+                redirect_url: "https://github.com/login/oauth/authorize?client_id=your-client-id&redirect_uri=https://yourapp.com/callback&scope=user"
+                session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1001"
+                message: "Invalid identity provider ID"
+                description: "The provided identity provider ID is invalid or empty"
+        "404":
+          description: 'Not Found: The identity provider with the specified ID does not exist.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1002"
+                message: "Identity provider not found"
+                description: "The requested identity provider could not be found"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+              example:
+                code: "AUTHN-5000"
+                message: "Internal server error"
+                description: "An unexpected error occurred while processing the request"
+
+  /oauth/github/authenticate/finish:
+    post:
+      summary: Finish Github authentication
+      description: Complete oauth authentication flow with a Github identity provider.
+      tags:
+      - Github
+      requestBody:
+        description: Github authentication completion data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthFinishRequest'
+            example:
+              session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+              code: "authorization-code"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthFinishResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1003"
+                message: "Authorization code is required"
+                description: "The authorization code must be provided to complete authentication"
+        "401":
+          description: 'Unauthorized'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1004"
+                message: "Invalid authorization code"
+                description: "The provided authorization code is invalid or has expired"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+              example:
+                code: "AUTHN-5000"
+                message: "Internal server error"
+                description: "An unexpected error occurred while processing the request"
+
+  /oauth/standard/authenticate/start:
+    post:
+      summary: Start standard OAuth authentication
+      description: Start OAuth authentication flow with a standard identity provider.
+      tags:
+      - Standard
+      requestBody:
+        description: Standard OAuth IDP authentication initiation data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthInitRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthInitResponse'
+              example:
+                redirect_url: "https://your-idp.com/oauth2/authorize?client_id=your-client-id&response_type=code&scope=openid%20email%20profile&redirect_uri=https://yourapp.com/callback"
+                session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1001"
+                message: "Invalid identity provider ID"
+                description: "The provided identity provider ID is invalid or empty"
+        "404":
+          description: 'Not Found: The identity provider with the specified ID does not exist.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1002"
+                message: "Identity provider not found"
+                description: "The requested identity provider could not be found"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+              example:
+                code: "AUTHN-5000"
+                message: "Internal server error"
+                description: "An unexpected error occurred while processing the request"
+
+  /oauth/standard/authenticate/finish:
+    post:
+      summary: Finish standard OAuth authentication
+      description: Complete oauth authentication flow with a standard identity provider.
+      tags:
+      - Standard
+      requestBody:
+        description: Standard OAuth IDP authentication completion data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IDPAuthFinishRequest'
+            example:
+              session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+              code: "authorization-code"
+              nonce: "random-nonce-value"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IDPAuthFinishResponse'
+        "400":
+          description: 'Bad Request: The request body is malformed or contains invalid data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1003"
+                message: "Authorization code is required"
+                description: "The authorization code must be provided to complete authentication"
+        "401":
+          description: 'Unauthorized'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+              example:
+                code: "AUTHN-1004"
+                message: "Invalid authorization code"
+                description: "The provided authorization code is invalid or has expired"
+        "500":
+          description: 'Internal Server Error: An unexpected error occurred while processing the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerErrorResponse'
+              example:
+                code: "AUTHN-5000"
+                message: "Internal server error"
+                description: "An unexpected error occurred while processing the request"
+
+components:
+  schemas:
+    IDPAuthInitRequest:
+      type: object
+      required:
+        - idp_id
+      properties:
+        idp_id:
+          type: string
+          description: Identity provider ID
+          example: "550e8400-e29b-41d4-a716-446655440000"
+    
+    IDPAuthInitResponse:
+      type: object
+      properties:
+        redirect_url:
+          type: string
+          description: URL to redirect the user for authentication
+          example: "https://accounts.google.com/o/oauth2/auth?client_id=your-client-id&response_type=code&scope=openid%20email%20profile&redirect_uri=https://yourapp.com/callback"
+        session_token:
+          type: string
+          description: JWT token for the authentication session
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    
+    IDPAuthFinishRequest:
+      type: object
+      required:
+        - session_token
+        - code
+      properties:
+        session_token:
+          type: string
+          description: JWT token for the authentication session
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        code:
+          type: string
+          description: Authorization code received from the identity provider
+      additionalProperties:
+        type: string
+        description: Additional parameters based on the identity provider configurations
+
+    IDPAuthFinishResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: "The unique identifier of the authenticated user"
+        type:
+          type: string
+          description: "The type of the authenticated user"
+        organizationUnit:
+          type: string
+          format: uuid
+          description: "The organization unit ID of the authenticated user"
+
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Error code
+        message:
+          type: string
+          description: Error message
+        description:
+          type: string
+          description: Detailed error description
+
+    ClientErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+
+    ServerErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object

--- a/docs/apis/authentication.yaml
+++ b/docs/apis/authentication.yaml
@@ -56,10 +56,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServerErrorResponse'
-              example:
-                code: "AUTHN-5000"
-                message: "Internal server error"
-                description: "An unexpected error occurred while processing the request"
 
   /auth/oauth/google/finish:
     post:
@@ -80,7 +76,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IDPAuthFinishResponse'
+                $ref: '#/components/schemas/AuthenticationResponse'
         "400":
           description: 'Bad Request: The request body is malformed or contains invalid data.'
           content:
@@ -97,10 +93,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServerErrorResponse'
-              example:
-                code: "AUTHN-5000"
-                message: "Internal server error"
-                description: "An unexpected error occurred while processing the request"
 
   /auth/oauth/github/start:
     post:
@@ -141,10 +133,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServerErrorResponse'
-              example:
-                code: "AUTHN-5000"
-                message: "Internal server error"
-                description: "An unexpected error occurred while processing the request"
 
   /auth/oauth/github/finish:
     post:
@@ -168,7 +156,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IDPAuthFinishResponse'
+                $ref: '#/components/schemas/AuthenticationResponse'
         "400":
           description: 'Bad Request: The request body is malformed or contains invalid data.'
           content:
@@ -185,10 +173,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServerErrorResponse'
-              example:
-                code: "AUTHN-5000"
-                message: "Internal server error"
-                description: "An unexpected error occurred while processing the request"
 
   /auth/oauth/standard/start:
     post:
@@ -229,10 +213,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServerErrorResponse'
-              example:
-                code: "AUTHN-5000"
-                message: "Internal server error"
-                description: "An unexpected error occurred while processing the request"
 
   /auth/oauth/standard/finish:
     post:
@@ -253,7 +233,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IDPAuthFinishResponse'
+                $ref: '#/components/schemas/AuthenticationResponse'
         "400":
           description: 'Bad Request: The request body is malformed or contains invalid data.'
           content:
@@ -270,13 +250,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServerErrorResponse'
-              example:
-                code: "AUTHN-5000"
-                message: "Internal server error"
-                description: "An unexpected error occurred while processing the request"
 
 components:
   schemas:
+    AuthenticationResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: "The unique identifier of the authenticated user"
+        type:
+          type: string
+          description: "The type of the authenticated user"
+        organization_unit:
+          type: string
+          format: uuid
+          description: "The organization unit ID of the authenticated user"
+
     IDPAuthInitRequest:
       type: object
       required:
@@ -313,21 +304,6 @@ components:
           type: string
           description: Authorization code received from the identity provider
 
-    IDPAuthFinishResponse:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: "The unique identifier of the authenticated user"
-        type:
-          type: string
-          description: "The type of the authenticated user"
-        organization_unit:
-          type: string
-          format: uuid
-          description: "The organization unit ID of the authenticated user"
-
     ErrorResponse:
       type: object
       properties:
@@ -350,3 +326,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/ErrorResponse'
         - type: object
+      example:
+        code: "AUTHN-5000"
+        message: "Internal server error"
+        description: "An unexpected error occurred while processing the request"

--- a/docs/apis/authentication.yaml
+++ b/docs/apis/authentication.yaml
@@ -50,16 +50,6 @@ paths:
                 code: "AUTHN-1001"
                 message: "Invalid identity provider ID"
                 description: "The provided identity provider ID is invalid or empty"
-        "404":
-          description: 'Not Found: The identity provider with the specified ID does not exist.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-              example:
-                code: "AUTHN-1002"
-                message: "Identity provider not found"
-                description: "The requested identity provider could not be found"
         "500":
           description: 'Internal Server Error: An unexpected error occurred while processing the request.'
           content:
@@ -84,10 +74,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IDPAuthFinishRequest'
-            example:
-              session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-              code: "authorization-code"
-              nonce: "random-nonce-value"
       responses:
         "200":
           description: OK
@@ -105,16 +91,6 @@ paths:
                 code: "AUTHN-1003"
                 message: "Authorization code is required"
                 description: "The authorization code must be provided to complete authentication"
-        "401":
-          description: 'Unauthorized'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-              example:
-                code: "AUTHN-1004"
-                message: "Invalid authorization code"
-                description: "The provided authorization code is invalid or has expired"
         "500":
           description: 'Internal Server Error: An unexpected error occurred while processing the request.'
           content:
@@ -159,16 +135,6 @@ paths:
                 code: "AUTHN-1001"
                 message: "Invalid identity provider ID"
                 description: "The provided identity provider ID is invalid or empty"
-        "404":
-          description: 'Not Found: The identity provider with the specified ID does not exist.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-              example:
-                code: "AUTHN-1002"
-                message: "Identity provider not found"
-                description: "The requested identity provider could not be found"
         "500":
           description: 'Internal Server Error: An unexpected error occurred while processing the request.'
           content:
@@ -213,16 +179,6 @@ paths:
                 code: "AUTHN-1003"
                 message: "Authorization code is required"
                 description: "The authorization code must be provided to complete authentication"
-        "401":
-          description: 'Unauthorized'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-              example:
-                code: "AUTHN-1004"
-                message: "Invalid authorization code"
-                description: "The provided authorization code is invalid or has expired"
         "500":
           description: 'Internal Server Error: An unexpected error occurred while processing the request.'
           content:
@@ -267,16 +223,6 @@ paths:
                 code: "AUTHN-1001"
                 message: "Invalid identity provider ID"
                 description: "The provided identity provider ID is invalid or empty"
-        "404":
-          description: 'Not Found: The identity provider with the specified ID does not exist.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-              example:
-                code: "AUTHN-1002"
-                message: "Identity provider not found"
-                description: "The requested identity provider could not be found"
         "500":
           description: 'Internal Server Error: An unexpected error occurred while processing the request.'
           content:
@@ -301,10 +247,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IDPAuthFinishRequest'
-            example:
-              session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-              code: "authorization-code"
-              nonce: "random-nonce-value"
       responses:
         "200":
           description: OK
@@ -322,16 +264,6 @@ paths:
                 code: "AUTHN-1003"
                 message: "Authorization code is required"
                 description: "The authorization code must be provided to complete authentication"
-        "401":
-          description: 'Unauthorized'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-              example:
-                code: "AUTHN-1004"
-                message: "Invalid authorization code"
-                description: "The provided authorization code is invalid or has expired"
         "500":
           description: 'Internal Server Error: An unexpected error occurred while processing the request.'
           content:
@@ -380,9 +312,6 @@ components:
         code:
           type: string
           description: Authorization code received from the identity provider
-      additionalProperties:
-        type: string
-        description: Additional parameters based on the identity provider configurations
 
     IDPAuthFinishResponse:
       type: object
@@ -394,7 +323,7 @@ components:
         type:
           type: string
           description: "The type of the authenticated user"
-        organizationUnit:
+        organization_unit:
           type: string
           format: uuid
           description: "The organization unit ID of the authenticated user"


### PR DESCRIPTION
## Purpose

This pull request introduces a new authentication API endpoint for authenticating users by sending a SMS OTP. This will be added in addition to the existing general OTP send and verify endpoints.

The most important changes are:

**Service Implementation**
- Implemented a new `otpAuthnService` wrapping the existing `internal/notification/otpService` for authentication specific handling.

**Authentication API Layer Improvements:**

* Added two new methods to `AuthenticationHandler` in `backend/internal/authn/handler.go` to handle send and verify SMS OTP authentication requests.
* Introduced request/response DTO models for SMS OTP authentication flows in `backend/internal/authn/model.go`, standardizing the data structures used for API communication.

**Service Routing:**

* Registered two new API endpoints in `AuthenticationService` in `backend/internal/system/services/authenticationservice.go`, to send and verify SMS OTP for authentication, with appropriate CORS and HTTP method handling.

## API endpoints

## Related Issues
- https://github.com/asgardeo/thunder/issues/449

## Related PRs
- https://github.com/asgardeo/thunder/pull/446