### PR TITLE
Add methods to verify jwt tokens without passing public key

### DIFF
--- a/backend/internal/notification/otpservice.go
+++ b/backend/internal/notification/otpservice.go
@@ -286,16 +286,11 @@ func (s *otpService) createSessionToken(sessionData common.OTPSessionData) (stri
 // verifyAndDecodeSessionToken verifies the JWT signature and decodes the session data.
 func (s *otpService) verifyAndDecodeSessionToken(token string, logger *log.Logger) (
 	*common.OTPSessionData, *serviceerror.ServiceError) {
-	publicKey := s.jwtSvc.GetPublicKey()
-	if publicKey == nil {
-		logger.Error("Error verifying session token: JWT public key is not available")
-		return nil, &ErrorInternalServerError
-	}
-
 	// Verify JWT signature
 	jwtConfig := config.GetThunderRuntime().Config.OAuth.JWT
-	err := s.jwtSvc.VerifyJWT(token, publicKey, "otp-svc", jwtConfig.Issuer)
+	err := s.jwtSvc.VerifyJWT(token, "otp-svc", jwtConfig.Issuer)
 	if err != nil {
+		logger.Debug("Invalid session token", log.Error(err))
 		return nil, &ErrorInvalidSessionToken
 	}
 

--- a/backend/internal/oauth/oauth2/authz/authzhandler.go
+++ b/backend/internal/oauth/oauth2/authz/authzhandler.go
@@ -505,13 +505,9 @@ func getAuthorizationCode(oAuthMessage *model.OAuthMessage, authUserID string) (
 
 // verifyAssertion verifies the JWT assertion.
 func (ah *AuthorizeHandler) verifyAssertion(assertion string, logger *log.Logger) error {
-	pubKey := ah.JWTService.GetPublicKey()
-	if pubKey == nil {
-		logger.Error("Server public key is not available for JWT assertion verification")
-		return errors.New("Internal server error")
-	}
-	if err := ah.JWTService.VerifyJWT(assertion, pubKey, "", ""); err != nil {
-		return errors.New("Invalid assertion signature")
+	if err := ah.JWTService.VerifyJWT(assertion, "", ""); err != nil {
+		logger.Debug("Invalid assertion signature", log.Error(err))
+		return errors.New("invalid assertion signature")
 	}
 
 	return nil

--- a/backend/internal/oauth/oauth2/granthandlers/refreshtoken.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refreshtoken.go
@@ -272,15 +272,7 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(tokenResponse *model.TokenR
 
 // verifyRefreshToken verifies the refresh token using the server's public key.
 func (h *refreshTokenGrantHandler) verifyRefreshToken(refreshToken string, logger *log.Logger) *model.ErrorResponse {
-	pubKey := h.JWTService.GetPublicKey()
-	if pubKey == nil {
-		logger.Error("Server public key is not available for JWT verification")
-		return &model.ErrorResponse{
-			Error:            constants.ErrorServerError,
-			ErrorDescription: "Server public key not available",
-		}
-	}
-	if err := h.JWTService.VerifyJWT(refreshToken, pubKey, "", ""); err != nil {
+	if err := h.JWTService.VerifyJWT(refreshToken, "", ""); err != nil {
 		logger.Error("Failed to verify refresh token signature", log.Error(err))
 		return &model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,

--- a/backend/internal/oauth/oauth2/granthandlers/refreshtoken_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refreshtoken_test.go
@@ -164,7 +164,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateGrant_MissingClientI
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_InvalidSignature() {
 	// Mock JWT service to return nil public key (simulating signature verification failure)
-	suite.mockJWTService.On("GetPublicKey").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", "valid.refresh.token", "", "").Return(errors.New("public key not available"))
 
 	ctx := &model.TokenContext{
 		TokenAttributes: make(map[string]interface{}),
@@ -174,8 +174,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_InvalidSignature
 
 	assert.Nil(suite.T(), response)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
-	assert.Equal(suite.T(), "Server public key not available", err.ErrorDescription)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, err.Error)
+	assert.Equal(suite.T(), "Invalid refresh token", err.ErrorDescription)
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() {

--- a/backend/tests/mocks/jwtmock/JWTServiceInterface_mock.go
+++ b/backend/tests/mocks/jwtmock/JWTServiceInterface_mock.go
@@ -218,16 +218,16 @@ func (_c *JWTServiceInterfaceMock_Init_Call) RunAndReturn(run func() error) *JWT
 }
 
 // VerifyJWT provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) VerifyJWT(jwtToken string, jwtPublicKey *rsa.PublicKey, expectedAud string, expectedIss string) error {
-	ret := _mock.Called(jwtToken, jwtPublicKey, expectedAud, expectedIss)
+func (_mock *JWTServiceInterfaceMock) VerifyJWT(jwtToken string, expectedAud string, expectedIss string) error {
+	ret := _mock.Called(jwtToken, expectedAud, expectedIss)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyJWT")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, *rsa.PublicKey, string, string) error); ok {
-		r0 = returnFunc(jwtToken, jwtPublicKey, expectedAud, expectedIss)
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = returnFunc(jwtToken, expectedAud, expectedIss)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -241,36 +241,30 @@ type JWTServiceInterfaceMock_VerifyJWT_Call struct {
 
 // VerifyJWT is a helper method to define mock.On call
 //   - jwtToken string
-//   - jwtPublicKey *rsa.PublicKey
 //   - expectedAud string
 //   - expectedIss string
-func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWT(jwtToken interface{}, jwtPublicKey interface{}, expectedAud interface{}, expectedIss interface{}) *JWTServiceInterfaceMock_VerifyJWT_Call {
-	return &JWTServiceInterfaceMock_VerifyJWT_Call{Call: _e.mock.On("VerifyJWT", jwtToken, jwtPublicKey, expectedAud, expectedIss)}
+func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWT(jwtToken interface{}, expectedAud interface{}, expectedIss interface{}) *JWTServiceInterfaceMock_VerifyJWT_Call {
+	return &JWTServiceInterfaceMock_VerifyJWT_Call{Call: _e.mock.On("VerifyJWT", jwtToken, expectedAud, expectedIss)}
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) Run(run func(jwtToken string, jwtPublicKey *rsa.PublicKey, expectedAud string, expectedIss string)) *JWTServiceInterfaceMock_VerifyJWT_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) Run(run func(jwtToken string, expectedAud string, expectedIss string)) *JWTServiceInterfaceMock_VerifyJWT_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
 			arg0 = args[0].(string)
 		}
-		var arg1 *rsa.PublicKey
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*rsa.PublicKey)
+			arg1 = args[1].(string)
 		}
 		var arg2 string
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
 		run(
 			arg0,
 			arg1,
 			arg2,
-			arg3,
 		)
 	})
 	return _c
@@ -281,22 +275,22 @@ func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) Return(err error) *JWTServiceI
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) RunAndReturn(run func(jwtToken string, jwtPublicKey *rsa.PublicKey, expectedAud string, expectedIss string) error) *JWTServiceInterfaceMock_VerifyJWT_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) RunAndReturn(run func(jwtToken string, expectedAud string, expectedIss string) error) *JWTServiceInterfaceMock_VerifyJWT_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyJWTSignature provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) VerifyJWTSignature(jwtToken string, jwtPublicKey *rsa.PublicKey) error {
-	ret := _mock.Called(jwtToken, jwtPublicKey)
+func (_mock *JWTServiceInterfaceMock) VerifyJWTSignature(jwtToken string) error {
+	ret := _mock.Called(jwtToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyJWTSignature")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, *rsa.PublicKey) error); ok {
-		r0 = returnFunc(jwtToken, jwtPublicKey)
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(jwtToken)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -310,24 +304,18 @@ type JWTServiceInterfaceMock_VerifyJWTSignature_Call struct {
 
 // VerifyJWTSignature is a helper method to define mock.On call
 //   - jwtToken string
-//   - jwtPublicKey *rsa.PublicKey
-func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWTSignature(jwtToken interface{}, jwtPublicKey interface{}) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
-	return &JWTServiceInterfaceMock_VerifyJWTSignature_Call{Call: _e.mock.On("VerifyJWTSignature", jwtToken, jwtPublicKey)}
+func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWTSignature(jwtToken interface{}) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
+	return &JWTServiceInterfaceMock_VerifyJWTSignature_Call{Call: _e.mock.On("VerifyJWTSignature", jwtToken)}
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) Run(run func(jwtToken string, jwtPublicKey *rsa.PublicKey)) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) Run(run func(jwtToken string)) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
 			arg0 = args[0].(string)
 		}
-		var arg1 *rsa.PublicKey
-		if args[1] != nil {
-			arg1 = args[1].(*rsa.PublicKey)
-		}
 		run(
 			arg0,
-			arg1,
 		)
 	})
 	return _c
@@ -338,7 +326,7 @@ func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) Return(err error) *JW
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) RunAndReturn(run func(jwtToken string, jwtPublicKey *rsa.PublicKey) error) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) RunAndReturn(run func(jwtToken string) error) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -396,6 +384,63 @@ func (_c *JWTServiceInterfaceMock_VerifyJWTSignatureWithJWKS_Call) Return(err er
 }
 
 func (_c *JWTServiceInterfaceMock_VerifyJWTSignatureWithJWKS_Call) RunAndReturn(run func(jwtToken string, jwksURL string) error) *JWTServiceInterfaceMock_VerifyJWTSignatureWithJWKS_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// VerifyJWTSignatureWithPublicKey provides a mock function for the type JWTServiceInterfaceMock
+func (_mock *JWTServiceInterfaceMock) VerifyJWTSignatureWithPublicKey(jwtToken string, jwtPublicKey *rsa.PublicKey) error {
+	ret := _mock.Called(jwtToken, jwtPublicKey)
+
+	if len(ret) == 0 {
+		panic("no return value specified for VerifyJWTSignatureWithPublicKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, *rsa.PublicKey) error); ok {
+		r0 = returnFunc(jwtToken, jwtPublicKey)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'VerifyJWTSignatureWithPublicKey'
+type JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call struct {
+	*mock.Call
+}
+
+// VerifyJWTSignatureWithPublicKey is a helper method to define mock.On call
+//   - jwtToken string
+//   - jwtPublicKey *rsa.PublicKey
+func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWTSignatureWithPublicKey(jwtToken interface{}, jwtPublicKey interface{}) *JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call {
+	return &JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call{Call: _e.mock.On("VerifyJWTSignatureWithPublicKey", jwtToken, jwtPublicKey)}
+}
+
+func (_c *JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call) Run(run func(jwtToken string, jwtPublicKey *rsa.PublicKey)) *JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 *rsa.PublicKey
+		if args[1] != nil {
+			arg1 = args[1].(*rsa.PublicKey)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call) Return(err error) *JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call) RunAndReturn(run func(jwtToken string, jwtPublicKey *rsa.PublicKey) error) *JWTServiceInterfaceMock_VerifyJWTSignatureWithPublicKey_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -465,6 +510,75 @@ func (_c *JWTServiceInterfaceMock_VerifyJWTWithJWKS_Call) Return(err error) *JWT
 }
 
 func (_c *JWTServiceInterfaceMock_VerifyJWTWithJWKS_Call) RunAndReturn(run func(jwtToken string, jwksURL string, expectedAud string, expectedIss string) error) *JWTServiceInterfaceMock_VerifyJWTWithJWKS_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// VerifyJWTWithPublicKey provides a mock function for the type JWTServiceInterfaceMock
+func (_mock *JWTServiceInterfaceMock) VerifyJWTWithPublicKey(jwtToken string, jwtPublicKey *rsa.PublicKey, expectedAud string, expectedIss string) error {
+	ret := _mock.Called(jwtToken, jwtPublicKey, expectedAud, expectedIss)
+
+	if len(ret) == 0 {
+		panic("no return value specified for VerifyJWTWithPublicKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, *rsa.PublicKey, string, string) error); ok {
+		r0 = returnFunc(jwtToken, jwtPublicKey, expectedAud, expectedIss)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'VerifyJWTWithPublicKey'
+type JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call struct {
+	*mock.Call
+}
+
+// VerifyJWTWithPublicKey is a helper method to define mock.On call
+//   - jwtToken string
+//   - jwtPublicKey *rsa.PublicKey
+//   - expectedAud string
+//   - expectedIss string
+func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWTWithPublicKey(jwtToken interface{}, jwtPublicKey interface{}, expectedAud interface{}, expectedIss interface{}) *JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call {
+	return &JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call{Call: _e.mock.On("VerifyJWTWithPublicKey", jwtToken, jwtPublicKey, expectedAud, expectedIss)}
+}
+
+func (_c *JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call) Run(run func(jwtToken string, jwtPublicKey *rsa.PublicKey, expectedAud string, expectedIss string)) *JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 *rsa.PublicKey
+		if args[1] != nil {
+			arg1 = args[1].(*rsa.PublicKey)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call) Return(err error) *JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call) RunAndReturn(run func(jwtToken string, jwtPublicKey *rsa.PublicKey, expectedAud string, expectedIss string) error) *JWTServiceInterfaceMock_VerifyJWTWithPublicKey_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Purpose

This pull request refactors how JWT signature verification is handled across the codebase, simplifying the interface and centralizing the use of the server's public key. The main change is that methods now use the server's public key internally by default, reducing the need to explicitly pass it around. Additionally, new methods are introduced to allow verification with a specific public key when needed. Corresponding updates are made to tests and error handling to reflect these changes.

Key changes include:

### JWT Service Refactoring

* Refactored `VerifyJWT` and `VerifyJWTSignature` in `JWTService` to use the server's public key internally, and added `VerifyJWTWithPublicKey` and `VerifyJWTSignatureWithPublicKey` methods for cases where a specific public key must be used. The service interface was updated accordingly. [[1]](diffhunk://#diff-a6adf3395a1977c374db36e94ae9a881988468a4e6610edf2e947a982751dd2dL58-R62) [[2]](diffhunk://#diff-a6adf3395a1977c374db36e94ae9a881988468a4e6610edf2e947a982751dd2dL216-R235) [[3]](diffhunk://#diff-a6adf3395a1977c374db36e94ae9a881988468a4e6610edf2e947a982751dd2dL245-R266)
* Updated all usages of `VerifyJWT` and `VerifyJWTSignature` across the codebase to match the new method signatures, removing the need to fetch and pass the public key explicitly. [[1]](diffhunk://#diff-cf992bb146677cb5b8caaea0fdae0f217821342d8254b3ce208a4432b80e9e38L289-R291) [[2]](diffhunk://#diff-4864994427dad587b2f19bb0cf43323dd878c032a554e03844c61f4e20d87529L508-R509) [[3]](diffhunk://#diff-d4d16d6e232e3a89a596076c48c8daa2b66e3f299cfe757fc056269dc8d3e237L275-R275) [[4]](diffhunk://#diff-b234ee4148fae43a2d667544e298416aab142a739f6b384d68088fe5dbb50193L81-R81) [[5]](diffhunk://#diff-a6adf3395a1977c374db36e94ae9a881988468a4e6610edf2e947a982751dd2dL330-R350)

### Error Handling and Test Adjustments

* Adjusted error handling for cases where the public key is unavailable, ensuring consistent error messages and behavior throughout the codebase. [[1]](diffhunk://#diff-d4d16d6e232e3a89a596076c48c8daa2b66e3f299cfe757fc056269dc8d3e237L275-R275) [[2]](diffhunk://#diff-4a4ec1329fd2c70f3c948c56f6021da172079975a0585e0f328c6c3e99f3cc1cL177-R178) [[3]](diffhunk://#diff-0a9d1f19d172764d752ed14600449dcff81afa5c9f85e8eca3907c1923f0295eL81-R94)
* Updated unit tests and mocks to reflect the new method signatures and error handling, including new test cases for `JWTService` to cover scenarios such as missing public key, invalid signature, and claim validation. [[1]](diffhunk://#diff-4a4ec1329fd2c70f3c948c56f6021da172079975a0585e0f328c6c3e99f3cc1cL167-R167) [[2]](diffhunk://#diff-0a9d1f19d172764d752ed14600449dcff81afa5c9f85e8eca3907c1923f0295eL81-R94) [[3]](diffhunk://#diff-0a9d1f19d172764d752ed14600449dcff81afa5c9f85e8eca3907c1923f0295eL114-R116) [[4]](diffhunk://#diff-0a9d1f19d172764d752ed14600449dcff81afa5c9f85e8eca3907c1923f0295eL213-R215) [[5]](diffhunk://#diff-0a9d1f19d172764d752ed14600449dcff81afa5c9f85e8eca3907c1923f0295eL225-R244) [[6]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1R617-R763) [[7]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1L640-R787) [[8]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1L650-R797) [[9]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1L665-L668) [[10]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1L683-R827) [[11]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1L696-R840)

These changes streamline JWT verification, improve code clarity, and enhance test coverage.