### PR TITLE
Add integration tests for OAuth/ OIDC/ SMS OTP authenticate APIs

### DIFF
--- a/tests/integration/authn/github_auth_test.go
+++ b/tests/integration/authn/github_auth_test.go
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	githubAuthStart  = "/auth/oauth/github/start"
+	githubAuthFinish = "/auth/oauth/github/finish"
+	mockGithubPort   = 8091
+)
+
+type GithubAuthTestSuite struct {
+	suite.Suite
+	mockGithubServer *testutils.MockGithubOAuthServer
+	idpID            string
+	userID           string
+}
+
+func TestGithubAuthTestSuite(t *testing.T) {
+	suite.Run(t, new(GithubAuthTestSuite))
+}
+
+func (suite *GithubAuthTestSuite) SetupSuite() {
+	suite.mockGithubServer = testutils.NewMockGithubOAuthServer(mockGithubPort,
+		"test-github-client", "test-github-secret")
+
+	email := "testuser@github.com"
+	suite.mockGithubServer.AddUser(&testutils.GithubUserInfo{
+		Login:     "testuser",
+		ID:        12345,
+		NodeID:    "MDQ6VXNlcjEyMzQ1",
+		Email:     &email,
+		Name:      "Test User",
+		AvatarURL: "https://avatars.githubusercontent.com/u/12345",
+		Type:      "User",
+		CreatedAt: "2020-01-01T00:00:00Z",
+		UpdatedAt: "2024-01-01T00:00:00Z",
+	}, []*testutils.GithubEmail{
+		{
+			Email:    email,
+			Primary:  true,
+			Verified: true,
+		},
+	})
+
+	err := suite.mockGithubServer.Start()
+	suite.Require().NoError(err, "Failed to start mock GitHub server")
+
+	userAttributes := map[string]interface{}{
+		"username":   "githubuser",
+		"password":   "Test@1234",
+		"sub":        "12345",
+		"email":      "testuser@github.com",
+		"givenName":  "Test",
+		"familyName": "User",
+	}
+
+	attributesJSON, err := json.Marshal(userAttributes)
+	suite.Require().NoError(err)
+
+	user := testutils.User{
+		Type:             "person",
+		OrganizationUnit: "root",
+		Attributes:       json.RawMessage(attributesJSON),
+	}
+
+	userID, err := testutils.CreateUser(user)
+	suite.Require().NoError(err, "Failed to create test user")
+	suite.userID = userID
+
+	idp := testutils.IDP{
+		Name:        "Test GitHub IDP",
+		Description: "GitHub Identity Provider for authentication testing",
+		Type:        "GITHUB",
+		Properties: []testutils.IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "test-github-client",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "test-github-secret",
+				IsSecret: true,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    suite.mockGithubServer.GetURL() + "/login/oauth/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    suite.mockGithubServer.GetURL() + "/login/oauth/access_token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    suite.mockGithubServer.GetURL() + "/user",
+				IsSecret: false,
+			},
+			{
+				Name:     "scopes",
+				Value:    "user:email,read:user",
+				IsSecret: false,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:8095/callback",
+				IsSecret: false,
+			},
+		},
+	}
+
+	idpID, err := testutils.CreateIDP(idp)
+	suite.Require().NoError(err, "Failed to create GitHub IDP")
+	suite.idpID = idpID
+}
+
+func (suite *GithubAuthTestSuite) TearDownSuite() {
+	if suite.userID != "" {
+		_ = testutils.DeleteUser(suite.userID)
+	}
+
+	if suite.idpID != "" {
+		_ = testutils.DeleteIDP(suite.idpID)
+	}
+
+	if suite.mockGithubServer != nil {
+		_ = suite.mockGithubServer.Stop()
+	}
+}
+
+func (suite *GithubAuthTestSuite) TestGithubAuthStartSuccess() {
+	// Start authentication
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	// Verify response contains redirect_url and session_token
+	suite.Contains(startResponse, "redirect_url")
+	suite.Contains(startResponse, "session_token")
+
+	redirectURL, ok := startResponse["redirect_url"].(string)
+	suite.Require().True(ok)
+	suite.Contains(redirectURL, suite.mockGithubServer.GetURL())
+	suite.Contains(redirectURL, "client_id=test-github-client")
+}
+
+func (suite *GithubAuthTestSuite) TestGithubAuthStartInvalidIDPID() {
+	startRequest := map[string]interface{}{
+		"idp_id": "invalid-idp-id",
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errorResponse testutils.ErrorResponse
+	err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+	suite.Require().NoError(err)
+	suite.NotEmpty(errorResponse.Code)
+	suite.NotEmpty(errorResponse.Message)
+}
+
+func (suite *GithubAuthTestSuite) TestGithubAuthStartMissingIDPID() {
+	startRequest := map[string]interface{}{}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *GithubAuthTestSuite) TestGithubAuthCompleteFlowSuccess() {
+	// Step 1: Start authentication
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	// Step 2: Simulate user authorization at GitHub (get authorization code)
+	authCode := suite.simulateGithubAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	// Step 3: Finish authentication
+	finishRequest := map[string]interface{}{
+		"session_token": sessionToken,
+		"code":          authCode,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+githubAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(authResponse, "id")
+	suite.Contains(authResponse, "type")
+	suite.Contains(authResponse, "organization_unit")
+}
+
+func (suite *GithubAuthTestSuite) TestGithubAuthFinishInvalidSessionToken() {
+	finishRequest := map[string]interface{}{
+		"session_token": "invalid-session-token",
+		"code":          "some-auth-code",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *GithubAuthTestSuite) TestGithubAuthFinishMissingCode() {
+	finishRequest := map[string]interface{}{
+		"session_token": "some-session-token",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// simulateGithubAuthorization simulates user authorization and returns authorization code
+func (suite *GithubAuthTestSuite) simulateGithubAuthorization(redirectURL string) string {
+	// Parse redirect URL to extract parameters
+	parsedURL, err := url.Parse(redirectURL)
+	suite.Require().NoError(err)
+
+	query := parsedURL.Query()
+	clientID := query.Get("client_id")
+	state := query.Get("state")
+	redirectURI := query.Get("redirect_uri")
+	scope := query.Get("scope")
+
+	// Build authorization request to mock server
+	authURL := fmt.Sprintf("%s/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s",
+		suite.mockGithubServer.GetURL(),
+		url.QueryEscape(clientID),
+		url.QueryEscape(redirectURI),
+		url.QueryEscape(scope),
+		url.QueryEscape(state))
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse // Don't follow redirects
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Get(authURL)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	suite.Require().NotEmpty(location)
+
+	locationURL, err := url.Parse(location)
+	suite.Require().NoError(err)
+
+	code := locationURL.Query().Get("code")
+	return code
+}

--- a/tests/integration/authn/google_auth_test.go
+++ b/tests/integration/authn/google_auth_test.go
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testServerURL    = testutils.TestServerURL
+	googleAuthStart  = "/auth/oauth/google/start"
+	googleAuthFinish = "/auth/oauth/google/finish"
+	mockGooglePort   = 8090
+)
+
+type GoogleAuthTestSuite struct {
+	suite.Suite
+	mockGoogleServer *testutils.MockGoogleOIDCServer
+	idpID            string
+	userID           string
+}
+
+func TestGoogleAuthTestSuite(t *testing.T) {
+	suite.Run(t, new(GoogleAuthTestSuite))
+}
+
+func (suite *GoogleAuthTestSuite) SetupSuite() {
+	mockServer, err := testutils.NewMockGoogleOIDCServer(mockGooglePort,
+		"test-google-client", "test-google-secret")
+	suite.Require().NoError(err, "Failed to create mock Google server")
+	suite.mockGoogleServer = mockServer
+
+	suite.mockGoogleServer.AddUser(&testutils.GoogleUserInfo{
+		Sub:           "google-test-user-123",
+		Email:         "testuser@gmail.com",
+		EmailVerified: true,
+		Name:          "Test User",
+		GivenName:     "Test",
+		FamilyName:    "User",
+		Picture:       "https://example.com/picture.jpg",
+		Locale:        "en",
+	})
+
+	err = suite.mockGoogleServer.Start()
+	suite.Require().NoError(err, "Failed to start mock Google server")
+
+	userAttributes := map[string]interface{}{
+		"username":   "googleuser",
+		"password":   "Test@1234",
+		"sub":        "google-test-user-123",
+		"email":      "testuser@gmail.com",
+		"givenName":  "Test",
+		"familyName": "User",
+	}
+
+	attributesJSON, err := json.Marshal(userAttributes)
+	suite.Require().NoError(err)
+
+	user := testutils.User{
+		Type:             "person",
+		OrganizationUnit: "root",
+		Attributes:       json.RawMessage(attributesJSON),
+	}
+
+	userID, err := testutils.CreateUser(user)
+	suite.Require().NoError(err, "Failed to create test user")
+	suite.userID = userID
+
+	idp := testutils.IDP{
+		Name:        "Test Google IDP",
+		Description: "Google Identity Provider for authentication testing",
+		Type:        "GOOGLE",
+		Properties: []testutils.IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "test-google-client",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "test-google-secret",
+				IsSecret: true,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    suite.mockGoogleServer.GetURL() + "/o/oauth2/v2/auth",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    suite.mockGoogleServer.GetURL() + "/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    suite.mockGoogleServer.GetURL() + "/v1/userinfo",
+				IsSecret: false,
+			},
+			{
+				Name:     "jwks_endpoint",
+				Value:    suite.mockGoogleServer.GetURL() + "/oauth2/v3/certs",
+				IsSecret: false,
+			},
+			{
+				Name:     "scopes",
+				Value:    "openid email profile",
+				IsSecret: false,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:8095/callback",
+				IsSecret: false,
+			},
+		},
+	}
+
+	idpID, err := testutils.CreateIDP(idp)
+	suite.Require().NoError(err, "Failed to create Google IDP")
+	suite.idpID = idpID
+}
+
+func (suite *GoogleAuthTestSuite) TearDownSuite() {
+	if suite.userID != "" {
+		_ = testutils.DeleteUser(suite.userID)
+	}
+
+	if suite.idpID != "" {
+		_ = testutils.DeleteIDP(suite.idpID)
+	}
+
+	if suite.mockGoogleServer != nil {
+		_ = suite.mockGoogleServer.Stop()
+	}
+}
+
+func (suite *GoogleAuthTestSuite) TestGoogleAuthStartSuccess() {
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+googleAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(startResponse, "redirect_url")
+	suite.Contains(startResponse, "session_token")
+
+	redirectURL, ok := startResponse["redirect_url"].(string)
+	suite.Require().True(ok)
+	suite.Contains(redirectURL, suite.mockGoogleServer.GetURL())
+	suite.Contains(redirectURL, "client_id=test-google-client")
+	suite.Contains(redirectURL, "response_type=code")
+}
+
+func (suite *GoogleAuthTestSuite) TestGoogleAuthStartInvalidIDPID() {
+	startRequest := map[string]interface{}{
+		"idp_id": "invalid-idp-id",
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+googleAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errorResponse testutils.ErrorResponse
+	err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+	suite.Require().NoError(err)
+	suite.NotEmpty(errorResponse.Code)
+	suite.NotEmpty(errorResponse.Message)
+}
+
+func (suite *GoogleAuthTestSuite) TestGoogleAuthStartMissingIDPID() {
+	startRequest := map[string]interface{}{}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+googleAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *GoogleAuthTestSuite) TestGoogleAuthCompleteFlowSuccess() {
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+googleAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	authCode := suite.simulateGoogleAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	finishRequest := map[string]interface{}{
+		"session_token": sessionToken,
+		"code":          authCode,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+googleAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(authResponse, "id")
+	suite.Contains(authResponse, "type")
+	suite.Contains(authResponse, "organization_unit")
+}
+
+func (suite *GoogleAuthTestSuite) TestGoogleAuthFinishInvalidSessionToken() {
+	finishRequest := map[string]interface{}{
+		"session_token": "invalid-session-token",
+		"code":          "some-auth-code",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+googleAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *GoogleAuthTestSuite) TestGoogleAuthFinishMissingCode() {
+	finishRequest := map[string]interface{}{
+		"session_token": "some-session-token",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+googleAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// simulateGoogleAuthorization simulates user authorization and returns authorization code
+func (suite *GoogleAuthTestSuite) simulateGoogleAuthorization(redirectURL string) string {
+	parsedURL, err := url.Parse(redirectURL)
+	suite.Require().NoError(err)
+
+	query := parsedURL.Query()
+	clientID := query.Get("client_id")
+	state := query.Get("state")
+	redirectURI := query.Get("redirect_uri")
+	scope := query.Get("scope")
+
+	authURL := fmt.Sprintf("%s/o/oauth2/v2/auth?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s",
+		suite.mockGoogleServer.GetURL(),
+		url.QueryEscape(clientID),
+		url.QueryEscape(redirectURI),
+		url.QueryEscape(scope),
+		url.QueryEscape(state))
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse // Don't follow redirects
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Get(authURL)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	suite.Require().NotEmpty(location)
+
+	locationURL, err := url.Parse(location)
+	suite.Require().NoError(err)
+
+	code := locationURL.Query().Get("code")
+	return code
+}
+
+// getHTTPClient returns a configured HTTP client
+func getHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+}

--- a/tests/integration/authn/oauth_auth_test.go
+++ b/tests/integration/authn/oauth_auth_test.go
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	oauthAuthStart  = "/auth/oauth/standard/start"
+	oauthAuthFinish = "/auth/oauth/standard/finish"
+	mockOAuthPort   = 8092
+)
+
+type OAuthAuthTestSuite struct {
+	suite.Suite
+	mockOAuthServer *testutils.MockOAuthServer
+	idpID           string
+	userID          string
+}
+
+func TestOAuthAuthTestSuite(t *testing.T) {
+	suite.Run(t, new(OAuthAuthTestSuite))
+}
+
+func (suite *OAuthAuthTestSuite) SetupSuite() {
+	suite.mockOAuthServer = testutils.NewMockOAuthServer(mockOAuthPort,
+		"test-oauth-client", "test-oauth-secret")
+
+	suite.mockOAuthServer.AddUser(&testutils.OAuthUserInfo{
+		Sub:     "user123",
+		Email:   "testuser@example.com",
+		Name:    "Test User",
+		Picture: "https://example.com/avatar.jpg",
+		Custom: map[string]interface{}{
+			"organization": "Test Org",
+			"department":   "Engineering",
+		},
+	})
+
+	err := suite.mockOAuthServer.Start()
+	suite.Require().NoError(err, "Failed to start mock OAuth server")
+
+	userAttributes := map[string]interface{}{
+		"username":   "oauthuser",
+		"password":   "Test@1234",
+		"sub":        "user123", // Must match OAuth user sub
+		"email":      "testuser@example.com",
+		"givenName":  "Test",
+		"familyName": "User",
+	}
+
+	attributesJSON, err := json.Marshal(userAttributes)
+	suite.Require().NoError(err)
+
+	user := testutils.User{
+		Type:             "person",
+		OrganizationUnit: "root",
+		Attributes:       json.RawMessage(attributesJSON),
+	}
+
+	userID, err := testutils.CreateUser(user)
+	suite.Require().NoError(err, "Failed to create test user")
+	suite.userID = userID
+
+	idp := testutils.IDP{
+		Name:        "Test OAuth IDP",
+		Description: "Standard OAuth 2.0 Identity Provider for authentication testing",
+		Type:        "OAUTH",
+		Properties: []testutils.IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "test-oauth-client",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "test-oauth-secret",
+				IsSecret: true,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    suite.mockOAuthServer.GetURL() + "/oauth/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    suite.mockOAuthServer.GetURL() + "/oauth/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    suite.mockOAuthServer.GetURL() + "/oauth/userinfo",
+				IsSecret: false,
+			},
+			{
+				Name:     "scopes",
+				Value:    "openid profile email",
+				IsSecret: false,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:8095/callback",
+				IsSecret: false,
+			},
+		},
+	}
+
+	idpID, err := testutils.CreateIDP(idp)
+	suite.Require().NoError(err, "Failed to create OAuth IDP")
+	suite.idpID = idpID
+}
+
+func (suite *OAuthAuthTestSuite) TearDownSuite() {
+	if suite.userID != "" {
+		_ = testutils.DeleteUser(suite.userID)
+	}
+
+	if suite.idpID != "" {
+		_ = testutils.DeleteIDP(suite.idpID)
+	}
+
+	if suite.mockOAuthServer != nil {
+		_ = suite.mockOAuthServer.Stop()
+	}
+}
+
+func (suite *OAuthAuthTestSuite) TestOAuthAuthStartSuccess() {
+	// Start authentication
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oauthAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	// Verify response contains redirect_url and session_token
+	suite.Contains(startResponse, "redirect_url")
+	suite.Contains(startResponse, "session_token")
+
+	redirectURL, ok := startResponse["redirect_url"].(string)
+	suite.Require().True(ok)
+	suite.Contains(redirectURL, suite.mockOAuthServer.GetURL())
+	suite.Contains(redirectURL, "client_id=test-oauth-client")
+}
+
+func (suite *OAuthAuthTestSuite) TestOAuthAuthStartInvalidIDPID() {
+	startRequest := map[string]interface{}{
+		"idp_id": "invalid-idp-id",
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oauthAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errorResponse testutils.ErrorResponse
+	err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+	suite.Require().NoError(err)
+	suite.NotEmpty(errorResponse.Code)
+	suite.NotEmpty(errorResponse.Message)
+}
+
+func (suite *OAuthAuthTestSuite) TestOAuthAuthStartMissingIDPID() {
+	startRequest := map[string]interface{}{}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oauthAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *OAuthAuthTestSuite) TestOAuthAuthCompleteFlowSuccess() {
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oauthAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	authCode := suite.simulateOAuthAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	finishRequest := map[string]interface{}{
+		"session_token": sessionToken,
+		"code":          authCode,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+oauthAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(authResponse, "id")
+	suite.Contains(authResponse, "type")
+	suite.Contains(authResponse, "organization_unit")
+}
+
+func (suite *OAuthAuthTestSuite) TestOAuthAuthFinishInvalidSessionToken() {
+	finishRequest := map[string]interface{}{
+		"session_token": "invalid-session-token",
+		"code":          "some-auth-code",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oauthAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *OAuthAuthTestSuite) TestOAuthAuthFinishMissingCode() {
+	finishRequest := map[string]interface{}{
+		"session_token": "some-session-token",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oauthAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *OAuthAuthTestSuite) TestOAuthAuthFinishWithError() {
+	// Start authentication to get a session token
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oauthAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+
+	// Try to finish with error parameter instead of code
+	finishRequest := map[string]interface{}{
+		"session_token":     sessionToken,
+		"error":             "access_denied",
+		"error_description": "User denied access",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+oauthAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// simulateOAuthAuthorization simulates user authorization and returns authorization code
+func (suite *OAuthAuthTestSuite) simulateOAuthAuthorization(redirectURL string) string {
+	parsedURL, err := url.Parse(redirectURL)
+	suite.Require().NoError(err)
+
+	query := parsedURL.Query()
+	clientID := query.Get("client_id")
+	state := query.Get("state")
+	redirectURI := query.Get("redirect_uri")
+	scope := query.Get("scope")
+
+	// Build authorization request to mock server
+	authURL := fmt.Sprintf("%s/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s&response_type=code",
+		suite.mockOAuthServer.GetURL(),
+		url.QueryEscape(clientID),
+		url.QueryEscape(redirectURI),
+		url.QueryEscape(scope),
+		url.QueryEscape(state))
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse // Don't follow redirects
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Get(authURL)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	suite.Require().NotEmpty(location)
+
+	locationURL, err := url.Parse(location)
+	suite.Require().NoError(err)
+
+	code := locationURL.Query().Get("code")
+	return code
+}

--- a/tests/integration/authn/oidc_auth_test.go
+++ b/tests/integration/authn/oidc_auth_test.go
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	oidcAuthStart  = "/auth/oauth/standard/start"
+	oidcAuthFinish = "/auth/oauth/standard/finish"
+	mockOIDCPort   = 8093
+)
+
+type OIDCAuthTestSuite struct {
+	suite.Suite
+	mockOIDCServer *testutils.MockOIDCServer
+	idpID          string
+	userID         string
+}
+
+func TestOIDCAuthTestSuite(t *testing.T) {
+	suite.Run(t, new(OIDCAuthTestSuite))
+}
+
+func (suite *OIDCAuthTestSuite) SetupSuite() {
+	var err error
+	suite.mockOIDCServer, err = testutils.NewMockOIDCServer(mockOIDCPort,
+		"test-oidc-client", "test-oidc-secret")
+	suite.Require().NoError(err, "Failed to create mock OIDC server")
+
+	suite.mockOIDCServer.AddUser(&testutils.OIDCUserInfo{
+		Sub:           "user456",
+		Email:         "testuser@oidc.com",
+		EmailVerified: true,
+		Name:          "OIDC Test User",
+		GivenName:     "OIDC",
+		FamilyName:    "User",
+		Picture:       "https://oidc.example.com/avatar.jpg",
+		Custom: map[string]interface{}{
+			"role":   "admin",
+			"tenant": "acme-corp",
+		},
+	})
+
+	err = suite.mockOIDCServer.Start()
+	suite.Require().NoError(err, "Failed to start mock OIDC server")
+
+	userAttributes := map[string]interface{}{
+		"username":   "oidcuser",
+		"password":   "Test@1234",
+		"sub":        "user456",
+		"email":      "testuser@oidc.com",
+		"givenName":  "OIDC",
+		"familyName": "User",
+	}
+
+	attributesJSON, err := json.Marshal(userAttributes)
+	suite.Require().NoError(err)
+
+	user := testutils.User{
+		Type:             "person",
+		OrganizationUnit: "root",
+		Attributes:       json.RawMessage(attributesJSON),
+	}
+
+	userID, err := testutils.CreateUser(user)
+	suite.Require().NoError(err, "Failed to create test user")
+	suite.userID = userID
+
+	idp := testutils.IDP{
+		Name:        "Test OIDC IDP",
+		Description: "Standard OpenID Connect Identity Provider for authentication testing",
+		Type:        "OIDC",
+		Properties: []testutils.IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "test-oidc-client",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "test-oidc-secret",
+				IsSecret: true,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    suite.mockOIDCServer.GetURL() + "/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    suite.mockOIDCServer.GetURL() + "/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    suite.mockOIDCServer.GetURL() + "/userinfo",
+				IsSecret: false,
+			},
+			{
+				Name:     "jwks_endpoint",
+				Value:    suite.mockOIDCServer.GetURL() + "/jwks",
+				IsSecret: false,
+			},
+			{
+				Name:     "scopes",
+				Value:    "openid profile email",
+				IsSecret: false,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:8095/callback",
+				IsSecret: false,
+			},
+		},
+	}
+
+	idpID, err := testutils.CreateIDP(idp)
+	suite.Require().NoError(err, "Failed to create OIDC IDP")
+	suite.idpID = idpID
+}
+
+func (suite *OIDCAuthTestSuite) TearDownSuite() {
+	if suite.userID != "" {
+		_ = testutils.DeleteUser(suite.userID)
+	}
+
+	if suite.idpID != "" {
+		_ = testutils.DeleteIDP(suite.idpID)
+	}
+
+	if suite.mockOIDCServer != nil {
+		_ = suite.mockOIDCServer.Stop()
+	}
+}
+
+func (suite *OIDCAuthTestSuite) TestOIDCAuthStartSuccess() {
+	// Start authentication
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	// Verify response contains redirect_url and session_token
+	suite.Contains(startResponse, "redirect_url")
+	suite.Contains(startResponse, "session_token")
+
+	redirectURL, ok := startResponse["redirect_url"].(string)
+	suite.Require().True(ok)
+	suite.Contains(redirectURL, suite.mockOIDCServer.GetURL())
+	suite.Contains(redirectURL, "client_id=test-oidc-client")
+	suite.Contains(redirectURL, "response_type=code")
+	suite.Contains(redirectURL, "scope=")
+	// Note: Thunder's OIDC implementation does not currently generate nonce values
+}
+
+func (suite *OIDCAuthTestSuite) TestOIDCAuthStartInvalidIDPID() {
+	startRequest := map[string]interface{}{
+		"idp_id": "invalid-idp-id",
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errorResponse testutils.ErrorResponse
+	err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+	suite.Require().NoError(err)
+	suite.NotEmpty(errorResponse.Code)
+	suite.NotEmpty(errorResponse.Message)
+}
+
+func (suite *OIDCAuthTestSuite) TestOIDCAuthStartMissingIDPID() {
+	startRequest := map[string]interface{}{}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *OIDCAuthTestSuite) TestOIDCAuthCompleteFlowSuccess() {
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	authCode := suite.simulateOIDCAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	finishRequest := map[string]interface{}{
+		"session_token": sessionToken,
+		"code":          authCode,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+oidcAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(authResponse, "id")
+	suite.Contains(authResponse, "type")
+	suite.Contains(authResponse, "organization_unit")
+}
+
+func (suite *OIDCAuthTestSuite) TestOIDCAuthFinishInvalidSessionToken() {
+	finishRequest := map[string]interface{}{
+		"session_token": "invalid-session-token",
+		"code":          "some-auth-code",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *OIDCAuthTestSuite) TestOIDCAuthFinishMissingCode() {
+	finishRequest := map[string]interface{}{
+		"session_token": "some-session-token",
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *OIDCAuthTestSuite) TestOIDCAuthWithNonce() {
+	// Note: Thunder's current OIDC implementation does not generate nonce values.
+	// This test verifies that authentication still works without nonce.
+
+	// Start authentication
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	redirectURL := startResponse["redirect_url"].(string)
+
+	parsedURL, err := url.Parse(redirectURL)
+	suite.Require().NoError(err)
+
+	query := parsedURL.Query()
+	suite.NotEmpty(query.Get("client_id"), "client_id should be present")
+	suite.NotEmpty(query.Get("response_type"), "response_type should be present")
+	suite.NotEmpty(query.Get("scope"), "scope should be present")
+	// nonce is optional - Thunder doesn't generate it currently
+}
+
+// simulateOIDCAuthorization simulates user authorization and returns authorization code
+func (suite *OIDCAuthTestSuite) simulateOIDCAuthorization(redirectURL string) string {
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse // Don't follow redirects
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Get(redirectURL)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	suite.Require().NotEmpty(location, "Mock server should redirect with authorization code")
+
+	locationURL, err := url.Parse(location)
+	suite.Require().NoError(err)
+
+	code := locationURL.Query().Get("code")
+	suite.Require().NotEmpty(code, "Authorization code should be present in redirect")
+	return code
+}

--- a/tests/integration/authn/sms_otp_auth_test.go
+++ b/tests/integration/authn/sms_otp_auth_test.go
@@ -1,0 +1,521 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authn
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	mockNotificationServerPort = 8099
+	smsOTPAuthSendEndpoint     = "/auth/otp/sms/send"
+	smsOTPAuthVerifyEndpoint   = "/auth/otp/sms/verify"
+	testMobileNumber           = "+1234567890"
+)
+
+type SMSOTPAuthTestSuite struct {
+	suite.Suite
+	mockServer   *testutils.MockNotificationServer
+	client       *http.Client
+	senderID     string
+	userID       string
+	mobileNumber string
+}
+
+func TestSMSOTPAuthTestSuite(t *testing.T) {
+	suite.Run(t, new(SMSOTPAuthTestSuite))
+}
+
+func (suite *SMSOTPAuthTestSuite) SetupSuite() {
+	suite.client = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	suite.mobileNumber = testMobileNumber
+
+	suite.mockServer = testutils.NewMockNotificationServer(mockNotificationServerPort)
+	err := suite.mockServer.Start()
+	suite.Require().NoError(err, "Failed to start mock notification server")
+
+	time.Sleep(100 * time.Millisecond)
+
+	customSender := NotificationSenderRequest{
+		Name:        "Test SMS OTP Auth Sender",
+		Description: "Sender for SMS OTP authentication testing",
+		Provider:    "custom",
+		Properties: []SenderProperty{
+			{
+				Name:     "url",
+				Value:    suite.mockServer.GetSendSMSURL(),
+				IsSecret: false,
+			},
+			{
+				Name:     "http_method",
+				Value:    "POST",
+				IsSecret: false,
+			},
+			{
+				Name:     "content_type",
+				Value:    "JSON",
+				IsSecret: false,
+			},
+		},
+	}
+
+	senderID, err := suite.createNotificationSender(customSender)
+	suite.Require().NoError(err, "Failed to create notification sender")
+	suite.senderID = senderID
+
+	userAttributes := map[string]interface{}{
+		"username":     "smsotp_user",
+		"password":     "Test@1234",
+		"email":        "smsotp@example.com",
+		"mobileNumber": suite.mobileNumber,
+	}
+	userAttributesJSON, err := json.Marshal(userAttributes)
+	suite.Require().NoError(err)
+
+	user := testutils.User{
+		Type:             "person",
+		OrganizationUnit: "1234-abcd-5678-efgh",
+		Attributes:       userAttributesJSON,
+	}
+	userID, err := testutils.CreateUser(user)
+	suite.Require().NoError(err, "Failed to create test user")
+	suite.userID = userID
+}
+
+func (suite *SMSOTPAuthTestSuite) TearDownSuite() {
+	if suite.userID != "" {
+		_ = testutils.DeleteUser(suite.userID)
+	}
+
+	if suite.senderID != "" {
+		_ = suite.deleteNotificationSender(suite.senderID)
+	}
+
+	if suite.mockServer != nil {
+		_ = suite.mockServer.Stop()
+	}
+}
+
+func (suite *SMSOTPAuthTestSuite) SetupTest() {
+	suite.mockServer.ClearMessages()
+}
+
+func (suite *SMSOTPAuthTestSuite) TestSendOTPSuccess() {
+	sendRequest := map[string]interface{}{
+		"sender_id": suite.senderID,
+		"recipient": suite.mobileNumber,
+	}
+	sendRequestJSON, err := json.Marshal(sendRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+smsOTPAuthSendEndpoint, bytes.NewReader(sendRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var sendResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&sendResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(sendResponse, "status")
+	suite.Equal("SUCCESS", sendResponse["status"])
+	suite.Contains(sendResponse, "session_token")
+	suite.NotEmpty(sendResponse["session_token"])
+
+	time.Sleep(100 * time.Millisecond)
+
+	lastMessage := suite.mockServer.GetLastMessage()
+	suite.Require().NotNil(lastMessage, "OTP message should be sent to mock server")
+	suite.NotEmpty(lastMessage.OTP, "OTP should be extractable from message")
+}
+
+func (suite *SMSOTPAuthTestSuite) TestSendOTPInvalidSender() {
+	sendRequest := map[string]interface{}{
+		"sender_id": "invalid-sender-id",
+		"recipient": suite.mobileNumber,
+	}
+	sendRequestJSON, err := json.Marshal(sendRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+smsOTPAuthSendEndpoint, bytes.NewReader(sendRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *SMSOTPAuthTestSuite) TestSendOTPMissingFields() {
+	testCases := []struct {
+		name    string
+		request map[string]interface{}
+	}{
+		{
+			name: "Missing sender_id",
+			request: map[string]interface{}{
+				"recipient": suite.mobileNumber,
+			},
+		},
+		{
+			name: "Missing recipient",
+			request: map[string]interface{}{
+				"sender_id": suite.senderID,
+			},
+		},
+		{
+			name: "Empty sender_id",
+			request: map[string]interface{}{
+				"sender_id": "",
+				"recipient": suite.mobileNumber,
+			},
+		},
+		{
+			name: "Empty recipient",
+			request: map[string]interface{}{
+				"sender_id": suite.senderID,
+				"recipient": "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			requestJSON, err := json.Marshal(tc.request)
+			suite.Require().NoError(err)
+
+			req, err := http.NewRequest("POST", testServerURL+smsOTPAuthSendEndpoint,
+				bytes.NewReader(requestJSON))
+			suite.Require().NoError(err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := suite.client.Do(req)
+			suite.Require().NoError(err)
+			defer resp.Body.Close()
+
+			suite.Equal(http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
+
+func (suite *SMSOTPAuthTestSuite) TestVerifyOTPSuccess() {
+	sessionToken, otp := suite.sendOTPAndExtract()
+
+	verifyRequest := map[string]interface{}{
+		"session_token": sessionToken,
+		"otp":           otp,
+	}
+	verifyRequestJSON, err := json.Marshal(verifyRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+smsOTPAuthVerifyEndpoint, bytes.NewReader(verifyRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(authResponse, "id")
+	suite.Equal(suite.userID, authResponse["id"])
+	suite.Contains(authResponse, "type")
+	suite.Contains(authResponse, "organization_unit")
+}
+
+func (suite *SMSOTPAuthTestSuite) TestVerifyOTPInvalidCode() {
+	sessionToken, _ := suite.sendOTPAndExtract()
+
+	verifyRequest := map[string]interface{}{
+		"session_token": sessionToken,
+		"otp":           "000000",
+	}
+	verifyRequestJSON, err := json.Marshal(verifyRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+smsOTPAuthVerifyEndpoint, bytes.NewReader(verifyRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *SMSOTPAuthTestSuite) TestVerifyOTPInvalidSessionToken() {
+	verifyRequest := map[string]interface{}{
+		"session_token": "invalid-session-token",
+		"otp":           "123456",
+	}
+	verifyRequestJSON, err := json.Marshal(verifyRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+smsOTPAuthVerifyEndpoint, bytes.NewReader(verifyRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (suite *SMSOTPAuthTestSuite) TestVerifyOTPMissingFields() {
+	testCases := []struct {
+		name    string
+		request map[string]interface{}
+	}{
+		{
+			name: "Missing session_token",
+			request: map[string]interface{}{
+				"otp": "123456",
+			},
+		},
+		{
+			name: "Missing otp",
+			request: map[string]interface{}{
+				"session_token": "some-token",
+			},
+		},
+		{
+			name: "Empty session_token",
+			request: map[string]interface{}{
+				"session_token": "",
+				"otp":           "123456",
+			},
+		},
+		{
+			name: "Empty otp",
+			request: map[string]interface{}{
+				"session_token": "some-token",
+				"otp":           "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			requestJSON, err := json.Marshal(tc.request)
+			suite.Require().NoError(err)
+
+			req, err := http.NewRequest("POST", testServerURL+smsOTPAuthVerifyEndpoint,
+				bytes.NewReader(requestJSON))
+			suite.Require().NoError(err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := suite.client.Do(req)
+			suite.Require().NoError(err)
+			defer resp.Body.Close()
+
+			suite.Equal(http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
+
+func (suite *SMSOTPAuthTestSuite) TestCompleteOTPAuthFlow() {
+	sendRequest := map[string]interface{}{
+		"sender_id": suite.senderID,
+		"recipient": suite.mobileNumber,
+	}
+	sendRequestJSON, err := json.Marshal(sendRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+smsOTPAuthSendEndpoint, bytes.NewReader(sendRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var sendResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&sendResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := sendResponse["session_token"].(string)
+	suite.NotEmpty(sessionToken)
+
+	time.Sleep(100 * time.Millisecond)
+
+	lastMessage := suite.mockServer.GetLastMessage()
+	suite.Require().NotNil(lastMessage)
+	otp := lastMessage.OTP
+	suite.Require().NotEmpty(otp)
+
+	verifyRequest := map[string]interface{}{
+		"session_token": sessionToken,
+		"otp":           otp,
+	}
+	verifyRequestJSON, err := json.Marshal(verifyRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+smsOTPAuthVerifyEndpoint, bytes.NewReader(verifyRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.Contains(authResponse, "id")
+	suite.Contains(authResponse, "type")
+	suite.Contains(authResponse, "organization_unit")
+	suite.Equal(suite.userID, authResponse["id"])
+}
+
+func (suite *SMSOTPAuthTestSuite) sendOTPAndExtract() (string, string) {
+	sendRequest := map[string]interface{}{
+		"sender_id": suite.senderID,
+		"recipient": suite.mobileNumber,
+	}
+	sendRequestJSON, err := json.Marshal(sendRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+smsOTPAuthSendEndpoint, bytes.NewReader(sendRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var sendResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&sendResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := sendResponse["session_token"].(string)
+
+	time.Sleep(100 * time.Millisecond)
+
+	lastMessage := suite.mockServer.GetLastMessage()
+	suite.Require().NotNil(lastMessage)
+	otp := lastMessage.OTP
+	suite.Require().NotEmpty(otp)
+
+	return sessionToken, otp
+}
+
+func (suite *SMSOTPAuthTestSuite) createNotificationSender(sender NotificationSenderRequest) (string, error) {
+	senderJSON, err := json.Marshal(sender)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal sender: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/notification-senders/message",
+		bytes.NewReader(senderJSON))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("expected status 201, got %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var respBody map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&respBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse response body: %w", err)
+	}
+
+	id, ok := respBody["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("response does not contain id")
+	}
+
+	return id, nil
+}
+
+func (suite *SMSOTPAuthTestSuite) deleteNotificationSender(senderID string) error {
+	req, err := http.NewRequest("DELETE", testServerURL+"/notification-senders/message/"+senderID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	resp, err := suite.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete sender: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("expected status 200 or 204, got %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+type NotificationSenderRequest struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Provider    string           `json:"provider"`
+	Properties  []SenderProperty `json:"properties"`
+}
+
+type SenderProperty struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	IsSecret bool   `json:"is_secret"`
+}

--- a/tests/integration/testutils/mock_github_oauth_server.go
+++ b/tests/integration/testutils/mock_github_oauth_server.go
@@ -1,0 +1,705 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package testutils
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MockGithubOAuthServer provides a mock GitHub OAuth server for testing
+type MockGithubOAuthServer struct {
+	server        *http.Server
+	port          int
+	mutex         sync.RWMutex
+	authCodes     map[string]*GithubAuthCodeData
+	accessTokens  map[string]*GithubTokenData
+	users         map[string]*GithubUserInfo
+	emails        map[string][]*GithubEmail
+	clientID      string
+	clientSecret  string
+	authorizeFunc func(login string) (string, error) // Custom authorize function for tests
+}
+
+// GithubAuthCodeData stores information about authorization codes
+type GithubAuthCodeData struct {
+	Code        string
+	Login       string
+	Scopes      []string
+	State       string
+	ExpiresAt   time.Time
+	RedirectURI string
+}
+
+// GithubTokenData stores information about access tokens
+type GithubTokenData struct {
+	AccessToken string
+	TokenType   string
+	Login       string
+	Scopes      []string
+	ExpiresAt   time.Time
+}
+
+// GithubUserInfo represents GitHub user information
+type GithubUserInfo struct {
+	Login             string  `json:"login"`
+	ID                int64   `json:"id"`
+	NodeID            string  `json:"node_id"`
+	AvatarURL         string  `json:"avatar_url"`
+	GravatarID        string  `json:"gravatar_id"`
+	URL               string  `json:"url"`
+	HTMLURL           string  `json:"html_url"`
+	FollowersURL      string  `json:"followers_url"`
+	FollowingURL      string  `json:"following_url"`
+	GistsURL          string  `json:"gists_url"`
+	StarredURL        string  `json:"starred_url"`
+	SubscriptionsURL  string  `json:"subscriptions_url"`
+	OrganizationsURL  string  `json:"organizations_url"`
+	ReposURL          string  `json:"repos_url"`
+	EventsURL         string  `json:"events_url"`
+	ReceivedEventsURL string  `json:"received_events_url"`
+	Type              string  `json:"type"`
+	SiteAdmin         bool    `json:"site_admin"`
+	Name              string  `json:"name"`
+	Company           string  `json:"company"`
+	Blog              string  `json:"blog"`
+	Location          string  `json:"location"`
+	Email             *string `json:"email"`
+	Hireable          *bool   `json:"hireable"`
+	Bio               string  `json:"bio"`
+	TwitterUsername   *string `json:"twitter_username"`
+	PublicRepos       int     `json:"public_repos"`
+	PublicGists       int     `json:"public_gists"`
+	Followers         int     `json:"followers"`
+	Following         int     `json:"following"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
+}
+
+// GithubEmail represents GitHub email information
+type GithubEmail struct {
+	Email      string `json:"email"`
+	Primary    bool   `json:"primary"`
+	Verified   bool   `json:"verified"`
+	Visibility string `json:"visibility,omitempty"`
+}
+
+// NewMockGithubOAuthServer creates a new mock GitHub OAuth server
+func NewMockGithubOAuthServer(port int, clientID, clientSecret string) *MockGithubOAuthServer {
+	return &MockGithubOAuthServer{
+		port:         port,
+		authCodes:    make(map[string]*GithubAuthCodeData),
+		accessTokens: make(map[string]*GithubTokenData),
+		users:        make(map[string]*GithubUserInfo),
+		emails:       make(map[string][]*GithubEmail),
+		clientID:     clientID,
+		clientSecret: clientSecret,
+	}
+}
+
+// Start starts the mock GitHub OAuth server
+func (m *MockGithubOAuthServer) Start() error {
+	mux := http.NewServeMux()
+
+	// OAuth authorization endpoint
+	mux.HandleFunc("/login/oauth/authorize", m.handleAuthorize)
+
+	// OAuth token endpoint
+	mux.HandleFunc("/login/oauth/access_token", m.handleAccessToken)
+
+	// User API endpoint
+	mux.HandleFunc("/user", m.handleUser)
+
+	// User emails API endpoint
+	mux.HandleFunc("/user/emails", m.handleUserEmails)
+
+	// Token check endpoint
+	mux.HandleFunc("/applications/", m.handleApplications)
+
+	m.server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", m.port),
+		Handler: mux,
+	}
+
+	go func() {
+		log.Printf("Starting mock GitHub OAuth server on port %d", m.port)
+		if err := m.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("Mock GitHub OAuth server error: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the mock GitHub OAuth server
+func (m *MockGithubOAuthServer) Stop() error {
+	if m.server != nil {
+		return m.server.Close()
+	}
+	return nil
+}
+
+// GetURL returns the base URL of the mock server
+func (m *MockGithubOAuthServer) GetURL() string {
+	return fmt.Sprintf("http://localhost:%d", m.port)
+}
+
+// GetAuthorizeURL returns the authorization endpoint URL
+func (m *MockGithubOAuthServer) GetAuthorizeURL() string {
+	return fmt.Sprintf("%s/login/oauth/authorize", m.GetURL())
+}
+
+// GetAccessTokenURL returns the access token endpoint URL
+func (m *MockGithubOAuthServer) GetAccessTokenURL() string {
+	return fmt.Sprintf("%s/login/oauth/access_token", m.GetURL())
+}
+
+// GetAPIURL returns the API base URL
+func (m *MockGithubOAuthServer) GetAPIURL() string {
+	return m.GetURL()
+}
+
+// SetAuthorizeFunc sets a custom authorization function for testing
+func (m *MockGithubOAuthServer) SetAuthorizeFunc(fn func(login string) (string, error)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.authorizeFunc = fn
+}
+
+// AddUser adds a test user to the mock server
+func (m *MockGithubOAuthServer) AddUser(user *GithubUserInfo, emails []*GithubEmail) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.users[user.Login] = user
+	if emails != nil {
+		m.emails[user.Login] = emails
+	}
+}
+
+// handleAuthorize handles the OAuth authorization endpoint
+func (m *MockGithubOAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	query := r.URL.Query()
+	clientID := query.Get("client_id")
+	redirectURI := query.Get("redirect_uri")
+	state := query.Get("state")
+	scope := query.Get("scope")
+
+	// Validate client ID
+	if clientID != m.clientID {
+		http.Error(w, "Invalid client_id", http.StatusBadRequest)
+		return
+	}
+
+	// Parse scopes
+	var scopes []string
+	if scope != "" {
+		scopes = strings.Split(scope, ",")
+	}
+
+	// Use custom authorize function if set
+	var login string
+	var err error
+	if m.authorizeFunc != nil {
+		login, err = m.authorizeFunc("")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		// Default: use first user or create a default one
+		m.mutex.RLock()
+		if len(m.users) == 0 {
+			// Create default user
+			login = "testuser"
+			m.mutex.RUnlock()
+			email := "test@example.com"
+			m.AddUser(&GithubUserInfo{
+				Login:     login,
+				ID:        12345,
+				NodeID:    "MDQ6VXNlcjEyMzQ1",
+				AvatarURL: "https://avatars.githubusercontent.com/u/12345?v=4",
+				URL:       fmt.Sprintf("%s/users/%s", m.GetURL(), login),
+				HTMLURL:   fmt.Sprintf("https://github.com/%s", login),
+				Type:      "User",
+				SiteAdmin: false,
+				Name:      "Test User",
+				Email:     &email,
+				CreatedAt: "2020-01-01T00:00:00Z",
+				UpdatedAt: "2024-01-01T00:00:00Z",
+			}, []*GithubEmail{
+				{
+					Email:    email,
+					Primary:  true,
+					Verified: true,
+				},
+			})
+		} else {
+			// Use first user
+			for _, user := range m.users {
+				login = user.Login
+				break
+			}
+			m.mutex.RUnlock()
+		}
+	}
+
+	// Generate authorization code
+	code := generateGithubRandomString(32)
+	m.mutex.Lock()
+	m.authCodes[code] = &GithubAuthCodeData{
+		Code:        code,
+		Login:       login,
+		Scopes:      scopes,
+		State:       state,
+		ExpiresAt:   time.Now().Add(10 * time.Minute),
+		RedirectURI: redirectURI,
+	}
+	m.mutex.Unlock()
+
+	// Redirect to redirect_uri with code and state
+	redirectURL, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, "Invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	q := redirectURL.Query()
+	q.Set("code", code)
+	if state != "" {
+		q.Set("state", state)
+	}
+	redirectURL.RawQuery = q.Encode()
+
+	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+}
+
+// handleAccessToken handles the OAuth access token endpoint
+func (m *MockGithubOAuthServer) handleAccessToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse request body
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, "Failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+	code := r.FormValue("code")
+	redirectURI := r.FormValue("redirect_uri")
+
+	// Validate client credentials
+	if clientID != m.clientID || clientSecret != m.clientSecret {
+		writeGithubTokenError(w, r.Header.Get("Accept"), "bad_verification_code",
+			"The client_id and/or client_secret passed are incorrect.")
+		return
+	}
+
+	// Validate authorization code
+	m.mutex.Lock()
+	authCodeData, exists := m.authCodes[code]
+	if !exists {
+		m.mutex.Unlock()
+		writeGithubTokenError(w, r.Header.Get("Accept"), "bad_verification_code",
+			"The code passed is incorrect or expired.")
+		return
+	}
+
+	// Check if code is expired
+	if time.Now().After(authCodeData.ExpiresAt) {
+		delete(m.authCodes, code)
+		m.mutex.Unlock()
+		writeGithubTokenError(w, r.Header.Get("Accept"), "bad_verification_code",
+			"The code passed is incorrect or expired.")
+		return
+	}
+
+	// Validate redirect URI if provided
+	if redirectURI != "" && authCodeData.RedirectURI != redirectURI {
+		m.mutex.Unlock()
+		writeGithubTokenError(w, r.Header.Get("Accept"), "redirect_uri_mismatch",
+			"The redirect_uri does not match.")
+		return
+	}
+
+	// Delete used authorization code
+	login := authCodeData.Login
+	scopes := authCodeData.Scopes
+	delete(m.authCodes, code)
+	m.mutex.Unlock()
+
+	// Generate access token
+	accessToken := "gho_" + generateGithubRandomString(36)
+
+	// Store access token
+	m.mutex.Lock()
+	m.accessTokens[accessToken] = &GithubTokenData{
+		AccessToken: accessToken,
+		TokenType:   "bearer",
+		Login:       login,
+		Scopes:      scopes,
+		ExpiresAt:   time.Now().Add(8 * time.Hour),
+	}
+	m.mutex.Unlock()
+
+	// Determine response format based on Accept header
+	acceptHeader := r.Header.Get("Accept")
+	scopeStr := strings.Join(scopes, ",")
+
+	if strings.Contains(acceptHeader, "application/json") {
+		response := map[string]interface{}{
+			"access_token": accessToken,
+			"token_type":   "bearer",
+			"scope":        scopeStr,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	} else {
+		// Default to form-encoded response
+		response := url.Values{}
+		response.Set("access_token", accessToken)
+		response.Set("token_type", "bearer")
+		response.Set("scope", scopeStr)
+
+		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response.Encode()))
+	}
+}
+
+// handleUser handles the user API endpoint
+func (m *MockGithubOAuthServer) handleUser(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract access token from Authorization header
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		// Also check for access_token query parameter (deprecated but still supported)
+		accessToken := r.URL.Query().Get("access_token")
+		if accessToken == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{
+				"message": "Requires authentication",
+			})
+			return
+		}
+		authHeader = "token " + accessToken
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || (parts[0] != "token" && parts[0] != "Bearer") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	accessToken := parts[1]
+
+	// Validate access token
+	m.mutex.RLock()
+	tokenData, exists := m.accessTokens[accessToken]
+	if !exists {
+		m.mutex.RUnlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	// Check if token is expired
+	if time.Now().After(tokenData.ExpiresAt) {
+		m.mutex.RUnlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	// Get user info
+	user, exists := m.users[tokenData.Login]
+	m.mutex.RUnlock()
+	if !exists {
+		http.Error(w, "User not found", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(user)
+}
+
+// handleUserEmails handles the user emails API endpoint
+func (m *MockGithubOAuthServer) handleUserEmails(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract access token from Authorization header
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Requires authentication",
+		})
+		return
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || (parts[0] != "token" && parts[0] != "Bearer") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	accessToken := parts[1]
+
+	// Validate access token
+	m.mutex.RLock()
+	tokenData, exists := m.accessTokens[accessToken]
+	if !exists {
+		m.mutex.RUnlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	// Check if token is expired
+	if time.Now().After(tokenData.ExpiresAt) {
+		m.mutex.RUnlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	// Check if user:email scope is granted
+	hasEmailScope := false
+	for _, scope := range tokenData.Scopes {
+		if scope == "user:email" || scope == "user" {
+			hasEmailScope = true
+			break
+		}
+	}
+
+	if !hasEmailScope {
+		m.mutex.RUnlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Must have user:email scope",
+		})
+		return
+	}
+
+	// Get user emails
+	emails, exists := m.emails[tokenData.Login]
+	m.mutex.RUnlock()
+	if !exists {
+		emails = []*GithubEmail{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(emails)
+}
+
+// handleApplications handles the applications API endpoint
+func (m *MockGithubOAuthServer) handleApplications(w http.ResponseWriter, r *http.Request) {
+	// Extract path to check which endpoint is being called
+	path := r.URL.Path
+
+	// Check token endpoint: POST /applications/{client_id}/token
+	if strings.HasSuffix(path, "/token") && r.Method == http.MethodPost {
+		m.handleCheckToken(w, r)
+		return
+	}
+
+	// Delete token endpoint: DELETE /applications/{client_id}/token
+	if strings.HasSuffix(path, "/token") && r.Method == http.MethodDelete {
+		m.handleDeleteToken(w, r)
+		return
+	}
+
+	http.Error(w, "Not found", http.StatusNotFound)
+}
+
+// handleCheckToken handles checking a token
+func (m *MockGithubOAuthServer) handleCheckToken(w http.ResponseWriter, r *http.Request) {
+	// Validate basic auth
+	username, password, ok := r.BasicAuth()
+	if !ok || username != m.clientID || password != m.clientSecret {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	// Parse request body
+	var body struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Validate access token
+	m.mutex.RLock()
+	tokenData, exists := m.accessTokens[body.AccessToken]
+	if !exists {
+		m.mutex.RUnlock()
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	user, exists := m.users[tokenData.Login]
+	m.mutex.RUnlock()
+	if !exists {
+		http.Error(w, "User not found", http.StatusInternalServerError)
+		return
+	}
+
+	// Return token info
+	response := map[string]interface{}{
+		"id":     1,
+		"token":  body.AccessToken,
+		"scopes": tokenData.Scopes,
+		"app": map[string]string{
+			"name":      "Test App",
+			"url":       m.GetURL(),
+			"client_id": m.clientID,
+		},
+		"user": map[string]interface{}{
+			"login":      user.Login,
+			"id":         user.ID,
+			"avatar_url": user.AvatarURL,
+			"type":       user.Type,
+		},
+		"created_at": "2020-01-01T00:00:00Z",
+		"updated_at": time.Now().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// handleDeleteToken handles deleting a token
+func (m *MockGithubOAuthServer) handleDeleteToken(w http.ResponseWriter, r *http.Request) {
+	// Validate basic auth
+	username, password, ok := r.BasicAuth()
+	if !ok || username != m.clientID || password != m.clientSecret {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+		return
+	}
+
+	// Parse request body
+	var body struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Delete access token
+	m.mutex.Lock()
+	delete(m.accessTokens, body.AccessToken)
+	m.mutex.Unlock()
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeGithubTokenError writes a GitHub token error response
+func writeGithubTokenError(w http.ResponseWriter, acceptHeader, errorCode, errorDescription string) {
+	if strings.Contains(acceptHeader, "application/json") {
+		response := map[string]string{
+			"error":             errorCode,
+			"error_description": errorDescription,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(response)
+	} else {
+		// Form-encoded response
+		response := url.Values{}
+		response.Set("error", errorCode)
+		response.Set("error_description", errorDescription)
+		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(response.Encode()))
+	}
+}
+
+// generateGithubRandomString generates a random string of specified length
+func generateGithubRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		b[i] = charset[n.Int64()]
+	}
+	return string(b)
+}

--- a/tests/integration/testutils/mock_google_oidc_server.go
+++ b/tests/integration/testutils/mock_google_oidc_server.go
@@ -1,0 +1,653 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package testutils
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MockGoogleOIDCServer provides a mock Google OIDC server for testing
+type MockGoogleOIDCServer struct {
+	server        *http.Server
+	port          int
+	mutex         sync.RWMutex
+	privateKey    *rsa.PrivateKey
+	authCodes     map[string]*AuthCodeData
+	accessTokens  map[string]*TokenData
+	users         map[string]*GoogleUserInfo
+	clientID      string
+	clientSecret  string
+	issuer        string
+	authorizeFunc func(email string) (string, error) // Custom authorize function for tests
+}
+
+// AuthCodeData stores information about authorization codes
+type AuthCodeData struct {
+	Code         string
+	Email        string
+	Scopes       []string
+	State        string
+	Nonce        string
+	ExpiresAt    time.Time
+	RedirectURI  string
+	CodeVerifier string // For PKCE
+}
+
+// TokenData stores information about access tokens
+type TokenData struct {
+	AccessToken  string
+	RefreshToken string
+	IDToken      string
+	Email        string
+	Scopes       []string
+	ExpiresAt    time.Time
+}
+
+// GoogleUserInfo represents Google user information
+type GoogleUserInfo struct {
+	Sub           string `json:"sub"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Name          string `json:"name"`
+	GivenName     string `json:"given_name"`
+	FamilyName    string `json:"family_name"`
+	Picture       string `json:"picture"`
+	Locale        string `json:"locale"`
+	HD            string `json:"hd,omitempty"` // Hosted domain
+}
+
+// DiscoveryDocument represents OIDC discovery document
+type DiscoveryDocument struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
+	JwksURI                           string   `json:"jwks_uri"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	SubjectTypesSupported             []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	ClaimsSupported                   []string `json:"claims_supported"`
+}
+
+// JWKS represents JSON Web Key Set
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK represents a JSON Web Key
+type JWK struct {
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// NewMockGoogleOIDCServer creates a new mock Google OIDC server
+func NewMockGoogleOIDCServer(port int, clientID, clientSecret string) (*MockGoogleOIDCServer, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+
+	// Use Google's actual issuer value for compatibility with Google auth service
+	issuer := "accounts.google.com"
+
+	return &MockGoogleOIDCServer{
+		port:         port,
+		privateKey:   privateKey,
+		authCodes:    make(map[string]*AuthCodeData),
+		accessTokens: make(map[string]*TokenData),
+		users:        make(map[string]*GoogleUserInfo),
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		issuer:       issuer,
+	}, nil
+}
+
+// Start starts the mock Google OIDC server
+func (m *MockGoogleOIDCServer) Start() error {
+	mux := http.NewServeMux()
+
+	// OIDC discovery endpoint
+	mux.HandleFunc("/.well-known/openid-configuration", m.handleDiscovery)
+
+	// Authorization endpoint
+	mux.HandleFunc("/o/oauth2/v2/auth", m.handleAuthorize)
+
+	// Token endpoint
+	mux.HandleFunc("/token", m.handleToken)
+
+	// Userinfo endpoint
+	mux.HandleFunc("/v1/userinfo", m.handleUserInfo)
+
+	// JWKS endpoint
+	mux.HandleFunc("/oauth2/v3/certs", m.handleJWKS)
+
+	// Token info endpoint (for validation)
+	mux.HandleFunc("/oauth2/v3/tokeninfo", m.handleTokenInfo)
+
+	m.server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", m.port),
+		Handler: mux,
+	}
+
+	go func() {
+		log.Printf("Starting mock Google OIDC server on port %d", m.port)
+		if err := m.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("Mock Google OIDC server error: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the mock Google OIDC server
+func (m *MockGoogleOIDCServer) Stop() error {
+	if m.server != nil {
+		return m.server.Close()
+	}
+	return nil
+}
+
+// GetURL returns the base URL of the mock server
+func (m *MockGoogleOIDCServer) GetURL() string {
+	return fmt.Sprintf("http://localhost:%d", m.port)
+}
+
+// SetAuthorizeFunc sets a custom authorization function for testing
+func (m *MockGoogleOIDCServer) SetAuthorizeFunc(fn func(email string) (string, error)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.authorizeFunc = fn
+}
+
+// AddUser adds a test user to the mock server
+func (m *MockGoogleOIDCServer) AddUser(user *GoogleUserInfo) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.users[user.Email] = user
+}
+
+// handleDiscovery handles OIDC discovery endpoint
+func (m *MockGoogleOIDCServer) handleDiscovery(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	baseURL := m.GetURL()
+	doc := DiscoveryDocument{
+		Issuer:                baseURL,
+		AuthorizationEndpoint: fmt.Sprintf("%s/o/oauth2/v2/auth", baseURL),
+		TokenEndpoint:         fmt.Sprintf("%s/token", baseURL),
+		UserinfoEndpoint:      fmt.Sprintf("%s/v1/userinfo", baseURL),
+		JwksURI:               fmt.Sprintf("%s/oauth2/v3/certs", baseURL),
+		ResponseTypesSupported: []string{"code", "token", "id_token", "code token", "code id_token",
+			"token id_token", "code token id_token"},
+		SubjectTypesSupported:             []string{"public"},
+		IDTokenSigningAlgValuesSupported:  []string{"RS256"},
+		ScopesSupported:                   []string{"openid", "email", "profile"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_post", "client_secret_basic"},
+		ClaimsSupported: []string{"aud", "email", "email_verified", "exp", "family_name",
+			"given_name", "iat", "iss", "locale", "name", "picture", "sub"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(doc)
+}
+
+// handleAuthorize handles authorization endpoint
+func (m *MockGoogleOIDCServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	query := r.URL.Query()
+	clientID := query.Get("client_id")
+	redirectURI := query.Get("redirect_uri")
+	state := query.Get("state")
+	scope := query.Get("scope")
+	nonce := query.Get("nonce")
+	responseType := query.Get("response_type")
+
+	// Validate client ID
+	if clientID != m.clientID {
+		http.Error(w, "Invalid client_id", http.StatusBadRequest)
+		return
+	}
+
+	// Validate response_type
+	if responseType != "code" {
+		http.Error(w, "Unsupported response_type", http.StatusBadRequest)
+		return
+	}
+
+	// Parse scopes
+	scopes := strings.Split(scope, " ")
+
+	// Use custom authorize function if set
+	var email string
+	var err error
+	if m.authorizeFunc != nil {
+		email, err = m.authorizeFunc("")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		// Default: use first user or create a default one
+		m.mutex.RLock()
+		if len(m.users) == 0 {
+			// Create default user
+			email = "test@example.com"
+			m.mutex.RUnlock()
+			m.AddUser(&GoogleUserInfo{
+				Sub:           "test-user-id",
+				Email:         email,
+				EmailVerified: true,
+				Name:          "Test User",
+				GivenName:     "Test",
+				FamilyName:    "User",
+				Picture:       "https://example.com/picture.jpg",
+				Locale:        "en",
+			})
+		} else {
+			// Use first user
+			for _, user := range m.users {
+				email = user.Email
+				break
+			}
+			m.mutex.RUnlock()
+		}
+	}
+
+	// Generate authorization code
+	code := generateRandomString(32)
+	m.mutex.Lock()
+	m.authCodes[code] = &AuthCodeData{
+		Code:        code,
+		Email:       email,
+		Scopes:      scopes,
+		State:       state,
+		Nonce:       nonce,
+		ExpiresAt:   time.Now().Add(10 * time.Minute),
+		RedirectURI: redirectURI,
+	}
+	m.mutex.Unlock()
+
+	// Redirect to redirect_uri with code and state
+	redirectURL, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, "Invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	q := redirectURL.Query()
+	q.Set("code", code)
+	if state != "" {
+		q.Set("state", state)
+	}
+	redirectURL.RawQuery = q.Encode()
+
+	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+}
+
+// handleToken handles token endpoint
+func (m *MockGoogleOIDCServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, "Failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+	code := r.FormValue("code")
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+	redirectURI := r.FormValue("redirect_uri")
+
+	// Validate grant type
+	if grantType != "authorization_code" {
+		writeTokenError(w, "unsupported_grant_type", "Grant type not supported")
+		return
+	}
+
+	// Validate client credentials
+	if clientID != m.clientID || clientSecret != m.clientSecret {
+		writeTokenError(w, "invalid_client", "Invalid client credentials")
+		return
+	}
+
+	// Validate authorization code
+	m.mutex.Lock()
+	authCodeData, exists := m.authCodes[code]
+	if !exists {
+		m.mutex.Unlock()
+		writeTokenError(w, "invalid_grant", "Invalid authorization code")
+		return
+	}
+
+	// Check if code is expired
+	if time.Now().After(authCodeData.ExpiresAt) {
+		delete(m.authCodes, code)
+		m.mutex.Unlock()
+		writeTokenError(w, "invalid_grant", "Authorization code expired")
+		return
+	}
+
+	// Validate redirect URI
+	if authCodeData.RedirectURI != redirectURI {
+		m.mutex.Unlock()
+		writeTokenError(w, "invalid_grant", "Redirect URI mismatch")
+		return
+	}
+
+	// Get user info
+	user, exists := m.users[authCodeData.Email]
+	if !exists {
+		m.mutex.Unlock()
+		writeTokenError(w, "invalid_grant", "User not found")
+		return
+	}
+
+	// Delete used authorization code
+	delete(m.authCodes, code)
+	m.mutex.Unlock()
+
+	// Generate tokens
+	accessToken := generateRandomString(64)
+	refreshToken := generateRandomString(64)
+
+	// Generate ID token
+	idToken, err := m.generateIDToken(user, authCodeData.Nonce, accessToken)
+	if err != nil {
+		log.Printf("Failed to generate ID token: %v", err)
+		http.Error(w, "Failed to generate ID token", http.StatusInternalServerError)
+		return
+	}
+
+	// Store access token
+	m.mutex.Lock()
+	m.accessTokens[accessToken] = &TokenData{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		IDToken:      idToken,
+		Email:        authCodeData.Email,
+		Scopes:       authCodeData.Scopes,
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+	}
+	m.mutex.Unlock()
+
+	// Return token response
+	response := map[string]interface{}{
+		"access_token":  accessToken,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"refresh_token": refreshToken,
+		"id_token":      idToken,
+		"scope":         strings.Join(authCodeData.Scopes, " "),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// handleUserInfo handles userinfo endpoint
+func (m *MockGoogleOIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract access token from Authorization header
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		http.Error(w, "Missing authorization header", http.StatusUnauthorized)
+		return
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		http.Error(w, "Invalid authorization header", http.StatusUnauthorized)
+		return
+	}
+
+	accessToken := parts[1]
+
+	// Validate access token
+	m.mutex.RLock()
+	tokenData, exists := m.accessTokens[accessToken]
+	if !exists {
+		m.mutex.RUnlock()
+		http.Error(w, "Invalid access token", http.StatusUnauthorized)
+		return
+	}
+
+	// Check if token is expired
+	if time.Now().After(tokenData.ExpiresAt) {
+		m.mutex.RUnlock()
+		http.Error(w, "Access token expired", http.StatusUnauthorized)
+		return
+	}
+
+	// Get user info
+	user, exists := m.users[tokenData.Email]
+	m.mutex.RUnlock()
+	if !exists {
+		http.Error(w, "User not found", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(user)
+}
+
+// handleJWKS handles JWKS endpoint
+func (m *MockGoogleOIDCServer) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Generate JWK from public key
+	publicKey := &m.privateKey.PublicKey
+
+	jwks := JWKS{
+		Keys: []JWK{
+			{
+				Kty: "RSA",
+				Use: "sig",
+				Kid: "mock-key-id",
+				Alg: "RS256",
+				N:   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+				E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(jwks)
+}
+
+// handleTokenInfo handles token info endpoint
+func (m *MockGoogleOIDCServer) handleTokenInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var idToken string
+	if r.Method == http.MethodGet {
+		idToken = r.URL.Query().Get("id_token")
+	} else {
+		err := r.ParseForm()
+		if err != nil {
+			http.Error(w, "Failed to parse form", http.StatusBadRequest)
+			return
+		}
+		idToken = r.FormValue("id_token")
+	}
+
+	if idToken == "" {
+		http.Error(w, "Missing id_token", http.StatusBadRequest)
+		return
+	}
+
+	// Parse JWT manually (simple validation)
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		http.Error(w, "Invalid token format", http.StatusBadRequest)
+		return
+	}
+
+	// Decode payload
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		http.Error(w, "Invalid token payload", http.StatusBadRequest)
+		return
+	}
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		http.Error(w, "Invalid token claims", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(claims)
+}
+
+// generateIDToken generates a signed ID token
+func (m *MockGoogleOIDCServer) generateIDToken(user *GoogleUserInfo, nonce, accessToken string) (string, error) {
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            m.issuer,
+		"sub":            user.Sub,
+		"aud":            m.clientID,
+		"exp":            now.Add(1 * time.Hour).Unix(),
+		"iat":            now.Unix(),
+		"email":          user.Email,
+		"email_verified": user.EmailVerified,
+		"name":           user.Name,
+		"given_name":     user.GivenName,
+		"family_name":    user.FamilyName,
+		"picture":        user.Picture,
+		"locale":         user.Locale,
+	}
+
+	if nonce != "" {
+		claims["nonce"] = nonce
+	}
+
+	if user.HD != "" {
+		claims["hd"] = user.HD
+	}
+
+	// Add at_hash for access token
+	if accessToken != "" {
+		claims["at_hash"] = generateRandomString(16)
+	}
+
+	// Create JWT header
+	header := map[string]interface{}{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": "mock-key-id",
+	}
+
+	// Encode header
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	headerEncoded := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	// Encode payload
+	payloadJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	payloadEncoded := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	// Create signing input
+	signingInput := headerEncoded + "." + payloadEncoded
+
+	// Sign with RSA private key
+	hashed := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, m.privateKey, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", err
+	}
+
+	signatureEncoded := base64.RawURLEncoding.EncodeToString(signature)
+
+	// Return complete JWT
+	return signingInput + "." + signatureEncoded, nil
+}
+
+// writeTokenError writes a token error response
+func writeTokenError(w http.ResponseWriter, errorCode, errorDescription string) {
+	response := map[string]string{
+		"error":             errorCode,
+		"error_description": errorDescription,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(response)
+}
+
+// generateRandomString generates a random string of specified length
+func generateRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		b[i] = charset[n.Int64()]
+	}
+	return string(b)
+}

--- a/tests/integration/testutils/mock_oauth_server.go
+++ b/tests/integration/testutils/mock_oauth_server.go
@@ -1,0 +1,459 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package testutils
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OAuthAuthCodeData stores information about OAuth authorization codes
+type OAuthAuthCodeData struct {
+	Code         string
+	UserID       string
+	Scopes       []string
+	State        string
+	ExpiresAt    time.Time
+	RedirectURI  string
+	CodeVerifier string // For PKCE
+	Nonce        string // For OIDC
+}
+
+// OAuthTokenData stores information about OAuth access tokens
+type OAuthTokenData struct {
+	AccessToken  string
+	RefreshToken string
+	TokenType    string
+	UserID       string
+	Scopes       []string
+	ExpiresAt    time.Time
+	IDToken      string // For OIDC
+}
+
+// OAuthUserInfo represents generic OAuth user information
+type OAuthUserInfo struct {
+	Sub     string                 `json:"sub"`
+	Email   string                 `json:"email,omitempty"`
+	Name    string                 `json:"name,omitempty"`
+	Picture string                 `json:"picture,omitempty"`
+	Custom  map[string]interface{} `json:"-"` // Additional custom fields
+}
+
+// MockOAuthServer provides a base mock OAuth 2.0 server
+type MockOAuthServer struct {
+	server        *http.Server
+	port          int
+	mutex         sync.RWMutex
+	authCodes     map[string]*OAuthAuthCodeData
+	accessTokens  map[string]*OAuthTokenData
+	users         map[string]*OAuthUserInfo
+	clientID      string
+	clientSecret  string
+	baseURL       string
+	authorizeFunc func(userID string) (string, error)
+
+	// Configurable endpoints
+	authorizePath string
+	tokenPath     string
+	userInfoPath  string
+}
+
+// NewMockOAuthServer creates a new mock OAuth 2.0 server
+func NewMockOAuthServer(port int, clientID, clientSecret string) *MockOAuthServer {
+	return &MockOAuthServer{
+		port:          port,
+		authCodes:     make(map[string]*OAuthAuthCodeData),
+		accessTokens:  make(map[string]*OAuthTokenData),
+		users:         make(map[string]*OAuthUserInfo),
+		clientID:      clientID,
+		clientSecret:  clientSecret,
+		baseURL:       fmt.Sprintf("http://localhost:%d", port),
+		authorizePath: "/oauth/authorize",
+		tokenPath:     "/oauth/token",
+		userInfoPath:  "/oauth/userinfo",
+	}
+}
+
+// Start starts the mock OAuth server
+func (m *MockOAuthServer) Start() error {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(m.authorizePath, m.handleAuthorize)
+	mux.HandleFunc(m.tokenPath, m.handleToken)
+	mux.HandleFunc(m.userInfoPath, m.handleUserInfo)
+
+	m.server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", m.port),
+		Handler: mux,
+	}
+
+	go func() {
+		if err := m.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("Mock OAuth server error: %v\n", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the mock OAuth server
+func (m *MockOAuthServer) Stop() error {
+	if m.server != nil {
+		return m.server.Close()
+	}
+	return nil
+}
+
+// GetURL returns the base URL
+func (m *MockOAuthServer) GetURL() string {
+	return m.baseURL
+}
+
+// GetAuthorizeURL returns the authorization endpoint URL
+func (m *MockOAuthServer) GetAuthorizeURL() string {
+	return m.baseURL + m.authorizePath
+}
+
+// GetTokenURL returns the token endpoint URL
+func (m *MockOAuthServer) GetTokenURL() string {
+	return m.baseURL + m.tokenPath
+}
+
+// GetUserInfoURL returns the userinfo endpoint URL
+func (m *MockOAuthServer) GetUserInfoURL() string {
+	return m.baseURL + m.userInfoPath
+}
+
+// SetAuthorizeFunc sets a custom authorization function
+func (m *MockOAuthServer) SetAuthorizeFunc(fn func(userID string) (string, error)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.authorizeFunc = fn
+}
+
+// AddUser adds a user to the mock server
+func (m *MockOAuthServer) AddUser(user *OAuthUserInfo) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.users[user.Sub] = user
+}
+
+// handleAuthorize handles the OAuth authorization endpoint
+func (m *MockOAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	query := r.URL.Query()
+	clientID := query.Get("client_id")
+	redirectURI := query.Get("redirect_uri")
+	state := query.Get("state")
+	scope := query.Get("scope")
+	responseType := query.Get("response_type")
+	nonce := query.Get("nonce")
+
+	// Validate client ID
+	if clientID != m.clientID {
+		http.Error(w, "Invalid client_id", http.StatusBadRequest)
+		return
+	}
+
+	// Validate response type
+	if responseType != "code" {
+		http.Error(w, "Unsupported response_type", http.StatusBadRequest)
+		return
+	}
+
+	// Parse scopes
+	var scopes []string
+	if scope != "" {
+		scopes = strings.Split(scope, " ")
+	}
+
+	// Get user to authenticate
+	var userID string
+	var err error
+	if m.authorizeFunc != nil {
+		userID, err = m.authorizeFunc("")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		// Use first user or create default
+		m.mutex.RLock()
+		if len(m.users) == 0 {
+			userID = "default-user"
+			m.mutex.RUnlock()
+			m.AddUser(&OAuthUserInfo{
+				Sub:   userID,
+				Email: "user@example.com",
+				Name:  "Test User",
+			})
+		} else {
+			for _, user := range m.users {
+				userID = user.Sub
+				break
+			}
+			m.mutex.RUnlock()
+		}
+	}
+
+	// Generate authorization code
+	code := generateOAuthRandomString(32)
+	m.mutex.Lock()
+	m.authCodes[code] = &OAuthAuthCodeData{
+		Code:        code,
+		UserID:      userID,
+		Scopes:      scopes,
+		State:       state,
+		Nonce:       nonce,
+		ExpiresAt:   time.Now().Add(10 * time.Minute),
+		RedirectURI: redirectURI,
+	}
+	m.mutex.Unlock()
+
+	// Redirect with code
+	redirectURL, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, "Invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	q := redirectURL.Query()
+	q.Set("code", code)
+	if state != "" {
+		q.Set("state", state)
+	}
+	redirectURL.RawQuery = q.Encode()
+
+	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+}
+
+// handleToken handles the OAuth token endpoint
+func (m *MockOAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+	code := r.FormValue("code")
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+	redirectURI := r.FormValue("redirect_uri")
+
+	// Validate grant type
+	if grantType != "authorization_code" {
+		writeOAuthTokenError(w, "unsupported_grant_type", "Grant type not supported")
+		return
+	}
+
+	// Validate client credentials
+	if clientID != m.clientID || clientSecret != m.clientSecret {
+		writeOAuthTokenError(w, "invalid_client", "Invalid client credentials")
+		return
+	}
+
+	// Validate authorization code
+	m.mutex.Lock()
+	authCodeData, exists := m.authCodes[code]
+	if !exists {
+		m.mutex.Unlock()
+		writeOAuthTokenError(w, "invalid_grant", "Invalid authorization code")
+		return
+	}
+
+	// Check expiration
+	if time.Now().After(authCodeData.ExpiresAt) {
+		delete(m.authCodes, code)
+		m.mutex.Unlock()
+		writeOAuthTokenError(w, "invalid_grant", "Authorization code expired")
+		return
+	}
+
+	// Validate redirect URI
+	if authCodeData.RedirectURI != redirectURI {
+		m.mutex.Unlock()
+		writeOAuthTokenError(w, "invalid_grant", "Redirect URI mismatch")
+		return
+	}
+
+	// Get user
+	user, exists := m.users[authCodeData.UserID]
+	if !exists {
+		m.mutex.Unlock()
+		writeOAuthTokenError(w, "invalid_grant", "User not found")
+		return
+	}
+
+	// Delete used code
+	delete(m.authCodes, code)
+	m.mutex.Unlock()
+
+	// Generate tokens
+	accessToken := "oauth_" + generateOAuthRandomString(40)
+	refreshToken := "refresh_" + generateOAuthRandomString(40)
+
+	// Store token
+	m.mutex.Lock()
+	m.accessTokens[accessToken] = &OAuthTokenData{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		UserID:       authCodeData.UserID,
+		Scopes:       authCodeData.Scopes,
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+	}
+	m.mutex.Unlock()
+
+	// Build response
+	response := map[string]interface{}{
+		"access_token":  accessToken,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"refresh_token": refreshToken,
+		"scope":         strings.Join(authCodeData.Scopes, " "),
+	}
+
+	// Add user info in response if requested
+	if contains(authCodeData.Scopes, "openid") {
+		response["id"] = user.Sub
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// handleUserInfo handles the OAuth userinfo endpoint
+func (m *MockOAuthServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract access token
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		http.Error(w, "Missing authorization header", http.StatusUnauthorized)
+		return
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		http.Error(w, "Invalid authorization header", http.StatusUnauthorized)
+		return
+	}
+
+	accessToken := parts[1]
+
+	// Validate token
+	m.mutex.RLock()
+	tokenData, exists := m.accessTokens[accessToken]
+	if !exists {
+		m.mutex.RUnlock()
+		http.Error(w, "Invalid access token", http.StatusUnauthorized)
+		return
+	}
+
+	if time.Now().After(tokenData.ExpiresAt) {
+		m.mutex.RUnlock()
+		http.Error(w, "Access token expired", http.StatusUnauthorized)
+		return
+	}
+
+	// Get user
+	user, exists := m.users[tokenData.UserID]
+	m.mutex.RUnlock()
+	if !exists {
+		http.Error(w, "User not found", http.StatusInternalServerError)
+		return
+	}
+
+	// Build response
+	response := map[string]interface{}{
+		"sub": user.Sub,
+	}
+
+	if user.Email != "" {
+		response["email"] = user.Email
+	}
+	if user.Name != "" {
+		response["name"] = user.Name
+	}
+	if user.Picture != "" {
+		response["picture"] = user.Picture
+	}
+
+	// Add custom fields
+	for k, v := range user.Custom {
+		response[k] = v
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// writeOAuthTokenError writes a token error response
+func writeOAuthTokenError(w http.ResponseWriter, errorCode, errorDescription string) {
+	response := map[string]string{
+		"error":             errorCode,
+		"error_description": errorDescription,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(response)
+}
+
+// generateOAuthRandomString generates a random string
+func generateOAuthRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		b[i] = charset[n.Int64()]
+	}
+	return string(b)
+}
+
+// contains checks if a string slice contains a value
+func contains(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/integration/testutils/mock_oidc_server.go
+++ b/tests/integration/testutils/mock_oidc_server.go
@@ -1,0 +1,680 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package testutils
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OIDCUserInfo represents OIDC user information
+type OIDCUserInfo struct {
+	Sub           string                 `json:"sub"`
+	Email         string                 `json:"email,omitempty"`
+	EmailVerified bool                   `json:"email_verified,omitempty"`
+	Name          string                 `json:"name,omitempty"`
+	GivenName     string                 `json:"given_name,omitempty"`
+	FamilyName    string                 `json:"family_name,omitempty"`
+	Picture       string                 `json:"picture,omitempty"`
+	Locale        string                 `json:"locale,omitempty"`
+	Custom        map[string]interface{} `json:"-"` // Additional custom fields
+}
+
+// OIDCDiscoveryDocument represents OIDC discovery document
+type OIDCDiscoveryDocument struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
+	JwksURI                           string   `json:"jwks_uri"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	SubjectTypesSupported             []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	ClaimsSupported                   []string `json:"claims_supported"`
+}
+
+// OIDCJWKS represents JSON Web Key Set
+type OIDCJWKS struct {
+	Keys []OIDCJWK `json:"keys"`
+}
+
+// OIDCJWK represents a JSON Web Key
+type OIDCJWK struct {
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// OIDCAuthCodeData stores information about OIDC authorization codes
+type OIDCAuthCodeData struct {
+	Code         string
+	UserID       string
+	Scopes       []string
+	State        string
+	Nonce        string
+	ExpiresAt    time.Time
+	RedirectURI  string
+	CodeVerifier string // For PKCE
+}
+
+// OIDCTokenData stores information about OIDC tokens
+type OIDCTokenData struct {
+	AccessToken  string
+	RefreshToken string
+	IDToken      string
+	UserID       string
+	Scopes       []string
+	ExpiresAt    time.Time
+}
+
+// MockOIDCServer provides a base mock OIDC server
+type MockOIDCServer struct {
+	server        *http.Server
+	port          int
+	mutex         sync.RWMutex
+	privateKey    *rsa.PrivateKey
+	authCodes     map[string]*OIDCAuthCodeData
+	accessTokens  map[string]*OIDCTokenData
+	users         map[string]*OIDCUserInfo
+	clientID      string
+	clientSecret  string
+	issuer        string
+	authorizeFunc func(userID string) (string, error)
+
+	// Configurable endpoints
+	discoveryPath string
+	authorizePath string
+	tokenPath     string
+	userInfoPath  string
+	jwksPath      string
+}
+
+// NewMockOIDCServer creates a new mock OIDC server
+func NewMockOIDCServer(port int, clientID, clientSecret string) (*MockOIDCServer, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+
+	issuer := fmt.Sprintf("http://localhost:%d", port)
+
+	return &MockOIDCServer{
+		port:          port,
+		privateKey:    privateKey,
+		authCodes:     make(map[string]*OIDCAuthCodeData),
+		accessTokens:  make(map[string]*OIDCTokenData),
+		users:         make(map[string]*OIDCUserInfo),
+		clientID:      clientID,
+		clientSecret:  clientSecret,
+		issuer:        issuer,
+		discoveryPath: "/.well-known/openid-configuration",
+		authorizePath: "/authorize",
+		tokenPath:     "/token",
+		userInfoPath:  "/userinfo",
+		jwksPath:      "/jwks",
+	}, nil
+}
+
+// Start starts the mock OIDC server
+func (m *MockOIDCServer) Start() error {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(m.discoveryPath, m.handleDiscovery)
+	mux.HandleFunc(m.authorizePath, m.handleAuthorize)
+	mux.HandleFunc(m.tokenPath, m.handleToken)
+	mux.HandleFunc(m.userInfoPath, m.handleUserInfo)
+	mux.HandleFunc(m.jwksPath, m.handleJWKS)
+
+	m.server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", m.port),
+		Handler: mux,
+	}
+
+	go func() {
+		if err := m.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("Mock OIDC server error: %v\n", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the mock OIDC server
+func (m *MockOIDCServer) Stop() error {
+	if m.server != nil {
+		return m.server.Close()
+	}
+	return nil
+}
+
+// GetURL returns the base URL
+func (m *MockOIDCServer) GetURL() string {
+	return m.issuer
+}
+
+// GetDiscoveryURL returns the discovery endpoint URL
+func (m *MockOIDCServer) GetDiscoveryURL() string {
+	return m.issuer + m.discoveryPath
+}
+
+// GetAuthorizeURL returns the authorization endpoint URL
+func (m *MockOIDCServer) GetAuthorizeURL() string {
+	return m.issuer + m.authorizePath
+}
+
+// GetTokenURL returns the token endpoint URL
+func (m *MockOIDCServer) GetTokenURL() string {
+	return m.issuer + m.tokenPath
+}
+
+// GetUserInfoURL returns the userinfo endpoint URL
+func (m *MockOIDCServer) GetUserInfoURL() string {
+	return m.issuer + m.userInfoPath
+}
+
+// GetJWKSURL returns the JWKS endpoint URL
+func (m *MockOIDCServer) GetJWKSURL() string {
+	return m.issuer + m.jwksPath
+}
+
+// SetAuthorizeFunc sets a custom authorization function
+func (m *MockOIDCServer) SetAuthorizeFunc(fn func(userID string) (string, error)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.authorizeFunc = fn
+}
+
+// AddUser adds a user to the mock server
+func (m *MockOIDCServer) AddUser(user *OIDCUserInfo) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.users[user.Sub] = user
+}
+
+// handleDiscovery handles OIDC discovery endpoint
+func (m *MockOIDCServer) handleDiscovery(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	doc := OIDCDiscoveryDocument{
+		Issuer:                m.issuer,
+		AuthorizationEndpoint: m.issuer + m.authorizePath,
+		TokenEndpoint:         m.issuer + m.tokenPath,
+		UserinfoEndpoint:      m.issuer + m.userInfoPath,
+		JwksURI:               m.issuer + m.jwksPath,
+		ResponseTypesSupported: []string{
+			"code", "token", "id_token", "code token", "code id_token", "token id_token",
+			"code token id_token",
+		},
+		SubjectTypesSupported:             []string{"public"},
+		IDTokenSigningAlgValuesSupported:  []string{"RS256"},
+		ScopesSupported:                   []string{"openid", "email", "profile"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_post", "client_secret_basic"},
+		ClaimsSupported: []string{
+			"sub", "email", "email_verified", "name", "given_name", "family_name", "picture",
+			"locale",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(doc)
+}
+
+// handleAuthorize handles authorization endpoint
+func (m *MockOIDCServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	query := r.URL.Query()
+	clientID := query.Get("client_id")
+	redirectURI := query.Get("redirect_uri")
+	state := query.Get("state")
+	scope := query.Get("scope")
+	nonce := query.Get("nonce")
+	responseType := query.Get("response_type")
+
+	// Validate client ID
+	if clientID != m.clientID {
+		http.Error(w, "Invalid client_id", http.StatusBadRequest)
+		return
+	}
+
+	// Validate response type
+	if responseType != "code" {
+		http.Error(w, "Unsupported response_type", http.StatusBadRequest)
+		return
+	}
+
+	// Parse scopes
+	var scopes []string
+	if scope != "" {
+		scopes = strings.Split(scope, " ")
+	}
+
+	// Get user to authenticate
+	var userID string
+	var err error
+	if m.authorizeFunc != nil {
+		userID, err = m.authorizeFunc("")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		// Use first user or create default
+		m.mutex.RLock()
+		if len(m.users) == 0 {
+			userID = "default-user"
+			m.mutex.RUnlock()
+			m.AddUser(&OIDCUserInfo{
+				Sub:           userID,
+				Email:         "user@example.com",
+				EmailVerified: true,
+				Name:          "Test User",
+				GivenName:     "Test",
+				FamilyName:    "User",
+			})
+		} else {
+			for _, user := range m.users {
+				userID = user.Sub
+				break
+			}
+			m.mutex.RUnlock()
+		}
+	}
+
+	// Generate authorization code
+	code := generateOIDCRandomString(32)
+	m.mutex.Lock()
+	m.authCodes[code] = &OIDCAuthCodeData{
+		Code:        code,
+		UserID:      userID,
+		Scopes:      scopes,
+		State:       state,
+		Nonce:       nonce,
+		ExpiresAt:   time.Now().Add(10 * time.Minute),
+		RedirectURI: redirectURI,
+	}
+	m.mutex.Unlock()
+
+	// Redirect with code
+	redirectURL, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, "Invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	q := redirectURL.Query()
+	q.Set("code", code)
+	if state != "" {
+		q.Set("state", state)
+	}
+	redirectURL.RawQuery = q.Encode()
+
+	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+}
+
+// handleToken handles token endpoint
+func (m *MockOIDCServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+	code := r.FormValue("code")
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+	redirectURI := r.FormValue("redirect_uri")
+
+	// Validate grant type
+	if grantType != "authorization_code" {
+		writeOIDCTokenError(w, "unsupported_grant_type", "Grant type not supported")
+		return
+	}
+
+	// Validate client credentials
+	if clientID != m.clientID || clientSecret != m.clientSecret {
+		writeOIDCTokenError(w, "invalid_client", "Invalid client credentials")
+		return
+	}
+
+	// Validate authorization code
+	m.mutex.Lock()
+	authCodeData, exists := m.authCodes[code]
+	if !exists {
+		m.mutex.Unlock()
+		writeOIDCTokenError(w, "invalid_grant", "Invalid authorization code")
+		return
+	}
+
+	// Check expiration
+	if time.Now().After(authCodeData.ExpiresAt) {
+		delete(m.authCodes, code)
+		m.mutex.Unlock()
+		writeOIDCTokenError(w, "invalid_grant", "Authorization code expired")
+		return
+	}
+
+	// Validate redirect URI
+	if authCodeData.RedirectURI != redirectURI {
+		m.mutex.Unlock()
+		writeOIDCTokenError(w, "invalid_grant", "Redirect URI mismatch")
+		return
+	}
+
+	// Get user
+	user, exists := m.users[authCodeData.UserID]
+	if !exists {
+		m.mutex.Unlock()
+		writeOIDCTokenError(w, "invalid_grant", "User not found")
+		return
+	}
+
+	// Delete used code
+	delete(m.authCodes, code)
+	m.mutex.Unlock()
+
+	// Generate tokens
+	accessToken := "oidc_" + generateOIDCRandomString(40)
+	refreshToken := "refresh_" + generateOIDCRandomString(40)
+
+	// Generate ID token
+	idToken, err := m.generateIDToken(user, authCodeData.Nonce, accessToken)
+	if err != nil {
+		http.Error(w, "Failed to generate ID token", http.StatusInternalServerError)
+		return
+	}
+
+	// Store token
+	m.mutex.Lock()
+	m.accessTokens[accessToken] = &OIDCTokenData{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		IDToken:      idToken,
+		UserID:       authCodeData.UserID,
+		Scopes:       authCodeData.Scopes,
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+	}
+	m.mutex.Unlock()
+
+	// Build response
+	response := map[string]interface{}{
+		"access_token":  accessToken,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"refresh_token": refreshToken,
+		"id_token":      idToken,
+		"scope":         strings.Join(authCodeData.Scopes, " "),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// handleUserInfo handles userinfo endpoint
+func (m *MockOIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract access token
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		http.Error(w, "Missing authorization header", http.StatusUnauthorized)
+		return
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		http.Error(w, "Invalid authorization header", http.StatusUnauthorized)
+		return
+	}
+
+	accessToken := parts[1]
+
+	// Validate token
+	m.mutex.RLock()
+	tokenData, exists := m.accessTokens[accessToken]
+	if !exists {
+		m.mutex.RUnlock()
+		http.Error(w, "Invalid access token", http.StatusUnauthorized)
+		return
+	}
+
+	if time.Now().After(tokenData.ExpiresAt) {
+		m.mutex.RUnlock()
+		http.Error(w, "Access token expired", http.StatusUnauthorized)
+		return
+	}
+
+	// Get user
+	user, exists := m.users[tokenData.UserID]
+	m.mutex.RUnlock()
+	if !exists {
+		http.Error(w, "User not found", http.StatusInternalServerError)
+		return
+	}
+
+	// Build response based on scopes
+	response := map[string]interface{}{
+		"sub": user.Sub,
+	}
+
+	if containsOIDC(tokenData.Scopes, "email") {
+		if user.Email != "" {
+			response["email"] = user.Email
+			response["email_verified"] = user.EmailVerified
+		}
+	}
+
+	if containsOIDC(tokenData.Scopes, "profile") {
+		if user.Name != "" {
+			response["name"] = user.Name
+		}
+		if user.GivenName != "" {
+			response["given_name"] = user.GivenName
+		}
+		if user.FamilyName != "" {
+			response["family_name"] = user.FamilyName
+		}
+		if user.Picture != "" {
+			response["picture"] = user.Picture
+		}
+		if user.Locale != "" {
+			response["locale"] = user.Locale
+		}
+	}
+
+	// Add custom fields
+	for k, v := range user.Custom {
+		response[k] = v
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// handleJWKS handles JWKS endpoint
+func (m *MockOIDCServer) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	publicKey := &m.privateKey.PublicKey
+
+	jwks := OIDCJWKS{
+		Keys: []OIDCJWK{
+			{
+				Kty: "RSA",
+				Use: "sig",
+				Kid: "oidc-key-1",
+				Alg: "RS256",
+				N:   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+				E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(jwks)
+}
+
+// generateIDToken generates a signed ID token
+func (m *MockOIDCServer) generateIDToken(user *OIDCUserInfo, nonce, accessToken string) (string, error) {
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss": m.issuer,
+		"sub": user.Sub,
+		"aud": m.clientID,
+		"exp": now.Add(1 * time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(), // Add nbf (not before) claim required by Thunder's JWT validation
+	}
+
+	if user.Email != "" {
+		claims["email"] = user.Email
+		claims["email_verified"] = user.EmailVerified
+	}
+	if user.Name != "" {
+		claims["name"] = user.Name
+	}
+	if user.GivenName != "" {
+		claims["given_name"] = user.GivenName
+	}
+	if user.FamilyName != "" {
+		claims["family_name"] = user.FamilyName
+	}
+	if user.Picture != "" {
+		claims["picture"] = user.Picture
+	}
+	if user.Locale != "" {
+		claims["locale"] = user.Locale
+	}
+	if nonce != "" {
+		claims["nonce"] = nonce
+	}
+	if accessToken != "" {
+		claims["at_hash"] = generateOIDCRandomString(16)
+	}
+
+	// Add custom claims
+	for k, v := range user.Custom {
+		claims[k] = v
+	}
+
+	// Create JWT header
+	header := map[string]interface{}{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": "oidc-key-1",
+	}
+
+	// Encode header
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	headerEncoded := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	// Encode payload
+	payloadJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	payloadEncoded := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	// Create signing input
+	signingInput := headerEncoded + "." + payloadEncoded
+
+	// Sign with RSA private key
+	hashed := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, m.privateKey, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", err
+	}
+
+	signatureEncoded := base64.RawURLEncoding.EncodeToString(signature)
+
+	return signingInput + "." + signatureEncoded, nil
+}
+
+// writeOIDCTokenError writes a token error response
+func writeOIDCTokenError(w http.ResponseWriter, errorCode, errorDescription string) {
+	response := map[string]string{
+		"error":             errorCode,
+		"error_description": errorDescription,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(response)
+}
+
+// generateOIDCRandomString generates a random string
+func generateOIDCRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		b[i] = charset[n.Int64()]
+	}
+	return string(b)
+}
+
+// containsOIDC checks if a string slice contains a value
+func containsOIDC(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Purpose

This pull request introduces new integration tests for Google/ GitHub, standard OAuth/ OIDC and SMS OTP authentication flows. The tests verify the complete authentication process, including success and error scenarios, using mock OAuth servers for both types of providers. These changes help ensure that the authentication flows are robust and function as expected in various cases.
