### PR TITLE
Improve storage mechanism of multi valued properties in the IDP configs (#239)

### DIFF
--- a/backend/internal/flow/utils/utils.go
+++ b/backend/internal/flow/utils/utils.go
@@ -320,17 +320,23 @@ func getIDPConfigs(idpProperties []cmodels.Property, execConfig *model.ExecutorC
 			clientSecret = value
 		case "redirect_uri":
 			redirectURI = value
-		case "scopes":
-			scopesStr = value
+		   case "scopes":
+			   // Prefer multi-valued property if available
+			   if len(prop.GetValues()) > 0 {
+				   scopes = prop.GetValues()
+			   } else {
+				   scopesStr = value
+			   }
 		default:
 			additionalParams[prop.GetName()] = value
 		}
 	}
-	if clientID == "" || clientSecret == "" || redirectURI == "" || scopesStr == "" {
-		return "", "", "", nil, nil, fmt.Errorf("missing required properties for executor with IDP name %s",
-			execConfig.IdpName)
-	}
-	scopes := sysutils.ParseStringArray(scopesStr, ",")
-
-	return clientID, clientSecret, redirectURI, scopes, additionalParams, nil
+	   if clientID == "" || clientSecret == "" || redirectURI == "" || (len(scopes) == 0 && scopesStr == "") {
+		   return "", "", "", nil, nil, fmt.Errorf("missing required properties for executor with IDP name %s",
+				   execConfig.IdpName)
+	   }
+	   if len(scopes) == 0 {
+		   scopes = sysutils.ParseStringArray(scopesStr, ",")
+	   }
+	   return clientID, clientSecret, redirectURI, scopes, additionalParams, nil
 }

--- a/backend/internal/system/cmodels/property.go
+++ b/backend/internal/system/cmodels/property.go
@@ -27,17 +27,27 @@ import (
 
 // Property represents a generic property with Name, Value, IsSecret, and isEncrypted fields.
 type Property struct {
+// GetValues returns the multi-valued property values.
+func (p *Property) GetValues() []string {
+	return p.values
+}
 	name        string
 	value       string
+	values      []string
 	isSecret    bool
 	isEncrypted bool
 }
 
 // PropertyDTO represents a property for API communication.
 type PropertyDTO struct {
-	Name     string `json:"name"`
-	Value    string `json:"value"`
-	IsSecret bool   `json:"is_secret"`
+// GetValues returns the multi-valued property values.
+func (p *PropertyDTO) GetValues() []string {
+	return p.Values
+}
+	Name     string   `json:"name"`
+	Value    string   `json:"value,omitempty"`
+	Values   []string `json:"values,omitempty"`
+	IsSecret bool     `json:"is_secret"`
 }
 
 // NewRawProperty creates a new Property instance with the given parameters.

--- a/tests/integration/idp/idpapi_test.go
+++ b/tests/integration/idp/idpapi_test.go
@@ -60,6 +60,7 @@ var (
 			{
 				Name:     "scopes",
 				Value:    "user:email,read:user",
+				Values:   []string{"user:email", "read:user"}, // Updated to use Values
 				IsSecret: false,
 			},
 		},
@@ -256,8 +257,8 @@ var (
 				IsSecret: false,
 			},
 			{
-				Name:     "scopes",
-				Value:    "openid,profile,email",
+				   Name:     "scopes",
+				   Values:   []string{"openid", "profile", "email"},
 				IsSecret: false,
 			},
 			{

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -56,9 +56,10 @@ type OrganizationUnit struct {
 
 // IDPProperty represents a property of an identity provider
 type IDPProperty struct {
-	Name     string `json:"name"`
-	Value    string `json:"value"`
-	IsSecret bool   `json:"is_secret"`
+	Name     string   `json:"name"`
+	Value    string   `json:"value"`
+	Values   []string `json:"values,omitempty"` // New field for multi-valued properties
+	IsSecret bool     `json:"is_secret"`
 }
 
 // IDP represents an identity provider in the system


### PR DESCRIPTION
Previously, multi-valued attributes (such as scopes) were stored as comma-separated strings, requiring manual splitting and joining during usage.

With this update :
-> Multi-valued properties are now stored natively as string arrays, improving clarity and maintainability.
->The relevant models, utility functions, and service logic have been refactored to support array-based storage and access.
-> Backward compatibility is maintained for single-valued properties.
-> Test cases and documentation have been updated to reflect the new approach.