### PR TITLE
Use correct error when retrieving flowContext

### DIFF
--- a/backend/internal/flow/constants/errorconstants.go
+++ b/backend/internal/flow/constants/errorconstants.go
@@ -244,3 +244,11 @@ var ErrorApplicationRetrievalServerError = serviceerror.ServiceError{
 	Error:            "Application retrieval error",
 	ErrorDescription: "Server error while retrieving application details",
 }
+
+// ErrorRetrievingContextInStore defines the error response for errors while retrieving the flow context in the store.
+var ErrorRetrievingContextInStore = serviceerror.ServiceError{
+	Code:             "FES-5021",
+	Type:             serviceerror.ServerErrorType,
+	Error:            "Something went wrong",
+	ErrorDescription: "Error retrieving flow context from the store",
+}

--- a/backend/internal/flow/flowexecservice.go
+++ b/backend/internal/flow/flowexecservice.go
@@ -203,7 +203,7 @@ func (s *FlowExecService) loadContextFromStore(flowID string) (*model.EngineCont
 
 	dbModel, err := s.flowStore.GetFlowContext(flowID)
 	if err != nil {
-		return nil, &constants.ErrorUpdatingContextInStore
+		return nil, &constants.ErrorRetrievingContextInStore
 	}
 
 	if dbModel == nil {


### PR DESCRIPTION
This pull request introduces a new error constant for handling failures when retrieving the flow context from the store, and updates the error handling logic in the flow execution service to use this new constant.

Error handling improvements:

* Added a new error constant `ErrorRetrievingContextInStore` in `errorconstants.go` to represent errors that occur when retrieving the flow context from the store.
* Updated the `loadContextFromStore` method in `flowexecservice.go` to return the new `ErrorRetrievingContextInStore` instead of the previous error constant when a retrieval error occurs.