### PR TITLE
Add default timeouts to notification sender clients

### DIFF
--- a/backend/internal/notification/message/client.go
+++ b/backend/internal/notification/message/client.go
@@ -19,7 +19,14 @@
 // Package message defines the service and interfaces for sending messages.
 package message
 
-import "github.com/asgardeo/thunder/internal/notification/common"
+import (
+	"time"
+
+	"github.com/asgardeo/thunder/internal/notification/common"
+)
+
+// httpClientTimeout is the timeout duration for the HTTP client.
+const httpClientTimeout = 10 * time.Second
 
 // MessageClientInterface defines the client interface for sending messages.
 type MessageClientInterface interface {

--- a/backend/internal/notification/message/customclient.go
+++ b/backend/internal/notification/message/customclient.go
@@ -123,7 +123,7 @@ func (c *CustomClient) SendSMS(sms common.SMSData) error {
 	}
 
 	// Send the HTTP request
-	client := httpservice.NewHTTPClient()
+	client := httpservice.NewHTTPClientWithTimeout(httpClientTimeout)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send HTTP request: %w", err)

--- a/backend/internal/notification/message/twilioclient.go
+++ b/backend/internal/notification/message/twilioclient.go
@@ -98,7 +98,7 @@ func (c *TwilioClient) SendSMS(sms common.SMSData) error {
 	req.SetBasicAuth(c.accountSID, c.authToken)
 
 	// Send the request
-	client := httpservice.NewHTTPClient()
+	client := httpservice.NewHTTPClientWithTimeout(httpClientTimeout)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send HTTP request: %w", err)

--- a/backend/internal/notification/message/vonageclient.go
+++ b/backend/internal/notification/message/vonageclient.go
@@ -112,7 +112,7 @@ func (v *VonageClient) SendSMS(sms common.SMSData) error {
 	req.SetBasicAuth(v.apiKey, v.apiSecret)
 
 	// Send the HTTP request
-	client := httpservice.NewHTTPClient()
+	client := httpservice.NewHTTPClientWithTimeout(httpClientTimeout)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send HTTP request: %w", err)


### PR DESCRIPTION
## Purpose

This pull request introduces a standardized HTTP client timeout for all SMS provider clients in the notification service. The main change is the addition of a configurable timeout to HTTP requests, ensuring that requests do not hang indefinitely and improving reliability across different SMS providers.

**Timeout configuration:**

* Added a new constant `httpClientTimeout` (set to 10 seconds) in `client.go` to define the default timeout for HTTP clients used in message sending.

**Provider client updates:**

* Updated the `CustomClient`, `TwilioClient`, and `VonageClient` implementations to use `httpservice.NewHTTPClientWithTimeout(httpClientTimeout)` instead of the default client, applying the timeout to all outgoing HTTP requests. [[1]](diffhunk://#diff-b74b00a94c94d809b99e3c781e660cfed173cd443365c0d048890a4b991c23b9L126-R128) [[2]](diffhunk://#diff-152b4dae41482e08cb1a589df69c852fb689206a4ee9c008c1131c8fe9131dcbL101-R101) [[3]](diffhunk://#diff-8fb09220d122c7e6ad9d266433de6e36a652d3556f7e3e62b9c738277699bf57L115-R115)

**Code organization:**

* Imported the `time` package in `client.go` to support the new timeout constant.

These changes help prevent potential issues with network delays and improve the robustness of the notification system.