### PR TITLE
Add Perf Test Trigger to Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -645,37 +645,47 @@ jobs:
       - name: 📥 Checkout Code
         uses: actions/checkout@v4
 
-      - name: ⚡ Trigger Performance Test Workflow
+      - name: ⚡ Trigger Performance Test Workflows
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.THUNDER_GITHUB_BOT_TOKEN }}
           script: |
-            try {
-              // Construct the Thunder pack URL using the release version
-              const releaseTag = '${{ needs.release.outputs.release_tag }}';
-              const thunderPackUrl = `https://github.com/${{ github.repository }}/releases/download/${releaseTag}/thunder-${releaseTag.replace('v', '')}-linux-x64.zip`;
+            // Construct the Thunder pack URL using the release version
+            const releaseTag = '${{ needs.release.outputs.release_tag }}';
+            const thunderPackUrl = `https://github.com/${{ github.repository }}/releases/download/${releaseTag}/thunder-${releaseTag.replace('v', '')}-linux-x64.zip`;
+            
+            // Define CPU core configurations to test
+            const cpuCoreConfigs = ['4', '8'];
+            
+            // Loop through each CPU core configuration and trigger a separate workflow
+            for (const cpuCores of cpuCoreConfigs) {
+              console.log(`🔄 Triggering performance test with ${cpuCores} CPU cores`);
               
-              const result = await github.rest.actions.createWorkflowDispatch({
-                owner: 'asgardeo',
-                repo: 'thunder-performance',
-                workflow_id: 'vm-perf-workflow.yml',
-                ref: 'main',
-                inputs: {
-                  THUNDER_PACK_URL: thunderPackUrl,
-                  DEPLOYMENT: 'single-node',
-                  CPU_CORES: '4',
-                  ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT: '-d 15 -w 5 -x false -y JWT',
-                  PERFORMANCE_REPO: 'https://github.com/asgardeo/thunder-performance',
-                  BRANCH: 'main',
-                  MODE: 'FULL',
-                  USE_DELAYS: 'true',
-                  CONCURRENCY: '50-500',
-                  DB_TYPE: 'postgres'
-                }
-              });
-              console.log('✅ Performance test workflow triggered successfully');
-              return result;
-            } catch (error) {
-              console.error('❌ Failed to trigger performance test workflow:', error);
-              core.setFailed('Failed to trigger performance test workflow: ' + error.message);
+              try {
+                const result = await github.rest.actions.createWorkflowDispatch({
+                  owner: 'asgardeo',
+                  repo: 'thunder-performance',
+                  workflow_id: 'vm-perf-workflow.yml',
+                  ref: 'main',
+                  inputs: {
+                    THUNDER_PACK_URL: thunderPackUrl,
+                    DEPLOYMENT: 'single-node',
+                    CPU_CORES: cpuCores,
+                    ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT: '-d 15 -w 5 -x false -y JWT',
+                    PERFORMANCE_REPO: 'https://github.com/asgardeo/thunder-performance',
+                    BRANCH: 'main',
+                    MODE: 'FULL',
+                    USE_DELAYS: 'true',
+                    CONCURRENCY: '50-3000',
+                    DB_TYPE: 'postgres'
+                  }
+                });
+                console.log(`✅ Performance test workflow with ${cpuCores} CPU cores triggered successfully`);
+              } catch (error) {
+                console.error(`❌ Failed to trigger performance test workflow with ${cpuCores} CPU cores:`, error);
+                // Continue with next configuration even if one fails
+              }
             }
+            
+            // Return success
+            return {success: true};


### PR DESCRIPTION
## Purpose
This PR adds a job to trigger Thunder Performance Tests after a successful release in the Release Workflow. This enables automated performance testing of newly released versions.

Key changes:

- Added a new workflow input parameter to control whether performance tests should run
- Modified the release job to output the release tag for downstream consumption
- Added a new job that triggers an external performance test workflow with the released version