### PR TITLE
Refactor DI pattern of group package

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/flow"
+	"github.com/asgardeo/thunder/internal/group"
 	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/notification"
 	"github.com/asgardeo/thunder/internal/ou"
@@ -42,10 +43,12 @@ func registerServices(mux *http.ServeMux) {
 		logger.Fatal("Failed to load private key", log.Error(err))
 	}
 
+	_ = userschema.Initialize(mux)
+	ouService := ou.Initialize(mux)
+	_ = group.Initialize(mux, ouService)
+
 	_ = idp.Initialize(mux)
 	_ = notification.Initialize(mux, jwtService)
-	_ = userschema.Initialize(mux)
-	_ = ou.Initialize(mux)
 
 	// TODO: Legacy way of initializing services. These need to be refactored in the future aligning to the
 	// dependency injection pattern used above.
@@ -67,9 +70,6 @@ func registerServices(mux *http.ServeMux) {
 
 	// Register the User service.
 	services.NewUserService(mux)
-
-	// Register the Group service.
-	services.NewGroupService(mux)
 
 	// Register the Application service.
 	services.NewApplicationService(mux)

--- a/backend/internal/group/errorconstants.go
+++ b/backend/internal/group/errorconstants.go
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-// Package constants defines error constants for group management operations.
-package constants
+package group
 
 import (
 	"errors"

--- a/backend/internal/group/model.go
+++ b/backend/internal/group/model.go
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-// Package model defines the data structures and interfaces for group management.
-package model
+package group
 
 // MemberType represents the type of member entity.
 type MemberType string

--- a/backend/internal/group/storeconstants.go
+++ b/backend/internal/group/storeconstants.go
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-// Package store provides the implementation for group persistence operations.
-package store
+package group
 
 import (
 	"fmt"


### PR DESCRIPTION
Part of https://github.com/asgardeo/thunder/issues/456

---
This pull request refactors the group management service in the backend, improving modularity and aligning it with the new dependency injection pattern. The changes consolidate group-related code into the `group` package, streamline initialization, and update references throughout the codebase. Legacy initialization is removed, and route registration is modernized.

**Group Service Refactoring and Initialization:**

* Consolidated group management code into the `group` package by renaming files and updating package declarations, removing the previous split between `constants`, `handler`, and `services`. (`backend/internal/group/errorconstants.go`, `backend/internal/group/handler.go`, `backend/internal/group/init.go`) [[1]](diffhunk://#diff-829f71af054d5bdb7391731a5004b1d80a339b5ef43800c69afea6b0e9a4a373L19-R20) [[2]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L19-R51) [[3]](diffhunk://#diff-9dc7a7a474826c304713eec4405603bde8a54bbd75a55b533ab75944f7726e27L19-R45)
* Refactored service initialization: replaced legacy `services.NewGroupService(mux)` with a new `group.Initialize(mux)` function that registers routes and returns the service instance, following the dependency injection pattern. (`backend/cmd/server/servicemanager.go`, `backend/internal/group/init.go`) [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216R26) [[2]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216R46) [[3]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L73-L75) [[4]](diffhunk://#diff-9dc7a7a474826c304713eec4405603bde8a54bbd75a55b533ab75944f7726e27L19-R45)

**Handler and Model Updates:**

* Updated handler implementation: changed struct and method names to use unexported `groupHandler`, removed references to old sub-packages, and replaced model references with direct types from the new package structure. (`backend/internal/group/handler.go`) [[1]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L19-R51) [[2]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L120-R127) [[3]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L161-R173) [[4]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L206-R213) [[5]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L244-R251) [[6]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L263-R267) [[7]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L301-R308) [[8]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L331-R338) [[9]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L418-R425) [[10]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L439-R446)
* Updated error handling to use new error constants from the unified package, replacing references to `constants.Error...` with `Error...`. (`backend/internal/group/handler.go`) [[1]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L120-R127) [[2]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L206-R213) [[3]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L244-R251) [[4]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L263-R267) [[5]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L301-R308) [[6]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L331-R338) [[7]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L378-R386) [[8]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L466-R471) [[9]](diffhunk://#diff-92ae08693c21c3950c1a5876dbdfa5b33ba0b8399d85b75ba38906518e0c1659L494-R492)

**Route Registration Modernization:**

* Modernized route registration: replaced the old `RegisterRoutes` method with a standalone `registerRoutes` function, registering all group-related endpoints using the new handler and CORS middleware. (`backend/internal/group/init.go`)

These changes improve code organization, maintainability, and make the group service consistent with the rest of the backend architecture.