### PR TITLE
Add support to list groups from user api

### DIFF
--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -56,8 +56,9 @@ type UserListResponse struct {
 
 // UserGroup represents a group with basic information for user endpoints.
 type UserGroup struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	OrganizationUnitID string `json:"organizationUnit"`
 }
 
 // UserGroupListResponse represents the response for listing groups that a user belongs to.

--- a/backend/internal/user/storeconstants.go
+++ b/backend/internal/user/storeconstants.go
@@ -67,6 +67,19 @@ var (
 		ID:    "ASQ-USER_MGT-07",
 		Query: "SELECT USER_ID, OU_ID, TYPE, ATTRIBUTES, CREDENTIALS FROM \"USER\" WHERE USER_ID = $1",
 	}
+	// QueryGetGroupCountForUser is the query to get the count of groups for a given user.
+	QueryGetGroupCountForUser = model.DBQuery{
+		ID:    "ASQ-USER_MGT-12",
+		Query: `SELECT COUNT(*) AS total FROM GROUP_MEMBER_REFERENCE WHERE MEMBER_ID = $1 AND MEMBER_TYPE = 'user'`,
+	}
+	// QueryGetGroupsForUser is the query to get groups for a given user with pagination.
+	QueryGetGroupsForUser = model.DBQuery{
+		ID: "ASQ-USER_MGT-13",
+		Query: `SELECT G.GROUP_ID, G.OU_ID, G.NAME FROM GROUP_MEMBER_REFERENCE GMR ` +
+			`INNER JOIN "GROUP" G ON GMR.GROUP_ID = G.GROUP_ID ` +
+			`WHERE GMR.MEMBER_ID = $1 AND GMR.MEMBER_TYPE = 'user' ` +
+			`ORDER BY G.NAME LIMIT $2 OFFSET $3`,
+	}
 )
 
 // buildIdentifyQuery constructs a query to identify a user based on the provided filters.

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -352,6 +352,82 @@ func (_c *UserServiceInterfaceMock_GetUser_Call) RunAndReturn(run func(userID st
 	return _c
 }
 
+// GetUserGroups provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) GetUserGroups(userID string, limit int, offset int) (*user.UserGroupListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(userID, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserGroups")
+	}
+
+	var r0 *user.UserGroupListResponse
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string, int, int) (*user.UserGroupListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(userID, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int, int) *user.UserGroupListResponse); ok {
+		r0 = returnFunc(userID, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*user.UserGroupListResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(userID, limit, offset)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_GetUserGroups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserGroups'
+type UserServiceInterfaceMock_GetUserGroups_Call struct {
+	*mock.Call
+}
+
+// GetUserGroups is a helper method to define mock.On call
+//   - userID string
+//   - limit int
+//   - offset int
+func (_e *UserServiceInterfaceMock_Expecter) GetUserGroups(userID interface{}, limit interface{}, offset interface{}) *UserServiceInterfaceMock_GetUserGroups_Call {
+	return &UserServiceInterfaceMock_GetUserGroups_Call{Call: _e.mock.On("GetUserGroups", userID, limit, offset)}
+}
+
+func (_c *UserServiceInterfaceMock_GetUserGroups_Call) Run(run func(userID string, limit int, offset int)) *UserServiceInterfaceMock_GetUserGroups_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserGroups_Call) Return(userGroupListResponse *user.UserGroupListResponse, serviceError *serviceerror.ServiceError) *UserServiceInterfaceMock_GetUserGroups_Call {
+	_c.Call.Return(userGroupListResponse, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserGroups_Call) RunAndReturn(run func(userID string, limit int, offset int) (*user.UserGroupListResponse, *serviceerror.ServiceError)) *UserServiceInterfaceMock_GetUserGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserList provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) GetUserList(limit int, offset int, filters map[string]interface{}) (*user.UserListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(limit, offset, filters)

--- a/backend/tests/mocks/usermock/userStoreInterface_mock.go
+++ b/backend/tests/mocks/usermock/userStoreInterface_mock.go
@@ -144,6 +144,66 @@ func (_c *userStoreInterfaceMock_DeleteUser_Call) RunAndReturn(run func(id strin
 	return _c
 }
 
+// GetGroupCountForUser provides a mock function for the type userStoreInterfaceMock
+func (_mock *userStoreInterfaceMock) GetGroupCountForUser(userID string) (int, error) {
+	ret := _mock.Called(userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupCountForUser")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
+		return returnFunc(userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
+		r0 = returnFunc(userID)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userStoreInterfaceMock_GetGroupCountForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupCountForUser'
+type userStoreInterfaceMock_GetGroupCountForUser_Call struct {
+	*mock.Call
+}
+
+// GetGroupCountForUser is a helper method to define mock.On call
+//   - userID string
+func (_e *userStoreInterfaceMock_Expecter) GetGroupCountForUser(userID interface{}) *userStoreInterfaceMock_GetGroupCountForUser_Call {
+	return &userStoreInterfaceMock_GetGroupCountForUser_Call{Call: _e.mock.On("GetGroupCountForUser", userID)}
+}
+
+func (_c *userStoreInterfaceMock_GetGroupCountForUser_Call) Run(run func(userID string)) *userStoreInterfaceMock_GetGroupCountForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetGroupCountForUser_Call) Return(n int, err error) *userStoreInterfaceMock_GetGroupCountForUser_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetGroupCountForUser_Call) RunAndReturn(run func(userID string) (int, error)) *userStoreInterfaceMock_GetGroupCountForUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUser provides a mock function for the type userStoreInterfaceMock
 func (_mock *userStoreInterfaceMock) GetUser(id string) (user.User, error) {
 	ret := _mock.Called(id)
@@ -200,6 +260,80 @@ func (_c *userStoreInterfaceMock_GetUser_Call) Return(user1 user.User, err error
 }
 
 func (_c *userStoreInterfaceMock_GetUser_Call) RunAndReturn(run func(id string) (user.User, error)) *userStoreInterfaceMock_GetUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserGroups provides a mock function for the type userStoreInterfaceMock
+func (_mock *userStoreInterfaceMock) GetUserGroups(userID string, limit int, offset int) ([]user.UserGroup, error) {
+	ret := _mock.Called(userID, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserGroups")
+	}
+
+	var r0 []user.UserGroup
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]user.UserGroup, error)); ok {
+		return returnFunc(userID, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int, int) []user.UserGroup); ok {
+		r0 = returnFunc(userID, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]user.UserGroup)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
+		r1 = returnFunc(userID, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userStoreInterfaceMock_GetUserGroups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserGroups'
+type userStoreInterfaceMock_GetUserGroups_Call struct {
+	*mock.Call
+}
+
+// GetUserGroups is a helper method to define mock.On call
+//   - userID string
+//   - limit int
+//   - offset int
+func (_e *userStoreInterfaceMock_Expecter) GetUserGroups(userID interface{}, limit interface{}, offset interface{}) *userStoreInterfaceMock_GetUserGroups_Call {
+	return &userStoreInterfaceMock_GetUserGroups_Call{Call: _e.mock.On("GetUserGroups", userID, limit, offset)}
+}
+
+func (_c *userStoreInterfaceMock_GetUserGroups_Call) Run(run func(userID string, limit int, offset int)) *userStoreInterfaceMock_GetUserGroups_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetUserGroups_Call) Return(userGroups []user.UserGroup, err error) *userStoreInterfaceMock_GetUserGroups_Call {
+	_c.Call.Return(userGroups, err)
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetUserGroups_Call) RunAndReturn(run func(userID string, limit int, offset int) ([]user.UserGroup, error)) *userStoreInterfaceMock_GetUserGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/apis/user.yaml
+++ b/docs/apis/user.yaml
@@ -367,8 +367,10 @@ paths:
                 groups:
                   - id: "550e8400-e29b-41d4-a716-446655440000"
                     name: "Premium Customers"
+                    organizationUnit: "456e8400-e29b-41d4-a716-446655440001"
                   - id: "660e8400-e29b-41d4-a716-446655440001"
                     name: "Mobile App Users"
+                    organizationUnit: "456e8400-e29b-41d4-a716-446655440001"
                 links:
                   - href: "users/9a475e1e-b0cb-4b29-8df5-2e5b24fb0ed3/groups?offset=2&limit=2"
                     rel: "next"
@@ -379,6 +381,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
               examples:
+                missing-user-id:
+                  summary: Missing user ID
+                  value:
+                    code: "USR-1002"
+                    message: "Invalid request format"
+                    description: "User ID is required"
                 invalid-limit:
                   summary: Invalid limit parameter
                   value:
@@ -403,6 +411,14 @@ paths:
                 description: "The user with the specified id does not exist"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-5001"
+                message: "Internal server error"
+                description: "An unexpected error occurred while processing the request"
 
   /users/tree/{path}:
     get:
@@ -1078,7 +1094,7 @@ components:
 
     UserGroup:
       type: object
-      required: [id, name]
+      required: [id, name, organizationUnit]
       properties:
         id:
           type: string
@@ -1087,6 +1103,10 @@ components:
         name:
           type: string
           description: "The name of the group"
+        organizationUnit:
+          type: string
+          format: uuid
+          description: "The organization unit ID that the group belongs to"
 
     UserListResponse:
       type: object

--- a/tests/integration/user/model.go
+++ b/tests/integration/user/model.go
@@ -27,8 +27,9 @@ import (
 
 // UserGroup represents a group with basic information for user endpoints.
 type UserGroup struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	OrganizationUnitID string `json:"organizationUnit"`
 }
 
 // AuthenticateUserResponse represents the response from user authentication


### PR DESCRIPTION
## Purpose
This pull request adds support for retrieving the groups a user belongs to, including pagination and proper error handling. It introduces a new API endpoint for fetching a user's groups, updates the service and store layers to support the required queries, and extends the user group model to include the organization unit ID.

**API and Routing Enhancements**
* Added a new route for `GET /users/{id}/groups` to fetch groups for a user, with logic to dispatch requests to either user details or user groups handler based on the path.
* Implemented `HandleUserGroupsGetRequest` in `UserHandler` to process requests for user groups, including parsing pagination parameters and returning appropriate error responses.

**Service and Store Layer Updates**
* Added `GetUserGroups` method to `UserServiceInterface` and implemented it in `UserService`, including validation, user existence checks, group count retrieval, and paginated group fetching. [[1]](diffhunk://#diff-9c4f35acdc7d776283e1d68652ae58442b48d74b6b6050c6f98341359b87a820R58) [[2]](diffhunk://#diff-9c4f35acdc7d776283e1d68652ae58442b48d74b6b6050c6f98341359b87a820R290-R338)
* Added new database queries and store methods: `GetGroupCountForUser`, `GetUserGroups`, and helper `buildGroupFromResultRow` for constructing group models from database rows. [[1]](diffhunk://#diff-31f25937c602b9a1c8c911295728399df581f06159f08ed165155a24b8a8fb5bR71-R83) [[2]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381R338-R391) [[3]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381R432-R457)

**Model Changes**
* Updated `UserGroup` model to include the `OrganizationUnitID` field (`ouId` in JSON).

**Testing Support**
* Added mock methods for `GetUserGroups` to facilitate unit testing of the new functionality.