### PR TITLE
Refactoring user error constants

### DIFF
--- a/backend/internal/user/constants/errorconstants.go
+++ b/backend/internal/user/constants/errorconstants.go
@@ -156,4 +156,7 @@ var (
 var (
 	// ErrUserNotFound is returned when the user is not found in the system.
 	ErrUserNotFound = errors.New("user not found")
+
+	// ErrBadAttributesInRequest is returned when the attributes in the request are invalid.
+	ErrBadAttributesInRequest = errors.New("failed to marshal attributes")
 )

--- a/backend/internal/user/model/user.go
+++ b/backend/internal/user/model/user.go
@@ -21,7 +21,6 @@ package model
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // User represents a user in the system.
@@ -103,9 +102,3 @@ type AuthenticateUserResponse struct {
 	Type             string `json:"type"`
 	OrganizationUnit string `json:"organizationUnit"`
 }
-
-// ErrUserNotFound is returned when the user is not found in the system.
-var ErrUserNotFound = errors.New("user not found")
-
-// ErrBadAttributesInRequest is returned when the attributes in the request are invalid.
-var ErrBadAttributesInRequest = errors.New("failed to marshal attributes")

--- a/backend/internal/user/service/userservice.go
+++ b/backend/internal/user/service/userservice.go
@@ -341,7 +341,7 @@ func (as *UserService) IdentifyUser(filters map[string]interface{}) (*string, *s
 
 	userID, err := store.IdentifyUser(filters)
 	if err != nil {
-		if errors.Is(err, model.ErrUserNotFound) {
+		if errors.Is(err, constants.ErrUserNotFound) {
 			logger.Debug("User not found with provided filters")
 			return nil, &constants.ErrorUserNotFound
 		}

--- a/backend/internal/user/store/store.go
+++ b/backend/internal/user/store/store.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/user/constants"
 	"github.com/asgardeo/thunder/internal/user/model"
 )
 
@@ -97,7 +98,7 @@ func CreateUser(user model.User, credentials []model.Credential) error {
 	// Convert attributes to JSON string
 	attributes, err := json.Marshal(user.Attributes)
 	if err != nil {
-		return model.ErrBadAttributesInRequest
+		return constants.ErrBadAttributesInRequest
 	}
 
 	// Convert credentials array to JSON string
@@ -107,7 +108,7 @@ func CreateUser(user model.User, credentials []model.Credential) error {
 	} else {
 		credentialsBytes, err := json.Marshal(credentials)
 		if err != nil {
-			return model.ErrBadAttributesInRequest
+			return constants.ErrBadAttributesInRequest
 		}
 		credentialsJSON = string(credentialsBytes)
 	}
@@ -140,7 +141,7 @@ func GetUser(id string) (model.User, error) {
 	}
 
 	if len(results) == 0 {
-		return model.User{}, model.ErrUserNotFound
+		return model.User{}, constants.ErrUserNotFound
 	}
 
 	if len(results) != 1 {
@@ -166,7 +167,7 @@ func UpdateUser(user *model.User) error {
 	// Convert attributes to JSON string
 	attributes, err := json.Marshal(user.Attributes)
 	if err != nil {
-		return model.ErrBadAttributesInRequest
+		return constants.ErrBadAttributesInRequest
 	}
 
 	rowsAffected, err := dbClient.Execute(
@@ -176,7 +177,7 @@ func UpdateUser(user *model.User) error {
 	}
 
 	if rowsAffected == 0 {
-		return model.ErrUserNotFound
+		return constants.ErrUserNotFound
 	}
 
 	return nil
@@ -227,7 +228,7 @@ func IdentifyUser(filters map[string]interface{}) (*string, error) {
 			maskedFilters := maskMapValues(filters)
 			logger.Debug("User not found with the provided filters", log.Any("filters", maskedFilters))
 		}
-		return nil, model.ErrUserNotFound
+		return nil, constants.ErrUserNotFound
 	}
 
 	if len(results) != 1 {
@@ -264,7 +265,7 @@ func VerifyUser(id string) (model.User, []model.Credential, error) {
 	}
 
 	if len(results) == 0 {
-		return model.User{}, []model.Credential{}, model.ErrUserNotFound
+		return model.User{}, []model.Credential{}, constants.ErrUserNotFound
 	}
 
 	if len(results) != 1 {


### PR DESCRIPTION
## Purpose
This pull request refactors error constant usage in the user service and store layers to improve maintainability and consistency. The main change is moving error definitions from the `model` package to a new `constants` package, and updating all references across the codebase to use the new location.

**Error constant refactoring:**

* Moved error definitions (`ErrUserNotFound`, `ErrBadAttributesInRequest`) from `backend/internal/user/model/user.go` to `backend/internal/user/constants/errorconstants.go`, removing them from the model package. [[1]](diffhunk://#diff-7a89e061f7ae421cd9cd1587a3e3e08ae4c23a1b37e54870b930fa32b052c674L106-L111) [[2]](diffhunk://#diff-b7424b93e2c0f74b96d7ba639f1829f80a7c4caaa0dbd4160e4b8c4c3f049486R159-R161)
* Updated all references to these errors in `backend/internal/user/store/store.go` to use the new `constants` package instead of the `model` package. [[1]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L100-R101) [[2]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L143-R144) [[3]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L169-R170) [[4]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L179-R180) [[5]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L230-R231) [[6]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L267-R268) [[7]](diffhunk://#diff-37b5e756cfa5f7a7cd05bbe30779610c6662c7e42593ec7f1197460712d6b381L110-R111)
* Updated the `IdentifyUser` method in `backend/internal/user/service/userservice.go` to reference the error from the new `constants` package.

**Imports cleanup:**

* Removed unnecessary `errors` import from `backend/internal/user/model/user.go` since error constants are no longer defined there.