### PR TITLE
Add assertion generation to the authn service and APIs

### DIFF
--- a/backend/internal/authn/common/model.go
+++ b/backend/internal/authn/common/model.go
@@ -45,4 +45,5 @@ type AuthenticationResponse struct {
 	ID               string
 	Type             string
 	OrganizationUnit string
+	Assertion        string
 }

--- a/backend/internal/authn/model.go
+++ b/backend/internal/authn/model.go
@@ -37,6 +37,7 @@ type AuthenticationResponseDTO struct {
 	ID               string `json:"id"`
 	Type             string `json:"type,omitempty"`
 	OrganizationUnit string `json:"organization_unit,omitempty"`
+	Assertion        string `json:"assertion,omitempty"`
 }
 
 // IDPAuthInitRequestDTO is the request to initiate IDP authentication.
@@ -52,8 +53,9 @@ type IDPAuthInitResponseDTO struct {
 
 // IDPAuthFinishRequestDTO is the request to complete IDP authentication.
 type IDPAuthFinishRequestDTO struct {
-	SessionToken string `json:"session_token"`
-	Code         string `json:"code"`
+	SessionToken  string `json:"session_token"`
+	SkipAssertion bool   `json:"skip_assertion"`
+	Code          string `json:"code"`
 }
 
 // SendOTPAuthRequestDTO is the request to send an OTP for authentication.
@@ -70,6 +72,7 @@ type SendOTPAuthResponseDTO struct {
 
 // VerifyOTPAuthRequestDTO is the request to verify an OTP for authentication.
 type VerifyOTPAuthRequestDTO struct {
-	SessionToken string `json:"session_token"`
-	OTP          string `json:"otp"`
+	SessionToken  string `json:"session_token"`
+	SkipAssertion bool   `json:"skip_assertion"`
+	OTP           string `json:"otp"`
 }

--- a/docs/apis/authentication.yaml
+++ b/docs/apis/authentication.yaml
@@ -43,7 +43,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClientErrorResponse'
-              examples:
+              example:
                 code: "AUTH-CRED-1001"
                 message: "Empty attributes or credentials"
                 description: "The user attributes or credentials cannot be empty"
@@ -137,7 +137,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClientErrorResponse'
-              examples:
+              example:
                 code: "AUTHN-OTP-1005"
                 message: "Invalid OTP"
                 description: "The provided OTP is invalid or empty"
@@ -298,9 +298,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IDPAuthFinishRequest'
-            example:
-              session_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-              code: "authorization-code"
       responses:
         "200":
           description: OK
@@ -406,10 +403,17 @@ components:
   schemas:
     CredentialAuthRequest:
       type: object
+      properties:
+        skip_assertion:
+          type: boolean
+          description: Skip generating assertion token in the response
+          default: false
+          example: false
       additionalProperties: true
       example:
         email: "jane.doe@example.com"
         password: "SecurePassword123!"
+        skip_assertion: false
     
     SendOtpAuthRequest:
       type: object
@@ -449,6 +453,11 @@ components:
           type: string
           description: The OTP code received by the user
           example: "123456"
+        skip_assertion:
+          type: boolean
+          description: Skip generating assertion token in the response
+          default: false
+          example: false
       required:
         - session_token
         - otp
@@ -467,6 +476,10 @@ components:
           type: string
           format: uuid
           description: "The organization unit ID of the authenticated user"
+        assertion:
+          type: string
+          description: "JWT assertion token for the authenticated user"
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 
     IDPAuthInitRequest:
       type: object
@@ -503,6 +516,11 @@ components:
         code:
           type: string
           description: Authorization code received from the identity provider
+        skip_assertion:
+          type: boolean
+          description: Skip generating assertion token in the response
+          default: false
+          example: false
 
     ErrorResponse:
       type: object

--- a/tests/integration/authn/credentials_auth_test.go
+++ b/tests/integration/authn/credentials_auth_test.go
@@ -208,6 +208,7 @@ func (suite *CredentialsAuthTestSuite) TestAuthenticateWithMultipleAttributes() 
 			suite.Equal("person", response.Type, "Response should contain correct user type")
 			suite.Equal(testOrgUnitID, response.OrganizationUnit, "Response should contain correct organization unit")
 			suite.Equal(suite.users["multiple_attributes"], response.ID, "Response should contain the correct user ID")
+			suite.NotEmpty(response.Assertion, "Response should contain assertion token by default")
 		})
 	}
 }
@@ -475,6 +476,44 @@ func (suite *CredentialsAuthTestSuite) TestAuthenticateWithDifferentAttributeCom
 			}
 		})
 	}
+}
+
+// TestAuthenticateWithSkipAssertionFalse tests authentication with skip_assertion explicitly set to false
+func (suite *CredentialsAuthTestSuite) TestAuthenticateWithSkipAssertionFalse() {
+	authRequest := map[string]interface{}{
+		"username":       "credtest_user1",
+		"password":       "TestPassword123!",
+		"skip_assertion": false,
+	}
+
+	response, statusCode, err := suite.sendAuthRequest(authRequest)
+	suite.Require().NoError(err, "Failed to send authenticate request")
+	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for successful authentication")
+
+	suite.NotEmpty(response.ID, "Response should contain user ID")
+	suite.Equal("person", response.Type, "Response should contain correct user type")
+	suite.Equal(testOrgUnitID, response.OrganizationUnit, "Response should contain correct organization unit")
+	suite.Equal(suite.users["username_password"], response.ID, "Response should contain the correct user ID")
+	suite.NotEmpty(response.Assertion, "Response should contain assertion token when skip_assertion is false")
+}
+
+// TestAuthenticateWithSkipAssertionTrue tests authentication with skip_assertion set to true
+func (suite *CredentialsAuthTestSuite) TestAuthenticateWithSkipAssertionTrue() {
+	authRequest := map[string]interface{}{
+		"username":       "credtest_user1",
+		"password":       "TestPassword123!",
+		"skip_assertion": true,
+	}
+
+	response, statusCode, err := suite.sendAuthRequest(authRequest)
+	suite.Require().NoError(err, "Failed to send authenticate request")
+	suite.Equal(http.StatusOK, statusCode, "Expected status 200 for successful authentication")
+
+	suite.NotEmpty(response.ID, "Response should contain user ID")
+	suite.Equal("person", response.Type, "Response should contain correct user type")
+	suite.Equal(testOrgUnitID, response.OrganizationUnit, "Response should contain correct organization unit")
+	suite.Equal(suite.users["username_password"], response.ID, "Response should contain the correct user ID")
+	suite.Empty(response.Assertion, "Response should not contain assertion token when skip_assertion is true")
 }
 
 func (suite *CredentialsAuthTestSuite) sendAuthRequest(authRequest map[string]interface{}) (

--- a/tests/integration/authn/github_auth_test.go
+++ b/tests/integration/authn/github_auth_test.go
@@ -289,6 +289,7 @@ func (suite *GithubAuthTestSuite) TestGithubAuthCompleteFlowSuccess() {
 	suite.NotEmpty(authResponse.Type, "Response should contain user type")
 	suite.NotEmpty(authResponse.OrganizationUnit, "Response should contain organization unit")
 	suite.Equal(suite.userID, authResponse.ID, "Response should contain the correct user ID")
+	suite.NotEmpty(authResponse.Assertion, "Response should contain assertion token by default")
 }
 
 func (suite *GithubAuthTestSuite) TestGithubAuthFinishInvalidSessionToken() {
@@ -328,6 +329,128 @@ func (suite *GithubAuthTestSuite) TestGithubAuthFinishMissingCode() {
 	defer resp.Body.Close()
 
 	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestGithubAuthCompleteFlowWithSkipAssertionFalse tests complete GitHub auth flow with skip_assertion=false
+func (suite *GithubAuthTestSuite) TestGithubAuthCompleteFlowWithSkipAssertionFalse() {
+	// Step 1: Start authentication
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	// Step 2: Simulate user authorization at GitHub
+	authCode := suite.simulateGithubAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	// Step 3: Finish authentication with skip_assertion=false
+	finishRequest := map[string]interface{}{
+		"session_token":  sessionToken,
+		"code":           authCode,
+		"skip_assertion": false,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+githubAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse testutils.AuthenticationResponse
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.NotEmpty(authResponse.ID, "Response should contain user ID")
+	suite.NotEmpty(authResponse.Type, "Response should contain user type")
+	suite.NotEmpty(authResponse.OrganizationUnit, "Response should contain organization unit")
+	suite.Equal(suite.userID, authResponse.ID, "Response should contain the correct user ID")
+	suite.NotEmpty(authResponse.Assertion, "Response should contain assertion token when skip_assertion is false")
+}
+
+// TestGithubAuthCompleteFlowWithSkipAssertionTrue tests complete GitHub auth flow with skip_assertion=true
+func (suite *GithubAuthTestSuite) TestGithubAuthCompleteFlowWithSkipAssertionTrue() {
+	// Step 1: Start authentication
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+githubAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	// Step 2: Simulate user authorization at GitHub
+	authCode := suite.simulateGithubAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	// Step 3: Finish authentication with skip_assertion=true
+	finishRequest := map[string]interface{}{
+		"session_token":  sessionToken,
+		"code":           authCode,
+		"skip_assertion": true,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+githubAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse testutils.AuthenticationResponse
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.NotEmpty(authResponse.ID, "Response should contain user ID")
+	suite.NotEmpty(authResponse.Type, "Response should contain user type")
+	suite.NotEmpty(authResponse.OrganizationUnit, "Response should contain organization unit")
+	suite.Equal(suite.userID, authResponse.ID, "Response should contain the correct user ID")
+	suite.Empty(authResponse.Assertion, "Response should not contain assertion token when skip_assertion is true")
 }
 
 // simulateGithubAuthorization simulates user authorization and returns authorization code

--- a/tests/integration/authn/oidc_auth_test.go
+++ b/tests/integration/authn/oidc_auth_test.go
@@ -290,6 +290,7 @@ func (suite *OIDCAuthTestSuite) TestOIDCAuthCompleteFlowSuccess() {
 	suite.NotEmpty(authResponse.Type, "Response should contain user type")
 	suite.NotEmpty(authResponse.OrganizationUnit, "Response should contain organization unit")
 	suite.Equal(suite.userID, authResponse.ID, "Response should contain the correct user ID")
+	suite.NotEmpty(authResponse.Assertion, "Response should contain assertion token by default")
 }
 
 func (suite *OIDCAuthTestSuite) TestOIDCAuthFinishInvalidSessionToken() {
@@ -367,6 +368,122 @@ func (suite *OIDCAuthTestSuite) TestOIDCAuthWithNonce() {
 	suite.NotEmpty(query.Get("response_type"), "response_type should be present")
 	suite.NotEmpty(query.Get("scope"), "scope should be present")
 	// nonce is optional - Thunder doesn't generate it currently
+}
+
+// TestOIDCAuthCompleteFlowWithSkipAssertionFalse tests complete OIDC flow with skip_assertion=false
+func (suite *OIDCAuthTestSuite) TestOIDCAuthCompleteFlowWithSkipAssertionFalse() {
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	authCode := suite.simulateOIDCAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	finishRequest := map[string]interface{}{
+		"session_token":  sessionToken,
+		"code":           authCode,
+		"skip_assertion": false,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+oidcAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse testutils.AuthenticationResponse
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.NotEmpty(authResponse.ID, "Response should contain user ID")
+	suite.NotEmpty(authResponse.Type, "Response should contain user type")
+	suite.NotEmpty(authResponse.OrganizationUnit, "Response should contain organization unit")
+	suite.Equal(suite.userID, authResponse.ID, "Response should contain the correct user ID")
+	suite.NotEmpty(authResponse.Assertion, "Response should contain assertion token when skip_assertion is false")
+}
+
+// TestOIDCAuthCompleteFlowWithSkipAssertionTrue tests complete OIDC flow with skip_assertion=true
+func (suite *OIDCAuthTestSuite) TestOIDCAuthCompleteFlowWithSkipAssertionTrue() {
+	startRequest := map[string]interface{}{
+		"idp_id": suite.idpID,
+	}
+	startRequestJSON, err := json.Marshal(startRequest)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+oidcAuthStart, bytes.NewReader(startRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var startResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&startResponse)
+	suite.Require().NoError(err)
+
+	sessionToken := startResponse["session_token"].(string)
+	redirectURL := startResponse["redirect_url"].(string)
+
+	authCode := suite.simulateOIDCAuthorization(redirectURL)
+	suite.Require().NotEmpty(authCode)
+
+	finishRequest := map[string]interface{}{
+		"session_token":  sessionToken,
+		"code":           authCode,
+		"skip_assertion": true,
+	}
+	finishRequestJSON, err := json.Marshal(finishRequest)
+	suite.Require().NoError(err)
+
+	req, err = http.NewRequest("POST", testServerURL+oidcAuthFinish, bytes.NewReader(finishRequestJSON))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var authResponse testutils.AuthenticationResponse
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	suite.Require().NoError(err)
+
+	suite.NotEmpty(authResponse.ID, "Response should contain user ID")
+	suite.NotEmpty(authResponse.Type, "Response should contain user type")
+	suite.NotEmpty(authResponse.OrganizationUnit, "Response should contain organization unit")
+	suite.Equal(suite.userID, authResponse.ID, "Response should contain the correct user ID")
+	suite.Empty(authResponse.Assertion, "Response should not contain assertion token when skip_assertion is true")
 }
 
 // simulateOIDCAuthorization simulates user authorization and returns authorization code

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -97,4 +97,5 @@ type AuthenticationResponse struct {
 	ID               string `json:"id"`
 	Type             string `json:"type"`
 	OrganizationUnit string `json:"organization_unit"`
+	Assertion        string `json:"assertion,omitempty"`
 }


### PR DESCRIPTION
## Purpose

This pull request introduces support for optionally generating an auth assertion (JWT access token) in authentication responses across all authentication methods (credentials, OTP, and IDP flows). By adding a `skip_assertion` flag to relevant API requests and propagating it through the backend, clients can now control whether the assertion token is included in the response. The implementation covers backend logic, DTOs, OpenAPI documentation, and integration tests.

By default, the APIs and related service will generate the token. Can skip by adding the `skip_assertion=true` to the request.

**Backend logic and API enhancements:**

* Added `skip_assertion` boolean flag support to credential, OTP, and IDP authentication requests, allowing clients to request authentication responses without an assertion token. This flag is propagated through handler, service, and DTO layers (`backend/internal/authn/handler.go`, `backend/internal/authn/model.go`, `backend/internal/authn/service.go`). [[1]](diffhunk://#diff-cefa363413faa7eb6b3b9fa69195ceaa69f9e5e7570a9c5c9c0ad7a5f46f35cdL51-R65) [[2]](diffhunk://#diff-cefa363413faa7eb6b3b9fa69195ceaa69f9e5e7570a9c5c9c0ad7a5f46f35cdL97-R106) [[3]](diffhunk://#diff-cefa363413faa7eb6b3b9fa69195ceaa69f9e5e7570a9c5c9c0ad7a5f46f35cdL133-R143) [[4]](diffhunk://#diff-cefa363413faa7eb6b3b9fa69195ceaa69f9e5e7570a9c5c9c0ad7a5f46f35cdL170-R180) [[5]](diffhunk://#diff-cefa363413faa7eb6b3b9fa69195ceaa69f9e5e7570a9c5c9c0ad7a5f46f35cdL207-R217) [[6]](diffhunk://#diff-8c077279143b48c95934496c09a313c8822c6af185ee37e6079300cbbc132013R57) [[7]](diffhunk://#diff-8c077279143b48c95934496c09a313c8822c6af185ee37e6079300cbbc132013R76) [[8]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L52-R60) [[9]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L89-R112) [[10]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L110-R143) [[11]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L178-R201)
* Refactored authentication service methods to generate and append the assertion token only if `skip_assertion` is false, and factored out assertion generation into a dedicated helper method (`appendAuthAssertion`).

**API documentation updates:**

* Updated OpenAPI docs to document the new `skip_assertion` property for all relevant request and response schemas, and provided examples for its usage (`docs/apis/authentication.yaml`). [[1]](diffhunk://#diff-a5455f21283cb76284d4576aa95d5d1745575ba71ccf4e61869625b0e4d79d5eR406-R416) [[2]](diffhunk://#diff-a5455f21283cb76284d4576aa95d5d1745575ba71ccf4e61869625b0e4d79d5eR456-R460) [[3]](diffhunk://#diff-a5455f21283cb76284d4576aa95d5d1745575ba71ccf4e61869625b0e4d79d5eR479-R482) [[4]](diffhunk://#diff-a5455f21283cb76284d4576aa95d5d1745575ba71ccf4e61869625b0e4d79d5eR519-R523)

**DTO and response changes:**

* Added `Assertion` field to `AuthenticationResponse` and related DTOs, ensuring the response can carry the assertion token if generated (`backend/internal/authn/common/model.go`, `backend/internal/authn/model.go`). [[1]](diffhunk://#diff-f5b254200ba632841a22b5d42dc4a5c077e5d073b2d08b2cf2b14fa7c8140c6eR48-R52) [[2]](diffhunk://#diff-8c077279143b48c95934496c09a313c8822c6af185ee37e6079300cbbc132013R40)

**Integration tests:**

* Added and updated integration tests to verify the default behavior (assertion included), as well as both cases for the new `skip_assertion` flag (true and false) for credential authentication. Also updated IDP and OTP authentication tests to check for the presence of the assertion token (`tests/integration/authn/credentials_auth_test.go`, `tests/integration/authn/github_auth_test.go`). [[1]](diffhunk://#diff-1fd688fbe30a052daa0ff3e4a71282163c6160bcd60983c0afed8a1598707908R211) [[2]](diffhunk://#diff-1fd688fbe30a052daa0ff3e4a71282163c6160bcd60983c0afed8a1598707908R481-R518) [[3]](diffhunk://#diff-de1ddda647114dce18b9a11b94be430c6f0b5b94fe75a848cbdd2035121e81beR292)

## Related Issues
- https://github.com/asgardeo/thunder/issues/481