### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,60 @@
+## Please refer to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners 
+## for the CODEOWNERS documentation.
+## 
+## Order is important; the last matching pattern takes the most precedence.
+
+
+## backend files
+
+/backend/cmd/server/ @ThaminduDilshan @darshanasbg @senthalan
+
+/backend/internal/application/ @ThaminduDilshan
+/backend/internal/authn/ @ThaminduDilshan
+/backend/internal/cert/ @ThaminduDilshan
+/backend/internal/executor/ @ThaminduDilshan
+/backend/internal/flow/ @ThaminduDilshan
+/backend/internal/group/ @darshanasbg
+/backend/internal/idp/ @ThaminduDilshan
+/backend/internal/notification/ @ThaminduDilshan
+/backend/internal/ou/ @darshanasbg
+/backend/internal/user/ @darshanasbg
+/backend/internal/userschema/ @darshanasbg
+
+/backend/internal/oauth/ @ThaminduDilshan
+/backend/internal/oauth/oauth2/pkce/ @thiva-k
+
+/backend/internal/system/ @ThaminduDilshan @darshanasbg
+/backend/internal/system/cache/ @ThaminduDilshan
+/backend/internal/system/cmodels/ @thiva-k
+/backend/internal/system/config/ @ThaminduDilshan
+/backend/internal/system/constants/ @ThaminduDilshan
+/backend/internal/system/crypto/ @hwupathum
+/backend/internal/system/database/ @ThaminduDilshan @darshanasbg
+/backend/internal/system/error/ @ThaminduDilshan
+/backend/internal/system/healthcheck/ @darshanasbg
+/backend/internal/system/http/ @ThaminduDilshan
+/backend/internal/system/jwt/ @ThaminduDilshan
+/backend/internal/system/log/ @ThaminduDilshan
+/backend/internal/system/middleware/ @senthalan
+/backend/internal/system/utils/ @ThaminduDilshan @darshanasbg
+
+
+## scripts
+
+/backend/dbscripts/ @ThaminduDilshan @darshanasbg
+/backend/scripts/ @ThaminduDilshan @darshanasbg
+
+
+## frontend files
+
+/frontend/ @jeradrutnam @DonOmalVindula
+
+
+## deployment files
+
+/install/helm/ @Lakshan-Banneheke
+
+
+## sample apps
+
+/samples/apps/oauth/ @jeradrutnam @DonOmalVindula


### PR DESCRIPTION
## Purpose

This pull request adds a new `.github/CODEOWNERS` file to the repository, establishing clear ownership for various parts of the codebase. This helps ensure that the right team members are automatically requested for reviews and can help maintain code quality and accountability.

Ownership assignments by theme:

* **Backend files:** Specific directories under `backend/` are assigned to individual contributors, ensuring clear responsibility for server, application, authentication, authorization, and system components.
* **Scripts:** Database and other backend scripts are assigned to relevant backend owners.
* **Frontend files:** The entire `frontend/` directory is assigned to the designated frontend team members.
* **Deployment files:** Helm deployment files are assigned to a specific owner for infrastructure management.
* **Sample apps:** Ownership for sample OAuth apps is given to frontend team members.