### PR TITLE
Improve mock generation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,8 @@ The project is structured as a monorepo to manage the backend, frontend, and sam
   - tests/: Common unit tests related files.
     - mocks/: Generated mocks for unit tests.
     - resources/: Test resource files.
-  - .mockery.yml: Mockery configurations related to mock generation.
+  - .mockery.private.yml: Mockery configurations for private interfaces.
+  - .mockery.public.yml: Mockery configurations for public interfaces.
 - frontend/: Individual frontend application code.
   - apps/gate/: Gate app implementation which serves UIs for login, registration and recovery. 
   - packages/: Common frontend packages such as UI components, services, and contexts.
@@ -113,7 +114,7 @@ The project is structured as a monorepo to manage the backend, frontend, and sam
 #### Unit Tests
 - Ensure unit tests are written to achieve at least 80% coverage.
 - Use `stretchr/testify` for tests and follow the test suite pattern.
-- `mockery` is used to generate mocks; configurations are in `/backend/.mockery.yml`.
+- `mockery` is used to generate mocks; configurations for private and public interfaces are in `.mockery.private.yml` and `.mockery.public.yml` respectively. Mocks can be generated using `make mockery` command from the project root directory.
 - Place generated mocks in the `/backend/tests/mocks/` directory.
 - Unit tests can be run using `make test_unit` command from the project root directory. Alternatively `go test` command can also be used from the `/backend` directory with applicable flags.
 

--- a/backend/.mockery.private.yml
+++ b/backend/.mockery.private.yml
@@ -1,0 +1,30 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+# Mockery configuration file for generating private mocks within the package
+template: testify
+template-data:
+  unroll-variadic: true
+packages:
+  github.com/asgardeo/thunder/internal/system/cache:
+    config:
+      all: true
+      dir: internal/system/cache
+      structname: '{{.InterfaceName}}Mock'
+      pkgname: cache
+      filename: "{{.InterfaceName}}_mock_test.go"

--- a/backend/.mockery.public.yml
+++ b/backend/.mockery.public.yml
@@ -16,6 +16,7 @@
 # under the License.
 # ------------------------------------------------------------------------------
 
+# Mockery configuration file for generating public mocks
 template: testify
 template-data:
   unroll-variadic: true
@@ -59,15 +60,6 @@ packages:
       structname: '{{.InterfaceName}}Mock'
       pkgname: providermock
       filename: "{{.InterfaceName}}_mock.go"
-  
-  # Uncomment to generate mocks in the cache package.
-  # github.com/asgardeo/thunder/internal/system/cache:
-  #   config:
-  #     all: true
-  #     dir: internal/system/cache
-  #     structname: '{{.InterfaceName}}Mock'
-  #     pkgname: cache
-  #     filename: "{{.InterfaceName}}_mock_test.go"
 
   github.com/asgardeo/thunder/internal/system/cache:
     config:


### PR DESCRIPTION
## Purpose

This pull request introduces improvements to the project's mock generation workflow and documentation. The main changes include splitting the mockery configuration into separate files for public and private interfaces, updating the Makefile to support these changes, and clarifying the documentation to reflect the new process.

**Mock generation workflow enhancements:**

* Added `backend/.mockery.private.yml` for private interface mocks and renamed `backend/.mockery.yml` to `backend/.mockery.public.yml` for public mocks, providing clearer separation and organization of mock configurations. [[1]](diffhunk://#diff-aa648ea8e724297a9b8cbc5df07db2af3a4192c862e53db2efb6ef27a7db42a5R1-R30) [[2]](diffhunk://#diff-d6c48c1097bc5a5f933289e9cf77f735eb15dfe614dbf3d0eceffda01cc68050R19)
* Updated the Makefile to add a new `mockery` target that generates mocks using both configuration files, and included installation logic for the mockery tool with version management. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R29-R33) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R102-R105) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R127-R135) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R146-R150)
