### PR TITLE
Improve quickstart to use compatible attributes with the oidc spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ To quickly get started with Thunder, you can use the sample app provided with th
         "auth_flow_graph_id": "auth_flow_config_basic",
         "registration_flow_graph_id": "registration_flow_config_basic",
         "is_registration_flow_enabled": true,
+        "user_attributes": ["given_name","family_name","email","groups"]
         "inbound_auth_config": [{
             "type": "oauth2",
             "config": {
@@ -163,7 +164,21 @@ To quickly get started with Thunder, you can use the sample app provided with th
                 "response_types": ["code"],
                 "token_endpoint_auth_methods": ["client_secret_basic", "client_secret_post"],
                 "pkce_required": false,
-                "public_client": false
+                "public_client": false,
+                "access_token": {
+                        "validity_period": 3600,
+                        "user_attributes": ["given_name","family_name","email","groups"]
+                },
+                "id_token": {
+                        "validity_period": 3600,
+                        "user_attributes": ["given_name","family_name","email","groups"],
+                        "scope_claims": {
+                            "profile": ["name","given_name","family_name","picture"],
+                            "email": ["email","email_verified"],
+                            "phone": ["phone_number","phone_number_verified"],
+                            "group": ["groups"]
+                        }
+                }
             }
         }]
     }'
@@ -389,10 +404,21 @@ To try out the Client Credentials flow, follow these steps:
                         "client_secret_post"
                     ],
                     "pkce_required": false,
-                    "public_client": false
-                }
-            }
-        ]
+                    "public_client": false,
+                    "access_token": {
+                        "validity_period": 3600,
+                        "user_attributes": ["given_name","family_name","email","groups"]
+                    },
+                    "id_token": {
+                        "validity_period": 3600,
+                        "user_attributes": ["given_name","family_name","email","groups"],
+                        "scope_claims": {
+                            "profile": ["name","given_name","family_name","picture"],
+                            "email": ["email","email_verified"],
+                            "phone": ["phone_number","phone_number_verified"],
+                            "group": ["groups"]
+                        }
+                    }
     }'
     ```
 
@@ -420,8 +446,8 @@ To try out the Client Credentials flow, follow these steps:
             "username": "thor",
             "password": "<password>",
             "email": "thor@thunder.sky",
-            "firstName": "Thor",
-            "lastName": "Odinson",
+            "given_name": "Thor",
+            "family_name": "Odinson",
             "age": 1534,
             "abilities": [
                 "strength",
@@ -606,8 +632,8 @@ curl -kL https://localhost:8090/oauth2/jwks
             "username": "thor",
             "password": "<password>",
             "email": "thor@thunder.sky",
-            "firstName": "Thor",
-            "lastName": "Odinson",
+            "given_name": "Thor",
+            "family_name": "Odinson",
             "age": 1534,
             "abilities": [
                 "strength",
@@ -1027,8 +1053,8 @@ curl -kL https://localhost:8090/oauth2/jwks
             "username": "thor",
             "password": "<password>",
             "email": "thor@thunder.sky",
-            "firstName": "Thor",
-            "lastName": "Odinson",
+            "given_name": "Thor",
+            "family_name": "Odinson",
             "mobileNumber": "+94xxxxxxxxx"
         }
     }'


### PR DESCRIPTION
This pull request updates the `README.md` to improve the consistency and clarity of user attribute naming and to provide more detailed examples for token configuration in sample OAuth2 flows. The main changes include renaming user fields to align with standard OpenID Connect conventions and expanding the example configuration to show how user attributes and claims are included in access and ID tokens.

**User attribute naming standardization:**

* Changed user fields from `firstName`/`lastName` to `given_name`/`family_name` throughout all sample user JSON payloads for consistency with OpenID Connect standards. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L423-R450) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L609-R636) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1030-R1057)

**Token configuration enhancements:**

* Added `user_attributes` to the top-level configuration and within both `access_token` and `id_token` sections to explicitly specify which user attributes are included in tokens. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R181) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L392-L395)
* Expanded the `id_token` example to include a `scope_claims` mapping, showing how different scopes correspond to specific claims in the token. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R181) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L392-L395)