### PR TITLE
Update default container image tag

### DIFF
--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -37,7 +37,7 @@ deployment:
     # -- Container image digest
     digest: ""
     # -- Container image tag. Either "tag" or "digest" should be defined
-    tag: "0.7.0"
+    tag: "0.10.0"
     pullPolicy: "Always"
   startupProbe:
     initialDelaySeconds: 1


### PR DESCRIPTION
## Purpose
This pull request updates the container image version used in the Helm chart configuration.

* Deployment configuration: Updated the container image `tag` in `install/helm/values.yaml` from `"0.7.0"` to `"0.10.0"` to use the latest version of the application image.

## Related Issues
- https://github.com/asgardeo/thunder/issues/562