### PR TITLE
Add CODEOWNERS for hash directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /backend/internal/system/crypto/ @hwupathum
 /backend/internal/system/database/ @ThaminduDilshan @darshanasbg
 /backend/internal/system/error/ @ThaminduDilshan
+/backend/internal/system/hash/ @hwupathum
 /backend/internal/system/healthcheck/ @darshanasbg
 /backend/internal/system/http/ @ThaminduDilshan
 /backend/internal/system/jwt/ @ThaminduDilshan


### PR DESCRIPTION
## Purpose
This pull request makes a small update to the `.github/CODEOWNERS` file to assign ownership of the `/backend/internal/system/hash/` directory to the appropriate team member.