### PR TITLE
Fix codecov.yml to properly track frontend coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,11 +21,24 @@ codecov:
   notify:
     wait_for_ci: true
 
+flags:
+  frontend-apps-develop-unit:
+    paths:
+      - frontend/apps/thunder-develop/src/**/*.ts
+      - frontend/apps/thunder-develop/src/**/*.tsx
+    carryforward: false
+
 coverage:
   status:
     project:
       default:
         enabled: true
+        target: auto
+        threshold: 1%
+        informational: false
+      frontend-apps-develop-unit:
+        flags:
+          - frontend-apps-develop-unit
         target: auto
         threshold: 1%
         informational: false


### PR DESCRIPTION
## Purpose
This pull request updates the `codecov.yml` configuration to exclude additional frontend-related files and directories from code coverage reporting. This helps ensure that coverage metrics focus on relevant source code and not on build artifacts, tests, or configuration files.

Coverage exclusion updates for frontend files:

* Added patterns to ignore build artifacts, test files, configuration files, mock data, type definitions, and public assets in all `frontend` directories.


## Related Issue
- https://github.com/asgardeo/thunder/issues/599