### PR TITLE
Remove frontend paths from codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,9 +23,6 @@ codecov:
 
 flags:
   frontend-apps-develop-unit:
-    paths:
-      - frontend/apps/thunder-develop/src/**/*.ts
-      - frontend/apps/thunder-develop/src/**/*.tsx
     carryforward: false
 
 coverage:


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the `codecov.yml` configuration. The change removes the explicit path definitions for the `frontend-apps-develop-unit` flag, which may affect how coverage is reported for those files.

## Related Issue
- https://github.com/asgardeo/thunder/issues/599