### PR TITLE
Add user type and ou to the flow assertion

### DIFF
--- a/backend/internal/authn/common/model.go
+++ b/backend/internal/authn/common/model.go
@@ -28,9 +28,11 @@ import (
 
 // AuthenticatedUser represents the user information of an authenticated user.
 type AuthenticatedUser struct {
-	IsAuthenticated bool
-	UserID          string
-	Attributes      map[string]interface{}
+	IsAuthenticated    bool
+	UserID             string
+	OrganizationUnitID string
+	UserType           string
+	Attributes         map[string]interface{}
 }
 
 // AuthenticationContext represents the context of an authentication session.

--- a/backend/internal/executor/authassert/authassertexecutor.go
+++ b/backend/internal/executor/authassert/authassertexecutor.go
@@ -204,6 +204,14 @@ func (a *AuthAssertExecutor) generateAuthAssertion(ctx *flowmodel.NodeContext, l
 		}
 	}
 
+	// Add user type and ou to the jwt claims
+	if ctx.AuthenticatedUser.UserType != "" {
+		jwtClaims["userType"] = ctx.AuthenticatedUser.UserType
+	}
+	if ctx.AuthenticatedUser.OrganizationUnitID != "" {
+		jwtClaims["ouId"] = ctx.AuthenticatedUser.OrganizationUnitID
+	}
+
 	token, _, err := a.JWTService.GenerateJWT(tokenSub, ctx.AppID, iss, validityPeriod, jwtClaims)
 	if err != nil {
 		logger.Error("Failed to generate JWT token", log.Error(err))

--- a/backend/internal/executor/basicauth/basicauthexecutor.go
+++ b/backend/internal/executor/basicauth/basicauthexecutor.go
@@ -132,13 +132,11 @@ func (b *BasicAuthExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.Exec
 	execResp.Status = flowconst.ExecComplete
 
 	// Add execution record for successful authentication
-	if authenticatedUser.IsAuthenticated {
-		execResp.ExecutionRecord = &flowmodel.NodeExecutionRecord{
-			ExecutorName: authncm.AuthenticatorCredentials,
-			ExecutorType: flowconst.ExecutorTypeAuthentication,
-			Timestamp:    time.Now().Unix(),
-			Status:       flowconst.FlowStatusComplete,
-		}
+	execResp.ExecutionRecord = &flowmodel.NodeExecutionRecord{
+		ExecutorName: authncm.AuthenticatorCredentials,
+		ExecutorType: flowconst.ExecutorTypeAuthentication,
+		Timestamp:    time.Now().Unix(),
+		Status:       flowconst.FlowStatusComplete,
 	}
 
 	logger.Debug("Basic authentication executor execution completed",
@@ -245,9 +243,11 @@ func (b *BasicAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 	}
 
 	authenticatedUser := authncm.AuthenticatedUser{
-		IsAuthenticated: true,
-		UserID:          user.ID,
-		Attributes:      attrs,
+		IsAuthenticated:    true,
+		UserID:             user.ID,
+		OrganizationUnitID: user.OrganizationUnit,
+		UserType:           user.Type,
+		Attributes:         attrs,
 	}
 	return &authenticatedUser, nil
 }

--- a/backend/internal/executor/githubauth/githubauthexecutor.go
+++ b/backend/internal/executor/githubauth/githubauthexecutor.go
@@ -168,17 +168,18 @@ func (o *GithubOAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext
 
 	if execResp.AuthenticatedUser.IsAuthenticated {
 		execResp.Status = flowconst.ExecComplete
-
-		// Add execution record for successful GitHub OAuth authentication
-		execResp.ExecutionRecord = &flowmodel.NodeExecutionRecord{
-			ExecutorName: authncm.AuthenticatorGithub,
-			ExecutorType: flowconst.ExecutorTypeAuthentication,
-			Timestamp:    time.Now().Unix(),
-			Status:       flowconst.FlowStatusComplete,
-		}
 	} else if ctx.FlowType != flowconst.FlowTypeRegistration {
 		execResp.Status = flowconst.ExecFailure
 		execResp.FailureReason = "Authentication failed. Authorization code not provided or invalid."
+		return nil
+	}
+
+	// Add execution record for successful GitHub OAuth authentication
+	execResp.ExecutionRecord = &flowmodel.NodeExecutionRecord{
+		ExecutorName: authncm.AuthenticatorGithub,
+		ExecutorType: flowconst.ExecutorTypeAuthentication,
+		Timestamp:    time.Now().Unix(),
+		Status:       flowconst.FlowStatusComplete,
 	}
 
 	return nil
@@ -283,9 +284,11 @@ func (o *GithubOAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.
 	}
 
 	authenticatedUser := authncm.AuthenticatedUser{
-		IsAuthenticated: true,
-		UserID:          userID,
-		Attributes:      getUserAttributes(userInfo, userID),
+		IsAuthenticated:    true,
+		UserID:             userID,
+		OrganizationUnitID: user.OrganizationUnit,
+		UserType:           user.Type,
+		Attributes:         getUserAttributes(userInfo, userID),
 	}
 
 	return &authenticatedUser, nil

--- a/backend/internal/executor/oauth/oauthexecutor.go
+++ b/backend/internal/executor/oauth/oauthexecutor.go
@@ -263,17 +263,18 @@ func (o *OAuthExecutor) ProcessAuthFlowResponse(ctx *flowmodel.NodeContext,
 
 	if execResp.AuthenticatedUser.IsAuthenticated {
 		execResp.Status = flowconst.ExecComplete
-
-		// Add execution record for successful OAuth authentication
-		execResp.ExecutionRecord = &flowmodel.NodeExecutionRecord{
-			ExecutorName: authncm.AuthenticatorOAuth,
-			ExecutorType: flowconst.ExecutorTypeAuthentication,
-			Timestamp:    time.Now().Unix(),
-			Status:       flowconst.FlowStatusComplete,
-		}
 	} else if ctx.FlowType != flowconst.FlowTypeRegistration {
 		execResp.Status = flowconst.ExecFailure
 		execResp.FailureReason = "Authentication failed. Authorization code not provided or invalid."
+		return nil
+	}
+
+	// Add execution record for successful OAuth authentication
+	execResp.ExecutionRecord = &flowmodel.NodeExecutionRecord{
+		ExecutorName: authncm.AuthenticatorOAuth,
+		ExecutorType: flowconst.ExecutorTypeAuthentication,
+		Timestamp:    time.Now().Unix(),
+		Status:       flowconst.FlowStatusComplete,
 	}
 
 	return nil
@@ -443,9 +444,11 @@ func (o *OAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowmodel.NodeCo
 	}
 
 	authenticatedUser := authncm.AuthenticatedUser{
-		IsAuthenticated: true,
-		UserID:          userID,
-		Attributes:      getUserAttributes(userInfo, userID),
+		IsAuthenticated:    true,
+		UserID:             userID,
+		OrganizationUnitID: user.OrganizationUnit,
+		UserType:           user.Type,
+		Attributes:         getUserAttributes(userInfo, userID),
 	}
 
 	return &authenticatedUser, nil

--- a/backend/internal/executor/provision/provisioningexecutor.go
+++ b/backend/internal/executor/provision/provisioningexecutor.go
@@ -153,9 +153,11 @@ func (p *ProvisioningExecutor) Execute(ctx *flowmodel.NodeContext) (*flowmodel.E
 	}
 
 	authenticatedUser := authncm.AuthenticatedUser{
-		IsAuthenticated: true,
-		UserID:          createdUser.ID,
-		Attributes:      retAttributes,
+		IsAuthenticated:    true,
+		UserID:             createdUser.ID,
+		OrganizationUnitID: createdUser.OrganizationUnit,
+		UserType:           createdUser.Type,
+		Attributes:         retAttributes,
 	}
 	execResp.AuthenticatedUser = authenticatedUser
 	execResp.Status = flowconst.ExecComplete
@@ -309,7 +311,7 @@ func (p *ProvisioningExecutor) createUserInStore(flowID string,
 		newUser.Type = userType.(string)
 	} else {
 		// TODO: Use a hard coded type for the moment. This needs to be resolved accordingly.
-		newUser.Type = "human"
+		newUser.Type = "person"
 	}
 
 	// Convert the user attributes to JSON.

--- a/backend/internal/executor/smsauth/smsauthexecutor.go
+++ b/backend/internal/executor/smsauth/smsauthexecutor.go
@@ -663,9 +663,11 @@ func (s *SMSOTPAuthExecutor) getAuthenticatedUser(ctx *flowmodel.NodeContext,
 	}
 
 	authenticatedUser := &authncm.AuthenticatedUser{
-		IsAuthenticated: true,
-		UserID:          user.ID,
-		Attributes:      attrs,
+		IsAuthenticated:    true,
+		UserID:             user.ID,
+		OrganizationUnitID: user.OrganizationUnit,
+		UserType:           user.Type,
+		Attributes:         attrs,
 	}
 
 	return authenticatedUser, nil

--- a/tests/integration/flowauthn/basicauth_test.go
+++ b/tests/integration/flowauthn/basicauth_test.go
@@ -162,6 +162,17 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccess() {
 	ts.Require().NotEmpty(completeFlowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccessWithSingleRequest() {
@@ -186,6 +197,17 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccessWithSingleRequest() {
 	ts.Require().NotEmpty(flowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(flowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(flowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
@@ -237,6 +259,17 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
 	ts.Require().NotEmpty(completeFlowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowInvalidCredentials() {

--- a/tests/integration/flowauthn/decisionauth_test.go
+++ b/tests/integration/flowauthn/decisionauth_test.go
@@ -260,6 +260,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() {
 	ts.Require().NotEmpty(completeFlowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
@@ -370,6 +381,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
 			"JWT assertion should be returned after successful authentication")
 		ts.Require().Empty(completeFlowStep.FailureReason,
 			"Failure reason should be empty for successful authentication")
+
+		// Decode and validate JWT claims
+		jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+		ts.Require().NoError(err, "Failed to decode JWT assertion")
+		ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+		// Validate JWT contains expected user type and OU ID
+		ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+		ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+		ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+		ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 	})
 
 	// Test case 2: Retry auth flow for same user - should not prompt for mobile again
@@ -468,6 +490,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
 			"JWT assertion should be returned after successful authentication")
 		ts.Require().Empty(completeFlowStep.FailureReason,
 			"Failure reason should be empty for successful authentication")
+
+		// Decode and validate JWT claims
+		jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+		ts.Require().NoError(err, "Failed to decode JWT assertion")
+		ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+		// Validate JWT contains expected user type and OU ID
+		ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+		ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+		ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+		ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 	})
 }
 
@@ -564,6 +597,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 	ts.Require().NotEmpty(completeFlowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *DecisionAndMFAFlowTestSuite) TestSMSOTPAuthWithInvalidMobile() {

--- a/tests/integration/flowauthn/smsauth_test.go
+++ b/tests/integration/flowauthn/smsauth_test.go
@@ -248,6 +248,17 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 	ts.Require().NotEmpty(completeFlowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(smsAuthTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(smsAuthTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
@@ -333,6 +344,17 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
 	ts.Require().NotEmpty(completeFlowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(smsAuthTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(smsAuthTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
@@ -438,4 +460,15 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {
 	ts.Require().NotEmpty(completeFlowStep.Assertion,
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(smsAuthTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(smsAuthTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }

--- a/tests/integration/flowregistration/basicregistration_test.go
+++ b/tests/integration/flowregistration/basicregistration_test.go
@@ -171,6 +171,17 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSuccess() {
 		"JWT assertion should be returned after successful registration")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful registration")
 
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(registrationOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
+
 	// Step 5: Verify the user was created by searching via the user API
 	user, err := testutils.FindUserByAttribute("username", username)
 	if err != nil {
@@ -287,6 +298,17 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 		"JWT assertion should be returned after successful registration")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful registration")
 
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(registrationOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
+
 	// Step 7: Verify the user was created by searching via the user API
 	user, err := testutils.FindUserByAttribute("username", username)
 	if err != nil {
@@ -323,6 +345,17 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSingleRequest
 	ts.Require().NotEmpty(flowStep.Assertion,
 		"JWT assertion should be returned after successful registration")
 	ts.Require().Empty(flowStep.FailureReason, "Failure reason should be empty for successful registration")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(flowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(registrationOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 
 	// Step 3: Verify the user was created by searching via the user API
 	user, err := testutils.FindUserByAttribute("username", username)

--- a/tests/integration/flowregistration/smsregistration_test.go
+++ b/tests/integration/flowregistration/smsregistration_test.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	mockNotificationServerPort = 8098
+	registrationOUID           = "00000000-0000-0000-0000-000000000000"
 )
 
 var (
@@ -224,6 +225,17 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowWithMobileNumber(
 	ts.Require().Empty(completeFlowStep.FailureReason,
 		"Failure reason should be empty for successful registration")
 
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(registrationOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
+
 	// Step 5: Verify the user was created by searching via the user API
 	user, err := testutils.FindUserByAttribute("mobileNumber", mobileNumber)
 	if err != nil {
@@ -323,6 +335,17 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowWithUsername() {
 		"JWT assertion should be returned after successful registration")
 	ts.Require().Empty(completeFlowStep.FailureReason,
 		"Failure reason should be empty for successful registration")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(registrationOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 
 	// Step 5: Verify the user was created by searching via the user API
 	user, err := testutils.FindUserByAttribute("username", username)
@@ -443,6 +466,17 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"JWT assertion should be returned after successful registration")
 	ts.Require().Empty(completeFlowStep.FailureReason,
 		"Failure reason should be empty for successful registration")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(registrationOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 
 	// Step 3: Verify the user was created by searching via the user API
 	user, err := testutils.FindUserByAttribute("mobileNumber", mobileNumber)

--- a/tests/integration/testutils/jwt_utils.go
+++ b/tests/integration/testutils/jwt_utils.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package testutils
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// JWTClaims represents the decoded JWT claims.
+type JWTClaims struct {
+	Sub       string                 `json:"sub"`
+	Aud       string                 `json:"aud"`
+	Iss       string                 `json:"iss"`
+	Exp       float64                `json:"exp"`
+	Iat       float64                `json:"iat"`
+	UserType  string                 `json:"userType,omitempty"`
+	OuID      string                 `json:"ouId,omitempty"`
+	Assurance map[string]interface{} `json:"assurance,omitempty"`
+	// Additional claims can be accessed via the map
+	Additional map[string]interface{} `json:"-"`
+}
+
+// DecodeJWT decodes a JWT assertion without verifying the signature.
+// This is useful for integration tests to validate the JWT payload content.
+func DecodeJWT(token string) (*JWTClaims, error) {
+	// Split the JWT into its three parts
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))
+	}
+
+	// Decode the payload (second part)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	// Unmarshal the payload into a map first to capture all claims
+	var allClaims map[string]interface{}
+	if err := json.Unmarshal(payload, &allClaims); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT payload: %w", err)
+	}
+
+	// Unmarshal into the structured JWTClaims
+	var claims JWTClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	// Store all claims in Additional for flexible access
+	claims.Additional = allClaims
+
+	return &claims, nil
+}
+
+// ValidateJWTClaims validates that the JWT contains the expected claims.
+func ValidateJWTClaims(claims *JWTClaims, expectedSub, expectedAud, expectedUserType, expectedOuID string) error {
+	if claims.Sub != expectedSub {
+		return fmt.Errorf("expected sub '%s', got '%s'", expectedSub, claims.Sub)
+	}
+	if claims.Aud != expectedAud {
+		return fmt.Errorf("expected aud '%s', got '%s'", expectedAud, claims.Aud)
+	}
+	if expectedUserType != "" && claims.UserType != expectedUserType {
+		return fmt.Errorf("expected userType '%s', got '%s'", expectedUserType, claims.UserType)
+	}
+	if expectedOuID != "" && claims.OuID != expectedOuID {
+		return fmt.Errorf("expected ouId '%s', got '%s'", expectedOuID, claims.OuID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Purpose

This pull request adds the userType and organization unit id to the flow assertions. Additionally this fixes the issue of not sending the auth assurance levels for the registration flows.

### User Attribute Propagation

* Added `OrganizationUnitID` and `UserType` fields to the `AuthenticatedUser` struct, and ensured these are set in all authentication executors (`basicauth`, `oauth`, `githubauth`, `oidcauth`, `googleauth`). This allows downstream systems to utilize richer user information. [[1]](diffhunk://#diff-f5b254200ba632841a22b5d42dc4a5c077e5d073b2d08b2cf2b14fa7c8140c6eR33-R34) [[2]](diffhunk://#diff-30649f0349d4fac2053a5338a4d4c25d63384d8b480080b85413323566d286e6R248-R249) [[3]](diffhunk://#diff-0a6f7bafb1251d2fdcec58f91621e2d597acafe660bfa38a3a52335201914203R449-R450) [[4]](diffhunk://#diff-951fd5f8dec16ef51e0f6a0c82fcf249dff635406138cc44e9aced054b2cc943R289-R290) [[5]](diffhunk://#diff-54fac994c10015c222ad71eab9aa68265726805b132564afc480625278dc43eaL451-R445) [[6]](diffhunk://#diff-ca7025fb54423922cb77527feeb4a04009d613a05583c714bfb5a1e461b97533L391-R389)

### User Resolution Refactor

* Refactored user resolution logic in OIDC and Google executors to return a full `User` object rather than just a user ID, improving type safety and making it easier to propagate additional user attributes. [[1]](diffhunk://#diff-ca7025fb54423922cb77527feeb4a04009d613a05583c714bfb5a1e461b97533L410-R401) [[2]](diffhunk://#diff-ca7025fb54423922cb77527feeb4a04009d613a05583c714bfb5a1e461b97533L428-R449) [[3]](diffhunk://#diff-54fac994c10015c222ad71eab9aa68265726805b132564afc480625278dc43eaL394-R403) [[4]](diffhunk://#diff-54fac994c10015c222ad71eab9aa68265726805b132564afc480625278dc43eaL422-L439) [[5]](diffhunk://#diff-54fac994c10015c222ad71eab9aa68265726805b132564afc480625278dc43eaL231-R254)

### Minor Codebase Cleanups

* Removed unnecessary conditional checks and simplified logic for execution record creation and attribute mapping. Also updated imports to support new logic. [[1]](diffhunk://#diff-30649f0349d4fac2053a5338a4d4c25d63384d8b480080b85413323566d286e6L135-L142) [[2]](diffhunk://#diff-ca7025fb54423922cb77527feeb4a04009d613a05583c714bfb5a1e461b97533R26) [[3]](diffhunk://#diff-ca7025fb54423922cb77527feeb4a04009d613a05583c714bfb5a1e461b97533R40) [[4]](diffhunk://#diff-ca7025fb54423922cb77527feeb4a04009d613a05583c714bfb5a1e461b97533L185-L189) [[5]](diffhunk://#diff-54fac994c10015c222ad71eab9aa68265726805b132564afc480625278dc43eaR41)

These changes collectively improve the reliability, maintainability, and extensibility of the authentication flow throughout the codebase.