### PR TITLE
Fix frontend folder not appearing in the codecov dashboard

### DIFF
--- a/frontend/apps/thunder-develop/vite.config.ts
+++ b/frontend/apps/thunder-develop/vite.config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
     css: true,
     coverage: {
       provider: 'istanbul',
-      reporter: ['text', 'json', 'html', 'lcov'],
+      reporter: ['text', 'json', 'html', ['lcov', {projectRoot: '../../../'}]],
       exclude: [
         'node_modules/',
         'dist/',


### PR DESCRIPTION
## Purpose
This pull request updates the test coverage reporter configuration in the Vite setup to improve coverage reporting. The change ensures that the LCOV report uses the correct project root directory.

Testing & coverage configuration:

* Updated the `reporter` option in the `coverage` configuration of `frontend/apps/thunder-develop/vite.config.ts` to specify the LCOV reporter with a custom `projectRoot` path, ensuring coverage output is mapped correctly.


## Related Issue
- https://github.com/asgardeo/thunder/issues/599