### PR TITLE
Update PR builder to run frontend unit tests

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -130,6 +130,11 @@ jobs:
           cd frontend
           pnpm build
 
+      - name: 🧪 Run Frontend Tests with Coverage
+        run: |
+          cd frontend/apps/thunder-develop
+          pnpm test:coverage
+
       - name: 📦 Upload Built Distribution
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Purpose
This pull request adds a step to the pull request builder workflow to run frontend tests with coverage reporting. This improvement helps ensure code quality by automatically verifying and measuring test coverage for the `thunder-develop` frontend app.

* **Testing and coverage:** Added a new workflow job to run frontend tests with coverage for `frontend/apps/thunder-develop` using the `pnpm test:coverage` command. (.github/workflows/pr-builder.yml)

## Related Issue
- https://github.com/asgardeo/thunder/issues/599