### PR TITLE
Fix limit param validation in user schema listing

### DIFF
--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
@@ -313,7 +314,7 @@ func (us *userSchemaService) getCompiledSchemaForUserType(
 
 // validatePaginationParams validates the limit and offset parameters.
 func validatePaginationParams(limit, offset int) *serviceerror.ServiceError {
-	if limit < 0 {
+	if limit < 1 || limit > serverconst.MaxPageSize {
 		return &ErrorInvalidLimit
 	}
 	if offset < 0 {


### PR DESCRIPTION
## Purpose
This pull request introduces an improvement to pagination parameter validation in the user schema service, ensuring that the `limit` parameter adheres to defined system constraints. The change enhances input validation and enforces consistency with global constants.

Validation improvements:

* Updated the `validatePaginationParams` function in `backend/internal/userschema/service.go` to require that `limit` is at least 1 and does not exceed `serverconst.MaxPageSize`, instead of only checking for negative values.
* Imported `serverconst` from `internal/system/constants` in `backend/internal/userschema/service.go` to access the `MaxPageSize` constant for validation.