### PR TITLE
Improve user API tests by defining user types for all user creations

### DIFF
--- a/tests/integration/authn/github_auth_test.go
+++ b/tests/integration/authn/github_auth_test.go
@@ -37,11 +37,36 @@ const (
 	mockGithubPort   = 8091
 )
 
+var githubUserSchema = testutils.UserSchema{
+	Name: "github_user",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{
+			"type": "string",
+		},
+		"password": map[string]interface{}{
+			"type": "string",
+		},
+		"sub": map[string]interface{}{
+			"type": "string",
+		},
+		"email": map[string]interface{}{
+			"type": "string",
+		},
+		"givenName": map[string]interface{}{
+			"type": "string",
+		},
+		"familyName": map[string]interface{}{
+			"type": "string",
+		},
+	},
+}
+
 type GithubAuthTestSuite struct {
 	suite.Suite
 	mockGithubServer *testutils.MockGithubOAuthServer
 	idpID            string
 	userID           string
+	userSchemaID     string
 }
 
 func TestGithubAuthTestSuite(t *testing.T) {
@@ -74,6 +99,10 @@ func (suite *GithubAuthTestSuite) SetupSuite() {
 	err := suite.mockGithubServer.Start()
 	suite.Require().NoError(err, "Failed to start mock GitHub server")
 
+	schemaID, err := testutils.CreateUserType(githubUserSchema)
+	suite.Require().NoError(err, "Failed to create GitHub user schema")
+	suite.userSchemaID = schemaID
+
 	userAttributes := map[string]interface{}{
 		"username":   "githubuser",
 		"password":   "Test@1234",
@@ -87,7 +116,7 @@ func (suite *GithubAuthTestSuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	user := testutils.User{
-		Type:             "person",
+		Type:             githubUserSchema.Name,
 		OrganizationUnit: "root",
 		Attributes:       json.RawMessage(attributesJSON),
 	}
@@ -147,6 +176,10 @@ func (suite *GithubAuthTestSuite) SetupSuite() {
 func (suite *GithubAuthTestSuite) TearDownSuite() {
 	if suite.userID != "" {
 		_ = testutils.DeleteUser(suite.userID)
+	}
+
+	if suite.userSchemaID != "" {
+		_ = testutils.DeleteUserType(suite.userSchemaID)
 	}
 
 	if suite.idpID != "" {

--- a/tests/integration/authn/sms_otp_auth_test.go
+++ b/tests/integration/authn/sms_otp_auth_test.go
@@ -39,6 +39,24 @@ const (
 	testMobileNumber           = "+1234567890"
 )
 
+var smsOTPUserSchema = testutils.UserSchema{
+	Name: "smsotp_user",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{
+			"type": "string",
+		},
+		"password": map[string]interface{}{
+			"type": "string",
+		},
+		"email": map[string]interface{}{
+			"type": "string",
+		},
+		"mobileNumber": map[string]interface{}{
+			"type": "string",
+		},
+	},
+}
+
 type SMSOTPAuthTestSuite struct {
 	suite.Suite
 	mockServer   *testutils.MockNotificationServer
@@ -46,6 +64,7 @@ type SMSOTPAuthTestSuite struct {
 	senderID     string
 	userID       string
 	mobileNumber string
+	userSchemaID string
 }
 
 func TestSMSOTPAuthTestSuite(t *testing.T) {
@@ -93,6 +112,10 @@ func (suite *SMSOTPAuthTestSuite) SetupSuite() {
 	suite.Require().NoError(err, "Failed to create notification sender")
 	suite.senderID = senderID
 
+	schemaID, err := testutils.CreateUserType(smsOTPUserSchema)
+	suite.Require().NoError(err, "Failed to create SMS OTP user schema")
+	suite.userSchemaID = schemaID
+
 	userAttributes := map[string]interface{}{
 		"username":     "smsotp_user",
 		"password":     "Test@1234",
@@ -103,7 +126,7 @@ func (suite *SMSOTPAuthTestSuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	user := testutils.User{
-		Type:             "person",
+		Type:             smsOTPUserSchema.Name,
 		OrganizationUnit: "1234-abcd-5678-efgh",
 		Attributes:       userAttributesJSON,
 	}
@@ -119,6 +142,10 @@ func (suite *SMSOTPAuthTestSuite) TearDownSuite() {
 
 	if suite.senderID != "" {
 		_ = suite.deleteNotificationSender(suite.senderID)
+	}
+
+	if suite.userSchemaID != "" {
+		_ = testutils.DeleteUserType(suite.userSchemaID)
 	}
 
 	if suite.mockServer != nil {

--- a/tests/integration/flowauthn/attributecollect_test.go
+++ b/tests/integration/flowauthn/attributecollect_test.go
@@ -49,9 +49,33 @@ var (
 		Parent:      nil,
 	}
 
+	attrCollectUserSchema = testutils.UserSchema{
+		Name: "attr_collect_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"firstName": map[string]interface{}{
+				"type": "string",
+			},
+			"lastName": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"mobileNumber": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
 	// User templates with different attribute configurations
 	testUserNoAttributes = testutils.User{
-		Type: "person",
+		Type: attrCollectUserSchema.Name,
 		Attributes: json.RawMessage(`{
 			"username": "noattrsuser",
 			"password": "testpassword"
@@ -59,7 +83,7 @@ var (
 	}
 
 	testUserPartialAttributes = testutils.User{
-		Type: "person",
+		Type: attrCollectUserSchema.Name,
 		Attributes: json.RawMessage(`{
 			"username": "partialuser",
 			"password": "testpassword",
@@ -69,7 +93,7 @@ var (
 	}
 
 	testUserFullAttributes = testutils.User{
-		Type: "person",
+		Type: attrCollectUserSchema.Name,
 		Attributes: json.RawMessage(`{
 			"username": "fulluser",
 			"password": "testpassword",
@@ -81,7 +105,7 @@ var (
 	}
 
 	testUserNoAttributes2 = testutils.User{
-		Type: "person",
+		Type: attrCollectUserSchema.Name,
 		Attributes: json.RawMessage(`{
 			"username": "noattrsuser2",
 			"password": "testpassword"
@@ -90,8 +114,9 @@ var (
 )
 
 var (
-	attrCollectTestAppID string
-	attrCollectTestOUID  string
+	attrCollectTestAppID    string
+	attrCollectTestOUID     string
+	attrCollectUserSchemaID string
 )
 
 type AttributeCollectTestData struct {
@@ -129,6 +154,12 @@ func (ts *AttributeCollectFlowTestSuite) SetupSuite() {
 		ts.T().Fatalf("Failed to create test application during setup: %v", err)
 	}
 	attrCollectTestAppID = appID
+
+	schemaID, err := testutils.CreateUserType(attrCollectUserSchema)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)
+	}
+	attrCollectUserSchemaID = schemaID
 
 	// Store original app config (this will be the created app config)
 	ts.config.OriginalAppConfig, err = getAppConfig(attrCollectTestAppID)
@@ -225,6 +256,12 @@ func (ts *AttributeCollectFlowTestSuite) TearDownSuite() {
 	if attrCollectTestOUID != "" {
 		if err := testutils.DeleteOrganizationUnit(attrCollectTestOUID); err != nil {
 			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+
+	if attrCollectUserSchemaID != "" {
+		if err := testutils.DeleteUserType(attrCollectUserSchemaID); err != nil {
+			ts.T().Logf("Failed to delete test user schema during teardown: %v", err)
 		}
 	}
 

--- a/tests/integration/flowauthn/basicauth_test.go
+++ b/tests/integration/flowauthn/basicauth_test.go
@@ -45,8 +45,29 @@ var (
 		Parent:      nil,
 	}
 
+	testUserSchema = testutils.UserSchema{
+		Name: "basic_auth_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"firstName": map[string]interface{}{
+				"type": "string",
+			},
+			"lastName": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
 	testUser = testutils.User{
-		Type: "person",
+		Type: testUserSchema.Name,
 		Attributes: json.RawMessage(`{
 			"username": "testuser",
 			"password": "testpassword",
@@ -58,8 +79,9 @@ var (
 )
 
 var (
-	testAppID string
-	testOUID  string
+	testAppID    string
+	testOUID     string
+	userSchemaID string
 )
 
 type BasicAuthFlowTestSuite struct {
@@ -89,6 +111,12 @@ func (ts *BasicAuthFlowTestSuite) SetupSuite() {
 	}
 	testAppID = appID
 
+	schemaID, err := testutils.CreateUserType(testUserSchema)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)
+	}
+	userSchemaID = schemaID
+
 	// Create test user with the created OU
 	testUser := testUser
 	testUser.OrganizationUnit = testOUID
@@ -116,6 +144,12 @@ func (ts *BasicAuthFlowTestSuite) TearDownSuite() {
 	if testOUID != "" {
 		if err := testutils.DeleteOrganizationUnit(testOUID); err != nil {
 			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+
+	if userSchemaID != "" {
+		if err := testutils.DeleteUserType(userSchemaID); err != nil {
+			ts.T().Logf("Failed to delete test user schema during teardown: %v", err)
 		}
 	}
 
@@ -169,7 +203,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccess() {
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
 	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
@@ -204,7 +238,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccessWithSingleRequest() {
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
 	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
@@ -266,7 +300,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
 	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")

--- a/tests/integration/flowauthn/decisionauth_test.go
+++ b/tests/integration/flowauthn/decisionauth_test.go
@@ -50,8 +50,32 @@ var (
 		Parent:      nil,
 	}
 
+	decisionUserSchema = testutils.UserSchema{
+		Name: "decision_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"firstName": map[string]interface{}{
+				"type": "string",
+			},
+			"lastName": map[string]interface{}{
+				"type": "string",
+			},
+			"mobileNumber": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
 	testUserWithMobileDecision = testutils.User{
-		Type: "person",
+		Type: decisionUserSchema.Name,
 		Attributes: json.RawMessage(`{
 			"username": "decisionuser1",
 			"password": "testpassword",
@@ -63,7 +87,7 @@ var (
 	}
 
 	testUserWithoutMobileDecision = testutils.User{
-		Type: "person",
+		Type: decisionUserSchema.Name,
 		Attributes: json.RawMessage(`{
 			"username": "decisionuser2",
 			"password": "testpassword",
@@ -75,8 +99,9 @@ var (
 )
 
 var (
-	decisionTestAppID string
-	decisionTestOUID  string
+	decisionTestAppID    string
+	decisionTestOUID     string
+	decisionUserSchemaID string
 )
 
 type DecisionAndMFAFlowTestSuite struct {
@@ -106,6 +131,12 @@ func (ts *DecisionAndMFAFlowTestSuite) SetupSuite() {
 		ts.T().Fatalf("Failed to create test application during setup: %v", err)
 	}
 	decisionTestAppID = appID
+
+	schemaID, err := testutils.CreateUserType(decisionUserSchema)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)
+	}
+	decisionUserSchemaID = schemaID
 
 	// Start mock notification server
 	ts.mockServer = testutils.NewMockNotificationServer(mockDecisionNotificationServerPort)
@@ -167,6 +198,12 @@ func (ts *DecisionAndMFAFlowTestSuite) TearDownSuite() {
 	if decisionTestOUID != "" {
 		if err := testutils.DeleteOrganizationUnit(decisionTestOUID); err != nil {
 			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+
+	if decisionUserSchemaID != "" {
+		if err := testutils.DeleteUserType(decisionUserSchemaID); err != nil {
+			ts.T().Logf("Failed to delete test user schema during teardown: %v", err)
 		}
 	}
 
@@ -267,7 +304,7 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() {
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
 	ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
@@ -388,7 +425,7 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
 		ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 		// Validate JWT contains expected user type and OU ID
-		ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+		ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
 		ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 		ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 		ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
@@ -497,7 +534,7 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
 		ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 		// Validate JWT contains expected user type and OU ID
-		ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+		ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
 		ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 		ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 		ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
@@ -604,7 +641,7 @@ func (ts *DecisionAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal("person", jwtClaims.UserType, "Expected userType to be 'person'")
+	ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
 	ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")

--- a/tests/integration/group/groupapi_test.go
+++ b/tests/integration/group/groupapi_test.go
@@ -31,16 +31,30 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	testServerURL = "https://localhost:8095"
-)
-
 var (
 	testOU = testutils.OrganizationUnit{
 		Handle:      "test-group-ou",
 		Name:        "Test Organization Unit for Groups",
 		Description: "Organization unit created for group API testing",
 		Parent:      nil,
+	}
+
+	testUserSchema = testutils.UserSchema{
+		Name: "person",
+		Schema: map[string]interface{}{
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"firstName": map[string]interface{}{
+				"type": "string",
+			},
+			"lastName": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+		},
 	}
 
 	testUser = testutils.User{
@@ -64,6 +78,7 @@ var (
 	createdGroupID string
 	testOUID       string
 	testUserID     string
+	userSchemaID   string
 )
 
 type GroupAPITestSuite struct {
@@ -77,6 +92,13 @@ func (suite *GroupAPITestSuite) SetupSuite() {
 		suite.T().Fatalf("Failed to create test organization unit during setup: %v", err)
 	}
 	testOUID = ouID
+
+	// Create test user type
+	schemaID, err := testutils.CreateUserType(testUserSchema)
+	if err != nil {
+		suite.T().Fatalf("Failed to create test user type during setup: %v", err)
+	}
+	userSchemaID = schemaID
 
 	// Create test user with the created OU
 	testUser := testUser
@@ -118,6 +140,14 @@ func (suite *GroupAPITestSuite) TearDownSuite() {
 		err := testutils.DeleteUser(testUserID)
 		if err != nil {
 			suite.T().Logf("Failed to delete test user during teardown: %v", err)
+		}
+	}
+
+	// Delete test user type
+	if userSchemaID != "" {
+		err := testutils.DeleteUserType(userSchemaID)
+		if err != nil {
+			suite.T().Logf("Failed to delete user type during teardown: %v", err)
 		}
 	}
 

--- a/tests/integration/group/model.go
+++ b/tests/integration/group/model.go
@@ -22,6 +22,10 @@ import (
 	"github.com/asgardeo/thunder/tests/integration/testutils"
 )
 
+const (
+	testServerURL = "https://localhost:8095"
+)
+
 // MemberType represents the type of member entity.
 type MemberType string
 

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -42,12 +42,33 @@ const (
 )
 
 var (
-	testOUID string
+	testOUID       string
+	testUserSchema = testutils.UserSchema{
+		Name: "person",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"firstName": map[string]interface{}{
+				"type": "string",
+			},
+			"lastName": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
 )
 
 type AuthzTestSuite struct {
 	suite.Suite
 	applicationID string
+	userSchemaID  string
 	client        *http.Client
 }
 
@@ -62,6 +83,12 @@ func (ts *AuthzTestSuite) SetupSuite() {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
+
+	schemaID, err := testutils.CreateUserType(testUserSchema)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user type: %v", err)
+	}
+	ts.userSchemaID = schemaID
 
 	app := map[string]interface{}{
 		"name":                         appName,
@@ -90,6 +117,7 @@ func (ts *AuthzTestSuite) SetupSuite() {
 		},
 	}
 
+	// TODO: Use testutils.CreateApplication
 	jsonData, err := json.Marshal(app)
 	if err != nil {
 		ts.T().Fatalf("Failed to marshal application data: %v", err)
@@ -128,6 +156,7 @@ func (ts *AuthzTestSuite) SetupSuite() {
 		"parent":      nil,
 	}
 
+	// TODO: Use testutils.CreateOrganizationUnit
 	ouJSON, err := json.Marshal(ouData)
 	if err != nil {
 		ts.T().Fatalf("Failed to marshal OU data: %v", err)
@@ -161,29 +190,27 @@ func (ts *AuthzTestSuite) SetupSuite() {
 }
 
 func (ts *AuthzTestSuite) TearDownSuite() {
-	if ts.applicationID == "" {
-		return
-	}
+	if ts.applicationID != "" {
+		req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/applications/%s", testServerURL, ts.applicationID), nil)
+		if err != nil {
+			ts.T().Errorf("Failed to create delete request: %v", err)
+			return
+		}
 
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/applications/%s", testServerURL, ts.applicationID), nil)
-	if err != nil {
-		ts.T().Errorf("Failed to create delete request: %v", err)
-		return
-	}
+		resp, err := ts.client.Do(req)
+		if err != nil {
+			ts.T().Errorf("Failed to delete application: %v", err)
+			return
+		}
+		defer resp.Body.Close()
 
-	resp, err := ts.client.Do(req)
-	if err != nil {
-		ts.T().Errorf("Failed to delete application: %v", err)
-		return
-	}
-	defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			ts.T().Errorf("Failed to delete application. Status: %d", resp.StatusCode)
+			return
+		}
 
-	if resp.StatusCode != http.StatusNoContent {
-		ts.T().Errorf("Failed to delete application. Status: %d", resp.StatusCode)
-		return
+		ts.T().Logf("Successfully deleted test application with ID: %s", ts.applicationID)
 	}
-
-	ts.T().Logf("Successfully deleted test application with ID: %s", ts.applicationID)
 
 	// Delete test organization unit
 	if testOUID != "" {
@@ -204,6 +231,13 @@ func (ts *AuthzTestSuite) TearDownSuite() {
 			ts.T().Errorf("Failed to delete organization unit. Status: %d", ouResp.StatusCode)
 		} else {
 			ts.T().Logf("Successfully deleted test organization unit with ID: %s", testOUID)
+		}
+	}
+
+	if ts.userSchemaID != "" {
+		err := testutils.DeleteUserType(ts.userSchemaID)
+		if err != nil {
+			ts.T().Errorf("Failed to delete test user type: %v", err)
 		}
 	}
 

--- a/tests/integration/testutils/apiutils.go
+++ b/tests/integration/testutils/apiutils.go
@@ -40,6 +40,48 @@ func getHTTPClient() *http.Client {
 	}
 }
 
+// CreateUserType creates a user type via API and returns the schema ID
+func CreateUserType(schema UserSchema) (string, error) {
+	payload, err := json.Marshal(schema)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal user schema: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", TestServerURL+"/user-schemas", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var createdSchema map[string]interface{}
+	err = json.Unmarshal(bodyBytes, &createdSchema)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse response body: %w. Response: %s", err, string(bodyBytes))
+	}
+
+	schemaID, ok := createdSchema["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("response does not contain id or id is not a string. Response: %s", string(bodyBytes))
+	}
+	return schemaID, nil
+}
+
 // CreateUser creates a user via API and returns the user ID
 func CreateUser(user User) (string, error) {
 	userJSON, err := json.Marshal(user)
@@ -60,22 +102,48 @@ func CreateUser(user User) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
 	if resp.StatusCode != http.StatusCreated {
-		bodyBytes, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var createdUser map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&createdUser)
+	err = json.Unmarshal(bodyBytes, &createdUser)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse response body: %w", err)
+		return "", fmt.Errorf("failed to parse response body: %w. Response: %s", err, string(bodyBytes))
 	}
 
 	userID, ok := createdUser["id"].(string)
 	if !ok {
-		return "", fmt.Errorf("response does not contain id")
+		return "", fmt.Errorf("response does not contain id or id is not a string. Response: %s", string(bodyBytes))
 	}
 	return userID, nil
+}
+
+// DeleteUserType deletes a user type by ID
+func DeleteUserType(schemaID string) error {
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/user-schemas/%s", TestServerURL, schemaID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete user schema: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 204, got %d. Response: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
 }
 
 // DeleteUser deletes a user by ID
@@ -93,7 +161,8 @@ func DeleteUser(userID string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("expected status 204, got %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 204, got %d. Response: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }
@@ -179,20 +248,24 @@ func CreateApplication(app Application) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
 	if resp.StatusCode != http.StatusCreated {
-		responseBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(responseBody))
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var createdApp map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&createdApp)
+	err = json.Unmarshal(bodyBytes, &createdApp)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse response body: %w", err)
+		return "", fmt.Errorf("failed to parse response body: %w. Response: %s", err, string(bodyBytes))
 	}
 
 	appID, ok := createdApp["id"].(string)
 	if !ok {
-		return "", fmt.Errorf("response does not contain id")
+		return "", fmt.Errorf("response does not contain id or id is not a string. Response: %s", string(bodyBytes))
 	}
 	return appID, nil
 }
@@ -238,20 +311,24 @@ func CreateOrganizationUnit(ou OrganizationUnit) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
 	if resp.StatusCode != http.StatusCreated {
-		responseBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(responseBody))
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var createdOU map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&createdOU)
+	err = json.Unmarshal(bodyBytes, &createdOU)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse response body: %w", err)
+		return "", fmt.Errorf("failed to parse response body: %w. Response: %s", err, string(bodyBytes))
 	}
 
 	ouID, ok := createdOU["id"].(string)
 	if !ok {
-		return "", fmt.Errorf("response does not contain id")
+		return "", fmt.Errorf("response does not contain id or id is not a string. Response: %s", string(bodyBytes))
 	}
 	return ouID, nil
 }
@@ -325,20 +402,24 @@ func CreateIDP(idp IDP) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
 	if resp.StatusCode != http.StatusCreated {
-		responseBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(responseBody))
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var createdIDP map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&createdIDP)
+	err = json.Unmarshal(bodyBytes, &createdIDP)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse response body: %w", err)
+		return "", fmt.Errorf("failed to parse response body: %w. Response: %s", err, string(bodyBytes))
 	}
 
 	idpID, ok := createdIDP["id"].(string)
 	if !ok {
-		return "", fmt.Errorf("response does not contain id")
+		return "", fmt.Errorf("response does not contain id or id is not a string. Response: %s", string(bodyBytes))
 	}
 	return idpID, nil
 }

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -22,6 +22,13 @@ import (
 	"encoding/json"
 )
 
+// UserSchema represents a user schema (user type) definition
+type UserSchema struct {
+	ID     string                 `json:"id,omitempty"`
+	Name   string                 `json:"name"`
+	Schema map[string]interface{} `json:"schema"`
+}
+
 // User represents a user in the system
 type User struct {
 	ID               string          `json:"id"`

--- a/tests/integration/user/user_filter_test.go
+++ b/tests/integration/user/user_filter_test.go
@@ -31,6 +31,55 @@ import (
 
 var (
 	// Test users specifically for filtering tests
+	filterTestUserSchemas = []testutils.UserSchema{
+		{
+			Name: "employee",
+			Schema: map[string]interface{}{
+				"username": map[string]interface{}{"type": "string"},
+				"email":    map[string]interface{}{"type": "string"},
+				"age":      map[string]interface{}{"type": "number"},
+				"department": map[string]interface{}{
+					"type": "string",
+				},
+				"isActive": map[string]interface{}{"type": "boolean"},
+				"address": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"city": map[string]interface{}{"type": "string"},
+						"zip":  map[string]interface{}{"type": "string"},
+					},
+				},
+				"contactPreferences": map[string]interface{}{
+					"type":  "array",
+					"items": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+		{
+			Name: "customer",
+			Schema: map[string]interface{}{
+				"username": map[string]interface{}{"type": "string"},
+				"email":    map[string]interface{}{"type": "string"},
+				"age":      map[string]interface{}{"type": "number"},
+				"department": map[string]interface{}{
+					"type": "string",
+				},
+				"isActive": map[string]interface{}{"type": "boolean"},
+				"address": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"city": map[string]interface{}{"type": "string"},
+						"zip":  map[string]interface{}{"type": "string"},
+					},
+				},
+				"contactPreferences": map[string]interface{}{
+					"type":  "array",
+					"items": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+	}
+
 	filterTestUsers = []testutils.User{
 		{
 			Type:       "employee",
@@ -59,8 +108,9 @@ var (
 )
 
 var (
-	filterTestOUID    string
-	filterTestUserIDs []string
+	filterTestOUID      string
+	filterTestUserIDs   []string
+	filterTestSchemaIDs []string
 )
 
 type UserFilterTestSuite struct {
@@ -79,6 +129,15 @@ func (ts *UserFilterTestSuite) SetupSuite() {
 		ts.T().Fatalf("Failed to create organization unit during filter test setup: %v", err)
 	}
 	filterTestOUID = ouID
+
+	filterTestSchemaIDs = make([]string, 0, len(filterTestUserSchemas))
+	for _, schema := range filterTestUserSchemas {
+		schemaID, err := testutils.CreateUserType(schema)
+		if err != nil {
+			ts.T().Fatalf("Failed to create user schema during filter test setup: %v", err)
+		}
+		filterTestSchemaIDs = append(filterTestSchemaIDs, schemaID)
+	}
 
 	// Create test users for filtering
 	filterTestUserIDs = make([]string, 0, len(filterTestUsers))
@@ -107,6 +166,15 @@ func (ts *UserFilterTestSuite) TearDownSuite() {
 		err := deleteOrganizationUnit(filterTestOUID)
 		if err != nil {
 			ts.T().Logf("Failed to delete filter test organization unit during teardown: %v", err)
+		}
+	}
+
+	for _, schemaID := range filterTestSchemaIDs {
+		if schemaID == "" {
+			continue
+		}
+		if err := testutils.DeleteUserType(schemaID); err != nil {
+			ts.T().Logf("Failed to delete filter test user schema during teardown: %v", err)
 		}
 	}
 }

--- a/tests/integration/user/userapi_test.go
+++ b/tests/integration/user/userapi_test.go
@@ -57,6 +57,24 @@ type groupCreateResponse struct {
 }
 
 var (
+	userSchema = testutils.UserSchema{
+		Name: "person",
+		Schema: map[string]interface{}{
+			"age": map[string]interface{}{"type": "number"},
+			"roles": map[string]interface{}{
+				"type":  "array",
+				"items": map[string]interface{}{"type": "string"},
+			},
+			"address": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"city": map[string]interface{}{"type": "string"},
+					"zip":  map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+	}
+
 	testUser = testutils.User{
 		Type:       "person",
 		Attributes: json.RawMessage(`{"age": 25, "roles": ["viewer"], "address": {"city": "Seattle", "zip": "98101"}}`),
@@ -84,6 +102,7 @@ var (
 	createdUserID  string
 	testOUID       string
 	createdGroupID string
+	userSchemaID   string
 )
 
 type UserAPITestSuite struct {
@@ -103,6 +122,12 @@ func (ts *UserAPITestSuite) SetupSuite() {
 		ts.T().Fatalf("Failed to create organization unit during setup: %v", err)
 	}
 	testOUID = ouID
+
+	schemaID, err := testutils.CreateUserType(userSchema)
+	if err != nil {
+		ts.T().Fatalf("Failed to create user schema during setup: %v", err)
+	}
+	userSchemaID = schemaID
 
 	// Update user template with the created OU ID
 	testUser := testUser
@@ -155,6 +180,12 @@ func (ts *UserAPITestSuite) TearDownSuite() {
 		err := deleteOrganizationUnit(testOUID)
 		if err != nil {
 			ts.T().Logf("Failed to delete organization unit during teardown: %v", err)
+		}
+	}
+
+	if userSchemaID != "" {
+		if err := testutils.DeleteUserType(userSchemaID); err != nil {
+			ts.T().Logf("Failed to delete user schema during teardown: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
## Purpose
Properly defining user schema's for each user creation/update operations as a prequisite for:
* https://github.com/asgardeo/thunder/issues/412