### PR TITLE
Update node pre-requisite in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ To try out the Client Credentials flow, follow these steps:
 ### Prerequisites
 
 - Go 1.25+
-- Node.js 20+
+- Node.js 24+
 
 ---
 
@@ -352,7 +352,7 @@ To try out the Client Credentials flow, follow these steps:
 ### Prerequisites
 
 - Go 1.24+
-- Node.js 20+
+- Node.js 24+
 
 ### Start Thunder in Development Mode
 


### PR DESCRIPTION
## Purpose
This pull request updates the documentation to reflect a change in the Node.js version requirement for development. The minimum required Node.js version has been increased from 20+ to 24+ in both relevant prerequisite sections.

Documentation updates:

* Updated the Node.js version requirement from 20+ to 24+ in the prerequisites for trying out the Client Credentials flow in `README.md`.
* Updated the Node.js version requirement from 20+ to 24+ in the general prerequisites section for starting Thunder in development mode in `README.md`.