### PR TITLE
Add collapsible sidebar for thunder-develop app

### DIFF
--- a/frontend/apps/thunder-develop/src/components/Sidebar/MenuContent.tsx
+++ b/frontend/apps/thunder-develop/src/components/Sidebar/MenuContent.tsx
@@ -17,15 +17,17 @@
  */
 
 import {NavLink} from 'react-router';
-import {List, ListItem, ListItemButton, ListItemIcon, ListItemText, Stack} from '@wso2/oxygen-ui';
+import {List, ListItem, ListItemButton, ListItemIcon, ListItemText, Stack, Tooltip} from '@wso2/oxygen-ui';
 import {Blocks, LayoutGrid, User, UsersRound} from 'lucide-react';
-import {useMemo, type JSX} from 'react';
+import {useContext, useMemo, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import useNavigation from '@/layouts/contexts/useNavigation';
+import SidebarContext from './context/SidebarContext';
 
 export default function MenuContent(): JSX.Element {
   const {currentPage, setCurrentPage} = useNavigation();
   const {t} = useTranslation();
+  const {mini} = useContext(SidebarContext);
 
   const mainListItems = useMemo(
     () => [
@@ -70,15 +72,36 @@ export default function MenuContent(): JSX.Element {
       <List dense>
         {mainListItems.map((item) => (
           <ListItem key={item.id} disablePadding sx={{display: 'block'}}>
-            <ListItemButton
-              component={NavLink}
-              to={item.path}
-              selected={currentPage === item.id}
-              onClick={() => handleListItemClick(item)}
-            >
-              <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.text} />
-            </ListItemButton>
+            <Tooltip title={mini ? item.text : ''} placement="right" arrow>
+              <ListItemButton
+                component={NavLink}
+                to={item.path}
+                selected={currentPage === item.id}
+                onClick={() => handleListItemClick(item)}
+                sx={{
+                  minHeight: 48,
+                  justifyContent: mini ? 'center' : 'initial',
+                  px: 2.5,
+                }}
+              >
+                <ListItemIcon
+                  sx={{
+                    minWidth: 0,
+                    mr: mini ? 'auto' : 3,
+                    justifyContent: 'center',
+                  }}
+                >
+                  {item.icon}
+                </ListItemIcon>
+                <ListItemText
+                  primary={item.text}
+                  sx={{
+                    opacity: mini ? 0 : 1,
+                    display: mini ? 'none' : 'block',
+                  }}
+                />
+              </ListItemButton>
+            </Tooltip>
           </ListItem>
         ))}
       </List>

--- a/frontend/apps/thunder-develop/src/components/Sidebar/SideMenu.tsx
+++ b/frontend/apps/thunder-develop/src/components/Sidebar/SideMenu.tsx
@@ -16,100 +16,210 @@
  * under the License.
  */
 
-import {styled, Avatar, Drawer as MuiDrawer, drawerClasses, Box, Divider, Stack, Typography} from '@wso2/oxygen-ui';
+import {Avatar, Drawer, drawerClasses, Box, Divider, Stack, Typography, IconButton, useTheme} from '@wso2/oxygen-ui';
 import {User} from '@asgardeo/react';
 import {ThemedIcon} from '@thunder/ui';
-import type {JSX} from 'react';
+import {List, ListCollapse} from 'lucide-react';
+import {useState, useEffect, useMemo, type JSX} from 'react';
 import MenuContent from './MenuContent';
 import OptionsMenu from './OptionsMenu';
+import SidebarContext from './context/SidebarContext';
+import {DRAWER_WIDTH, MINI_DRAWER_WIDTH} from './constants';
 
-const drawerWidth = 240;
+export interface SideMenuProps {
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  disableCollapsible?: boolean;
+}
 
-const Drawer = styled(MuiDrawer)({
-  width: drawerWidth,
-  flexShrink: 0,
-  boxSizing: 'border-box',
-  mt: 10,
-  [`& .${drawerClasses.paper}`]: {
-    width: drawerWidth,
-    boxSizing: 'border-box',
-  },
-});
+export default function SideMenu({
+  expanded: controlledExpanded,
+  onExpandedChange,
+  disableCollapsible = false,
+}: SideMenuProps = {}): JSX.Element {
+  const theme = useTheme();
+  const [internalExpanded, setInternalExpanded] = useState(true);
+  const expanded = controlledExpanded ?? internalExpanded;
 
-export default function SideMenu(): JSX.Element {
+  const [isFullyExpanded, setIsFullyExpanded] = useState(expanded);
+  const [isFullyCollapsed, setIsFullyCollapsed] = useState(!expanded);
+
+  useEffect(() => {
+    if (expanded) {
+      const drawerWidthTransitionTimeout = setTimeout(() => {
+        setIsFullyExpanded(true);
+      }, theme.transitions.duration.enteringScreen);
+
+      return () => clearTimeout(drawerWidthTransitionTimeout);
+    }
+
+    setIsFullyExpanded(false);
+
+    return () => {};
+  }, [expanded, theme.transitions.duration.enteringScreen]);
+
+  useEffect(() => {
+    if (!expanded) {
+      const drawerWidthTransitionTimeout = setTimeout(() => {
+        setIsFullyCollapsed(true);
+      }, theme.transitions.duration.leavingScreen);
+
+      return () => clearTimeout(drawerWidthTransitionTimeout);
+    }
+
+    setIsFullyCollapsed(false);
+
+    return () => {};
+  }, [expanded, theme.transitions.duration.leavingScreen]);
+
+  const mini = !disableCollapsible && !expanded;
+
+  const handleToggle = () => {
+    const newExpanded = !expanded;
+    if (onExpandedChange) {
+      onExpandedChange(newExpanded);
+    } else {
+      setInternalExpanded(newExpanded);
+    }
+  };
+
+  const sidebarContextValue = useMemo(
+    () => ({
+      mini,
+      fullyExpanded: isFullyExpanded,
+      fullyCollapsed: isFullyCollapsed,
+      hasDrawerTransitions: true,
+    }),
+    [mini, isFullyExpanded, isFullyCollapsed],
+  );
+
+  const drawerWidth = mini ? MINI_DRAWER_WIDTH : DRAWER_WIDTH;
+
   return (
-    <Drawer
-      variant="permanent"
-      sx={{
-        display: {xs: 'none', md: 'block'},
-        [`& .${drawerClasses.paper}`]: {
-          borderRadius: "0 !important",
-        },
-      }}
-    >
-      <Box
+    <SidebarContext.Provider value={sidebarContextValue}>
+      <Drawer
+        variant="permanent"
+        open
         sx={{
-          display: 'flex',
-          mt: 'calc(var(--template-frame-height, 0px) + 4px)',
-          p: 1.5,
-          justifyContent: 'center',
-          alignItems: 'center'
+          display: {xs: 'none', md: 'block'},
+          width: drawerWidth,
+          flexShrink: 0,
+          boxSizing: 'border-box',
+          whiteSpace: 'nowrap',
+          transition: (t) =>
+            t.transitions.create('width', {
+              easing: t.transitions.easing.sharp,
+              duration: expanded ? t.transitions.duration.enteringScreen : t.transitions.duration.leavingScreen,
+            }),
+          [`& .${drawerClasses.paper}`]: {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+            overflowX: 'hidden',
+            borderRadius: '0 !important',
+            transition: (t) =>
+              t.transitions.create('width', {
+                easing: t.transitions.easing.sharp,
+                duration: expanded ? t.transitions.duration.enteringScreen : t.transitions.duration.leavingScreen,
+              }),
+          },
         }}
       >
-        <ThemedIcon
-          src={{
-            light: `${import.meta.env.BASE_URL}/assets/images/logo.svg`,
-            dark: `${import.meta.env.BASE_URL}/assets/images/logo-inverted.svg`,
+        <Box
+          sx={{
+            display: 'flex',
+            mt: 'calc(var(--template-frame-height, 0px) + 4px)',
+            p: 1.5,
+            justifyContent: mini ? 'center' : 'space-between',
+            alignItems: 'center',
+            overflow: 'hidden',
           }}
-          alt={{light: 'Logo (Light)', dark: 'Logo (Dark)'}}
-          height={16}
-          width="auto"
-          alignItems="center"
-        />
-        <Typography variant="h6" sx={{mt: '4px', ml: 1, alignSelf: 'center', fontWeight: 400}}>
-          Develop
-        </Typography>
-      </Box>
-      <Divider />
-      <Box
-        sx={{
-          overflow: 'auto',
-          height: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        <MenuContent />
-      </Box>
-      <Stack
-        direction="row"
-        sx={{
-          p: 2,
-          gap: 1,
-          alignItems: 'center',
-          borderTop: '1px solid',
-          borderColor: 'divider',
-        }}
-      >
-        <User>
-          {(user) => (
-            <>
-              <Avatar sizes="small" alt={user?.name as string} sx={{width: 36, height: 36}}>
-                {(user?.name as string)?.charAt(0).toUpperCase()}
-              </Avatar>
-              <Box sx={{mr: 'auto'}}>
-                <Typography variant="body2" sx={{fontWeight: 500, lineHeight: '16px'}}>
-                  {user?.name}
-                </Typography>
-                <Typography variant="caption" sx={{color: 'text.secondary'}}>
-                  {user?.email}
-                </Typography>
-              </Box>
-              <OptionsMenu />
-            </>
+        >
+          {mini ? (
+            !disableCollapsible && (
+              <IconButton onClick={handleToggle} size="small" aria-label="Expand sidebar">
+                <List size={20} />
+              </IconButton>
+            )
+          ) : (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            >
+              {!disableCollapsible && (
+                <IconButton onClick={handleToggle} size="small" aria-label="Collapse sidebar" sx={{mr: 1}}>
+                  <ListCollapse size={20} />
+                </IconButton>
+              )}
+              <ThemedIcon
+                src={{
+                  light: `${import.meta.env.BASE_URL}/assets/images/logo.svg`,
+                  dark: `${import.meta.env.BASE_URL}/assets/images/logo-inverted.svg`,
+                }}
+                alt={{light: 'Logo (Light)', dark: 'Logo (Dark)'}}
+                height={16}
+                width="auto"
+                alignItems="center"
+                marginBottom="4px"
+              />
+              <Typography
+                variant="h6"
+                sx={{ml: 1, alignSelf: 'center', fontSize: 14, fontWeight: 400, whiteSpace: 'nowrap'}}
+              >
+                Develop
+              </Typography>
+            </Box>
           )}
-        </User>
-      </Stack>
-    </Drawer>
+        </Box>
+        <Divider />
+        <Box
+          sx={{
+            overflow: 'auto',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            scrollbarGutter: mini ? 'stable' : 'auto',
+            overflowX: 'hidden',
+          }}
+        >
+          <MenuContent />
+        </Box>
+        <Stack
+          direction="row"
+          sx={{
+            p: 2,
+            gap: 1,
+            alignItems: 'center',
+            borderTop: '1px solid',
+            borderColor: 'divider',
+            justifyContent: mini ? 'center' : 'flex-start',
+          }}
+        >
+          <User>
+            {(user) => (
+              <>
+                <Avatar sizes="small" alt={user?.name as string} sx={{width: 36, height: 36}}>
+                  {(user?.name as string)?.charAt(0).toUpperCase()}
+                </Avatar>
+                {!mini && (
+                  <>
+                    <Box sx={{mr: 'auto'}}>
+                      <Typography variant="body2" sx={{fontWeight: 500, lineHeight: '16px'}}>
+                        {user?.name}
+                      </Typography>
+                      <Typography variant="caption" sx={{color: 'text.secondary'}}>
+                        {user?.email}
+                      </Typography>
+                    </Box>
+                    <OptionsMenu />
+                  </>
+                )}
+              </>
+            )}
+          </User>
+        </Stack>
+      </Drawer>
+    </SidebarContext.Provider>
   );
 }

--- a/frontend/apps/thunder-develop/src/components/Sidebar/constants.ts
+++ b/frontend/apps/thunder-develop/src/components/Sidebar/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const DRAWER_WIDTH = 240;
+export const MINI_DRAWER_WIDTH = 64;

--- a/frontend/apps/thunder-develop/src/components/Sidebar/context/SidebarContext.tsx
+++ b/frontend/apps/thunder-develop/src/components/Sidebar/context/SidebarContext.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {createContext} from 'react';
+
+/**
+ * Context value for the sidebar component, providing state information
+ * about the sidebar's expansion and animation states.
+ */
+export interface SidebarContextValue {
+  /**
+   * Indicates whether the sidebar is in mini (collapsed) mode.
+   * When true, the sidebar shows only icons without text.
+   * This is true when the sidebar is collapsed AND collapsible functionality is enabled.
+   */
+  mini: boolean;
+
+  /**
+   * Indicates whether the sidebar has fully completed its expansion animation.
+   * Use this to conditionally render content that should only appear after
+   * the expansion transition is complete (e.g., text labels with opacity transitions).
+   */
+  fullyExpanded: boolean;
+
+  /**
+   * Indicates whether the sidebar has fully completed its collapse animation.
+   * Use this to conditionally render content that should only appear after
+   * the collapse transition is complete.
+   */
+  fullyCollapsed: boolean;
+
+  /**
+   * Indicates whether drawer transitions are enabled.
+   * Typically true for desktop viewports where smooth transitions enhance UX,
+   * and may be false for mobile/tablet to avoid transition conflicts.
+   */
+  hasDrawerTransitions: boolean;
+}
+
+/**
+ * Context for sharing sidebar state across child components.
+ * Allows components like MenuContent to adapt their rendering based on
+ * whether the sidebar is expanded, collapsed, or mid-transition.
+ */
+const SidebarContext = createContext<SidebarContextValue>({
+  mini: false,
+  fullyExpanded: true,
+  fullyCollapsed: false,
+  hasDrawerTransitions: true,
+});
+
+export default SidebarContext;


### PR DESCRIPTION
## Purpose

This pull request introduces a major refactor of the `SideMenu` sidebar component to support a collapsible (mini) sidebar mode, improve accessibility, and enhance test coverage. The sidebar can now be expanded or collapsed, either in a controlled or uncontrolled way, and exposes its state via a new React context. The UI adapts responsively, hiding or showing content as appropriate, and the test suite has been significantly expanded to cover all new behaviors.

**Sidebar collapsibility and context:**

* Refactored `SideMenu` to support both controlled and uncontrolled expanded/collapsed states, with new props (`expanded`, `onExpandedChange`, `disableCollapsible`). Added logic to animate transitions and manage internal state. [[1]](diffhunk://#diff-001d3c7c73d8441ed39f6ba8244cd4b667630acbc7b20b41f17562bb9fe2f196L19-R124) [[2]](diffhunk://#diff-001d3c7c73d8441ed39f6ba8244cd4b667630acbc7b20b41f17562bb9fe2f196L55-R155)
* Introduced `SidebarContext` (with `mini`, `fullyExpanded`, `fullyCollapsed`, `hasDrawerTransitions`) to provide sidebar state to descendant components. 

**UI/UX improvements:**

* Updated sidebar UI to show/hide logo, title, user info, and options menu based on collapsed state. Added expand/collapse buttons with accessible labels. Adapted `MenuContent` to use tooltips and hide text when in mini mode. 

**Testing enhancements:**

* Greatly expanded test suite for `SideMenu` to cover collapsibility, context, controlled/uncontrolled usage, accessibility, and visual state. Added tests for expand/collapse buttons, content visibility, and drawer width. 
These changes make the sidebar more flexible, accessible, and robust, and set up a foundation for further enhancements.