### PR TITLE
Add support to exchange auth assertions to access tokens

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -57,7 +57,8 @@
   },
   "jwt": {
     "issuer": "thunder",
-    "validity_period": 3600
+    "validity_period": 3600,
+    "audience": "application"
   },
   "oauth": {
     "refresh_token": {

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -346,7 +346,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(authResponse *co
 
 	// Generate auth assertion JWT
 	jwtConfig := config.GetThunderRuntime().Config.JWT
-	token, _, err := as.jwtService.GenerateJWT(user.ID, "application", jwtConfig.Issuer,
+	token, _, err := as.jwtService.GenerateJWT(user.ID, jwtConfig.Audience, jwtConfig.Issuer,
 		jwtConfig.ValidityPeriod, jwtClaims)
 	if err != nil {
 		logger.Error("Failed to generate auth assertion", log.Error(err))

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -83,6 +83,7 @@ func (suite *AuthenticationServiceTestSuite) SetupSuite() {
 		JWT: config.JWTConfig{
 			Issuer:         "test-issuer",
 			ValidityPeriod: 3600,
+			Audience:       "application",
 		},
 	}
 	err := config.InitializeThunderRuntime("", testConfig)

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -179,10 +179,14 @@ type TokenTypeIdentifier string
 
 // RFC 8693 Token Type Identifiers
 const (
-	TokenTypeIdentifierAccessToken  TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:access_token"  //nolint:gosec
-	TokenTypeIdentifierRefreshToken TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:refresh_token" //nolint:gosec
-	TokenTypeIdentifierIDToken      TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:id_token"      //nolint:gosec
-	TokenTypeIdentifierJWT          TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:jwt"           //nolint:gosec
+	//nolint:gosec // Token type identifier, not a credential
+	TokenTypeIdentifierAccessToken TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:access_token"
+	//nolint:gosec // Token type identifier, not a credential
+	TokenTypeIdentifierRefreshToken TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:refresh_token"
+	//nolint:gosec // Token type identifier, not a credential
+	TokenTypeIdentifierIDToken TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:id_token"
+	//nolint:gosec // Token type identifier, not a credential
+	TokenTypeIdentifierJWT TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:jwt"
 )
 
 // supportedTokenTypeIdentifiers is the single source of truth for all supported token type identifiers.

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -38,6 +38,7 @@ const (
 	testRefreshToken = "test-refresh-token" //nolint:gosec // Test token, not a real credential
 	testIDToken      = "test-id-token"      //nolint:gosec // Test token, not a real credential
 	testUserName     = "John Doe"
+	testAppID        = "app123"
 )
 
 type TokenBuilderTestSuite struct {
@@ -415,7 +416,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["scope"] == "read write" &&
 				claims["access_token_sub"] == "user123" &&
-				claims["access_token_aud"] == "app123" &&
+				claims["access_token_aud"] == testAppID &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["access_token_user_attributes"].(map[string]interface{})["name"] == testUserName
 		}),

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -128,18 +128,27 @@ func extractInt64Claim(claims map[string]interface{}, key string) (int64, error)
 }
 
 // extractScopesFromClaims extracts and parses scopes from a claims map.
-func extractScopesFromClaims(claims map[string]interface{}) []string {
+func extractScopesFromClaims(claims map[string]interface{}, isAuthAssertion bool) []string {
 	scopeValue, ok := claims["scope"]
-	if !ok {
-		return []string{}
+	if ok {
+		scopeString, ok := scopeValue.(string)
+		if ok && scopeString != "" {
+			return ParseScopes(scopeString)
+		}
 	}
 
-	scopeString, ok := scopeValue.(string)
-	if !ok {
-		return []string{}
+	// This allows auth assertions with authorized_permissions to be used in token exchange
+	if isAuthAssertion {
+		authorizedPermsValue, ok := claims["authorized_permissions"]
+		if ok {
+			authorizedPermsString, ok := authorizedPermsValue.(string)
+			if ok && authorizedPermsString != "" {
+				return ParseScopes(authorizedPermsString)
+			}
+		}
 	}
 
-	return ParseScopes(scopeString)
+	return []string{}
 }
 
 // DetermineAudience determines the audience for a token based on priority.

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -100,6 +100,7 @@ type CacheConfig struct {
 type JWTConfig struct {
 	Issuer         string `yaml:"issuer" json:"issuer"`
 	ValidityPeriod int64  `yaml:"validity_period" json:"validity_period"`
+	Audience       string `yaml:"audience" json:"audience"`
 }
 
 // RefreshTokenConfig holds the refresh token configuration details.

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -191,6 +191,7 @@ The following table lists the configurable parameters of the Thunder chart and t
 | `configuration.cache.cleanupInterval`  | Cache cleanup interval in seconds                               | `300`                        |
 | `configuration.jwt.issuer`             | JWT issuer                                                      | `thunder`                    |
 | `configuration.jwt.validityPeriod`     | JWT validity period in seconds                                  | `3600`                       |
+| `configuration.jwt.audience`           | Default audience for auth assertions                            | `application`                |
 | `configuration.oauth.refreshToken.renewOnGrant` | Renew refresh token on grant                           | `false`                      |
 | `configuration.oauth.refreshToken.validityPeriod` | Refresh token validity period in seconds             | `86400`                      |
 | `configuration.flow.graphDirectory`    | Flow graph directory                                            | `repository/resources/graphs/` |

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -69,6 +69,7 @@ cache:
 jwt:
   issuer: {{ .Values.configuration.jwt.issuer | quote }}
   validity_period: {{ .Values.configuration.jwt.validityPeriod }}
+  audience: {{ .Values.configuration.jwt.audience | quote }}
 
 oauth:
   refresh_token:

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -174,6 +174,7 @@ configuration:
   jwt:
     issuer: "thunder"
     validityPeriod: 3600
+    audience: "application"
 
   # OAuth configuration
   oauth:


### PR DESCRIPTION
## Purpose

This pull request introduces improvements to Thunder's OAuth2 token handling, with a focus on supporting Thunder authentication assertions and audience validation. The main changes include stricter audience checks for JWT-based assertions, enhanced scope extraction logic, and updates to configuration and tests to support these features.

## Approach

**Thunder Auth Assertion Support and Audience Validation:**

* Added logic to identify Thunder authentication assertions in JWT tokens and require the `aud` (audience) claim to match the configured default audience from `JWTConfig`. This enforces stricter validation for tokens used in token exchange flows. [[1]](diffhunk://#diff-ef8e3cff68ea3a4ac66f0ee805abcd05c771536d7c66506883aff62d976e76cfR119-L126) [[2]](diffhunk://#diff-ef8e3cff68ea3a4ac66f0ee805abcd05c771536d7c66506883aff62d976e76cfR228-R239) [[3]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR102) [[4]](diffhunk://#diff-beec713bb8f44ef8633de8d745de6dcd555593b5cd0758d7788470fee3b2d974L59-R60)

* Updated scope extraction logic to support `authorized_permissions` as an alternative to `scope` for Thunder auth assertions, ensuring correct permissions mapping during token exchange. [[1]](diffhunk://#diff-7fac18f248ec76631f539f74b8f48c45d14f03a3af8d3ad2e7313cd87b934280L130-R150) [[2]](diffhunk://#diff-ef8e3cff68ea3a4ac66f0ee805abcd05c771536d7c66506883aff62d976e76cfL67-R68) [[3]](diffhunk://#diff-9cf5f758280a4ba701f1c00ba69b8bef27fe08ae78fa88771e9796942a76e844L527-R527)

**Configuration and Constants Updates:**

* Added an `audience` field to the `JWTConfig` struct and updated the default configuration in `default.json` to include this field. [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR102) [[2]](diffhunk://#diff-beec713bb8f44ef8633de8d745de6dcd555593b5cd0758d7788470fee3b2d974L59-R60)

* Improved comments and formatting for token type identifiers to clarify their usage and suppress security linting warnings.

**Testing Enhancements:**

* Added comprehensive test cases for Thunder authentication assertions, covering success, audience mismatch, missing audience, and client ID matching scenarios. These tests validate the new assertion handling logic in the token exchange grant handler.

* Updated tests and mocks to reflect changes in scope extraction and configuration, including new constants and improved mock function signatures for authentication service. [[1]](diffhunk://#diff-8276502870b096bf0083b464c29debde17f11b4c176293395d9dbb8f4d64fcdfR41) [[2]](diffhunk://#diff-8276502870b096bf0083b464c29debde17f11b4c176293395d9dbb8f4d64fcdfL418-R419) [[3]](diffhunk://#diff-24d76d122ff9e5aa64854979f68bcfbe5ea929e6b6e2729ba8104316b33d8696L44-R64) [[4]](diffhunk://#diff-24d76d122ff9e5aa64854979f68bcfbe5ea929e6b6e2729ba8104316b33d8696L82-R87) [[5]](diffhunk://#diff-24d76d122ff9e5aa64854979f68bcfbe5ea929e6b6e2729ba8104316b33d8696R101-R109)

## Related issue

- https://github.com/asgardeo/thunder/issues/716