### PR TITLE
Add immutable config export support for applications

### DIFF
--- a/backend/cmd/server/repository/conf/immutable_resources/applications/application_1.yaml
+++ b/backend/cmd/server/repository/conf/immutable_resources/applications/application_1.yaml
@@ -13,10 +13,12 @@ user_attributes:
 inbound_auth_config:
   - type: "oauth2"
     config:
-      client_id: "${{CLIENT_ID}}"
-      client_secret: "${{CLIENT_SECRET}}"
+      client_id: "{{ .CLIENT_ID }}"
+      client_secret: "{{ .CLIENT_SECRET }}"
       redirect_uris:
-        - "$REDIRECT_URI"
+        {{- range .REDIRECT_URIS}}
+          - {{.}}
+        {{- end}}
       grant_types:
         - "authorization_code"
         - "client_credentials"

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -37,6 +37,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth"
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/role"
+	"github.com/asgardeo/thunder/internal/system/export"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/services"
@@ -73,6 +74,9 @@ func registerServices(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) {
 	certservice := cert.Initialize()
 	brandingService := branding.Initialize(mux)
 	applicationService := application.Initialize(mux, certservice, flowMgtService, brandingService, userSchemaService)
+
+	// Initialize export service with application service dependency
+	_ = export.Initialize(mux, applicationService)
 
 	flowExecService := flowexec.Initialize(mux, flowMgtService, applicationService, execRegistry)
 

--- a/backend/internal/application/init.go
+++ b/backend/internal/application/init.go
@@ -66,7 +66,8 @@ func Initialize(
 			}
 			validatedApp, _, svcErr := appService.ValidateApplication(appDTO)
 			if svcErr != nil {
-				logger.Fatal("Error validating application", log.String("applicationName", appDTO.Name))
+				logger.Fatal("Error validating application",
+					log.String("applicationName", appDTO.Name), log.Any("serviceError", svcErr))
 			}
 
 			err = appStore.CreateApplication(*validatedApp)
@@ -83,13 +84,14 @@ func Initialize(
 }
 
 func parseToApplicationDTO(data []byte) (*model.ApplicationDTO, error) {
-	var appRequest model.ApplicationRequest
+	var appRequest model.ApplicationRequestWithID
 	err := yaml.Unmarshal(data, &appRequest)
 	if err != nil {
 		return nil, err
 	}
 
 	appDTO := model.ApplicationDTO{
+		ID:                        appRequest.ID,
 		Name:                      appRequest.Name,
 		Description:               appRequest.Description,
 		AuthFlowGraphID:           appRequest.AuthFlowGraphID,

--- a/backend/internal/application/model/application.go
+++ b/backend/internal/application/model/application.go
@@ -25,30 +25,30 @@ import (
 
 // TokenConfig represents the token configuration structure for application-level (root) token configs.
 type TokenConfig struct {
-	Issuer         string   `json:"issuer"`
-	ValidityPeriod int64    `json:"validity_period"`
-	UserAttributes []string `json:"user_attributes"`
+	Issuer         string   `json:"issuer" yaml:"issuer,omitempty"`
+	ValidityPeriod int64    `json:"validity_period" yaml:"validity_period,omitempty"`
+	UserAttributes []string `json:"user_attributes" yaml:"user_attributes,omitempty"`
 }
 
 // AccessTokenConfig represents the access token configuration structure.
 type AccessTokenConfig struct {
-	ValidityPeriod int64    `json:"validity_period"`
-	UserAttributes []string `json:"user_attributes"`
+	ValidityPeriod int64    `json:"validity_period" yaml:"validity_period,omitempty"`
+	UserAttributes []string `json:"user_attributes" yaml:"user_attributes,omitempty"`
 }
 
 // IDTokenConfig represents the ID token configuration structure.
 type IDTokenConfig struct {
-	ValidityPeriod int64               `json:"validity_period"`
-	UserAttributes []string            `json:"user_attributes"`
-	ScopeClaims    map[string][]string `json:"scope_claims"`
+	ValidityPeriod int64               `json:"validity_period" yaml:"validity_period,omitempty"`
+	UserAttributes []string            `json:"user_attributes" yaml:"user_attributes,omitempty"`
+	ScopeClaims    map[string][]string `json:"scope_claims,omitempty" yaml:"scope_claims,omitempty"`
 }
 
 // OAuthTokenConfig represents the OAuth token configuration structure with access_token and id_token wrappers.
 // The Issuer field at this level is used by both access and ID tokens.
 type OAuthTokenConfig struct {
-	Issuer      string             `json:"issuer,omitempty"`
-	AccessToken *AccessTokenConfig `json:"access_token,omitempty"`
-	IDToken     *IDTokenConfig     `json:"id_token,omitempty"`
+	Issuer      string             `json:"issuer,omitempty" yaml:"issuer,omitempty"`
+	AccessToken *AccessTokenConfig `json:"access_token,omitempty" yaml:"access_token,omitempty"`
+	IDToken     *IDTokenConfig     `json:"id_token,omitempty" yaml:"id_token,omitempty"`
 }
 
 // ApplicationDTO represents the data transfer object for application service operations.
@@ -86,26 +86,48 @@ type BasicApplicationDTO struct {
 	LogoURL                   string
 }
 
-// ApplicationProcessedDTO represents the processed data transfer object for application service operations.
-type ApplicationProcessedDTO struct {
-	ID                        string
-	Name                      string
-	Description               string
-	AuthFlowGraphID           string
-	RegistrationFlowGraphID   string
-	IsRegistrationFlowEnabled bool
-	BrandingID                string
+// Application represents the structure for application which returns in GetApplicationById.
+type Application struct {
+	ID                        string `yaml:"id,omitempty"`
+	Name                      string `yaml:"name,omitempty"`
+	Description               string `yaml:"description,omitempty"`
+	AuthFlowGraphID           string `yaml:"auth_flow_graph_id,omitempty"`
+	RegistrationFlowGraphID   string `yaml:"registration_flow_graph_id,omitempty"`
+	IsRegistrationFlowEnabled bool   `yaml:"is_registration_flow_enabled,omitempty"`
+	BrandingID                string `yaml:"branding_id,omitempty"`
 
-	URL       string
-	LogoURL   string
-	TosURI    string
-	PolicyURI string
+	URL       string `yaml:"url,omitempty"`
+	LogoURL   string `yaml:"logo_url,omitempty"`
+	TosURI    string `yaml:"tos_uri,omitempty"`
+	PolicyURI string `yaml:"policy_uri,omitempty"`
 	Contacts  []string
 
-	Token             *TokenConfig
-	Certificate       *ApplicationCertificate
-	InboundAuthConfig []InboundAuthConfigProcessedDTO
-	AllowedUserTypes  []string
+	Token             *TokenConfig                `yaml:"token,omitempty"`
+	Certificate       *ApplicationCertificate     `yaml:"certificate,omitempty"`
+	InboundAuthConfig []InboundAuthConfigComplete `yaml:"inbound_auth_config,omitempty"`
+	AllowedUserTypes  []string                    `yaml:"allowed_user_types,omitempty"`
+}
+
+// ApplicationProcessedDTO represents the processed data transfer object for application service operations.
+type ApplicationProcessedDTO struct {
+	ID                        string `yaml:"id,omitempty"`
+	Name                      string `yaml:"name,omitempty"`
+	Description               string `yaml:"description,omitempty"`
+	AuthFlowGraphID           string `yaml:"auth_flow_graph_id,omitempty"`
+	RegistrationFlowGraphID   string `yaml:"registration_flow_graph_id,omitempty"`
+	IsRegistrationFlowEnabled bool   `yaml:"is_registration_flow_enabled,omitempty"`
+	BrandingID                string `yaml:"branding_id,omitempty"`
+
+	URL       string `yaml:"url,omitempty"`
+	LogoURL   string `yaml:"logo_url,omitempty"`
+	TosURI    string `yaml:"tos_uri,omitempty"`
+	PolicyURI string `yaml:"policy_uri,omitempty"`
+	Contacts  []string
+
+	Token             *TokenConfig                    `yaml:"token,omitempty"`
+	Certificate       *ApplicationCertificate         `yaml:"certificate,omitempty"`
+	InboundAuthConfig []InboundAuthConfigProcessedDTO `yaml:"inbound_auth_config,omitempty"`
+	AllowedUserTypes  []string                        `yaml:"allowed_user_types,omitempty"`
 }
 
 // InboundAuthConfigDTO represents the data transfer object for inbound authentication configuration.
@@ -118,20 +140,42 @@ type InboundAuthConfigDTO struct {
 // InboundAuthConfigProcessedDTO represents the processed data transfer object for inbound authentication
 // configuration.
 type InboundAuthConfigProcessedDTO struct {
-	Type           InboundAuthType             `json:"type"`
-	OAuthAppConfig *OAuthAppConfigProcessedDTO `json:"oauth_app_config,omitempty"`
+	Type           InboundAuthType             `json:"type" yaml:"type,omitempty"`
+	OAuthAppConfig *OAuthAppConfigProcessedDTO `json:"oauth_app_config,omitempty" yaml:"config,omitempty"`
 }
 
 // ApplicationCertificate represents the certificate structure in the application request response.
 type ApplicationCertificate struct {
-	Type  cert.CertificateType `json:"type"`
-	Value string               `json:"value"`
+	Type  cert.CertificateType `json:"type" yaml:"type,omitempty"`
+	Value string               `json:"value" yaml:"value,omitempty"`
 }
 
 // ApplicationRequest represents the request structure for creating or updating an application.
 //
 //nolint:lll
 type ApplicationRequest struct {
+	Name                      string                      `json:"name" yaml:"name"`
+	Description               string                      `json:"description" yaml:"description"`
+	AuthFlowGraphID           string                      `json:"auth_flow_graph_id,omitempty" yaml:"auth_flow_graph_id,omitempty"`
+	RegistrationFlowGraphID   string                      `json:"registration_flow_graph_id,omitempty" yaml:"registration_flow_graph_id,omitempty"`
+	IsRegistrationFlowEnabled bool                        `json:"is_registration_flow_enabled" yaml:"is_registration_flow_enabled"`
+	BrandingID                string                      `json:"branding_id,omitempty" yaml:"branding_id,omitempty"`
+	URL                       string                      `json:"url,omitempty" yaml:"url,omitempty"`
+	LogoURL                   string                      `json:"logo_url,omitempty" yaml:"logo_url,omitempty"`
+	Token                     *TokenConfig                `json:"token,omitempty" yaml:"token,omitempty"`
+	Certificate               *ApplicationCertificate     `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	TosURI                    string                      `json:"tos_uri,omitempty" yaml:"tos_uri,omitempty"`
+	PolicyURI                 string                      `json:"policy_uri,omitempty" yaml:"policy_uri,omitempty"`
+	Contacts                  []string                    `json:"contacts,omitempty" yaml:"contacts,omitempty"`
+	InboundAuthConfig         []InboundAuthConfigComplete `json:"inbound_auth_config,omitempty" yaml:"inbound_auth_config,omitempty"`
+	AllowedUserTypes          []string                    `json:"allowed_user_types,omitempty" yaml:"allowed_user_types,omitempty"`
+}
+
+// ApplicationRequestWithID represents the request structure for importing an application using file based runtime.
+//
+//nolint:lll
+type ApplicationRequestWithID struct {
+	ID                        string                      `json:"id" yaml:"id"`
 	Name                      string                      `json:"name" yaml:"name"`
 	Description               string                      `json:"description" yaml:"description"`
 	AuthFlowGraphID           string                      `json:"auth_flow_graph_id,omitempty" yaml:"auth_flow_graph_id,omitempty"`

--- a/backend/internal/application/model/oauth_app.go
+++ b/backend/internal/application/model/oauth_app.go
@@ -48,7 +48,7 @@ type OAuthAppConfig struct {
 //nolint:lll
 type OAuthAppConfigComplete struct {
 	ClientID                string                              `json:"client_id" yaml:"client_id"`
-	ClientSecret            string                              `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	ClientSecret            string                              `json:"client_secret,omitempty" yaml:"client_secret"`
 	RedirectURIs            []string                            `json:"redirect_uris" yaml:"redirect_uris"`
 	GrantTypes              []oauth2const.GrantType             `json:"grant_types" yaml:"grant_types"`
 	ResponseTypes           []oauth2const.ResponseType          `json:"response_types" yaml:"response_types"`
@@ -96,17 +96,17 @@ func (o *OAuthAppConfigDTO) ValidateRedirectURI(redirectURI string) error {
 
 // OAuthAppConfigProcessedDTO represents the processed data transfer object for OAuth application configuration.
 type OAuthAppConfigProcessedDTO struct {
-	AppID                   string
-	ClientID                string
-	HashedClientSecret      string
-	RedirectURIs            []string
-	GrantTypes              []oauth2const.GrantType
-	ResponseTypes           []oauth2const.ResponseType
-	TokenEndpointAuthMethod oauth2const.TokenEndpointAuthMethod
-	PKCERequired            bool
-	PublicClient            bool
-	Token                   *OAuthTokenConfig
-	Scopes                  []string
+	AppID                   string                              `yaml:"app_id,omitempty"`
+	ClientID                string                              `yaml:"client_id,omitempty"`
+	HashedClientSecret      string                              `yaml:"hashed_client_secret,omitempty"`
+	RedirectURIs            []string                            `yaml:"redirect_uris,omitempty"`
+	GrantTypes              []oauth2const.GrantType             `yaml:"grant_types,omitempty"`
+	ResponseTypes           []oauth2const.ResponseType          `yaml:"response_types,omitempty"`
+	TokenEndpointAuthMethod oauth2const.TokenEndpointAuthMethod `yaml:"token_endpoint_auth_method,omitempty"`
+	PKCERequired            bool                                `yaml:"pkce_required,omitempty"`
+	PublicClient            bool                                `yaml:"public_client,omitempty"`
+	Token                   *OAuthTokenConfig                   `yaml:"token,omitempty"`
+	Scopes                  []string                            `yaml:"scopes,omitempty"`
 }
 
 // IsAllowedGrantType checks if the provided grant type is allowed.

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -36,7 +36,7 @@ type NodeContext struct {
 	UserInputData  map[string]string
 	RuntimeData    map[string]string
 
-	Application       appmodel.ApplicationProcessedDTO
+	Application       appmodel.Application
 	AuthenticatedUser authncm.AuthenticatedUser
 	ExecutionHistory  map[string]*common.NodeExecutionRecord
 }

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -121,7 +121,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 				EndTime:      1234567890,
 			},
 		},
-		Application: appmodel.ApplicationProcessedDTO{},
+		Application: appmodel.Application{},
 	}
 
 	suite.mockAssertGenerator.On("GenerateAssertion", mock.MatchedBy(func(refs []authncm.AuthenticatorReference) bool {
@@ -175,7 +175,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAuthorizedPermissions(
 			"authorized_permissions": "read:documents write:documents",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application:      appmodel.ApplicationProcessedDTO{},
+		Application:      appmodel.Application{},
 	}
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
@@ -207,7 +207,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserAttributes() {
 			Attributes:      map[string]interface{}{"email": "test@example.com"},
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application: appmodel.ApplicationProcessedDTO{
+		Application: appmodel.Application{
 			Token: &appmodel.TokenConfig{
 				UserAttributes: []string{"email", "phone"},
 			},
@@ -244,7 +244,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_JWTGenerationFails() {
 			UserID:          "user-123",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application:      appmodel.ApplicationProcessedDTO{},
+		Application:      appmodel.Application{},
 	}
 
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
@@ -274,7 +274,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AssertionGenerationFails_S
 				Step:         1,
 			},
 		},
-		Application: appmodel.ApplicationProcessedDTO{},
+		Application: appmodel.Application{},
 	}
 
 	suite.mockAssertGenerator.On("GenerateAssertion", mock.Anything).
@@ -412,7 +412,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 			OrganizationUnitID: "ou-456",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application:      appmodel.ApplicationProcessedDTO{},
+		Application:      appmodel.Application{},
 	}
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
@@ -440,7 +440,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithCustomTokenConfig() {
 			UserID:          "user-123",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application: appmodel.ApplicationProcessedDTO{
+		Application: appmodel.Application{
 			Token: &appmodel.TokenConfig{
 				Issuer:         "custom-issuer",
 				ValidityPeriod: 7200,
@@ -470,7 +470,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 			OrganizationUnitID: "ou-789",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application:      appmodel.ApplicationProcessedDTO{},
+		Application:      appmodel.Application{},
 	}
 
 	suite.mockOUService.On("GetOrganizationUnit", "ou-789").Return(ou.OrganizationUnit{
@@ -509,7 +509,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 			UserID:          "user-123",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application: appmodel.ApplicationProcessedDTO{
+		Application: appmodel.Application{
 			Token: &appmodel.TokenConfig{
 				UserAttributes: []string{"email"},
 			},
@@ -574,7 +574,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendOUDetailsToClaimsFai
 			OrganizationUnitID: "ou-123",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application:      appmodel.ApplicationProcessedDTO{},
+		Application:      appmodel.Application{},
 	}
 
 	suite.mockOUService.On("GetOrganizationUnit", "ou-123").
@@ -601,7 +601,7 @@ func (suite *AuthAssertExecutorTestSuite) TestAppendUserDetailsToClaims_GetUserA
 			Attributes:      map[string]interface{}{"email": "test@example.com"},
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application: appmodel.ApplicationProcessedDTO{
+		Application: appmodel.Application{
 			Token: &appmodel.TokenConfig{
 				UserAttributes: []string{"email", "phone"},
 			},
@@ -632,7 +632,7 @@ func (suite *AuthAssertExecutorTestSuite) TestAppendOUDetailsToClaims_GetOrganiz
 			OrganizationUnitID: "ou-invalid",
 		},
 		ExecutionHistory: map[string]*flowcm.NodeExecutionRecord{},
-		Application:      appmodel.ApplicationProcessedDTO{},
+		Application:      appmodel.Application{},
 	}
 
 	suite.mockOUService.On("GetOrganizationUnit", "ou-invalid").

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -41,7 +41,7 @@ type EngineContext struct {
 	CurrentActionID     string
 
 	Graph       core.GraphInterface
-	Application appmodel.ApplicationProcessedDTO
+	Application appmodel.Application
 
 	AuthenticatedUser authncm.AuthenticatedUser
 	ExecutionHistory  map[string]*common.NodeExecutionRecord

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -106,7 +106,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 	appID := "test-app-123"
 
 	// Mock application and graph - shared across all test cases
-	mockApp := &appmodel.ApplicationProcessedDTO{
+	mockApp := &appmodel.Application{
 		ID:              "app-id-123",
 		AuthFlowGraphID: "auth-graph-1",
 	}
@@ -277,7 +277,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 				mockFlowMgtSvc *flowmgtmock.FlowMgtServiceInterfaceMock,
 			) {
 				// Mock application service to return valid app
-				mockApp := &appmodel.ApplicationProcessedDTO{
+				mockApp := &appmodel.Application{
 					ID:              "app-id-123",
 					AuthFlowGraphID: "auth-graph-1",
 				}
@@ -297,7 +297,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 				mockFlowMgtSvc *flowmgtmock.FlowMgtServiceInterfaceMock,
 			) {
 				// Mock application service to return valid app
-				mockApp := &appmodel.ApplicationProcessedDTO{
+				mockApp := &appmodel.Application{
 					ID:              "app-id-123",
 					AuthFlowGraphID: "auth-graph-1",
 				}

--- a/backend/internal/system/export/error_constants.go
+++ b/backend/internal/system/export/error_constants.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import "github.com/asgardeo/thunder/internal/system/error/serviceerror"
+
+// Client errors for export operations.
+var (
+	// ErrorInvalidRequest is the error returned when an invalid export request is provided.
+	ErrorInvalidRequest = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "EXP-1001",
+		Error:            "Invalid export request",
+		ErrorDescription: "The provided export request is invalid or malformed",
+	}
+
+	// ErrorNoResourcesFound is the error returned when no valid resources are found for export.
+	ErrorNoResourcesFound = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "EXP-1002",
+		Error:            "No resources found",
+		ErrorDescription: "No valid resources found for the provided identifiers",
+	}
+)
+
+// Server errors for export operations.
+var (
+	// ErrorInternalServerError is the error returned when an internal server error occurs.
+	ErrorInternalServerError = serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "EXP-5001",
+		Error:            "Internal server error",
+		ErrorDescription: "An unexpected error occurred while processing the export request",
+	}
+)

--- a/backend/internal/system/export/handler.go
+++ b/backend/internal/system/export/handler.go
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/error/apierror"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
+)
+
+// exportHandler defines the handler for managing export API requests.
+type exportHandler struct {
+	service ExportServiceInterface
+}
+
+func newExportHandler(service ExportServiceInterface) *exportHandler {
+	return &exportHandler{
+		service: service,
+	}
+}
+
+// HandleExportRequest handles the export request and returns YAML content.
+func (eh *exportHandler) HandleExportRequest(w http.ResponseWriter, r *http.Request) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ExportHandler"))
+
+	exportRequest, err := sysutils.DecodeJSONBody[ExportRequest](r)
+	if err != nil {
+		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+		w.WriteHeader(http.StatusBadRequest)
+
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorInvalidRequest.Code,
+			Message:     ErrorInvalidRequest.Error,
+			Description: ErrorInvalidRequest.ErrorDescription,
+		}
+		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
+			logger.Error("Error encoding error response", log.Error(encodeErr))
+			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Export resources using the export service
+	exportResponse, svcErr := eh.service.ExportResources(exportRequest)
+	if svcErr != nil {
+		eh.handleError(w, logger, svcErr)
+		return
+	}
+
+	// Combine all YAML files into a single response with separators
+	var combinedYAML string
+	for i, file := range exportResponse.Files {
+		if i > 0 {
+			combinedYAML += "\n---\n" // YAML document separator
+		}
+		combinedYAML += "# File: " + file.FileName + "\n"
+		combinedYAML += file.Content
+	}
+
+	// Return the combined YAML content
+	w.Header().Set(serverconst.ContentTypeHeaderName, "application/yaml")
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write([]byte(combinedYAML)); err != nil {
+		logger.Error("Error writing YAML response", log.Error(err))
+		return
+	}
+}
+
+// HandleExportJSONRequest handles the export request and returns JSON with files.
+func (eh *exportHandler) HandleExportJSONRequest(w http.ResponseWriter, r *http.Request) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ExportHandler"))
+
+	exportRequest, err := sysutils.DecodeJSONBody[ExportRequest](r)
+	if err != nil {
+		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+		w.WriteHeader(http.StatusBadRequest)
+
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorInvalidRequest.Code,
+			Message:     ErrorInvalidRequest.Error,
+			Description: ErrorInvalidRequest.ErrorDescription,
+		}
+		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
+			logger.Error("Error encoding error response", log.Error(encodeErr))
+			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Export resources using the export service
+	exportResponse, svcErr := eh.service.ExportResources(exportRequest)
+	if svcErr != nil {
+		eh.handleError(w, logger, svcErr)
+		return
+	}
+
+	// Return the JSON response with files
+	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(exportResponse); err != nil {
+		logger.Error("Error encoding JSON export response", log.Error(err))
+		http.Error(w, "Failed to encode export response", http.StatusInternalServerError)
+		return
+	}
+}
+
+// HandleExportZipRequest handles the export request and returns a ZIP file containing all resources.
+func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.Request) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ExportHandler"))
+
+	exportRequest, err := sysutils.DecodeJSONBody[ExportRequest](r)
+	if err != nil {
+		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+		w.WriteHeader(http.StatusBadRequest)
+
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorInvalidRequest.Code,
+			Message:     ErrorInvalidRequest.Error,
+			Description: ErrorInvalidRequest.ErrorDescription,
+		}
+		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
+			logger.Error("Error encoding error response", log.Error(encodeErr))
+			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Export resources using the export service
+	exportResponse, svcErr := eh.service.ExportResources(exportRequest)
+	if svcErr != nil {
+		eh.handleError(w, logger, svcErr)
+		return
+	}
+
+	// Generate ZIP file and send response
+	if err := eh.generateAndSendZipResponse(w, logger, exportResponse); err != nil {
+		logger.Error("Error generating ZIP response", log.Error(err))
+		http.Error(w, "Failed to generate ZIP file", http.StatusInternalServerError)
+		return
+	}
+}
+
+// generateAndSendZipResponse creates a ZIP file from export files and sends it as HTTP response.
+func (eh *exportHandler) generateAndSendZipResponse(
+	w http.ResponseWriter, logger *log.Logger, exportResponse *ExportResponse) error {
+	// Create ZIP file in memory
+	var zipBuffer bytes.Buffer
+	zipWriter := zip.NewWriter(&zipBuffer)
+
+	// Add each file to the ZIP
+	for _, file := range exportResponse.Files {
+		// Create the full path within the ZIP
+		zipPath := file.FileName
+		if file.FolderPath != "" {
+			zipPath = file.FolderPath + "/" + file.FileName
+		}
+
+		fileWriter, err := zipWriter.Create(zipPath)
+		if err != nil {
+			logger.Error("Error creating file in ZIP", log.String("zipPath", zipPath), log.Error(err))
+			return fmt.Errorf("failed to create file in ZIP: %w", err)
+		}
+
+		if _, err := fileWriter.Write([]byte(file.Content)); err != nil {
+			logger.Error("Error writing file content to ZIP", log.String("zipPath", zipPath), log.Error(err))
+			return fmt.Errorf("failed to write content to ZIP: %w", err)
+		}
+	}
+
+	// Close the ZIP writer
+	if err := zipWriter.Close(); err != nil {
+		logger.Error("Error closing ZIP writer", log.Error(err))
+		return fmt.Errorf("failed to close ZIP writer: %w", err)
+	}
+
+	// Set headers for ZIP file download
+	w.Header().Set(serverconst.ContentTypeHeaderName, "application/zip")
+	w.Header().Set("Content-Disposition", "attachment; filename=exported_resources.zip")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", zipBuffer.Len()))
+	w.WriteHeader(http.StatusOK)
+
+	// Write the ZIP content
+	if _, err := w.Write(zipBuffer.Bytes()); err != nil {
+		logger.Error("Error writing ZIP response", log.Error(err))
+		return fmt.Errorf("failed to write ZIP response: %w", err)
+	}
+
+	return nil
+}
+
+// handleError handles service errors and sends appropriate HTTP responses.
+func (eh *exportHandler) handleError(w http.ResponseWriter, logger *log.Logger, svcErr *serviceerror.ServiceError) {
+	statusCode := http.StatusInternalServerError
+	if svcErr.Type == serviceerror.ClientErrorType {
+		statusCode = http.StatusBadRequest
+	}
+
+	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
+	w.WriteHeader(statusCode)
+
+	errResp := apierror.ErrorResponse{
+		Code:        svcErr.Code,
+		Message:     svcErr.Error,
+		Description: svcErr.ErrorDescription,
+	}
+
+	if err := json.NewEncoder(w).Encode(errResp); err != nil {
+		logger.Error("Error encoding error response", log.Error(err))
+		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
+	}
+}

--- a/backend/internal/system/export/handler_test.go
+++ b/backend/internal/system/export/handler_test.go
@@ -1,0 +1,864 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/system/config"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// HandlerTestSuite contains comprehensive tests for the export handler functions.
+type HandlerTestSuite struct {
+	suite.Suite
+	mockAppService *applicationmock.ApplicationServiceInterfaceMock
+	exportService  ExportServiceInterface
+	handler        *exportHandler
+}
+
+func (suite *HandlerTestSuite) SetupTest() {
+	// Initialize config for tests
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{
+			AllowedOrigins: []string{"https://localhost:3000"},
+		},
+	}
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	suite.Require().NoError(err)
+
+	// Setup services and handler
+	suite.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
+	suite.exportService = newExportService(suite.mockAppService)
+	suite.handler = newExportHandler(suite.exportService)
+}
+
+func (suite *HandlerTestSuite) TearDownTest() {
+	config.ResetThunderRuntime()
+}
+
+func TestHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(HandlerTestSuite))
+}
+
+// TestGenerateAndSendZipResponse_Success tests successful ZIP generation and response.
+func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_Success() {
+	// Setup test data
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{
+			{
+				FileName:   "app1.yaml",
+				FolderPath: "applications",
+				Content:    "name: test-app-1\ndescription: Test Application 1",
+				Size:       42,
+			},
+			{
+				FileName:   "app2.yaml",
+				FolderPath: "applications",
+				Content:    "name: test-app-2\ndescription: Test Application 2",
+				Size:       42,
+			},
+		},
+		Summary: &ExportSummary{
+			TotalFiles: 2,
+			TotalSize:  84,
+		},
+	}
+
+	// Create test request and response writer
+	w := httptest.NewRecorder()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
+
+	// Execute
+	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+
+	// Assert no error
+	assert.NoError(suite.T(), err)
+
+	// Verify response headers
+	assert.Equal(suite.T(), "application/zip", w.Header().Get(serverconst.ContentTypeHeaderName))
+	assert.Equal(suite.T(), "attachment; filename=exported_resources.zip", w.Header().Get("Content-Disposition"))
+	assert.NotEmpty(suite.T(), w.Header().Get("Content-Length"))
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	// Verify ZIP content
+	zipBytes := w.Body.Bytes()
+	assert.NotEmpty(suite.T(), zipBytes)
+
+	// Read and verify ZIP contents
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), zipReader.File, 2)
+
+	// Verify first file
+	file1 := zipReader.File[0]
+	assert.Equal(suite.T(), "applications/app1.yaml", file1.Name)
+	reader1, err := file1.Open()
+	assert.NoError(suite.T(), err)
+	content1, err := io.ReadAll(reader1)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "name: test-app-1\ndescription: Test Application 1", string(content1))
+	err = reader1.Close()
+	assert.NoError(suite.T(), err)
+
+	// Verify second file
+	file2 := zipReader.File[1]
+	assert.Equal(suite.T(), "applications/app2.yaml", file2.Name)
+	reader2, err := file2.Open()
+	assert.NoError(suite.T(), err)
+	content2, err := io.ReadAll(reader2)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "name: test-app-2\ndescription: Test Application 2", string(content2))
+	err = reader2.Close()
+	assert.NoError(suite.T(), err)
+}
+
+// Helper function to test ZIP response generation
+func (suite *HandlerTestSuite) testZipResponse(
+	exportResponse *ExportResponse, expectedFilePath, expectedContent string) {
+	// Create test request and response writer
+	w := httptest.NewRecorder()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
+
+	// Execute
+	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+
+	// Assert no error
+	assert.NoError(suite.T(), err)
+
+	// Verify response
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	// Verify ZIP content
+	zipBytes := w.Body.Bytes()
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), zipReader.File, 1)
+
+	// Verify file
+	file := zipReader.File[0]
+	assert.Equal(suite.T(), expectedFilePath, file.Name)
+	reader, err := file.Open()
+	assert.NoError(suite.T(), err)
+	content, err := io.ReadAll(reader)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), expectedContent, string(content))
+	_ = reader.Close()
+}
+
+// TestGenerateAndSendZipResponse_SingleFileNoFolder tests ZIP generation with a single file without folder.
+func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_SingleFileNoFolder() {
+	// Setup test data with no folder path
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{
+			{
+				FileName:   "standalone.yaml",
+				FolderPath: "", // No folder path
+				Content:    "name: standalone-app\ndescription: Standalone Application",
+				Size:       52,
+			},
+		},
+		Summary: &ExportSummary{
+			TotalFiles: 1,
+			TotalSize:  52,
+		},
+	}
+
+	suite.testZipResponse(exportResponse, "standalone.yaml", "name: standalone-app\ndescription: Standalone Application")
+}
+
+// TestGenerateAndSendZipResponse_EmptyFiles tests ZIP generation with empty files list.
+func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_EmptyFiles() {
+	// Setup test data with no files
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{},
+		Summary: &ExportSummary{
+			TotalFiles: 0,
+			TotalSize:  0,
+		},
+	}
+
+	// Create test request and response writer
+	w := httptest.NewRecorder()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
+
+	// Execute
+	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+
+	// Assert no error (empty ZIP should be valid)
+	assert.NoError(suite.T(), err)
+
+	// Verify response
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	// Verify empty ZIP content
+	zipBytes := w.Body.Bytes()
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), zipReader.File, 0) // Empty ZIP
+}
+
+// TestGenerateAndSendZipResponse_LargeContent tests ZIP generation with large content.
+func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_LargeContent() {
+	// Generate large content (1MB)
+	largeContent := strings.Repeat("# This is a large YAML file with lots of content\n", 20000)
+
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{
+			{
+				FileName:   "large-app.yaml",
+				FolderPath: "large",
+				Content:    largeContent,
+				Size:       int64(len(largeContent)),
+			},
+		},
+		Summary: &ExportSummary{
+			TotalFiles: 1,
+			TotalSize:  int64(len(largeContent)),
+		},
+	}
+
+	// Create test request and response writer
+	w := httptest.NewRecorder()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
+
+	// Execute
+	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+
+	// Assert no error
+	assert.NoError(suite.T(), err)
+
+	// Verify response
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	// Verify ZIP content
+	zipBytes := w.Body.Bytes()
+	assert.True(suite.T(), len(zipBytes) > 0)
+	assert.True(suite.T(), len(zipBytes) < len(largeContent)) // Should be compressed
+
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), zipReader.File, 1)
+
+	// Verify compressed file
+	file := zipReader.File[0]
+	assert.Equal(suite.T(), "large/large-app.yaml", file.Name)
+	reader, err := file.Open()
+	assert.NoError(suite.T(), err)
+	content, err := io.ReadAll(reader)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), largeContent, string(content))
+	_ = reader.Close()
+}
+
+// TestGenerateAndSendZipResponse_SpecialCharactersInPath tests ZIP generation with special characters in paths.
+func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_SpecialCharactersInPath() {
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{
+			{
+				FileName:   "app with spaces.yaml",
+				FolderPath: "special-chars/ñañé-çæß",
+				Content:    "name: app-with-special-chars\ndata: ñañé-çæß-special",
+				Size:       50,
+			},
+		},
+		Summary: &ExportSummary{
+			TotalFiles: 1,
+			TotalSize:  50,
+		},
+	}
+
+	suite.testZipResponse(exportResponse, "special-chars/ñañé-çæß/app with spaces.yaml",
+		"name: app-with-special-chars\ndata: ñañé-çæß-special")
+}
+
+// TestGenerateAndSendZipResponse_DeepFolderStructure tests ZIP generation with deep folder structure.
+func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_DeepFolderStructure() {
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{
+			{
+				FileName:   "deep-app.yaml",
+				FolderPath: "level1/level2/level3/level4/level5",
+				Content:    "name: deep-nested-app\nlocation: very-deep",
+				Size:       42,
+			},
+		},
+		Summary: &ExportSummary{
+			TotalFiles: 1,
+			TotalSize:  42,
+		},
+	}
+
+	suite.testZipResponse(exportResponse,
+		"level1/level2/level3/level4/level5/deep-app.yaml", "name: deep-nested-app\nlocation: very-deep")
+}
+
+// Standalone tests for simpler use cases
+
+// TestGenerateAndSendZipResponse_Standalone tests the function without suite dependencies.
+func TestGenerateAndSendZipResponse_Standalone(t *testing.T) {
+	// Setup config
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{
+			AllowedOrigins: []string{"*"},
+		},
+	}
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	assert.NoError(t, err)
+	defer config.ResetThunderRuntime()
+
+	// Setup handler
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	exportService := newExportService(mockAppService)
+	handler := newExportHandler(exportService)
+
+	// Test data
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{
+			{
+				FileName:   "test.yaml",
+				FolderPath: "test",
+				Content:    "test: content",
+				Size:       13,
+			},
+		},
+	}
+
+	// Execute
+	w := httptest.NewRecorder()
+	logger := log.GetLogger()
+	err = handler.generateAndSendZipResponse(w, logger, exportResponse)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/zip", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+}
+
+// TestNewExportHandler tests the handler constructor.
+func TestNewExportHandler(t *testing.T) {
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	exportService := newExportService(mockAppService)
+
+	handler := newExportHandler(exportService)
+
+	assert.NotNil(t, handler)
+	assert.Equal(t, exportService, handler.service)
+}
+
+// Handler Function Tests
+
+// TestHandleExportRequest_Success tests successful YAML export.
+func (suite *HandlerTestSuite) TestHandleExportRequest_Success() {
+	// Setup mock expectations
+	suite.mockAppService.EXPECT().GetApplication("app1").Return(&model.Application{
+		ID:          "app1",
+		Name:        "Test App 1",
+		Description: "Test Application 1",
+		URL:         "https://example.com",
+	}, nil).Once()
+
+	// Create request body
+	requestBody := &ExportRequest{
+		Applications: []string{"app1"},
+		Options: &ExportOptions{
+			Format:          "yaml",
+			IncludeMetadata: true,
+		},
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	// Create HTTP request
+	req := httptest.NewRequest("POST", "/export", bytes.NewReader(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportRequest(w, req)
+
+	// Assert response
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	assert.Equal(suite.T(), "application/yaml", w.Header().Get("Content-Type"))
+
+	responseBody := w.Body.String()
+	assert.NotEmpty(suite.T(), responseBody)
+	assert.Contains(suite.T(), responseBody, "# File:")
+	assert.Contains(suite.T(), responseBody, "name: Test App 1")
+}
+
+// TestHandleExportRequest_InvalidJSON tests invalid JSON request handling.
+func (suite *HandlerTestSuite) TestHandleExportRequest_InvalidJSON() {
+	// Create malformed JSON request
+	req := httptest.NewRequest("POST", "/export", strings.NewReader("{invalid json}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportRequest(w, req)
+
+	// Assert error response
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var errResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "EXP-1001", errResp["code"])
+	assert.Equal(suite.T(), "Invalid export request", errResp["message"])
+}
+
+// Helper function to test service error responses
+func (suite *HandlerTestSuite) testServiceErrorResponse(
+	method, endpoint, appID string, serviceError *serviceerror.ServiceError, expectedErrorCode string) {
+	// Setup mock to return service error
+	suite.mockAppService.EXPECT().GetApplication(appID).Return(nil, serviceError).Once()
+
+	// Create request body
+	requestBody := &ExportRequest{
+		Applications: []string{appID},
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	// Create HTTP request
+	req := httptest.NewRequest(method, endpoint, bytes.NewReader(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute based on endpoint
+	switch endpoint {
+	case "/export":
+		suite.handler.HandleExportRequest(w, req)
+	case "/export/json":
+		suite.handler.HandleExportJSONRequest(w, req)
+	case "/export/zip":
+		suite.handler.HandleExportZipRequest(w, req)
+	}
+
+	// Assert error response
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var errResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), expectedErrorCode, errResp["code"])
+}
+
+// TestHandleExportRequest_ServiceError tests service error handling.
+func (suite *HandlerTestSuite) TestHandleExportRequest_ServiceError() {
+	suite.testServiceErrorResponse("POST", "/export", "app1", &ErrorNoResourcesFound, "EXP-1002")
+}
+
+// TestHandleExportRequest_MultipleFiles tests YAML export with multiple files.
+func (suite *HandlerTestSuite) TestHandleExportRequest_MultipleFiles() {
+	// Setup mock expectations for multiple applications
+	suite.mockAppService.EXPECT().GetApplication("app1").Return(&model.Application{
+		ID:   "app1",
+		Name: "App One",
+	}, nil).Once()
+	suite.mockAppService.EXPECT().GetApplication("app2").Return(&model.Application{
+		ID:   "app2",
+		Name: "App Two",
+	}, nil).Once()
+
+	// Create request body
+	requestBody := &ExportRequest{
+		Applications: []string{"app1", "app2"},
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	// Create HTTP request
+	req := httptest.NewRequest("POST", "/export", bytes.NewReader(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportRequest(w, req)
+
+	// Assert response
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	responseBody := w.Body.String()
+
+	// Verify YAML separator between files
+	assert.Contains(suite.T(), responseBody, "---")
+	assert.Contains(suite.T(), responseBody, "name: App One")
+	assert.Contains(suite.T(), responseBody, "name: App Two")
+
+	// Count file headers
+	fileHeaders := strings.Count(responseBody, "# File:")
+	assert.Equal(suite.T(), 2, fileHeaders)
+}
+
+// TestHandleExportJSONRequest_Success tests successful JSON export.
+func (suite *HandlerTestSuite) TestHandleExportJSONRequest_Success() {
+	// Setup mock expectations
+	suite.mockAppService.EXPECT().GetApplication("app1").Return(&model.Application{
+		ID:          "app1",
+		Name:        "Test App JSON",
+		Description: "JSON Test Application",
+	}, nil).Once()
+
+	// Create request body
+	requestBody := &ExportRequest{
+		Applications: []string{"app1"},
+		Options: &ExportOptions{
+			Format: "json", // Note: JSON format currently falls back to YAML
+		},
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	// Create HTTP request
+	req := httptest.NewRequest("POST", "/export/json", bytes.NewReader(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportJSONRequest(w, req)
+
+	// Assert response
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var response ExportResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), response.Files, 1)
+	// Note: Service currently generates YAML files even with JSON format (fallback behavior)
+	assert.Equal(suite.T(), "Test_App_JSON.yaml", response.Files[0].FileName)
+	assert.Contains(suite.T(), response.Files[0].Content, "Test App JSON")
+	assert.NotNil(suite.T(), response.Summary)
+	assert.Equal(suite.T(), 1, response.Summary.TotalFiles)
+}
+
+// TestHandleExportJSONRequest_InvalidJSON tests invalid JSON handling for JSON export.
+func (suite *HandlerTestSuite) TestHandleExportJSONRequest_InvalidJSON() {
+	// Create malformed JSON request
+	req := httptest.NewRequest("POST", "/export/json", strings.NewReader("invalid"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportJSONRequest(w, req)
+
+	// Assert error response
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var errResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "EXP-1001", errResp["code"])
+}
+
+// TestHandleExportJSONRequest_ServiceError tests service error handling for JSON export.
+func (suite *HandlerTestSuite) TestHandleExportJSONRequest_ServiceError() {
+	// Setup mock to return service error
+	suite.testServiceErrorResponse("POST", "/export/json", "app1", &ErrorInternalServerError, "EXP-1002")
+}
+
+// TestHandleExportZipRequest_Success tests successful ZIP export.
+func (suite *HandlerTestSuite) TestHandleExportZipRequest_Success() {
+	// Setup mock expectations
+	suite.mockAppService.EXPECT().GetApplication("app1").Return(&model.Application{
+		ID:   "app1",
+		Name: "ZIP Test App",
+	}, nil).Once()
+
+	// Create request body
+	requestBody := &ExportRequest{
+		Applications: []string{"app1"},
+		Options: &ExportOptions{
+			FolderStructure: &FolderStructureOptions{
+				GroupByType: true,
+			},
+		},
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	// Create HTTP request
+	req := httptest.NewRequest("POST", "/export/zip", bytes.NewReader(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportZipRequest(w, req)
+
+	// Assert response
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	assert.Equal(suite.T(), "application/zip", w.Header().Get("Content-Type"))
+	assert.Contains(suite.T(), w.Header().Get("Content-Disposition"), "attachment")
+	assert.Contains(suite.T(), w.Header().Get("Content-Disposition"), "exported_resources.zip")
+	assert.NotEmpty(suite.T(), w.Header().Get("Content-Length"))
+
+	// Verify ZIP content
+	zipBytes := w.Body.Bytes()
+	assert.NotEmpty(suite.T(), zipBytes)
+
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), zipReader.File, 1)
+	// Note: Service uses name-based file naming
+	assert.Equal(suite.T(), "applications/ZIP_Test_App.yaml", zipReader.File[0].Name)
+}
+
+// TestHandleExportZipRequest_InvalidJSON tests invalid JSON handling for ZIP export.
+func (suite *HandlerTestSuite) TestHandleExportZipRequest_InvalidJSON() {
+	// Create malformed JSON request
+	req := httptest.NewRequest("POST", "/export/zip", strings.NewReader("}{"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportZipRequest(w, req)
+
+	// Assert error response
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var errResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "EXP-1001", errResp["code"])
+}
+
+// TestHandleExportZipRequest_ServiceError tests service error handling for ZIP export.
+func (suite *HandlerTestSuite) TestHandleExportZipRequest_ServiceError() {
+	suite.testServiceErrorResponse("POST", "/export/zip", "nonexistent", &ErrorNoResourcesFound, "EXP-1002")
+}
+
+// TestHandleError_ClientError tests error handling for client errors.
+func (suite *HandlerTestSuite) TestHandleError_ClientError() {
+	w := httptest.NewRecorder()
+	logger := log.GetLogger()
+
+	// Create client error
+	clientErr := &ErrorNoResourcesFound
+
+	// Execute
+	suite.handler.handleError(w, logger, clientErr)
+
+	// Assert response
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var errResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "EXP-1002", errResp["code"])
+	assert.Equal(suite.T(), "No resources found", errResp["message"])
+	assert.Equal(suite.T(), "No valid resources found for the provided identifiers", errResp["description"])
+}
+
+// TestHandleError_ServerError tests error handling for server errors.
+func (suite *HandlerTestSuite) TestHandleError_ServerError() {
+	w := httptest.NewRecorder()
+	logger := log.GetLogger()
+
+	// Create server error
+	serverErr := &ErrorInternalServerError
+
+	// Execute
+	suite.handler.handleError(w, logger, serverErr)
+
+	// Assert response
+	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var errResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "EXP-5001", errResp["code"])
+	assert.Equal(suite.T(), "Internal server error", errResp["message"])
+	assert.Equal(suite.T(), "An unexpected error occurred while processing the export request", errResp["description"])
+}
+
+// Edge case tests
+
+// TestHandleExportRequest_EmptyBody tests empty request body.
+func (suite *HandlerTestSuite) TestHandleExportRequest_EmptyBody() {
+	req := httptest.NewRequest("POST", "/export", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportRequest(w, req)
+
+	// Assert error response
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+}
+
+// TestHandleExportRequest_NilOptions tests request with nil options.
+func (suite *HandlerTestSuite) TestHandleExportRequest_NilOptions() {
+	// Setup mock expectations
+	suite.mockAppService.EXPECT().GetApplication("app1").Return(&model.Application{
+		ID:   "app1",
+		Name: "Test App",
+	}, nil).Once()
+
+	// Create request body with nil options
+	requestBody := &ExportRequest{
+		Applications: []string{"app1"},
+		Options:      nil, // Test nil options
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	// Create HTTP request
+	req := httptest.NewRequest("POST", "/export", bytes.NewReader(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportRequest(w, req)
+
+	// Assert successful response with default behavior
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	assert.Equal(suite.T(), "application/yaml", w.Header().Get("Content-Type"))
+}
+
+// TestHandleExportJSONRequest_EmptyFiles tests JSON export with no files.
+func (suite *HandlerTestSuite) TestHandleExportJSONRequest_EmptyFiles() {
+	// Create request body with empty applications
+	requestBody := &ExportRequest{
+		Applications: []string{}, // No applications
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	// Create HTTP request
+	req := httptest.NewRequest("POST", "/export/json", bytes.NewReader(requestJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Execute
+	suite.handler.HandleExportJSONRequest(w, req)
+
+	// Assert error response (empty applications list returns NoResourcesFound error)
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var errResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "EXP-1002", errResp["code"]) // NoResourcesFound
+	assert.Equal(suite.T(), "No resources found", errResp["message"])
+}
+
+// Benchmark tests
+
+// BenchmarkGenerateAndSendZipResponse benchmarks ZIP generation performance.
+func BenchmarkGenerateAndSendZipResponse(b *testing.B) {
+	// Setup
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{}
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+	defer config.ResetThunderRuntime()
+
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(b)
+	exportService := newExportService(mockAppService)
+	handler := newExportHandler(exportService)
+
+	exportResponse := &ExportResponse{
+		Files: []ExportFile{
+			{
+				FileName:   "benchmark.yaml",
+				FolderPath: "benchmark",
+				Content:    strings.Repeat("data: value\n", 100),
+				Size:       1100,
+			},
+		},
+	}
+
+	logger := log.GetLogger()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		_ = handler.generateAndSendZipResponse(w, logger, exportResponse)
+	}
+}
+
+// Helper function for benchmark tests
+func setupBenchmarkTest(b *testing.B) (*exportHandler, []byte) {
+	// Setup
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{}
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+	b.Cleanup(func() { config.ResetThunderRuntime() })
+
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(b)
+	exportService := newExportService(mockAppService)
+	handler := newExportHandler(exportService)
+
+	// Setup mock expectation
+	mockAppService.EXPECT().GetApplication("benchmark-app").Return(&model.Application{
+		ID:   "benchmark-app",
+		Name: "Benchmark Application",
+	}, nil).Times(b.N)
+
+	// Create request body
+	requestBody := &ExportRequest{
+		Applications: []string{"benchmark-app"},
+	}
+	requestJSON, _ := json.Marshal(requestBody)
+
+	return handler, requestJSON
+}
+
+// BenchmarkHandleExportRequest benchmarks YAML export performance.
+func BenchmarkHandleExportRequest(b *testing.B) {
+	handler, requestJSON := setupBenchmarkTest(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest("POST", "/export", bytes.NewReader(requestJSON))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.HandleExportRequest(w, req)
+	}
+}
+
+// BenchmarkHandleExportJSONRequest benchmarks JSON export performance.
+func BenchmarkHandleExportJSONRequest(b *testing.B) {
+	handler, requestJSON := setupBenchmarkTest(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest("POST", "/export/json", bytes.NewReader(requestJSON))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.HandleExportJSONRequest(w, req)
+	}
+}

--- a/backend/internal/system/export/init.go
+++ b/backend/internal/system/export/init.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package export provides functionality for exporting various resource configurations.
+package export
+
+import (
+	"net/http"
+
+	"github.com/asgardeo/thunder/internal/application"
+	"github.com/asgardeo/thunder/internal/system/middleware"
+)
+
+// Initialize initializes the export service and registers its routes.
+func Initialize(mux *http.ServeMux, appService application.ApplicationServiceInterface) ExportServiceInterface {
+	// Create the export service with dependencies
+
+	exportService := newExportService(appService)
+
+	// Create the handler
+	exportHandler := newExportHandler(exportService)
+
+	// Register routes
+	registerRoutes(mux, exportHandler)
+
+	return exportService
+}
+
+func registerRoutes(mux *http.ServeMux, exportHandler *exportHandler) {
+	opts := middleware.CORSOptions{
+		AllowedMethods:   "POST",
+		AllowedHeaders:   "Content-Type, Authorization",
+		AllowCredentials: true,
+	}
+
+	// YAML export endpoint - returns application/yaml
+	mux.HandleFunc(middleware.WithCORS("POST /export",
+		exportHandler.HandleExportRequest, opts))
+
+	// JSON export endpoint - returns JSON with files (for backward compatibility)
+	mux.HandleFunc(middleware.WithCORS("POST /export/json",
+		exportHandler.HandleExportJSONRequest, opts))
+
+	// ZIP export endpoint - returns application/zip with individual files
+	mux.HandleFunc(middleware.WithCORS("POST /export/zip",
+		exportHandler.HandleExportZipRequest, opts))
+
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /export",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}, opts))
+}

--- a/backend/internal/system/export/init_test.go
+++ b/backend/internal/system/export/init_test.go
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// InitTestSuite contains comprehensive tests for the init.go file.
+// The test suite covers:
+// - Initialize function with proper service creation and route registration
+// - registerRoutes function with CORS setup and endpoint registration
+// - Route handling validation for all export endpoints
+// - HTTP method validation and OPTIONS request handling
+type InitTestSuite struct {
+	suite.Suite
+	mockAppService *applicationmock.ApplicationServiceInterfaceMock
+}
+
+func (suite *InitTestSuite) SetupTest() {
+	suite.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
+	// Initialize config for CORS middleware
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{
+			AllowedOrigins: []string{"https://example.com", "https://localhost:3000"},
+		},
+	}
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	if err != nil {
+		suite.T().Fatalf("Failed to initialize config: %v", err)
+	}
+}
+
+func (suite *InitTestSuite) TearDownTest() {
+	// Reset config to clear singleton state for next test
+	config.ResetThunderRuntime()
+}
+
+func TestInitTestSuite(t *testing.T) {
+	suite.Run(t, new(InitTestSuite))
+}
+
+// TestInitialize tests the Initialize function
+func (suite *InitTestSuite) TestInitialize() {
+	mux := http.NewServeMux()
+
+	// Execute
+	service := Initialize(mux, suite.mockAppService)
+
+	// Assert
+	assert.NotNil(suite.T(), service)
+	assert.Implements(suite.T(), (*ExportServiceInterface)(nil), service)
+}
+
+// TestInitialize_ServiceCreation tests that Initialize creates the service with proper dependencies
+func (suite *InitTestSuite) TestInitialize_ServiceCreation() {
+	mux := http.NewServeMux()
+
+	// Execute
+	service := Initialize(mux, suite.mockAppService)
+
+	// Assert
+	assert.NotNil(suite.T(), service)
+	// Verify that the service is properly configured with dependencies
+	// Since we can't directly access the internal fields, we test through interface
+	assert.Implements(suite.T(), (*ExportServiceInterface)(nil), service)
+}
+
+// TestRegisterRoutes tests the route registration function
+func (suite *InitTestSuite) TestRegisterRoutes() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	// Execute
+	assert.NotPanics(suite.T(), func() {
+		registerRoutes(mux, exportHandler)
+	})
+}
+
+// TestRegisterRoutes_YAMLEndpoint tests the YAML export endpoint registration
+func (suite *InitTestSuite) TestRegisterRoutes_YAMLEndpoint() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test POST /export endpoint
+	req := httptest.NewRequest("POST", "/export", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// The mux should handle the request (even if it fails due to invalid request body)
+	mux.ServeHTTP(w, req)
+
+	// Should not be 404 (route exists)
+	assert.NotEqual(suite.T(), http.StatusNotFound, w.Code)
+}
+
+// TestRegisterRoutes_JSONEndpoint tests the JSON export endpoint registration
+func (suite *InitTestSuite) TestRegisterRoutes_JSONEndpoint() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test POST /export/json endpoint
+	req := httptest.NewRequest("POST", "/export/json", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Should not be 404 (route exists)
+	assert.NotEqual(suite.T(), http.StatusNotFound, w.Code)
+}
+
+// TestRegisterRoutes_ZIPEndpoint tests the ZIP export endpoint registration
+func (suite *InitTestSuite) TestRegisterRoutes_ZIPEndpoint() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test POST /export/zip endpoint
+	req := httptest.NewRequest("POST", "/export/zip", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Should not be 404 (route exists)
+	assert.NotEqual(suite.T(), http.StatusNotFound, w.Code)
+}
+
+// TestRegisterRoutes_OptionsEndpoint tests the OPTIONS endpoint registration
+func (suite *InitTestSuite) TestRegisterRoutes_OptionsEndpoint() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test OPTIONS /export endpoint
+	req := httptest.NewRequest("OPTIONS", "/export", nil)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Should return 204 No Content for OPTIONS request
+	assert.Equal(suite.T(), http.StatusNoContent, w.Code)
+}
+
+// TestRegisterRoutes_CORSHeaders tests that CORS headers are properly set
+func (suite *InitTestSuite) TestRegisterRoutes_CORSHeaders() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test CORS headers on OPTIONS request with Origin header
+	req := httptest.NewRequest("OPTIONS", "/export", nil)
+	req.Header.Set("Origin", "https://example.com") // This is required for CORS headers
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Check that CORS headers are present when Origin is provided
+	headers := w.Header()
+	assert.Contains(suite.T(), headers, "Access-Control-Allow-Origin")
+	assert.Contains(suite.T(), headers, "Access-Control-Allow-Methods")
+	assert.Contains(suite.T(), headers, "Access-Control-Allow-Headers")
+	assert.Contains(suite.T(), headers, "Access-Control-Allow-Credentials")
+}
+
+// TestRegisterRoutes_InvalidMethod tests that invalid HTTP methods return appropriate responses
+func (suite *InitTestSuite) TestRegisterRoutes_InvalidMethod() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test GET method on POST-only endpoint
+	req := httptest.NewRequest("GET", "/export", nil)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Should return method not allowed
+	assert.Equal(suite.T(), http.StatusMethodNotAllowed, w.Code)
+}
+
+// TestRegisterRoutes_UnregisteredPath tests that unregistered paths return 404
+func (suite *InitTestSuite) TestRegisterRoutes_UnregisteredPath() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test unregistered path
+	req := httptest.NewRequest("POST", "/export/invalid", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Should return 404 for unregistered path
+	assert.Equal(suite.T(), http.StatusNotFound, w.Code)
+}
+
+// TestRegisterRoutes_WithNilHandler tests that registerRoutes handles nil handler gracefully
+func (suite *InitTestSuite) TestRegisterRoutes_WithNilHandler() {
+	mux := http.NewServeMux()
+
+	// This should not panic even with nil handler
+	assert.NotPanics(suite.T(), func() {
+		registerRoutes(mux, nil)
+	})
+}
+
+// TestRegisterRoutes_PreflightRequest tests CORS preflight request handling
+func (suite *InitTestSuite) TestRegisterRoutes_PreflightRequest() {
+	mux := http.NewServeMux()
+	mockService := newExportService(suite.mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	registerRoutes(mux, exportHandler)
+
+	// Test preflight request with proper Origin header
+	req := httptest.NewRequest("OPTIONS", "/export", nil)
+	req.Header.Set("Origin", "https://example.com") // This is required for CORS headers
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "Content-Type, Authorization")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Should return 204 No Content for preflight
+	assert.Equal(suite.T(), http.StatusNoContent, w.Code)
+
+	// Verify CORS headers when Origin is provided
+	headers := w.Header()
+	assert.NotEmpty(suite.T(), headers.Get("Access-Control-Allow-Methods"))
+	assert.NotEmpty(suite.T(), headers.Get("Access-Control-Allow-Headers"))
+}
+
+// Benchmark tests for performance evaluation
+
+// BenchmarkInitialize benchmarks the Initialize function
+func BenchmarkInitialize(b *testing.B) {
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mux := http.NewServeMux()
+		Initialize(mux, mockAppService)
+	}
+}
+
+// BenchmarkRegisterRoutes benchmarks the route registration
+func BenchmarkRegisterRoutes(b *testing.B) {
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(b)
+	mockService := newExportService(mockAppService)
+	exportHandler := newExportHandler(mockService)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mux := http.NewServeMux()
+		registerRoutes(mux, exportHandler)
+	}
+}
+
+// Individual test functions that don't rely on suite setup
+
+// TestInitialize_Standalone tests Initialize function without suite dependencies
+func TestInitialize_Standalone(t *testing.T) {
+	// Setup config for CORS middleware
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{
+			AllowedOrigins: []string{"https://example.com", "https://localhost:3000"},
+		},
+	}
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	assert.NoError(t, err)
+	defer config.ResetThunderRuntime()
+
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mux := http.NewServeMux()
+
+	// Execute
+	service := Initialize(mux, mockAppService)
+
+	// Assert
+	assert.NotNil(t, service)
+	assert.Implements(t, (*ExportServiceInterface)(nil), service)
+}
+
+// TestRegisterRoutes_Standalone tests route registration without suite dependencies
+func TestRegisterRoutes_Standalone(t *testing.T) {
+	// Setup config for CORS middleware
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{
+			AllowedOrigins: []string{"https://example.com", "https://localhost:3000"},
+		},
+	}
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	assert.NoError(t, err)
+	defer config.ResetThunderRuntime()
+
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mockService := newExportService(mockAppService)
+	exportHandler := newExportHandler(mockService)
+	mux := http.NewServeMux()
+
+	// Execute - should not panic
+	assert.NotPanics(t, func() {
+		registerRoutes(mux, exportHandler)
+	})
+}
+
+// TestRouteHandling_Standalone tests that routes are properly handled
+func TestRouteHandling_Standalone(t *testing.T) {
+	// Setup config for CORS middleware
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{
+			AllowedOrigins: []string{"https://example.com", "https://localhost:3000"},
+		},
+	}
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	assert.NoError(t, err)
+	defer config.ResetThunderRuntime()
+
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mux := http.NewServeMux()
+	Initialize(mux, mockAppService)
+
+	// Test that all routes are registered
+	testCases := []struct {
+		method         string
+		path           string
+		expectNotFound bool
+	}{
+		{"POST", "/export", false},
+		{"POST", "/export/json", false},
+		{"POST", "/export/zip", false},
+		{"OPTIONS", "/export", false},
+		{"GET", "/export", true},   // Should be method not allowed, not not found
+		{"POST", "/invalid", true}, // Should be not found
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			mux.ServeHTTP(w, req)
+
+			if tc.expectNotFound {
+				if tc.method == "GET" && tc.path == "/export" {
+					// This should be method not allowed, not not found
+					assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+				} else {
+					assert.Equal(t, http.StatusNotFound, w.Code)
+				}
+			} else {
+				assert.NotEqual(t, http.StatusNotFound, w.Code)
+			}
+		})
+	}
+}
+
+// TestCORSConfiguration_Standalone tests CORS configuration without suite
+func TestCORSConfiguration_Standalone(t *testing.T) {
+	// Setup config for CORS middleware
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{
+			AllowedOrigins: []string{"https://example.com", "https://localhost:3000"},
+		},
+	}
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	assert.NoError(t, err)
+	defer config.ResetThunderRuntime()
+
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mux := http.NewServeMux()
+	Initialize(mux, mockAppService)
+
+	// Test CORS on actual request with Origin header
+	req := httptest.NewRequest("OPTIONS", "/export", nil)
+	req.Header.Set("Origin", "https://localhost:3000") // This is required for CORS headers
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	// Verify response code
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	// Verify CORS headers are present when Origin is provided
+	headers := w.Header()
+	assert.True(t, len(headers) > 0, "CORS headers should be present")
+}

--- a/backend/internal/system/export/model.go
+++ b/backend/internal/system/export/model.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+// ExportRequest represents the request structure for exporting resources.
+type ExportRequest struct {
+	Applications []string `json:"applications,omitempty"`
+
+	Options *ExportOptions `json:"options,omitempty"`
+}
+
+// ExportOptions provides configuration for export behavior.
+type ExportOptions struct {
+	// IncludeMetadata determines whether to include metadata (creation dates, IDs, etc.)
+	IncludeMetadata bool `json:"include_metadata,omitempty"`
+
+	// IncludeDependencies automatically exports related resources
+	IncludeDependencies bool `json:"include_dependencies,omitempty"`
+
+	// Format specifies the output format for individual files (yaml, json)
+	Format string `json:"format,omitempty"` // Default: "yaml"
+
+	// Folder structure options
+	FolderStructure *FolderStructureOptions `json:"folder_structure,omitempty"`
+
+	// Pagination for bulk exports
+	Pagination *PaginationOptions `json:"pagination,omitempty"`
+}
+
+// FolderStructureOptions configures how files are organized in exports.
+type FolderStructureOptions struct {
+	// GroupByType creates separate folders for each resource type
+	GroupByType bool `json:"group_by_type,omitempty"`
+
+	// CustomStructure allows defining custom folder paths
+	CustomStructure map[string]string `json:"custom_structure,omitempty"`
+
+	// FileNamingPattern defines how files should be named
+	FileNamingPattern string `json:"file_naming_pattern,omitempty"` // e.g., "${name}_${id}", "${type}_${name}"
+}
+
+// PaginationOptions configures pagination for bulk exports.
+type PaginationOptions struct {
+	// Page number (1-based)
+	Page int `json:"page,omitempty"`
+
+	// Number of resources per page
+	Limit int `json:"limit,omitempty"`
+}
+
+// ExportResponse represents the response structure for exporting resources.
+type ExportResponse struct {
+	Files []ExportFile `json:"files"`
+
+	// Summary information about the export
+	Summary *ExportSummary `json:"summary,omitempty"`
+}
+
+// ExportSummary provides metadata about the export operation.
+type ExportSummary struct {
+	TotalFiles    int             `json:"total_files"`
+	TotalSize     int64           `json:"total_size_bytes,omitempty"`
+	ExportedAt    string          `json:"exported_at,omitempty"`
+	ResourceTypes map[string]int  `json:"resource_types,omitempty"` // Type -> count
+	Errors        []ExportError   `json:"errors,omitempty"`
+	Pagination    *PaginationInfo `json:"pagination,omitempty"`
+}
+
+// ExportError represents errors that occurred during export.
+type ExportError struct {
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id,omitempty"`
+	Error        string `json:"error"`
+	Code         string `json:"code,omitempty"`
+}
+
+// PaginationInfo provides pagination metadata.
+type PaginationInfo struct {
+	Page       int  `json:"page"`
+	Limit      int  `json:"limit"`
+	TotalPages int  `json:"total_pages,omitempty"`
+	HasMore    bool `json:"has_more"`
+}
+
+// ExportFile represents a single YAML file in the export response.
+type ExportFile struct {
+	FileName     string `json:"file_name"`
+	Content      string `json:"content"`
+	FolderPath   string `json:"folder_path,omitempty"`   // Relative path within the export
+	ResourceType string `json:"resource_type,omitempty"` // application, group, user, idp
+	ResourceID   string `json:"resource_id,omitempty"`   // ID of the exported resource
+	Size         int64  `json:"size,omitempty"`          // File size in bytes
+}

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -1,0 +1,978 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+type templatingRules struct {
+	Application      *resourceRules `yaml:"Application,omitempty"`
+	IdentityProvider *resourceRules `yaml:"IdentityProvider,omitempty"`
+}
+
+// ResourceRules defines variables and array variables to parameterize
+type resourceRules struct {
+	Variables      []string `yaml:"Variables,omitempty"`
+	ArrayVariables []string `yaml:"ArrayVariables,omitempty"`
+}
+
+// Parameterizer handles the templating logic
+type parameterizer struct {
+	rules templatingRules
+}
+
+// newParameterizer creates a new Parameterizer instance with the given templating rules
+func newParameterizer(rules templatingRules) *parameterizer {
+	return &parameterizer{rules: rules}
+}
+
+// ToParameterizedYAML converts an object directly to parameterized YAML
+// This is the easiest method when you already have the object
+func (p *parameterizer) ToParameterizedYAML(obj interface{}, resourceType string, resourceName string) (string, error) {
+	// Get rules for the resource type
+	var rules *resourceRules
+	switch resourceType {
+	case "Application":
+		rules = p.rules.Application
+	case "IdentityProvider":
+		rules = p.rules.IdentityProvider
+	default:
+		return "", fmt.Errorf("unknown resource type: %s", resourceType)
+	}
+
+	// Convert object to yaml.Node directly to preserve field order and handle omitempty
+	// Pass rules so fields in parameterization rules bypass omitempty
+	var node yaml.Node
+	if err := p.structToNodeIgnoringOmitempty(obj, &node, rules, ""); err != nil {
+		return "", fmt.Errorf("failed to convert object to node: %w", err)
+	}
+
+	if rules == nil {
+		// No rules, just marshal the node as-is
+		var buf bytes.Buffer
+		encoder := yaml.NewEncoder(&buf)
+		encoder.SetIndent(2)
+		if err := encoder.Encode(&node); err != nil {
+			return "", fmt.Errorf("failed to marshal data: %w", err)
+		}
+		err := encoder.Close()
+		if err != nil {
+			return "", fmt.Errorf("failed to close encoder: %w", err)
+		}
+		return buf.String(), nil
+	}
+
+	// Convert struct field paths to YAML field paths
+	rulesWithYAMLPaths := p.convertStructPathsToYAMLPaths(obj, rules)
+
+	// Apply parameterization to the node tree
+	if err := p.parameterizeNode(&node, rulesWithYAMLPaths, resourceName); err != nil {
+		return "", err
+	}
+
+	// Marshal back to YAML with preserved indentation
+	// Use custom renderer to handle template syntax properly
+	var buf bytes.Buffer
+	if err := p.renderNode(&buf, &node, 0); err != nil {
+		return "", fmt.Errorf("failed to render parameterized YAML: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// structToNodeIgnoringOmitempty converts a struct to yaml.Node while preserving field order
+// and respecting omitempty tags (skip empty fields unless they're in parameterization rules)
+func (p *parameterizer) structToNodeIgnoringOmitempty(
+	obj interface{}, node *yaml.Node, rules *resourceRules, currentPath string,
+) error {
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			node.Kind = yaml.ScalarNode
+			node.Tag = "!!null"
+			node.Value = "null"
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("expected struct, got %v", v.Kind())
+	}
+
+	// Create document node
+	node.Kind = yaml.DocumentNode
+
+	// Create mapping node for the struct
+	mappingNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+		fieldValue := v.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Get the yaml tag
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag == "" || yamlTag == "-" {
+			continue
+		}
+
+		// Parse yaml tag to check for omitempty
+		tagParts := strings.Split(yamlTag, ",")
+		yamlFieldName := tagParts[0]
+		hasOmitEmpty := false
+		for _, part := range tagParts[1:] {
+			if part == "omitempty" {
+				hasOmitEmpty = true
+				break
+			}
+		}
+
+		// Build the current field path (using struct field names)
+		fieldPath := field.Name
+		if currentPath != "" {
+			fieldPath = currentPath + "." + field.Name
+		}
+
+		// Skip empty fields if omitempty is set AND field is NOT in parameterization rules
+		if hasOmitEmpty && p.isEmptyValue(fieldValue) && !p.isFieldInRules(rules, fieldPath) {
+			continue
+		}
+
+		// Create key node
+		keyNode := &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: yamlFieldName,
+		}
+
+		// Create value node
+		valueNode := p.fieldToNode(fieldValue, rules, fieldPath)
+
+		// Add key-value pair to mapping
+		mappingNode.Content = append(mappingNode.Content, keyNode, valueNode)
+	}
+
+	node.Content = []*yaml.Node{mappingNode}
+	return nil
+}
+
+// isEmptyValue checks if a reflect.Value is considered empty for omitempty purposes
+func (p *parameterizer) isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+// isFieldInRules checks if a field path exists in the parameterization rules
+func (p *parameterizer) isFieldInRules(rules *resourceRules, fieldPath string) bool {
+	if rules == nil {
+		return false
+	}
+
+	// Normalize the field path to lowercase for case-insensitive matching
+	normalizedPath := strings.ToLower(fieldPath)
+
+	// Check Variables
+	for _, varPath := range rules.Variables {
+		normalizedVarPath := strings.ToLower(varPath)
+		if normalizedVarPath == normalizedPath {
+			return true
+		}
+	}
+
+	// Check ArrayVariables
+	for _, arrPath := range rules.ArrayVariables {
+		normalizedArrPath := strings.ToLower(arrPath)
+		if normalizedArrPath == normalizedPath {
+			return true
+		}
+	}
+
+	return false
+}
+
+// findFieldByNameCaseInsensitive finds a struct field by name, case-insensitively
+func (p *parameterizer) findFieldByNameCaseInsensitive(t reflect.Type, name string) (reflect.StructField, bool) {
+	// First try exact match
+	if field, found := t.FieldByName(name); found {
+		return field, true
+	}
+
+	// Try case-insensitive match
+	lowerName := strings.ToLower(name)
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if strings.ToLower(field.Name) == lowerName {
+			return field, true
+		}
+	}
+
+	return reflect.StructField{}, false
+}
+
+// fieldToNode converts a reflect.Value to yaml.Node
+func (p *parameterizer) fieldToNode(v reflect.Value, rules *resourceRules, currentPath string) *yaml.Node {
+	// Handle nil pointers
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!null",
+			Value: "null",
+		}
+	}
+
+	// Dereference pointers
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		// Recursively convert nested structs
+		node := &yaml.Node{Kind: yaml.MappingNode}
+		t := v.Type()
+
+		for i := 0; i < v.NumField(); i++ {
+			field := t.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+
+			yamlTag := field.Tag.Get("yaml")
+			if yamlTag == "" || yamlTag == "-" {
+				continue
+			}
+
+			tagParts := strings.Split(yamlTag, ",")
+			yamlFieldName := tagParts[0]
+
+			// Check if this field has omitempty
+			hasOmitEmpty := false
+			for _, part := range tagParts[1:] {
+				if part == "omitempty" {
+					hasOmitEmpty = true
+					break
+				}
+			}
+
+			// Build the nested field path
+			nestedFieldPath := field.Name
+			if currentPath != "" {
+				nestedFieldPath = currentPath + "." + field.Name
+			}
+
+			// Skip empty fields if omitempty is set AND field is NOT in parameterization rules
+			fieldValue := v.Field(i)
+			if hasOmitEmpty && p.isEmptyValue(fieldValue) && !p.isFieldInRules(rules, nestedFieldPath) {
+				continue
+			}
+
+			keyNode := &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: yamlFieldName,
+			}
+			valueNode := p.fieldToNode(fieldValue, rules, nestedFieldPath)
+			node.Content = append(node.Content, keyNode, valueNode)
+		}
+		return node
+
+	case reflect.Slice, reflect.Array:
+		// Convert slices/arrays
+		node := &yaml.Node{Kind: yaml.SequenceNode}
+		for i := 0; i < v.Len(); i++ {
+			itemNode := p.fieldToNode(v.Index(i), rules, currentPath)
+			node.Content = append(node.Content, itemNode)
+		}
+		return node
+
+	case reflect.Map:
+		// Convert maps
+		node := &yaml.Node{Kind: yaml.MappingNode}
+		iter := v.MapRange()
+		for iter.Next() {
+			keyNode := &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: fmt.Sprintf("%v", iter.Key().Interface()),
+			}
+			valueNode := p.fieldToNode(iter.Value(), rules, currentPath)
+			node.Content = append(node.Content, keyNode, valueNode)
+		}
+		return node
+
+	case reflect.String:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: v.String(),
+		}
+
+	case reflect.Bool:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!bool",
+			Value: fmt.Sprintf("%t", v.Bool()),
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!int",
+			Value: fmt.Sprintf("%d", v.Int()),
+		}
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!int",
+			Value: fmt.Sprintf("%d", v.Uint()),
+		}
+
+	case reflect.Float32, reflect.Float64:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!float",
+			Value: fmt.Sprintf("%g", v.Float()),
+		}
+
+	default:
+		// For other types, use interface conversion
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: fmt.Sprintf("%v", v.Interface()),
+		}
+	}
+}
+
+// structToMapIgnoringOmitempty converts a struct to a map while including all fields
+// regardless of omitempty tags. This ensures fields to be parameterized are present
+// even if they're empty/nil in the original struct.
+func (p *parameterizer) structToMapIgnoringOmitempty(obj interface{}) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected struct, got %v", v.Kind())
+	}
+
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+		fieldValue := v.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Get the yaml tag
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag == "" || yamlTag == "-" {
+			continue
+		}
+
+		// Parse yaml tag to get field name (ignore omitempty and other options)
+		tagParts := strings.Split(yamlTag, ",")
+		yamlFieldName := tagParts[0]
+
+		// Convert the field value to interface
+		fieldInterface := p.convertFieldToInterface(fieldValue)
+		result[yamlFieldName] = fieldInterface
+	}
+
+	return result, nil
+}
+
+// convertFieldToInterface recursively converts reflect.Value to interface{}
+// handling nested structs, maps, slices, and pointers
+func (p *parameterizer) convertFieldToInterface(v reflect.Value) interface{} {
+	// Handle nil pointers
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return nil
+	}
+
+	// Dereference pointers
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		// Recursively convert nested structs
+		result := make(map[string]interface{})
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			field := t.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+
+			yamlTag := field.Tag.Get("yaml")
+			if yamlTag == "" || yamlTag == "-" {
+				continue
+			}
+
+			tagParts := strings.Split(yamlTag, ",")
+			yamlFieldName := tagParts[0]
+			result[yamlFieldName] = p.convertFieldToInterface(v.Field(i))
+		}
+		return result
+
+	case reflect.Slice, reflect.Array:
+		// Convert slices/arrays
+		result := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			result[i] = p.convertFieldToInterface(v.Index(i))
+		}
+		return result
+
+	case reflect.Map:
+		// Convert maps
+		result := make(map[string]interface{})
+		iter := v.MapRange()
+		for iter.Next() {
+			key := iter.Key()
+			val := iter.Value()
+			keyStr := fmt.Sprintf("%v", key.Interface())
+			result[keyStr] = p.convertFieldToInterface(val)
+		}
+		return result
+
+	default:
+		// For basic types, return the interface value
+		return v.Interface()
+	}
+}
+
+// convertStructPathsToYAMLPaths converts Go struct field paths to YAML field paths
+// e.g., "InboundAuthConfig[].OAuthAppConfig.ClientID" -> "inbound_auth_config[].config.client_id"
+func (p *parameterizer) convertStructPathsToYAMLPaths(obj interface{}, rules *resourceRules) *resourceRules {
+	logger := log.GetLogger().With(log.String("component", "Parameterizer"))
+
+	converted := &resourceRules{
+		Variables:      make([]string, len(rules.Variables)),
+		ArrayVariables: make([]string, len(rules.ArrayVariables)),
+	}
+
+	objType := reflect.TypeOf(obj)
+	if objType.Kind() == reflect.Ptr {
+		objType = objType.Elem()
+	}
+
+	for i, path := range rules.Variables {
+		yamlPath := p.convertPathToYAMLPath(objType, path)
+		converted.Variables[i] = yamlPath
+		// Debug log to help troubleshoot path resolution
+		logger.Debug("Converted variable path",
+			log.String("original", path),
+			log.String("yaml", yamlPath))
+	}
+
+	for i, path := range rules.ArrayVariables {
+		yamlPath := p.convertPathToYAMLPath(objType, path)
+		converted.ArrayVariables[i] = yamlPath
+		// Debug log to help troubleshoot path resolution
+		logger.Debug("Converted array variable path",
+			log.String("original", path),
+			log.String("yaml", yamlPath))
+	}
+
+	return converted
+}
+
+// convertPathToYAMLPath converts a single struct field path to YAML field path
+// Handles array notation (e.g., "FieldName[]" or "FieldName[].SubField")
+func (p *parameterizer) convertPathToYAMLPath(objType reflect.Type, path string) string {
+	parts := strings.Split(path, ".")
+	yamlParts := make([]string, 0, len(parts))
+
+	currentType := objType
+	for _, part := range parts {
+		if currentType.Kind() == reflect.Ptr {
+			currentType = currentType.Elem()
+		}
+
+		// Check if this part indicates an array access (e.g., "FieldName[]")
+		isArrayAccess := strings.HasSuffix(part, "[]")
+		fieldName := part
+		if isArrayAccess {
+			// Remove the [] suffix to get the actual field name
+			fieldName = strings.TrimSuffix(part, "[]")
+		}
+
+		if currentType.Kind() != reflect.Struct {
+			// Can't continue, just use the original part
+			yamlParts = append(yamlParts, part)
+			continue
+		}
+
+		// Find the field by name (case-insensitive)
+		field, found := p.findFieldByNameCaseInsensitive(currentType, fieldName)
+		if !found {
+			// Field not found, use original part
+			yamlParts = append(yamlParts, part)
+			continue
+		}
+
+		// Get YAML tag
+		yamlTag := field.Tag.Get("yaml")
+		if yamlTag == "" || yamlTag == "-" {
+			// No yaml tag, use field name
+			yamlParts = append(yamlParts, part)
+			currentType = field.Type
+			continue
+		}
+
+		// Parse yaml tag (format: "name,omitempty,flow" etc.)
+		yamlName := strings.Split(yamlTag, ",")[0]
+
+		// Preserve the array notation in the YAML path
+		if isArrayAccess {
+			yamlParts = append(yamlParts, yamlName+"[]")
+			// For arrays/slices, get the element type
+			if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
+				currentType = field.Type.Elem()
+			} else {
+				currentType = field.Type
+			}
+		} else {
+			yamlParts = append(yamlParts, yamlName)
+			currentType = field.Type
+		}
+	}
+
+	return strings.Join(yamlParts, ".")
+}
+
+// parameterizeNode applies templating rules to yaml.Node tree
+func (p *parameterizer) parameterizeNode(node *yaml.Node, rules *resourceRules, resourceName string) error {
+	if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {
+		return nil
+	}
+
+	root := node.Content[0]
+
+	// Process simple variables
+	for _, path := range rules.Variables {
+		varName := p.pathToVariableName(resourceName, path)
+		if err := p.replaceNodeValue(root, path, fmt.Sprintf("{{.%s}}", varName)); err != nil {
+			return err
+		}
+	}
+
+	// Process array variables
+	for _, path := range rules.ArrayVariables {
+		varName := p.pathToVariableName(resourceName, path)
+		if err := p.replaceArrayNode(root, path, varName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// pathToVariableName converts path to uppercase variable name with app name prefix
+// e.g., "My App", "InboundAuthConfig.oauth.RedirectURIs" -> "MY_APP_REDIRECT_URIS"
+func (p *parameterizer) pathToVariableName(appName, path string) string {
+	parts := strings.Split(path, ".")
+	lastPart := parts[len(parts)-1]
+
+	// Convert appName: replace spaces with underscores, convert camelCase to snake_case, then uppercase
+	appPrefix := strings.ReplaceAll(appName, " ", "_")
+	appPrefix = p.toSnakeCase(appPrefix)
+
+	// Convert field name from camelCase/PascalCase to snake_case
+	fieldName := p.toSnakeCase(lastPart)
+
+	// Prepend app prefix to field name
+	return appPrefix + "_" + fieldName
+}
+
+// toSnakeCase converts camelCase/PascalCase to UPPER_SNAKE_CASE
+func (p *parameterizer) toSnakeCase(s string) string {
+	var result strings.Builder
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		// Add underscore before uppercase letter if:
+		// 1. Not at the beginning (i > 0)
+		// 2. Previous character is lowercase (not underscore or uppercase) OR
+		// 3. Next character exists and is lowercase (handles acronyms like "ClientID" -> "CLIENT_ID")
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			prev := runes[i-1]
+			// Check if previous char is lowercase (skip if it's underscore or uppercase)
+			if prev >= 'a' && prev <= 'z' {
+				result.WriteRune('_')
+			} else if prev != '_' && i+1 < len(runes) {
+				// Previous is uppercase (but not underscore), check next
+				next := runes[i+1]
+				if next >= 'a' && next <= 'z' {
+					result.WriteRune('_')
+				}
+			}
+		}
+
+		result.WriteRune(r)
+	}
+
+	return strings.ToUpper(result.String())
+}
+
+// replaceNodeValue finds and replaces a scalar value in the node tree
+// Handles array notation (e.g., "field[]" means iterate all array elements)
+func (p *parameterizer) replaceNodeValue(node *yaml.Node, path string, replacement string) error {
+	parts := strings.Split(path, ".")
+	current := node
+
+	for i, part := range parts {
+		// Check if this part indicates array access
+		isArrayAccess := strings.HasSuffix(part, "[]")
+		fieldName := part
+		if isArrayAccess {
+			fieldName = strings.TrimSuffix(part, "[]")
+		}
+
+		if current.Kind != yaml.MappingNode {
+			return nil // Path doesn't exist
+		}
+
+		found := false
+		for j := 0; j < len(current.Content); j += 2 {
+			keyNode := current.Content[j]
+			valueNode := current.Content[j+1]
+
+			if keyNode.Value == fieldName {
+				if isArrayAccess {
+					// Handle array access - need to iterate through array elements
+					if valueNode.Kind == yaml.SequenceNode {
+						// Process each element in the sequence
+						for _, elemNode := range valueNode.Content {
+							if i == len(parts)-1 {
+								// This shouldn't happen for array access without further path
+								return nil
+							}
+							// Continue with remaining path on each element
+							remainingPath := strings.Join(parts[i+1:], ".")
+							if err := p.replaceNodeValue(elemNode, remainingPath, replacement); err != nil {
+								return err
+							}
+						}
+						return nil
+					}
+				} else if i == len(parts)-1 {
+					// Replace the value
+					valueNode.Kind = yaml.ScalarNode
+					valueNode.Tag = "!!str"
+					valueNode.Value = replacement
+					valueNode.Style = yaml.LiteralStyle
+					return nil
+				}
+				current = valueNode
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil // Path doesn't exist
+		}
+	}
+
+	return nil
+}
+
+// replaceArrayNode finds and replaces an array with template range syntax
+// Handles array notation (e.g., "field[]" means iterate all array elements)
+func (p *parameterizer) replaceArrayNode(node *yaml.Node, path string, varName string) error {
+	parts := strings.Split(path, ".")
+	current := node
+
+	for i, part := range parts {
+		// Check if this part indicates array access
+		isArrayAccess := strings.HasSuffix(part, "[]")
+		fieldName := part
+		if isArrayAccess {
+			fieldName = strings.TrimSuffix(part, "[]")
+		}
+
+		if current.Kind != yaml.MappingNode {
+			return nil // Path doesn't exist
+		}
+
+		found := false
+		for j := 0; j < len(current.Content); j += 2 {
+			keyNode := current.Content[j]
+			valueNode := current.Content[j+1]
+
+			if keyNode.Value == fieldName {
+				if isArrayAccess {
+					// Handle array access - need to iterate through array elements
+					if valueNode.Kind == yaml.SequenceNode {
+						// Process each element in the sequence
+						for _, elemNode := range valueNode.Content {
+							if i == len(parts)-1 {
+								// This shouldn't happen for array access without further path
+								return nil
+							}
+							// Continue with remaining path on each element
+							remainingPath := strings.Join(parts[i+1:], ".")
+							if err := p.replaceArrayNode(elemNode, remainingPath, varName); err != nil {
+								return err
+							}
+						}
+						return nil
+					}
+				} else if i == len(parts)-1 {
+					// Replace array with template range syntax
+					if valueNode.Kind == yaml.SequenceNode {
+						// Create a new sequence node with template content
+						// Instead of replacing with a scalar, we create template nodes within the sequence
+
+						// Create template range start comment
+						rangeStartNode := &yaml.Node{
+							Kind:  yaml.ScalarNode,
+							Tag:   "!!str",
+							Value: fmt.Sprintf("{{- range .%s}}", varName),
+							Style: yaml.FlowStyle,
+						}
+
+						// Create template item node
+						itemNode := &yaml.Node{
+							Kind:  yaml.ScalarNode,
+							Tag:   "!!str",
+							Value: "{{.}}",
+							Style: yaml.FlowStyle,
+						}
+
+						// Create template range end comment
+						rangeEndNode := &yaml.Node{
+							Kind:  yaml.ScalarNode,
+							Tag:   "!!str",
+							Value: "{{- end}}",
+							Style: yaml.FlowStyle,
+						}
+
+						// Replace the sequence content with template nodes
+						valueNode.Content = []*yaml.Node{rangeStartNode, itemNode, rangeEndNode}
+					}
+					return nil
+				}
+				current = valueNode
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil // Path doesn't exist
+		}
+	}
+
+	return nil
+}
+
+// isTemplateSequence checks if a sequence node contains template range syntax
+func (p *parameterizer) isTemplateSequence(node *yaml.Node) bool {
+	return node.Kind == yaml.SequenceNode &&
+		len(node.Content) > 0 &&
+		strings.HasPrefix(node.Content[0].Value, "{{- range")
+}
+
+// renderTemplateSequence renders a template sequence with range syntax
+func (p *parameterizer) renderTemplateSequence(buf *bytes.Buffer, node *yaml.Node, indent int) {
+	for _, item := range node.Content {
+		if strings.HasPrefix(item.Value, "{{- range") || strings.HasPrefix(item.Value, "{{- end}}") {
+			// Range start/end - write at same indent level
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString(item.Value)
+			buf.WriteString("\n")
+		} else {
+			// Item template - write as list item
+			buf.WriteString(strings.Repeat(" ", indent))
+			buf.WriteString("- ")
+			buf.WriteString(item.Value)
+			buf.WriteString("\n")
+		}
+	}
+}
+
+// renderMappingValue renders the value part of a mapping key-value pair
+func (p *parameterizer) renderMappingValue(buf *bytes.Buffer, valueNode *yaml.Node, indent int) error {
+	// Check if value needs special handling
+	if valueNode.Kind == yaml.ScalarNode && strings.HasPrefix(valueNode.Value, "{{") {
+		// Template value - write inline
+		buf.WriteString(" ")
+		buf.WriteString(valueNode.Value)
+		buf.WriteString("\n")
+	} else if p.isTemplateSequence(valueNode) {
+		// Template sequence - render template syntax
+		buf.WriteString("\n")
+		p.renderTemplateSequence(buf, valueNode, indent+2)
+	} else if valueNode.Kind == yaml.SequenceNode {
+		// Regular sequence
+		buf.WriteString("\n")
+		if err := p.renderNode(buf, valueNode, indent+2); err != nil {
+			return err
+		}
+	} else if valueNode.Kind == yaml.MappingNode {
+		// Nested mapping
+		buf.WriteString("\n")
+		if err := p.renderNode(buf, valueNode, indent+2); err != nil {
+			return err
+		}
+	} else {
+		// Regular scalar value
+		buf.WriteString(" ")
+		buf.WriteString(valueNode.Value)
+		buf.WriteString("\n")
+	}
+	return nil
+}
+
+// renderSequenceItemMapping renders an inline mapping within a sequence item
+func (p *parameterizer) renderSequenceItemMapping(buf *bytes.Buffer, item *yaml.Node, indent int) error {
+	first := true
+	for j := 0; j < len(item.Content); j += 2 {
+		keyNode := item.Content[j]
+		valueNode := item.Content[j+1]
+
+		if !first {
+			buf.WriteString(strings.Repeat(" ", indent+2))
+		}
+		first = false
+
+		buf.WriteString(keyNode.Value)
+		buf.WriteString(":")
+
+		if valueNode.Kind == yaml.ScalarNode {
+			// Template or regular scalar value
+			buf.WriteString(" ")
+			buf.WriteString(valueNode.Value)
+			buf.WriteString("\n")
+		} else if p.isTemplateSequence(valueNode) {
+			// Template sequence
+			buf.WriteString("\n")
+			p.renderTemplateSequence(buf, valueNode, indent+4)
+		} else {
+			// Regular sequence, nested mapping, or other
+			buf.WriteString("\n")
+			if err := p.renderNode(buf, valueNode, indent+4); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// renderMappingNode renders a mapping node (key-value pairs)
+func (p *parameterizer) renderMappingNode(buf *bytes.Buffer, node *yaml.Node, indent int) error {
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		// Write indentation and key
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString(keyNode.Value)
+		buf.WriteString(":")
+
+		// Render the value
+		if err := p.renderMappingValue(buf, valueNode, indent); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderSequenceNode renders a sequence node (array items)
+func (p *parameterizer) renderSequenceNode(buf *bytes.Buffer, node *yaml.Node, indent int) error {
+	for _, item := range node.Content {
+		buf.WriteString(strings.Repeat(" ", indent))
+		buf.WriteString("- ")
+
+		if item.Kind == yaml.MappingNode {
+			// Inline mapping for sequence item
+			if err := p.renderSequenceItemMapping(buf, item, indent); err != nil {
+				return err
+			}
+		} else {
+			// Scalar value
+			buf.WriteString(item.Value)
+			buf.WriteString("\n")
+		}
+	}
+	return nil
+}
+
+// renderNode renders a yaml.Node to a buffer with custom handling for template syntax
+func (p *parameterizer) renderNode(buf *bytes.Buffer, node *yaml.Node, indent int) error {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		// Render document children
+		for _, child := range node.Content {
+			if err := p.renderNode(buf, child, indent); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		return p.renderMappingNode(buf, node, indent)
+	case yaml.SequenceNode:
+		return p.renderSequenceNode(buf, node, indent)
+	case yaml.ScalarNode:
+		// Just write the value
+		buf.WriteString(node.Value)
+	}
+	return nil
+}

--- a/backend/internal/system/export/parameterizer_test.go
+++ b/backend/internal/system/export/parameterizer_test.go
@@ -1,0 +1,1186 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test struct with omitempty tags
+type TestApp struct {
+	Name        string     `yaml:"name"`
+	ClientID    string     `yaml:"clientId,omitempty"`
+	RedirectURI string     `yaml:"redirectUri,omitempty"`
+	OAuth       *TestOAuth `yaml:"oauth,omitempty"`
+	Scopes      []string   `yaml:"scopes,omitempty"`
+}
+
+type TestOAuth struct {
+	GrantTypes   []string `yaml:"grantTypes,omitempty"`
+	ClientSecret string   `yaml:"clientSecret,omitempty"`
+}
+
+func TestToParameterizedYAML_WithOmitemptyFields(t *testing.T) {
+	// Test struct with empty/nil fields that have omitempty tags
+	app := &TestApp{
+		Name:        "TestApp",
+		ClientID:    "", // Empty - would normally be omitted
+		RedirectURI: "", // Empty - would normally be omitted
+		OAuth: &TestOAuth{
+			GrantTypes:   nil, // Nil slice - would normally be omitted
+			ClientSecret: "",  // Empty - would normally be omitted
+		},
+		Scopes: nil, // Nil slice - would normally be omitted
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"ClientID",
+				"RedirectURI",
+				"OAuth.ClientSecret",
+			},
+			ArrayVariables: []string{
+				"OAuth.GrantTypes",
+				"Scopes",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	// Verify that omitempty fields are included and parameterized
+	assert.Contains(t, result, "clientId:", "ClientID field should be present even though it's empty")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+
+	assert.Contains(t, result, "redirectUri:", "RedirectURI field should be present even though it's empty")
+	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+
+	assert.Contains(t, result, "clientSecret:", "ClientSecret field should be present even though it's empty")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+
+	// Verify array parameterization
+	assert.Contains(t, result, "grantTypes:", "GrantTypes field should be present")
+	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+
+	assert.Contains(t, result, "scopes:", "Scopes field should be present")
+	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+}
+
+func TestToParameterizedYAML_WithPopulatedFields(t *testing.T) {
+	// Test struct with populated fields
+	app := &TestApp{
+		Name:        "TestApp",
+		ClientID:    "test-client-id",
+		RedirectURI: "https://example.com/callback",
+		OAuth: &TestOAuth{
+			GrantTypes:   []string{"authorization_code", "refresh_token"},
+			ClientSecret: "secret123",
+		},
+		Scopes: []string{"openid", "profile"},
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"ClientID",
+				"RedirectURI",
+				"OAuth.ClientSecret",
+			},
+			ArrayVariables: []string{
+				"OAuth.GrantTypes",
+				"Scopes",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	// Verify parameterization replaced actual values
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.NotContains(t, result, "test-client-id", "Original ClientID value should be replaced")
+
+	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.NotContains(t, result, "https://example.com/callback", "Original RedirectURI should be replaced")
+
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.NotContains(t, result, "secret123", "Original ClientSecret should be replaced")
+
+	// Verify array parameterization
+	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+	assert.NotContains(t, result, "authorization_code", "Original grant type should be replaced")
+
+	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+	assert.NotContains(t, result, "openid", "Original scope should be replaced")
+}
+
+func TestToParameterizedYAML_MixedEmptyAndPopulated(t *testing.T) {
+	// Test with mix of empty and populated fields
+	app := &TestApp{
+		Name:        "TestApp",
+		ClientID:    "populated-client-id",
+		RedirectURI: "", // Empty
+		OAuth: &TestOAuth{
+			GrantTypes:   []string{"authorization_code"}, // Populated
+			ClientSecret: "",                             // Empty
+		},
+		Scopes: nil, // Nil
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"ClientID",
+				"RedirectURI",
+				"OAuth.ClientSecret",
+			},
+			ArrayVariables: []string{
+				"OAuth.GrantTypes",
+				"Scopes",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	// All fields should be parameterized regardless of whether they were empty
+	assert.Contains(t, result, "clientId:", "ClientID field should be present")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+
+	assert.Contains(t, result, "redirectUri:", "RedirectURI field should be present even though empty")
+	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+
+	assert.Contains(t, result, "clientSecret:", "ClientSecret field should be present even though empty")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+
+	assert.Contains(t, result, "grantTypes:", "GrantTypes should be present")
+	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+
+	assert.Contains(t, result, "scopes:", "Scopes should be present even though nil")
+	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+}
+
+func TestStructToMapIgnoringOmitempty(t *testing.T) {
+	app := &TestApp{
+		Name:        "TestApp",
+		ClientID:    "",
+		RedirectURI: "",
+		OAuth: &TestOAuth{
+			GrantTypes:   nil,
+			ClientSecret: "",
+		},
+		Scopes: nil,
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.structToMapIgnoringOmitempty(app)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// All fields should be present in the map, even if empty
+	assert.Contains(t, result, "name")
+	assert.Contains(t, result, "clientId")
+	assert.Contains(t, result, "redirectUri")
+	assert.Contains(t, result, "oauth")
+	assert.Contains(t, result, "scopes")
+
+	// Check nested struct
+	oauth, ok := result["oauth"].(map[string]interface{})
+	require.True(t, ok, "oauth should be a map")
+	assert.Contains(t, oauth, "grantTypes")
+	assert.Contains(t, oauth, "clientSecret")
+}
+
+func TestConvertFieldToInterface_NestedStructs(t *testing.T) {
+	app := &TestApp{
+		Name: "TestApp",
+		OAuth: &TestOAuth{
+			GrantTypes:   []string{"code"},
+			ClientSecret: "secret",
+		},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.structToMapIgnoringOmitempty(app)
+
+	require.NoError(t, err)
+
+	oauth, ok := result["oauth"].(map[string]interface{})
+	require.True(t, ok)
+
+	grantTypes, ok := oauth["grantTypes"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, grantTypes, 1)
+	assert.Equal(t, "code", grantTypes[0])
+
+	clientSecret, ok := oauth["clientSecret"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "secret", clientSecret)
+}
+
+func TestPathToVariableName(t *testing.T) {
+	parameterizer := newParameterizer(templatingRules{})
+
+	tests := []struct {
+		appName  string
+		path     string
+		expected string
+	}{
+		{"TestApp", "ClientID", "TEST_APP_CLIENT_ID"},
+		{"TestApp", "RedirectURI", "TEST_APP_REDIRECT_URI"},
+		{"TestApp", "OAuth.ClientSecret", "TEST_APP_CLIENT_SECRET"},
+		{"TestApp", "OAuth.GrantTypes", "TEST_APP_GRANT_TYPES"},
+		{"TestApp", "InboundAuthConfig.OAuth.ClientID", "TEST_APP_CLIENT_ID"},
+		{"TestApp", "simpleField", "TEST_APP_SIMPLE_FIELD"},
+		{"TestApp", "ALLCAPS", "TEST_APP_ALLCAPS"},
+		{"My App", "ClientID", "MY_APP_CLIENT_ID"},
+		{"My Test App", "RedirectURI", "MY_TEST_APP_REDIRECT_URI"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.appName+"_"+tt.path, func(t *testing.T) {
+			result := parameterizer.pathToVariableName(tt.appName, tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// =============================================================================
+// Phase 2: Omitempty Behavior Tests
+// =============================================================================
+
+// TestOmitempty_EmptyFieldsWithoutRules tests that empty fields with omitempty
+// are omitted when they're NOT in parameterization rules
+func TestOmitempty_EmptyFieldsWithoutRules(t *testing.T) {
+	app := &TestApp{
+		Name:        "TestApp",
+		ClientID:    "", // Empty with omitempty - should be omitted
+		RedirectURI: "", // Empty with omitempty - should be omitted
+		OAuth: &TestOAuth{
+			GrantTypes:   nil, // Nil slice with omitempty - should be omitted
+			ClientSecret: "",  // Empty with omitempty - should be omitted
+		},
+		Scopes: nil, // Nil slice with omitempty - should be omitted
+	}
+
+	// No parameterization rules - omitempty should work normally
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	// Verify omitempty fields are NOT present
+	assert.NotContains(t, result, "clientId:", "Empty ClientID should be omitted")
+	assert.NotContains(t, result, "redirectUri:", "Empty RedirectURI should be omitted")
+	assert.NotContains(t, result, "grantTypes:", "Nil GrantTypes should be omitted")
+	assert.NotContains(t, result, "clientSecret:", "Empty ClientSecret should be omitted")
+	assert.NotContains(t, result, "scopes:", "Nil Scopes should be omitted")
+
+	// Verify non-omitempty fields are present
+	assert.Contains(t, result, "name: TestApp", "Name field should be present")
+}
+
+// TestOmitempty_EmptyArraysOmitted verifies empty arrays with omitempty are not in output
+func TestOmitempty_EmptyArraysOmitted(t *testing.T) {
+	app := &TestApp{
+		Name: "TestApp",
+		OAuth: &TestOAuth{
+			GrantTypes: []string{}, // Empty array - should be omitted
+		},
+		Scopes: []string{}, // Empty array - should be omitted
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+	assert.NotContains(t, result, "grantTypes:", "Empty GrantTypes array should be omitted")
+	assert.NotContains(t, result, "scopes:", "Empty Scopes array should be omitted")
+}
+
+// TestOmitempty_NilSlicesOmitted verifies nil slices with omitempty are not in output
+func TestOmitempty_NilSlicesOmitted(t *testing.T) {
+	app := &TestApp{
+		Name: "TestApp",
+		OAuth: &TestOAuth{
+			GrantTypes: nil, // Nil slice
+		},
+		Scopes: nil, // Nil slice
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+	assert.NotContains(t, result, "grantTypes:", "Nil GrantTypes should be omitted")
+	assert.NotContains(t, result, "scopes:", "Nil Scopes should be omitted")
+}
+
+// TestOmitempty_NilPointersOmitted verifies nil pointers with omitempty are not in output
+func TestOmitempty_NilPointersOmitted(t *testing.T) {
+	app := &TestApp{
+		Name:  "TestApp",
+		OAuth: nil, // Nil pointer - should be omitted
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+	assert.NotContains(t, result, "oauth:", "Nil OAuth pointer should be omitted")
+	assert.Contains(t, result, "name: TestApp")
+}
+
+// =============================================================================
+// Phase 3: Parameterization Override Tests
+// =============================================================================
+
+// TestParameterization_OverridesOmitemptyForVariables verifies that empty string
+// fields in parameterization rules are included despite omitempty
+func TestParameterization_OverridesOmitemptyForVariables(t *testing.T) {
+	app := &TestApp{
+		Name:        "TestApp",
+		ClientID:    "", // Empty but in rules - should be included and parameterized
+		RedirectURI: "", // Empty but in rules - should be included and parameterized
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"ClientID",
+				"RedirectURI",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// These fields should be present and parameterized despite being empty
+	assert.Contains(t, result, "clientId:", "ClientID should be present (in rules)")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+
+	assert.Contains(t, result, "redirectUri:", "RedirectURI should be present (in rules)")
+	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+}
+
+// TestParameterization_OverridesOmitemptyForArrays verifies that empty array
+// fields in parameterization rules are included despite omitempty
+func TestParameterization_OverridesOmitemptyForArrays(t *testing.T) {
+	app := &TestApp{
+		Name:   "TestApp",
+		Scopes: nil, // Nil but in rules - should be included and parameterized
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			ArrayVariables: []string{
+				"Scopes",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Scopes should be present and parameterized despite being nil
+	assert.Contains(t, result, "scopes:", "Scopes should be present (in rules)")
+	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should be parameterized")
+}
+
+// TestParameterization_NestedFieldsWithOmitempty verifies nested empty fields
+// in parameterization are included
+func TestParameterization_NestedFieldsWithOmitempty(t *testing.T) {
+	app := &TestApp{
+		Name: "TestApp",
+		OAuth: &TestOAuth{
+			ClientSecret: "",  // Empty but in rules
+			GrantTypes:   nil, // Nil but in rules
+		},
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"OAuth.ClientSecret",
+			},
+			ArrayVariables: []string{
+				"OAuth.GrantTypes",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Nested fields should be present and parameterized
+	assert.Contains(t, result, "oauth:", "OAuth should be present")
+	assert.Contains(t, result, "clientSecret:", "ClientSecret should be present (in rules)")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "grantTypes:", "GrantTypes should be present (in rules)")
+	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should be parameterized")
+}
+
+// TestParameterization_MixedRulesAndOmitempty verifies correct behavior when
+// some fields are in rules and some are not
+func TestParameterization_MixedRulesAndOmitempty(t *testing.T) {
+	app := &TestApp{
+		Name:        "TestApp",
+		ClientID:    "Id", // Empty AND in rules - should be included
+		RedirectURI: "",   // Empty but NOT in rules - should be omitted
+		OAuth: &TestOAuth{
+			ClientSecret: "",  // Empty AND in rules - should be included
+			GrantTypes:   nil, // Nil but NOT in rules - should be omitted
+		},
+		Scopes: nil, // Nil but NOT in rules - should be omitted
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"ClientID",
+				"oauth.ClientSecret",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Fields in rules should be present
+	assert.Contains(t, result, "clientId:", "ClientID should be present (in rules)")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "clientSecret:", "ClientSecret should be present (in rules)")
+	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+
+	// Fields NOT in rules should be omitted
+	assert.NotContains(t, result, "redirectUri:", "RedirectURI should be omitted (not in rules)")
+	assert.NotContains(t, result, "grantTypes:", "GrantTypes should be omitted (not in rules)")
+	assert.NotContains(t, result, "scopes:", "Scopes should be omitted (not in rules)")
+}
+
+// =============================================================================
+// Phase 4: Field Order Preservation Tests
+// =============================================================================
+
+type OrderTestStruct struct {
+	FieldA string `yaml:"fieldA"`
+	FieldB string `yaml:"fieldB"`
+	FieldC string `yaml:"fieldC,omitempty"`
+	FieldD string `yaml:"fieldD"`
+	FieldE string `yaml:"fieldE,omitempty"`
+}
+
+// TestFieldOrder_TopLevelFieldsPreserved verifies top-level fields maintain struct order
+func TestFieldOrder_TopLevelFieldsPreserved(t *testing.T) {
+	obj := &OrderTestStruct{
+		FieldA: "valueA",
+		FieldB: "valueB",
+		FieldC: "valueC",
+		FieldD: "valueD",
+		FieldE: "valueE",
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Check that fields appear in order
+	indexA := indexOf(result, "fieldA:")
+	indexB := indexOf(result, "fieldB:")
+	indexC := indexOf(result, "fieldC:")
+	indexD := indexOf(result, "fieldD:")
+	indexE := indexOf(result, "fieldE:")
+
+	assert.True(t, indexA < indexB, "FieldA should come before FieldB")
+	assert.True(t, indexB < indexC, "FieldB should come before FieldC")
+	assert.True(t, indexC < indexD, "FieldC should come before FieldD")
+	assert.True(t, indexD < indexE, "FieldD should come before FieldE")
+}
+
+// TestFieldOrder_WithOmittedFields verifies remaining fields maintain relative order after omission
+func TestFieldOrder_WithOmittedFields(t *testing.T) {
+	obj := &OrderTestStruct{
+		FieldA: "valueA",
+		FieldB: "valueB",
+		FieldC: "", // Empty with omitempty - will be omitted
+		FieldD: "valueD",
+		FieldE: "", // Empty with omitempty - will be omitted
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Check that remaining fields maintain order
+	indexA := indexOf(result, "fieldA:")
+	indexB := indexOf(result, "fieldB:")
+	indexD := indexOf(result, "fieldD:")
+
+	assert.True(t, indexA < indexB, "FieldA should come before FieldB")
+	assert.True(t, indexB < indexD, "FieldB should come before FieldD")
+
+	// Verify omitted fields are not present
+	assert.NotContains(t, result, "fieldC:")
+	assert.NotContains(t, result, "fieldE:")
+}
+
+type NestedOrderStruct struct {
+	Name   string           `yaml:"name"`
+	Config *NestedConfigObj `yaml:"config"`
+	Extra  string           `yaml:"extra"`
+}
+
+type NestedConfigObj struct {
+	Setting1 string `yaml:"setting1"`
+	Setting2 string `yaml:"setting2"`
+	Setting3 string `yaml:"setting3"`
+}
+
+// TestFieldOrder_NestedFieldsPreserved verifies nested struct fields maintain order
+func TestFieldOrder_NestedFieldsPreserved(t *testing.T) {
+	obj := &NestedOrderStruct{
+		Name: "test",
+		Config: &NestedConfigObj{
+			Setting1: "val1",
+			Setting2: "val2",
+			Setting3: "val3",
+		},
+		Extra: "extra",
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Check top-level order
+	indexName := indexOf(result, "name:")
+	indexConfig := indexOf(result, "config:")
+	indexExtra := indexOf(result, "extra:")
+
+	assert.True(t, indexName < indexConfig, "name should come before config")
+	assert.True(t, indexConfig < indexExtra, "config should come before extra")
+
+	// Check nested order
+	indexSetting1 := indexOf(result, "setting1:")
+	indexSetting2 := indexOf(result, "setting2:")
+	indexSetting3 := indexOf(result, "setting3:")
+
+	assert.True(t, indexSetting1 < indexSetting2, "setting1 should come before setting2")
+	assert.True(t, indexSetting2 < indexSetting3, "setting2 should come before setting3")
+}
+
+// =============================================================================
+// Phase 5: Edge Case Tests
+// =============================================================================
+
+type DeeplyNestedStruct struct {
+	Level1 *Level1Struct `yaml:"level1,omitempty"`
+}
+
+type Level1Struct struct {
+	Name   string        `yaml:"name"`
+	Level2 *Level2Struct `yaml:"level2,omitempty"`
+}
+
+type Level2Struct struct {
+	Name   string        `yaml:"name"`
+	Level3 *Level3Struct `yaml:"level3,omitempty"`
+}
+
+type Level3Struct struct {
+	Name  string   `yaml:"name"`
+	Items []string `yaml:"items,omitempty"`
+}
+
+// TestEdgeCase_DeeplyNestedStructures tests 3+ level nested structures
+func TestEdgeCase_DeeplyNestedStructures(t *testing.T) {
+	obj := &DeeplyNestedStruct{
+		Level1: &Level1Struct{
+			Name: "L1",
+			Level2: &Level2Struct{
+				Name: "L2",
+				Level3: &Level3Struct{
+					Name:  "L3",
+					Items: []string{"item1", "item2"},
+				},
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "level1:")
+	assert.Contains(t, result, "level2:")
+	assert.Contains(t, result, "level3:")
+	assert.Contains(t, result, "items:")
+	assert.Contains(t, result, "- item1")
+	assert.Contains(t, result, "- item2")
+}
+
+type ArrayOfStructsTest struct {
+	Name  string       `yaml:"name"`
+	Items []ItemStruct `yaml:"items"`
+}
+
+type ItemStruct struct {
+	ID    string `yaml:"id"`
+	Value string `yaml:"value,omitempty"`
+}
+
+// TestEdgeCase_ArraysOfStructs tests arrays containing struct elements
+func TestEdgeCase_ArraysOfStructs(t *testing.T) {
+	obj := &ArrayOfStructsTest{
+		Name: "TestArray",
+		Items: []ItemStruct{
+			{ID: "1", Value: "val1"},
+			{ID: "2", Value: ""},
+		},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "items:")
+	assert.Contains(t, result, "id: \"1\"")
+	assert.Contains(t, result, "id: \"2\"")
+	assert.Contains(t, result, "value: val1")
+	// Second item's value should be omitted due to omitempty
+	// Count occurrences of "value:" - should only be 1
+	valueCount := countOccurrences(result, "value:")
+	assert.Equal(t, 1, valueCount, "Only first item should have value field")
+}
+
+// TestEdgeCase_EmptyStructWithOmitempty tests struct with all empty fields
+func TestEdgeCase_EmptyStructWithOmitempty(t *testing.T) {
+	app := &TestApp{
+		Name:  "TestApp",
+		OAuth: &TestOAuth{
+			// All fields empty with omitempty
+		},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// OAuth should still be present (not nil), but its fields should be omitted
+	assert.Contains(t, result, "oauth:")
+	assert.NotContains(t, result, "grantTypes:")
+	assert.NotContains(t, result, "clientSecret:")
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// indexOf returns the index of substr in str, or -1 if not found
+func indexOf(str, substr string) int {
+	for i := 0; i <= len(str)-len(substr); i++ {
+		if str[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+// countOccurrences counts how many times substr appears in str
+func countOccurrences(str, substr string) int {
+	count := 0
+	for i := 0; i <= len(str)-len(substr); i++ {
+		if str[i:i+len(substr)] == substr {
+			count++
+			i += len(substr) - 1
+		}
+	}
+	return count
+}
+
+// =============================================================================
+// Additional Coverage Tests for isEmptyValue
+// =============================================================================
+
+type NumericTestStruct struct {
+	IntField     int     `yaml:"intField,omitempty"`
+	Int8Field    int8    `yaml:"int8Field,omitempty"`
+	Int16Field   int16   `yaml:"int16Field,omitempty"`
+	Int32Field   int32   `yaml:"int32Field,omitempty"`
+	Int64Field   int64   `yaml:"int64Field,omitempty"`
+	UintField    uint    `yaml:"uintField,omitempty"`
+	Uint8Field   uint8   `yaml:"uint8Field,omitempty"`
+	Uint16Field  uint16  `yaml:"uint16Field,omitempty"`
+	Uint32Field  uint32  `yaml:"uint32Field,omitempty"`
+	Uint64Field  uint64  `yaml:"uint64Field,omitempty"`
+	Float32Field float32 `yaml:"float32Field,omitempty"`
+	Float64Field float64 `yaml:"float64Field,omitempty"`
+	BoolField    bool    `yaml:"boolField,omitempty"`
+}
+
+// TestIsEmptyValue_IntegerTypes tests integer type detection
+func TestIsEmptyValue_IntegerTypes(t *testing.T) {
+	obj := &NumericTestStruct{
+		IntField:   0,
+		Int8Field:  0,
+		Int16Field: 0,
+		Int32Field: 0,
+		Int64Field: 0,
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// All zero integer fields should be omitted
+	assert.NotContains(t, result, "intField:")
+	assert.NotContains(t, result, "int8Field:")
+	assert.NotContains(t, result, "int16Field:")
+	assert.NotContains(t, result, "int32Field:")
+	assert.NotContains(t, result, "int64Field:")
+}
+
+// TestIsEmptyValue_UnsignedIntegerTypes tests unsigned integer type detection
+func TestIsEmptyValue_UnsignedIntegerTypes(t *testing.T) {
+	obj := &NumericTestStruct{
+		UintField:   0,
+		Uint8Field:  0,
+		Uint16Field: 0,
+		Uint32Field: 0,
+		Uint64Field: 0,
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// All zero unsigned integer fields should be omitted
+	assert.NotContains(t, result, "uintField:")
+	assert.NotContains(t, result, "uint8Field:")
+	assert.NotContains(t, result, "uint16Field:")
+	assert.NotContains(t, result, "uint32Field:")
+	assert.NotContains(t, result, "uint64Field:")
+}
+
+// TestIsEmptyValue_FloatTypes tests float type detection
+func TestIsEmptyValue_FloatTypes(t *testing.T) {
+	obj := &NumericTestStruct{
+		Float32Field: 0.0,
+		Float64Field: 0.0,
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// All zero float fields should be omitted
+	assert.NotContains(t, result, "float32Field:")
+	assert.NotContains(t, result, "float64Field:")
+}
+
+// TestIsEmptyValue_BoolType tests bool type detection
+func TestIsEmptyValue_BoolType(t *testing.T) {
+	obj := &NumericTestStruct{
+		BoolField: false,
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// False bool field should be omitted
+	assert.NotContains(t, result, "boolField:")
+}
+
+// TestIsEmptyValue_NonZeroValues tests that non-zero values are NOT omitted
+func TestIsEmptyValue_NonZeroValues(t *testing.T) {
+	obj := &NumericTestStruct{
+		IntField:     42,
+		UintField:    99,
+		Float32Field: 3.14,
+		Float64Field: 2.718,
+		BoolField:    true,
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Non-zero fields should be present
+	assert.Contains(t, result, "intField: 42")
+	assert.Contains(t, result, "uintField: 99")
+	assert.Contains(t, result, "float32Field: 3.14")
+	assert.Contains(t, result, "float64Field: 2.718")
+	assert.Contains(t, result, "boolField: true")
+}
+
+// =============================================================================
+// Additional Coverage Tests for convertFieldToInterface
+// =============================================================================
+
+type MapTestStruct struct {
+	StringMap map[string]string      `yaml:"stringMap"`
+	IntMap    map[string]int         `yaml:"intMap"`
+	NestedMap map[string]interface{} `yaml:"nestedMap,omitempty"`
+}
+
+// TestConvertFieldToInterface_Maps tests map conversion
+func TestConvertFieldToInterface_Maps(t *testing.T) {
+	obj := &MapTestStruct{
+		StringMap: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+		IntMap: map[string]int{
+			"count": 42,
+		},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.structToMapIgnoringOmitempty(obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Check maps are converted
+	stringMap, ok := result["stringMap"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "value1", stringMap["key1"])
+	assert.Equal(t, "value2", stringMap["key2"])
+
+	intMap, ok := result["intMap"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 42, intMap["count"])
+}
+
+// TestConvertFieldToInterface_EmptyMap tests empty map handling
+func TestConvertFieldToInterface_EmptyMap(t *testing.T) {
+	obj := &MapTestStruct{
+		StringMap: map[string]string{},
+		IntMap:    nil,
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.structToMapIgnoringOmitempty(obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Empty map should still be in result
+	stringMap, ok := result["stringMap"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Empty(t, stringMap)
+}
+
+type PrimitiveArrayStruct struct {
+	IntArray     []int     `yaml:"intArray"`
+	BoolArray    []bool    `yaml:"boolArray"`
+	Float64Array []float64 `yaml:"float64Array"`
+}
+
+// TestConvertFieldToInterface_PrimitiveArrays tests arrays of primitive types
+func TestConvertFieldToInterface_PrimitiveArrays(t *testing.T) {
+	obj := &PrimitiveArrayStruct{
+		IntArray:     []int{1, 2, 3},
+		BoolArray:    []bool{true, false, true},
+		Float64Array: []float64{1.1, 2.2, 3.3},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.structToMapIgnoringOmitempty(obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Check int array
+	intArray, ok := result["intArray"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, intArray, 3)
+	assert.Equal(t, 1, intArray[0])
+	assert.Equal(t, 2, intArray[1])
+	assert.Equal(t, 3, intArray[2])
+
+	// Check bool array
+	boolArray, ok := result["boolArray"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, boolArray, 3)
+	assert.Equal(t, true, boolArray[0])
+	assert.Equal(t, false, boolArray[1])
+
+	// Check float array
+	floatArray, ok := result["float64Array"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, floatArray, 3)
+	assert.Equal(t, 1.1, floatArray[0])
+}
+
+// =============================================================================
+// Additional Coverage Tests for renderNode edge cases
+// =============================================================================
+
+type ComplexRenderStruct struct {
+	Name           string                `yaml:"name"`
+	TemplateField  string                `yaml:"templateField"`
+	NestedTemplate *NestedTemplateStruct `yaml:"nestedTemplate"`
+	ArrayOfMaps    []map[string]string   `yaml:"arrayOfMaps,omitempty"`
+}
+
+type NestedTemplateStruct struct {
+	Value       string   `yaml:"value"`
+	TemplateArr []string `yaml:"templateArr"`
+}
+
+// TestRenderNode_ComplexTemplateStructures tests complex rendering scenarios
+func TestRenderNode_ComplexTemplateStructures(t *testing.T) {
+	obj := &ComplexRenderStruct{
+		Name:          "ComplexTest",
+		TemplateField: "original_value",
+		NestedTemplate: &NestedTemplateStruct{
+			Value:       "nested_value",
+			TemplateArr: []string{"item1", "item2"},
+		},
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"TemplateField",
+				"NestedTemplate.Value",
+			},
+			ArrayVariables: []string{
+				"NestedTemplate.TemplateArr",
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Check template replacements
+	assert.Contains(t, result, "{{.TEST_APP_TEMPLATE_FIELD}}")
+	assert.Contains(t, result, "{{.TEST_APP_VALUE}}")
+	assert.Contains(t, result, "{{- range .TEST_APP_TEMPLATE_ARR}}")
+	assert.Contains(t, result, "{{- end}}")
+}
+
+// TestRenderNode_ArrayOfMaps tests rendering arrays containing maps
+func TestRenderNode_ArrayOfMaps(t *testing.T) {
+	obj := &ComplexRenderStruct{
+		Name: "MapArrayTest",
+		ArrayOfMaps: []map[string]string{
+			{"key1": "value1", "key2": "value2"},
+			{"key3": "value3"},
+		},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Check array of maps is rendered
+	assert.Contains(t, result, "arrayOfMaps:")
+	assert.Contains(t, result, "key1: value1")
+	assert.Contains(t, result, "key2: value2")
+	assert.Contains(t, result, "key3: value3")
+}
+
+// TestToParameterizedYAML_UnknownResourceType tests error handling for unknown resource types
+func TestToParameterizedYAML_UnknownResourceType(t *testing.T) {
+	obj := &TestApp{
+		Name: "TestApp",
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	_, err := parameterizer.ToParameterizedYAML(obj, "UnknownType", "TestApp")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown resource type")
+}
+
+// TestToParameterizedYAML_NilRules tests behavior with nil rules
+func TestToParameterizedYAML_NilRules(t *testing.T) {
+	obj := &TestApp{
+		Name:     "TestApp",
+		ClientID: "test-client",
+	}
+
+	rules := templatingRules{
+		Application: nil, // Nil rules
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	// Without rules, should just output normal YAML
+	assert.Contains(t, result, "name: TestApp")
+	assert.Contains(t, result, "clientId: test-client")
+	assert.NotContains(t, result, "{{.")
+}
+
+// TestStructToMapIgnoringOmitempty_NonStructInput tests error handling for non-struct input
+func TestStructToMapIgnoringOmitempty_NonStructInput(t *testing.T) {
+	parameterizer := newParameterizer(templatingRules{})
+
+	// Test with string
+	_, err := parameterizer.structToMapIgnoringOmitempty("not a struct")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected struct")
+
+	// Test with int
+	_, err = parameterizer.structToMapIgnoringOmitempty(123)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected struct")
+}
+
+type ComplexNestedArrayStruct struct {
+	Name  string                `yaml:"name"`
+	Items []NestedItemWithArray `yaml:"items"`
+}
+
+type NestedItemWithArray struct {
+	ID     string   `yaml:"id"`
+	Values []string `yaml:"values"`
+}
+
+// TestRenderNode_NestedArraysInSequence tests rendering nested arrays in sequence items
+func TestRenderNode_NestedArraysInSequence(t *testing.T) {
+	obj := &ComplexNestedArrayStruct{
+		Name: "NestedArrayTest",
+		Items: []NestedItemWithArray{
+			{
+				ID:     "item1",
+				Values: []string{"val1", "val2"},
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Check nested array rendering
+	assert.Contains(t, result, "items:")
+	assert.Contains(t, result, "id: item1")
+	assert.Contains(t, result, "values:")
+	assert.Contains(t, result, "- val1")
+	assert.Contains(t, result, "- val2")
+}
+
+// TestFieldToNode_NilPointer tests nil pointer handling in fieldToNode
+func TestFieldToNode_NilPointer(t *testing.T) {
+	obj := &TestApp{
+		Name:  "TestApp",
+		OAuth: nil, // Nil pointer
+	}
+
+	parameterizer := newParameterizer(templatingRules{})
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+
+	// Nil OAuth pointer should be omitted due to omitempty
+	assert.NotContains(t, result, "oauth:")
+}
+
+// TestConvertPathToYAMLPath_NonStructType tests path conversion with non-struct types
+func TestConvertPathToYAMLPath_NonStructType(t *testing.T) {
+	obj := &TestApp{
+		Name:   "TestApp",
+		Scopes: []string{"scope1"}, // Scopes is a slice, not a struct
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"Scopes.InvalidPath", // This path tries to access a field on a slice
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+	// Should still generate output, even though path doesn't fully resolve
+	assert.Contains(t, result, "name: TestApp")
+}
+
+// TestFindFieldByNameCaseInsensitive_NotFound tests field lookup when field doesn't exist
+func TestFindFieldByNameCaseInsensitive_NotFound(t *testing.T) {
+	obj := &TestApp{
+		Name: "TestApp",
+	}
+
+	rules := templatingRules{
+		Application: &resourceRules{
+			Variables: []string{
+				"NonExistentField", // Field that doesn't exist
+			},
+		},
+	}
+
+	parameterizer := newParameterizer(rules)
+	result, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp")
+
+	require.NoError(t, err)
+	// Should generate output without the non-existent field
+	assert.Contains(t, result, "name: TestApp")
+}

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"strings"
+	"time"
+
+	"github.com/asgardeo/thunder/internal/application"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+const (
+	formatYAML = "yaml"
+	formatJSON = "json"
+)
+
+var parameterizerInstance = newParameterizer(rules)
+
+// ExportServiceInterface defines the interface for the export service.
+type ExportServiceInterface interface {
+	ExportResources(request *ExportRequest) (*ExportResponse, *serviceerror.ServiceError)
+}
+
+// exportService implements the ExportServiceInterface.
+type exportService struct {
+	applicationService application.ApplicationServiceInterface
+	// Future: Add other service dependencies
+	// groupService group.GroupServiceInterface
+	// userService  user.UserServiceInterface
+	// idpService   idp.IDPServiceInterface
+}
+
+// newExportService creates a new instance of exportService.
+func newExportService(appService application.ApplicationServiceInterface) ExportServiceInterface {
+	return &exportService{
+		applicationService: appService,
+	}
+}
+
+// ExportResources exports the specified resources as YAML files.
+func (es *exportService) ExportResources(request *ExportRequest) (*ExportResponse, *serviceerror.ServiceError) {
+	if request == nil {
+		return nil, serviceerror.CustomServiceError(
+			ErrorInvalidRequest,
+			"Export request cannot be nil",
+		)
+	}
+
+	// Set default options if not provided
+	options := request.Options
+	if options == nil {
+		options = &ExportOptions{
+			Format: formatYAML,
+		}
+	}
+	if options.Format == "" {
+		options.Format = formatYAML
+	}
+
+	var exportFiles []ExportFile
+	var exportErrors []ExportError
+	resourceCounts := make(map[string]int)
+
+	// Export applications if requested
+	if len(request.Applications) > 0 {
+		appFiles, appErrors := es.exportApplications(request.Applications, options)
+		exportFiles = append(exportFiles, appFiles...)
+		exportErrors = append(exportErrors, appErrors...)
+		resourceCounts["applications"] = len(appFiles)
+	}
+
+	if len(exportFiles) == 0 {
+		return nil, serviceerror.CustomServiceError(
+			ErrorNoResourcesFound,
+			"No valid resources found for export",
+		)
+	}
+
+	// Calculate total size
+	var totalSize int64
+	for i := range exportFiles {
+		exportFiles[i].Size = int64(len(exportFiles[i].Content))
+		totalSize += exportFiles[i].Size
+	}
+
+	summary := &ExportSummary{
+		TotalFiles:    len(exportFiles),
+		TotalSize:     totalSize,
+		ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+		ResourceTypes: resourceCounts,
+		Errors:        exportErrors,
+	}
+
+	return &ExportResponse{
+		Files:   exportFiles,
+		Summary: summary,
+	}, nil
+}
+
+// exportApplications exports application configurations as YAML files.
+func (es *exportService) exportApplications(applicationIDs []string, options *ExportOptions) (
+	[]ExportFile, []ExportError) {
+	logger := log.GetLogger().With(log.String("component", "ExportService"))
+	exportFiles := make([]ExportFile, 0, len(applicationIDs))
+	exportErrors := make([]ExportError, 0, len(applicationIDs))
+
+	applicationIDList := make([]string, 0)
+	if len(applicationIDs) == 1 && applicationIDs[0] == "*" {
+		// Support pagination once applicationList supports it.
+		apps, err := es.applicationService.GetApplicationList()
+		if err != nil {
+			logger.Warn("Failed to get all applications", log.Any("error", err))
+			return nil, nil
+		}
+		for _, app := range apps.Applications {
+			applicationIDList = append(applicationIDList, app.ID)
+		}
+	} else {
+		applicationIDList = applicationIDs
+	}
+
+	for _, appID := range applicationIDList {
+		// Get the application
+		app, svcErr := es.applicationService.GetApplication(appID)
+		if svcErr != nil {
+			logger.Warn("Failed to get application for export",
+				log.String("appID", appID), log.String("error", svcErr.Error))
+			exportErrors = append(exportErrors, ExportError{
+				ResourceType: "application",
+				ResourceID:   appID,
+				Error:        svcErr.Error,
+				Code:         svcErr.Code,
+			})
+			continue // Skip applications that can't be found
+		}
+
+		// Convert to export format based on options
+		var content string
+		var fileName string
+
+		if options.Format == formatJSON {
+			// Convert to JSON format (could be implemented later)
+			logger.Warn("JSON format not yet implemented, falling back to YAML")
+			options.Format = formatYAML
+		}
+
+		templateContent, err := generateTemplateFromStruct(app, app.Name)
+		if err != nil {
+			logger.Warn("Failed to generate template from struct",
+				log.String("appID", appID), log.String("error", err.Error()))
+			exportErrors = append(exportErrors, ExportError{
+				ResourceType: "application",
+				ResourceID:   appID,
+				Error:        err.Error(),
+				Code:         "TemplateGenerationError",
+			})
+			continue
+		}
+		content = templateContent
+
+		// Determine file name and folder path based on options
+		fileName = es.generateFileName(app.Name, "application", appID, options)
+		folderPath := es.generateFolderPath("application", options)
+
+		// Create export file
+		exportFile := ExportFile{
+			FileName:     fileName,
+			Content:      content,
+			FolderPath:   folderPath,
+			ResourceType: "application",
+			ResourceID:   appID,
+		}
+		exportFiles = append(exportFiles, exportFile)
+	}
+
+	return exportFiles, exportErrors
+}
+
+func generateTemplateFromStruct(data interface{}, appName string) (string, error) {
+	template, err := parameterizerInstance.ToParameterizedYAML(data, "Application", appName)
+	if err != nil {
+		return "", err
+	}
+	return template, nil
+}
+
+// sanitizeFileName sanitizes a filename by removing invalid characters.
+func sanitizeFileName(name string) string {
+	// Replace spaces with underscores and remove special characters
+	sanitized := strings.ReplaceAll(name, " ", "_")
+	// Remove any characters that are not alphanumeric, hyphens, or underscores
+	var result strings.Builder
+	for _, char := range sanitized {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '-' || char == '_' {
+			result.WriteRune(char)
+		}
+	}
+	sanitizedName := result.String()
+	if sanitizedName == "" {
+		sanitizedName = "resource"
+	}
+	return sanitizedName
+}
+
+// generateFileName generates a file name based on naming pattern and options.
+// nolint:unparam
+func (es *exportService) generateFileName(
+	resourceName, resourceType, resourceID string, options *ExportOptions) string {
+	// Get file extension based on format
+	ext := ".yaml"
+	if options.Format == "json" {
+		ext = ".json"
+	}
+
+	// Use custom naming pattern if provided
+	if options.FolderStructure != nil && options.FolderStructure.FileNamingPattern != "" {
+		pattern := options.FolderStructure.FileNamingPattern
+		pattern = strings.ReplaceAll(pattern, "${name}", sanitizeFileName(resourceName))
+		pattern = strings.ReplaceAll(pattern, "${type}", resourceType)
+		pattern = strings.ReplaceAll(pattern, "${id}", resourceID)
+		return pattern + ext
+	}
+
+	// Default naming: sanitized resource name
+	return sanitizeFileName(resourceName) + ext
+}
+
+// generateFolderPath generates the folder path for a resource based on options.
+// nolint:unparam
+func (es *exportService) generateFolderPath(resourceType string, options *ExportOptions) string {
+	if options.FolderStructure == nil {
+		return "" // No folder structure
+	}
+
+	// Check for custom structure first
+	if options.FolderStructure.CustomStructure != nil {
+		if customPath, exists := options.FolderStructure.CustomStructure[resourceType]; exists {
+			return customPath
+		}
+	}
+
+	// Group by type if enabled
+	if options.FolderStructure.GroupByType {
+		return resourceType + "s" // applications, groups, users, etc.
+	}
+
+	return ""
+}

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"testing"
+
+	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testAppID = "test-app-id"
+)
+
+// ExportServiceTestSuite defines the test suite for the export service.
+type ExportServiceTestSuite struct {
+	suite.Suite
+	appServiceMock *applicationmock.ApplicationServiceInterfaceMock
+	exportService  ExportServiceInterface
+}
+
+// SetupTest sets up the test environment before each test.
+func (suite *ExportServiceTestSuite) SetupTest() {
+	suite.appServiceMock = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
+	suite.exportService = newExportService(suite.appServiceMock)
+}
+
+// TestExportServiceTestSuite runs the test suite.
+func TestExportServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(ExportServiceTestSuite))
+}
+
+// TestExportResources_NilRequest tests ExportResources with nil request.
+func (suite *ExportServiceTestSuite) TestExportResources_NilRequest() {
+	result, err := suite.exportService.ExportResources(nil)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorInvalidRequest.Code, err.Code)
+	assert.Equal(suite.T(), "Invalid export request", err.Error)
+}
+
+// TestExportResources_EmptyRequest tests ExportResources with empty request.
+func (suite *ExportServiceTestSuite) TestExportResources_EmptyRequest() {
+	request := &ExportRequest{}
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorNoResourcesFound.Code, err.Code)
+	assert.Equal(suite.T(), "No resources found", err.Error)
+}
+
+// TestExportResources_DefaultOptions tests ExportResources with default options.
+func (suite *ExportServiceTestSuite) TestExportResources_DefaultOptions() {
+	appID := testAppID
+	request := &ExportRequest{
+		Applications: []string{appID},
+	}
+
+	mockApp := &appmodel.Application{
+		ID:          appID,
+		Name:        "Test App",
+		Description: "Test Description",
+	}
+
+	suite.appServiceMock.EXPECT().GetApplication(appID).Return(mockApp, nil)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 1)
+	assert.Equal(suite.T(), 1, result.Summary.TotalFiles)
+	assert.Contains(suite.T(), result.Summary.ResourceTypes, "applications")
+}
+
+// TestExportResources_ApplicationNotFound tests ExportResources when application is not found.
+func (suite *ExportServiceTestSuite) TestExportResources_ApplicationNotFound() {
+	appID := "non-existent-app"
+	request := &ExportRequest{
+		Applications: []string{appID},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	appError := &serviceerror.ServiceError{
+		Code:  "APP_NOT_FOUND",
+		Error: "Application not found",
+	}
+
+	suite.appServiceMock.EXPECT().GetApplication(appID).Return(nil, appError)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorNoResourcesFound.Code, err.Code)
+}
+
+// TestExportResources_CompleteOAuthApplication tests exporting an application with OAuth config.
+func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplication() {
+	appID := "oauth-app-id"
+	request := &ExportRequest{
+		Applications: []string{appID},
+		Options: &ExportOptions{
+			Format: "yaml",
+			FolderStructure: &FolderStructureOptions{
+				GroupByType:       true,
+				FileNamingPattern: "${name}_${id}",
+			},
+		},
+	}
+
+	mockOAuthConfig := &appmodel.OAuthAppConfigComplete{
+		ClientID:                "client123",
+		RedirectURIs:            []string{"http://localhost:3000/callback"},
+		GrantTypes:              []oauth2const.GrantType{oauth2const.GrantTypeAuthorizationCode},
+		ResponseTypes:           []oauth2const.ResponseType{oauth2const.ResponseTypeCode},
+		TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodClientSecretPost,
+		PKCERequired:            true,
+		PublicClient:            false,
+		Scopes:                  []string{"openid", "profile"},
+		Token: &appmodel.OAuthTokenConfig{
+			Issuer: "https://localhost:8090",
+			AccessToken: &appmodel.AccessTokenConfig{
+				ValidityPeriod: 3600,
+				UserAttributes: []string{"email", "username"},
+			},
+			IDToken: &appmodel.IDTokenConfig{
+				ValidityPeriod: 1800,
+				UserAttributes: []string{"email"},
+				ScopeClaims: map[string][]string{
+					"profile": {"name", "picture"},
+				},
+			},
+		},
+	}
+
+	mockApp := &appmodel.Application{
+		ID:          appID,
+		Name:        "OAuth Test App",
+		Description: "OAuth Test Description",
+		URL:         "https://example.com",
+		InboundAuthConfig: []appmodel.InboundAuthConfigComplete{
+			{
+				Type:           appmodel.OAuthInboundAuthType,
+				OAuthAppConfig: mockOAuthConfig,
+			},
+		},
+		Token: &appmodel.TokenConfig{
+			UserAttributes: []string{"email", "username"},
+		},
+	}
+
+	suite.appServiceMock.EXPECT().GetApplication(appID).Return(mockApp, nil)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 1)
+
+	file := result.Files[0]
+	assert.Equal(suite.T(), "OAuth_Test_App_oauth-app-id.yaml", file.FileName)
+	assert.Equal(suite.T(), "applications", file.FolderPath)
+	assert.Contains(suite.T(), file.Content, "name: OAuth Test App")
+	assert.Contains(suite.T(), file.Content, "client_id: {{.O_AUTH_TEST_APP_CLIENT_ID}}")
+	assert.Contains(suite.T(), file.Content, "client_secret: {{.O_AUTH_TEST_APP_CLIENT_SECRET}}")
+	assert.Contains(suite.T(), file.Content, "redirect_uris:")
+	assert.Contains(suite.T(), file.Content, "{{- range .O_AUTH_TEST_APP_REDIRECT_URIS}}")
+
+	assert.Equal(suite.T(), 1, result.Summary.ResourceTypes["applications"])
+	assert.Equal(suite.T(), int64(len(file.Content)), file.Size)
+}
+
+// TestExportResources_MultipleApplications tests exporting multiple applications.
+func (suite *ExportServiceTestSuite) TestExportResources_MultipleApplications() {
+	app1ID := "app1"
+	app2ID := "app2"
+	request := &ExportRequest{
+		Applications: []string{app1ID, app2ID},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	mockApp1 := &appmodel.Application{
+		ID:          app1ID,
+		Name:        "App One",
+		Description: "First App",
+	}
+
+	mockApp2 := &appmodel.Application{
+		ID:          app2ID,
+		Name:        "App Two",
+		Description: "Second App",
+	}
+
+	suite.appServiceMock.EXPECT().GetApplication(app1ID).Return(mockApp1, nil)
+	suite.appServiceMock.EXPECT().GetApplication(app2ID).Return(mockApp2, nil)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 2)
+	assert.Equal(suite.T(), 2, result.Summary.TotalFiles)
+	assert.Equal(suite.T(), 2, result.Summary.ResourceTypes["applications"])
+}
+
+// TestExportResources_PartialFailure tests exporting when some applications fail.
+func (suite *ExportServiceTestSuite) TestExportResources_PartialFailure() {
+	app1ID := "valid-app"
+	app2ID := "invalid-app"
+	request := &ExportRequest{
+		Applications: []string{app1ID, app2ID},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	mockApp1 := &appmodel.Application{
+		ID:   app1ID,
+		Name: "Valid App",
+	}
+
+	appError := &serviceerror.ServiceError{
+		Code:  "APP_NOT_FOUND",
+		Error: "Application not found",
+	}
+
+	suite.appServiceMock.EXPECT().GetApplication(app1ID).Return(mockApp1, nil)
+	suite.appServiceMock.EXPECT().GetApplication(app2ID).Return(nil, appError)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 1) // Only one successful export
+	assert.Equal(suite.T(), 1, result.Summary.TotalFiles)
+	assert.Len(suite.T(), result.Summary.Errors, 1) // One error recorded
+	assert.Equal(suite.T(), "application", result.Summary.Errors[0].ResourceType)
+	assert.Equal(suite.T(), app2ID, result.Summary.Errors[0].ResourceID)
+}
+
+// TestExportResources_WildcardApplications tests exporting all applications using wildcard.
+func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications() {
+	request := &ExportRequest{
+		Applications: []string{"*"},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	// Mock GetApplicationList to return 3 applications
+	mockAppList := &appmodel.ApplicationListResponse{
+		TotalResults: 3,
+		Count:        3,
+		Applications: []appmodel.BasicApplicationResponse{
+			{ID: "app1", Name: "Application One"},
+			{ID: "app2", Name: "Application Two"},
+			{ID: "app3", Name: "Application Three"},
+		},
+	}
+
+	mockApp1 := &appmodel.Application{
+		ID:          "app1",
+		Name:        "Application One",
+		Description: "First App",
+	}
+
+	mockApp2 := &appmodel.Application{
+		ID:          "app2",
+		Name:        "Application Two",
+		Description: "Second App",
+	}
+
+	mockApp3 := &appmodel.Application{
+		ID:          "app3",
+		Name:        "Application Three",
+		Description: "Third App",
+	}
+
+	suite.appServiceMock.EXPECT().GetApplicationList().Return(mockAppList, nil)
+	suite.appServiceMock.EXPECT().GetApplication("app1").Return(mockApp1, nil)
+	suite.appServiceMock.EXPECT().GetApplication("app2").Return(mockApp2, nil)
+	suite.appServiceMock.EXPECT().GetApplication("app3").Return(mockApp3, nil)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 3) // All 3 applications exported
+	assert.Equal(suite.T(), 3, result.Summary.TotalFiles)
+	assert.Equal(suite.T(), 3, result.Summary.ResourceTypes["applications"])
+	assert.Len(suite.T(), result.Summary.Errors, 0) // No errors
+}
+
+// TestExportResources_WildcardApplications_ListFailure tests wildcard export when GetApplicationList fails.
+func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications_ListFailure() {
+	request := &ExportRequest{
+		Applications: []string{"*"},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	listError := &serviceerror.ServiceError{
+		Code:  "LIST_FAILED",
+		Error: "Failed to list applications",
+	}
+
+	suite.appServiceMock.EXPECT().GetApplicationList().Return(nil, listError)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorNoResourcesFound.Code, err.Code)
+}
+
+// TestExportResources_WildcardApplications_EmptyList tests wildcard export with empty application list.
+func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications_EmptyList() {
+	request := &ExportRequest{
+		Applications: []string{"*"},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	// Mock GetApplicationList to return empty list
+	mockAppList := &appmodel.ApplicationListResponse{
+		TotalResults: 0,
+		Count:        0,
+		Applications: []appmodel.BasicApplicationResponse{},
+	}
+
+	suite.appServiceMock.EXPECT().GetApplicationList().Return(mockAppList, nil)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorNoResourcesFound.Code, err.Code)
+}
+
+// TestExportResources_WildcardApplications_PartialFailure tests wildcard export with partial failures.
+func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications_PartialFailure() {
+	request := &ExportRequest{
+		Applications: []string{"*"},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	// Mock GetApplicationList to return 3 applications
+	mockAppList := &appmodel.ApplicationListResponse{
+		TotalResults: 3,
+		Count:        3,
+		Applications: []appmodel.BasicApplicationResponse{
+			{ID: "app1", Name: "Application One"},
+			{ID: "app2", Name: "Application Two"},
+			{ID: "app3", Name: "Application Three"},
+		},
+	}
+
+	mockApp1 := &appmodel.Application{
+		ID:          "app1",
+		Name:        "Application One",
+		Description: "First App",
+	}
+
+	mockApp3 := &appmodel.Application{
+		ID:          "app3",
+		Name:        "Application Three",
+		Description: "Third App",
+	}
+
+	appError := &serviceerror.ServiceError{
+		Code:  "APP_NOT_FOUND",
+		Error: "Application not found",
+	}
+
+	suite.appServiceMock.EXPECT().GetApplicationList().Return(mockAppList, nil)
+	suite.appServiceMock.EXPECT().GetApplication("app1").Return(mockApp1, nil)
+	suite.appServiceMock.EXPECT().GetApplication("app2").Return(nil, appError)
+	suite.appServiceMock.EXPECT().GetApplication("app3").Return(mockApp3, nil)
+
+	result, err := suite.exportService.ExportResources(request)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 2) // 2 successful exports
+	assert.Equal(suite.T(), 2, result.Summary.TotalFiles)
+	assert.Equal(suite.T(), 2, result.Summary.ResourceTypes["applications"])
+	assert.Len(suite.T(), result.Summary.Errors, 1) // One error recorded
+	assert.Equal(suite.T(), "application", result.Summary.Errors[0].ResourceType)
+	assert.Equal(suite.T(), "app2", result.Summary.Errors[0].ResourceID)
+}

--- a/backend/internal/system/export/template_rules.go
+++ b/backend/internal/system/export/template_rules.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+var rules templatingRules = templatingRules{
+	Application: &resourceRules{
+		Variables: []string{
+			"InboundAuthConfig[].OAuthAppConfig.ClientID",
+			"InboundAuthConfig[].OAuthAppConfig.ClientSecret",
+		},
+		ArrayVariables: []string{
+			"InboundAuthConfig[].OAuthAppConfig.RedirectURIs",
+		},
+	},
+}

--- a/backend/tests/mocks/applicationmock/ApplicationServiceInterface_mock.go
+++ b/backend/tests/mocks/applicationmock/ApplicationServiceInterface_mock.go
@@ -155,23 +155,23 @@ func (_c *ApplicationServiceInterfaceMock_DeleteApplication_Call) RunAndReturn(r
 }
 
 // GetApplication provides a mock function for the type ApplicationServiceInterfaceMock
-func (_mock *ApplicationServiceInterfaceMock) GetApplication(appID string) (*model.ApplicationProcessedDTO, *serviceerror.ServiceError) {
+func (_mock *ApplicationServiceInterfaceMock) GetApplication(appID string) (*model.Application, *serviceerror.ServiceError) {
 	ret := _mock.Called(appID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetApplication")
 	}
 
-	var r0 *model.ApplicationProcessedDTO
+	var r0 *model.Application
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*model.ApplicationProcessedDTO, *serviceerror.ServiceError)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) (*model.Application, *serviceerror.ServiceError)); ok {
 		return returnFunc(appID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *model.ApplicationProcessedDTO); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) *model.Application); ok {
 		r0 = returnFunc(appID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.ApplicationProcessedDTO)
+			r0 = ret.Get(0).(*model.Application)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
@@ -208,12 +208,12 @@ func (_c *ApplicationServiceInterfaceMock_GetApplication_Call) Run(run func(appI
 	return _c
 }
 
-func (_c *ApplicationServiceInterfaceMock_GetApplication_Call) Return(applicationProcessedDTO *model.ApplicationProcessedDTO, serviceError *serviceerror.ServiceError) *ApplicationServiceInterfaceMock_GetApplication_Call {
-	_c.Call.Return(applicationProcessedDTO, serviceError)
+func (_c *ApplicationServiceInterfaceMock_GetApplication_Call) Return(application *model.Application, serviceError *serviceerror.ServiceError) *ApplicationServiceInterfaceMock_GetApplication_Call {
+	_c.Call.Return(application, serviceError)
 	return _c
 }
 
-func (_c *ApplicationServiceInterfaceMock_GetApplication_Call) RunAndReturn(run func(appID string) (*model.ApplicationProcessedDTO, *serviceerror.ServiceError)) *ApplicationServiceInterfaceMock_GetApplication_Call {
+func (_c *ApplicationServiceInterfaceMock_GetApplication_Call) RunAndReturn(run func(appID string) (*model.Application, *serviceerror.ServiceError)) *ApplicationServiceInterfaceMock_GetApplication_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/export/exportapi_test.go
+++ b/tests/integration/export/exportapi_test.go
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testServerURL = "https://localhost:8095"
+)
+
+// ExportAPITestSuite is a test suite for export API tests.
+type ExportAPITestSuite struct {
+	suite.Suite
+}
+
+// TestExportAPITestSuite runs the export API test suite.
+func TestExportAPITestSuite(t *testing.T) {
+	suite.Run(t, new(ExportAPITestSuite))
+}
+
+// SetupSuite sets up the test suite.
+func (ts *ExportAPITestSuite) SetupSuite() {
+	// Initialize any setup if needed
+}
+
+// TearDownSuite tears down the test suite.
+func (ts *ExportAPITestSuite) TearDownSuite() {
+	// Clean up any resources if needed
+}
+
+// TestApplicationExportYAML tests the application export functionality returning YAML.
+func (ts *ExportAPITestSuite) TestApplicationExportYAML() {
+	// Create a test application first
+	app := Application{
+		Name:                      "Export Test App",
+		Description:               "Test application for export functionality",
+		IsRegistrationFlowEnabled: true,
+		URL:                       "https://exporttest.example.com",
+		LogoURL:                   "https://exporttest.example.com/logo.png",
+		AuthFlowGraphID:           "auth_flow_config_basic",
+		RegistrationFlowGraphID:   "registration_flow_config_basic",
+		Certificate: &ApplicationCert{
+			Type:  "NONE",
+			Value: "",
+		},
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                "export_test_client",
+					ClientSecret:            "export_test_secret",
+					RedirectURIs:            []string{"https://exporttest.example.com/callback"},
+					GrantTypes:              []string{"authorization_code", "refresh_token"},
+					ResponseTypes:           []string{"code"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					PKCERequired:            false,
+					PublicClient:            false,
+				},
+			},
+		},
+	}
+
+	appID, err := ts.createApplication(app)
+	ts.Require().NoError(err)
+	defer ts.deleteApplication(appID)
+
+	// Test YAML export functionality
+	exportRequest := ExportRequest{
+		Applications: []string{appID},
+	}
+
+	yamlContent, err := ts.exportResourcesYAML(exportRequest)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	// Verify the exported YAML content
+	ts.Assert().Contains(yamlContent, "name: Export Test App")
+	ts.Assert().Contains(yamlContent, "description: Test application for export functionality")
+	ts.Assert().Contains(yamlContent, "client_id: {{.EXPORT_TEST_APP_CLIENT_ID}}")
+	ts.Assert().NotContains(yamlContent, "export_test_secret") // Client secret should not be exported
+	ts.Assert().Contains(yamlContent, "# File: Export_Test_App.yaml")
+
+	// Test JSON export functionality for backward compatibility
+	exportResponse, err := ts.exportResourcesJSON(exportRequest)
+	ts.Require().NoError(err)
+	ts.Require().NotNil(exportResponse)
+	ts.Assert().Len(exportResponse.Files, 1)
+
+	// Verify the exported file
+	exportedFile := exportResponse.Files[0]
+	ts.Assert().Equal("Export_Test_App.yaml", exportedFile.FileName)
+	ts.Assert().Contains(exportedFile.Content, "name: Export Test App")
+}
+
+// TestExportWithInvalidApplicationID tests export with invalid application ID.
+func (ts *ExportAPITestSuite) TestExportWithInvalidApplicationID() {
+	// Test export with invalid application ID
+	invalidExportRequest := ExportRequest{
+		Applications: []string{"invalid-uuid"},
+	}
+
+	_, err := ts.exportResourcesYAML(invalidExportRequest)
+	ts.Require().Error(err)
+}
+
+// TestExportWithEmptyRequest tests export with empty request.
+func (ts *ExportAPITestSuite) TestExportWithEmptyRequest() {
+	// Test export with empty request
+	emptyExportRequest := ExportRequest{
+		Applications: []string{},
+	}
+
+	_, err := ts.exportResourcesYAML(emptyExportRequest)
+	ts.Require().Error(err)
+}
+
+// Helper functions
+
+func (ts *ExportAPITestSuite) createApplication(app Application) (string, error) {
+	appJSON, err := json.Marshal(app)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal application: %w", err)
+	}
+
+	reqBody := bytes.NewReader(appJSON)
+	req, err := http.NewRequest("POST", testServerURL+"/applications", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+
+	var createdApp Application
+	err = json.NewDecoder(resp.Body).Decode(&createdApp)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse response body: %w", err)
+	}
+
+	id := createdApp.ID
+	if id == "" {
+		return "", fmt.Errorf("response does not contain id")
+	}
+	return id, nil
+}
+
+func (ts *ExportAPITestSuite) deleteApplication(appID string) error {
+	req, err := http.NewRequest("DELETE", testServerURL+"/applications/"+appID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 204, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+	return nil
+}
+
+func (ts *ExportAPITestSuite) exportResourcesYAML(exportRequest ExportRequest) (string, error) {
+	reqJSON, err := json.Marshal(exportRequest)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal export request: %w", err)
+	}
+
+	reqBody := bytes.NewReader(reqJSON)
+	req, err := http.NewRequest("POST", testServerURL+"/export", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to create export request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send export request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+
+	// Verify Content-Type is application/yaml
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/yaml") {
+		return "", fmt.Errorf("expected Content-Type to contain 'application/yaml', got '%s'", contentType)
+	}
+
+	yamlContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read YAML response: %w", err)
+	}
+
+	return string(yamlContent), nil
+}
+
+func (ts *ExportAPITestSuite) exportResourcesJSON(exportRequest ExportRequest) (*ExportResponse, error) {
+	reqJSON, err := json.Marshal(exportRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal export request: %w", err)
+	}
+
+	reqBody := bytes.NewReader(reqJSON)
+	req, err := http.NewRequest("POST", testServerURL+"/export/json", reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create export request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send export request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+
+	var exportResponse ExportResponse
+	err = json.NewDecoder(resp.Body).Decode(&exportResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse export response: %w", err)
+	}
+
+	return &exportResponse, nil
+}

--- a/tests/integration/export/model.go
+++ b/tests/integration/export/model.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package export
+
+// ExportRequest represents the request structure for exporting resources.
+type ExportRequest struct {
+	Applications []string `json:"applications,omitempty"`
+}
+
+// ExportResponse represents the response structure for exporting resources.
+type ExportResponse struct {
+	Files []ExportFile `json:"files"`
+}
+
+// ExportFile represents a single YAML file in the export response.
+type ExportFile struct {
+	FileName string `json:"file_name"`
+	Content  string `json:"content"`
+}
+
+// Application represents the structure for application request and response in tests.
+type Application struct {
+	ID                        string              `json:"id,omitempty"`
+	Name                      string              `json:"name"`
+	Description               string              `json:"description,omitempty"`
+	ClientID                  string              `json:"client_id,omitempty"`
+	ClientSecret              string              `json:"client_secret,omitempty"`
+	AuthFlowGraphID           string              `json:"auth_flow_graph_id,omitempty"`
+	RegistrationFlowGraphID   string              `json:"registration_flow_graph_id,omitempty"`
+	IsRegistrationFlowEnabled bool                `json:"is_registration_flow_enabled"`
+	URL                       string              `json:"url,omitempty"`
+	LogoURL                   string              `json:"logo_url,omitempty"`
+	Certificate               *ApplicationCert    `json:"certificate,omitempty"`
+	Token                     *TokenConfig        `json:"token,omitempty"`
+	TosURI                    string              `json:"tos_uri,omitempty"`
+	PolicyURI                 string              `json:"policy_uri,omitempty"`
+	Contacts                  []string            `json:"contacts,omitempty"`
+	InboundAuthConfig         []InboundAuthConfig `json:"inbound_auth_config,omitempty"`
+}
+
+// ApplicationCert represents the certificate structure in the application.
+type ApplicationCert struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// InboundAuthConfig represents the inbound authentication configuration.
+type InboundAuthConfig struct {
+	Type           string          `json:"type"`
+	OAuthAppConfig *OAuthAppConfig `json:"config,omitempty"`
+}
+
+// OAuthAppConfig represents the OAuth application configuration.
+type OAuthAppConfig struct {
+	ClientID                string            `json:"client_id"`
+	ClientSecret            string            `json:"client_secret,omitempty"`
+	RedirectURIs            []string          `json:"redirect_uris"`
+	GrantTypes              []string          `json:"grant_types"`
+	ResponseTypes           []string          `json:"response_types"`
+	TokenEndpointAuthMethod string            `json:"token_endpoint_auth_method"`
+	PKCERequired            bool              `json:"pkce_required"`
+	PublicClient            bool              `json:"public_client"`
+	Scopes                  []string          `json:"scopes,omitempty"`
+	Token                   *OAuthTokenConfig `json:"token,omitempty"`
+}
+
+// OAuthTokenConfig represents the OAuth token configuration.
+type OAuthTokenConfig struct {
+	Issuer      string         `json:"issuer,omitempty"`
+	AccessToken *TokenConfig   `json:"access_token,omitempty"`
+	IDToken     *IDTokenConfig `json:"id_token,omitempty"`
+}
+
+// TokenConfig represents the token configuration.
+type TokenConfig struct {
+	Issuer         string   `json:"issuer,omitempty"`
+	ValidityPeriod int64    `json:"validity_period,omitempty"`
+	UserAttributes []string `json:"user_attributes,omitempty"`
+}
+
+// IDTokenConfig represents the ID token configuration.
+type IDTokenConfig struct {
+	ValidityPeriod int64               `json:"validity_period,omitempty"`
+	UserAttributes []string            `json:"user_attributes,omitempty"`
+	ScopeClaims    map[string][]string `json:"scope_claims,omitempty"`
+}


### PR DESCRIPTION
Add immutable config export functionality 

====
This pull request introduces a new export feature to the backend, allowing resource configurations (such as applications) to be exported in YAML, JSON, or ZIP formats via dedicated API endpoints. It also refactors application import logic to support IDs, improves error handling and logging, and enhances the flexibility of OAuth redirect URI configuration.

**Export feature implementation:**

* Added a new `export` package with service, handler, error constants, and initialization logic, supporting `/export`, `/export/json`, and `/export/zip` endpoints for exporting resources in YAML, JSON, and ZIP formats. [[1]](diffhunk://#diff-72590139f527e0ad8726cb3948c1dd8a432a80acd6760f7a4134032f1ea2424fR1-R51) [[2]](diffhunk://#diff-78c53809249d829a1617eaff91bed3f4681aec84d9c289f1acee75d0acde2912R1-R236) [[3]](diffhunk://#diff-1217bff0737bbac1e7a6615e6634472604f2938af67134bc0b1ffaff386cb1d5R1-R66)
* Registered the export service and its routes in the server, wiring it to the application service for resource access. [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216R29) [[2]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216R72-R74)

**Application import and validation improvements:**

* Added a new `ApplicationRequestWithID` type to support importing applications with explicit IDs, and updated parsing logic to use this type. [[1]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4R137-R156) [[2]](diffhunk://#diff-2bcac82e89f0873b3de4734f00ac822a66f3f07e2fd5c3378d5c5b0d6928b30dL77-R84)
* Enhanced application validation to use the provided ID if available, or generate a new UUID if missing.
* Improved error logging to include service error details during application validation.

**OAuth configuration flexibility and logging:**

* Improved the handling of `redirect_uris` in application YAML by allowing multiple URIs to be specified via templating, instead of a single environment variable.
* Added info-level logging for redirect URIs when authorization code grant type is used, aiding in debugging and validation.