### PR TITLE
Automate thunder helm chart release

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -324,6 +324,46 @@ jobs:
           echo "📦 Image available at: ${IMAGE_NAME}:${DOCKER_VERSION}"
           echo "📦 Image available at: ${IMAGE_NAME}:latest"
 
+      - name: ⚙️ Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.12.3'
+
+      - name: 📦 Package and Push Helm Chart to GHCR
+        run: |
+          CHART_NAME="thunder"
+          OWNER_NAME=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          HELM_REGISTRY="ghcr.io/${OWNER_NAME}"
+          
+          # Get version without 'v' prefix for Helm chart version
+          CHART_VERSION="${{ github.event.inputs.version }}"
+          if [[ $CHART_VERSION == v* ]]; then
+            CHART_VERSION="${CHART_VERSION#v}"
+          fi
+          
+          echo "📦 Packaging Helm chart: ${CHART_NAME} version ${CHART_VERSION}"
+
+          # Ensure target directory exists
+          mkdir -p target/dist/
+          
+          # Package the Helm chart
+          helm package install/helm --version "${CHART_VERSION}" --app-version "${CHART_VERSION}" --destination target/dist/
+
+          # Validate package was created
+          if [ ! -f "target/dist/${CHART_NAME}-${CHART_VERSION}.tgz" ]; then
+            echo "❌ Error: Helm chart package not found"
+            exit 1
+          fi
+
+          # Authenticate Helm to GHCR
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          
+          # Push the Helm chart to GHCR
+          helm push "target/dist/${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${HELM_REGISTRY}/helm-charts"
+          
+          echo "✅ Helm chart pushed successfully!"
+          echo "📦 Helm chart available at: oci://${HELM_REGISTRY}/helm-charts"
+
       - name: 📝 Calculate Next Version
         id: next_version
         run: |

--- a/install/helm/Chart.yaml
+++ b/install/helm/Chart.yaml
@@ -18,5 +18,5 @@ apiVersion: v2
 name: thunder
 description: A Helm chart for WSO2 Thunder - Lightweight user and identity management system
 type: application
-version: 0.0.1
-appVersion: "0.7.0"
+version: 0.11.0
+appVersion: "0.11.0"

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -20,34 +20,33 @@ This repository contains the Helm chart for WSO2 Thunder, a lightweight user and
 
 Follow these steps to deploy Thunder in your Kubernetes cluster:
 
-### 1. Clone the Thunder repository
+### 1. Install the Thunder Helm chart
 
 ```bash
-git clone https://github.com/asgardeo/thunder.git
-cd thunder/install/helm
+# Pull and install from GitHub Container Registry
+helm install my-thunder oci://ghcr.io/asgardeo/helm-charts/thunder
 ```
 
-### 2. Install the Thunder Helm chart
-
-You can install the Thunder Helm chart with the release name `my-thunder` as follows:
+If you wish to install another version, use the command below to specify the desired version.
 
 ```bash
-helm install my-thunder .
+helm install my-thunder oci://ghcr.io/asgardeo/helm-charts/thunder --version <VERSION>
 ```
+
+> To see which chart versions are available, you can:
+> - Visit the [Thunder Helm Chart Registry](https://github.com/asgardeo/thunder/pkgs/container/helm-charts%2Fthunder) on GitHub Container Registry.
 
 If you want to customize the installation, create a `custom-values.yaml` file with your configurations and use:
 
 ```bash
-helm install my-thunder . -f custom-values.yaml
+helm install my-thunder oci://ghcr.io/asgardeo/helm-charts/thunder -f custom-values.yaml
 ```
 
 The command deploys Thunder on the Kubernetes cluster with the default configuration. The [Parameters](#parameters) section lists the available parameters that can be configured during installation.
 
-### 3. Access Thunder
+### 2. Obtain the External IP
 
-### 4. Obtain the External IP
-
-After deploying WSO2 Identity Server, you need to find its external IP address to access it outside the cluster. Run the following command to list the Ingress resources:
+After deploying Thunder, you need to find its external IP address to access it outside the cluster. Run the following command to list the Ingress resources:
 
 ```bash
 kubectl get ingress


### PR DESCRIPTION
### Purpose
This pull request adds automated packaging and publishing of the Thunder Helm chart to the GitHub Container Registry (GHCR) as part of the release workflow, updates the Helm chart version to `0.11.0`, and revises documentation to guide users on installing the chart directly from GHCR. These changes streamline the release process and improve the user experience for deploying Thunder via Helm.

**Release workflow enhancements:**
* Added steps to the `.github/workflows/release-builder.yml` workflow to package the Helm chart and push it to GHCR, including Helm setup, version handling, authentication, and error checking.

**Helm chart version update:**
* Updated `version` and `appVersion` in `install/helm/Chart.yaml` to `0.11.0` to reflect the latest release.

**Documentation improvements:**
* Revised `install/helm/README.md` to instruct users to install the Thunder Helm chart directly from GHCR, including commands for installing specific versions and customizing deployments, and updated instructions for accessing the deployed service.

## Related Issues
- https://github.com/asgardeo/thunder/issues/715