### PR TITLE
Refactor API hooks in thunder-develop app to use Asgardeo's HTTP client

### DIFF
--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useCreateUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useCreateUserType.test.ts
@@ -31,6 +31,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useCreateUserType', () => {
   const mockUserSchema: ApiUserSchema = {
     id: '123',

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useDeleteUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useDeleteUserType.test.ts
@@ -30,6 +30,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useDeleteUserType', () => {
   const mockUserTypeId = '123';
 

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserType.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useGetUserType', () => {
   const mockUserSchema: ApiUserSchema = {
     id: '123',

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useGetUserTypes', () => {
   const mockUserSchemaList: UserSchemaListResponse = {
     totalResults: 2,

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
@@ -31,6 +31,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useUpdateUserType', () => {
   const mockUserTypeId = '123';
   const mockRequest: UpdateUserSchemaRequest = {

--- a/frontend/apps/thunder-develop/src/features/user-types/api/useCreateUserType.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/useCreateUserType.ts
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import {useState} from 'react';
+import {useState, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
-
+import {useConfig} from '@thunder/commons-contexts';
 import type {ApiError, ApiUserSchema, CreateUserSchemaRequest} from '../types/user-types';
 
 /**
@@ -27,9 +27,15 @@ import type {ApiError, ApiUserSchema, CreateUserSchemaRequest} from '../types/us
  */
 export default function useCreateUserType() {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [data, setData] = useState<ApiUserSchema | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
 
   const createUserType = async (requestData: CreateUserSchemaRequest): Promise<void> => {
     try {
@@ -38,7 +44,7 @@ export default function useCreateUserType() {
       setData(null);
 
       const response = await http.request({
-        url: 'https://localhost:8090/user-schemas',
+        url: `${API_BASE_URL}/user-schemas`,
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/thunder-develop/src/features/user-types/api/useDeleteUserType.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/useDeleteUserType.ts
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-import {useState} from 'react';
+import {useState, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 
 import type {ApiError} from '../types/user-types';
 
@@ -27,8 +28,14 @@ import type {ApiError} from '../types/user-types';
  */
 export default function useDeleteUserType() {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
 
   const deleteUserType = async (userTypeId: string): Promise<boolean> => {
     try {
@@ -36,7 +43,7 @@ export default function useDeleteUserType() {
       setError(null);
 
       await http.request({
-        url: `https://localhost:8090/user-schemas/${userTypeId}`,
+        url: `${API_BASE_URL}/user-schemas/${userTypeId}`,
         method: 'DELETE',
       } as unknown as Parameters<typeof http.request>[0]);
 

--- a/frontend/apps/thunder-develop/src/features/user-types/api/useGetUserType.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/useGetUserType.ts
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-import {useEffect, useRef, useState, useCallback} from 'react';
+import {useEffect, useRef, useState, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 
 import type {ApiError, ApiUserSchema} from '../types/user-types';
 
@@ -29,6 +30,7 @@ import type {ApiError, ApiUserSchema} from '../types/user-types';
  */
 export default function useGetUserType(id?: string) {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [data, setData] = useState<ApiUserSchema | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
@@ -37,49 +39,9 @@ export default function useGetUserType(id?: string) {
   const hasFetchedRef = useRef(false);
   const lastIdRef = useRef<string | undefined>(undefined);
 
-  const fetchUserType = useCallback(async (userTypeId: string) => {
-    try {
-      setLoading(true);
-      setError(null);
-
-      const response = await http.request({
-        url: `https://localhost:8090/user-schemas/${userTypeId}`,
-        method: 'GET',
-      } as unknown as Parameters<typeof http.request>[0]);
-
-      const jsonData = response.data as ApiUserSchema;
-      setData(jsonData);
-      setError(null);
-    } catch (err) {
-      const apiError: ApiError = {
-        code: 'FETCH_USER_TYPE_ERROR',
-        message: err instanceof Error ? err.message : 'An unknown error occurred',
-        description: 'Failed to fetch user type',
-      };
-      setError(apiError);
-      setData(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [http]);
-
-  const refetch = useCallback(
-    async (newId?: string) => {
-      const idToFetch = newId ?? id;
-      if (!idToFetch) return;
-
-      // Reset the hasFetched flag when explicitly refetching
-      hasFetchedRef.current = false;
-      lastIdRef.current = idToFetch;
-
-      (async () => {
-        await fetchUserType(idToFetch);
-      })().catch(() => {
-        // TODO: Log the errors
-        // Tracker: https://github.com/asgardeo/thunder/issues/618
-      });
-    },
-    [id, fetchUserType],
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
   );
 
   useEffect(() => {
@@ -98,13 +60,79 @@ export default function useGetUserType(id?: string) {
     hasFetchedRef.current = true;
     lastIdRef.current = id;
 
-    (async () => {
-      await fetchUserType(id);
-    })().catch(() => {
+    const fetchUserType = async (): Promise<void> => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const response = await http.request({
+          url: `${API_BASE_URL}/user-schemas/${id}`,
+          method: 'GET',
+        } as unknown as Parameters<typeof http.request>[0]);
+
+        const jsonData = response.data as ApiUserSchema;
+        setData(jsonData);
+        setError(null);
+      } catch (err) {
+        const apiError: ApiError = {
+          code: 'FETCH_USER_TYPE_ERROR',
+          message: err instanceof Error ? err.message : 'An unknown error occurred',
+          description: 'Failed to fetch user type',
+        };
+        setError(apiError);
+        setData(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserType().catch(() => {
       // TODO: Log the errors
       // Tracker: https://github.com/asgardeo/thunder/issues/618
     });
-  }, [id, fetchUserType]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const refetch = async (newId?: string): Promise<void> => {
+    const schemaId = newId ?? id;
+    if (!schemaId) {
+      setError({
+        code: 'INVALID_ID',
+        message: 'Invalid schema ID',
+        description: 'Schema ID is required',
+      });
+      return;
+    }
+
+    // Reset the hasFetched flag when explicitly refetching
+    hasFetchedRef.current = false;
+    lastIdRef.current = schemaId;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await http.request({
+        url: `${API_BASE_URL}/user-schemas/${schemaId}`,
+        method: 'GET',
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      const jsonData = response.data as ApiUserSchema;
+      setData(jsonData);
+      setError(null);
+    } catch (err) {
+      const apiError: ApiError = {
+        code: 'FETCH_USER_TYPE_ERROR',
+        message: err instanceof Error ? err.message : 'An unknown error occurred',
+        description: 'Failed to fetch user type',
+      };
+      setError(apiError);
+      setData(null);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return {
     data,

--- a/frontend/apps/thunder-develop/src/features/user-types/api/useUpdateUserType.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/useUpdateUserType.ts
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-import {useState} from 'react';
+import {useState, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 
 import type {ApiError, ApiUserSchema, UpdateUserSchemaRequest} from '../types/user-types';
 
@@ -27,9 +28,15 @@ import type {ApiError, ApiUserSchema, UpdateUserSchemaRequest} from '../types/us
  */
 export default function useUpdateUserType() {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [data, setData] = useState<ApiUserSchema | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
 
   const updateUserType = async (userTypeId: string, requestData: UpdateUserSchemaRequest): Promise<void> => {
     try {
@@ -38,7 +45,7 @@ export default function useUpdateUserType() {
       setData(null);
 
       const response = await http.request({
-        url: `https://localhost:8090/user-schemas/${userTypeId}`,
+        url: `${API_BASE_URL}/user-schemas/${userTypeId}`,
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/thunder-develop/src/features/user-types/components/UserTypesList.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/UserTypesList.tsx
@@ -251,7 +251,7 @@ export default function UserTypesList() {
         open={snackbarOpen}
         autoHideDuration={6000}
         onClose={handleCloseSnackbar}
-        anchorOrigin={{vertical: 'top', horizontal: 'right'}}
+        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
       >
         <Alert onClose={handleCloseSnackbar} severity="error" sx={{width: '100%'}}>
           {error?.message ?? t('common:messages.saveError')}

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useCreateUser.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useCreateUser.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useCreateUser', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -113,7 +120,7 @@ describe('useCreateUser', () => {
       expect(result.current.error).toEqual({
         code: 'CREATE_USER_ERROR',
         message: 'Validation failed',
-        description: 'An error occurred while creating the user',
+        description: 'Failed to create user',
       });
       expect(result.current.data).toBeNull();
     });
@@ -144,7 +151,7 @@ describe('useCreateUser', () => {
       expect(result.current.error).toEqual({
         code: 'CREATE_USER_ERROR',
         message: 'Internal Server Error',
-        description: 'An error occurred while creating the user',
+        description: 'Failed to create user',
       });
       expect(result.current.data).toBeNull();
     });
@@ -171,7 +178,7 @@ describe('useCreateUser', () => {
       expect(result.current.error).toEqual({
         code: 'CREATE_USER_ERROR',
         message: 'Network error',
-        description: 'An error occurred while creating the user',
+        description: 'Failed to create user',
       });
     });
   });

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useDeleteUser.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useDeleteUser.test.ts
@@ -31,6 +31,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useDeleteUser', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -85,7 +92,7 @@ describe('useDeleteUser', () => {
       expect(result.current.error).toEqual({
         code: 'DELETE_USER_ERROR',
         message: 'User not found',
-        description: 'An error occurred while deleting the user',
+        description: 'Failed to delete user',
       });
     });
   });
@@ -106,7 +113,7 @@ describe('useDeleteUser', () => {
       expect(result.current.error).toEqual({
         code: 'DELETE_USER_ERROR',
         message: 'Internal Server Error',
-        description: 'An error occurred while deleting the user',
+        description: 'Failed to delete user',
       });
     });
   });
@@ -127,7 +134,7 @@ describe('useDeleteUser', () => {
       expect(result.current.error).toEqual({
         code: 'DELETE_USER_ERROR',
         message: 'Network error',
-        description: 'An error occurred while deleting the user',
+        description: 'Failed to delete user',
       });
     });
   });
@@ -175,7 +182,7 @@ describe('useDeleteUser', () => {
       expect(result.current.error).toEqual({
         code: 'DELETE_USER_ERROR',
         message: 'User not found',
-        description: 'An error occurred while deleting the user',
+        description: 'Failed to delete user',
       });
     });
 

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUser.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUser.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useGetUser', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -100,7 +107,7 @@ describe('useGetUser', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'User not found',
-      description: 'An error occurred while fetching user',
+      description: 'Failed to fetch user',
     });
     expect(result.current.data).toBeNull();
   });
@@ -117,7 +124,7 @@ describe('useGetUser', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Internal Server Error',
-      description: 'An error occurred while fetching user',
+      description: 'Failed to fetch user',
     });
     expect(result.current.data).toBeNull();
   });
@@ -134,7 +141,7 @@ describe('useGetUser', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Network error',
-      description: 'An error occurred while fetching user',
+      description: 'Failed to fetch user',
     });
     expect(result.current.data).toBeNull();
   });

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUserSchema.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUserSchema.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useGetUserSchema', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -105,7 +112,7 @@ describe('useGetUserSchema', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Schema not found',
-      description: 'An error occurred while fetching user schema',
+      description: 'Failed to fetch user schema',
     });
     expect(result.current.data).toBeNull();
   });
@@ -122,7 +129,7 @@ describe('useGetUserSchema', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Internal Server Error',
-      description: 'An error occurred while fetching user schema',
+      description: 'Failed to fetch user schema',
     });
     expect(result.current.data).toBeNull();
   });
@@ -139,7 +146,7 @@ describe('useGetUserSchema', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Network error',
-      description: 'An error occurred while fetching user schema',
+      description: 'Failed to fetch user schema',
     });
     expect(result.current.data).toBeNull();
   });
@@ -164,7 +171,7 @@ describe('useGetUserSchema', () => {
       expect(result.current.data).toEqual(mockSchema);
     });
 
-    result.current.refetch();
+    await result.current.refetch();
 
     await waitFor(() => {
       expect(mockHttpRequest).toHaveBeenCalledTimes(2);
@@ -194,9 +201,7 @@ describe('useGetUserSchema', () => {
       },
     };
 
-    mockHttpRequest
-      .mockResolvedValueOnce({data: mockSchema1})
-      .mockResolvedValueOnce({data: mockSchema2});
+    mockHttpRequest.mockResolvedValueOnce({data: mockSchema1}).mockResolvedValueOnce({data: mockSchema2});
 
     const {result} = renderHook(() => useGetUserSchema('schema-123'));
 
@@ -204,7 +209,7 @@ describe('useGetUserSchema', () => {
       expect(result.current.data).toEqual(mockSchema1);
     });
 
-    result.current.refetch('schema-456');
+    await result.current.refetch('schema-456');
 
     await waitFor(() => {
       expect(result.current.data).toEqual(mockSchema2);
@@ -214,7 +219,7 @@ describe('useGetUserSchema', () => {
   it('should set error when refetch is called without id', async () => {
     const {result} = renderHook(() => useGetUserSchema());
 
-    result.current.refetch();
+    await result.current.refetch();
 
     await waitFor(() => {
       expect(result.current.error).toEqual({
@@ -272,9 +277,7 @@ describe('useGetUserSchema', () => {
       },
     };
 
-    mockHttpRequest
-      .mockResolvedValueOnce({data: mockSchema1})
-      .mockResolvedValueOnce({data: mockSchema2});
+    mockHttpRequest.mockResolvedValueOnce({data: mockSchema1}).mockResolvedValueOnce({data: mockSchema2});
 
     const {result, rerender} = renderHook(({id}: {id?: string}) => useGetUserSchema(id), {
       initialProps: {id: 'schema-123'},

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUserSchemas.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUserSchemas.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useGetUserSchemas', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -168,11 +175,11 @@ describe('useGetUserSchemas', () => {
       expect(result.current.loading).toBe(false);
     });
 
-      expect(result.current.error).toEqual({
-        code: 'FETCH_ERROR',
-        message: 'Unauthorized access',
-        description: 'An error occurred while fetching user schemas',
-      });
+    expect(result.current.error).toEqual({
+      code: 'FETCH_ERROR',
+      message: 'Unauthorized access',
+      description: 'Failed to fetch user schemas',
+    });
     expect(result.current.data).toBeNull();
   });
 
@@ -185,11 +192,12 @@ describe('useGetUserSchemas', () => {
       expect(result.current.loading).toBe(false);
     });
 
-      expect(result.current.error).toEqual({
-        code: 'FETCH_ERROR',
-        message: 'Internal Server Error',
-        description: 'An error occurred while fetching user schemas',
-      });
+    expect(result.current.error).toEqual({
+      code: 'FETCH_ERROR',
+      message: 'Internal Server Error',
+      description: 'Failed to fetch user schemas',
+    });
+
     expect(result.current.data).toBeNull();
   });
 
@@ -205,7 +213,7 @@ describe('useGetUserSchemas', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Network error',
-      description: 'An error occurred while fetching user schemas',
+      description: 'Failed to fetch user schemas',
     });
     expect(result.current.data).toBeNull();
   });

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUsers.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUsers.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useGetUsers', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -199,7 +206,7 @@ describe('useGetUsers', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Schema not found',
-      description: 'An error occurred while fetching users',
+      description: 'Failed to fetch users',
     });
     expect(result.current.data).toBeNull();
   });
@@ -217,7 +224,7 @@ describe('useGetUsers', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Internal Server Error',
-      description: 'An error occurred while fetching users',
+      description: 'Failed to fetch users',
     });
     expect(result.current.data).toBeNull();
   });
@@ -234,7 +241,7 @@ describe('useGetUsers', () => {
     expect(result.current.error).toEqual({
       code: 'FETCH_ERROR',
       message: 'Network error',
-      description: 'An error occurred while fetching users',
+      description: 'Failed to fetch users',
     });
     expect(result.current.data).toBeNull();
   });

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useUpdateUser.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useUpdateUser.test.ts
@@ -32,6 +32,13 @@ vi.mock('@asgardeo/react', () => ({
   }),
 }));
 
+// Mock useConfig
+vi.mock('@thunder/commons-contexts', () => ({
+  useConfig: () => ({
+    getServerUrl: () => 'https://localhost:8090',
+  }),
+}));
+
 describe('useUpdateUser', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -117,7 +124,7 @@ describe('useUpdateUser', () => {
       expect(result.current.error).toEqual({
         code: 'UPDATE_USER_ERROR',
         message: 'Validation failed',
-        description: 'An error occurred while updating the user',
+        description: 'Failed to update user',
       });
       expect(result.current.data).toBeNull();
     });
@@ -148,7 +155,7 @@ describe('useUpdateUser', () => {
       expect(result.current.error).toEqual({
         code: 'UPDATE_USER_ERROR',
         message: 'Internal Server Error',
-        description: 'An error occurred while updating the user',
+        description: 'Failed to update user',
       });
       expect(result.current.data).toBeNull();
     });
@@ -179,7 +186,7 @@ describe('useUpdateUser', () => {
       expect(result.current.error).toEqual({
         code: 'UPDATE_USER_ERROR',
         message: 'Network error',
-        description: 'An error occurred while updating the user',
+        description: 'Failed to update user',
       });
     });
   });

--- a/frontend/apps/thunder-develop/src/features/users/api/useDeleteUser.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useDeleteUser.ts
@@ -16,57 +16,57 @@
  * under the License.
  */
 
-import {useState, useCallback} from 'react';
+import {useState, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 import type {ApiError} from '../types/users';
 
-const API_BASE_URL = 'https://localhost:8090';
-
 /**
- * Hook to delete a user by ID
- * DELETE https://localhost:8090/users/{userId}
+ * Custom hook to delete a user by ID
+ * @returns Object containing deleteUser function, loading state, error, and reset function
  */
 export default function useDeleteUser() {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const deleteUser = useCallback(async (userId: string) => {
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
+
+  const deleteUser = async (userId: string): Promise<boolean> => {
     try {
       setLoading(true);
       setError(null);
 
-      const url = `${API_BASE_URL}/users/${userId}`;
-
       await http.request({
-        url,
+        url: `${API_BASE_URL}/users/${userId}`,
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
         },
       } as unknown as Parameters<typeof http.request>[0]);
 
-      // 204 No Content - successful deletion
+      setError(null);
       return true;
     } catch (err) {
-      if (err instanceof Error) {
-        const apiError: ApiError = {
-          code: 'DELETE_USER_ERROR',
-          message: err.message,
-          description: 'An error occurred while deleting the user',
-        };
-        setError(apiError);
-        throw err;
-      }
+      const apiError: ApiError = {
+        code: 'DELETE_USER_ERROR',
+        message: err instanceof Error ? err.message : 'An unknown error occurred',
+        description: 'Failed to delete user',
+      };
+      setError(apiError);
       throw err;
     } finally {
       setLoading(false);
     }
-  }, [http]);
+  };
 
-  const reset = useCallback(() => {
+  const reset = () => {
     setError(null);
-  }, []);
+  };
 
   return {
     deleteUser,

--- a/frontend/apps/thunder-develop/src/features/users/api/useGetUser.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useGetUser.ts
@@ -16,68 +16,103 @@
  * under the License.
  */
 
-import {useState, useCallback, useEffect} from 'react';
+import {useState, useEffect, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 import type {ApiUser, ApiError} from '../types/users';
 
-const API_BASE_URL = 'https://localhost:8090';
-
 /**
- * Hook to fetch a single user by ID
- * GET https://localhost:8090/users/{userId}
+ * Custom hook to fetch a single user by ID
+ * @param userId - The ID of the user to fetch
+ * @returns Object containing data, loading state, error, and refetch function
  */
 export default function useGetUser(userId: string | undefined) {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [data, setData] = useState<ApiUser | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
 
-  const fetchUser = useCallback(async () => {
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
+
+  useEffect(() => {
     if (!userId) {
       return;
     }
 
-    setIsLoading(true);
-    setError(null);
+    const fetchUser = async (): Promise<void> => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const response = await http.request({
+          url: `${API_BASE_URL}/users/${userId}`,
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        } as unknown as Parameters<typeof http.request>[0]);
+
+        const jsonData = response.data as ApiUser;
+        setData(jsonData);
+        setError(null);
+      } catch (err) {
+        const apiError: ApiError = {
+          code: 'FETCH_ERROR',
+          message: err instanceof Error ? err.message : 'An unknown error occurred',
+          description: 'Failed to fetch user',
+        };
+        setError(apiError);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUser().catch(() => {
+      // Error already handled
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId]);
+
+  const refetch = async (): Promise<void> => {
+    if (!userId) {
+      return;
+    }
 
     try {
-      const url = `${API_BASE_URL}/users/${userId}`;
+      setLoading(true);
+      setError(null);
 
       const response = await http.request({
-        url,
+        url: `${API_BASE_URL}/users/${userId}`,
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
         },
       } as unknown as Parameters<typeof http.request>[0]);
 
-      const result = response.data as ApiUser;
-      setData(result);
+      const jsonData = response.data as ApiUser;
+      setData(jsonData);
+      setError(null);
     } catch (err) {
-      if (err instanceof Error) {
-        setError({
-          code: 'FETCH_ERROR',
-          message: err.message,
-          description: 'An error occurred while fetching user',
-        });
-      }
+      const apiError: ApiError = {
+        code: 'FETCH_ERROR',
+        message: err instanceof Error ? err.message : 'An unknown error occurred',
+        description: 'Failed to fetch user',
+      };
+      setError(apiError);
       throw err;
     } finally {
-      setIsLoading(false);
+      setLoading(false);
     }
-  }, [userId, http]);
-
-  useEffect(() => {
-    fetchUser().catch(() => {
-      // Error already handled
-    });
-  }, [fetchUser]);
-
-  const refetch = useCallback(() => fetchUser(), [fetchUser]);
+  };
 
   return {
     data,
-    loading: isLoading,
+    loading,
     error,
     refetch,
   };

--- a/frontend/apps/thunder-develop/src/features/users/api/useGetUserSchema.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useGetUserSchema.ts
@@ -16,56 +16,29 @@
  * under the License.
  */
 
-import {useState, useEffect, useCallback, useRef} from 'react';
+import {useState, useEffect, useRef, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 import type {ApiUserSchema, ApiError} from '../types/users';
 
-const API_BASE_URL = 'https://localhost:8090';
-
 /**
- * Hook to fetch a single user schema by ID from the API
- * GET https://localhost:8090/user-schemas/{id}
+ * Custom hook to fetch a single user schema by ID
+ * @param id - The ID of the user schema to fetch
+ * @returns Object containing data, loading state, error, and refetch function
  */
 export default function useGetUserSchema(id?: string) {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [data, setData] = useState<ApiUserSchema | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
   const hasFetchedRef = useRef(false);
   const lastIdRef = useRef<string | undefined>(undefined);
 
-  const fetchUserSchema = useCallback(async (schemaId: string) => {
-    try {
-      setLoading(true);
-      setError(null);
-
-      const url = `${API_BASE_URL}/user-schemas/${schemaId}`;
-
-      const response = await http.request({
-        url,
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      } as unknown as Parameters<typeof http.request>[0]);
-
-      const result = response.data as ApiUserSchema;
-      setData(result);
-
-      return result;
-    } catch (err) {
-      if (err instanceof Error) {
-        setError({
-          code: 'FETCH_ERROR',
-          message: err.message,
-          description: 'An error occurred while fetching user schema',
-        });
-      }
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  }, [http]);
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
 
   useEffect(() => {
     if (!id) {
@@ -79,29 +52,78 @@ export default function useGetUserSchema(id?: string) {
     hasFetchedRef.current = true;
     lastIdRef.current = id;
 
-    fetchUserSchema(id).catch(() => {
-      // Error is already handled in fetchUserSchema
-    });
-  }, [id, fetchUserSchema]);
+    const fetchUserSchema = async (): Promise<void> => {
+      try {
+        setLoading(true);
+        setError(null);
 
-  const refetch = useCallback(
-    (newId?: string) => {
-      const schemaId = newId ?? id;
-      if (!schemaId) {
-        setError({
-          code: 'INVALID_ID',
-          message: 'Invalid schema ID',
-          description: 'Schema ID is required',
-        });
-        return;
+        const response = await http.request({
+          url: `${API_BASE_URL}/user-schemas/${id}`,
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        } as unknown as Parameters<typeof http.request>[0]);
+
+        const jsonData = response.data as ApiUserSchema;
+        setData(jsonData);
+        setError(null);
+      } catch (err) {
+        const apiError: ApiError = {
+          code: 'FETCH_ERROR',
+          message: err instanceof Error ? err.message : 'An unknown error occurred',
+          description: 'Failed to fetch user schema',
+        };
+        setError(apiError);
+      } finally {
+        setLoading(false);
       }
+    };
 
-      fetchUserSchema(schemaId).catch(() => {
-        // Error is already handled in fetchUserSchema
+    fetchUserSchema().catch(() => {
+      // Error already handled
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const refetch = async (newId?: string): Promise<void> => {
+    const schemaId = newId ?? id;
+    if (!schemaId) {
+      setError({
+        code: 'INVALID_ID',
+        message: 'Invalid schema ID',
+        description: 'Schema ID is required',
       });
-    },
-    [id, fetchUserSchema],
-  );
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await http.request({
+        url: `${API_BASE_URL}/user-schemas/${schemaId}`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      const jsonData = response.data as ApiUserSchema;
+      setData(jsonData);
+      setError(null);
+    } catch (err) {
+      const apiError: ApiError = {
+        code: 'FETCH_ERROR',
+        message: err instanceof Error ? err.message : 'An unknown error occurred',
+        description: 'Failed to fetch user schema',
+      };
+      setError(apiError);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return {
     data,

--- a/frontend/apps/thunder-develop/src/features/users/api/useGetUserSchemas.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useGetUserSchemas.ts
@@ -16,76 +16,79 @@
  * under the License.
  */
 
-import {useState, useEffect, useCallback, useRef} from 'react';
+import {useState, useEffect, useRef, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 import type {UserSchemaListResponse, SchemaListParams, ApiError} from '../types/users';
 
-const API_BASE_URL = 'https://localhost:8090';
-
+/**
+ * Custom hook to fetch a list of user schemas
+ * @param params - Optional query parameters for pagination
+ * @returns Object containing data, loading state, error, and refetch function
+ */
 export default function useGetUserSchemas(params?: SchemaListParams) {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [data, setData] = useState<UserSchemaListResponse | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  const fetchUserSchemas = useCallback(
-    async (queryParams?: SchemaListParams) => {
-      // Cancel previous request
-      abortControllerRef.current?.abort();
-      abortControllerRef.current = new AbortController();
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
 
-      setIsLoading(true);
-      setError(null);
+  useEffect(() => {
+    // Cancel previous request
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = new AbortController();
 
+    const fetchUserSchemas = async (): Promise<void> => {
       try {
-        const searchParams = new URLSearchParams();
-        const finalParams = queryParams ?? params;
+        setLoading(true);
+        setError(null);
 
-        if (finalParams?.limit !== undefined) {
-          searchParams.append('limit', String(finalParams.limit));
+        const searchParams = new URLSearchParams();
+
+        if (params?.limit !== undefined) {
+          searchParams.append('limit', String(params.limit));
         }
-        if (finalParams?.offset !== undefined) {
-          searchParams.append('offset', String(finalParams.offset));
+        if (params?.offset !== undefined) {
+          searchParams.append('offset', String(params.offset));
         }
 
         const queryString = searchParams.toString();
-        const url = `${API_BASE_URL}/user-schemas${queryString ? `?${queryString}` : ''}`;
 
         const response = await http.request({
-          url,
+          url: `${API_BASE_URL}/user-schemas${queryString ? `?${queryString}` : ''}`,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          signal: abortControllerRef.current.signal,
+          signal: abortControllerRef.current?.signal,
         } as unknown as Parameters<typeof http.request>[0]);
 
-        const result = response.data as UserSchemaListResponse;
-        setData(result);
-        return result;
+        const jsonData = response.data as UserSchemaListResponse;
+        setData(jsonData);
+        setError(null);
       } catch (err) {
         // Don't set error if request was aborted
         if (err instanceof Error && err.name === 'AbortError') {
-          return null;
+          return;
         }
 
-        if (err instanceof Error) {
-          setError({
-            code: 'FETCH_ERROR',
-            message: err.message,
-            description: 'An error occurred while fetching user schemas',
-          });
-        }
-        throw err;
+        const apiError: ApiError = {
+          code: 'FETCH_ERROR',
+          message: err instanceof Error ? err.message : 'An unknown error occurred',
+          description: 'Failed to fetch user schemas',
+        };
+        setError(apiError);
       } finally {
-        setIsLoading(false);
+        setLoading(false);
       }
-    },
-    [params, http],
-  );
+    };
 
-  useEffect(() => {
     fetchUserSchemas().catch(() => {
       // Error already handled
     });
@@ -94,13 +97,63 @@ export default function useGetUserSchemas(params?: SchemaListParams) {
     return () => {
       abortControllerRef.current?.abort();
     };
-  }, [fetchUserSchemas]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params]);
 
-  const refetch = useCallback((newParams?: SchemaListParams) => fetchUserSchemas(newParams), [fetchUserSchemas]);
+  const refetch = async (newParams?: SchemaListParams): Promise<void> => {
+    // Cancel previous request
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = new AbortController();
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const searchParams = new URLSearchParams();
+      const finalParams = newParams ?? params;
+
+      if (finalParams?.limit !== undefined) {
+        searchParams.append('limit', String(finalParams.limit));
+      }
+      if (finalParams?.offset !== undefined) {
+        searchParams.append('offset', String(finalParams.offset));
+      }
+
+      const queryString = searchParams.toString();
+
+      const response = await http.request({
+        url: `${API_BASE_URL}/user-schemas${queryString ? `?${queryString}` : ''}`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: abortControllerRef.current?.signal,
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      const jsonData = response.data as UserSchemaListResponse;
+      setData(jsonData);
+      setError(null);
+    } catch (err) {
+      // Don't set error if request was aborted
+      if (err instanceof Error && err.name === 'AbortError') {
+        return;
+      }
+
+      const apiError: ApiError = {
+        code: 'FETCH_ERROR',
+        message: err instanceof Error ? err.message : 'An unknown error occurred',
+        description: 'Failed to fetch user schemas',
+      };
+      setError(apiError);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return {
     data,
-    loading: isLoading,
+    loading,
     error,
     refetch,
   };

--- a/frontend/apps/thunder-develop/src/features/users/api/useUpdateUser.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useUpdateUser.ts
@@ -16,11 +16,10 @@
  * under the License.
  */
 
-import {useState, useCallback} from 'react';
+import {useState, useMemo} from 'react';
 import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
 import type {ApiError, ApiUser} from '../types/users';
-
-const API_BASE_URL = 'https://localhost:8090';
 
 /**
  * Request body for updating a user
@@ -34,25 +33,29 @@ export interface UpdateUserRequest {
 }
 
 /**
- * Hook to update an existing user
- * PUT https://localhost:8090/users/{userId}
+ * Custom hook to update an existing user
+ * @returns Object containing updateUser function, data, loading state, error, and reset function
  */
 export default function useUpdateUser() {
   const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
   const [data, setData] = useState<ApiUser | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const updateUser = useCallback(async (userId: string, userData: UpdateUserRequest) => {
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
+
+  const updateUser = async (userId: string, userData: UpdateUserRequest): Promise<void> => {
     try {
       setLoading(true);
       setError(null);
       setData(null);
 
-      const url = `${API_BASE_URL}/users/${userId}`;
-
       const response = await http.request({
-        url,
+        url: `${API_BASE_URL}/users/${userId}`,
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -60,30 +63,26 @@ export default function useUpdateUser() {
         data: userData,
       } as unknown as Parameters<typeof http.request>[0]);
 
-      const result = response.data as ApiUser;
-      setData(result);
-
-      return result;
+      const jsonData = response.data as ApiUser;
+      setData(jsonData);
+      setError(null);
     } catch (err) {
-      if (err instanceof Error) {
-        const apiError: ApiError = {
-          code: 'UPDATE_USER_ERROR',
-          message: err.message,
-          description: 'An error occurred while updating the user',
-        };
-        setError(apiError);
-        throw err;
-      }
+      const apiError: ApiError = {
+        code: 'UPDATE_USER_ERROR',
+        message: err instanceof Error ? err.message : 'An unknown error occurred',
+        description: 'Failed to update user',
+      };
+      setError(apiError);
       throw err;
     } finally {
       setLoading(false);
     }
-  }, [http]);
+  };
 
-  const reset = useCallback(() => {
+  const reset = () => {
     setData(null);
     setError(null);
-  }, []);
+  };
 
   return {
     updateUser,

--- a/frontend/apps/thunder-develop/src/test/test-utils.tsx
+++ b/frontend/apps/thunder-develop/src/test/test-utils.tsx
@@ -21,6 +21,7 @@ import type {ReactElement, ReactNode} from 'react';
 import {render, type RenderOptions} from '@testing-library/react';
 import {MemoryRouter} from 'react-router';
 import OxygenUIThemeProvider from '@wso2/oxygen-ui/OxygenUIThemeProvider';
+import {ConfigProvider} from '@thunder/commons-contexts';
 
 interface ProvidersProps {
   children: ReactNode;
@@ -28,9 +29,28 @@ interface ProvidersProps {
 
 // Wrapper component with common providers
 function Providers({children}: ProvidersProps) {
+  // Setup window.__THUNDER_RUNTIME_CONFIG__ for tests
+  // eslint-disable-next-line no-underscore-dangle
+  if (typeof window !== 'undefined' && !window.__THUNDER_RUNTIME_CONFIG__) {
+    // eslint-disable-next-line no-underscore-dangle
+    window.__THUNDER_RUNTIME_CONFIG__ = {
+      client: {
+        base: '/develop',
+        client_id: 'DEVELOP',
+      },
+      server: {
+        hostname: 'localhost',
+        port: 8090,
+        http_only: false,
+      },
+    };
+  }
+
   return (
     <MemoryRouter>
-      <OxygenUIThemeProvider>{children}</OxygenUIThemeProvider>
+      <ConfigProvider>
+        <OxygenUIThemeProvider>{children}</OxygenUIThemeProvider>
+      </ConfigProvider>
     </MemoryRouter>
   );
 }


### PR DESCRIPTION
### Purpose
This pull request refactors the API-related tests for user type features to use a mocked Asgardeo HTTP client (`useAsgardeo`) instead of the global `fetch` function. This change improves test isolation and better reflects the application's actual API integration. The tests for creating, deleting, and fetching user types have been updated to use the new mock, with error handling and assertions adapted accordingly.

**Testing infrastructure refactor:**

* Replaced all usage of `global.fetch` with a mock of the Asgardeo HTTP client's `request` method across the tests for `useCreateUserType`, `useDeleteUserType`, and `useGetUserType`. This includes mocking the module and updating before/after hooks for proper reset and cleanup. 

**Test logic and assertions updates:**

* Updated success and error case assertions to use the new `mockHttpRequest` mock, including adapting expectations to match the Asgardeo client's request and response format. 
* Simplified error handling in tests by removing separate JSON and non-JSON error response scenarios, instead using rejected promises with error messages for API and network errors. 

**Consistency and maintainability improvements:**

* Streamlined test setup and teardown by replacing `vi.restoreAllMocks()` with `vi.clearAllMocks()` and ensuring mock state is reset before each test. 

**Error handling consistency:**

* Unified error expectations in tests to check for error objects or messages rather than specific status codes or error structures, aligning with the new mocking approach. [