### PR TITLE
Allow storing flexible node properties

### DIFF
--- a/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
@@ -454,19 +454,19 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetPreviousNodeList_Call) RunAndReturn
 }
 
 // GetProperties provides a mock function for the type ExecutorBackedNodeInterfaceMock
-func (_mock *ExecutorBackedNodeInterfaceMock) GetProperties() map[string]string {
+func (_mock *ExecutorBackedNodeInterfaceMock) GetProperties() map[string]interface{} {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProperties")
 	}
 
-	var r0 map[string]string
-	if returnFunc, ok := ret.Get(0).(func() map[string]string); ok {
+	var r0 map[string]interface{}
+	if returnFunc, ok := ret.Get(0).(func() map[string]interface{}); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
+			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
 	return r0
@@ -489,12 +489,12 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) Run(run func()) *E
 	return _c
 }
 
-func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) Return(stringToString map[string]string) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
-	_c.Call.Return(stringToString)
+func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) Return(stringToIfaceVal map[string]interface{}) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
+	_c.Call.Return(stringToIfaceVal)
 	return _c
 }
 
-func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]string) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
+func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]interface{}) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/core/FlowFactoryInterface_mock_test.go
+++ b/backend/internal/flow/core/FlowFactoryInterface_mock_test.go
@@ -291,7 +291,7 @@ func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) RunAndReturn(run func(id st
 }
 
 // CreateNode provides a mock function for the type FlowFactoryInterfaceMock
-func (_mock *FlowFactoryInterfaceMock) CreateNode(id string, _type string, properties map[string]string, isStartNode bool, isFinalNode bool) (NodeInterface, error) {
+func (_mock *FlowFactoryInterfaceMock) CreateNode(id string, _type string, properties map[string]interface{}, isStartNode bool, isFinalNode bool) (NodeInterface, error) {
 	ret := _mock.Called(id, _type, properties, isStartNode, isFinalNode)
 
 	if len(ret) == 0 {
@@ -300,17 +300,17 @@ func (_mock *FlowFactoryInterfaceMock) CreateNode(id string, _type string, prope
 
 	var r0 NodeInterface
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]string, bool, bool) (NodeInterface, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]interface{}, bool, bool) (NodeInterface, error)); ok {
 		return returnFunc(id, _type, properties, isStartNode, isFinalNode)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]string, bool, bool) NodeInterface); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]interface{}, bool, bool) NodeInterface); ok {
 		r0 = returnFunc(id, _type, properties, isStartNode, isFinalNode)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(NodeInterface)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, map[string]string, bool, bool) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(string, string, map[string]interface{}, bool, bool) error); ok {
 		r1 = returnFunc(id, _type, properties, isStartNode, isFinalNode)
 	} else {
 		r1 = ret.Error(1)
@@ -326,14 +326,14 @@ type FlowFactoryInterfaceMock_CreateNode_Call struct {
 // CreateNode is a helper method to define mock.On call
 //   - id string
 //   - _type string
-//   - properties map[string]string
+//   - properties map[string]interface{}
 //   - isStartNode bool
 //   - isFinalNode bool
 func (_e *FlowFactoryInterfaceMock_Expecter) CreateNode(id interface{}, _type interface{}, properties interface{}, isStartNode interface{}, isFinalNode interface{}) *FlowFactoryInterfaceMock_CreateNode_Call {
 	return &FlowFactoryInterfaceMock_CreateNode_Call{Call: _e.mock.On("CreateNode", id, _type, properties, isStartNode, isFinalNode)}
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Run(run func(id string, _type string, properties map[string]string, isStartNode bool, isFinalNode bool)) *FlowFactoryInterfaceMock_CreateNode_Call {
+func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Run(run func(id string, _type string, properties map[string]interface{}, isStartNode bool, isFinalNode bool)) *FlowFactoryInterfaceMock_CreateNode_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -343,9 +343,9 @@ func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Run(run func(id string, _typ
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 map[string]string
+		var arg2 map[string]interface{}
 		if args[2] != nil {
-			arg2 = args[2].(map[string]string)
+			arg2 = args[2].(map[string]interface{})
 		}
 		var arg3 bool
 		if args[3] != nil {
@@ -371,7 +371,7 @@ func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Return(nodeInterface NodeInt
 	return _c
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateNode_Call) RunAndReturn(run func(id string, _type string, properties map[string]string, isStartNode bool, isFinalNode bool) (NodeInterface, error)) *FlowFactoryInterfaceMock_CreateNode_Call {
+func (_c *FlowFactoryInterfaceMock_CreateNode_Call) RunAndReturn(run func(id string, _type string, properties map[string]interface{}, isStartNode bool, isFinalNode bool) (NodeInterface, error)) *FlowFactoryInterfaceMock_CreateNode_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/core/NodeInterface_mock_test.go
+++ b/backend/internal/flow/core/NodeInterface_mock_test.go
@@ -364,19 +364,19 @@ func (_c *NodeInterfaceMock_GetPreviousNodeList_Call) RunAndReturn(run func() []
 }
 
 // GetProperties provides a mock function for the type NodeInterfaceMock
-func (_mock *NodeInterfaceMock) GetProperties() map[string]string {
+func (_mock *NodeInterfaceMock) GetProperties() map[string]interface{} {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProperties")
 	}
 
-	var r0 map[string]string
-	if returnFunc, ok := ret.Get(0).(func() map[string]string); ok {
+	var r0 map[string]interface{}
+	if returnFunc, ok := ret.Get(0).(func() map[string]interface{}); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
+			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
 	return r0
@@ -399,12 +399,12 @@ func (_c *NodeInterfaceMock_GetProperties_Call) Run(run func()) *NodeInterfaceMo
 	return _c
 }
 
-func (_c *NodeInterfaceMock_GetProperties_Call) Return(stringToString map[string]string) *NodeInterfaceMock_GetProperties_Call {
-	_c.Call.Return(stringToString)
+func (_c *NodeInterfaceMock_GetProperties_Call) Return(stringToIfaceVal map[string]interface{}) *NodeInterfaceMock_GetProperties_Call {
+	_c.Call.Return(stringToIfaceVal)
 	return _c
 }
 
-func (_c *NodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]string) *NodeInterfaceMock_GetProperties_Call {
+func (_c *NodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]interface{}) *NodeInterfaceMock_GetProperties_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/core/decision_node.go
+++ b/backend/internal/flow/core/decision_node.go
@@ -32,7 +32,7 @@ type decisionNode struct {
 }
 
 // newDecisionNode creates a new DecisionNode with the given details.
-func newDecisionNode(id string, properties map[string]string, isStartNode bool, isFinalNode bool) NodeInterface {
+func newDecisionNode(id string, properties map[string]interface{}, isStartNode bool, isFinalNode bool) NodeInterface {
 	return &decisionNode{
 		node: &node{
 			id:               id,

--- a/backend/internal/flow/core/decision_node_test.go
+++ b/backend/internal/flow/core/decision_node_test.go
@@ -35,7 +35,7 @@ func TestDecisionNodeTestSuite(t *testing.T) {
 }
 
 func (s *DecisionNodeTestSuite) TestNewDecisionNode() {
-	node := newDecisionNode("decision-1", map[string]string{"key": "value"}, true, false)
+	node := newDecisionNode("decision-1", map[string]interface{}{"key": "value"}, true, false)
 
 	s.NotNil(node)
 	s.Equal("decision-1", node.GetID())
@@ -56,7 +56,7 @@ func (s *DecisionNodeTestSuite) TestExecuteWithValidActionID() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			node := newDecisionNode("decision-1", map[string]string{}, false, false)
+			node := newDecisionNode("decision-1", map[string]interface{}{}, false, false)
 			node.AddNextNodeID("next-1")
 			node.AddNextNodeID("next-2")
 
@@ -72,7 +72,7 @@ func (s *DecisionNodeTestSuite) TestExecuteWithValidActionID() {
 }
 
 func (s *DecisionNodeTestSuite) TestExecuteWithInvalidActionID() {
-	node := newDecisionNode("decision-1", map[string]string{}, false, false)
+	node := newDecisionNode("decision-1", map[string]interface{}{}, false, false)
 	node.AddNextNodeID("next-1")
 	node.AddNextNodeID("next-2")
 
@@ -87,7 +87,7 @@ func (s *DecisionNodeTestSuite) TestExecuteWithInvalidActionID() {
 }
 
 func (s *DecisionNodeTestSuite) TestExecuteWithoutActionID() {
-	node := newDecisionNode("decision-1", map[string]string{}, false, false)
+	node := newDecisionNode("decision-1", map[string]interface{}{}, false, false)
 	node.AddNextNodeID("next-1")
 	node.AddNextNodeID("next-2")
 
@@ -111,7 +111,7 @@ func (s *DecisionNodeTestSuite) TestExecuteWithoutActionID() {
 }
 
 func (s *DecisionNodeTestSuite) TestExecuteNoNextNodesWithActionIDFailure() {
-	node := newDecisionNode("decision-1", map[string]string{}, false, false)
+	node := newDecisionNode("decision-1", map[string]interface{}{}, false, false)
 	ctx := &NodeContext{FlowID: "test-flow", CurrentActionID: "some-action"}
 
 	resp, err := node.Execute(ctx)
@@ -123,7 +123,7 @@ func (s *DecisionNodeTestSuite) TestExecuteNoNextNodesWithActionIDFailure() {
 }
 
 func (s *DecisionNodeTestSuite) TestExecuteNoNextNodesWithoutActionIDError() {
-	node := newDecisionNode("decision-1", map[string]string{}, false, false)
+	node := newDecisionNode("decision-1", map[string]interface{}{}, false, false)
 	ctx := &NodeContext{FlowID: "test-flow", CurrentActionID: ""}
 
 	resp, err := node.Execute(ctx)

--- a/backend/internal/flow/core/factory.go
+++ b/backend/internal/flow/core/factory.go
@@ -28,7 +28,7 @@ import (
 
 // FlowFactoryInterface defines the interface for creating flow graph components.
 type FlowFactoryInterface interface {
-	CreateNode(id, _type string, properties map[string]string, isStartNode, isFinalNode bool) (
+	CreateNode(id, _type string, properties map[string]interface{}, isStartNode, isFinalNode bool) (
 		NodeInterface, error)
 	CreateGraph(id string, _type common.FlowType) GraphInterface
 	CreateExecutor(name string, executorType common.ExecutorType,
@@ -45,7 +45,7 @@ func newFlowFactory() FlowFactoryInterface {
 }
 
 // CreateNode creates a new node based on the provided type and properties
-func (f *flowFactory) CreateNode(id, _type string, properties map[string]string,
+func (f *flowFactory) CreateNode(id, _type string, properties map[string]interface{},
 	isStartNode, isFinalNode bool) (NodeInterface, error) {
 	var nodeType common.NodeType
 	if _type == "" {
@@ -54,7 +54,7 @@ func (f *flowFactory) CreateNode(id, _type string, properties map[string]string,
 		nodeType = common.NodeType(_type)
 	}
 	if properties == nil {
-		properties = make(map[string]string)
+		properties = make(map[string]interface{})
 	}
 
 	switch nodeType {
@@ -101,11 +101,11 @@ func (f *flowFactory) CloneNode(source NodeInterface) (NodeInterface, error) {
 	}
 
 	// Deep copy properties
-	var propertiesCopy map[string]string
+	var propertiesCopy map[string]interface{}
 	if source.GetProperties() != nil {
-		propertiesCopy = sysutils.DeepCopyMapOfStrings(source.GetProperties())
+		propertiesCopy = sysutils.DeepCopyMap(source.GetProperties())
 	} else {
-		propertiesCopy = make(map[string]string)
+		propertiesCopy = make(map[string]interface{})
 	}
 
 	// Create new node

--- a/backend/internal/flow/core/factory_test.go
+++ b/backend/internal/flow/core/factory_test.go
@@ -49,19 +49,19 @@ func (s *FlowFactoryTestSuite) TestCreateNodeSuccess() {
 		name         string
 		nodeID       string
 		nodeType     string
-		properties   map[string]string
+		properties   map[string]interface{}
 		isStartNode  bool
 		isFinalNode  bool
 		expectedType common.NodeType
 	}{
 		{"Create task execution node", "node-1", string(common.NodeTypeTaskExecution),
-			map[string]string{"key": "value"}, true, false, common.NodeTypeTaskExecution},
+			map[string]interface{}{"key": "value"}, true, false, common.NodeTypeTaskExecution},
 		{"Create decision node", "node-2", string(common.NodeTypeDecision),
-			map[string]string{}, false, false, common.NodeTypeDecision},
+			map[string]interface{}{}, false, false, common.NodeTypeDecision},
 		{"Create prompt only node", "node-3", string(common.NodeTypePromptOnly),
 			nil, false, true, common.NodeTypePromptOnly},
 		{"Create auth success node", "node-4", string(common.NodeTypeAuthSuccess),
-			map[string]string{}, false, true, common.NodeTypeTaskExecution},
+			map[string]interface{}{}, false, true, common.NodeTypeTaskExecution},
 	}
 
 	for _, tt := range tests {
@@ -93,8 +93,7 @@ func (s *FlowFactoryTestSuite) TestCreateNodeFailure() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			node, err := s.factory.CreateNode("node-1", tt.nodeType, map[string]string{}, false, false)
-
+			node, err := s.factory.CreateNode("node-1", tt.nodeType, map[string]interface{}{}, false, false)
 			s.Error(err)
 			s.Nil(node)
 		})
@@ -152,7 +151,7 @@ func (s *FlowFactoryTestSuite) TestCreateExecutor() {
 
 func (s *FlowFactoryTestSuite) TestCloneNodeSuccess() {
 	node, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{"key": "value"}, true, false)
+		map[string]interface{}{"key": "value"}, true, false)
 	node.SetInputData([]common.InputData{{Name: "input1", Required: true}})
 	node.AddNextNodeID("next-1")
 	node.AddPreviousNodeID("prev-1")
@@ -193,9 +192,9 @@ func (s *FlowFactoryTestSuite) TestCloneNodeNil() {
 func (s *FlowFactoryTestSuite) TestCloneNodesSuccess() {
 	nodes := make(map[string]NodeInterface)
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	node2, _ := s.factory.CreateNode("node-2", string(common.NodeTypeDecision),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	nodes["node-1"] = node1
 	nodes["node-2"] = node2
 
@@ -243,7 +242,7 @@ func (f *fakeExecutorBackedNode) GetType() common.NodeType {
 	return common.NodeTypeDecision
 }
 
-func (f *fakeExecutorBackedNode) GetProperties() map[string]string {
+func (f *fakeExecutorBackedNode) GetProperties() map[string]interface{} {
 	return nil
 }
 

--- a/backend/internal/flow/core/graph_test.go
+++ b/backend/internal/flow/core/graph_test.go
@@ -52,7 +52,7 @@ func (s *GraphTestSuite) TestGetType() {
 
 func (s *GraphTestSuite) TestAddNodeSuccess() {
 	node, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 
 	err := s.graph.AddNode(node)
 
@@ -69,7 +69,7 @@ func (s *GraphTestSuite) TestAddNodeNil() {
 
 func (s *GraphTestSuite) TestGetNode() {
 	node, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	_ = s.graph.AddNode(node)
 
 	tests := []struct {
@@ -97,9 +97,9 @@ func (s *GraphTestSuite) TestGetNode() {
 
 func (s *GraphTestSuite) TestAddEdgeSuccess() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	node2, _ := s.factory.CreateNode("node-2", string(common.NodeTypeDecision),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node1)
 	_ = s.graph.AddNode(node2)
 
@@ -112,9 +112,9 @@ func (s *GraphTestSuite) TestAddEdgeSuccess() {
 
 func (s *GraphTestSuite) TestAddEdgeFailure() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	node2, _ := s.factory.CreateNode("node-2", string(common.NodeTypeDecision),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node1)
 	_ = s.graph.AddNode(node2)
 
@@ -141,9 +141,9 @@ func (s *GraphTestSuite) TestAddEdgeFailure() {
 
 func (s *GraphTestSuite) TestRemoveEdgeSuccess() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	node2, _ := s.factory.CreateNode("node-2", string(common.NodeTypeDecision),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node1)
 	_ = s.graph.AddNode(node2)
 	_ = s.graph.AddEdge("node-1", "node-2")
@@ -155,7 +155,7 @@ func (s *GraphTestSuite) TestRemoveEdgeSuccess() {
 
 func (s *GraphTestSuite) TestRemoveEdgeFailure() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	_ = s.graph.AddNode(node1)
 
 	tests := []struct {
@@ -179,9 +179,9 @@ func (s *GraphTestSuite) TestRemoveEdgeFailure() {
 
 func (s *GraphTestSuite) TestGetNodes() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	node2, _ := s.factory.CreateNode("node-2", string(common.NodeTypeDecision),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node1)
 	_ = s.graph.AddNode(node2)
 
@@ -195,7 +195,7 @@ func (s *GraphTestSuite) TestGetNodes() {
 
 func (s *GraphTestSuite) TestSetNodes() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	nodes := map[string]NodeInterface{"node-1": node1}
 
 	s.graph.SetNodes(nodes)
@@ -212,9 +212,9 @@ func (s *GraphTestSuite) TestSetNodes() {
 
 func (s *GraphTestSuite) TestGetEdges() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, true, false)
+		map[string]interface{}{}, true, false)
 	node2, _ := s.factory.CreateNode("node-2", string(common.NodeTypeDecision),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node1)
 	_ = s.graph.AddNode(node2)
 	_ = s.graph.AddEdge("node-1", "node-2")
@@ -243,7 +243,7 @@ func (s *GraphTestSuite) TestSetEdges() {
 
 func (s *GraphTestSuite) TestSetStartNodeSuccess() {
 	node, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node)
 
 	err := s.graph.SetStartNode("node-1")
@@ -262,7 +262,7 @@ func (s *GraphTestSuite) TestSetStartNodeFailure() {
 
 func (s *GraphTestSuite) TestGetStartNodeID() {
 	node, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node)
 	_ = s.graph.SetStartNode("node-1")
 
@@ -272,7 +272,7 @@ func (s *GraphTestSuite) TestGetStartNodeID() {
 
 func (s *GraphTestSuite) TestGetStartNodeSuccess() {
 	node, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{}, false, false)
+		map[string]interface{}{}, false, false)
 	_ = s.graph.AddNode(node)
 	_ = s.graph.SetStartNode("node-1")
 
@@ -293,9 +293,9 @@ func (s *GraphTestSuite) TestGetStartNodeFailure() {
 
 func (s *GraphTestSuite) TestToJSON() {
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
-		map[string]string{"key": "value"}, true, false)
+		map[string]interface{}{"key": "value"}, true, false)
 	node2, _ := s.factory.CreateNode("node-2", string(common.NodeTypeDecision),
-		map[string]string{}, false, true)
+		map[string]interface{}{}, false, true)
 
 	if execNode, ok := node1.(ExecutorBackedNodeInterface); ok {
 		execNode.SetExecutorName("test-executor")

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -31,7 +31,7 @@ type NodeContext struct {
 	AppID           string
 	CurrentActionID string
 
-	NodeProperties map[string]string
+	NodeProperties map[string]interface{}
 	NodeInputData  []common.InputData
 	UserInputData  map[string]string
 	RuntimeData    map[string]string

--- a/backend/internal/flow/core/node.go
+++ b/backend/internal/flow/core/node.go
@@ -28,7 +28,7 @@ type NodeInterface interface {
 	Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError)
 	GetID() string
 	GetType() common.NodeType
-	GetProperties() map[string]string
+	GetProperties() map[string]interface{}
 	IsStartNode() bool
 	SetAsStartNode()
 	IsFinalNode() bool
@@ -59,7 +59,7 @@ type ExecutorBackedNodeInterface interface {
 type node struct {
 	id               string
 	_type            common.NodeType
-	properties       map[string]string
+	properties       map[string]interface{}
 	isStartNode      bool
 	isFinalNode      bool
 	nextNodeList     []string
@@ -85,7 +85,7 @@ func (n *node) GetType() common.NodeType {
 }
 
 // GetProperties returns the node's properties
-func (n *node) GetProperties() map[string]string {
+func (n *node) GetProperties() map[string]interface{} {
 	return n.properties
 }
 

--- a/backend/internal/flow/core/node_test.go
+++ b/backend/internal/flow/core/node_test.go
@@ -111,7 +111,7 @@ func (s *NodeTestSuite) TestNextAndPreviousNodeListBehavior() {
 }
 
 func (s *NodeTestSuite) TestInputDataAndProperties() {
-	props := map[string]string{"k": "v"}
+	props := map[string]interface{}{"k": "v"}
 	node := newTaskExecutionNode("t1", props, false, false)
 
 	s.Equal(props, node.GetProperties())

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -32,7 +32,7 @@ type promptOnlyNode struct {
 }
 
 // newPromptOnlyNode creates a new PromptOnlyNode with the given details.
-func newPromptOnlyNode(id string, properties map[string]string, isStartNode bool, isFinalNode bool) NodeInterface {
+func newPromptOnlyNode(id string, properties map[string]interface{}, isStartNode bool, isFinalNode bool) NodeInterface {
 	return &promptOnlyNode{
 		node: &node{
 			id:               id,

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -35,7 +35,7 @@ func TestPromptOnlyNodeTestSuite(t *testing.T) {
 }
 
 func (s *PromptOnlyNodeTestSuite) TestNewPromptOnlyNode() {
-	node := newPromptOnlyNode("prompt-1", map[string]string{"key": "value"}, true, false)
+	node := newPromptOnlyNode("prompt-1", map[string]interface{}{"key": "value"}, true, false)
 
 	s.NotNil(node)
 	s.Equal("prompt-1", node.GetID())
@@ -45,7 +45,7 @@ func (s *PromptOnlyNodeTestSuite) TestNewPromptOnlyNode() {
 }
 
 func (s *PromptOnlyNodeTestSuite) TestExecuteNoInputData() {
-	node := newPromptOnlyNode("prompt-1", map[string]string{}, false, false)
+	node := newPromptOnlyNode("prompt-1", map[string]interface{}{}, false, false)
 	ctx := &NodeContext{FlowID: "test-flow", UserInputData: map[string]string{}}
 
 	resp, err := node.Execute(ctx)
@@ -75,7 +75,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithRequiredData() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			node := newPromptOnlyNode("prompt-1", map[string]string{}, false, false)
+			node := newPromptOnlyNode("prompt-1", map[string]interface{}{}, false, false)
 			node.SetInputData([]common.InputData{
 				{Name: "username", Required: true},
 				{Name: "email", Required: true},
@@ -100,7 +100,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithRequiredData() {
 }
 
 func (s *PromptOnlyNodeTestSuite) TestExecuteWithOptionalData() {
-	node := newPromptOnlyNode("prompt-1", map[string]string{}, false, false)
+	node := newPromptOnlyNode("prompt-1", map[string]interface{}{}, false, false)
 	node.SetInputData([]common.InputData{
 		{Name: "username", Required: true},
 		{Name: "nickname", Required: false},
@@ -116,7 +116,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithOptionalData() {
 }
 
 func (s *PromptOnlyNodeTestSuite) TestExecuteMissingRequiredOnly() {
-	node := newPromptOnlyNode("prompt-1", map[string]string{}, false, false)
+	node := newPromptOnlyNode("prompt-1", map[string]interface{}{}, false, false)
 	node.SetInputData([]common.InputData{
 		{Name: "username", Required: true},
 		{Name: "nickname", Required: false},

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -37,7 +37,7 @@ type taskExecutionNode struct {
 var _ ExecutorBackedNodeInterface = (*taskExecutionNode)(nil)
 
 // newTaskExecutionNode creates a new TaskExecutionNode with the given details.
-func newTaskExecutionNode(id string, properties map[string]string, isStartNode bool,
+func newTaskExecutionNode(id string, properties map[string]interface{}, isStartNode bool,
 	isFinalNode bool) NodeInterface {
 	return &taskExecutionNode{
 		node: &node{
@@ -71,7 +71,7 @@ func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *se
 	if len(n.GetProperties()) > 0 {
 		ctx.NodeProperties = n.GetProperties()
 	} else {
-		ctx.NodeProperties = make(map[string]string)
+		ctx.NodeProperties = make(map[string]interface{})
 	}
 
 	execResp, svcErr := n.triggerExecutor(ctx, logger)

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -43,7 +43,7 @@ func (s *TaskExecutionNodeTestSuite) SetupTest() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestNewTaskExecutionNode() {
-	node := newTaskExecutionNode("task-1", map[string]string{"key": "value"}, true, false)
+	node := newTaskExecutionNode("task-1", map[string]interface{}{"key": "value"}, true, false)
 
 	s.NotNil(node)
 	s.Equal("task-1", node.GetID())
@@ -53,7 +53,7 @@ func (s *TaskExecutionNodeTestSuite) TestNewTaskExecutionNode() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecutorMethods() {
-	node := newTaskExecutionNode("task-1", map[string]string{}, false, false)
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	execNode, ok := node.(ExecutorBackedNodeInterface)
 	s.True(ok)
 
@@ -70,7 +70,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecutorMethods() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteNoExecutor() {
-	node := newTaskExecutionNode("task-1", map[string]string{}, false, false)
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	ctx := &NodeContext{FlowID: "test-flow"}
 
 	resp, err := node.Execute(ctx)
@@ -149,7 +149,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			mockExec := NewExecutorInterfaceMock(s.T())
-			node := newTaskExecutionNode("task-1", map[string]string{}, false, false)
+			node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 			execNode, _ := node.(ExecutorBackedNodeInterface)
 			tt.setupMock(mockExec)
 			execNode.SetExecutor(mockExec)
@@ -172,7 +172,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailure() {
 		nil,
 	).Once()
 
-	node := newTaskExecutionNode("task-1", map[string]string{}, false, false)
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	execNode, _ := node.(ExecutorBackedNodeInterface)
 	execNode.SetExecutor(s.mockExecutor)
 
@@ -189,7 +189,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteExecutorError() {
 	s.mockExecutor.On("GetName").Return("test-executor").Once()
 	s.mockExecutor.On("Execute", mock.Anything).Return(nil, assert.AnError).Once()
 
-	node := newTaskExecutionNode("task-1", map[string]string{}, false, false)
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	execNode, _ := node.(ExecutorBackedNodeInterface)
 	execNode.SetExecutor(s.mockExecutor)
 
@@ -201,7 +201,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteExecutorError() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteNilExecutorResponse() {
-	node := newTaskExecutionNode("task-1", map[string]string{}, false, false)
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	execNode, _ := node.(ExecutorBackedNodeInterface)
 
 	s.mockExecutor.On("GetName").Return("test-executor").Once()
@@ -218,7 +218,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteNilExecutorResponse() {
 func (s *TaskExecutionNodeTestSuite) TestExecutePopulatedNodeProperties() {
 	mockExec := NewExecutorInterfaceMock(s.T())
 
-	props := map[string]string{"k": "v"}
+	props := map[string]interface{}{"k": "v"}
 	node := newTaskExecutionNode("task-props", props, false, false)
 	execNode, _ := node.(ExecutorBackedNodeInterface)
 

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -295,7 +295,9 @@ func (o *oAuthExecutor) GetUserInfo(ctx *flowcore.NodeContext, execResp *flowcm.
 func (o *oAuthExecutor) GetIdpID(ctx *flowcore.NodeContext) (string, error) {
 	if len(ctx.NodeProperties) > 0 {
 		if val, ok := ctx.NodeProperties["idpId"]; ok {
-			return val, nil
+			if idpID, valid := val.(string); valid && idpID != "" {
+				return idpID, nil
+			}
 		}
 	}
 	return "", errors.New("idpId is not configured in node properties")

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -72,7 +72,7 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorize
 		FlowType:      flowcm.FlowTypeAuthentication,
 		UserInputData: map[string]string{},
 		NodeInputData: []flowcm.InputData{{Name: "code", Type: "string", Required: true}},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -101,7 +101,7 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser(
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -147,7 +147,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_Success() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -176,7 +176,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_IDPNotConfigured() {
 	ctx := &flowcore.NodeContext{
 		FlowID:         "flow-123",
 		FlowType:       flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{},
+		NodeProperties: map[string]interface{}{},
 	}
 
 	execResp := &flowcm.ExecutorResponse{
@@ -194,7 +194,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLClientError(
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -222,7 +222,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLServerError(
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -250,7 +250,7 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_Success() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -287,7 +287,7 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ClientError() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -316,7 +316,7 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ServerError() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -345,7 +345,7 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_Success() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -378,7 +378,7 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ClientError() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -407,7 +407,7 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ServerError() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -436,7 +436,7 @@ func (suite *OAuthExecutorTestSuite) TestGetIdpID_Success() {
 	ctx := &flowcore.NodeContext{
 		FlowID:   "flow-123",
 		FlowType: flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -451,7 +451,7 @@ func (suite *OAuthExecutorTestSuite) TestGetIdpID_NotConfigured() {
 	ctx := &flowcore.NodeContext{
 		FlowID:         "flow-123",
 		FlowType:       flowcm.FlowTypeAuthentication,
-		NodeProperties: map[string]string{},
+		NodeProperties: map[string]interface{}{},
 	}
 
 	idpID, err := suite.executor.GetIdpID(ctx)
@@ -468,7 +468,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -518,7 +518,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNo
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -565,7 +565,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExis
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -612,7 +612,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvided(
 		FlowID:        "flow-123",
 		FlowType:      flowcm.FlowTypeAuthentication,
 		UserInputData: map[string]string{},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -636,7 +636,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyScope() {
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -671,7 +671,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -72,7 +72,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthor
 		FlowType:      flowcm.FlowTypeAuthentication,
 		UserInputData: map[string]string{},
 		NodeInputData: []flowcm.InputData{{Name: "code", Type: "string", Required: true}},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -101,7 +101,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_Au
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -161,7 +161,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidIDToken
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -221,7 +221,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce
 			"code":  "auth_code_123",
 			"nonce": "expected_nonce_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -264,7 +264,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim()
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -307,7 +307,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -363,7 +363,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_Use
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -410,7 +410,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyE
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -527,7 +527,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_WithAddition
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -592,7 +592,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvid
 		FlowID:        "flow-123",
 		FlowType:      flowcm.FlowTypeAuthentication,
 		UserInputData: map[string]string{},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}
@@ -616,7 +616,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUs
 		UserInputData: map[string]string{
 			"code": "auth_code_123",
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
 	}

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -299,7 +299,9 @@ func (p *provisioningExecutor) getOuID(ctx *flowcore.NodeContext) string {
 	if ouID == "" {
 		if len(ctx.NodeProperties) > 0 {
 			if val, ok := ctx.NodeProperties["ouId"]; ok {
-				ouID = val
+				if valStr, valid := val.(string); valid && valStr != "" {
+					ouID = valStr
+				}
 			}
 		}
 	}
@@ -316,7 +318,9 @@ func (p *provisioningExecutor) getUserType(ctx *flowcore.NodeContext) string {
 	if userType == "" {
 		if len(ctx.NodeProperties) > 0 {
 			if val, ok := ctx.NodeProperties["userType"]; ok {
-				userType = val
+				if valStr, valid := val.(string); valid && valStr != "" {
+					userType = valStr
+				}
 			}
 		}
 	}

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -123,7 +123,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 			{Name: "username", Type: "string", Required: true},
 			{Name: "email", Type: "string", Required: true},
 		},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"ouId":     "ou-123",
 			"userType": "INTERNAL",
 		},
@@ -203,7 +203,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 			"username": "newuser",
 		},
 		NodeInputData: []flowcm.InputData{{Name: "username", Type: "string", Required: true}},
-		NodeProperties: map[string]string{
+		NodeProperties: map[string]interface{}{
 			"ouId":     "ou-123",
 			"userType": "INTERNAL",
 		},

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -459,8 +459,14 @@ func (s *smsOTPAuthExecutor) generateAndSendOTP(mobileNumber string, ctx *flowco
 	if len(ctx.NodeProperties) == 0 {
 		return errors.New("message sender id is not configured in node properties")
 	}
-	senderID, ok := ctx.NodeProperties["senderId"]
-	if !ok || senderID == "" {
+
+	senderID := ""
+	if senderIDVal, ok := ctx.NodeProperties["senderId"]; ok {
+		if sid, valid := senderIDVal.(string); valid && sid != "" {
+			senderID = sid
+		}
+	}
+	if senderID == "" {
 		return errors.New("senderId is not configured in node properties")
 	}
 

--- a/backend/internal/flow/flowmgt/model.go
+++ b/backend/internal/flow/flowmgt/model.go
@@ -27,12 +27,12 @@ type graphDefinition struct {
 
 // nodeDefinition represents a node in the graph definition
 type nodeDefinition struct {
-	ID         string             `json:"id"`
-	Type       string             `json:"type"`
-	Properties map[string]string  `json:"properties,omitempty"`
-	InputData  []inputDefinition  `json:"inputData"`
-	Executor   executorDefinition `json:"executor"`
-	Next       []string           `json:"next,omitempty"`
+	ID         string                 `json:"id"`
+	Type       string                 `json:"type"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+	InputData  []inputDefinition      `json:"inputData"`
+	Executor   executorDefinition     `json:"executor"`
+	Next       []string               `json:"next,omitempty"`
 }
 
 // inputDefinition represents an input parameter for a node

--- a/backend/internal/flow/flowmgt/service.go
+++ b/backend/internal/flow/flowmgt/service.go
@@ -415,7 +415,7 @@ func (s *flowMgtService) createProvisioningNode() (core.NodeInterface, error) {
 	provisioningNode, err := s.flowFactory.CreateNode(
 		"provisioning",
 		string(common.NodeTypeTaskExecution),
-		map[string]string{},
+		map[string]interface{}{},
 		false,
 		false,
 	)

--- a/backend/internal/system/utils/sliceutil.go
+++ b/backend/internal/system/utils/sliceutil.go
@@ -69,6 +69,42 @@ func DeepCopyMapOfClonables[T ClonableInterface](src map[string]T) (map[string]T
 	return dst, nil
 }
 
+// DeepCopyMap creates a deep copy of a map with interface{} values.
+// It recursively copies nested maps and slices.
+func DeepCopyMap(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		dst[k] = deepCopyValue(v)
+	}
+	return dst
+}
+
+// deepCopyValue creates a deep copy of interface{} values.
+func deepCopyValue(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	switch val := v.(type) {
+	case map[string]interface{}:
+		return DeepCopyMap(val)
+	case []interface{}:
+		copied := make([]interface{}, len(val))
+		for i, item := range val {
+			copied[i] = deepCopyValue(item)
+		}
+		return copied
+	case []string:
+		return append([]string(nil), val...)
+	default:
+		// For primitive types (string, int, float, bool, etc.), direct assignment is sufficient
+		return v
+	}
+}
+
 // MergeInterfaceMaps merges two maps of interface{} and returns the result.
 func MergeInterfaceMaps(dst, src map[string]interface{}) map[string]interface{} {
 	if dst == nil {

--- a/backend/internal/system/utils/sliceutil_test.go
+++ b/backend/internal/system/utils/sliceutil_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const testKeyModified = "modified"
+
 type SliceUtilTestSuite struct {
 	suite.Suite
 }
@@ -140,8 +142,8 @@ func (suite *SliceUtilTestSuite) TestDeepCopyMapOfStrings() {
 			// Verify it's a deep copy (modifying original doesn't affect copy)
 			if len(tt.input) > 0 {
 				for k := range tt.input {
-					tt.input[k] = "modified"
-					assert.NotEqual(suite.T(), "modified", result[k])
+					tt.input[k] = testKeyModified
+					assert.NotEqual(suite.T(), testKeyModified, result[k])
 					break
 				}
 			}
@@ -193,8 +195,8 @@ func (suite *SliceUtilTestSuite) TestDeepCopyMapOfStringSlices() {
 			if len(tt.input) > 0 {
 				for k := range tt.input {
 					if len(tt.input[k]) > 0 {
-						tt.input[k][0] = "modified"
-						assert.NotEqual(suite.T(), "modified", result[k][0])
+						tt.input[k][0] = testKeyModified
+						assert.NotEqual(suite.T(), testKeyModified, result[k][0])
 					}
 					break
 				}
@@ -246,6 +248,293 @@ func (suite *SliceUtilTestSuite) TestMergeInterfaceMaps() {
 		suite.Run(tt.name, func() {
 			result := MergeInterfaceMaps(tt.dst, tt.src)
 			assert.Equal(suite.T(), tt.expected, result)
+		})
+	}
+}
+
+func (suite *SliceUtilTestSuite) TestDeepCopyMap() {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "Nil map",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "Empty map",
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "Map with primitive types",
+			input: map[string]interface{}{
+				"string": "value",
+				"int":    42,
+				"float":  3.14,
+				"bool":   true,
+			},
+			expected: map[string]interface{}{
+				"string": "value",
+				"int":    42,
+				"float":  3.14,
+				"bool":   true,
+			},
+		},
+		{
+			name: "Map with nil value",
+			input: map[string]interface{}{
+				"key1": "value1",
+				"key2": nil,
+			},
+			expected: map[string]interface{}{
+				"key1": "value1",
+				"key2": nil,
+			},
+		},
+		{
+			name: "Map with nested map",
+			input: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "value",
+					"count": 10,
+				},
+			},
+			expected: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "value",
+					"count": 10,
+				},
+			},
+		},
+		{
+			name: "Map with slice of interfaces",
+			input: map[string]interface{}{
+				"list": []interface{}{"a", "b", "c"},
+			},
+			expected: map[string]interface{}{
+				"list": []interface{}{"a", "b", "c"},
+			},
+		},
+		{
+			name: "Map with slice of strings",
+			input: map[string]interface{}{
+				"strings": []string{"x", "y", "z"},
+			},
+			expected: map[string]interface{}{
+				"strings": []string{"x", "y", "z"},
+			},
+		},
+		{
+			name: "Map with complex nested structure",
+			input: map[string]interface{}{
+				"level1": map[string]interface{}{
+					"level2": map[string]interface{}{
+						"level3": []interface{}{
+							"value1",
+							map[string]interface{}{
+								"nested": "deep",
+							},
+							[]string{"a", "b"},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"level1": map[string]interface{}{
+					"level2": map[string]interface{}{
+						"level3": []interface{}{
+							"value1",
+							map[string]interface{}{
+								"nested": "deep",
+							},
+							[]string{"a", "b"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Map with mixed types in slice",
+			input: map[string]interface{}{
+				"mixed": []interface{}{
+					"string",
+					42,
+					true,
+					3.14,
+					nil,
+					map[string]interface{}{"key": "value"},
+					[]string{"nested", "slice"},
+				},
+			},
+			expected: map[string]interface{}{
+				"mixed": []interface{}{
+					"string",
+					42,
+					true,
+					3.14,
+					nil,
+					map[string]interface{}{"key": "value"},
+					[]string{"nested", "slice"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := DeepCopyMap(tt.input)
+
+			if tt.expected == nil {
+				assert.Nil(suite.T(), result)
+				return
+			}
+
+			assert.Equal(suite.T(), tt.expected, result)
+
+			// Verify it's a deep copy by modifying nested structures
+			if len(tt.input) > 0 {
+				// Test modifying nested map
+				if nestedMap, ok := tt.input["outer"].(map[string]interface{}); ok {
+					nestedMap[testKeyModified] = "test"
+					resultNested := result["outer"].(map[string]interface{})
+					_, exists := resultNested[testKeyModified]
+					assert.False(suite.T(), exists,
+						"Modifying original nested map should not affect copy")
+				}
+
+				// Test modifying nested slice
+				if nestedSlice, ok := tt.input["list"].([]interface{}); ok && len(nestedSlice) > 0 {
+					nestedSlice[0] = testKeyModified
+					resultSlice := result["list"].([]interface{})
+					assert.NotEqual(suite.T(), testKeyModified, resultSlice[0],
+						"Modifying original slice should not affect copy")
+				}
+
+				// Test modifying string slice
+				if stringSlice, ok := tt.input["strings"].([]string); ok && len(stringSlice) > 0 {
+					stringSlice[0] = testKeyModified
+					resultSlice := result["strings"].([]string)
+					assert.NotEqual(suite.T(), testKeyModified, resultSlice[0],
+						"Modifying original string slice should not affect copy")
+				}
+			}
+		})
+	}
+}
+
+func (suite *SliceUtilTestSuite) TestDeepCopyValue() {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "Nil value",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "String value",
+			input:    "test string",
+			expected: "test string",
+		},
+		{
+			name:     "Integer value",
+			input:    42,
+			expected: 42,
+		},
+		{
+			name:     "Float value",
+			input:    3.14159,
+			expected: 3.14159,
+		},
+		{
+			name:     "Boolean value",
+			input:    true,
+			expected: true,
+		},
+		{
+			name: "Map value",
+			input: map[string]interface{}{
+				"key": "value",
+			},
+			expected: map[string]interface{}{
+				"key": "value",
+			},
+		},
+		{
+			name:     "Slice of interfaces",
+			input:    []interface{}{"a", 1, true},
+			expected: []interface{}{"a", 1, true},
+		},
+		{
+			name:     "Slice of strings",
+			input:    []string{"x", "y", "z"},
+			expected: []string{"x", "y", "z"},
+		},
+		{
+			name: "Nested map in slice",
+			input: []interface{}{
+				map[string]interface{}{
+					"nested": "value",
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"nested": "value",
+				},
+			},
+		},
+		{
+			name:     "Empty slice of interfaces",
+			input:    []interface{}{},
+			expected: []interface{}{},
+		},
+		{
+			name:     "Empty slice of strings",
+			input:    []string{},
+			expected: []string(nil), // append returns nil for empty slices
+		},
+		{
+			name:     "Empty map",
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := deepCopyValue(tt.input)
+			assert.Equal(suite.T(), tt.expected, result)
+
+			// Verify deep copy for complex types
+			switch v := tt.input.(type) {
+			case map[string]interface{}:
+				if len(v) > 0 {
+					v[testKeyModified] = "test"
+					resultMap := result.(map[string]interface{})
+					_, exists := resultMap[testKeyModified]
+					assert.False(suite.T(), exists,
+						"Modifying original map should not affect copy")
+				}
+			case []interface{}:
+				if len(v) > 0 {
+					v[0] = testKeyModified
+					resultSlice := result.([]interface{})
+					assert.NotEqual(suite.T(), testKeyModified, resultSlice[0],
+						"Modifying original slice should not affect copy")
+				}
+			case []string:
+				if len(v) > 0 {
+					v[0] = testKeyModified
+					resultSlice := result.([]string)
+					assert.NotEqual(suite.T(), testKeyModified, resultSlice[0],
+						"Modifying original string slice should not affect copy")
+				}
+			}
 		})
 	}
 }

--- a/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
@@ -455,19 +455,19 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetPreviousNodeList_Call) RunAndReturn
 }
 
 // GetProperties provides a mock function for the type ExecutorBackedNodeInterfaceMock
-func (_mock *ExecutorBackedNodeInterfaceMock) GetProperties() map[string]string {
+func (_mock *ExecutorBackedNodeInterfaceMock) GetProperties() map[string]interface{} {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProperties")
 	}
 
-	var r0 map[string]string
-	if returnFunc, ok := ret.Get(0).(func() map[string]string); ok {
+	var r0 map[string]interface{}
+	if returnFunc, ok := ret.Get(0).(func() map[string]interface{}); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
+			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
 	return r0
@@ -490,12 +490,12 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) Run(run func()) *E
 	return _c
 }
 
-func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) Return(stringToString map[string]string) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
-	_c.Call.Return(stringToString)
+func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) Return(stringToIfaceVal map[string]interface{}) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
+	_c.Call.Return(stringToIfaceVal)
 	return _c
 }
 
-func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]string) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
+func (_c *ExecutorBackedNodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]interface{}) *ExecutorBackedNodeInterfaceMock_GetProperties_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/coremock/FlowFactoryInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/FlowFactoryInterface_mock.go
@@ -292,7 +292,7 @@ func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) RunAndReturn(run func(id st
 }
 
 // CreateNode provides a mock function for the type FlowFactoryInterfaceMock
-func (_mock *FlowFactoryInterfaceMock) CreateNode(id string, _type string, properties map[string]string, isStartNode bool, isFinalNode bool) (core.NodeInterface, error) {
+func (_mock *FlowFactoryInterfaceMock) CreateNode(id string, _type string, properties map[string]interface{}, isStartNode bool, isFinalNode bool) (core.NodeInterface, error) {
 	ret := _mock.Called(id, _type, properties, isStartNode, isFinalNode)
 
 	if len(ret) == 0 {
@@ -301,17 +301,17 @@ func (_mock *FlowFactoryInterfaceMock) CreateNode(id string, _type string, prope
 
 	var r0 core.NodeInterface
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]string, bool, bool) (core.NodeInterface, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]interface{}, bool, bool) (core.NodeInterface, error)); ok {
 		return returnFunc(id, _type, properties, isStartNode, isFinalNode)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]string, bool, bool) core.NodeInterface); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, string, map[string]interface{}, bool, bool) core.NodeInterface); ok {
 		r0 = returnFunc(id, _type, properties, isStartNode, isFinalNode)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(core.NodeInterface)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, map[string]string, bool, bool) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(string, string, map[string]interface{}, bool, bool) error); ok {
 		r1 = returnFunc(id, _type, properties, isStartNode, isFinalNode)
 	} else {
 		r1 = ret.Error(1)
@@ -327,14 +327,14 @@ type FlowFactoryInterfaceMock_CreateNode_Call struct {
 // CreateNode is a helper method to define mock.On call
 //   - id string
 //   - _type string
-//   - properties map[string]string
+//   - properties map[string]interface{}
 //   - isStartNode bool
 //   - isFinalNode bool
 func (_e *FlowFactoryInterfaceMock_Expecter) CreateNode(id interface{}, _type interface{}, properties interface{}, isStartNode interface{}, isFinalNode interface{}) *FlowFactoryInterfaceMock_CreateNode_Call {
 	return &FlowFactoryInterfaceMock_CreateNode_Call{Call: _e.mock.On("CreateNode", id, _type, properties, isStartNode, isFinalNode)}
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Run(run func(id string, _type string, properties map[string]string, isStartNode bool, isFinalNode bool)) *FlowFactoryInterfaceMock_CreateNode_Call {
+func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Run(run func(id string, _type string, properties map[string]interface{}, isStartNode bool, isFinalNode bool)) *FlowFactoryInterfaceMock_CreateNode_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -344,9 +344,9 @@ func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Run(run func(id string, _typ
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 map[string]string
+		var arg2 map[string]interface{}
 		if args[2] != nil {
-			arg2 = args[2].(map[string]string)
+			arg2 = args[2].(map[string]interface{})
 		}
 		var arg3 bool
 		if args[3] != nil {
@@ -372,7 +372,7 @@ func (_c *FlowFactoryInterfaceMock_CreateNode_Call) Return(nodeInterface core.No
 	return _c
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateNode_Call) RunAndReturn(run func(id string, _type string, properties map[string]string, isStartNode bool, isFinalNode bool) (core.NodeInterface, error)) *FlowFactoryInterfaceMock_CreateNode_Call {
+func (_c *FlowFactoryInterfaceMock_CreateNode_Call) RunAndReturn(run func(id string, _type string, properties map[string]interface{}, isStartNode bool, isFinalNode bool) (core.NodeInterface, error)) *FlowFactoryInterfaceMock_CreateNode_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
@@ -365,19 +365,19 @@ func (_c *NodeInterfaceMock_GetPreviousNodeList_Call) RunAndReturn(run func() []
 }
 
 // GetProperties provides a mock function for the type NodeInterfaceMock
-func (_mock *NodeInterfaceMock) GetProperties() map[string]string {
+func (_mock *NodeInterfaceMock) GetProperties() map[string]interface{} {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProperties")
 	}
 
-	var r0 map[string]string
-	if returnFunc, ok := ret.Get(0).(func() map[string]string); ok {
+	var r0 map[string]interface{}
+	if returnFunc, ok := ret.Get(0).(func() map[string]interface{}); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
+			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
 	return r0
@@ -400,12 +400,12 @@ func (_c *NodeInterfaceMock_GetProperties_Call) Run(run func()) *NodeInterfaceMo
 	return _c
 }
 
-func (_c *NodeInterfaceMock_GetProperties_Call) Return(stringToString map[string]string) *NodeInterfaceMock_GetProperties_Call {
-	_c.Call.Return(stringToString)
+func (_c *NodeInterfaceMock_GetProperties_Call) Return(stringToIfaceVal map[string]interface{}) *NodeInterfaceMock_GetProperties_Call {
+	_c.Call.Return(stringToIfaceVal)
 	return _c
 }
 
-func (_c *NodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]string) *NodeInterfaceMock_GetProperties_Call {
+func (_c *NodeInterfaceMock_GetProperties_Call) RunAndReturn(run func() map[string]interface{}) *NodeInterfaceMock_GetProperties_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request refactors the flow core codebase to use `map[string]interface{}` for node properties instead of `map[string]string`. This change increases flexibility for storing node properties and affects the interface definitions, implementations, mocks, and related tests throughout the flow system.

### Approach

### Interface and Implementation Updates

* Changed the `FlowFactoryInterface.CreateNode` method signature and its implementation in `factory.go` to accept `properties map[string]interface{}` instead of `map[string]string`. All usages and default initializations were updated accordingly. [[1]](diffhunk://#diff-b48e92e47f756cb067e6cf31a8bc99a1740ecb0d90525df74747298f05ecf2cbL31-R31) [[2]](diffhunk://#diff-b48e92e47f756cb067e6cf31a8bc99a1740ecb0d90525df74747298f05ecf2cbL48-R48) [[3]](diffhunk://#diff-b48e92e47f756cb067e6cf31a8bc99a1740ecb0d90525df74747298f05ecf2cbL57-R57)
* Updated `decision_node.go` and its constructor `newDecisionNode` to use `map[string]interface{}` for properties.

### Mock and Test Refactoring

* Updated all mock interfaces and helper methods in `ExecutorBackedNodeInterface_mock_test.go`, `FlowFactoryInterface_mock_test.go`, and `NodeInterface_mock_test.go` to use `map[string]interface{}` for properties. This includes method signatures, return types, and argument handling. [[1]](diffhunk://#diff-152a86a49efa541919763b005fee28b6d4d9ceca91db631a79bc01a960ab8219L457-R469) [[2]](diffhunk://#diff-152a86a49efa541919763b005fee28b6d4d9ceca91db631a79bc01a960ab8219L492-R497) [[3]](diffhunk://#diff-15f165a9e6188ab0edfbc903fcfc2de54059f53b0058b5bd754e0a444fec286dL294-R294) [[4]](diffhunk://#diff-15f165a9e6188ab0edfbc903fcfc2de54059f53b0058b5bd754e0a444fec286dL303-R313) [[5]](diffhunk://#diff-15f165a9e6188ab0edfbc903fcfc2de54059f53b0058b5bd754e0a444fec286dL329-R336) [[6]](diffhunk://#diff-15f165a9e6188ab0edfbc903fcfc2de54059f53b0058b5bd754e0a444fec286dL346-R348) [[7]](diffhunk://#diff-15f165a9e6188ab0edfbc903fcfc2de54059f53b0058b5bd754e0a444fec286dL374-R374) [[8]](diffhunk://#diff-51040484fe9150f3ace041a0fbcc6f36e9a1dbe1d6ba39e050dc5145c264b045L367-R379) [[9]](diffhunk://#diff-51040484fe9150f3ace041a0fbcc6f36e9a1dbe1d6ba39e050dc5145c264b045L402-R407)
* Refactored all related unit tests in `decision_node_test.go`, `factory_test.go`, and `graph_test.go` to use `map[string]interface{}` for node properties. [[1]](diffhunk://#diff-01ae329654d89bf866d2e6a31aeb4dc4638106f26336564a9ca46bfb2c546bc2L38-R38) [[2]](diffhunk://#diff-01ae329654d89bf866d2e6a31aeb4dc4638106f26336564a9ca46bfb2c546bc2L59-R59) [[3]](diffhunk://#diff-01ae329654d89bf866d2e6a31aeb4dc4638106f26336564a9ca46bfb2c546bc2L75-R75) [[4]](diffhunk://#diff-01ae329654d89bf866d2e6a31aeb4dc4638106f26336564a9ca46bfb2c546bc2L90-R90) [[5]](diffhunk://#diff-01ae329654d89bf866d2e6a31aeb4dc4638106f26336564a9ca46bfb2c546bc2L114-R114) [[6]](diffhunk://#diff-01ae329654d89bf866d2e6a31aeb4dc4638106f26336564a9ca46bfb2c546bc2L126-R126) [[7]](diffhunk://#diff-43ae4188edb4c3ec7055b711c637c53a65b020d6983670af00693852932c0e2bL52-R64) [[8]](diffhunk://#diff-43ae4188edb4c3ec7055b711c637c53a65b020d6983670af00693852932c0e2bL96-R96) [[9]](diffhunk://#diff-43ae4188edb4c3ec7055b711c637c53a65b020d6983670af00693852932c0e2bL155-R154) [[10]](diffhunk://#diff-43ae4188edb4c3ec7055b711c637c53a65b020d6983670af00693852932c0e2bL196-R197) [[11]](diffhunk://#diff-43ae4188edb4c3ec7055b711c637c53a65b020d6983670af00693852932c0e2bL246-R245) [[12]](diffhunk://#diff-b3ff71ba393fe8c5f071f2fc2035ff6b7f01c23c2eaa36143598fb4fde6d2e49L55-R55) [[13]](diffhunk://#diff-b3ff71ba393fe8c5f071f2fc2035ff6b7f01c23c2eaa36143598fb4fde6d2e49L72-R72) [[14]](diffhunk://#diff-b3ff71ba393fe8c5f071f2fc2035ff6b7f01c23c2eaa36143598fb4fde6d2e49L100-R102)

### Utility Function Adjustment

* Updated the deep copy logic in `factory.go` to use a new utility `DeepCopyMap` for `map[string]interface{}` instead of `DeepCopyMapOfStrings`.

These changes ensure that node properties can now hold values of any type, improving extensibility and future-proofing the flow system.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
