### PR TITLE
Add allowed user types to application

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -626,6 +626,12 @@ components:
             format: email
           description: Array of email addresses of people responsible for the application.
           example: ["admin@myapp.example.com", "support@myapp.example.com"]
+        allowed_user_types:
+          type: array
+          items:
+            type: string
+          description: Array of allowed user types for this application.
+          example: ["employee", "customer", "partner"]
 
     ApplicationCompleteResponse:
       type: object
@@ -695,6 +701,12 @@ components:
             format: email
           description: Array of email addresses of people responsible for the application.
           example: ["admin@myapp.example.com", "support@myapp.example.com"]
+        allowed_user_types:
+          type: array
+          items:
+            type: string
+          description: Array of allowed user types for this application.
+          example: ["employee", "customer", "partner"]
 
     ApplicationGetResponse:
       type: object
@@ -764,6 +776,12 @@ components:
             format: email
           description: Array of email addresses of people responsible for the application.
           example: ["admin@myapp.example.com", "support@myapp.example.com"]
+        allowed_user_types:
+          type: array
+          items:
+            type: string
+          description: Array of allowed user types for this application.
+          example: ["employee", "customer", "partner"]
 
     BasicApplicationResponse:
       type: object

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -70,7 +70,7 @@ func registerServices(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) {
 		logger.Fatal("Failed to initialize FlowMgtService", log.Error(err))
 	}
 	certservice := cert.Initialize()
-	applicationService := application.Initialize(mux, certservice, flowMgtService)
+	applicationService := application.Initialize(mux, certservice, flowMgtService, userSchemaService)
 
 	flowExecService := flowexec.Initialize(mux, flowMgtService, applicationService, execRegistry)
 

--- a/backend/internal/application/error_constants.go
+++ b/backend/internal/application/error_constants.go
@@ -194,6 +194,13 @@ var (
 		Error:            "Invalid OAuth configuration",
 		ErrorDescription: "The OAuth configuration is invalid",
 	}
+	// ErrorInvalidUserType is the error returned when an invalid user type is provided in allowed_user_types.
+	ErrorInvalidUserType = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "APP-1025",
+		Error:            "Invalid user type",
+		ErrorDescription: "One or more user types in allowed_user_types do not exist in the system",
+	}
 )
 
 // Server errors for application operations.

--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -76,6 +76,7 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 		TosURI:                    appRequest.TosURI,
 		PolicyURI:                 appRequest.PolicyURI,
 		Contacts:                  appRequest.Contacts,
+		AllowedUserTypes:          appRequest.AllowedUserTypes,
 	}
 	appDTO.InboundAuthConfig = ah.processInboundAuthConfigFromRequest(appRequest.InboundAuthConfig)
 
@@ -100,6 +101,7 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 		TosURI:                    createdAppDTO.TosURI,
 		PolicyURI:                 createdAppDTO.PolicyURI,
 		Contacts:                  createdAppDTO.Contacts,
+		AllowedUserTypes:          createdAppDTO.AllowedUserTypes,
 	}
 
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.
@@ -193,6 +195,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		TosURI:                    appDTO.TosURI,
 		PolicyURI:                 appDTO.PolicyURI,
 		Contacts:                  appDTO.Contacts,
+		AllowedUserTypes:          appDTO.AllowedUserTypes,
 	}
 
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.
@@ -333,6 +336,7 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 		TosURI:                    appRequest.TosURI,
 		PolicyURI:                 appRequest.PolicyURI,
 		Contacts:                  appRequest.Contacts,
+		AllowedUserTypes:          appRequest.AllowedUserTypes,
 	}
 	updateReqAppDTO.InboundAuthConfig = ah.processInboundAuthConfigFromRequest(appRequest.InboundAuthConfig)
 
@@ -357,6 +361,7 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 		TosURI:                    updatedAppDTO.TosURI,
 		PolicyURI:                 updatedAppDTO.PolicyURI,
 		Contacts:                  updatedAppDTO.Contacts,
+		AllowedUserTypes:          updatedAppDTO.AllowedUserTypes,
 	}
 
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.

--- a/backend/internal/application/init.go
+++ b/backend/internal/application/init.go
@@ -29,13 +29,18 @@ import (
 	filebasedruntime "github.com/asgardeo/thunder/internal/system/file_based_runtime"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/middleware"
+	"github.com/asgardeo/thunder/internal/userschema"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Initialize initializes the application service and registers its routes.
-func Initialize(mux *http.ServeMux, certService cert.CertificateServiceInterface,
-	flowMgtService flowmgt.FlowMgtServiceInterface) ApplicationServiceInterface {
+func Initialize(
+	mux *http.ServeMux,
+	certService cert.CertificateServiceInterface,
+	flowMgtService flowmgt.FlowMgtServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
+) ApplicationServiceInterface {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationInit"))
 	var appStore applicationStoreInterface
 	if config.GetThunderRuntime().Config.ImmutableResources.Enabled {
@@ -45,7 +50,7 @@ func Initialize(mux *http.ServeMux, certService cert.CertificateServiceInterface
 		appStore = newCachedBackedApplicationStore(store)
 	}
 
-	appService := newApplicationService(appStore, certService, flowMgtService)
+	appService := newApplicationService(appStore, certService, flowMgtService, userSchemaService)
 
 	if config.GetThunderRuntime().Config.ImmutableResources.Enabled {
 		configs, err := filebasedruntime.GetConfigs("applications")
@@ -92,6 +97,7 @@ func parseToApplicationDTO(data []byte) (*model.ApplicationDTO, error) {
 		LogoURL:                   appRequest.LogoURL,
 		Token:                     appRequest.Token,
 		Certificate:               appRequest.Certificate,
+		AllowedUserTypes:          appRequest.AllowedUserTypes,
 	}
 	if len(appRequest.InboundAuthConfig) > 0 {
 		inboundAuthConfigDTOs := make([]model.InboundAuthConfigDTO, 0)

--- a/backend/internal/application/init_test.go
+++ b/backend/internal/application/init_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/tests/mocks/certmock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/flowmgtmock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -42,14 +43,15 @@ import (
 // - Error handling scenarios for configuration parsing and validation
 type InitTestSuite struct {
 	suite.Suite
-	mockCertService    *certmock.CertificateServiceInterfaceMock
-	mockFlowMgtService *flowmgtmock.FlowMgtServiceInterfaceMock
+	mockCertService       *certmock.CertificateServiceInterfaceMock
+	mockFlowMgtService    *flowmgtmock.FlowMgtServiceInterfaceMock
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 }
 
 func (suite *InitTestSuite) SetupTest() {
 	suite.mockCertService = certmock.NewCertificateServiceInterfaceMock(suite.T())
 	suite.mockFlowMgtService = flowmgtmock.NewFlowMgtServiceInterfaceMock(suite.T())
-	// Note: We'll handle config initialization in individual tests as needed
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 }
 
 func (suite *InitTestSuite) TearDownTest() {
@@ -76,7 +78,7 @@ func (suite *InitTestSuite) TestInitialize_WithImmutableResourcesDisabled() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service := Initialize(mux, suite.mockCertService, suite.mockFlowMgtService)
+	service := Initialize(mux, suite.mockCertService, suite.mockFlowMgtService, suite.mockUserSchemaService)
 
 	// Assert
 	assert.NotNil(suite.T(), service)
@@ -463,9 +465,10 @@ func TestInitialize_Standalone(t *testing.T) {
 	mux := http.NewServeMux()
 	mockCertService := certmock.NewCertificateServiceInterfaceMock(t)
 	mockFlowMgtService := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockUserSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 
 	// Execute
-	service := Initialize(mux, mockCertService, mockFlowMgtService)
+	service := Initialize(mux, mockCertService, mockFlowMgtService, mockUserSchemaService)
 
 	// Assert
 	assert.NotNil(t, service)
@@ -500,9 +503,10 @@ func TestInitialize_WithImmutableResources_Standalone(t *testing.T) {
 	mux := http.NewServeMux()
 	mockCertService := certmock.NewCertificateServiceInterfaceMock(t)
 	mockFlowMgtService := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockUserSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 
 	// Execute
-	service := Initialize(mux, mockCertService, mockFlowMgtService)
+	service := Initialize(mux, mockCertService, mockFlowMgtService, mockUserSchemaService)
 
 	// Assert
 	assert.NotNil(t, service)

--- a/backend/internal/application/model/application.go
+++ b/backend/internal/application/model/application.go
@@ -62,6 +62,7 @@ type ApplicationDTO struct {
 	Token             *TokenConfig
 	Certificate       *ApplicationCertificate
 	InboundAuthConfig []InboundAuthConfigDTO
+	AllowedUserTypes  []string
 }
 
 // BasicApplicationDTO represents a simplified data transfer object for application service operations.
@@ -93,6 +94,7 @@ type ApplicationProcessedDTO struct {
 	Token             *TokenConfig
 	Certificate       *ApplicationCertificate
 	InboundAuthConfig []InboundAuthConfigProcessedDTO
+	AllowedUserTypes  []string
 }
 
 // InboundAuthConfigDTO represents the data transfer object for inbound authentication configuration.
@@ -132,6 +134,7 @@ type ApplicationRequest struct {
 	PolicyURI                 string                      `json:"policy_uri,omitempty" yaml:"policy_uri,omitempty"`
 	Contacts                  []string                    `json:"contacts,omitempty" yaml:"contacts,omitempty"`
 	InboundAuthConfig         []InboundAuthConfigComplete `json:"inbound_auth_config,omitempty" yaml:"inbound_auth_config,omitempty"`
+	AllowedUserTypes          []string                    `json:"allowed_user_types,omitempty" yaml:"allowed_user_types,omitempty"`
 }
 
 // ApplicationCompleteResponse represents the complete response structure for an application.
@@ -151,6 +154,7 @@ type ApplicationCompleteResponse struct {
 	PolicyURI                 string                      `json:"policy_uri,omitempty"`
 	Contacts                  []string                    `json:"contacts,omitempty"`
 	InboundAuthConfig         []InboundAuthConfigComplete `json:"inbound_auth_config,omitempty"`
+	AllowedUserTypes          []string                    `json:"allowed_user_types,omitempty"`
 }
 
 // ApplicationGetResponse represents the response structure for getting an application.
@@ -170,6 +174,7 @@ type ApplicationGetResponse struct {
 	PolicyURI                 string                  `json:"policy_uri,omitempty"`
 	Contacts                  []string                `json:"contacts,omitempty"`
 	InboundAuthConfig         []InboundAuthConfig     `json:"inbound_auth_config,omitempty"`
+	AllowedUserTypes          []string                `json:"allowed_user_types,omitempty"`
 }
 
 // BasicApplicationResponse represents a simplified response structure for an application.

--- a/tests/integration/application/model.go
+++ b/tests/integration/application/model.go
@@ -35,6 +35,7 @@ type Application struct {
 	TosURI                    string              `json:"tos_uri,omitempty"`
 	PolicyURI                 string              `json:"policy_uri,omitempty"`
 	Contacts                  []string            `json:"contacts,omitempty"`
+	AllowedUserTypes          []string            `json:"allowed_user_types,omitempty"`
 	InboundAuthConfig         []InboundAuthConfig `json:"inbound_auth_config,omitempty"`
 }
 
@@ -138,6 +139,11 @@ func (app *Application) equals(expectedApp Application) bool {
 
 	// Contacts
 	if !compareStringSlices(app.Contacts, expectedApp.Contacts) {
+		return false
+	}
+
+	// AllowedUserTypes
+	if !compareStringSlices(app.AllowedUserTypes, expectedApp.AllowedUserTypes) {
 		return false
 	}
 


### PR DESCRIPTION
This pull request adds support for specifying allowed user types for applications, ensuring that only valid user types defined in the system can be associated with an application. The changes introduce a new `allowed_user_types` field to the API schema and application models, update service and handler logic to process and validate this field, and extend error handling and tests to cover invalid user types.

**API Schema and Model Updates:**

* Added `allowed_user_types` as an array of strings to `ApplicationCompleteResponse`, `ApplicationGetResponse`, and `BasicApplicationResponse` in `api/application.yaml`, with documentation and examples. [[1]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211R629-R634) [[2]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211R704-R709) [[3]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211R779-R784)
* Added `AllowedUserTypes` field to various application-related structs in `backend/internal/application/model/application.go`, including `ApplicationDTO`, `ApplicationProcessedDTO`, `ApplicationRequest`, and response types. [[1]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4R65) [[2]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4R97) [[3]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4R137) [[4]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4R157) [[5]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4R177)

**Service and Handler Logic:**

* Updated service initialization to require a `UserSchemaServiceInterface` and propagate it through the application service and handler layers, ensuring user type validation is possible. [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L73-R73) [[2]](diffhunk://#diff-2bcac82e89f0873b3de4734f00ac822a66f3f07e2fd5c3378d5c5b0d6928b30dR32-R39) [[3]](diffhunk://#diff-2bcac82e89f0873b3de4734f00ac822a66f3f07e2fd5c3378d5c5b0d6928b30dL48-R49) [[4]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831R37) [[5]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831R57-R67)
* Modified handler logic to handle the new `AllowedUserTypes` field for create, update, and get requests, mapping the field between request/response and DTOs. [[1]](diffhunk://#diff-6d6046411d1133782ea6228adddfc69fc39d887a22ee505353f6f49285440cf9R79) [[2]](diffhunk://#diff-6d6046411d1133782ea6228adddfc69fc39d887a22ee505353f6f49285440cf9R104) [[3]](diffhunk://#diff-6d6046411d1133782ea6228adddfc69fc39d887a22ee505353f6f49285440cf9R198) [[4]](diffhunk://#diff-6d6046411d1133782ea6228adddfc69fc39d887a22ee505353f6f49285440cf9R339) [[5]](diffhunk://#diff-6d6046411d1133782ea6228adddfc69fc39d887a22ee505353f6f49285440cf9R364)
* Updated DTO parsing and service methods to include `AllowedUserTypes` in application creation and update flows. [[1]](diffhunk://#diff-2bcac82e89f0873b3de4734f00ac822a66f3f07e2fd5c3378d5c5b0d6928b30dR96) [[2]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831R129) [[3]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831R214) [[4]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831R412-R415)

**Validation and Error Handling:**

* Implemented validation for `AllowedUserTypes` in the service layer, ensuring all specified user types exist in the system, and returning a new error if any are invalid.
* Added `ErrorInvalidUserType` to `backend/internal/application/error_constants.go` for handling invalid user type errors.

**Testing Enhancements:**

* Updated tests to mock the new user schema service and verify initialization and error handling for user type validation. [[1]](diffhunk://#diff-9229d71e7169d6b217d05b386571b1a7f7402f8a511a77e9f88c73eac9d72817R30-R37) [[2]](diffhunk://#diff-9229d71e7169d6b217d05b386571b1a7f7402f8a511a77e9f88c73eac9d72817R51-R57) [[3]](diffhunk://#diff-9229d71e7169d6b217d05b386571b1a7f7402f8a511a77e9f88c73eac9d72817L79-R84) [[4]](diffhunk://#diff-9229d71e7169d6b217d05b386571b1a7f7402f8a511a77e9f88c73eac9d72817R471-R482) [[5]](diffhunk://#diff-9229d71e7169d6b217d05b386571b1a7f7402f8a511a77e9f88c73eac9d72817R517-R528)