### PR TITLE
Add applicationld in the gate app redirection

### DIFF
--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -206,6 +206,7 @@ func (ah *authorizeHandler) handleInitialAuthorizationRequest(msg *OAuthMessage,
 	// Add required query parameters.
 	queryParams := make(map[string]string)
 	queryParams[oauth2const.SessionDataKey] = identifier
+	queryParams[oauth2const.AppID] = app.AppID
 	queryParams[oauth2const.FlowID] = flowID
 
 	// Add insecure warning if the redirect URI is not using TLS.

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -59,6 +59,7 @@ const (
 	SessionDataKey        string = "sessionDataKey"
 	SessionDataKeyConsent string = "sessionDataKeyConsent"
 	ShowInsecureWarning   string = "showInsecureWarning"
+	AppID                 string = "applicationId"
 	FlowID                string = "flowId"
 	Assertion             string = "assertion"
 )


### PR DESCRIPTION
### Purpose
With this https://github.com/asgardeo/thunder/pull/624, we have removed the appId in the redirection to the Gate App. It is now needed to support the self registration in the Gate app. Ideally it should be retrieved from the flowId, but for the time being we are adding it back to the redirection.

### Approach
Add applicationld in the gate app redirection

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
