### PR TITLE
Add ou details to the auth assertion

### DIFF
--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -61,7 +61,7 @@ func Initialize(
 
 	reg.RegisterExecutor(ExecutorNameAttributeCollect, newAttributeCollector(flowFactory, userService))
 	reg.RegisterExecutor(ExecutorNameAuthAssert, newAuthAssertExecutor(flowFactory, jwtService,
-		userService, authRegistry.AuthAssertGenerator))
+		userService, ouService, authRegistry.AuthAssertGenerator))
 	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService))
 	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory))
 

--- a/tests/integration/flowauthn/decisionauth_test.go
+++ b/tests/integration/flowauthn/decisionauth_test.go
@@ -298,16 +298,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() {
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
 
-	// Decode and validate JWT claims
-	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
-	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	// Validate JWT assertion fields using common utility
+	jwtClaims, err := testutils.ValidateJWTAssertionFields(
+		completeFlowStep.Assertion,
+		decisionTestAppID,
+		decisionUserSchema.Name,
+		decisionTestOUID,
+		decisionTestOU.Name,
+		decisionTestOU.Handle,
+	)
+	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
-
-	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-	ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
-	ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
-	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
@@ -419,16 +420,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
 		ts.Require().Empty(completeFlowStep.FailureReason,
 			"Failure reason should be empty for successful authentication")
 
-		// Decode and validate JWT claims
-		jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
-		ts.Require().NoError(err, "Failed to decode JWT assertion")
+		// Validate JWT assertion fields using common utility
+		jwtClaims, err := testutils.ValidateJWTAssertionFields(
+			completeFlowStep.Assertion,
+			decisionTestAppID,
+			decisionUserSchema.Name,
+			decisionTestOUID,
+			decisionTestOU.Name,
+			decisionTestOU.Handle,
+		)
+		ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 		ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
-
-		// Validate JWT contains expected user type and OU ID
-		ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-		ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
-		ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
-		ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 	})
 
 	// Test case 2: Retry auth flow for same user - should not prompt for mobile again
@@ -528,16 +530,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP() {
 		ts.Require().Empty(completeFlowStep.FailureReason,
 			"Failure reason should be empty for successful authentication")
 
-		// Decode and validate JWT claims
-		jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
-		ts.Require().NoError(err, "Failed to decode JWT assertion")
+		// Validate JWT assertion fields using common utility
+		jwtClaims, err := testutils.ValidateJWTAssertionFields(
+			completeFlowStep.Assertion,
+			decisionTestAppID,
+			decisionUserSchema.Name,
+			decisionTestOUID,
+			decisionTestOU.Name,
+			decisionTestOU.Handle,
+		)
+		ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 		ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
-
-		// Validate JWT contains expected user type and OU ID
-		ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-		ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
-		ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
-		ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 	})
 }
 
@@ -635,16 +638,17 @@ func (ts *DecisionAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 		"JWT assertion should be returned after successful authentication")
 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
 
-	// Decode and validate JWT claims
-	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
-	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	// Validate JWT assertion fields using common utility
+	jwtClaims, err := testutils.ValidateJWTAssertionFields(
+		completeFlowStep.Assertion,
+		decisionTestAppID,
+		decisionUserSchema.Name,
+		decisionTestOUID,
+		decisionTestOU.Name,
+		decisionTestOU.Handle,
+	)
+	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
-
-	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal(decisionUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-	ts.Require().Equal(decisionTestOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
-	ts.Require().Equal(decisionTestAppID, jwtClaims.Aud, "Expected aud to match the application ID")
-	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 }
 
 func (ts *DecisionAndMFAFlowTestSuite) TestSMSOTPAuthWithInvalidMobile() {

--- a/tests/integration/flowauthn/utils.go
+++ b/tests/integration/flowauthn/utils.go
@@ -29,6 +29,11 @@ import (
 
 const (
 	testServerURL = "https://localhost:8095"
+
+	// Pre-configured OU from database scripts
+	testOUID     = "test-ou-id"
+	testOUName   = "Test Organization Unit"
+	testOUHandle = "test-ou"
 )
 
 // Helper function to initiate the authentication flow

--- a/tests/integration/ou/ouapi_test.go
+++ b/tests/integration/ou/ouapi_test.go
@@ -37,8 +37,8 @@ const (
 
 var (
 	ouToCreate = CreateOURequest{
-		Name:        "Test Organization Unit",
-		Handle:      "test-org-unit",
+		Name:        "OU API Test Organization Unit",
+		Handle:      "ou-api-test-org-unit",
 		Description: "Test OU for integration testing",
 		Parent:      nil,
 	}

--- a/tests/integration/resources/dbscripts/thunderdb/postgres.sql
+++ b/tests/integration/resources/dbscripts/thunderdb/postgres.sql
@@ -181,6 +181,10 @@ CREATE TABLE CERTIFICATE (
     UNIQUE (REF_TYPE, REF_ID)
 );
 
+-- Insert a pre-configured organization unit for integration tests
+INSERT INTO ORGANIZATION_UNIT (OU_ID, PARENT_ID, HANDLE, NAME, DESCRIPTION) VALUES
+('test-ou-id', NULL, 'test-ou', 'Test Organization Unit', 'Organization unit for integration tests');
+
 -- Insert a pre-configured notification sender for SMS OTP tests
 INSERT INTO NOTIFICATION_SENDER (NAME, SENDER_ID, DESCRIPTION, TYPE, PROVIDER, PROPERTIES) VALUES
 ('Custom SMS Sender', 'test-sms-sender-id', 'Custom SMS sender for integration tests', 'MESSAGE', 'custom', 

--- a/tests/integration/resources/dbscripts/thunderdb/sqlite.sql
+++ b/tests/integration/resources/dbscripts/thunderdb/sqlite.sql
@@ -183,6 +183,10 @@ CREATE TABLE USER_SCHEMAS (
     UPDATED_AT TEXT DEFAULT (datetime('now'))
 );
 
+-- Insert a pre-configured organization unit for integration tests
+INSERT INTO ORGANIZATION_UNIT (OU_ID, PARENT_ID, HANDLE, NAME, DESCRIPTION) VALUES
+('test-ou-id', NULL, 'test-ou', 'Test Organization Unit', 'Organization unit for integration tests');
+
 -- Insert a pre-configured notification sender for SMS OTP tests
 INSERT INTO NOTIFICATION_SENDER (NAME, SENDER_ID, DESCRIPTION, TYPE, PROVIDER, PROPERTIES) VALUES
 ('Custom SMS Sender', 'test-sms-sender-id', 'Custom SMS sender for integration tests', 'MESSAGE', 'custom', 


### PR DESCRIPTION
### Purpose
This pull request enhances the authentication assertion flow by improving how organization unit (OU) details are included in JWT claims, refactoring related code for better modularity, and updating tests to reflect these changes. 

The most important update is the addition of OU name and handle to the auth assertion.

### Approach
**Authentication Assertion Improvements:**

* Added `OrganizationUnitServiceInterface` (`ouService`) to `authAssertExecutor` to fetch organization unit details for authenticated users and include additional OU fields (`ouId`, `ouName`, `ouHandle`) in JWT claims. [[1]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR47) [[2]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR59) [[3]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR72) [[4]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL153-R169) [[5]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR276-R297)
* Refactored user and OU claim population logic into helper methods (`appendUserDetailsToClaims`, `appendOUDetailsToClaims`) for improved readability and maintainability. [[1]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL153-R169) [[2]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR220-R257) [[3]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR276-R297)

**Test Coverage and Refactoring:**

* Updated unit tests to use the new `ouService` mock and verify OU details in JWT claims, including new test cases for OU name and handle. [[1]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R34-R49) [[2]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R65) [[3]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L70-R74) [[4]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R136-R137) [[5]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R423-R424) [[6]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R461-R497)
* Refactored user attribute retrieval in tests to match the new helper method signature. [[1]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L359-R365) [[2]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L373-R379) [[3]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L389-R395)

**Integration and Initialization:**

* Updated executor initialization to inject `ouService` into `authAssertExecutor`.

**Integration Test Improvements:**

* Changed integration tests to use pre-configured OU details from database scripts and validate JWT claims using a shared utility, ensuring OU fields are correctly asserted. [[1]](diffhunk://#diff-c7c1282c0f5efd62828faf0cc1383e4f62c39a6499cec31773f1e8182c2e5f00L41-L47) [[2]](diffhunk://#diff-c7c1282c0f5efd62828faf0cc1383e4f62c39a6499cec31773f1e8182c2e5f00R74-L83) [[3]](diffhunk://#diff-c7c1282c0f5efd62828faf0cc1383e4f62c39a6499cec31773f1e8182c2e5f00L100-L106) [[4]](diffhunk://#diff-c7c1282c0f5efd62828faf0cc1383e4f62c39a6499cec31773f1e8182c2e5f00L143-R135) [[5]](diffhunk://#diff-c7c1282c0f5efd62828faf0cc1383e4f62c39a6499cec31773f1e8182c2e5f00L200-L209) [[6]](diffhunk://#diff-c7c1282c0f5efd62828faf0cc1383e4f62c39a6499cec31773f1e8182c2e5f00L235-L244) [[7]](diffhunk://#diff-c7c1282c0f5efd62828faf0cc1383e4f62c39a6499cec31773f1e8182c2e5f00L297-L306)

**Sample Assertion**
```json
{
  "assurance": {
    "aal": "AAL1",
    "ial": "IAL1",
    "authenticators": [
      {
        "authenticator": "SMSOTPAuthenticator",
        "step": 1,
        "timestamp": 1763045713
      }
    ]
  },
  "aud": "55ac81bb-e4f8-4c27-9250-c06c02a48c28",
  "exp": 1763049313,
  "iat": 1763045713,
  "iss": "thunder",
  "jti": "808a343f-b6d9-461d-9f62-8b0b74e7cc75",
  "nbf": 1763045713,
  "ouHandle": "engineering",
  "ouId": "827c1484-48fc-4ae9-b3d2-cb787a7f0ce4",
  "ouName": "Engineering",
  "sub": "6dff5edf-5074-4ebe-b3c1-06cd70ec5dc3",
  "userType": "person",
  "username": "loki"
}
```

### Related Issues
- https://github.com/asgardeo/thunder/issues/747

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
