### PR TITLE
Improve application token resolve logic

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -834,6 +834,9 @@ components:
 
     TokenConfig:
       type: object
+      description: |
+        Token configuration for application-level (root) tokens. This includes an issuer field
+        since application-level tokens can have their own issuer.
       properties:
         issuer:
           type: string
@@ -850,12 +853,32 @@ components:
           description: The user attributes to include in the token.
           example: ["email", "username"]
 
-    IDTokenConfig:
+    AccessTokenConfig:
       type: object
+      description: |
+        Access token configuration for OAuth applications. Note that access tokens do NOT have
+        their own issuer field - they use the OAuth-level issuer (specified in the parent token.issuer field).
       properties:
         validity_period:
           type: integer
-          description: The validity period of the ID token in seconds. If not specified, uses the same validity as access token.
+          description: The validity period of the access token in seconds. If not specified, falls back to application-level or deployment default.
+          example: 3600
+        user_attributes:
+          type: array
+          items:
+            type: string
+          description: The user attributes to include in the access token.
+          example: ["email", "username"]
+
+    IDTokenConfig:
+      type: object
+      description: |
+        ID token configuration for OAuth applications. Note that ID tokens do NOT have their own
+        issuer field - they use the OAuth-level issuer (specified in the parent token.issuer field).
+      properties:
+        validity_period:
+          type: integer
+          description: The validity period of the ID token in seconds. If not specified, falls back to application-level or deployment default.
           example: 3600
         user_attributes:
           type: array
@@ -972,7 +995,7 @@ components:
                 The issuer for both access token and ID token.
               example: "thunder-oauth"
             access_token:
-              $ref: '#/components/schemas/TokenConfig'
+              $ref: '#/components/schemas/AccessTokenConfig'
             id_token:
               $ref: '#/components/schemas/IDTokenConfig'
 
@@ -1038,7 +1061,7 @@ components:
                 The issuer for both access token and ID token.
               example: "thunder-oauth"
             access_token:
-              $ref: '#/components/schemas/TokenConfig'
+              $ref: '#/components/schemas/AccessTokenConfig'
             id_token:
               $ref: '#/components/schemas/IDTokenConfig'
 

--- a/backend/internal/application/model/application.go
+++ b/backend/internal/application/model/application.go
@@ -23,9 +23,15 @@ import (
 	"github.com/asgardeo/thunder/internal/cert"
 )
 
-// TokenConfig represents the token configuration structure.
+// TokenConfig represents the token configuration structure for application-level (root) token configs.
 type TokenConfig struct {
 	Issuer         string   `json:"issuer"`
+	ValidityPeriod int64    `json:"validity_period"`
+	UserAttributes []string `json:"user_attributes"`
+}
+
+// AccessTokenConfig represents the access token configuration structure.
+type AccessTokenConfig struct {
 	ValidityPeriod int64    `json:"validity_period"`
 	UserAttributes []string `json:"user_attributes"`
 }
@@ -34,14 +40,15 @@ type TokenConfig struct {
 type IDTokenConfig struct {
 	ValidityPeriod int64               `json:"validity_period"`
 	UserAttributes []string            `json:"user_attributes"`
-	ScopeClaims    map[string][]string `json:"scope_claims,omitempty"`
+	ScopeClaims    map[string][]string `json:"scope_claims"`
 }
 
 // OAuthTokenConfig represents the OAuth token configuration structure with access_token and id_token wrappers.
+// The Issuer field at this level is used by both access and ID tokens.
 type OAuthTokenConfig struct {
-	Issuer      string         `json:"issuer,omitempty"`
-	AccessToken *TokenConfig   `json:"access_token,omitempty"`
-	IDToken     *IDTokenConfig `json:"id_token,omitempty"`
+	Issuer      string             `json:"issuer,omitempty"`
+	AccessToken *AccessTokenConfig `json:"access_token,omitempty"`
+	IDToken     *IDTokenConfig     `json:"id_token,omitempty"`
 }
 
 // ApplicationDTO represents the data transfer object for application service operations.

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -138,7 +138,9 @@ func (as *applicationService) CreateApplication(app *model.ApplicationDTO) (*mod
 		Contacts:                  app.Contacts,
 		AllowedUserTypes:          app.AllowedUserTypes,
 	}
-	if inboundAuthConfig != nil {
+	if inboundAuthConfig != nil && len(processedDTO.InboundAuthConfig) > 0 {
+		processedTokenConfig := processedDTO.InboundAuthConfig[0].OAuthAppConfig.Token
+
 		returnInboundAuthConfig := model.InboundAuthConfigDTO{
 			Type: model.OAuthInboundAuthType,
 			OAuthAppConfig: &model.OAuthAppConfigDTO{
@@ -151,7 +153,7 @@ func (as *applicationService) CreateApplication(app *model.ApplicationDTO) (*mod
 				TokenEndpointAuthMethod: inboundAuthConfig.OAuthAppConfig.TokenEndpointAuthMethod,
 				PKCERequired:            inboundAuthConfig.OAuthAppConfig.PKCERequired,
 				PublicClient:            inboundAuthConfig.OAuthAppConfig.PublicClient,
-				Token:                   inboundAuthConfig.OAuthAppConfig.Token,
+				Token:                   processedTokenConfig,
 				Scopes:                  inboundAuthConfig.OAuthAppConfig.Scopes,
 			},
 		}
@@ -1131,7 +1133,7 @@ func getDefaultTokenConfigFromDeployment() *model.TokenConfig {
 
 // processTokenConfiguration processes token configuration for an application, applying defaults where necessary.
 func processTokenConfiguration(app *model.ApplicationDTO) (
-	*model.TokenConfig, *model.TokenConfig, *model.IDTokenConfig, string) {
+	*model.TokenConfig, *model.AccessTokenConfig, *model.IDTokenConfig, string) {
 	// Resolve root token config
 	var rootToken *model.TokenConfig
 	if app.Token != nil {
@@ -1156,11 +1158,14 @@ func processTokenConfiguration(app *model.ApplicationDTO) (
 	}
 
 	// Resolve OAuth access token config
-	var oauthAccessToken *model.TokenConfig
+	var oauthAccessToken *model.AccessTokenConfig
 	if len(app.InboundAuthConfig) > 0 && app.InboundAuthConfig[0].OAuthAppConfig != nil &&
 		app.InboundAuthConfig[0].OAuthAppConfig.Token != nil &&
 		app.InboundAuthConfig[0].OAuthAppConfig.Token.AccessToken != nil {
-		oauthAccessToken = app.InboundAuthConfig[0].OAuthAppConfig.Token.AccessToken
+		oauthAccessToken = &model.AccessTokenConfig{
+			ValidityPeriod: app.InboundAuthConfig[0].OAuthAppConfig.Token.AccessToken.ValidityPeriod,
+			UserAttributes: app.InboundAuthConfig[0].OAuthAppConfig.Token.AccessToken.UserAttributes,
+		}
 	}
 
 	if oauthAccessToken != nil {
@@ -1171,7 +1176,7 @@ func processTokenConfiguration(app *model.ApplicationDTO) (
 			oauthAccessToken.UserAttributes = make([]string, 0)
 		}
 	} else {
-		oauthAccessToken = &model.TokenConfig{
+		oauthAccessToken = &model.AccessTokenConfig{
 			ValidityPeriod: rootToken.ValidityPeriod,
 			UserAttributes: rootToken.UserAttributes,
 		}
@@ -1182,7 +1187,11 @@ func processTokenConfiguration(app *model.ApplicationDTO) (
 	if len(app.InboundAuthConfig) > 0 && app.InboundAuthConfig[0].OAuthAppConfig != nil &&
 		app.InboundAuthConfig[0].OAuthAppConfig.Token != nil &&
 		app.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken != nil {
-		oauthIDToken = app.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken
+		oauthIDToken = &model.IDTokenConfig{
+			ValidityPeriod: app.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ValidityPeriod,
+			UserAttributes: app.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.UserAttributes,
+			ScopeClaims:    app.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims,
+		}
 	}
 
 	if oauthIDToken != nil {

--- a/backend/internal/application/store.go
+++ b/backend/internal/application/store.go
@@ -45,14 +45,13 @@ type oAuthConfig struct {
 
 // oAuthTokenConfig represents the OAuth token configuration structure for JSON marshaling/unmarshaling.
 type oAuthTokenConfig struct {
-	Issuer      string         `json:"issuer,omitempty"`
-	AccessToken *tokenConfig   `json:"access_token,omitempty"`
-	IDToken     *idTokenConfig `json:"id_token,omitempty"`
+	Issuer      string             `json:"issuer,omitempty"`
+	AccessToken *accessTokenConfig `json:"access_token,omitempty"`
+	IDToken     *idTokenConfig     `json:"id_token,omitempty"`
 }
 
-// tokenConfig represents the token configuration structure for JSON marshaling/unmarshaling.
-type tokenConfig struct {
-	Issuer         string   `json:"issuer,omitempty"`
+// accessTokenConfig represents the access token configuration structure for JSON marshaling/unmarshaling.
+type accessTokenConfig struct {
 	ValidityPeriod int64    `json:"validity_period,omitempty"`
 	UserAttributes []string `json:"user_attributes,omitempty"`
 }
@@ -234,17 +233,28 @@ func (st *applicationStore) GetOAuthApplication(clientID string) (*model.OAuthAp
 			Issuer: oAuthConfig.Token.Issuer,
 		}
 		if oAuthConfig.Token.AccessToken != nil {
-			oauthTokenConfig.AccessToken = &model.TokenConfig{
-				Issuer:         oAuthConfig.Token.AccessToken.Issuer,
+			userAttributes := oAuthConfig.Token.AccessToken.UserAttributes
+			if userAttributes == nil {
+				userAttributes = make([]string, 0)
+			}
+			oauthTokenConfig.AccessToken = &model.AccessTokenConfig{
 				ValidityPeriod: oAuthConfig.Token.AccessToken.ValidityPeriod,
-				UserAttributes: oAuthConfig.Token.AccessToken.UserAttributes,
+				UserAttributes: userAttributes,
 			}
 		}
 		if oAuthConfig.Token.IDToken != nil {
+			userAttributes := oAuthConfig.Token.IDToken.UserAttributes
+			if userAttributes == nil {
+				userAttributes = make([]string, 0)
+			}
+			scopeClaims := oAuthConfig.Token.IDToken.ScopeClaims
+			if scopeClaims == nil {
+				scopeClaims = make(map[string][]string)
+			}
 			oauthTokenConfig.IDToken = &model.IDTokenConfig{
 				ValidityPeriod: oAuthConfig.Token.IDToken.ValidityPeriod,
-				UserAttributes: oAuthConfig.Token.IDToken.UserAttributes,
-				ScopeClaims:    oAuthConfig.Token.IDToken.ScopeClaims,
+				UserAttributes: userAttributes,
+				ScopeClaims:    scopeClaims,
 			}
 		}
 	}
@@ -423,8 +433,7 @@ func getOAuthConfigJSONBytes(inboundAuthConfig model.InboundAuthConfigProcessedD
 			Issuer: inboundAuthConfig.OAuthAppConfig.Token.Issuer,
 		}
 		if inboundAuthConfig.OAuthAppConfig.Token.AccessToken != nil {
-			oauthConfig.Token.AccessToken = &tokenConfig{
-				Issuer:         inboundAuthConfig.OAuthAppConfig.Token.AccessToken.Issuer,
+			oauthConfig.Token.AccessToken = &accessTokenConfig{
 				ValidityPeriod: inboundAuthConfig.OAuthAppConfig.Token.AccessToken.ValidityPeriod,
 				UserAttributes: inboundAuthConfig.OAuthAppConfig.Token.AccessToken.UserAttributes,
 			}
@@ -740,17 +749,28 @@ func buildOAuthInboundAuthConfig(row map[string]interface{}, basicApp model.Basi
 			Issuer: oauthConfig.Token.Issuer,
 		}
 		if oauthConfig.Token.AccessToken != nil {
-			oauthTokenConfig.AccessToken = &model.TokenConfig{
-				Issuer:         oauthConfig.Token.AccessToken.Issuer,
+			userAttributes := oauthConfig.Token.AccessToken.UserAttributes
+			if userAttributes == nil {
+				userAttributes = make([]string, 0)
+			}
+			oauthTokenConfig.AccessToken = &model.AccessTokenConfig{
 				ValidityPeriod: oauthConfig.Token.AccessToken.ValidityPeriod,
-				UserAttributes: oauthConfig.Token.AccessToken.UserAttributes,
+				UserAttributes: userAttributes,
 			}
 		}
 		if oauthConfig.Token.IDToken != nil {
+			userAttributes := oauthConfig.Token.IDToken.UserAttributes
+			if userAttributes == nil {
+				userAttributes = make([]string, 0)
+			}
+			scopeClaims := oauthConfig.Token.IDToken.ScopeClaims
+			if scopeClaims == nil {
+				scopeClaims = make(map[string][]string)
+			}
 			oauthTokenConfig.IDToken = &model.IDTokenConfig{
 				ValidityPeriod: oauthConfig.Token.IDToken.ValidityPeriod,
-				UserAttributes: oauthConfig.Token.IDToken.UserAttributes,
-				ScopeClaims:    oauthConfig.Token.IDToken.ScopeClaims,
+				UserAttributes: userAttributes,
+				ScopeClaims:    scopeClaims,
 			}
 		}
 	}

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -86,7 +86,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) SetupTest() {
 		ResponseTypes:           []constants.ResponseType{constants.ResponseTypeCode},
 		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretPost,
 		Token: &appmodel.OAuthTokenConfig{
-			AccessToken: &appmodel.TokenConfig{
+			AccessToken: &appmodel.AccessTokenConfig{
 				UserAttributes: []string{"email", "username"},
 			},
 		},
@@ -525,7 +525,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 				ResponseTypes:           []constants.ResponseType{constants.ResponseTypeCode},
 				TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretPost,
 				Token: &appmodel.OAuthTokenConfig{
-					AccessToken: &appmodel.TokenConfig{
+					AccessToken: &appmodel.AccessTokenConfig{
 						UserAttributes: accessTokenAttrs,
 					},
 					IDToken: idTokenConfig,
@@ -716,7 +716,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 				ResponseTypes:           []constants.ResponseType{constants.ResponseTypeCode},
 				TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretPost,
 				Token: &appmodel.OAuthTokenConfig{
-					AccessToken: &appmodel.TokenConfig{
+					AccessToken: &appmodel.AccessTokenConfig{
 						UserAttributes: accessTokenAttrs,
 					},
 					IDToken: idTokenConfig,

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -95,7 +95,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) SetupTest() {
 		GrantTypes:              []constants.GrantType{constants.GrantTypeRefreshToken},
 		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretPost,
 		Token: &appmodel.OAuthTokenConfig{
-			AccessToken: &appmodel.TokenConfig{
+			AccessToken: &appmodel.AccessTokenConfig{
 				UserAttributes: []string{"email", "username"},
 			},
 		},

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -89,8 +89,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) SetupTest() {
 		ResponseTypes:           []constants.ResponseType{constants.ResponseTypeCode},
 		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
 		Token: &appmodel.OAuthTokenConfig{
-			AccessToken: &appmodel.TokenConfig{
-				Issuer:         testCustomIssuer,
+			AccessToken: &appmodel.AccessTokenConfig{
 				ValidityPeriod: 7200,
 			},
 		},

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -70,8 +70,7 @@ func (suite *TokenBuilderTestSuite) SetupTest() {
 		ClientID: "test-client",
 		Token: &appmodel.OAuthTokenConfig{
 			Issuer: "https://thunder.io",
-			AccessToken: &appmodel.TokenConfig{
-				Issuer:         "https://thunder.io",
+			AccessToken: &appmodel.AccessTokenConfig{
 				ValidityPeriod: 3600,
 			},
 		},
@@ -311,8 +310,8 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomIssuer() 
 	customOAuthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		ClientID: "test-client",
 		Token: &appmodel.OAuthTokenConfig{
-			AccessToken: &appmodel.TokenConfig{
-				Issuer:         "https://custom.thunder.io",
+			Issuer: "https://custom.thunder.io", // OAuth-level issuer used for all tokens
+			AccessToken: &appmodel.AccessTokenConfig{
 				ValidityPeriod: 7200,
 			},
 		},
@@ -334,7 +333,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomIssuer() 
 	suite.mockJWTService.On("GenerateJWT",
 		"user123",
 		"app123",
-		"https://custom.thunder.io",
+		"https://custom.thunder.io", // OAuth-level issuer
 		int64(7200),
 		mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
@@ -388,8 +387,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 		ClientID: "test-client",
 		Token: &appmodel.OAuthTokenConfig{
 			Issuer: "https://thunder.io",
-			AccessToken: &appmodel.TokenConfig{
-				Issuer:         "https://thunder.io",
+			AccessToken: &appmodel.AccessTokenConfig{
 				ValidityPeriod: 3600,
 				UserAttributes: []string{"name"}, // Configure user attributes
 			},
@@ -535,8 +533,9 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_CustomIssuer()
 	customOAuthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		ClientID: "test-client",
 		Token: &appmodel.OAuthTokenConfig{
-			AccessToken: &appmodel.TokenConfig{
-				Issuer: "https://custom.thunder.io",
+			Issuer:      "https://custom.thunder.io",
+			AccessToken: &appmodel.AccessTokenConfig{
+				// AccessToken uses OAuth-level issuer
 			},
 		},
 	}

--- a/tests/integration/application/application_api_test.go
+++ b/tests/integration/application/application_api_test.go
@@ -1215,8 +1215,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithTokenConfiguration() {
 					Scopes:                  []string{"openid", "profile"},
 					Token: &OAuthTokenConfig{
 						Issuer: "https://tokenconfig.example.com",
-						AccessToken: &TokenConfig{
-							Issuer:         "https://tokenconfig.example.com",
+						AccessToken: &AccessTokenConfig{
 							ValidityPeriod: 3600,
 							UserAttributes: []string{"email", "username"},
 						},
@@ -1311,7 +1310,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithTokenConfigChanges()
 					TokenEndpointAuthMethod: "client_secret_basic",
 					Scopes:                  []string{"openid"},
 					Token: &OAuthTokenConfig{
-						AccessToken: &TokenConfig{
+						AccessToken: &AccessTokenConfig{
 							ValidityPeriod: 1800,
 						},
 					},
@@ -1327,8 +1326,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithTokenConfigChanges()
 	// Update with more complex token config
 	app.InboundAuthConfig[0].OAuthAppConfig.Token = &OAuthTokenConfig{
 		Issuer: "https://tokenconfigupdate.example.com",
-		AccessToken: &TokenConfig{
-			Issuer:         "https://tokenconfigupdate.example.com",
+		AccessToken: &AccessTokenConfig{
 			ValidityPeriod: 7200,
 			UserAttributes: []string{"email", "username", "role"},
 		},
@@ -1569,8 +1567,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithOnlyAccessToken() {
 					Scopes:                  []string{"api.read", "api.write"},
 					Token: &OAuthTokenConfig{
 						Issuer: "https://accesstokenonly.example.com",
-						AccessToken: &TokenConfig{
-							Issuer:         "https://accesstokenonly.example.com",
+						AccessToken: &AccessTokenConfig{
 							ValidityPeriod: 7200,
 							UserAttributes: []string{"email", "username", "role", "department"},
 						},
@@ -1657,8 +1654,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithBothTokenTypes() {
 					Scopes:                  []string{"openid", "profile", "email"},
 					Token: &OAuthTokenConfig{
 						Issuer: "https://bothtokens.example.com",
-						AccessToken: &TokenConfig{
-							Issuer:         "https://bothtokens.example.com",
+						AccessToken: &AccessTokenConfig{
 							ValidityPeriod: 5400,
 							UserAttributes: []string{"email", "username"},
 						},
@@ -1800,7 +1796,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithEmptyTokenIssuer() {
 					Scopes:                  []string{"openid"},
 					Token: &OAuthTokenConfig{
 						// Empty Issuer
-						AccessToken: &TokenConfig{
+						AccessToken: &AccessTokenConfig{
 							ValidityPeriod: 3600,
 						},
 					},
@@ -2193,8 +2189,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithCompleteMetadata() {
 					Scopes:                  []string{"openid", "profile", "email"},
 					Token: &OAuthTokenConfig{
 						Issuer: "https://oauth-issuer.example.com",
-						AccessToken: &TokenConfig{
-							Issuer:         "https://oauth-issuer.example.com",
+						AccessToken: &AccessTokenConfig{
 							ValidityPeriod: 3600,
 							UserAttributes: []string{"sub", "email"},
 						},

--- a/tests/integration/application/model.go
+++ b/tests/integration/application/model.go
@@ -68,14 +68,20 @@ type OAuthAppConfig struct {
 
 // OAuthTokenConfig represents the OAuth token configuration.
 type OAuthTokenConfig struct {
-	Issuer      string         `json:"issuer,omitempty"`
-	AccessToken *TokenConfig   `json:"access_token,omitempty"`
-	IDToken     *IDTokenConfig `json:"id_token,omitempty"`
+	Issuer      string             `json:"issuer,omitempty"`
+	AccessToken *AccessTokenConfig `json:"access_token,omitempty"`
+	IDToken     *IDTokenConfig     `json:"id_token,omitempty"`
 }
 
-// TokenConfig represents the token configuration.
+// TokenConfig represents the token configuration (used for application-level token config).
 type TokenConfig struct {
 	Issuer         string   `json:"issuer,omitempty"`
+	ValidityPeriod int64    `json:"validity_period,omitempty"`
+	UserAttributes []string `json:"user_attributes,omitempty"`
+}
+
+// AccessTokenConfig represents the access token configuration.
+type AccessTokenConfig struct {
 	ValidityPeriod int64    `json:"validity_period,omitempty"`
 	UserAttributes []string `json:"user_attributes,omitempty"`
 }


### PR DESCRIPTION
### Purpose

This pull request refactors the handling of token configuration for OAuth applications by introducing a dedicated `AccessTokenConfig` type, separating it from the previously shared `TokenConfig`. The changes clarify and enforce that OAuth access tokens do not have their own issuer field, and instead use the OAuth-level issuer. The update affects YAML API schemas, Go models, service logic, store logic, and relevant tests to ensure consistent usage of the new configuration structure.

### Breaking change

With this PR, the issuer within access token will not be honored. Only the OAuth-level issuer will be honored.

The resolution chain for access/ID/refresh token issuer will be:

**OAuth-level issuer -> App-level issuer -> Deployment config issuer**

### Approach

**API and Model Refactoring**

* Added a new `AccessTokenConfig` type to both the OpenAPI YAML (`api/application.yaml`) and Go models (`application.go`), making access token configuration distinct from root/application-level token configuration. [[1]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211R856-R881) [[2]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4L26-R50)
* Updated references throughout the API schema and Go code to use `AccessTokenConfig` for OAuth access tokens, ensuring issuer is only specified at the OAuth level. [[1]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211L975-R998) [[2]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211L1041-R1064) [[3]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L49-R54)

**Service and Store Logic Updates**

* Refactored application service and store logic to work with the new `AccessTokenConfig`, including processing, defaulting, and marshaling/unmarshaling of token configs. [[1]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1134-R1136) [[2]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1159-R1168) [[3]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1174-R1179) [[4]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L1185-R1194) [[5]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L237-R257) [[6]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L426-R436) [[7]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L743-R773)

**Test Adjustments**

* Updated all relevant tests to use `AccessTokenConfig` instead of `TokenConfig` for OAuth access tokens, ensuring test coverage matches the new configuration structure. [[1]](diffhunk://#diff-0dcbccf58e29fcf825f6cae700867e94be259f41dad65ca474d97755fe5c4ee6L89-R89) [[2]](diffhunk://#diff-0dcbccf58e29fcf825f6cae700867e94be259f41dad65ca474d97755fe5c4ee6L528-R528) [[3]](diffhunk://#diff-0dcbccf58e29fcf825f6cae700867e94be259f41dad65ca474d97755fe5c4ee6L719-R719) [[4]](diffhunk://#diff-812a100cf1b8eb0223abb7259e65851b4f63b994a87839757bc951b00e4bcb09L98-R98) [[5]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L92-R92) [[6]](diffhunk://#diff-8276502870b096bf0083b464c29debde17f11b4c176293395d9dbb8f4d64fcdfL73-R73) [[7]](diffhunk://#diff-8276502870b096bf0083b464c29debde17f11b4c176293395d9dbb8f4d64fcdfL314-R314) [[8]](diffhunk://#diff-8276502870b096bf0083b464c29debde17f11b4c176293395d9dbb8f4d64fcdfL337-R336) [[9]](diffhunk://#diff-8276502870b096bf0083b464c29debde17f11b4c176293395d9dbb8f4d64fcdfL391-R390) [[10]](diffhunk://#diff-8276502870b096bf0083b464c29debde17f11b4c176293395d9dbb8f4d64fcdfL538-R537)

**Documentation Improvements**

* Improved comments and descriptions in both the YAML and Go code to clarify the distinction between application-level and OAuth-level token configuration, especially regarding issuer handling. [[1]](diffhunk://#diff-6dac2b7f2335d416962ade34090110b2675033ad0a0d2da68be85f457edee211R837-R839) [[2]](diffhunk://#diff-7fac18f248ec76631f539f74b8f48c45d14f03a3af8d3ad2e7313cd87b934280R53)