### PR TITLE
Fix flakiness in thunder-develop unit tests

### DIFF
--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useCreateUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useCreateUserType.test.ts
@@ -101,12 +101,13 @@ describe('useCreateUserType', () => {
   });
 
   it('should set loading state during creation', async () => {
-    mockHttpRequest.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(() => resolve({data: mockUserSchema}), 100);
-        }),
-    );
+    // Create a promise we can control
+    let resolveRequest: (value: {data: ApiUserSchema}) => void;
+    const requestPromise = new Promise<{data: ApiUserSchema}>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    mockHttpRequest.mockReturnValueOnce(requestPromise);
 
     const {result} = renderHook(() => useCreateUserType());
 
@@ -115,6 +116,9 @@ describe('useCreateUserType', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(true);
     });
+
+    // Now resolve the request
+    resolveRequest!({data: mockUserSchema});
 
     await promise;
 

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useDeleteUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useDeleteUserType.test.ts
@@ -80,12 +80,13 @@ describe('useDeleteUserType', () => {
   });
 
   it('should set loading state during deletion', async () => {
-    mockHttpRequest.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(() => resolve({data: null}), 100);
-        }),
-    );
+    // Create a promise we can control
+    let resolveRequest: (value: {data: null}) => void;
+    const requestPromise = new Promise<{data: null}>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    mockHttpRequest.mockReturnValueOnce(requestPromise);
 
     const {result} = renderHook(() => useDeleteUserType());
 
@@ -94,6 +95,9 @@ describe('useDeleteUserType', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(true);
     });
+
+    // Now resolve the request
+    resolveRequest!({data: null});
 
     await promise;
 

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserType.test.ts
@@ -87,24 +87,22 @@ describe('useGetUserType', () => {
   });
 
   it('should set loading state during fetch', async () => {
-    mockHttpRequest.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(
-            () =>
-              resolve({
-                data: mockUserSchema,
-              }),
-            100,
-          );
-        }),
-    );
+    // Create a promise we can control
+    let resolveRequest: (value: {data: ApiUserSchema}) => void;
+    const requestPromise = new Promise<{data: ApiUserSchema}>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    mockHttpRequest.mockReturnValueOnce(requestPromise);
 
     const {result} = renderHook(() => useGetUserType('123'));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(true);
     });
+
+    // Now resolve the request
+    resolveRequest!({data: mockUserSchema});
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
@@ -101,12 +101,13 @@ describe('useUpdateUserType', () => {
   });
 
   it('should set loading state during update', async () => {
-    mockHttpRequest.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(() => resolve({data: mockUserSchema}), 50);
-        }),
-    );
+    // Create a promise we can control
+    let resolveRequest: (value: {data: ApiUserSchema}) => void;
+    const requestPromise = new Promise<{data: ApiUserSchema}>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    mockHttpRequest.mockReturnValueOnce(requestPromise);
 
     const {result} = renderHook(() => useUpdateUserType());
 
@@ -115,6 +116,9 @@ describe('useUpdateUserType', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(true);
     });
+
+    // Now resolve the request
+    resolveRequest!({data: mockUserSchema});
 
     await promise;
 

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useUpdateUser.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useUpdateUser.test.ts
@@ -211,18 +211,13 @@ describe('useUpdateUser', () => {
       },
     };
 
-    mockHttpRequest.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(
-            () =>
-              resolve({
-                data: mockResponse,
-              }),
-            50,
-          );
-        }),
-    );
+    // Create a promise we can control
+    let resolveRequest: (value: {data: ApiUser}) => void;
+    const requestPromise = new Promise<{data: ApiUser}>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    mockHttpRequest.mockReturnValueOnce(requestPromise);
 
     const {result} = renderHook(() => useUpdateUser());
 
@@ -234,6 +229,9 @@ describe('useUpdateUser', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(true);
     });
+
+    // Now resolve the request
+    resolveRequest!({data: mockResponse});
 
     await promise;
 


### PR DESCRIPTION
### Purpose
This pull request refactors the test for the `useCreateUser` hook to improve reliability and control over asynchronous behavior. The main change is replacing the previous mock implementation with a manually controlled promise, allowing for more precise testing of loading states.

Testing improvements:

* Replaced the previous `mockImplementationOnce` with a manually controlled promise and `mockReturnValueOnce` for `mockHttpRequest`, enabling explicit control over when the request resolves.
* Updated the test to resolve the promise at the appropriate time and await the completion of the request, ensuring that loading state transitions are tested accurately.