### PR TITLE
Add user type resolver to dynamically resolve userType and ouId in registration flows

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic.json
@@ -3,6 +3,11 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": ["basic_auth"]
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "executor": {
@@ -42,10 +47,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "<default-ou-id>",
-                "userType": "<default-user-type>"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
@@ -3,6 +3,11 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": ["choose_auth"]
+        },
+        {
             "id": "choose_auth",
             "type": "DECISION",
             "next": [
@@ -50,10 +55,6 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "properties": {
-                "ouId": "<default-ou-id>",
-                "userType": "<default-user-type>"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github_sms.json
@@ -3,6 +3,11 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": ["choose_auth"]
+        },
+        {
             "id": "choose_auth",
             "type": "DECISION",
             "next": [
@@ -118,10 +123,6 @@
                     "required": false
                 }
             ],
-            "properties": {
-                "ouId": "<default-ou-id>",
-                "userType": "<default-user-type>"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },
@@ -149,10 +150,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "<default-ou-id>",
-                "userType": "<default-user-type>"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },
@@ -163,10 +160,6 @@
         {
             "id": "provisioning_social",
             "type": "TASK_EXECUTION",
-            "properties": {
-                "ouId": "<default-ou-id>",
-                "userType": "<default-user-type>"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_sms.json
@@ -3,6 +3,11 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": ["prompt_mobile"]
+        },
+        {
             "id": "prompt_mobile",
             "type": "PROMPT_ONLY",
             "inputData": [
@@ -54,10 +59,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "<default-ou-id>",
-                "userType": "<default-user-type>"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -65,7 +65,7 @@ func registerServices(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) {
 	// Initialize flow and executor services.
 	flowFactory := flowcore.Initialize()
 	execRegistry := executor.Initialize(flowFactory, userService, ouService,
-		idpService, otpService, jwtService, authSvcRegistry, authZService)
+		idpService, otpService, jwtService, authSvcRegistry, authZService, userSchemaService)
 
 	flowMgtService, err := flowmgt.Initialize(flowFactory, execRegistry)
 	if err != nil {

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -59,6 +59,8 @@ type NodeType string
 const (
 	// NodeTypeAuthSuccess represents a node that does auth assertion
 	NodeTypeAuthSuccess NodeType = "AUTHENTICATION_SUCCESS"
+	// NodeTypeRegistrationStart represents the beginning of a registration flow
+	NodeTypeRegistrationStart NodeType = "REGISTRATION_START"
 	// NodeTypeTaskExecution represents a task execution node
 	NodeTypeTaskExecution NodeType = "TASK_EXECUTION"
 	// NodeTypePromptOnly represents a prompt-only node

--- a/backend/internal/flow/common/model.go
+++ b/backend/internal/flow/common/model.go
@@ -24,9 +24,10 @@ import (
 
 // InputData represents the input data required for a flow step
 type InputData struct {
-	Name     string `json:"name"`
-	Type     string `json:"type"`
-	Required bool   `json:"required"`
+	Name     string   `json:"name"`
+	Type     string   `json:"type"`
+	Required bool     `json:"required"`
+	Options  []string `json:"options,omitempty"`
 }
 
 // Action represents an action to be executed in a flow step

--- a/backend/internal/flow/core/factory.go
+++ b/backend/internal/flow/core/factory.go
@@ -66,6 +66,8 @@ func (f *flowFactory) CreateNode(id, _type string, properties map[string]interfa
 		return newPromptOnlyNode(id, properties, isStartNode, isFinalNode), nil
 	case common.NodeTypeAuthSuccess:
 		return newTaskExecutionNode(id, properties, isStartNode, isFinalNode), nil
+	case common.NodeTypeRegistrationStart:
+		return newTaskExecutionNode(id, properties, isStartNode, isFinalNode), nil
 	default:
 		return nil, errors.New("unsupported node type: " + _type)
 	}

--- a/backend/internal/flow/core/graph.go
+++ b/backend/internal/flow/core/graph.go
@@ -193,9 +193,10 @@ func (g *graph) SetStartNode(startNodeID string) error {
 // ToJSON converts the graph to a JSON string representation
 func (g *graph) ToJSON() (string, error) {
 	type JSONInputData struct {
-		Name     string `json:"name"`
-		Type     string `json:"type"`
-		Required bool   `json:"required"`
+		Name     string   `json:"name"`
+		Type     string   `json:"type"`
+		Required bool     `json:"required"`
+		Options  []string `json:"options,omitempty"`
 	}
 
 	type JSONNode struct {

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -160,7 +160,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *flowcore.NodeContext, lo
 
 	// Add user type to the claims
 	if ctx.AuthenticatedUser.UserType != "" {
-		jwtClaims["userType"] = ctx.AuthenticatedUser.UserType
+		jwtClaims[userTypeKey] = ctx.AuthenticatedUser.UserType
 	}
 
 	if ctx.AuthenticatedUser.OrganizationUnitID != "" {
@@ -276,21 +276,21 @@ func (a *authAssertExecutor) getUserAttributes(userID string) (*user.User, map[s
 
 // appendOUDetailsToClaims appends organization unit details to the JWT claims.
 func (a *authAssertExecutor) appendOUDetailsToClaims(ouID string, jwtClaims map[string]interface{}) error {
-	logger := a.logger.With(log.String("ouID", ouID))
+	logger := a.logger.With(log.String(ouIDKey, ouID))
 
 	organizationUnit, svcErr := a.ouService.GetOrganizationUnit(ouID)
 	if svcErr != nil {
 		logger.Error("Failed to fetch organization unit details",
-			log.String("ouID", ouID), log.Any("error", svcErr))
+			log.String(ouIDKey, ouID), log.Any("error", svcErr))
 		return errors.New("something went wrong while fetching organization unit: " + svcErr.ErrorDescription)
 	}
 
-	jwtClaims["ouId"] = organizationUnit.ID
+	jwtClaims[ouIDKey] = organizationUnit.ID
 	if organizationUnit.Name != "" {
-		jwtClaims["ouName"] = organizationUnit.Name
+		jwtClaims[userInputOuName] = organizationUnit.Name
 	}
 	if organizationUnit.Handle != "" {
-		jwtClaims["ouHandle"] = organizationUnit.Handle
+		jwtClaims[userInputOuHandle] = organizationUnit.Handle
 	}
 
 	return nil

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -417,7 +417,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
-			return claims["userType"] == "EXTERNAL" && claims["ouId"] == "ou-456"
+			return claims[userTypeKey] == "EXTERNAL" && claims[ouIDKey] == "ou-456"
 		})).Return("jwt-token", int64(3600), nil)
 
 	suite.mockOUService.On("GetOrganizationUnit", "ou-456").Return(ou.OrganizationUnit{ID: "ou-456"}, nil)
@@ -481,9 +481,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
-			return claims["ouId"] == "ou-789" &&
-				claims["ouName"] == "Engineering" &&
-				claims["ouHandle"] == "eng"
+			return claims[ouIDKey] == "ou-789" &&
+				claims[userInputOuName] == "Engineering" &&
+				claims[userInputOuHandle] == "eng"
 		})).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -33,6 +33,7 @@ const (
 	ExecutorNameAuthorization    = "AuthorizationExecutor"
 	ExecutorNameOUCreation       = "OUExecutor"
 	ExecutorNameHTTPRequest      = "HTTPRequestExecutor"
+	ExecutorNameUserTypeResolver = "UserTypeResolver"
 )
 
 // User attribute and input constants
@@ -47,7 +48,10 @@ const (
 	userInputOuName   = "ouName"
 	userInputOuHandle = "ouHandle"
 	userInputOuDesc   = "ouDescription"
-	ouIDKey           = "ouId"
+
+	ouIDKey        = "ouId"
+	defaultOUIDKey = "defaultOUID"
+	userTypeKey    = "userType"
 )
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.
@@ -55,7 +59,7 @@ var nonSearchableInputs = []string{"password", "code", "nonce", "otp"}
 
 // nonUserAttributes contains the list of user attributes that do not belong to user entity.
 var nonUserAttributes = []string{"userID", "code", "nonce", "state", "flowID",
-	"otp", "attemptCount", "expiryTimeInMillis", "value"}
+	"otp", "attemptCount", "expiryTimeInMillis", "value", userTypeKey, ouIDKey, defaultOUIDKey}
 
 // Failure reason constants
 const (

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -28,6 +28,7 @@ import (
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 // Initialize registers available executors and returns the executor registry.
@@ -40,6 +41,7 @@ func Initialize(
 	jwtService jwt.JWTServiceInterface,
 	authRegistry *authn.AuthServiceRegistry,
 	authZService authz.AuthorizationServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 ) ExecutorRegistryInterface {
 	reg := newExecutorRegistry()
 	reg.RegisterExecutor(ExecutorNameBasicAuth, newBasicAuthExecutor(
@@ -64,6 +66,7 @@ func Initialize(
 		userService, ouService, authRegistry.AuthAssertGenerator))
 	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService))
 	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory))
+	reg.RegisterExecutor(ExecutorNameUserTypeResolver, newUserTypeResolver(flowFactory, userSchemaService))
 
 	return reg
 }

--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -145,9 +145,16 @@ func (o *ouExecutor) Execute(ctx *flowcore.NodeContext) (*flowcm.ExecutorRespons
 
 // getOrganizationUnitRequest constructs an OrganizationUnitRequest from the NodeContext.
 func (o *ouExecutor) getOrganizationUnitRequest(ctx *flowcore.NodeContext) ou.OrganizationUnitRequest {
-	return ou.OrganizationUnitRequest{
+	ouRequest := ou.OrganizationUnitRequest{
 		Name:        ctx.UserInputData[userInputOuName],
 		Handle:      ctx.UserInputData[userInputOuHandle],
 		Description: ctx.UserInputData[userInputOuDesc],
 	}
+
+	// Set parent OU ID if defaultOUID is present in runtime data
+	if val, ok := ctx.RuntimeData[defaultOUIDKey]; ok && val != "" {
+		ouRequest.Parent = &val
+	}
+
+	return ouRequest
 }

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -290,39 +290,28 @@ func (p *provisioningExecutor) createUserInStore(ctx *flowcore.NodeContext,
 	return retUser, nil
 }
 
-// getOuID retrieves the organization unit ID from the context or executor properties.
+// getOuID retrieves the organization unit ID from runtime data.
 func (p *provisioningExecutor) getOuID(ctx *flowcore.NodeContext) string {
 	ouID := ""
-	if val, ok := ctx.RuntimeData["ouId"]; ok {
+	// Check for ouId in runtime data
+	if val, ok := ctx.RuntimeData[ouIDKey]; ok && val != "" {
 		ouID = val
 	}
+	// If not found, check for defaultOUID in runtime data
 	if ouID == "" {
-		if len(ctx.NodeProperties) > 0 {
-			if val, ok := ctx.NodeProperties["ouId"]; ok {
-				if valStr, valid := val.(string); valid && valStr != "" {
-					ouID = valStr
-				}
-			}
+		if val, ok := ctx.RuntimeData[defaultOUIDKey]; ok && val != "" {
+			ouID = val
 		}
 	}
 
 	return ouID
 }
 
-// getUserType retrieves the user type from the context or executor properties.
+// getUserType retrieves the user type from runtime data.
 func (p *provisioningExecutor) getUserType(ctx *flowcore.NodeContext) string {
 	userType := ""
-	if val, ok := ctx.RuntimeData["userType"]; ok {
+	if val, ok := ctx.RuntimeData[userTypeKey]; ok && val != "" {
 		userType = val
-	}
-	if userType == "" {
-		if len(ctx.NodeProperties) > 0 {
-			if val, ok := ctx.NodeProperties["userType"]; ok {
-				if valStr, valid := val.(string); valid && valStr != "" {
-					userType = valStr
-				}
-			}
-		}
 	}
 
 	return userType

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -119,13 +119,13 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 			"username": "newuser",
 			"email":    "new@example.com",
 		},
+		RuntimeData: map[string]string{
+			ouIDKey:     "ou-123",
+			userTypeKey: "INTERNAL",
+		},
 		NodeInputData: []flowcm.InputData{
 			{Name: "username", Type: "string", Required: true},
 			{Name: "email", Type: "string", Required: true},
-		},
-		NodeProperties: map[string]interface{}{
-			"ouId":     "ou-123",
-			"userType": "INTERNAL",
 		},
 	}
 
@@ -202,11 +202,11 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 		UserInputData: map[string]string{
 			"username": "newuser",
 		},
-		NodeInputData: []flowcm.InputData{{Name: "username", Type: "string", Required: true}},
-		NodeProperties: map[string]interface{}{
-			"ouId":     "ou-123",
-			"userType": "INTERNAL",
+		RuntimeData: map[string]string{
+			ouIDKey:     "ou-123",
+			userTypeKey: "INTERNAL",
 		},
+		NodeInputData: []flowcm.InputData{{Name: "username", Type: "string", Required: true}},
 	}
 
 	suite.mockUserService.On("IdentifyUser", mock.Anything).Return(nil, &user.ErrorUserNotFound)

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"fmt"
+	"slices"
+
+	flowcm "github.com/asgardeo/thunder/internal/flow/common"
+	flowcore "github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/userschema"
+)
+
+const (
+	userTypeResolverLoggerComponentName = "UserTypeResolver"
+)
+
+// schemaWithOU represents a user schema along with its associated organization unit ID.
+type schemaWithOU struct {
+	userSchema *userschema.UserSchema
+	ouID       string
+}
+
+// userTypeResolver is a registration-flow executor that resolves the user type at flow start.
+type userTypeResolver struct {
+	flowcore.ExecutorInterface
+	userSchemaService userschema.UserSchemaServiceInterface
+	logger            *log.Logger
+}
+
+var _ flowcore.ExecutorInterface = (*userTypeResolver)(nil)
+
+// newUserTypeResolver creates a new instance of the UserTypeResolver executor.
+func newUserTypeResolver(
+	flowFactory flowcore.FlowFactoryInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
+) *userTypeResolver {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userTypeResolverLoggerComponentName),
+		log.String(log.LoggerKeyExecutorName, ExecutorNameUserTypeResolver))
+
+	base := flowFactory.CreateExecutor(ExecutorNameUserTypeResolver, flowcm.ExecutorTypeRegistration,
+		[]flowcm.InputData{}, []flowcm.InputData{})
+
+	return &userTypeResolver{
+		ExecutorInterface: base,
+		userSchemaService: userSchemaService,
+		logger:            logger,
+	}
+}
+
+// Execute resolves the user type from inputs or prompts the user to select one.
+func (u *userTypeResolver) Execute(ctx *flowcore.NodeContext) (*flowcm.ExecutorResponse, error) {
+	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Executing user type resolver")
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// Only applies to registration flows
+	if ctx.FlowType != flowcm.FlowTypeRegistration {
+		execResp.Status = flowcm.ExecComplete
+		return execResp, nil
+	}
+
+	allowed := ctx.Application.AllowedUserTypes
+
+	// If a userType is provided in inputs, validate and accept it
+	if userType, ok := ctx.UserInputData[userTypeKey]; ok && userType != "" {
+		err := u.resolveUserTypeFromInput(execResp, userType, allowed)
+		return execResp, err
+	}
+
+	// Check for allowed user types to decide next steps
+	if len(allowed) == 0 {
+		// TODO: This should be improved to fallback to the application's ou when the support is available.
+		//  userType has an attached ou. Need to find userType from the application's ou.
+		//  Also should check if self registration is enabled for the user type when the support is available.
+
+		logger.Debug("No allowed user types found for the application")
+		execResp.Status = flowcm.ExecFailure
+		execResp.FailureReason = "Self-registration not available for this application"
+		return execResp, nil
+	}
+
+	if len(allowed) == 1 {
+		err := u.resolveUserTypeFromSingleAllowed(execResp, allowed[0])
+		return execResp, err
+	}
+
+	err := u.resolveUserTypeFromMultipleAllowed(execResp, allowed)
+	return execResp, err
+}
+
+// resolveUserTypeFromInput resolves the user type from input and updates the executor response accordingly.
+func (u *userTypeResolver) resolveUserTypeFromInput(execResp *flowcm.ExecutorResponse,
+	userType string, allowed []string) error {
+	logger := u.logger
+	if len(allowed) == 0 || slices.Contains(allowed, userType) {
+		logger.Debug("User type resolved from input", log.String(userTypeKey, userType))
+
+		userSchema, ouID, err := u.getUserSchemaAndOU(userType)
+		if err != nil {
+			return err
+		}
+		if !userSchema.AllowSelfRegistration {
+			logger.Debug("Self registration not enabled for user type", log.String(userTypeKey, userType))
+			execResp.Status = flowcm.ExecFailure
+			execResp.FailureReason = "Self-registration not enabled for the user type"
+			return nil
+		}
+
+		// Add userType and ouID to runtime data
+		execResp.RuntimeData[userTypeKey] = userType
+		execResp.RuntimeData[defaultOUIDKey] = ouID
+
+		execResp.Status = flowcm.ExecComplete
+		return nil
+	}
+
+	execResp.Status = flowcm.ExecFailure
+	execResp.FailureReason = "Application does not allow registration for the user type"
+	return nil
+}
+
+// resolveUserTypeFromSingleAllowed resolves the user type when there is only a single allowed user type.
+func (u *userTypeResolver) resolveUserTypeFromSingleAllowed(execResp *flowcm.ExecutorResponse,
+	allowedUserType string) error {
+	logger := u.logger
+	userSchema, ouID, err := u.getUserSchemaAndOU(allowedUserType)
+	if err != nil {
+		return err
+	}
+
+	if !userSchema.AllowSelfRegistration {
+		logger.Debug("Self registration not enabled for user type", log.String(userTypeKey, allowedUserType))
+		execResp.Status = flowcm.ExecFailure
+		execResp.FailureReason = "Self-registration not enabled for the user type"
+		return nil
+	}
+
+	logger.Debug("User type resolved from allowed list", log.String(userTypeKey, allowedUserType))
+
+	// Add userType and ouID to runtime data
+	execResp.RuntimeData[userTypeKey] = allowedUserType
+	execResp.RuntimeData[defaultOUIDKey] = ouID
+
+	execResp.Status = flowcm.ExecComplete
+	return nil
+}
+
+// resolveUserTypeFromMultipleAllowed resolves the user type when multiple allowed user types exist.
+func (u *userTypeResolver) resolveUserTypeFromMultipleAllowed(execResp *flowcm.ExecutorResponse,
+	allowed []string) error {
+	logger := u.logger
+
+	// Filter self registration enabled user types
+	selfRegEnabledUserTypes := make([]schemaWithOU, 0)
+	for _, userType := range allowed {
+		userSchema, ouID, err := u.getUserSchemaAndOU(userType)
+		if err != nil {
+			return err
+		}
+		if userSchema.AllowSelfRegistration {
+			selfRegEnabledUserTypes = append(selfRegEnabledUserTypes, schemaWithOU{
+				userSchema: userSchema,
+				ouID:       ouID,
+			})
+		}
+	}
+
+	// Fail if no user types have self registration enabled
+	if len(selfRegEnabledUserTypes) == 0 {
+		logger.Debug("No user types with self registration enabled")
+		execResp.Status = flowcm.ExecFailure
+		execResp.FailureReason = "Self-registration not available for this application"
+		return nil
+	}
+
+	// If only one user type has self registration enabled, select it automatically
+	if len(selfRegEnabledUserTypes) == 1 {
+		record := selfRegEnabledUserTypes[0]
+		logger.Debug("User type auto-selected", log.String(userTypeKey, record.userSchema.Name))
+
+		// Add userType and ouID to runtime data
+		execResp.RuntimeData[userTypeKey] = record.userSchema.Name
+		execResp.RuntimeData[defaultOUIDKey] = record.ouID
+
+		execResp.Status = flowcm.ExecComplete
+		return nil
+	}
+
+	// If multiple user types are allowed, prompt the user to select one
+	selfRegUserTypes := make([]string, 0, len(selfRegEnabledUserTypes))
+	for _, record := range selfRegEnabledUserTypes {
+		selfRegUserTypes = append(selfRegUserTypes, record.userSchema.Name)
+	}
+
+	logger.Debug("Prompting for user type selection as multiple user types are available for self registration",
+		log.Any("userTypes", selfRegUserTypes))
+
+	execResp.Status = flowcm.ExecUserInputRequired
+	execResp.RequiredData = []flowcm.InputData{
+		{
+			Name:     userTypeKey,
+			Type:     "dropdown",
+			Required: true,
+			Options:  selfRegUserTypes,
+		},
+	}
+	return nil
+}
+
+// getUserSchemaAndOU retrieves the user schema by name and returns the schema and organization unit ID.
+func (u *userTypeResolver) getUserSchemaAndOU(userType string) (*userschema.UserSchema, string, error) {
+	logger := u.logger.With(log.String(userTypeKey, userType))
+
+	userSchema, svcErr := u.userSchemaService.GetUserSchemaByName(userType)
+	if svcErr != nil {
+		logger.Error("Failed to resolve user schema for user type",
+			log.String(userTypeKey, userType), log.String("error", svcErr.Error))
+		return nil, "", fmt.Errorf("failed to resolve user schema for user type: %s", userType)
+	}
+
+	if userSchema.OrganizationUnitID == "" {
+		logger.Error("No organization unit found for user type", log.String(userTypeKey, userType))
+		return nil, "", fmt.Errorf("no organization unit found for user type: %s", userType)
+	}
+
+	logger.Debug("User schema resolved for user type", log.String(userTypeKey, userType),
+		log.String(ouIDKey, userSchema.OrganizationUnitID))
+	return userSchema, userSchema.OrganizationUnitID, nil
+}

--- a/backend/internal/flow/executor/user_type_resolver_test.go
+++ b/backend/internal/flow/executor/user_type_resolver_test.go
@@ -1,0 +1,746 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	flowcm "github.com/asgardeo/thunder/internal/flow/common"
+	flowcore "github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/userschema"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
+)
+
+type UserTypeResolverTestSuite struct {
+	suite.Suite
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
+	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	executor              *userTypeResolver
+}
+
+func TestUserTypeResolverSuite(t *testing.T) {
+	suite.Run(t, new(UserTypeResolverTestSuite))
+}
+
+func (suite *UserTypeResolverTestSuite) SetupTest() {
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+
+	// Mock the CreateExecutor method to return a base executor
+	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameUserTypeResolver, flowcm.ExecutorTypeRegistration,
+		[]flowcm.InputData{}, []flowcm.InputData{}).
+		Return(createMockUserTypeResolverExecutor(suite.T()))
+
+	suite.executor = newUserTypeResolver(suite.mockFlowFactory, suite.mockUserSchemaService)
+}
+
+func createMockUserTypeResolverExecutor(t *testing.T) flowcore.ExecutorInterface {
+	mockExec := coremock.NewExecutorInterfaceMock(t)
+	mockExec.On("GetName").Return(ExecutorNameUserTypeResolver).Maybe()
+	mockExec.On("GetType").Return(flowcm.ExecutorTypeRegistration).Maybe()
+	mockExec.On("GetDefaultExecutorInputs").Return([]flowcm.InputData{}).Maybe()
+	mockExec.On("GetPrerequisites").Return([]flowcm.InputData{}).Maybe()
+	return mockExec
+}
+
+func (suite *UserTypeResolverTestSuite) TestNewUserTypeResolver() {
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockUserSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
+
+	mockFlowFactory.On("CreateExecutor", ExecutorNameUserTypeResolver, flowcm.ExecutorTypeRegistration,
+		[]flowcm.InputData{}, []flowcm.InputData{}).
+		Return(createMockUserTypeResolverExecutor(suite.T()))
+
+	executor := newUserTypeResolver(mockFlowFactory, mockUserSchemaService)
+
+	assert.NotNil(suite.T(), executor)
+	assert.Equal(suite.T(), ExecutorNameUserTypeResolver, executor.GetName())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_NonRegistrationFlow() {
+	testCases := []struct {
+		name     string
+		flowType flowcm.FlowType
+	}{
+		{
+			name:     "Authentication flow",
+			flowType: flowcm.FlowTypeAuthentication,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			ctx := &flowcore.NodeContext{
+				FlowID:   "flow-123",
+				FlowType: tc.flowType,
+				Application: appmodel.Application{
+					AllowedUserTypes: []string{"employee"},
+				},
+			}
+
+			result, err := suite.executor.Execute(ctx)
+
+			assert.NoError(suite.T(), err)
+			assert.NotNil(suite.T(), result)
+			assert.Equal(suite.T(), flowcm.ExecComplete, result.Status)
+			assert.Empty(suite.T(), result.RuntimeData[userTypeKey])
+			suite.mockUserSchemaService.AssertNotCalled(suite.T(), "GetOUForUserType")
+		})
+	}
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_Success() {
+	testCases := []struct {
+		name             string
+		allowedUserTypes []string
+		providedUserType string
+		expectedOUID     string
+	}{
+		{
+			name:             "Valid user type with OU",
+			allowedUserTypes: []string{"employee", "customer"},
+			providedUserType: "employee",
+			expectedOUID:     "ou-123",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			ctx := &flowcore.NodeContext{
+				FlowID:   "flow-123",
+				FlowType: flowcm.FlowTypeRegistration,
+				Application: appmodel.Application{
+					AllowedUserTypes: tc.allowedUserTypes,
+				},
+				UserInputData: map[string]string{
+					userTypeKey: tc.providedUserType,
+				},
+				RuntimeData: map[string]string{},
+			}
+
+			userSchema := &userschema.UserSchema{
+				ID:                    "schema-123",
+				Name:                  tc.providedUserType,
+				OrganizationUnitID:    tc.expectedOUID,
+				AllowSelfRegistration: true,
+			}
+			suite.mockUserSchemaService.On("GetUserSchemaByName", tc.providedUserType).
+				Return(userSchema, nil)
+
+			result, err := suite.executor.Execute(ctx)
+
+			assert.NoError(suite.T(), err)
+			assert.NotNil(suite.T(), result)
+			assert.Equal(suite.T(), flowcm.ExecComplete, result.Status)
+			assert.Equal(suite.T(), tc.providedUserType, result.RuntimeData[userTypeKey])
+			assert.Equal(suite.T(), tc.expectedOUID, result.RuntimeData[defaultOUIDKey])
+
+			suite.mockUserSchemaService.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_NoOU() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer"},
+		},
+		UserInputData: map[string]string{
+			userTypeKey: "employee",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "",
+		AllowSelfRegistration: true,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "no organization unit found for user type")
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_NotAllowed() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer"},
+		},
+		UserInputData: map[string]string{
+			userTypeKey: "partner",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "Application does not allow registration for the user type", result.FailureReason)
+	suite.mockUserSchemaService.AssertNotCalled(suite.T(), "GetUserSchemaByName")
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_OUResolutionFails() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{
+			userTypeKey: "employee",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	svcErr := &serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "SCHEMA-500",
+		Error:            "Internal Server Error",
+		ErrorDescription: "Failed to retrieve OU",
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(nil, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to resolve user schema")
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_NoAllowedUserTypes() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "Self-registration not available for this application", result.FailureReason)
+	suite.mockUserSchemaService.AssertNotCalled(suite.T(), "GetUserSchemaByName")
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_NoAllowedUserTypes_WithUserTypeInput() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{},
+		},
+		UserInputData: map[string]string{
+			userTypeKey: "employee",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-123",
+		AllowSelfRegistration: true,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "ou-123", result.RuntimeData[defaultOUIDKey])
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_Success() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-123",
+		AllowSelfRegistration: true,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "ou-123", result.RuntimeData[defaultOUIDKey])
+
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_NoOU() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "",
+		AllowSelfRegistration: true,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "no organization unit found for user type")
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_OUResolutionFails() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	svcErr := &serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "SCHEMA-500",
+		Error:            "Internal Server Error",
+		ErrorDescription: "Failed to retrieve OU",
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(nil, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to resolve user schema")
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_PromptUser() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	// Mock all three user types with self registration enabled
+	for _, userType := range []string{"employee", "customer", "partner"} {
+		userSchema := &userschema.UserSchema{
+			ID:                    "schema-" + userType,
+			Name:                  userType,
+			OrganizationUnitID:    "ou-" + userType,
+			AllowSelfRegistration: true,
+		}
+		suite.mockUserSchemaService.On("GetUserSchemaByName", userType).
+			Return(userSchema, nil)
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecUserInputRequired, result.Status)
+	assert.NotEmpty(suite.T(), result.RequiredData)
+	assert.Len(suite.T(), result.RequiredData, 1)
+
+	requiredInput := result.RequiredData[0]
+	assert.Equal(suite.T(), userTypeKey, requiredInput.Name)
+	assert.Equal(suite.T(), "dropdown", requiredInput.Type)
+	assert.True(suite.T(), requiredInput.Required)
+	assert.ElementsMatch(suite.T(), []string{"employee", "customer", "partner"}, requiredInput.Options)
+
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_EmptyUserTypeInput() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer"},
+		},
+		UserInputData: map[string]string{
+			userTypeKey: "",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	// Mock both user types with self registration enabled
+	for _, userType := range []string{"employee", "customer"} {
+		userSchema := &userschema.UserSchema{
+			ID:                    "schema-" + userType,
+			Name:                  userType,
+			OrganizationUnitID:    "ou-" + userType,
+			AllowSelfRegistration: true,
+		}
+		suite.mockUserSchemaService.On("GetUserSchemaByName", userType).
+			Return(userSchema, nil)
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecUserInputRequired, result.Status)
+	assert.NotEmpty(suite.T(), result.RequiredData)
+	assert.Len(suite.T(), result.RequiredData, 1)
+
+	requiredInput := result.RequiredData[0]
+	assert.Equal(suite.T(), userTypeKey, requiredInput.Name)
+	assert.Equal(suite.T(), "dropdown", requiredInput.Type)
+
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_SelfRegistrationDisabled() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{
+			userTypeKey: "employee",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-123",
+		AllowSelfRegistration: false,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "Self-registration not enabled for the user type", result.FailureReason)
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_SelfRegistrationDisabled() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-123",
+		AllowSelfRegistration: false,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "Self-registration not enabled for the user type", result.FailureReason)
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_OnlyOneSelfRegEnabled() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	// Only customer has self-registration enabled
+	employeeSchema := &userschema.UserSchema{
+		ID:                    "schema-employee",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-employee",
+		AllowSelfRegistration: false,
+	}
+	customerSchema := &userschema.UserSchema{
+		ID:                    "schema-customer",
+		Name:                  "customer",
+		OrganizationUnitID:    "ou-customer",
+		AllowSelfRegistration: true,
+	}
+	partnerSchema := &userschema.UserSchema{
+		ID:                    "schema-partner",
+		Name:                  "partner",
+		OrganizationUnitID:    "ou-partner",
+		AllowSelfRegistration: false,
+	}
+
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+		Return(customerSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "partner").
+		Return(partnerSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "customer", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "ou-customer", result.RuntimeData[defaultOUIDKey])
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_NoSelfRegEnabled() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	// None have self-registration enabled
+	employeeSchema := &userschema.UserSchema{
+		ID:                    "schema-employee",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-employee",
+		AllowSelfRegistration: false,
+	}
+	customerSchema := &userschema.UserSchema{
+		ID:                    "schema-customer",
+		Name:                  "customer",
+		OrganizationUnitID:    "ou-customer",
+		AllowSelfRegistration: false,
+	}
+
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+		Return(customerSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), flowcm.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "Self-registration not available for this application", result.FailureReason)
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_SchemaResolutionFails() {
+	suite.SetupTest()
+
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer"},
+		},
+		UserInputData: map[string]string{},
+		RuntimeData:   map[string]string{},
+	}
+
+	// First schema succeeds, second fails
+	employeeSchema := &userschema.UserSchema{
+		ID:                    "schema-employee",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-employee",
+		AllowSelfRegistration: true,
+	}
+	svcErr := &serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "SCHEMA-500",
+		Error:            "Internal Server Error",
+		ErrorDescription: "Failed to retrieve schema",
+	}
+
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+		Return(nil, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to resolve user schema for user type")
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestGetUserSchemaAndOU_Success() {
+	suite.SetupTest()
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "ou-123",
+		AllowSelfRegistration: true,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	schema, ouID, err := suite.executor.getUserSchemaAndOU("employee")
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), schema)
+	assert.Equal(suite.T(), "ou-123", ouID)
+	assert.Equal(suite.T(), "employee", schema.Name)
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestGetUserSchemaAndOU_NoOUFound() {
+	suite.SetupTest()
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    "",
+		AllowSelfRegistration: true,
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	schema, ouID, err := suite.executor.getUserSchemaAndOU("employee")
+
+	assert.NotNil(suite.T(), err)
+	assert.Nil(suite.T(), schema)
+	assert.Equal(suite.T(), "", ouID)
+	assert.Contains(suite.T(), err.Error(), "no organization unit found for user type")
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestGetUserSchemaAndOU_SchemaNotFound() {
+	suite.SetupTest()
+
+	svcErr := &serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "SCHEMA-404",
+		Error:            "Not Found",
+		ErrorDescription: "User schema not found",
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(nil, svcErr)
+
+	schema, ouID, err := suite.executor.getUserSchemaAndOU("employee")
+
+	assert.NotNil(suite.T(), err)
+	assert.Nil(suite.T(), schema)
+	assert.Equal(suite.T(), "", ouID)
+	assert.Contains(suite.T(), err.Error(), "failed to resolve user schema for user type")
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+}

--- a/tests/integration/flowregistration/githubregistration_test.go
+++ b/tests/integration/flowregistration/githubregistration_test.go
@@ -30,6 +30,37 @@ import (
 )
 
 var (
+	githubRegTestOU = testutils.OrganizationUnit{
+		Handle:      "github-reg-flow-test-ou",
+		Name:        "GitHub Registration Flow Test Organization Unit",
+		Description: "Organization unit for GitHub registration flow testing",
+		Parent:      nil,
+	}
+
+	githubRegUserSchema = testutils.UserSchema{
+		Name: "github_reg_flow_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"sub": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"givenName": map[string]interface{}{
+				"type": "string",
+			},
+			"familyName": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
 	githubRegTestApp = testutils.Application{
 		Name:                      "GitHub Registration Flow Test Application",
 		Description:               "Application for testing GitHub registration flows",
@@ -39,13 +70,7 @@ var (
 		ClientID:                  "github_reg_flow_test_client",
 		ClientSecret:              "github_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
-	}
-
-	githubRegTestOU = testutils.OrganizationUnit{
-		Handle:      "github-reg-flow-test-ou",
-		Name:        "GitHub Registration Flow Test Organization Unit",
-		Description: "Organization unit for GitHub registration flow testing",
-		Parent:      nil,
+		AllowedUserTypes:          []string{githubRegUserSchema.Name},
 	}
 )
 
@@ -57,30 +82,6 @@ var (
 const (
 	mockGithubRegFlowPort = 8092
 )
-
-var githubRegUserSchema = testutils.UserSchema{
-	Name: "github_reg_flow_user",
-	Schema: map[string]interface{}{
-		"username": map[string]interface{}{
-			"type": "string",
-		},
-		"password": map[string]interface{}{
-			"type": "string",
-		},
-		"sub": map[string]interface{}{
-			"type": "string",
-		},
-		"email": map[string]interface{}{
-			"type": "string",
-		},
-		"givenName": map[string]interface{}{
-			"type": "string",
-		},
-		"familyName": map[string]interface{}{
-			"type": "string",
-		},
-	},
-}
 
 type GithubRegistrationFlowTestSuite struct {
 	suite.Suite
@@ -135,11 +136,12 @@ func (ts *GithubRegistrationFlowTestSuite) SetupSuite() {
 
 	// Create user schema
 	githubRegUserSchema.OrganizationUnitId = githubRegTestOUID
+	githubRegUserSchema.AllowSelfRegistration = true
 	schemaID, err := testutils.CreateUserType(githubRegUserSchema)
 	ts.Require().NoError(err, "Failed to create GitHub user schema")
 	ts.userSchemaID = schemaID
 
-	// Create test application for GitHub registration tests
+	// Create test application
 	appID, err := testutils.CreateApplication(githubRegTestApp)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test application during setup: %v", err)

--- a/tests/integration/flowregistration/googleregistration_test.go
+++ b/tests/integration/flowregistration/googleregistration_test.go
@@ -30,6 +30,37 @@ import (
 )
 
 var (
+	googleRegTestOU = testutils.OrganizationUnit{
+		Handle:      "google-reg-flow-test-ou",
+		Name:        "Google Registration Flow Test Organization Unit",
+		Description: "Organization unit for Google registration flow testing",
+		Parent:      nil,
+	}
+
+	googleRegUserSchema = testutils.UserSchema{
+		Name: "google_reg_flow_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"sub": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"givenName": map[string]interface{}{
+				"type": "string",
+			},
+			"familyName": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
 	googleRegTestApp = testutils.Application{
 		Name:                      "Google Registration Flow Test Application",
 		Description:               "Application for testing Google registration flows",
@@ -39,13 +70,7 @@ var (
 		ClientID:                  "google_reg_flow_test_client",
 		ClientSecret:              "google_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
-	}
-
-	googleRegTestOU = testutils.OrganizationUnit{
-		Handle:      "google-reg-flow-test-ou",
-		Name:        "Google Registration Flow Test Organization Unit",
-		Description: "Organization unit for Google registration flow testing",
-		Parent:      nil,
+		AllowedUserTypes:          []string{googleRegUserSchema.Name},
 	}
 )
 
@@ -57,30 +82,6 @@ var (
 const (
 	mockGoogleRegFlowPort = 8093
 )
-
-var googleRegUserSchema = testutils.UserSchema{
-	Name: "google_reg_flow_user",
-	Schema: map[string]interface{}{
-		"username": map[string]interface{}{
-			"type": "string",
-		},
-		"password": map[string]interface{}{
-			"type": "string",
-		},
-		"sub": map[string]interface{}{
-			"type": "string",
-		},
-		"email": map[string]interface{}{
-			"type": "string",
-		},
-		"givenName": map[string]interface{}{
-			"type": "string",
-		},
-		"familyName": map[string]interface{}{
-			"type": "string",
-		},
-	},
-}
 
 type GoogleRegistrationFlowTestSuite struct {
 	suite.Suite
@@ -129,11 +130,12 @@ func (ts *GoogleRegistrationFlowTestSuite) SetupSuite() {
 
 	// Create user schema
 	googleRegUserSchema.OrganizationUnitId = googleRegTestOUID
+	googleRegUserSchema.AllowSelfRegistration = true
 	schemaID, err := testutils.CreateUserType(googleRegUserSchema)
 	ts.Require().NoError(err, "Failed to create Google user schema")
 	ts.userSchemaID = schemaID
 
-	// Create test application for Google registration tests
+	// Create test application
 	appID, err := testutils.CreateApplication(googleRegTestApp)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test application during setup: %v", err)

--- a/tests/integration/flowregistration/httprequestexecutor_registration_test.go
+++ b/tests/integration/flowregistration/httprequestexecutor_registration_test.go
@@ -31,14 +31,6 @@ const (
 )
 
 var (
-	httpRequestRegTestApp = testutils.Application{
-		Name:                      "HTTP Request Executor Registration Test Application",
-		Description:               "Application for testing HTTP request executor in registration flows",
-		AuthFlowGraphID:           "auth_flow_config_basic",
-		RegistrationFlowGraphID:   "registration_flow_config_basic_http_request",
-		IsRegistrationFlowEnabled: true,
-	}
-
 	httpRequestRegTestOU = testutils.OrganizationUnit{
 		Name:        "HTTP Request Registration Test OU",
 		Handle:      "http-request-reg-test-ou",
@@ -64,6 +56,15 @@ var (
 				"type": "string",
 			},
 		},
+	}
+
+	httpRequestRegTestApp = testutils.Application{
+		Name:                      "HTTP Request Executor Registration Test Application",
+		Description:               "Application for testing HTTP request executor in registration flows",
+		AuthFlowGraphID:           "auth_flow_config_basic",
+		RegistrationFlowGraphID:   "registration_flow_config_basic_http_request",
+		IsRegistrationFlowEnabled: true,
+		AllowedUserTypes:          []string{httpRequestRegTestUserSchema.Name},
 	}
 )
 
@@ -96,6 +97,7 @@ func (ts *HTTPRequestRegistrationFlowTestSuite) SetupSuite() {
 
 	// Create test user schema within the test OU
 	httpRequestRegTestUserSchema.OrganizationUnitId = httpRequestRegTestOUID
+	httpRequestRegTestUserSchema.AllowSelfRegistration = true
 	schemaID, err := testutils.CreateUserType(httpRequestRegTestUserSchema)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)

--- a/tests/integration/flowregistration/ouregistration_test.go
+++ b/tests/integration/flowregistration/ouregistration_test.go
@@ -32,17 +32,6 @@ const (
 )
 
 var (
-	ouRegTestApp = testutils.Application{
-		Name:                      "OU Registration Flow Test Application",
-		Description:               "Application for testing OU registration flows",
-		IsRegistrationFlowEnabled: true,
-		AuthFlowGraphID:           "auth_flow_config_basic",
-		RegistrationFlowGraphID:   "registration_flow_config_basic_with_ou",
-		ClientID:                  "ou_reg_flow_test_client",
-		ClientSecret:              "ou_reg_flow_test_secret",
-		RedirectURIs:              []string{"http://localhost:3000/callback"},
-	}
-
 	ouRegTestOU = testutils.OrganizationUnit{
 		Handle:      "ou-reg-flow-test-ou",
 		Name:        "OU Registration Flow Test Organization Unit",
@@ -72,6 +61,18 @@ var (
 				"type": "string",
 			},
 		},
+	}
+
+	ouRegTestApp = testutils.Application{
+		Name:                      "OU Registration Flow Test Application",
+		Description:               "Application for testing OU registration flows",
+		IsRegistrationFlowEnabled: true,
+		AuthFlowGraphID:           "auth_flow_config_basic",
+		RegistrationFlowGraphID:   "registration_flow_config_basic_with_ou",
+		ClientID:                  "ou_reg_flow_test_client",
+		ClientSecret:              "ou_reg_flow_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{dynamicUserSchema.Name},
 	}
 )
 
@@ -103,11 +104,25 @@ func (ts *OURegistrationFlowTestSuite) SetupSuite() {
 
 	// Create dynamic user schema
 	dynamicUserSchema.OrganizationUnitId = ts.basicFlowTestOUID
+	dynamicUserSchema.AllowSelfRegistration = true
 	schemaID, err := testutils.CreateUserType(dynamicUserSchema)
 	if err != nil {
 		ts.T().Fatalf("Failed to create dynamic user schema during setup: %v", err)
 	}
 	ts.userSchemaID = schemaID
+
+	// Create test application with allowed user types
+	ouRegTestApp := testutils.Application{
+		Name:                      "OU Registration Flow Test Application",
+		Description:               "Application for testing OU registration flows",
+		IsRegistrationFlowEnabled: true,
+		AuthFlowGraphID:           "auth_flow_config_basic",
+		RegistrationFlowGraphID:   "registration_flow_config_basic_with_ou",
+		ClientID:                  "ou_reg_flow_test_client",
+		ClientSecret:              "ou_reg_flow_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{dynamicUserSchema.Name},
+	}
 
 	appID, err := testutils.CreateApplication(ouRegTestApp)
 	if err != nil {
@@ -124,6 +139,7 @@ func (ts *OURegistrationFlowTestSuite) SetupSuite() {
 		ClientID:                  "ou_sms_reg_flow_test_client",
 		ClientSecret:              "ou_sms_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{dynamicUserSchema.Name},
 	}
 
 	smsAppID, err := testutils.CreateApplication(smsApp)
@@ -254,6 +270,9 @@ func (ts *OURegistrationFlowTestSuite) TestBasicRegistrationFlowWithOU() {
 			ts.Require().NoError(err)
 			ts.Require().Equal(tc.ouName, ou.Name)
 			ts.Require().Equal(tc.ouHandle, ou.Handle)
+			ts.Require().NotNil(ou.Parent, "Created OU should have a parent")
+			ts.Require().Equal(ts.basicFlowTestOUID, *ou.Parent,
+				"Created OU should be a child of the user schema's OU")
 
 			if tc.ouDescription != "" {
 				ts.Require().Equal(tc.ouDescription, ou.Description)
@@ -279,7 +298,7 @@ func (ts *OURegistrationFlowTestSuite) TestBasicRegistrationFlowWithOUCreationDu
 			existingOUHandle:    generateUniqueHandle("duplicate-name"),
 			newOUName:           "Duplicate OU Name",
 			newOUHandle:         generateUniqueHandle("new-handle"),
-			expectedErrorSubstr: "organization unit with the same name already exists",
+			expectedErrorSubstr: "An organization unit with the same name already exists",
 		},
 		{
 			name:                "DuplicateOUHandle",
@@ -287,7 +306,7 @@ func (ts *OURegistrationFlowTestSuite) TestBasicRegistrationFlowWithOUCreationDu
 			existingOUHandle:    generateUniqueHandle("duplicate-handle"),
 			newOUName:           "New OU Name",
 			newOUHandle:         "",
-			expectedErrorSubstr: "organization unit with the same handle already exists",
+			expectedErrorSubstr: "An organization unit with the same handle already exists",
 		},
 	}
 
@@ -297,7 +316,7 @@ func (ts *OURegistrationFlowTestSuite) TestBasicRegistrationFlowWithOUCreationDu
 				Handle:      tc.existingOUHandle,
 				Name:        tc.existingOUName,
 				Description: "Existing OU",
-				Parent:      nil,
+				Parent:      &ts.basicFlowTestOUID,
 			}
 
 			existingOUID, err := testutils.CreateOrganizationUnit(existingOU)
@@ -403,6 +422,9 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 			ts.Require().NoError(err)
 			ts.Require().Equal(tc.ouName, ou.Name)
 			ts.Require().Equal(tc.ouHandle, ou.Handle)
+			ts.Require().NotNil(ou.Parent, "Created OU should have a parent")
+			ts.Require().Equal(ts.basicFlowTestOUID, *ou.Parent,
+				"Created OU should be a child of the user schema's OU")
 
 			if tc.ouDescription != "" {
 				ts.Require().Equal(tc.ouDescription, ou.Description)
@@ -428,7 +450,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 			existingOUHandle:    generateUniqueHandle("sms-duplicate-name"),
 			newOUName:           "SMS Duplicate OU Name",
 			newOUHandle:         generateUniqueHandle("new-sms-handle"),
-			expectedErrorSubstr: "organization unit with the same name already exists",
+			expectedErrorSubstr: "An organization unit with the same name already exists",
 		},
 		{
 			name:                "DuplicateOUHandle",
@@ -436,7 +458,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 			existingOUHandle:    generateUniqueHandle("sms-duplicate-handle"),
 			newOUName:           "SMS New OU Name",
 			newOUHandle:         "",
-			expectedErrorSubstr: "organization unit with the same handle already exists",
+			expectedErrorSubstr: "An organization unit with the same handle already exists",
 		},
 	}
 
@@ -446,7 +468,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 				Handle:      tc.existingOUHandle,
 				Name:        tc.existingOUName,
 				Description: "Existing OU",
-				Parent:      nil,
+				Parent:      &ts.basicFlowTestOUID,
 			}
 
 			existingOUID, err := testutils.CreateOrganizationUnit(existingOU)

--- a/tests/integration/flowregistration/smsregistration_test.go
+++ b/tests/integration/flowregistration/smsregistration_test.go
@@ -32,30 +32,44 @@ const (
 )
 
 var (
-	smsRegTestApp = testutils.Application{
-		Name:                      "SMS Registration Flow Test Application",
-		Description:               "Application for testing SMS registration flows",
-		IsRegistrationFlowEnabled: true,
-		AuthFlowGraphID:           "auth_flow_config_basic",
-		RegistrationFlowGraphID:   "registration_flow_config_sms",
-		ClientID:                  "sms_reg_flow_test_client",
-		ClientSecret:              "sms_reg_flow_test_secret",
-		RedirectURIs:              []string{"http://localhost:3000/callback"},
-	}
-
 	smsRegTestOU = testutils.OrganizationUnit{
 		Handle:      "sms-reg-flow-test-ou",
 		Name:        "SMS Registration Flow Test Organization Unit",
 		Description: "Organization unit for SMS registration flow testing",
 		Parent:      nil,
 	}
+
+	smsRegTestUserSchema = testutils.UserSchema{
+		Name: "sms-test-user-type",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"firstName": map[string]interface{}{
+				"type": "string",
+			},
+			"lastName": map[string]interface{}{
+				"type": "string",
+			},
+			"mobileNumber": map[string]interface{}{
+				"type": "string",
+			},
+		},
+		AllowSelfRegistration: true,
+	}
 )
 
 type SMSRegistrationFlowTestSuite struct {
 	suite.Suite
-	config         *TestSuiteConfig
-	mockServer     *testutils.MockNotificationServer
-	userSchemaID   string
+	config       *TestSuiteConfig
+	mockServer   *testutils.MockNotificationServer
+	userSchemaID string
 }
 
 func TestSMSRegistrationFlowTestSuite(t *testing.T) {
@@ -73,15 +87,27 @@ func (ts *SMSRegistrationFlowTestSuite) SetupSuite() {
 	}
 	testOUID = ouID
 
-	// Create test user schema
-	testUserSchema.OrganizationUnitId = testOUID
-	schemaID, err := testutils.CreateUserType(testUserSchema)
+	// Create test user schema for SMS tests
+	smsRegTestUserSchema.OrganizationUnitId = testOUID
+	schemaID, err := testutils.CreateUserType(smsRegTestUserSchema)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)
 	}
 	ts.userSchemaID = schemaID
 
-	// Create test application for SMS tests
+	// Create test application with allowed user types
+	smsRegTestApp := testutils.Application{
+		Name:                      "SMS Registration Flow Test Application",
+		Description:               "Application for testing SMS registration flows",
+		IsRegistrationFlowEnabled: true,
+		AuthFlowGraphID:           "auth_flow_config_basic",
+		RegistrationFlowGraphID:   "registration_flow_config_sms",
+		ClientID:                  "sms_reg_flow_test_client",
+		ClientSecret:              "sms_reg_flow_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{smsRegTestUserSchema.Name},
+	}
+
 	appID, err := testutils.CreateApplication(smsRegTestApp)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test application during setup: %v", err)
@@ -245,8 +271,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowWithMobileNumber(
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-	ts.Require().Equal(regUserOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(smsRegTestUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
+	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 
@@ -356,8 +382,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowWithUsername() {
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-	ts.Require().Equal(regUserOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(smsRegTestUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
+	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 
@@ -487,8 +513,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
 	// Validate JWT contains expected user type and OU ID
-	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-	ts.Require().Equal(regUserOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(smsRegTestUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
+	ts.Require().Equal(testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
 	ts.Require().Equal(testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 

--- a/tests/integration/resources/graphs/registration_flow_config_basic.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "basic_auth"
+            ]
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "executor": {
@@ -42,10 +49,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "test-ou-id",
-                "userType": "test-user-type"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/resources/graphs/registration_flow_config_basic_http_request.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic_http_request.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "provision_user"
+            ]
+        },
+        {
             "id": "provision_user",
             "type": "TASK_EXECUTION",
             "inputData": [
@@ -32,10 +39,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "test-ou-id",
-                "userType": "http_request_reg_test_person"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/resources/graphs/registration_flow_config_basic_with_ou.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic_with_ou.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "basic_auth"
+            ]
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "executor": {
@@ -52,10 +59,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "ouId",
-                "userType": "dynamic-user-type"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/resources/graphs/registration_flow_config_github.json
+++ b/tests/integration/resources/graphs/registration_flow_config_github.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "github_auth"
+            ]
+        },
+        {
             "id": "github_auth",
             "type": "TASK_EXECUTION",
             "properties": {
@@ -18,10 +25,6 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "properties": {
-                "ouId": "test-ou-id",
-                "userType": "github_reg_flow_user"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/resources/graphs/registration_flow_config_google.json
+++ b/tests/integration/resources/graphs/registration_flow_config_google.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "google_auth"
+            ]
+        },
+        {
             "id": "google_auth",
             "type": "TASK_EXECUTION",
             "properties": {
@@ -18,10 +25,6 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "properties": {
-                "ouId": "test-ou-id",
-                "userType": "google_reg_flow_user"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/resources/graphs/registration_flow_config_sms.json
+++ b/tests/integration/resources/graphs/registration_flow_config_sms.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "prompt_mobile"
+            ]
+        },
+        {
             "id": "prompt_mobile",
             "type": "PROMPT_ONLY",
             "inputData": [
@@ -54,10 +61,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "test-ou-id",
-                "userType": "test-user-type"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/resources/graphs/registration_flow_config_sms_with_ou.json
+++ b/tests/integration/resources/graphs/registration_flow_config_sms_with_ou.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "sms_auth"
+            ]
+        },
+        {
             "id": "sms_auth",
             "type": "TASK_EXECUTION",
             "properties": {
@@ -67,10 +74,6 @@
                     "required": true
                 }
             ],
-            "properties": {
-                "ouId": "ouId",
-                "userType": "dynamic-user-type"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/resources/graphs/registration_flow_config_sms_with_username.json
+++ b/tests/integration/resources/graphs/registration_flow_config_sms_with_username.json
@@ -3,6 +3,13 @@
     "type": "REGISTRATION",
     "nodes": [
         {
+            "id": "registration_start",
+            "type": "REGISTRATION_START",
+            "next": [
+                "mobile_prompt_username"
+            ]
+        },
+        {
             "id": "mobile_prompt_username",
             "type": "PROMPT_ONLY",
             "inputData": [
@@ -32,10 +39,6 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "properties": {
-                "ouId": "test-ou-id",
-                "userType": "test-user-type"
-            },
             "executor": {
                 "name": "ProvisioningExecutor"
             },

--- a/tests/integration/testutils/apiutils.go
+++ b/tests/integration/testutils/apiutils.go
@@ -50,6 +50,10 @@ func getHTTPClient() *http.Client {
 
 // CreateUserType creates a user type via API and returns the schema ID
 func CreateUserType(schema UserSchema) (string, error) {
+	if !schema.AllowSelfRegistration {
+		schema.AllowSelfRegistration = true
+	}
+
 	payload, err := json.Marshal(schema)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal user schema: %w", err)
@@ -236,6 +240,11 @@ func CreateApplication(app Application) (string, error) {
 				},
 			},
 		},
+	}
+
+	// Add allowed_user_types if provided
+	if len(app.AllowedUserTypes) > 0 {
+		appData["allowed_user_types"] = app.AllowedUserTypes
 	}
 
 	appJSON, err := json.Marshal(appData)

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -50,6 +50,7 @@ type Application struct {
 	ClientID                  string                   `json:"client_id,omitempty"`
 	ClientSecret              string                   `json:"client_secret,omitempty"`
 	RedirectURIs              []string                 `json:"redirect_uris,omitempty"`
+	AllowedUserTypes          []string                 `json:"allowed_user_types,omitempty"`
 	Certificate               map[string]interface{}   `json:"certificate,omitempty"`
 	InboundAuthConfig         []map[string]interface{} `json:"inbound_auth_config,omitempty"`
 }


### PR DESCRIPTION
### Purpose
This pull request updates the registration flow graph configurations and refactors how organization unit ID and user type are handled during user provisioning. The main changes include introducing a dedicated registration start node to all registration flows with a associated new `UserTypeResolver` executor, removing default organization unit and user type properties from graph definitions, and ensuring these values are passed via runtime data. Additionally, the provisioning executor and related tests are updated to reflect this new approach.

This PR;
- Introduces a new `REGISTRATION_START` type node to the registration flows.
- Eliminates the need for defining `userType` and `ouId` in registration flows.
- Fixes the broken feature of inferring registration graphs from authentication graphs.
- Allows specifying user type as flow input data (optional)
- Modify the ou executor to create sub ous under the application associated ou
- Introduces a new input type to the flow response to prompt user's to pick one from a given list of options

---
### ⚠️ Breaking Changes

This PR introduces breaking changes that require updates to existing registration flow definitions and configuration.

#### 🔧 Summary of Breaking Changes

**1. ✂️ Removal of `ouId` and `userType` node properties**
The `ouId` and `userType` properties have been removed from registration flow graph nodes.

A new start node of type **`REGISTRATION_START`** must now be added to all registration flow definitions:

```json
{
  "id": "registration_start",
  "type": "REGISTRATION_START",
  "next": ["your_node_id"]
}
```

**2. 🧩 User type selection when multiple types are enabled**
If multiple user types with self-registration enabled are attached to the application, the flow will prompt the user to select a user type:

```json
{
  "flowId": "f2b3e255-fb15-4f37-941f-ac304d13178a",
  "flowStatus": "INCOMPLETE",
  "type": "VIEW",
  "data": {
    "inputs": [
      {
        "name": "userType",
        "type": "dropdown",
        "required": true,
        "options": ["person", "person_2"]
      }
    ]
  }
}
```

**3. 🚫 Self-registration failure when no eligible user types exist**
Self-registration will now fail if **none** of the user types attached to the application have self-registration enabled.

**4. 🌳 OU Executor behavior change**
The OU Executor now creates **sub-OUs** instead of root-level OUs.  
Sub-OUs are created under the OU associated with the selected user type.

---
### Approach
**New User Type Resolver:**
* Introduced a new user type resolving executor that will resolve user type from the flow associated application. If it cannot resolve to a single user type, executor will prompt the user to pick one.
* Resolve and add ouId to the runtime data based on the resolved user type.

**Provisioning Executor Refactor:**
* Updated the provisioning executor to retrieve `ouId` and `userType` exclusively from runtime data, removing the fallback to node properties.
* Adjusted the organization unit executor to set the parent OU based on the presence of `defaultOUID` in runtime data.

**Registration Flow Graph Updates:**

* Added a `REGISTRATION_START` node to all registration flow graph JSON files to standardize the start of registration flows. (`registration_flow_config_basic.json`, `registration_flow_config_basic_google_github.json`, `registration_flow_config_basic_google_github_sms.json`, `registration_flow_config_sms.json`) [[1]](diffhunk://#diff-64ad9b639d15429da8bdea37a50b0c2c9ae700ddfb2e58fdfaab4e08e48c1378R5-R9) [[2]](diffhunk://#diff-96058260f41eaaf71d1090f44c45bebdcc8bff8d9e501ddb4b2e19a619112331R5-R9) [[3]](diffhunk://#diff-ad4ee82412fc07baba341afa705a691b7ff115418782560d9da51695d0917f4dR5-R9) [[4]](diffhunk://#diff-f5eac38c139e09bf046273b38a4aceb8ed2c79a07c4cee5a88f5b20cb95d4b4cR5-R9)
* Removed `ouId` and `userType` properties from provisioning nodes in all registration flow graph JSON files, so these values are now expected in runtime data rather than static configuration. [[1]](diffhunk://#diff-64ad9b639d15429da8bdea37a50b0c2c9ae700ddfb2e58fdfaab4e08e48c1378L45-L48) [[2]](diffhunk://#diff-96058260f41eaaf71d1090f44c45bebdcc8bff8d9e501ddb4b2e19a619112331L53-L56) [[3]](diffhunk://#diff-ad4ee82412fc07baba341afa705a691b7ff115418782560d9da51695d0917f4dL121-L124) [[4]](diffhunk://#diff-ad4ee82412fc07baba341afa705a691b7ff115418782560d9da51695d0917f4dL152-L155) [[5]](diffhunk://#diff-ad4ee82412fc07baba341afa705a691b7ff115418782560d9da51695d0917f4dL166-L169) [[6]](diffhunk://#diff-f5eac38c139e09bf046273b38a4aceb8ed2c79a07c4cee5a88f5b20cb95d4b4cL57-L60)

### Related Issues
- https://github.com/asgardeo/thunder/issues/758

### Related PRs
- https://github.com/asgardeo/thunder/pull/756

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
