### PR TITLE
Introduce service method to get user schema by name

### DIFF
--- a/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
+++ b/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
@@ -219,6 +219,70 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetUserSchemaByName provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(schemaName string) (*UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(schemaName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserSchemaByName")
+	}
+
+	var r0 *UserSchema
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string) (*UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(schemaName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *UserSchema); ok {
+		r0 = returnFunc(schemaName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*UserSchema)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(schemaName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaByName'
+type UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call struct {
+	*mock.Call
+}
+
+// GetUserSchemaByName is a helper method to define mock.On call
+//   - schemaName string
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaByName(schemaName interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", schemaName)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Run(run func(schemaName string)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Return(userSchema *UserSchema, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Return(userSchema, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(schemaName string) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserSchemaList provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(limit int, offset int) (*UserSchemaListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(limit, offset)

--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -38,6 +38,7 @@ type UserSchemaServiceInterface interface {
 	GetUserSchemaList(limit, offset int) (*UserSchemaListResponse, *serviceerror.ServiceError)
 	CreateUserSchema(request CreateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)
 	GetUserSchema(schemaID string) (*UserSchema, *serviceerror.ServiceError)
+	GetUserSchemaByName(schemaName string) (*UserSchema, *serviceerror.ServiceError)
 	UpdateUserSchema(schemaID string, request UpdateUserSchemaRequest) (
 		*UserSchema, *serviceerror.ServiceError)
 	DeleteUserSchema(schemaID string) *serviceerror.ServiceError
@@ -153,6 +154,25 @@ func (us *userSchemaService) GetUserSchema(schemaID string) (*UserSchema, *servi
 			return nil, &ErrorUserSchemaNotFound
 		}
 		return nil, logAndReturnServerError(logger, "Failed to get user schema", err)
+	}
+
+	return &userSchema, nil
+}
+
+// GetUserSchemaByName retrieves a user schema by its name.
+func (us *userSchemaService) GetUserSchemaByName(schemaName string) (*UserSchema, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaLoggerComponentName))
+
+	if schemaName == "" {
+		return nil, invalidSchemaRequestError("schema name must not be empty")
+	}
+
+	userSchema, err := us.userSchemaStore.GetUserSchemaByName(schemaName)
+	if err != nil {
+		if errors.Is(err, ErrUserSchemaNotFound) {
+			return nil, &ErrorUserSchemaNotFound
+		}
+		return nil, logAndReturnServerError(logger, "Failed to get user schema by name", err)
 	}
 
 	return &userSchema, nil

--- a/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
@@ -220,6 +220,70 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) RunAndReturn(run fu
 	return _c
 }
 
+// GetUserSchemaByName provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(schemaName string) (*userschema.UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(schemaName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserSchemaByName")
+	}
+
+	var r0 *userschema.UserSchema
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(schemaName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *userschema.UserSchema); ok {
+		r0 = returnFunc(schemaName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*userschema.UserSchema)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(schemaName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaByName'
+type UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call struct {
+	*mock.Call
+}
+
+// GetUserSchemaByName is a helper method to define mock.On call
+//   - schemaName string
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaByName(schemaName interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", schemaName)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Run(run func(schemaName string)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Return(userSchema *userschema.UserSchema, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Return(userSchema, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(schemaName string) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserSchemaList provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(limit int, offset int) (*userschema.UserSchemaListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(limit, offset)


### PR DESCRIPTION
### Purpose
This pull request adds support for retrieving user schemas by their name, enhancing the flexibility of the user schema service. The main changes include introducing a new method to fetch schemas by name, updating the service interface, and adding comprehensive unit tests to cover different scenarios.

**User schema retrieval improvements:**

* Added the `GetUserSchemaByName` method to the `UserSchemaServiceInterface` in `service.go`, enabling lookup of user schemas using their name instead of only their ID.
* Implemented the `GetUserSchemaByName` method in the `userSchemaService` struct, including error handling for not found, invalid input, and internal errors.

**Testing enhancements:**

* Added unit tests in `service_test.go` for `GetUserSchemaByName`, covering successful retrieval, not found errors, internal errors, and validation for empty schema names.