### PR TITLE
Enforce OU validation in the user schema

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -50,7 +50,7 @@ func registerServices(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) {
 	logger := log.GetLogger()
 
 	ouService := ou.Initialize(mux)
-	userSchemaService := userschema.Initialize(mux)
+	userSchemaService := userschema.Initialize(mux, ouService)
 	userService := user.Initialize(mux, ouService, userSchemaService)
 	groupService := group.Initialize(mux, ouService, userService)
 	roleService := role.Initialize(mux, userService, groupService, ouService)

--- a/backend/internal/userschema/init.go
+++ b/backend/internal/userschema/init.go
@@ -21,12 +21,16 @@ package userschema
 import (
 	"net/http"
 
+	oupkg "github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
 
 // Initialize initializes the user schema service and registers its routes.
-func Initialize(mux *http.ServeMux) UserSchemaServiceInterface {
-	userSchemaService := newUserSchemaService()
+func Initialize(
+	mux *http.ServeMux,
+	ouService oupkg.OrganizationUnitServiceInterface,
+) UserSchemaServiceInterface {
+	userSchemaService := newUserSchemaService(ouService)
 	userSchemaHandler := newUserSchemaHandler(userSchemaService)
 	registerRoutes(mux, userSchemaHandler)
 	return userSchemaService


### PR DESCRIPTION
### Purpose
This pull request enhances the user schema service by introducing validation to ensure organization units exist before creating or updating user schemas. It also refactors service initialization to inject dependencies and adds comprehensive tests for the new validation logic. These changes improve data integrity and error handling in the user schema workflow.

**User Schema Service Validation Enhancements:**

* Added a check in `CreateUserSchema` and `UpdateUserSchema` methods to validate that the referenced organization unit exists, using the organization unit service. If the organization unit does not exist or the validation fails, appropriate errors are returned. [[1]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaR112-R115) [[2]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaR209-R212) [[3]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaR356-R381)

**Dependency Injection and Initialization:**

* Refactored the initialization of the user schema service to accept an organization unit service as a dependency, ensuring the service can perform organization unit validations. This change propagates through the service manager and initialization logic. [[1]](diffhunk://#diff-43991b8ba4652e7fdc74d7c2b4d1884866b3ba59952d555bc439d33987b6323fR24-R33) [[2]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L53-R53) [[3]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaR27) [[4]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaR54-R61)

**Testing Improvements:**

* Added new unit tests in `service_test.go` to verify error scenarios when the organization unit is missing or when organization unit validation fails, covering both create and update operations.

