### PR TITLE
Fix setup scripts to include ou in user schema creation

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -102,6 +102,7 @@ log_info "Creating default user schema (person)..."
 
 RESPONSE=$(thunder_api_call POST "/user-schemas" '{
   "name": "person",
+  "ouId": "'${DEFAULT_OU_ID}'",
   "schema": {
     "sub": {
       "type": "string",

--- a/setup.sh
+++ b/setup.sh
@@ -345,19 +345,21 @@ else
 
     # Find scripts in main bootstrap directory (exclude common.sh)
     if [ -d "$BOOTSTRAP_DIR" ]; then
-        while IFS= read -r -d '' script; do
-            # Skip common.sh as it's a library, not a script to execute
-            if [[ "$(basename "$script")" != "common.sh" ]]; then
-                SCRIPTS+=("$script")
+        for script in "$BOOTSTRAP_DIR"/*.sh "$BOOTSTRAP_DIR"/*.bash; do
+            [ ! -e "$script" ] && continue
+            if [[ "$(basename "$script")" == "common.sh" ]]; then
+                continue
             fi
-        done < <(find -L "$BOOTSTRAP_DIR" -maxdepth 1 -type f \( -name "*.sh" -o -name "*.bash" \) -print0 2>/dev/null)
+            SCRIPTS+=("$script")
+        done
     fi
 
     # Find scripts in custom directory
     if [ -d "$BOOTSTRAP_DIR/custom" ]; then
-        while IFS= read -r -d '' script; do
+        for script in "$BOOTSTRAP_DIR/custom"/*.sh "$BOOTSTRAP_DIR/custom"/*.bash; do
+            [ ! -e "$script" ] && continue
             SCRIPTS+=("$script")
-        done < <(find -L "$BOOTSTRAP_DIR/custom" -maxdepth 1 -type f \( -name "*.sh" -o -name "*.bash" \) -print0 2>/dev/null)
+        done
     fi
 
     # Sort scripts by filename (numeric prefix determines order)


### PR DESCRIPTION
### Purpose
This pull request updates the bootstrap script logic to simplify how startup scripts are discovered and adds an organizational unit ID to the default user schema creation. The main improvements are in script discovery reliability and more explicit resource initialization.

**Bootstrap script discovery improvements:**

* Replaced the use of `find` and `read` loops with simpler `for` loops to enumerate `.sh` and `.bash` files, improving readability and reliability, and ensuring that `common.sh` is skipped as intended in `setup.sh`.
* Added checks to skip non-existent files during script enumeration, preventing errors if no matching scripts are present.

**Default resource initialization:**

* Modified the default user schema creation to explicitly include the organizational unit ID (`ouId`) in the API payload, ensuring the schema is properly associated with the correct organizational unit.