### PR TITLE
Improve user-schema UIs to include OU ID & allowSelfRegistration details

### DIFF
--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useCreateUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useCreateUserType.test.ts
@@ -42,6 +42,8 @@ describe('useCreateUserType', () => {
   const mockUserSchema: ApiUserSchema = {
     id: '123',
     name: 'TestUserType',
+    ouId: 'root-ou',
+    allowSelfRegistration: true,
     schema: {
       username: {
         type: 'string',
@@ -52,6 +54,8 @@ describe('useCreateUserType', () => {
 
   const mockRequest: CreateUserSchemaRequest = {
     name: 'TestUserType',
+    ouId: 'root-ou',
+    allowSelfRegistration: true,
     schema: {
       username: {
         type: 'string',

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserType.test.ts
@@ -43,6 +43,8 @@ describe('useGetUserType', () => {
   const mockUserSchema: ApiUserSchema = {
     id: '123',
     name: 'TestUserType',
+    ouId: 'root-ou',
+    allowSelfRegistration: true,
     schema: {
       username: {
         type: 'string',

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
@@ -45,8 +45,8 @@ describe('useGetUserTypes', () => {
     startIndex: 1,
     count: 2,
     schemas: [
-      {id: '123', name: 'UserType1'},
-      {id: '456', name: 'UserType2'},
+      {id: '123', name: 'UserType1', ouId: 'root-ou', allowSelfRegistration: false},
+      {id: '456', name: 'UserType2', ouId: 'child-ou', allowSelfRegistration: true},
     ],
     links: [
       {rel: 'self', href: 'https://localhost:8090/user-schemas'},

--- a/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
@@ -42,6 +42,8 @@ describe('useUpdateUserType', () => {
   const mockUserTypeId = '123';
   const mockRequest: UpdateUserSchemaRequest = {
     name: 'UpdatedUserType',
+    ouId: 'root-ou',
+    allowSelfRegistration: true,
     schema: {
       username: {
         type: 'string',
@@ -57,6 +59,8 @@ describe('useUpdateUserType', () => {
   const mockUserSchema: ApiUserSchema = {
     id: mockUserTypeId,
     name: 'UpdatedUserType',
+    ouId: 'root-ou',
+    allowSelfRegistration: true,
     schema: mockRequest.schema,
   };
 

--- a/frontend/apps/thunder-develop/src/features/user-types/components/UserTypesList.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/UserTypesList.tsx
@@ -35,6 +35,7 @@ import {
   DialogActions,
   Button,
   DataGrid,
+  Chip,
 } from '@wso2/oxygen-ui';
 import {EllipsisVertical, Trash2, Eye} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
@@ -142,6 +143,25 @@ export default function UserTypesList() {
       flex: 1,
       minWidth: 250,
       valueGetter: (_value, row) => row.id ?? null,
+    },
+    {
+      field: 'ouId',
+      headerName: t('userTypes:ouId'),
+      flex: 1,
+      minWidth: 220,
+      valueGetter: (_value, row) => row.ouId ?? null,
+    },
+    {
+      field: 'allowSelfRegistration',
+      headerName: t('userTypes:allowSelfRegistration'),
+      width: 200,
+      renderCell: (params: GridRenderCellParams<UserSchemaListItem>) => (
+        <Chip
+          label={params.row.allowSelfRegistration ? t('common:status.enabled') : t('common:status.disabled')}
+          color={params.row.allowSelfRegistration ? 'success' : 'default'}
+          size="small"
+        />
+      ),
     },
     {
       field: 'actions',

--- a/frontend/apps/thunder-develop/src/features/user-types/components/__tests__/UserTypesList.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/__tests__/UserTypesList.test.tsx
@@ -141,8 +141,8 @@ describe('UserTypesList', () => {
     startIndex: 1,
     count: 2,
     schemas: [
-      {id: 'schema1', name: 'Employee Schema'},
-      {id: 'schema2', name: 'Contractor Schema'},
+      {id: 'schema1', name: 'Employee Schema', ouId: 'root-ou', allowSelfRegistration: false},
+      {id: 'schema2', name: 'Contractor Schema', ouId: 'child-ou', allowSelfRegistration: true},
     ],
   };
 

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
@@ -21,7 +21,7 @@ import {screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import render from '@/test/test-utils';
 import ViewUserTypePage from '../ViewUserTypePage';
-import type {ApiUserSchema, ApiError} from '../../types/user-types';
+import type {ApiUserSchema, ApiError, UpdateUserSchemaRequest} from '../../types/user-types';
 
 const mockNavigate = vi.fn();
 const mockRefetch = vi.fn();
@@ -48,7 +48,7 @@ interface UseGetUserTypeReturn {
 }
 
 interface UseUpdateUserTypeReturn {
-  updateUserType: (id: string, data: {name: string; schema: Record<string, unknown>}) => Promise<void>;
+  updateUserType: (id: string, data: UpdateUserSchemaRequest) => Promise<void>;
   error: ApiError | null;
   reset: () => void;
 }
@@ -79,6 +79,8 @@ describe('ViewUserTypePage', () => {
   const mockUserType: ApiUserSchema = {
     id: 'schema-123',
     name: 'Employee Schema',
+    ouId: 'root-ou',
+    allowSelfRegistration: false,
     schema: {
       email: {
         type: 'string',
@@ -230,6 +232,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithEnum: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           status: {
             type: 'string',
@@ -255,6 +259,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithRegex: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           username: {
             type: 'string',
@@ -392,6 +398,8 @@ describe('ViewUserTypePage', () => {
       await waitFor(() => {
         expect(mockUpdateUserType).toHaveBeenCalledWith('schema-123', {
           name: 'Updated Schema',
+          ouId: 'root-ou',
+          allowSelfRegistration: false,
           schema: expect.any(Object) as Record<string, unknown>,
         });
         expect(mockRefetch).toHaveBeenCalledWith('schema-123');
@@ -443,6 +451,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithString: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           status: {
             type: 'string',
@@ -479,6 +489,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithEnum: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           status: {
             type: 'string',
@@ -515,6 +527,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithString: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           username: {
             type: 'string',
@@ -677,6 +691,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithString: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           status: {
             type: 'string',
@@ -710,6 +726,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithNumber: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           employeeId: {
             type: 'number',
@@ -743,6 +761,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithArray: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           tags: {
             type: 'array',
@@ -786,6 +806,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithObject: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           address: {
             type: 'object',
@@ -853,6 +875,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithString: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           status: {
             type: 'string',
@@ -896,6 +920,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithRegex: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           username: {
             type: 'string',
@@ -939,6 +965,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithString: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           status: {
             type: 'string',
@@ -979,6 +1007,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithString: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           status: {
             type: 'string',
@@ -1038,6 +1068,8 @@ describe('ViewUserTypePage', () => {
       const userTypeWithUniqueNumber: ApiUserSchema = {
         id: 'schema-123',
         name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
         schema: {
           employeeId: {
             type: 'number',

--- a/frontend/apps/thunder-develop/src/features/user-types/types/user-types.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/types/user-types.ts
@@ -102,6 +102,8 @@ export type UserSchemaDefinition = Record<string, PropertyDefinition>;
 export interface ApiUserSchema {
   id: string;
   name: string;
+  ouId: string;
+  allowSelfRegistration: boolean;
   schema: UserSchemaDefinition;
 }
 
@@ -111,6 +113,8 @@ export interface ApiUserSchema {
 export interface UserSchemaListItem {
   id: string;
   name: string;
+  ouId: string;
+  allowSelfRegistration: boolean;
 }
 
 /**
@@ -137,6 +141,8 @@ export interface UserSchemaListResponse {
  */
 export interface CreateUserSchemaRequest {
   name: string;
+  ouId: string;
+  allowSelfRegistration?: boolean;
   schema: UserSchemaDefinition;
 }
 
@@ -145,6 +151,8 @@ export interface CreateUserSchemaRequest {
  */
 export interface UpdateUserSchemaRequest {
   name: string;
+  ouId: string;
+  allowSelfRegistration?: boolean;
   schema: UserSchemaDefinition;
 }
 

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -352,6 +352,9 @@ const translations = {
     userTypeDetails: 'User Type Details',
     typeName: 'Type Name',
     typeNamePlaceholder: 'e.g., Employee, Customer, Partner',
+    ouId: 'Organization Unit ID',
+    ouIdPlaceholder: 'e.g., f47ac10b-58cc-4b77-9c42-1b48f9871f0b',
+    allowSelfRegistration: 'Allow Self Registration',
     description: 'Description',
     createDescription: 'Define a new user type schema for your organization',
     permissions: 'Permissions',
@@ -375,6 +378,7 @@ const translations = {
     },
     validationErrors: {
       nameRequired: 'Please enter a user type name',
+      ouIdRequired: 'Please provide an organization unit ID',
       propertiesRequired: 'Please add at least one property',
       duplicateProperties: 'Duplicate property names found: {{duplicates}}',
     },


### PR DESCRIPTION
### Purpose
This pull request adds support for two new fields—`ouId` (Organization Unit ID) and `allowSelfRegistration`—to the user type creation, update, viewing, and listing flows in the Thunder Develop frontend. The changes ensure these fields are included in the UI forms, API requests, and displayed in lists and detail views. Comprehensive test coverage is added and updated to validate the new functionality and required field checks.

**User Type API and UI Enhancements**

* Added `ouId` and `allowSelfRegistration` fields to user type creation, update, and retrieval requests, and ensured these fields are passed throughout the API layer and reflected in test mocks. [[1]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aL200-R226) [[2]](diffhunk://#diff-7c0d043671d36255ac9ee9bcdc76268a4ce2066b9ed5664adaace0d6b958aac8R45-R46) [[3]](diffhunk://#diff-7c0d043671d36255ac9ee9bcdc76268a4ce2066b9ed5664adaace0d6b958aac8R62-R63) [[4]](diffhunk://#diff-11ad1096f61ea274b9cee465af49a14139606dc13e160a1cd244be6e95487762R57-R58) [[5]](diffhunk://#diff-11ad1096f61ea274b9cee465af49a14139606dc13e160a1cd244be6e95487762R45-R46) [[6]](diffhunk://#diff-8c8ce6b89f8b515e40cfa5416495cb1ce9d41066d2cf4f6994585542d5b717f4R46-R47) [[7]](diffhunk://#diff-8160a8155cbda6417eb0e299d8f3d7dae0c2aeab75752edd5aa778f29c283490L48-R49) [[8]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6L40-R40)
* Updated the user type creation and update pages to include input fields for Organization Unit ID (with validation) and a checkbox for self-registration, and ensured these values are handled in state and submitted with the request. [[1]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aR154-R160) [[2]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aR291-R315) [[3]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R68-R69) [[4]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R89-R90) [[5]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R104-R105) [[6]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R201-R202)
* Modified the user types list and detail views to display the new `ouId` and `allowSelfRegistration` fields, using a chip to visually indicate self-registration status. [[1]](diffhunk://#diff-d64e8385cd877c3d9daa31bb3b027ec934441dd526bd7188d094e7a422a74a62R140-R158) [[2]](diffhunk://#diff-d64e8385cd877c3d9daa31bb3b027ec934441dd526bd7188d094e7a422a74a62R38) [[3]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R368-R409)
* Improved and extended test coverage for the new fields, including validation errors for missing organization unit ID, correct request payloads, and UI display of the new fields in both list and detail views. [[1]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6R172-R173) [[2]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6R185-R209) [[3]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6R397) [[4]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6R414) [[5]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6R429-R459) [[6]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6R523) [[7]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6R552) [[8]](diffhunk://#diff-9b0a313f5a5f8d33c6cf96bfde708fd85a23782f2ac53aa38c004295b78870c4L144-R145)
* Updated type definitions and imports to support the new fields and API request shape. [[1]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aL41-R56) [[2]](diffhunk://#diff-c7fc047318f03c28cc7aeb97f7a4fbe10c8b8ab04503dc10c2ba55e6d31150d6L24-R24)