### PR TITLE
Add userType and ou details to the oauth tokens

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -81,7 +81,7 @@ func registerServices(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) {
 	flowExecService := flowexec.Initialize(mux, flowMgtService, applicationService, execRegistry)
 
 	// Initialize OAuth services.
-	oauth.Initialize(mux, applicationService, userService, jwtService, flowExecService)
+	oauth.Initialize(mux, applicationService, userService, ouService, jwtService, flowExecService)
 
 	// TODO: Legacy way of initializing services. These need to be refactored in the future aligning to the
 	// dependency injection pattern used above.

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -32,6 +32,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/token"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/userinfo"
 	"github.com/asgardeo/thunder/internal/oauth/scope"
+	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/user"
 )
@@ -41,11 +42,13 @@ func Initialize(
 	mux *http.ServeMux,
 	applicationService application.ApplicationServiceInterface,
 	userService user.UserServiceInterface,
+	ouService ou.OrganizationUnitServiceInterface,
 	jwtService jwt.JWTServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 ) {
 	jwks.Initialize(mux)
-	grantHandlerProvider := granthandlers.Initialize(mux, jwtService, userService, applicationService, flowExecService)
+	grantHandlerProvider := granthandlers.Initialize(
+		mux, jwtService, userService, ouService, applicationService, flowExecService)
 	scopeValidator := scope.Initialize()
 	token.Initialize(mux, applicationService, grantHandlerProvider, scopeValidator)
 	introspect.Initialize(mux, jwtService)

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -263,6 +263,14 @@ const (
 	ClaimAuthTime string = "auth_time"
 )
 
+// Custom JWT claim names.
+const (
+	ClaimUserType string = "userType"
+	ClaimOUID     string = "ouId"
+	ClaimOUName   string = "ouName"
+	ClaimOUHandle string = "ouHandle"
+)
+
 // JWT signing algorithms.
 const (
 	SigningAlgorithmRS256 string = "RS256"

--- a/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
+++ b/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
@@ -34,6 +34,11 @@ type GrantHandlerInterface interface {
 // RefreshTokenGrantHandlerInterface defines the interface for handling refresh token grants.
 type RefreshTokenGrantHandlerInterface interface {
 	GrantHandlerInterface
-	IssueRefreshToken(tokenResponse *model.TokenResponseDTO, oauthApp *appmodel.OAuthAppConfigProcessedDTO,
-		subject string, audience string, grantType string, scopes []string) *model.ErrorResponse
+	IssueRefreshToken(
+		tokenResponse *model.TokenResponseDTO,
+		oauthApp *appmodel.OAuthAppConfigProcessedDTO,
+		subject, audience, grantType string,
+		scopes []string,
+		userType, ouID, ouName, ouHandle string,
+	) *model.ErrorResponse
 }

--- a/backend/internal/oauth/oauth2/granthandlers/init.go
+++ b/backend/internal/oauth/oauth2/granthandlers/init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/authz"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/user"
 )
@@ -34,11 +35,13 @@ func Initialize(
 	mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface,
 	userService user.UserServiceInterface,
+	ouService ou.OrganizationUnitServiceInterface,
 	applicationService application.ApplicationServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 ) GrantHandlerProviderInterface {
 	authzService := authz.Initialize(mux, applicationService, jwtService, flowExecService)
 	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService)
-	grantHandlerProvider := newGrantHandlerProvider(jwtService, userService, authzService, tokenBuilder, tokenValidator)
+	grantHandlerProvider := newGrantHandlerProvider(
+		jwtService, userService, ouService, authzService, tokenBuilder, tokenValidator)
 	return grantHandlerProvider
 }

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/authz"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
+	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/user"
 )
@@ -43,15 +44,18 @@ type GrantHandlerProvider struct {
 func newGrantHandlerProvider(
 	jwtService jwt.JWTServiceInterface,
 	userService user.UserServiceInterface,
+	ouService ou.OrganizationUnitServiceInterface,
 	authzService authz.AuthorizeServiceInterface,
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
 ) GrantHandlerProviderInterface {
 	return &GrantHandlerProvider{
 		clientCredentialsGrantHandler: newClientCredentialsGrantHandler(tokenBuilder),
-		authorizationCodeGrantHandler: newAuthorizationCodeGrantHandler(userService, authzService, tokenBuilder),
-		refreshTokenGrantHandler:      newRefreshTokenGrantHandler(jwtService, userService, tokenBuilder, tokenValidator),
-		tokenExchangeGrantHandler:     newTokenExchangeGrantHandler(tokenBuilder, tokenValidator),
+		authorizationCodeGrantHandler: newAuthorizationCodeGrantHandler(
+			userService, ouService, authzService, tokenBuilder),
+		refreshTokenGrantHandler: newRefreshTokenGrantHandler(
+			jwtService, userService, tokenBuilder, tokenValidator),
+		tokenExchangeGrantHandler: newTokenExchangeGrantHandler(tokenBuilder, tokenValidator),
 	}
 }
 

--- a/backend/internal/oauth/oauth2/granthandlers/provider_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/authzmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
+	"github.com/asgardeo/thunder/tests/mocks/oumock"
 	usersvcmock "github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
@@ -36,6 +37,7 @@ type GrantHandlerProviderTestSuite struct {
 	provider           GrantHandlerProviderInterface
 	mockJWTService     *jwtmock.JWTServiceInterfaceMock
 	mockUserService    *usersvcmock.UserServiceInterfaceMock
+	mockOUService      *oumock.OrganizationUnitServiceInterfaceMock
 	authzService       *authzmock.AuthorizeServiceInterfaceMock
 	mockTokenBuilder   *tokenservicemock.TokenBuilderInterfaceMock
 	mockTokenValidator *tokenservicemock.TokenValidatorInterfaceMock
@@ -48,12 +50,14 @@ func TestGrantHandlerProviderSuite(t *testing.T) {
 func (suite *GrantHandlerProviderTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
 	suite.authzService = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
 	suite.provider = newGrantHandlerProvider(
 		suite.mockJWTService,
 		suite.mockUserService,
+		suite.mockOUService,
 		suite.authzService,
 		suite.mockTokenBuilder,
 		suite.mockTokenValidator,
@@ -64,6 +68,7 @@ func (suite *GrantHandlerProviderTestSuite) TestNewGrantHandlerProvider() {
 	provider := newGrantHandlerProvider(
 		suite.mockJWTService,
 		suite.mockUserService,
+		suite.mockOUService,
 		suite.authzService,
 		suite.mockTokenBuilder,
 		suite.mockTokenValidator,

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -193,12 +193,13 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_InvalidSignature
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() {
 	// Mock token builder for refresh token generation
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(func(ctx *tokenservice.RefreshTokenBuildContext) bool {
-		return ctx.ClientID == "test-client-id" &&
-			ctx.GrantType == "authorization_code" &&
-			ctx.AccessTokenSubject == testRefreshTokenUserID &&
-			ctx.AccessTokenAudience == testRefreshTokenAudience
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
+			return ctx.ClientID == "test-client-id" &&
+				ctx.GrantType == "authorization_code" &&
+				ctx.AccessTokenSubject == testRefreshTokenUserID &&
+				ctx.AccessTokenAudience == testRefreshTokenAudience
+		})).Return(&model.TokenDTO{
 		Token:     "new.refresh.token",
 		TokenType: "",
 		IssuedAt:  int64(1234567890),
@@ -209,8 +210,9 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() 
 
 	tokenResponse := &model.TokenResponseDTO{}
 
-	err := suite.handler.IssueRefreshToken(tokenResponse, suite.oauthApp, testRefreshTokenUserID, testRefreshTokenAudience,
-		"authorization_code", []string{"read", "write"})
+	err := suite.handler.IssueRefreshToken(tokenResponse, suite.oauthApp,
+		testRefreshTokenUserID, testRefreshTokenAudience,
+		"authorization_code", []string{"read", "write"}, "", "", "", "")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), tokenResponse.RefreshToken)
@@ -230,7 +232,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_JWTGenerat
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(tokenResponse, suite.oauthApp, "", "",
-		"authorization_code", []string{"read"})
+		"authorization_code", []string{"read"}, "", "", "", "")
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
@@ -239,9 +241,10 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_JWTGenerat
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyTokenAttributes() {
 	// Mock token builder with matcher that checks for empty sub and aud
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(func(ctx *tokenservice.RefreshTokenBuildContext) bool {
-		return ctx.AccessTokenSubject == "" && ctx.AccessTokenAudience == ""
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
+			return ctx.AccessTokenSubject == "" && ctx.AccessTokenAudience == ""
+		})).Return(&model.TokenDTO{
 		Token:    "new.refresh.token",
 		IssuedAt: int64(1234567890),
 	}, nil)
@@ -249,7 +252,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyT
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(tokenResponse, suite.oauthApp, "", "",
-		"authorization_code", []string{"read"})
+		"authorization_code", []string{"read"}, "", "", "", "")
 
 	assert.Nil(suite.T(), err)
 }
@@ -267,11 +270,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testRefreshTokenUserID &&
-			ctx.ClientID == "test-client-id" &&
-			len(ctx.Scopes) == 1 && ctx.Scopes[0] == "read"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testRefreshTokenUserID &&
+				ctx.ClientID == "test-client-id" &&
+				len(ctx.Scopes) == 1 && ctx.Scopes[0] == "read"
+		})).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 3600,
@@ -312,10 +316,11 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	}, nil)
 
 	// Mock successful refresh token generation
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(func(ctx *tokenservice.RefreshTokenBuildContext) bool {
-		return ctx.AccessTokenSubject == testRefreshTokenUserID &&
-			ctx.AccessTokenAudience == testRefreshTokenAudience
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
+			return ctx.AccessTokenSubject == testRefreshTokenUserID &&
+				ctx.AccessTokenAudience == testRefreshTokenAudience
+		})).Return(&model.TokenDTO{
 		Token:     "new.refresh.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 86400,

--- a/backend/internal/oauth/oauth2/model/token.go
+++ b/backend/internal/oauth/oauth2/model/token.go
@@ -62,6 +62,10 @@ type TokenDTO struct {
 	UserAttributes map[string]interface{}
 	Subject        string
 	Audience       string
+	UserType       string
+	OuID           string
+	OuName         string
+	OuHandle       string
 }
 
 // TokenResponseDTO represents the data transfer object for token responses.

--- a/backend/internal/oauth/oauth2/token/token_handler.go
+++ b/backend/internal/oauth/oauth2/token/token_handler.go
@@ -187,7 +187,9 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 
 		refreshTokenError := refreshGrantHandlerTyped.IssueRefreshToken(tokenRespDTO, oauthApp,
 			tokenRespDTO.AccessToken.Subject, tokenRespDTO.AccessToken.Audience,
-			grantTypeStr, tokenRespDTO.AccessToken.Scopes)
+			grantTypeStr, tokenRespDTO.AccessToken.Scopes,
+			tokenRespDTO.AccessToken.UserType, tokenRespDTO.AccessToken.OuID,
+			tokenRespDTO.AccessToken.OuName, tokenRespDTO.AccessToken.OuHandle)
 		if refreshTokenError != nil && refreshTokenError.Error != "" {
 			utils.WriteJSONError(w, refreshTokenError.Error, refreshTokenError.ErrorDescription,
 				http.StatusInternalServerError, nil)

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -52,6 +52,10 @@ type AccessTokenBuildContext struct {
 	GrantType      string
 	OAuthApp       *appmodel.OAuthAppConfigProcessedDTO
 	ActorClaims    *SubjectTokenClaims
+	UserType       string
+	OuID           string
+	OuName         string
+	OuHandle       string
 }
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
@@ -63,6 +67,10 @@ type RefreshTokenBuildContext struct {
 	AccessTokenAudience  string
 	AccessTokenUserAttrs map[string]interface{}
 	OAuthApp             *appmodel.OAuthAppConfigProcessedDTO
+	UserType             string
+	OuID                 string
+	OuName               string
+	OuHandle             string
 }
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
@@ -74,6 +82,10 @@ type IDTokenBuildContext struct {
 	UserGroups     []string
 	AuthTime       int64
 	OAuthApp       *appmodel.OAuthAppConfigProcessedDTO
+	UserType       string
+	OuID           string
+	OuName         string
+	OuHandle       string
 }
 
 // RefreshTokenClaims represents the validated claims from a refresh token.
@@ -84,6 +96,10 @@ type RefreshTokenClaims struct {
 	Scopes         []string
 	UserAttributes map[string]interface{}
 	Iat            int64
+	UserType       string
+	OuID           string
+	OuName         string
+	OuHandle       string
 }
 
 // SubjectTokenClaims represents the validated claims from a subject token (for token exchange).

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -26,6 +26,7 @@ import (
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/user"
 )
@@ -257,31 +258,32 @@ func BuildOIDCClaimsFromScopes(
 }
 
 // FetchUserAttributesAndGroups fetches user attributes and groups from the user service.
-// It returns errors that callers should log with their own context.
+// It returns user attributes, user groups, user type, ouId, and an error if any.
+// Callers should log errors with their own context.
 func FetchUserAttributesAndGroups(
 	userService user.UserServiceInterface,
 	userID string,
 	includeGroups bool,
-) (map[string]interface{}, []string, error) {
+) (map[string]interface{}, []string, string, string, error) {
 	user, svcErr := userService.GetUser(userID)
 	if svcErr != nil {
-		return nil, nil, fmt.Errorf("failed to fetch user: %s", svcErr.Error)
+		return nil, nil, "", "", fmt.Errorf("failed to fetch user: %s", svcErr.Error)
 	}
 
 	var attrs map[string]interface{}
 	if user.Attributes != nil {
 		if err := json.Unmarshal(user.Attributes, &attrs); err != nil {
-			return nil, nil, fmt.Errorf("failed to unmarshal user attributes: %w", err)
+			return nil, nil, "", "", fmt.Errorf("failed to unmarshal user attributes: %w", err)
 		}
 	}
 
 	if !includeGroups {
-		return attrs, []string{}, nil
+		return attrs, []string{}, user.Type, user.OrganizationUnit, nil
 	}
 
 	groups, svcErr := userService.GetUserGroups(userID, constants.DefaultGroupListLimit, 0)
 	if svcErr != nil {
-		return nil, nil, fmt.Errorf("failed to fetch user groups: %s", svcErr.Error)
+		return nil, nil, "", "", fmt.Errorf("failed to fetch user groups: %s", svcErr.Error)
 	}
 
 	userGroups := make([]string, 0, len(groups.Groups))
@@ -289,5 +291,16 @@ func FetchUserAttributesAndGroups(
 		userGroups = append(userGroups, group.Name)
 	}
 
-	return attrs, userGroups, nil
+	return attrs, userGroups, user.Type, user.OrganizationUnit, nil
+}
+
+// FetchUserOU fetches the organization unit details for a given OU ID. It returns the OU details
+// and an error if any. Callers should log errors with their own context.
+func FetchUserOU(ouService ou.OrganizationUnitServiceInterface, ouID string) (*ou.OrganizationUnit, error) {
+	ouEntity, svcErr := ouService.GetOrganizationUnit(ouID)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to fetch organization unit: %s", svcErr.Error)
+	}
+
+	return &ouEntity, nil
 }

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 )
 
@@ -72,6 +73,12 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 		userAttributes = userAttrs
 	}
 
+	// Extract user type and organizational unit details if present
+	userType, _ := extractStringClaim(claims, constants.ClaimUserType)
+	ouID, _ := extractStringClaim(claims, constants.ClaimOUID)
+	ouName, _ := extractStringClaim(claims, constants.ClaimOUName)
+	ouHandle, _ := extractStringClaim(claims, constants.ClaimOUHandle)
+
 	return &RefreshTokenClaims{
 		Sub:            sub,
 		Aud:            aud,
@@ -79,6 +86,10 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 		Scopes:         scopes,
 		UserAttributes: userAttributes,
 		Iat:            iat,
+		UserType:       userType,
+		OuID:           ouID,
+		OuName:         ouName,
+		OuHandle:       ouHandle,
 	}, nil
 }
 

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -93,7 +93,7 @@ func (s *userInfoService) GetUserInfo(accessToken string) (map[string]interface{
 		oauthApp.Token.IDToken != nil &&
 		slices.Contains(oauthApp.Token.IDToken.UserAttributes, constants.UserAttributeGroups)
 
-	userAttributes, userGroups, err := tokenservice.FetchUserAttributesAndGroups(
+	userAttributes, userGroups, _, _, err := tokenservice.FetchUserAttributesAndGroups(
 		s.userService,
 		sub,
 		includeGroups,

--- a/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
@@ -108,16 +108,16 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_HandleGrant_Call) RunAndReturn(r
 }
 
 // IssueRefreshToken provides a mock function for the type RefreshTokenGrantHandlerInterfaceMock
-func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string) *model.ErrorResponse {
-	ret := _mock.Called(tokenResponse, oauthApp, subject, audience, grantType, scopes)
+func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, userType string, ouID string, ouName string, ouHandle string) *model.ErrorResponse {
+	ret := _mock.Called(tokenResponse, oauthApp, subject, audience, grantType, scopes, userType, ouID, ouName, ouHandle)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IssueRefreshToken")
 	}
 
 	var r0 *model.ErrorResponse
-	if returnFunc, ok := ret.Get(0).(func(*model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string) *model.ErrorResponse); ok {
-		r0 = returnFunc(tokenResponse, oauthApp, subject, audience, grantType, scopes)
+	if returnFunc, ok := ret.Get(0).(func(*model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string, string, string, string, string) *model.ErrorResponse); ok {
+		r0 = returnFunc(tokenResponse, oauthApp, subject, audience, grantType, scopes, userType, ouID, ouName, ouHandle)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ErrorResponse)
@@ -138,11 +138,15 @@ type RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call struct {
 //   - audience string
 //   - grantType string
 //   - scopes []string
-func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
-	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", tokenResponse, oauthApp, subject, audience, grantType, scopes)}
+//   - userType string
+//   - ouID string
+//   - ouName string
+//   - ouHandle string
+func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}, userType interface{}, ouID interface{}, ouName interface{}, ouHandle interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", tokenResponse, oauthApp, subject, audience, grantType, scopes, userType, ouID, ouName, ouHandle)}
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, userType string, ouID string, ouName string, ouHandle string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *model.TokenResponseDTO
 		if args[0] != nil {
@@ -168,6 +172,22 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 		if args[5] != nil {
 			arg5 = args[5].([]string)
 		}
+		var arg6 string
+		if args[6] != nil {
+			arg6 = args[6].(string)
+		}
+		var arg7 string
+		if args[7] != nil {
+			arg7 = args[7].(string)
+		}
+		var arg8 string
+		if args[8] != nil {
+			arg8 = args[8].(string)
+		}
+		var arg9 string
+		if args[9] != nil {
+			arg9 = args[9].(string)
+		}
 		run(
 			arg0,
 			arg1,
@@ -175,6 +195,10 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 			arg3,
 			arg4,
 			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
 		)
 	})
 	return _c
@@ -185,7 +209,7 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Return(e
 	return _c
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, userType string, ouID string, ouName string, ouHandle string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request introduces support for including user type and organizational unit (OU) details in OAuth2 access tokens, refresh tokens, and ID tokens. The changes propagate OU information through the token issuance flow, update service initialization to inject the OU service, and extend token models and claims to carry these new fields.

### Approach
**Integration of Organizational Unit (OU) and User Type Information:**

* Added new JWT claims for `userType`, `ouId`, `ouName`, and `ouHandle` in `constants.go`, and updated token models (`TokenDTO`) and builder logic to include these fields in access and refresh tokens. [[1]](diffhunk://#diff-68fc6075f5e8a7ea5d0a73f85fecdccdcba3269b653f5a7a9f032d6a70b3915eR266-R273) [[2]](diffhunk://#diff-81242b42b0efb0e4e76622bf7874d577c46cc2923c4172bf223993e29f45ee11R65-R68) [[3]](diffhunk://#diff-815bf1edba705536c891a9646b1c671ba6dab8784ab6837faf333400ff9c6fc7R61-R90) [[4]](diffhunk://#diff-815bf1edba705536c891a9646b1c671ba6dab8784ab6837faf333400ff9c6fc7R208-R235)
* The authorization code grant handler now fetches OU details and user type, sets them in the token build context, and includes them in issued tokens and ID tokens if available. [[1]](diffhunk://#diff-353c0ae473a7f38190e1aacc728880e021da05be2fb9ceedfd844e378bee7c9eL138-R142) [[2]](diffhunk://#diff-353c0ae473a7f38190e1aacc728880e021da05be2fb9ceedfd844e378bee7c9eL164-R199) [[3]](diffhunk://#diff-353c0ae473a7f38190e1aacc728880e021da05be2fb9ceedfd844e378bee7c9eL179-R236)
* The refresh token grant handler and its interface are updated to support passing and storing user type and OU details when issuing new refresh tokens. [[1]](diffhunk://#diff-8786bac9b527eb260e6fdc83592efdb46b63767bbc71ce53a046c3c0d52c1277L37-R43) [[2]](diffhunk://#diff-19ce85dd7746918fa4de5ae1d38f3b703437b0310170c484c773917ab57a67adR108-R111) [[3]](diffhunk://#diff-19ce85dd7746918fa4de5ae1d38f3b703437b0310170c484c773917ab57a67adL130-R136) [[4]](diffhunk://#diff-19ce85dd7746918fa4de5ae1d38f3b703437b0310170c484c773917ab57a67adL150-R188)

**Service Initialization and Dependency Injection:**

* Updated service initialization in `servicemanager.go`, `init.go`, and grant handler provider logic to inject the OU service where required, enabling handlers to fetch organizational unit information. [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L84-R84) [[2]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4R35) [[3]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4R45-R51) [[4]](diffhunk://#diff-838c1f5c81b14a0b50875260562450b7c28ff52c60ab58cfec8caa8fd9bf8d31R28) [[5]](diffhunk://#diff-838c1f5c81b14a0b50875260562450b7c28ff52c60ab58cfec8caa8fd9bf8d31R38-R45) [[6]](diffhunk://#diff-142a1e42dbc54aeb7ed490852ed61943e0aedd860ec1bf1da2039037348e5bc6R25) [[7]](diffhunk://#diff-142a1e42dbc54aeb7ed490852ed61943e0aedd860ec1bf1da2039037348e5bc6R47-R57)

**Token Handling and Propagation:**

* Modified token handler logic to pass user type and OU details when issuing refresh tokens, ensuring these fields are preserved across token renewals.
* Refactored token builder methods to construct and populate token DTOs with the new fields, and append them to JWT claims if present. [[1]](diffhunk://#diff-815bf1edba705536c891a9646b1c671ba6dab8784ab6837faf333400ff9c6fc7L72-R106) [[2]](diffhunk://#diff-815bf1edba705536c891a9646b1c671ba6dab8784ab6837faf333400ff9c6fc7L195-R251)

These changes collectively ensure that user type and organizational unit information are consistently managed and propagated throughout the OAuth2 token lifecycle.

### Related Issues
- https://github.com/asgardeo/thunder/issues/772

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
