### PR TITLE
Enforce validation of the ou id of the users

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -84,49 +84,52 @@ Write-Host ""
 
 Log-Info "Creating default user schema (person)..."
 
-$response = Invoke-ThunderApi -Method POST -Endpoint "/user-schemas" -Data '{
-  "name": "person",
-  "schema": {
-    "sub": {
-      "type": "string",
-      "required": true,
-      "unique": true
-    },
-    "email": {
-      "type": "string",
-      "required": true,
-      "unique": true
-    },
-    "email_verified": {
-      "type": "boolean",
-      "required": false
-    },
-    "name": {
-      "type": "string",
-      "required": false
-    },
-    "given_name": {
-      "type": "string",
-      "required": false
-    },
-    "family_name": {
-      "type": "string",
-      "required": false
-    },
-    "picture": {
-      "type": "string",
-      "required": false
-    },
-    "phone_number": {
-      "type": "string",
-      "required": false
-    },
-    "phone_number_verified": {
-      "type": "boolean",
-      "required": false
+$userSchemaData = ([ordered]@{
+    name = "person"
+    ouId = $DEFAULT_OU_ID
+    schema = [ordered]@{
+        sub = @{
+            type = "string"
+            required = $true
+            unique = $true
+        }
+        email = @{
+            type = "string"
+            required = $true
+            unique = $true
+        }
+        email_verified = @{
+            type = "boolean"
+            required = $false
+        }
+        name = @{
+            type = "string"
+            required = $false
+        }
+        given_name = @{
+            type = "string"
+            required = $false
+        }
+        family_name = @{
+            type = "string"
+            required = $false
+        }
+        picture = @{
+            type = "string"
+            required = $false
+        }
+        phone_number = @{
+            type = "string"
+            required = $false
+        }
+        phone_number_verified = @{
+            type = "boolean"
+            required = $false
+        }
     }
-  }
-}'
+} | ConvertTo-Json -Depth 5)
+
+$response = Invoke-ThunderApi -Method POST -Endpoint "/user-schemas" -Data $userSchemaData
 
 if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     Log-Success "User schema created successfully"
@@ -147,22 +150,25 @@ Write-Host ""
 
 Log-Info "Creating admin user..."
 
-$response = Invoke-ThunderApi -Method POST -Endpoint "/users" -Data '{
-  "type": "person",
-  "attributes": {
-    "username": "admin",
-    "password": "admin",
-    "sub": "admin",
-    "email": "admin@thunder.dev",
-    "email_verified": true,
-    "name": "Administrator",
-    "given_name": "Admin",
-    "family_name": "User",
-    "picture": "https://example.com/avatar.jpg",
-    "phone_number": "+12345678920",
-    "phone_number_verified": true
-  }
-}'
+$adminUserData = ([ordered]@{
+    type = "person"
+    organizationUnit = $DEFAULT_OU_ID
+    attributes = @{
+        username = "admin"
+        password = "admin"
+        sub = "admin"
+        email = "admin@thunder.dev"
+        email_verified = $true
+        name = "Administrator"
+        given_name = "Admin"
+        family_name = "User"
+        picture = "https://example.com/avatar.jpg"
+        phone_number = "+12345678920"
+        phone_number_verified = $true
+    }
+} | ConvertTo-Json -Depth 5)
+
+$response = Invoke-ThunderApi -Method POST -Endpoint "/users" -Data $adminUserData
 
 if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     Log-Success "Admin user created successfully"

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -166,6 +166,7 @@ log_info "Creating admin user..."
 
 RESPONSE=$(thunder_api_call POST "/users" '{
   "type": "person",
+  "organizationUnit": "'${DEFAULT_OU_ID}'",
   "attributes": {
     "username": "admin",
     "password": "admin",

--- a/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
+++ b/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
@@ -916,6 +916,74 @@ func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call) Ru
 	return _c
 }
 
+// IsParent provides a mock function for the type OrganizationUnitServiceInterfaceMock
+func (_mock *OrganizationUnitServiceInterfaceMock) IsParent(parentID string, childID string) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(parentID, childID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsParent")
+	}
+
+	var r0 bool
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string, string) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(parentID, childID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string) bool); ok {
+		r0 = returnFunc(parentID, childID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(parentID, childID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OrganizationUnitServiceInterfaceMock_IsParent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsParent'
+type OrganizationUnitServiceInterfaceMock_IsParent_Call struct {
+	*mock.Call
+}
+
+// IsParent is a helper method to define mock.On call
+//   - parentID string
+//   - childID string
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsParent(parentID interface{}, childID interface{}) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	return &OrganizationUnitServiceInterfaceMock_IsParent_Call{Call: _e.mock.On("IsParent", parentID, childID)}
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsParent_Call) Run(run func(parentID string, childID string)) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsParent_Call) Return(b bool, serviceError *serviceerror.ServiceError) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	_c.Call.Return(b, serviceError)
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsParent_Call) RunAndReturn(run func(parentID string, childID string) (bool, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateOrganizationUnit provides a mock function for the type OrganizationUnitServiceInterfaceMock
 func (_mock *OrganizationUnitServiceInterfaceMock) UpdateOrganizationUnit(id string, request OrganizationUnitRequest) (OrganizationUnit, *serviceerror.ServiceError) {
 	ret := _mock.Called(id, request)

--- a/backend/internal/user/errorconstants.go
+++ b/backend/internal/user/errorconstants.go
@@ -145,6 +145,20 @@ var (
 		Error:            "User schema not found",
 		ErrorDescription: "The specified user schema does not exist",
 	}
+	// ErrorInvalidOrganizationUnitID is returned when the organization unit ID is missing or malformed.
+	ErrorInvalidOrganizationUnitID = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "USR-1022",
+		Error:            "Invalid organization unit",
+		ErrorDescription: "Organization unit id must be specified as a valid UUID",
+	}
+	// ErrorOrganizationUnitMismatch is returned when the organization unit does not match the user type definition.
+	ErrorOrganizationUnitMismatch = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "USR-1023",
+		Error:            "Organization unit mismatch",
+		ErrorDescription: "The organization unit does not match the user type configuration",
+	}
 )
 
 // Server errors for user management operations.

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -25,280 +25,645 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	oupkg "github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/userschema"
+	"github.com/asgardeo/thunder/tests/mocks/oumock"
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
-func TestValidateUserAndUniquenessReturnsInternalErrorWhenSchemaValidationFails(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+const testUserType = "employee"
 
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(false, &serviceerror.ServiceError{
-			Code:  "USRS-5000",
-			Type:  serviceerror.ServerErrorType,
-			Error: "schema validation failed",
+func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
+	type testMocks struct {
+		schemaService *userschemamock.UserSchemaServiceInterfaceMock
+		userStore     *userStoreInterfaceMock
+	}
+
+	payloadWithEmail := []byte(`{"email":"employee@example.com"}`)
+	emptyPayload := []byte(`{}`)
+
+	testCases := []struct {
+		name    string
+		payload []byte
+		setup   func(t *testing.T) (*userService, testMocks)
+		assert  func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks)
+	}{
+		{
+			name:    "ReturnsInternalErrorWhenSchemaValidationFails",
+			payload: payloadWithEmail,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(false, &serviceerror.ServiceError{
+						Code:  "USRS-5000",
+						Type:  serviceerror.ServerErrorType,
+						Error: "schema validation failed",
+					}).
+					Once()
+
+				return &userService{
+					userSchemaService: schemaMock,
+				}, testMocks{schemaService: schemaMock}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorInternalServerError.Code, err.Code)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name:    "ReturnsUserSchemaNotFoundWhenSchemaMissing",
+			payload: emptyPayload,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(false, &userschema.ErrorUserSchemaNotFound).
+					Once()
+
+				return &userService{
+					userSchemaService: schemaMock,
+				}, testMocks{schemaService: schemaMock}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorUserSchemaNotFound, *err)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name:    "ReturnsInternalErrorWhenSchemaLookupFails",
+			payload: emptyPayload,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(false, &serviceerror.ServiceError{
+						Code:  "USRS-5000",
+						Type:  serviceerror.ServerErrorType,
+						Error: "unexpected error",
+					}).
+					Once()
+
+				return &userService{
+					userSchemaService: schemaMock,
+				}, testMocks{schemaService: schemaMock}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorInternalServerError, *err)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name:    "ReturnsSchemaValidationFailed",
+			payload: payloadWithEmail,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(false, nil).
+					Once()
+
+				return &userService{
+					userSchemaService: schemaMock,
+				}, testMocks{schemaService: schemaMock}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorSchemaValidationFailed, *err)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name:    "ReturnsInternalErrorWhenUniquenessValidationFails",
+			payload: payloadWithEmail,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(true, nil).
+					Once()
+				schemaMock.
+					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					Return(false, &serviceerror.ServiceError{
+						Code:  "USRS-5000",
+						Type:  serviceerror.ServerErrorType,
+						Error: "validation failed",
+					}).
+					Once()
+
+				return &userService{
+					userSchemaService: schemaMock,
+				}, testMocks{schemaService: schemaMock}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorInternalServerError, *err)
+			},
+		},
+		{
+			name:    "ReturnsUserSchemaNotFoundWhenUniquenessSchemaMissing",
+			payload: payloadWithEmail,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(true, nil).
+					Once()
+				schemaMock.
+					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					Return(false, &userschema.ErrorUserSchemaNotFound).
+					Once()
+
+				return &userService{
+					userSchemaService: schemaMock,
+				}, testMocks{schemaService: schemaMock}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorUserSchemaNotFound, *err)
+			},
+		},
+		{
+			name:    "ReturnsAttributeConflictWhenUniquenessCheckFails",
+			payload: payloadWithEmail,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				existingUserID := "user-123"
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userStoreMock := newUserStoreInterfaceMock(t)
+				userStoreMock.
+					On("IdentifyUser", mock.AnythingOfType("map[string]interface {}")).
+					Return(&existingUserID, nil).
+					Once()
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(true, nil).
+					Once()
+				schemaMock.
+					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						identify := args.Get(2).(func(map[string]interface{}) (*string, error))
+
+						id, err := identify(map[string]interface{}{"email": "employee@example.com"})
+						require.NoError(t, err)
+						require.NotNil(t, id)
+						require.Equal(t, existingUserID, *id)
+					}).
+					Return(false, nil).
+					Once()
+
+				return &userService{
+						userSchemaService: schemaMock,
+						userStore:         userStoreMock,
+					}, testMocks{
+						schemaService: schemaMock,
+						userStore:     userStoreMock,
+					}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorAttributeConflict, *err)
+			},
+		},
+		{
+			name:    "ReturnsNilWhenValidationSucceeds",
+			payload: payloadWithEmail,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userStoreMock := newUserStoreInterfaceMock(t)
+				userStoreMock.
+					On("IdentifyUser", mock.AnythingOfType("map[string]interface {}")).
+					Return((*string)(nil), nil).
+					Once()
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(true, nil).
+					Once()
+				schemaMock.
+					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						identify := args.Get(2).(func(map[string]interface{}) (*string, error))
+
+						id, err := identify(map[string]interface{}{"email": "employee@example.com"})
+						require.NoError(t, err)
+						require.Nil(t, id)
+					}).
+					Return(true, nil).
+					Once()
+
+				return &userService{
+						userSchemaService: schemaMock,
+						userStore:         userStoreMock,
+					}, testMocks{
+						schemaService: schemaMock,
+						userStore:     userStoreMock,
+					}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.Nil(t, err)
+			},
+		},
+		{
+			name:    "ReturnsInternalErrorWhenIdentifyFails",
+			payload: payloadWithEmail,
+			setup: func(t *testing.T) (*userService, testMocks) {
+				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userStoreMock := newUserStoreInterfaceMock(t)
+				userStoreMock.
+					On("IdentifyUser", mock.AnythingOfType("map[string]interface {}")).
+					Return((*string)(nil), errors.New("store failure")).
+					Once()
+				schemaMock.
+					On("ValidateUser", testUserType, mock.Anything).
+					Return(true, nil).
+					Once()
+				schemaMock.
+					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						identify := args.Get(2).(func(map[string]interface{}) (*string, error))
+
+						id, err := identify(map[string]interface{}{"email": "employee@example.com"})
+						require.Error(t, err)
+						require.Nil(t, id)
+					}).
+					Return(false, &serviceerror.ServiceError{
+						Code:  "USRS-5000",
+						Type:  serviceerror.ServerErrorType,
+						Error: "validation failed",
+					}).
+					Once()
+
+				return &userService{
+						userSchemaService: schemaMock,
+						userStore:         userStoreMock,
+					}, testMocks{
+						schemaService: schemaMock,
+						userStore:     userStoreMock,
+					}
+			},
+			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
+				require.NotNil(t, err)
+				require.Equal(t, ErrorInternalServerError, *err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			service, mocks := tc.setup(t)
+			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
+
+			err := service.validateUserAndUniqueness(testUserType, tc.payload, logger)
+			tc.assert(t, err, mocks)
+		})
+	}
+}
+
+func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
+	type testMocks struct {
+		ouService         *oumock.OrganizationUnitServiceInterfaceMock
+		userSchemaService *userschemamock.UserSchemaServiceInterfaceMock
+	}
+
+	testCases := []struct {
+		name        string
+		userType    string
+		ouID        string
+		setup       func(t *testing.T) (*userService, testMocks)
+		expectedErr *serviceerror.ServiceError
+	}{
+		{
+			name:     "ReturnsErrorWhenIDEmpty",
+			userType: testUserType,
+			ouID:     "",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				return &userService{}, testMocks{}
+			},
+			expectedErr: &ErrorInvalidOrganizationUnitID,
+		},
+		{
+			name:     "ReturnsErrorWhenIDInvalid",
+			userType: testUserType,
+			ouID:     "invalid-id",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				return &userService{}, testMocks{}
+			},
+			expectedErr: &ErrorInvalidOrganizationUnitID,
+		},
+		{
+			name:     "ReturnsErrorWhenOrganizationUnitMissing",
+			userType: testUserType,
+			ouID:     "4d8b40d6-3a17-4c19-9a94-5866df9b6bf5",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"4d8b40d6-3a17-4c19-9a94-5866df9b6bf5").Return(false, (*serviceerror.ServiceError)(nil)).Once()
+
+				return &userService{
+						ouService: ouServiceMock,
+					}, testMocks{
+						ouService: ouServiceMock,
+					}
+			},
+			expectedErr: &ErrorOrganizationUnitNotFound,
+		},
+		{
+			name:     "HandlesClientErrorWhenOrganizationUnitMissing",
+			userType: testUserType,
+			ouID:     "6c8f5afd-8884-4ea0-a317-3d8579346d86",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"6c8f5afd-8884-4ea0-a317-3d8579346d86").Return(false, &serviceerror.ServiceError{
+					Type: serviceerror.ClientErrorType,
+					Code: oupkg.ErrorOrganizationUnitNotFound.Code,
+				}).Once()
+
+				return &userService{
+						ouService: ouServiceMock,
+					}, testMocks{
+						ouService: ouServiceMock,
+					}
+			},
+			expectedErr: &ErrorOrganizationUnitNotFound,
+		},
+		{
+			name:     "HandlesClientErrorWhenOrganizationUnitIDInvalid",
+			userType: testUserType,
+			ouID:     "8d0c2f4e-8bb1-40bc-a0e1-ca5c4aacff63",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"8d0c2f4e-8bb1-40bc-a0e1-ca5c4aacff63").Return(false, &serviceerror.ServiceError{
+					Type: serviceerror.ClientErrorType,
+					Code: oupkg.ErrorInvalidRequestFormat.Code,
+				}).Once()
+
+				return &userService{
+						ouService: ouServiceMock,
+					}, testMocks{
+						ouService: ouServiceMock,
+					}
+			},
+			expectedErr: &ErrorInvalidOrganizationUnitID,
+		},
+		{
+			name:     "ReturnsMismatchWhenSchemaDoesNotMatchOU",
+			userType: testUserType,
+			ouID:     "f4e7c7b2-0b11-46a4-83be-4b43a7f69c7e",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				parentOU := "a88cbecc-53a3-4c3e-958f-7ee4bf2d7a28"
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"f4e7c7b2-0b11-46a4-83be-4b43a7f69c7e").Return(true, (*serviceerror.ServiceError)(nil)).Once()
+				ouServiceMock.
+					On("IsParent", parentOU, "f4e7c7b2-0b11-46a4-83be-4b43a7f69c7e").
+					Return(false, (*serviceerror.ServiceError)(nil)).
+					Once()
+
+				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userSchemaMock.
+					On("GetUserSchemaByName", testUserType).
+					Return(&userschema.UserSchema{
+						OrganizationUnitID: parentOU,
+					}, (*serviceerror.ServiceError)(nil)).
+					Once()
+
+				return &userService{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}, testMocks{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}
+			},
+			expectedErr: &ErrorOrganizationUnitMismatch,
+		},
+		{
+			name:     "AllowsChildOrganizationUnit",
+			userType: testUserType,
+			ouID:     "1b5c7208-0d6f-4d5d-8fb9-6e8573549533",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				parentOU := "c7e99c3b-e563-4c47-981f-1f7f755c8c68"
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"1b5c7208-0d6f-4d5d-8fb9-6e8573549533").Return(true, (*serviceerror.ServiceError)(nil)).Once()
+				ouServiceMock.On("IsParent", parentOU,
+					"1b5c7208-0d6f-4d5d-8fb9-6e8573549533").Return(true, (*serviceerror.ServiceError)(nil)).Once()
+
+				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userSchemaMock.
+					On("GetUserSchemaByName", testUserType).
+					Return(&userschema.UserSchema{
+						OrganizationUnitID: parentOU,
+					}, (*serviceerror.ServiceError)(nil)).
+					Once()
+
+				return &userService{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}, testMocks{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "HandlesParentCheckErrorsOrganizationUnitNotFound",
+			userType: testUserType,
+			ouID:     "d9e12416-58d3-4c17-a4e4-cc4d96122598",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				parentOU := "0a08d914-d223-48c2-8939-55d719739a17"
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"d9e12416-58d3-4c17-a4e4-cc4d96122598").Return(true, (*serviceerror.ServiceError)(nil)).Once()
+				ouServiceMock.On("IsParent", parentOU,
+					"d9e12416-58d3-4c17-a4e4-cc4d96122598").Return(false, &serviceerror.ServiceError{
+					Code: oupkg.ErrorOrganizationUnitNotFound.Code,
+				}).Once()
+
+				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userSchemaMock.
+					On("GetUserSchemaByName", testUserType).
+					Return(&userschema.UserSchema{
+						OrganizationUnitID: parentOU,
+					}, (*serviceerror.ServiceError)(nil)).
+					Once()
+
+				return &userService{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}, testMocks{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}
+			},
+			expectedErr: &ErrorOrganizationUnitNotFound,
+		},
+		{
+			name:     "HandlesParentCheckErrorsInternalServerError",
+			userType: testUserType,
+			ouID:     "d9e12416-58d3-4c17-a4e4-cc4d96122598",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				parentOU := "0a08d914-d223-48c2-8939-55d719739a17"
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"d9e12416-58d3-4c17-a4e4-cc4d96122598").Return(true, (*serviceerror.ServiceError)(nil)).Once()
+				ouServiceMock.On("IsParent", parentOU,
+					"d9e12416-58d3-4c17-a4e4-cc4d96122598").Return(false, &serviceerror.ServiceError{
+					Code: oupkg.ErrorInternalServerError.Code,
+				}).Once()
+
+				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userSchemaMock.
+					On("GetUserSchemaByName", testUserType).
+					Return(&userschema.UserSchema{
+						OrganizationUnitID: parentOU,
+					}, (*serviceerror.ServiceError)(nil)).
+					Once()
+
+				return &userService{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}, testMocks{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}
+			},
+			expectedErr: &ErrorInternalServerError,
+		},
+		{
+			name:     "ReturnsNilWhenValid",
+			userType: testUserType,
+			ouID:     "e5c3aa8a-d7df-46f8-9f3f-bb3245c95d7c",
+			setup: func(t *testing.T) (*userService, testMocks) {
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.On("IsOrganizationUnitExists",
+					"e5c3aa8a-d7df-46f8-9f3f-bb3245c95d7c").Return(true, (*serviceerror.ServiceError)(nil)).Once()
+
+				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+				userSchemaMock.
+					On("GetUserSchemaByName", testUserType).
+					Return(&userschema.UserSchema{
+						OrganizationUnitID: "e5c3aa8a-d7df-46f8-9f3f-bb3245c95d7c",
+					}, (*serviceerror.ServiceError)(nil)).
+					Once()
+
+				return &userService{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}, testMocks{
+						ouService:         ouServiceMock,
+						userSchemaService: userSchemaMock,
+					}
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			service, _ := tc.setup(t)
+			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
+
+			err := service.validateOrganizationUnitForUserType(tc.userType, tc.ouID, logger)
+			if tc.expectedErr == nil {
+				require.Nil(t, err)
+				return
+			}
+
+			require.NotNil(t, err)
+			require.Equal(t, *tc.expectedErr, *err)
+		})
+	}
+}
+
+func TestUserService_GetUsersByPath_HandlesOUServiceErrors(t *testing.T) {
+	testCases := []struct {
+		name        string
+		setup       func(t *testing.T) *userService
+		expectedErr *serviceerror.ServiceError
+	}{
+		{
+			name: "ReturnsInvalidHandlePathWhenResolverFails",
+			setup: func(t *testing.T) *userService {
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.
+					On("GetOrganizationUnitByPath", "root").
+					Return(oupkg.OrganizationUnit{}, &serviceerror.ServiceError{
+						Type: serviceerror.ClientErrorType,
+						Code: oupkg.ErrorInvalidHandlePath.Code,
+					}).
+					Once()
+
+				return &userService{
+					ouService: ouServiceMock,
+				}
+			},
+			expectedErr: &ErrorInvalidHandlePath,
+		},
+		{
+			name: "ReturnsInvalidLimitWhenListingUsersFails",
+			setup: func(t *testing.T) *userService {
+				ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+				ouServiceMock.
+					On("GetOrganizationUnitByPath", "root").
+					Return(oupkg.OrganizationUnit{ID: "ou-id"}, (*serviceerror.ServiceError)(nil)).
+					Once()
+				ouServiceMock.
+					On("GetOrganizationUnitUsers", "ou-id", 10, 0).
+					Return((*oupkg.UserListResponse)(nil), &serviceerror.ServiceError{
+						Type: serviceerror.ClientErrorType,
+						Code: oupkg.ErrorInvalidLimit.Code,
+					}).
+					Once()
+
+				return &userService{
+					ouService: ouServiceMock,
+				}
+			},
+			expectedErr: &ErrorInvalidLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			service := tc.setup(t)
+
+			resp, err := service.GetUsersByPath("root", 10, 0, nil)
+			require.Nil(t, resp)
+			require.NotNil(t, err)
+			require.Equal(t, *tc.expectedErr, *err)
+		})
+	}
+}
+
+func TestUserService_CreateUserByPath_HandlesOUServiceErrors(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.
+		On("GetOrganizationUnitByPath", "root/engineering").
+		Return(oupkg.OrganizationUnit{}, &serviceerror.ServiceError{
+			Type: serviceerror.ClientErrorType,
+			Code: oupkg.ErrorInvalidHandlePath.Code,
 		}).
 		Once()
 
 	service := &userService{
-		userSchemaService: mockSchemaService,
+		ouService: ouServiceMock,
 	}
 
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{"email":"employee@example.com"}`), logger)
-
+	resp, err := service.CreateUserByPath("root/engineering", CreateUserByPathRequest{
+		Type: testUserType,
+	})
+	require.Nil(t, resp)
 	require.NotNil(t, err)
-	require.Equal(t, ErrorInternalServerError.Code, err.Code)
-
-	mockSchemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
-}
-
-func TestValidateUserAndUniquenessReturnsUserSchemaNotFoundWhenSchemaMissing(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(false, &userschema.ErrorUserSchemaNotFound).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{}`), logger)
-
-	require.NotNil(t, err)
-	require.Equal(t, ErrorUserSchemaNotFound, *err)
-
-	mockSchemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
-}
-
-func TestValidateUserAndUniquenessReturnsInternalErrorWhenSchemaLookupFails(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(false, &serviceerror.ServiceError{
-			Code:  "USRS-5000",
-			Type:  serviceerror.ServerErrorType,
-			Error: "unexpected error",
-		}).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{}`), logger)
-
-	require.NotNil(t, err)
-	require.Equal(t, ErrorInternalServerError, *err)
-
-	mockSchemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
-}
-
-func TestValidateUserAndUniquenessReturnsSchemaValidationFailed(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(false, nil).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{"email":"employee@example.com"}`), logger)
-
-	require.NotNil(t, err)
-	require.Equal(t, ErrorSchemaValidationFailed, *err)
-
-	mockSchemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
-}
-
-func TestValidateUserAndUniquenessReturnsInternalErrorWhenUniquenessValidationFails(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(true, nil).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUserUniqueness", "employee", mock.Anything, mock.Anything).
-		Return(false, &serviceerror.ServiceError{
-			Code:  "USRS-5000",
-			Type:  serviceerror.ServerErrorType,
-			Error: "validation failed",
-		}).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{"email":"employee@example.com"}`), logger)
-
-	require.NotNil(t, err)
-	require.Equal(t, ErrorInternalServerError, *err)
-}
-
-func TestValidateUserAndUniquenessReturnsUserSchemaNotFoundWhenUniquenessSchemaMissing(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(true, nil).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUserUniqueness", "employee", mock.Anything, mock.Anything).
-		Return(false, &userschema.ErrorUserSchemaNotFound).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{"email":"employee@example.com"}`), logger)
-
-	require.NotNil(t, err)
-	require.Equal(t, ErrorUserSchemaNotFound, *err)
-}
-
-func TestValidateUserAndUniquenessReturnsAttributeConflictWhenUniquenessCheckFails(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	existingUserID := "user-123"
-	userStoreMock := newUserStoreInterfaceMock(t)
-	userStoreMock.
-		On("IdentifyUser", mock.AnythingOfType("map[string]interface {}")).
-		Return(&existingUserID, nil).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(true, nil).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUserUniqueness", "employee", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			identify := args.Get(2).(func(map[string]interface{}) (*string, error))
-
-			id, err := identify(map[string]interface{}{"email": "employee@example.com"})
-			require.NoError(t, err)
-			require.NotNil(t, id)
-			require.Equal(t, existingUserID, *id)
-		}).
-		Return(false, nil).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-		userStore:         userStoreMock,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{"email":"employee@example.com"}`), logger)
-
-	require.NotNil(t, err)
-	require.Equal(t, ErrorAttributeConflict, *err)
-}
-
-func TestValidateUserAndUniquenessReturnsNilWhenValidationSucceeds(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	userStoreMock := newUserStoreInterfaceMock(t)
-	userStoreMock.
-		On("IdentifyUser", mock.AnythingOfType("map[string]interface {}")).
-		Return((*string)(nil), nil).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(true, nil).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUserUniqueness", "employee", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			identify := args.Get(2).(func(map[string]interface{}) (*string, error))
-
-			id, err := identify(map[string]interface{}{"email": "employee@example.com"})
-			require.NoError(t, err)
-			require.Nil(t, id)
-		}).
-		Return(true, nil).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-		userStore:         userStoreMock,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{"email":"employee@example.com"}`), logger)
-
-	require.Nil(t, err)
-}
-
-func TestValidateUserAndUniquenessReturnsInternalErrorWhenIdentifyFails(t *testing.T) {
-	mockSchemaService := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-
-	userStoreMock := newUserStoreInterfaceMock(t)
-	userStoreMock.
-		On("IdentifyUser", mock.AnythingOfType("map[string]interface {}")).
-		Return((*string)(nil), errors.New("store failure")).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUser", "employee", mock.Anything).
-		Return(true, nil).
-		Once()
-
-	mockSchemaService.
-		On("ValidateUserUniqueness", "employee", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			identify := args.Get(2).(func(map[string]interface{}) (*string, error))
-
-			id, err := identify(map[string]interface{}{"email": "employee@example.com"})
-			require.Error(t, err)
-			require.Nil(t, id)
-		}).
-		Return(false, &serviceerror.ServiceError{
-			Code:  "USRS-5000",
-			Type:  serviceerror.ServerErrorType,
-			Error: "validation failed",
-		}).
-		Once()
-
-	service := &userService{
-		userSchemaService: mockSchemaService,
-		userStore:         userStoreMock,
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
-
-	err := service.validateUserAndUniqueness("employee", []byte(`{"email":"employee@example.com"}`), logger)
-
-	require.NotNil(t, err)
-	require.Equal(t, ErrorInternalServerError, *err)
+	require.Equal(t, ErrorInvalidHandlePath, *err)
 }

--- a/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
+++ b/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
@@ -917,6 +917,74 @@ func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call) Ru
 	return _c
 }
 
+// IsParent provides a mock function for the type OrganizationUnitServiceInterfaceMock
+func (_mock *OrganizationUnitServiceInterfaceMock) IsParent(parentID string, childID string) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(parentID, childID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsParent")
+	}
+
+	var r0 bool
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string, string) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(parentID, childID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string) bool); ok {
+		r0 = returnFunc(parentID, childID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(parentID, childID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OrganizationUnitServiceInterfaceMock_IsParent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsParent'
+type OrganizationUnitServiceInterfaceMock_IsParent_Call struct {
+	*mock.Call
+}
+
+// IsParent is a helper method to define mock.On call
+//   - parentID string
+//   - childID string
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsParent(parentID interface{}, childID interface{}) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	return &OrganizationUnitServiceInterfaceMock_IsParent_Call{Call: _e.mock.On("IsParent", parentID, childID)}
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsParent_Call) Run(run func(parentID string, childID string)) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsParent_Call) Return(b bool, serviceError *serviceerror.ServiceError) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	_c.Call.Return(b, serviceError)
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsParent_Call) RunAndReturn(run func(parentID string, childID string) (bool, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_IsParent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateOrganizationUnit provides a mock function for the type OrganizationUnitServiceInterfaceMock
 func (_mock *OrganizationUnitServiceInterfaceMock) UpdateOrganizationUnit(id string, request ou.OrganizationUnitRequest) (ou.OrganizationUnit, *serviceerror.ServiceError) {
 	ret := _mock.Called(id, request)

--- a/tests/integration/flowauthn/githubauth_test.go
+++ b/tests/integration/flowauthn/githubauth_test.go
@@ -44,6 +44,11 @@ var (
 
 var (
 	githubAuthTestAppID string
+	githubAuthTestOU = testutils.OrganizationUnit{
+		Handle:      "github-auth-flow-test-ou",
+		Name:        "GitHub Auth Flow Test OU",
+		Description: "Organization unit for GitHub authentication flow tests",
+	}
 )
 
 const (
@@ -117,15 +122,11 @@ func (ts *GithubAuthFlowTestSuite) SetupSuite() {
 	ts.idpID = "test-github-idp-id"
 
 	// Create test organization unit for GitHub auth tests
-	githubAuthTestOU := testutils.OrganizationUnit{
-		Handle:      "github-auth-flow-test-ou",
-		Name:        "GitHub Auth Flow Test OU",
-		Description: "Organization unit for GitHub authentication flow tests",
-	}
 	ouID, err := testutils.CreateOrganizationUnit(githubAuthTestOU)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test organization unit during setup: %v", err)
 	}
+	githubAuthTestOU.ID = ouID
 
 	// Create user schema
 	githubUserSchema.OrganizationUnitId = ouID
@@ -149,7 +150,7 @@ func (ts *GithubAuthFlowTestSuite) SetupSuite() {
 	// Create user in the pre-configured OU from database scripts
 	user := testutils.User{
 		Type:             githubUserSchema.Name,
-		OrganizationUnit: testOUID,
+		OrganizationUnit: githubUserSchema.OrganizationUnitId,
 		Attributes:       json.RawMessage(attributesJSON),
 	}
 
@@ -280,9 +281,9 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteSuccess() {
 		completeFlowStep.Assertion,
 		githubAuthTestAppID,
 		githubUserSchema.Name,
-		testOUID,
-		testOUName,
-		testOUHandle,
+		githubAuthTestOU.ID,
+		githubAuthTestOU.Name,
+		githubAuthTestOU.Handle,
 	)
 	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")

--- a/tests/integration/flowauthn/googleauth_test.go
+++ b/tests/integration/flowauthn/googleauth_test.go
@@ -44,6 +44,11 @@ var (
 
 var (
 	googleAuthTestAppID string
+	googleAuthTestOU = testutils.OrganizationUnit{
+		Handle:      "google-auth-flow-test-ou",
+		Name:        "Google Auth Flow Test OU",
+		Description: "Organization unit for Google authentication flow tests",
+	}
 )
 
 const (
@@ -111,15 +116,11 @@ func (ts *GoogleAuthFlowTestSuite) SetupSuite() {
 	ts.idpID = "test-google-idp-id"
 
 	// Create test organization unit for Google auth tests
-	googleAuthTestOU := testutils.OrganizationUnit{
-		Handle:      "google-auth-flow-test-ou",
-		Name:        "Google Auth Flow Test OU",
-		Description: "Organization unit for Google authentication flow tests",
-	}
 	ouID, err := testutils.CreateOrganizationUnit(googleAuthTestOU)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test organization unit during setup: %v", err)
 	}
+	googleAuthTestOU.ID = ouID
 
 	// Create user schema
 	googleUserSchema.OrganizationUnitId = ouID
@@ -143,7 +144,7 @@ func (ts *GoogleAuthFlowTestSuite) SetupSuite() {
 	// Create user in the pre-configured OU from database scripts
 	user := testutils.User{
 		Type:             googleUserSchema.Name,
-		OrganizationUnit: testOUID,
+		OrganizationUnit: googleUserSchema.OrganizationUnitId,
 		Attributes:       json.RawMessage(attributesJSON),
 	}
 
@@ -277,9 +278,9 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteSuccess() {
 		completeFlowStep.Assertion,
 		googleAuthTestAppID,
 		googleUserSchema.Name,
-		testOUID,
-		testOUName,
-		testOUHandle,
+		googleAuthTestOU.ID,
+		googleAuthTestOU.Name,
+		googleAuthTestOU.Handle,
 	)
 	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
@@ -373,9 +374,9 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowMultipleUsersSuccess() {
 		completeFlowStep.Assertion,
 		googleAuthTestAppID,
 		googleUserSchema.Name,
-		testOUID,
-		testOUName,
-		testOUHandle,
+		googleAuthTestOU.ID,
+		googleAuthTestOU.Name,
+		googleAuthTestOU.Handle,
 	)
 	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")

--- a/tests/integration/flowauthn/smsauth_test.go
+++ b/tests/integration/flowauthn/smsauth_test.go
@@ -83,6 +83,11 @@ var (
 var (
 	smsAuthTestAppID    string
 	smsAuthUserSchemaID string
+	smsAuthTestOU = testutils.OrganizationUnit{
+		Handle:      "sms-auth-flow-test-ou",
+		Name:        "SMS Auth Flow Test OU",
+		Description: "Organization unit for SMS authentication flow tests",
+	}
 )
 
 // NotificationSenderRequest represents the request to create a message notification sender.
@@ -124,15 +129,11 @@ func (ts *SMSAuthFlowTestSuite) SetupSuite() {
 	ts.config = &TestSuiteConfig{}
 
 	// Create test organization unit for SMS auth tests
-	smsAuthTestOU := testutils.OrganizationUnit{
-		Handle:      "sms-auth-flow-test-ou",
-		Name:        "SMS Auth Flow Test OU",
-		Description: "Organization unit for SMS authentication flow tests",
-	}
 	ouID, err := testutils.CreateOrganizationUnit(smsAuthTestOU)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test organization unit during setup: %v", err)
 	}
+	smsAuthTestOU.ID = ouID
 
 	// Create test application for SMS auth tests
 	appID, err := testutils.CreateApplication(smsAuthTestApp)
@@ -159,7 +160,7 @@ func (ts *SMSAuthFlowTestSuite) SetupSuite() {
 
 	// Create test user with mobile number using the created OU
 	testUserWithMobile := testUserWithMobile
-	testUserWithMobile.OrganizationUnit = testOUID
+	testUserWithMobile.OrganizationUnit = smsAuthTestOU.ID
 	userIDs, err := testutils.CreateMultipleUsers(testUserWithMobile)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test user during setup: %v", err)
@@ -283,9 +284,9 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 		completeFlowStep.Assertion,
 		smsAuthTestAppID,
 		smsAuthUserSchema.Name,
-		testOUID,
-		testOUName,
-		testOUHandle,
+		smsAuthTestOU.ID,
+		smsAuthTestOU.Name,
+		smsAuthTestOU.Handle,
 	)
 	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
@@ -380,9 +381,9 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
 		completeFlowStep.Assertion,
 		smsAuthTestAppID,
 		smsAuthUserSchema.Name,
-		testOUID,
-		testOUName,
-		testOUHandle,
+		smsAuthTestOU.ID,
+		smsAuthTestOU.Name,
+		smsAuthTestOU.Handle,
 	)
 	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
@@ -497,9 +498,9 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {
 		completeFlowStep.Assertion,
 		smsAuthTestAppID,
 		smsAuthUserSchema.Name,
-		testOUID,
-		testOUName,
-		testOUHandle,
+		smsAuthTestOU.ID,
+		smsAuthTestOU.Name,
+		smsAuthTestOU.Handle,
 	)
 	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")

--- a/tests/integration/flowauthn/utils.go
+++ b/tests/integration/flowauthn/utils.go
@@ -27,14 +27,7 @@ import (
 	"net/http"
 )
 
-const (
-	testServerURL = "https://localhost:8095"
-
-	// Pre-configured OU from database scripts
-	testOUID     = "test-ou-id"
-	testOUName   = "Test Organization Unit"
-	testOUHandle = "test-ou"
-)
+const testServerURL = "https://localhost:8095"
 
 // Helper function to initiate the authentication flow
 func initiateAuthFlow(appID string, inputs map[string]string) (*FlowStep, error) {

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -43,9 +43,8 @@ const (
 )
 
 var (
-	testOUID       string
 	testUserSchema = testutils.UserSchema{
-		Name: "person",
+		Name: "userinfo-person",
 		Schema: map[string]interface{}{
 			"username": map[string]interface{}{
 				"type": "string",
@@ -72,6 +71,7 @@ type UserInfoTestSuite struct {
 	userSchemaID  string
 	userID        string
 	client        *http.Client
+	ouID          string
 }
 
 func TestUserInfoTestSuite(t *testing.T) {
@@ -96,11 +96,12 @@ func (ts *UserInfoTestSuite) SetupSuite() {
 		Description: "Organization unit for UserInfo integration testing",
 		Parent:      nil,
 	}
-	testOUID, err := testutils.CreateOrganizationUnit(ou)
+	ouID, err := testutils.CreateOrganizationUnit(ou)
 	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
 
 	// Create user schema
-	testUserSchema.OrganizationUnitId = testOUID
+	testUserSchema.OrganizationUnitId = ts.ouID
 	schemaID, err := testutils.CreateUserType(testUserSchema)
 	ts.Require().NoError(err, "Failed to create test user schema")
 	ts.userSchemaID = schemaID
@@ -124,8 +125,8 @@ func (ts *UserInfoTestSuite) TearDownSuite() {
 	}
 
 	// Clean up organization unit
-	if testOUID != "" {
-		testutils.DeleteOrganizationUnit(testOUID)
+	if ts.ouID != "" {
+		testutils.DeleteOrganizationUnit(ts.ouID)
 	}
 
 	// Clean up user schema
@@ -149,8 +150,8 @@ func (ts *UserInfoTestSuite) createTestUser() string {
 	ts.Require().NoError(err, "Failed to marshal user attributes")
 
 	user := testutils.User{
-		Type:             "person",
-		OrganizationUnit: testOUID,
+		Type:             "userinfo-person",
+		OrganizationUnit: ts.ouID,
 		Attributes:       json.RawMessage(attributesJSON),
 	}
 

--- a/tests/integration/role/roleapi_test.go
+++ b/tests/integration/role/roleapi_test.go
@@ -45,7 +45,7 @@ var (
 	}
 
 	testUserSchema = testutils.UserSchema{
-		Name: "person",
+		Name: "role-person",
 		Schema: map[string]interface{}{
 			"email": map[string]interface{}{
 				"type": "string",
@@ -63,7 +63,7 @@ var (
 	}
 
 	testUser1 = testutils.User{
-		Type: "person",
+		Type: "role-person",
 		Attributes: json.RawMessage(`{
 			"email": "roleuser1@example.com",
 			"firstName": "Role",
@@ -73,7 +73,7 @@ var (
 	}
 
 	testUser2 = testutils.User{
-		Type: "person",
+		Type: "role-person",
 		Attributes: json.RawMessage(`{
 			"email": "roleuser2@example.com",
 			"firstName": "Role",

--- a/tests/integration/userschema/user_validation_edge_cases_test.go
+++ b/tests/integration/userschema/user_validation_edge_cases_test.go
@@ -259,6 +259,7 @@ func (ts *UserValidationEdgeCasesTestSuite) TestUpdateUserChangeType() {
 	// Update user to different type with valid attributes for new schema
 	updateUserReq := UpdateUserRequest{
 		Type: "numeric-user",
+		OrganizationUnit: ts.organizationUnitID,
 		Attributes: json.RawMessage(`{
 			"age": 30,
 			"salary": 75000.0,
@@ -271,6 +272,7 @@ func (ts *UserValidationEdgeCasesTestSuite) TestUpdateUserChangeType() {
 	// Update user to different type with invalid attributes for new schema
 	updateUserReq2 := UpdateUserRequest{
 		Type: "numeric-user",
+		OrganizationUnit: ts.organizationUnitID,
 		Attributes: json.RawMessage(`{
 			"age": "thirty",
 			"salary": 75000.0,

--- a/tests/integration/userschema/user_validation_test.go
+++ b/tests/integration/userschema/user_validation_test.go
@@ -257,6 +257,7 @@ func (ts *UserValidationTestSuite) TestUpdateUserWithValidSchema() {
 	// Update user with valid data
 	updateUserReq := UpdateUserRequest{
 		Type: "employee",
+		OrganizationUnit: ts.organizationUnitID,
 		Attributes: json.RawMessage(`{
 			"firstName": "John",
 			"lastName": "Smith",
@@ -290,6 +291,7 @@ func (ts *UserValidationTestSuite) TestUpdateUserWithInvalidSchema() {
 	// Update user with invalid data (wrong type for isManager)
 	updateUserReq := UpdateUserRequest{
 		Type: "employee",
+		OrganizationUnit: ts.organizationUnitID,
 		Attributes: json.RawMessage(`{
 			"firstName": "John",
 			"lastName": "Smith",


### PR DESCRIPTION
### Purpose
$subject. With this PR, during the user creation or user update, its performing strict validation of the OU id.
* OU ID should be valid UUID
* OU ID should be a ID of valid/existing OU
* OU ID of the create request or update request should be match with the user schema. ie. OU specified in the user create/update request should be same or child of the OU specified in the user schema.

### Approach
This pull request introduces validation to ensure that a user's organization unit is both valid and matches the user type's configuration, improving data integrity in user management operations. The changes include new error types, additional validation logic in user creation and update flows, and enhancements to organization unit hierarchy checks. Comprehensive unit tests have also been added to verify these behaviors.

**Organization Unit Validation Enhancements:**

* Added a new method `IsParent` to the `OrganizationUnitServiceInterface` and its implementation, allowing checks if an organization unit is an ancestor of another. [[1]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510R44) [[2]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510R235-R267)
* Extended the user service with a `validateOrganizationUnitForUserType` method to ensure the provided organization unit ID is valid, exists, and matches the user type’s schema or is a descendant. This validation is now invoked during user creation and update. [[1]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR170-R173) [[2]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR351-R354) [[3]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR560-R634)

**Error Handling Improvements:**

* Introduced new error constants: `ErrorInvalidOrganizationUnitID` and `ErrorOrganizationUnitMismatch` for more specific feedback when organization unit validation fails.

**Testing and Mocking:**

* Added comprehensive unit tests for the new organization unit hierarchy logic and validation behaviors, including edge cases and error handling.
* Updated organization unit and user service mocks to support the new `IsParent` method and validation logic.

**Test Consistency:**

* Refactored user service tests to consistently use a constant for user type, improving maintainability and readability. [[1]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745R28-R42) [[2]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L52-R56) [[3]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L64-R68) [[4]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L74-R78) [[5]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L86-R90) [[6]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L100-R104) [[7]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L112-R116) [[8]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L122-R126) [[9]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L134-R143) [[10]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L153-R157) [[11]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L163-R172) [[12]](diffhunk://#diff-0c0db27826059e36e41de3823032e63d8f80f10ec692af01196976ea5ccf5745L178-R182)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests