### PR TITLE
Disable application view button

### DIFF
--- a/frontend/apps/thunder-develop/src/features/applications/components/ApplicationsList.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/ApplicationsList.tsx
@@ -69,17 +69,6 @@ export default function ApplicationsList(): JSX.Element {
     setSelectedAppId(null);
   };
 
-  const handleViewApplication = useCallback(() => {
-    if (!selectedAppId) return;
-    handleMenuClose();
-    (async (): Promise<void> => {
-      await navigate(`/applications/${selectedAppId}`);
-    })().catch(() => {
-      // TODO: Log the errors
-      // Tracker: https://github.com/asgardeo/thunder/issues/618
-    });
-  }, [selectedAppId, navigate]);
-
   const getInitials = (name: string): string =>
     name
       .split(' ')
@@ -231,7 +220,7 @@ export default function ApplicationsList(): JSX.Element {
 
       {/* Actions Menu */}
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
-        <MenuItem onClick={handleViewApplication}>
+        <MenuItem disabled>
           <ListItemIcon>
             <Eye size={16} />
           </ListItemIcon>

--- a/frontend/apps/thunder-develop/src/features/applications/components/__tests__/ApplicationsList.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/__tests__/ApplicationsList.test.tsx
@@ -293,7 +293,7 @@ describe('ApplicationsList', () => {
     });
   });
 
-  it('should navigate to application details when clicking View action', async () => {
+  it('should show View action as disabled', async () => {
     const user = userEvent.setup();
 
     vi.mocked(useGetApplications).mockReturnValue({
@@ -311,12 +311,8 @@ describe('ApplicationsList', () => {
       expect(screen.getByRole('menu')).toBeInTheDocument();
     });
 
-    const viewMenuItem = screen.getByText('View');
-    await user.click(viewMenuItem);
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/applications/app-1');
-    });
+    const viewMenuItem = screen.getByText('View').closest('li');
+    expect(viewMenuItem).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('should close menu when pressing Escape', async () => {


### PR DESCRIPTION
### Purpose
Disabling the application view button as it is not implemented yet.

<img width="201" height="274" alt="image" src="https://github.com/user-attachments/assets/a0bed673-7910-48ba-9561-36cc56c9c25d" />

This pull request makes a minor update to the `ApplicationsList` component by disabling the "View Application" menu item and removing its click handler. This means users can no longer select this action from the menu.

- User interface update:
  * Disabled the "View Application" option in the actions menu by removing the `handleViewApplication` function and setting the corresponding `MenuItem` to `disabled`. [[1]](diffhunk://#diff-d186c2c51f129e391e6149294082bf6bba3457be01dfa8b23aa5a425412a84acL72-L82) [[2]](diffhunk://#diff-d186c2c51f129e391e6149294082bf6bba3457be01dfa8b23aa5a425412a84acL234-R223)

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
