### PR TITLE
Fix create user ui to include correct ou

### DIFF
--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUserSchemas.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUserSchemas.test.ts
@@ -65,10 +65,12 @@ describe('useGetUserSchemas', () => {
         {
           id: 'schema-1',
           name: 'Customer',
+          ouId: 'root-ou',
         },
         {
           id: 'schema-2',
           name: 'Employee',
+          ouId: 'child-ou',
         },
       ],
     };

--- a/frontend/apps/thunder-develop/src/features/users/pages/CreateUserPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/CreateUserPage.tsx
@@ -83,9 +83,16 @@ export default function CreateUserPage() {
       // Extract schema from form data (schema already contains the schema name)
       const {schema, ...attributes} = data;
 
+      const trimmedOuId = selectedSchema?.ouId?.trim();
+      const organizationUnitId = trimmedOuId === '' ? undefined : trimmedOuId;
+
+      if (!organizationUnitId) {
+        throw new Error('Organization unit ID is missing for the selected user type');
+      }
+
       // Prepare the request body according to the API spec
       const requestBody = {
-        organizationUnit: 'test-ou', // TODO: Add organization unit field or get from context
+        organizationUnit: organizationUnitId,
         type: schema,
         attributes,
       };

--- a/frontend/apps/thunder-develop/src/features/users/pages/ViewUserPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/ViewUserPage.tsx
@@ -59,11 +59,17 @@ export default function ViewUserPage() {
   const {data: userSchemas} = useGetUserSchemas();
 
   // Find the schema ID based on the user's type (which is the schema name)
-  const schemaId = useMemo(() => {
-    if (!user?.type || !userSchemas?.schemas) return undefined;
-    const schema = userSchemas.schemas.find((s) => s.name === user.type);
-    return schema?.id;
+  const matchedSchema = useMemo(() => {
+    if (!user?.type || !userSchemas?.schemas) {
+      return undefined;
+    }
+
+    return userSchemas.schemas.find((s) => s.name === user.type);
   }, [user?.type, userSchemas?.schemas]);
+
+  const schemaId = matchedSchema?.id;
+  const trimmedOuId = matchedSchema?.ouId?.trim();
+  const schemaOuId = trimmedOuId === '' ? undefined : trimmedOuId;
 
   const {data: userSchema, loading: isSchemaLoading, error: schemaError} = useGetUserSchema(schemaId);
 
@@ -86,13 +92,15 @@ export default function ViewUserPage() {
   }, [user, userSchema, setValue]);
 
   const onSubmit = async (data: UpdateUserFormData) => {
-    if (!userId || !user?.organizationUnit || !user?.type) return;
+    const organizationUnitId = schemaOuId ?? user?.organizationUnit;
+
+    if (!userId || !organizationUnitId || !user?.type) return;
 
     try {
       setIsSubmitting(true);
 
       const requestBody = {
-        organizationUnit: user.organizationUnit,
+        organizationUnit: organizationUnitId,
         type: user.type,
         attributes: data,
       };

--- a/frontend/apps/thunder-develop/src/features/users/pages/__tests__/UsersListPage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/__tests__/UsersListPage.test.tsx
@@ -60,8 +60,8 @@ describe('UsersListPage', () => {
     startIndex: 1,
     count: 2,
     schemas: [
-      {id: 'schema1', name: 'Employee Schema'},
-      {id: 'schema2', name: 'Contractor Schema'},
+      {id: 'schema1', name: 'Employee Schema', ouId: 'root-ou'},
+      {id: 'schema2', name: 'Contractor Schema', ouId: 'child-ou'},
     ],
   };
 

--- a/frontend/apps/thunder-develop/src/features/users/types/users.ts
+++ b/frontend/apps/thunder-develop/src/features/users/types/users.ts
@@ -221,4 +221,5 @@ export interface UserSchemaListResponse {
 export interface SchemaInterface {
   id: string;
   name: string;
+  ouId: string;
 }


### PR DESCRIPTION
### Purpose
This pull request adds support for associating user schemas with organization units, ensuring that user creation uses the correct organization unit ID from the selected schema. The changes update the data model, API usage, and tests to handle this new field.

**Data model update:**

* Added a new `ouId` field to the `SchemaInterface` in `users.ts` to represent the organization unit ID for each user schema.

**API and form logic improvements:**

* Updated `CreateUserPage.tsx` to extract the organization unit ID from the selected schema and use it when creating a user; throws an error if the ID is missing to prevent invalid requests.

**Test coverage:**

* Modified the test data in `useGetUserSchemas.test.ts` to include the new `ouId` field for each schema, ensuring tests reflect the updated data model.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
