### PR TITLE
Refactor db provider to have dedicated db client methods

### DIFF
--- a/backend/internal/application/store.go
+++ b/backend/internal/application/store.go
@@ -114,7 +114,7 @@ func (st *applicationStore) CreateApplication(app model.ApplicationProcessedDTO)
 
 // GetTotalApplicationCount retrieves the total count of applications from the database.
 func (st *applicationStore) GetTotalApplicationCount() (int, error) {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -140,7 +140,7 @@ func (st *applicationStore) GetTotalApplicationCount() (int, error) {
 func (st *applicationStore) GetApplicationList() ([]model.BasicApplicationDTO, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationPersistence"))
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		logger.Error("Failed to get database client", log.Error(err))
 		return nil, fmt.Errorf("failed to get database client: %w", err)
@@ -170,7 +170,7 @@ func (st *applicationStore) GetApplicationList() ([]model.BasicApplicationDTO, e
 func (st *applicationStore) GetOAuthApplication(clientID string) (*model.OAuthAppConfigProcessedDTO, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationStore"))
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		logger.Error("Failed to get database client", log.Error(err))
 		return nil, fmt.Errorf("failed to get database client: %w", err)
@@ -289,7 +289,7 @@ func (st *applicationStore) getApplicationByQuery(query dbmodel.DBQuery, param s
 	*model.ApplicationProcessedDTO, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationStore"))
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		logger.Error("Failed to get database client", log.Error(err))
 		return nil, fmt.Errorf("failed to get database client: %w", err)
@@ -361,7 +361,7 @@ func (st *applicationStore) UpdateApplication(existingApp, updatedApp *model.App
 func (st *applicationStore) DeleteApplication(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationStore"))
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		logger.Error("Failed to get database client", log.Error(err))
 		return fmt.Errorf("failed to get database client: %w", err)
@@ -822,7 +822,7 @@ func buildOAuthInboundAuthConfig(row map[string]interface{}, basicApp model.Basi
 func executeTransaction(queries []func(tx dbmodel.TxInterface) error) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationStore"))
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/branding/store.go
+++ b/backend/internal/branding/store.go
@@ -211,7 +211,7 @@ func (s *brandingStore) GetApplicationsCountByBrandingID(id string) (int, error)
 
 // getIdentityDBClient is a helper method to get the database client for the identity database.
 func (s *brandingStore) getIdentityDBClient() (provider.DBClientInterface, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/branding/store_test.go
+++ b/backend/internal/branding/store_test.go
@@ -51,7 +51,7 @@ func (suite *BrandingStoreTestSuite) SetupTest() {
 
 // GetBrandingListCount Tests
 func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingListCount).Return([]map[string]interface{}{
 		{"total": int64(10)},
 	}, nil)
@@ -63,7 +63,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_Success() {
 }
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_EmptyResult() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingListCount).Return([]map[string]interface{}{}, nil)
 
 	count, err := suite.store.GetBrandingListCount()
@@ -74,7 +74,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_EmptyResult() {
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_DBClientError() {
 	dbError := errors.New("database connection error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	count, err := suite.store.GetBrandingListCount()
 
@@ -85,7 +85,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_DBClientError() {
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_QueryError() {
 	queryError := errors.New("query error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingListCount).Return(nil, queryError)
 
 	count, err := suite.store.GetBrandingListCount()
@@ -96,7 +96,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_QueryError() {
 }
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_InvalidCountResult() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingListCount).Return([]map[string]interface{}{
 		{"invalid": "value"},
 	}, nil)
@@ -110,7 +110,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingListCount_InvalidCountResult
 
 // GetBrandingList Tests
 func (suite *BrandingStoreTestSuite) TestGetBrandingList_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingList, 10, 0).Return([]map[string]interface{}{
 		{
 			"branding_id":  "brand1",
@@ -133,7 +133,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingList_Success() {
 }
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingList_EmptyResult() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingList, 10, 0).Return([]map[string]interface{}{}, nil)
 
 	brandings, err := suite.store.GetBrandingList(10, 0)
@@ -144,7 +144,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingList_EmptyResult() {
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingList_DBClientError() {
 	dbError := errors.New("database connection error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	brandings, err := suite.store.GetBrandingList(10, 0)
 
@@ -155,7 +155,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingList_DBClientError() {
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingList_QueryError() {
 	queryError := errors.New("query error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingList, 10, 0).Return(nil, queryError)
 
 	brandings, err := suite.store.GetBrandingList(10, 0)
@@ -166,7 +166,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingList_QueryError() {
 }
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingList_InvalidBrandingID() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingList, 10, 0).Return([]map[string]interface{}{
 		{"branding_id": 123, "preferences": `{}`}, // Invalid type
 	}, nil)
@@ -180,7 +180,7 @@ func (suite *BrandingStoreTestSuite) TestGetBrandingList_InvalidBrandingID() {
 
 func (suite *BrandingStoreTestSuite) TestGetBrandingList_PreferencesAsMap() {
 	// Note: GetBrandingList now only returns id and displayName (no preferences)
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingList, 10, 0).Return([]map[string]interface{}{
 		{
 			"branding_id":  "brand1",
@@ -204,7 +204,7 @@ func (suite *BrandingStoreTestSuite) TestCreateBranding_Success() {
 		Preferences: preferencesJSON,
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryCreateBranding, "brand1",
 		"Application 1 Branding", mock.Anything).Return(int64(1), nil)
 
@@ -221,7 +221,7 @@ func (suite *BrandingStoreTestSuite) TestCreateBranding_DBClientError() {
 		Preferences: preferencesJSON,
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	err := suite.store.CreateBranding("brand1", request)
 
@@ -237,7 +237,7 @@ func (suite *BrandingStoreTestSuite) TestCreateBranding_ExecuteError() {
 	}
 	executeError := errors.New("execute error")
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryCreateBranding, "brand1",
 		"Application 1 Branding", mock.Anything).Return(int64(0), executeError)
 
@@ -250,7 +250,7 @@ func (suite *BrandingStoreTestSuite) TestCreateBranding_ExecuteError() {
 // GetBranding Tests
 func (suite *BrandingStoreTestSuite) TestGetBranding_Success() {
 	preferencesJSON := json.RawMessage(`{"theme":{"activeColorScheme":"dark"}}`)
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingByID, "brand1").Return([]map[string]interface{}{
 		{
 			"branding_id":  "brand1",
@@ -267,7 +267,7 @@ func (suite *BrandingStoreTestSuite) TestGetBranding_Success() {
 }
 
 func (suite *BrandingStoreTestSuite) TestGetBranding_NotFound() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingByID, "brand1").Return([]map[string]interface{}{}, nil)
 
 	branding, err := suite.store.GetBranding("brand1")
@@ -278,7 +278,7 @@ func (suite *BrandingStoreTestSuite) TestGetBranding_NotFound() {
 }
 
 func (suite *BrandingStoreTestSuite) TestGetBranding_MultipleResults() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingByID, "brand1").Return([]map[string]interface{}{
 		{"branding_id": "brand1", "display_name": "Application 1 Branding", "preferences": `{}`},
 		{"branding_id": "brand2", "display_name": "Application 2 Branding", "preferences": `{}`},
@@ -293,7 +293,7 @@ func (suite *BrandingStoreTestSuite) TestGetBranding_MultipleResults() {
 
 func (suite *BrandingStoreTestSuite) TestGetBranding_DBClientError() {
 	dbError := errors.New("database connection error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	branding, err := suite.store.GetBranding("brand1")
 
@@ -304,7 +304,7 @@ func (suite *BrandingStoreTestSuite) TestGetBranding_DBClientError() {
 
 func (suite *BrandingStoreTestSuite) TestGetBranding_QueryError() {
 	queryError := errors.New("query error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetBrandingByID, "brand1").Return(nil, queryError)
 
 	branding, err := suite.store.GetBranding("brand1")
@@ -316,7 +316,7 @@ func (suite *BrandingStoreTestSuite) TestGetBranding_QueryError() {
 
 // IsBrandingExist Tests
 func (suite *BrandingStoreTestSuite) TestIsBrandingExist_True() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckBrandingExists, "brand1").Return([]map[string]interface{}{
 		{"count": int64(1)},
 	}, nil)
@@ -328,7 +328,7 @@ func (suite *BrandingStoreTestSuite) TestIsBrandingExist_True() {
 }
 
 func (suite *BrandingStoreTestSuite) TestIsBrandingExist_False() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckBrandingExists, "brand1").Return([]map[string]interface{}{
 		{"count": int64(0)},
 	}, nil)
@@ -340,7 +340,7 @@ func (suite *BrandingStoreTestSuite) TestIsBrandingExist_False() {
 }
 
 func (suite *BrandingStoreTestSuite) TestIsBrandingExist_EmptyResult() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckBrandingExists, "brand1").Return([]map[string]interface{}{}, nil)
 
 	exists, err := suite.store.IsBrandingExist("brand1")
@@ -350,7 +350,7 @@ func (suite *BrandingStoreTestSuite) TestIsBrandingExist_EmptyResult() {
 }
 
 func (suite *BrandingStoreTestSuite) TestIsBrandingExist_InvalidCount() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckBrandingExists, "brand1").Return([]map[string]interface{}{
 		{"invalid": "value"},
 	}, nil)
@@ -364,7 +364,7 @@ func (suite *BrandingStoreTestSuite) TestIsBrandingExist_InvalidCount() {
 
 func (suite *BrandingStoreTestSuite) TestIsBrandingExist_DBClientError() {
 	dbError := errors.New("database connection error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	exists, err := suite.store.IsBrandingExist("brand1")
 
@@ -375,7 +375,7 @@ func (suite *BrandingStoreTestSuite) TestIsBrandingExist_DBClientError() {
 
 func (suite *BrandingStoreTestSuite) TestIsBrandingExist_QueryError() {
 	queryError := errors.New("query error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckBrandingExists, "brand1").Return(nil, queryError)
 
 	exists, err := suite.store.IsBrandingExist("brand1")
@@ -393,7 +393,7 @@ func (suite *BrandingStoreTestSuite) TestUpdateBranding_Success() {
 		Preferences: preferencesJSON,
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryUpdateBranding, "Application 2 Branding",
 		mock.Anything, "brand1").Return(int64(1), nil)
 
@@ -409,7 +409,7 @@ func (suite *BrandingStoreTestSuite) TestUpdateBranding_NotFound() {
 		Preferences: preferencesJSON,
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryUpdateBranding, "Application 1 Branding",
 		mock.Anything, "brand1").Return(int64(0), nil)
 
@@ -427,7 +427,7 @@ func (suite *BrandingStoreTestSuite) TestUpdateBranding_DBClientError() {
 		Preferences: preferencesJSON,
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	err := suite.store.UpdateBranding("brand1", request)
 
@@ -443,7 +443,7 @@ func (suite *BrandingStoreTestSuite) TestUpdateBranding_ExecuteError() {
 	}
 	executeError := errors.New("execute error")
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryUpdateBranding, "Application 1 Branding",
 		mock.Anything, "brand1").Return(int64(0), executeError)
 
@@ -455,7 +455,7 @@ func (suite *BrandingStoreTestSuite) TestUpdateBranding_ExecuteError() {
 
 // DeleteBranding Tests
 func (suite *BrandingStoreTestSuite) TestDeleteBranding_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryDeleteBranding, "brand1").Return(int64(1), nil)
 
 	err := suite.store.DeleteBranding("brand1")
@@ -464,7 +464,7 @@ func (suite *BrandingStoreTestSuite) TestDeleteBranding_Success() {
 }
 
 func (suite *BrandingStoreTestSuite) TestDeleteBranding_NotFound() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryDeleteBranding, "brand1").Return(int64(0), nil)
 
 	err := suite.store.DeleteBranding("brand1")
@@ -474,7 +474,7 @@ func (suite *BrandingStoreTestSuite) TestDeleteBranding_NotFound() {
 
 func (suite *BrandingStoreTestSuite) TestDeleteBranding_DBClientError() {
 	dbError := errors.New("database connection error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	err := suite.store.DeleteBranding("brand1")
 
@@ -484,7 +484,7 @@ func (suite *BrandingStoreTestSuite) TestDeleteBranding_DBClientError() {
 
 func (suite *BrandingStoreTestSuite) TestDeleteBranding_ExecuteError() {
 	executeError := errors.New("execute error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryDeleteBranding, "brand1").Return(int64(0), executeError)
 
 	err := suite.store.DeleteBranding("brand1")
@@ -495,7 +495,7 @@ func (suite *BrandingStoreTestSuite) TestDeleteBranding_ExecuteError() {
 
 // GetApplicationsCountByBrandingID Tests
 func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetApplicationsCountByBrandingID, "brand1").Return([]map[string]interface{}{
 		{"count": int64(3)},
 	}, nil)
@@ -507,7 +507,7 @@ func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_Succes
 }
 
 func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_Zero() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetApplicationsCountByBrandingID, "brand1").Return([]map[string]interface{}{
 		{"count": int64(0)},
 	}, nil)
@@ -519,7 +519,7 @@ func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_Zero()
 }
 
 func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_EmptyResult() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetApplicationsCountByBrandingID, "brand1").Return([]map[string]interface{}{}, nil)
 
 	count, err := suite.store.GetApplicationsCountByBrandingID("brand1")
@@ -530,7 +530,7 @@ func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_EmptyR
 
 func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_DBClientError() {
 	dbError := errors.New("database connection error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	count, err := suite.store.GetApplicationsCountByBrandingID("brand1")
 
@@ -541,7 +541,7 @@ func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_DBClie
 
 func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_QueryError() {
 	queryError := errors.New("query error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetApplicationsCountByBrandingID, "brand1").Return(nil, queryError)
 
 	count, err := suite.store.GetApplicationsCountByBrandingID("brand1")

--- a/backend/internal/cert/store.go
+++ b/backend/internal/cert/store.go
@@ -62,7 +62,7 @@ func (s *certificateStore) GetCertificateByReference(refType CertificateReferenc
 
 // getCertificate retrieves a certificate based on a query and its arguments.
 func (s *certificateStore) getCertificate(query dbmodel.DBQuery, args ...interface{}) (*Certificate, error) {
-	dbClient, err := s.DBProvider.GetDBClient("identity")
+	dbClient, err := s.DBProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -125,7 +125,7 @@ func (s *certificateStore) buildCertificateFromResultRow(row map[string]interfac
 
 // CreateCertificate creates a new certificate in the database.
 func (s *certificateStore) CreateCertificate(cert *Certificate) error {
-	dbClient, err := s.DBProvider.GetDBClient("identity")
+	dbClient, err := s.DBProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -154,7 +154,7 @@ func (s *certificateStore) UpdateCertificateByReference(existingCert, updatedCer
 
 // updateCertificate updates a certificate based on a query and its arguments.
 func (s *certificateStore) updateCertificate(query dbmodel.DBQuery, args ...interface{}) error {
-	dbClient, err := s.DBProvider.GetDBClient("identity")
+	dbClient, err := s.DBProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -183,7 +183,7 @@ func (s *certificateStore) DeleteCertificateByReference(refType CertificateRefer
 
 // deleteCertificate deletes a certificate based on a query and its arguments.
 func (s *certificateStore) deleteCertificate(query dbmodel.DBQuery, args ...interface{}) error {
-	dbClient, err := s.DBProvider.GetDBClient("identity")
+	dbClient, err := s.DBProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/flow/flowexec/store.go
+++ b/backend/internal/flow/flowexec/store.go
@@ -74,7 +74,7 @@ func (s *flowStore) StoreFlowContext(ctx EngineContext) error {
 
 // GetFlowContext retrieves the flow context from the database.
 func (s *flowStore) GetFlowContext(flowID string) (*FlowContextWithUserDataDB, error) {
-	dbClient, err := s.dbProvider.GetDBClient("runtime")
+	dbClient, err := s.dbProvider.GetRuntimeDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -138,7 +138,7 @@ func (s *flowStore) DeleteFlowContext(flowID string) error {
 
 // executeTransaction is a helper function to handle database transactions.
 func (s *flowStore) executeTransaction(queries []func(tx dbmodel.TxInterface) error) error {
-	dbClient, err := s.dbProvider.GetDBClient("runtime")
+	dbClient, err := s.dbProvider.GetRuntimeDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -62,7 +62,7 @@ func newGroupStore() groupStoreInterface {
 
 // GetGroupListCount retrieves the total count of root groups.
 func (s *groupStore) GetGroupListCount() (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -84,7 +84,7 @@ func (s *groupStore) GetGroupListCount() (int, error) {
 
 // GetGroupList retrieves root groups.
 func (s *groupStore) GetGroupList(limit, offset int) ([]GroupBasicDAO, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -116,7 +116,7 @@ func (s *groupStore) GetGroupList(limit, offset int) ([]GroupBasicDAO, error) {
 
 // CreateGroup creates a new group in the database.
 func (s *groupStore) CreateGroup(group GroupDAO) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -157,7 +157,7 @@ func (s *groupStore) CreateGroup(group GroupDAO) error {
 
 // GetGroup retrieves a group by its id.
 func (s *groupStore) GetGroup(id string) (GroupDAO, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return GroupDAO{}, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -186,7 +186,7 @@ func (s *groupStore) GetGroup(id string) (GroupDAO, error) {
 
 // GetGroupMembers retrieves members of a group with pagination.
 func (s *groupStore) GetGroupMembers(groupID string, limit, offset int) ([]Member, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -213,7 +213,7 @@ func (s *groupStore) GetGroupMembers(groupID string, limit, offset int) ([]Membe
 
 // GetGroupMemberCount retrieves the total count of members in a group.
 func (s *groupStore) GetGroupMemberCount(groupID string) (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -236,7 +236,7 @@ func (s *groupStore) GetGroupMemberCount(groupID string) (int, error) {
 
 // UpdateGroup updates an existing group.
 func (s *groupStore) UpdateGroup(group GroupDAO) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -294,7 +294,7 @@ func (s *groupStore) UpdateGroup(group GroupDAO) error {
 func (s *groupStore) DeleteGroup(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, storeLoggerComponentName))
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -340,7 +340,7 @@ func (s *groupStore) ValidateGroupIDs(groupIDs []string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -375,7 +375,7 @@ func (s *groupStore) ValidateGroupIDs(groupIDs []string) ([]string, error) {
 // CheckGroupNameConflictForCreate checks if the new group name conflicts with existing groups
 // in the same organization unit.
 func (s *groupStore) CheckGroupNameConflictForCreate(name string, organizationUnitID string) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -386,7 +386,7 @@ func (s *groupStore) CheckGroupNameConflictForCreate(name string, organizationUn
 // CheckGroupNameConflictForUpdate checks if the new group name conflicts with other groups
 // in the same organization unit.
 func (s *groupStore) CheckGroupNameConflictForUpdate(name string, organizationUnitID string, groupID string) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -396,7 +396,7 @@ func (s *groupStore) CheckGroupNameConflictForUpdate(name string, organizationUn
 
 // GetGroupsByOrganizationUnitCount retrieves the total count of groups in a specific organization unit.
 func (s *groupStore) GetGroupsByOrganizationUnitCount(organizationUnitID string) (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -421,7 +421,7 @@ func (s *groupStore) GetGroupsByOrganizationUnitCount(organizationUnitID string)
 func (s *groupStore) GetGroupsByOrganizationUnit(
 	organizationUnitID string, limit, offset int,
 ) ([]GroupBasicDAO, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/group/store_test.go
+++ b/backend/internal/group/store_test.go
@@ -73,7 +73,7 @@ func assertEmptyInputPostconditions(
 	builderCalled bool,
 ) {
 	require.False(t, builderCalled)
-	providerMock.AssertNotCalled(t, "GetDBClient", mock.Anything)
+	providerMock.AssertNotCalled(t, "GetConfigDBClient", mock.Anything)
 	dbClientMock.AssertNotCalled(t, "Query", mock.Anything, mock.Anything)
 }
 
@@ -153,7 +153,7 @@ func testExecRollbackError(t *testing.T, query string, operation func(*groupStor
 	group := GroupDAO{ID: "grp-001"}
 
 	providerMock.
-		On("GetDBClient", "identity").
+		On("GetConfigDBClient").
 		Return(dbClientMock, nil).
 		Once()
 
@@ -199,7 +199,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupListCount() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -217,7 +217,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupListCount() {
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("no client")).
 					Once()
 			},
@@ -231,7 +231,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupListCount() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -295,7 +295,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupList() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -333,7 +333,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupList() {
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("boom")).
 					Once()
 			},
@@ -348,7 +348,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupList() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -368,7 +368,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupList() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -465,7 +465,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -516,7 +516,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -554,7 +554,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				_ *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client error")).
 					Once()
 			},
@@ -579,7 +579,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -628,7 +628,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -677,7 +677,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				_ *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -698,7 +698,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -801,7 +801,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroup() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -830,7 +830,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroup() {
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -844,7 +844,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroup() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -863,7 +863,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroup() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -882,7 +882,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroup() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -904,7 +904,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroup() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -973,7 +973,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMembers() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1001,7 +1001,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMembers() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1020,7 +1020,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMembers() {
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -1072,7 +1072,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMemberCount() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1093,7 +1093,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMemberCount() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1112,7 +1112,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMemberCount() {
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -1126,7 +1126,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMemberCount() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1145,7 +1145,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupMemberCount() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1226,7 +1226,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1260,7 +1260,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				_ *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -1285,7 +1285,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1320,7 +1320,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1355,7 +1355,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1408,7 +1408,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1460,7 +1460,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				_ *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1480,7 +1480,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1515,7 +1515,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1558,7 +1558,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 				dbClientMock.
@@ -1669,7 +1669,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				_ *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1690,7 +1690,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1725,7 +1725,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1769,7 +1769,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1813,7 +1813,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1857,7 +1857,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1901,7 +1901,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				_ *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -1917,7 +1917,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1952,7 +1952,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -1996,7 +1996,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock *modelmock.TxInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2094,7 +2094,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2113,7 +2113,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2132,7 +2132,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2151,7 +2151,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 			},
@@ -2176,7 +2176,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -2206,7 +2206,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2270,7 +2270,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnitCoun
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -2283,7 +2283,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnitCoun
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2301,7 +2301,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnitCoun
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2319,7 +2319,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnitCoun
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2373,7 +2373,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnit() {
 				_ *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -2386,7 +2386,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnit() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2404,7 +2404,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByOrganizationUnit() {
 				dbClientMock *clientmock.DBClientInterfaceMock,
 			) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(dbClientMock, nil).
 					Once()
 
@@ -2495,7 +2495,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CheckGroupNameConflictForCreate
 			name: "database client error",
 			setupProvider: func(providerMock *providermock.DBProviderInterfaceMock, _ *clientmock.DBClientInterfaceMock) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},
@@ -2553,7 +2553,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CheckGroupNameConflictForUpdate
 			name: "database client error",
 			setupProvider: func(providerMock *providermock.DBProviderInterfaceMock, _ *clientmock.DBClientInterfaceMock) {
 				providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("client fail")).
 					Once()
 			},

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -51,7 +51,7 @@ func newIDPStore() idpStoreInterface {
 
 // CreateIdentityProvider handles the IdP creation in the database.
 func (s *idpStore) CreateIdentityProvider(idp IDPDTO) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -74,7 +74,7 @@ func (s *idpStore) CreateIdentityProvider(idp IDPDTO) error {
 
 // GetIdentityProviderList retrieves a list of IdPs from the database.
 func (s *idpStore) GetIdentityProviderList() ([]BasicIDPDTO, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -108,7 +108,7 @@ func (s *idpStore) GetIdentityProviderByName(name string) (*IDPDTO, error) {
 
 // getIDP retrieves an IDP based on the provided query and identifier.
 func (s *idpStore) getIDP(query dbmodel.DBQuery, identifier string) (*IDPDTO, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -163,7 +163,7 @@ func (s *idpStore) getIDP(query dbmodel.DBQuery, identifier string) (*IDPDTO, er
 
 // UpdateIdentityProvider updates the idp in the database.
 func (s *idpStore) UpdateIdentityProvider(idp *IDPDTO) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -190,7 +190,7 @@ func (s *idpStore) UpdateIdentityProvider(idp *IDPDTO) error {
 func (s *idpStore) DeleteIdentityProvider(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPStore"))
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/notification/store.go
+++ b/backend/internal/notification/store.go
@@ -57,7 +57,7 @@ func newNotificationStore() notificationStoreInterface {
 
 // createSender creates a new notification sender.
 func (s *notificationStore) createSender(sender common.NotificationSenderDTO) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -82,7 +82,7 @@ func (s *notificationStore) createSender(sender common.NotificationSenderDTO) er
 
 // listSenders retrieves all notification senders
 func (s *notificationStore) listSenders() ([]common.NotificationSenderDTO, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -137,7 +137,7 @@ func (s *notificationStore) getSender(query dbmodel.DBQuery,
 	identifier string) (*common.NotificationSenderDTO, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationStore"))
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -181,7 +181,7 @@ func (s *notificationStore) getSender(query dbmodel.DBQuery,
 
 // updateSender updates an existing notification sender.
 func (s *notificationStore) updateSender(id string, sender common.NotificationSenderDTO) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -208,7 +208,7 @@ func (s *notificationStore) updateSender(id string, sender common.NotificationSe
 func (s *notificationStore) deleteSender(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationStore"))
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/notification/store_test.go
+++ b/backend/internal/notification/store_test.go
@@ -77,7 +77,7 @@ func (suite *StoreTestSuite) TestCreateSender() {
 		Properties:  []cmodels.Property{*p},
 	}
 
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	propsJSON, err := cmodels.SerializePropertiesToJSONArray([]cmodels.Property{*p})
 	suite.NoError(err)
 	suite.mockDBClient.EXPECT().Execute(queryCreateNotificationSender, sender.Name, sender.ID,
@@ -87,8 +87,8 @@ func (suite *StoreTestSuite) TestCreateSender() {
 	suite.NoError(err)
 }
 
-func (suite *StoreTestSuite) TestCreateSender_GetDBClientError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(nil, errors.New("db err")).Once()
+func (suite *StoreTestSuite) TestCreateSender_GetConfigDBClientError() {
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 	sender := common.NotificationSenderDTO{ID: "s1"}
 	err := suite.store.createSender(sender)
 	suite.Error(err)
@@ -104,7 +104,7 @@ func (suite *StoreTestSuite) TestCreateSender_DBExecuteError() {
 		Properties: []cmodels.Property{*p},
 	}
 
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	propsJSON, err := cmodels.SerializePropertiesToJSONArray([]cmodels.Property{*p})
 	suite.NoError(err)
 	suite.mockDBClient.EXPECT().Execute(queryCreateNotificationSender, sender.Name, sender.ID,
@@ -128,7 +128,7 @@ func (suite *StoreTestSuite) TestCreateSender_SerializeError() {
 	suite.NoError(err)
 	sender := common.NotificationSenderDTO{ID: "s-ser", Name: "n", Properties: []cmodels.Property{*p}}
 
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 
 	err = suite.store.createSender(sender)
 	suite.Error(err)
@@ -161,7 +161,7 @@ func (suite *StoreTestSuite) TestListSenders_WithPropertiesStringAndBytes() {
 		"properties":  []byte(propsJSON),
 	}
 
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetAllNotificationSenders).Return(
 		[]map[string]interface{}{row1, row2}, nil).Once()
 
@@ -172,8 +172,8 @@ func (suite *StoreTestSuite) TestListSenders_WithPropertiesStringAndBytes() {
 	suite.Len(senders[1].Properties, 1)
 }
 
-func (suite *StoreTestSuite) TestListSenders_GetDBClientError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(nil, errors.New("db err")).Once()
+func (suite *StoreTestSuite) TestListSenders_GetConfigDBClientError() {
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 	res, err := suite.store.listSenders()
 	suite.Error(err)
 	suite.Nil(res)
@@ -181,7 +181,7 @@ func (suite *StoreTestSuite) TestListSenders_GetDBClientError() {
 }
 
 func (suite *StoreTestSuite) TestListSenders_WithError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetAllNotificationSenders).Return(nil, errors.New("query fail")).Once()
 
 	res, err := suite.store.listSenders()
@@ -190,7 +190,7 @@ func (suite *StoreTestSuite) TestListSenders_WithError() {
 	suite.Contains(err.Error(), "failed to execute query")
 
 	badRow := map[string]interface{}{"name": "n1"}
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetAllNotificationSenders).Return(
 		[]map[string]interface{}{badRow}, nil).Once()
 
@@ -208,7 +208,7 @@ func (suite *StoreTestSuite) TestListSenders_WithError() {
 		"provider":    "twilio",
 		"properties":  "not-json",
 	}
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetAllNotificationSenders).Return(
 		[]map[string]interface{}{row}, nil).Once()
 
@@ -228,7 +228,7 @@ func (suite *StoreTestSuite) TestGetSenderByID() {
 		"provider":    "twilio",
 		"properties":  "",
 	}
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s1").Return(
 		[]map[string]interface{}{row}, nil).Once()
 
@@ -238,7 +238,7 @@ func (suite *StoreTestSuite) TestGetSenderByID() {
 	suite.Equal("s1", s.ID)
 
 	// not found
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s-x").Return(
 		[]map[string]interface{}{}, nil).Once()
 	s2, err := suite.store.getSenderByID("s-x")
@@ -246,7 +246,7 @@ func (suite *StoreTestSuite) TestGetSenderByID() {
 	suite.Nil(s2)
 
 	// multiple results -> error
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s-multi").Return(
 		[]map[string]interface{}{row, row}, nil).Once()
 	s3, err := suite.store.getSenderByID("s-multi")
@@ -254,15 +254,15 @@ func (suite *StoreTestSuite) TestGetSenderByID() {
 	suite.Nil(s3)
 }
 
-func (suite *StoreTestSuite) TestGetSenderByID_GetDBClientError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(nil, errors.New("db err")).Once()
+func (suite *StoreTestSuite) TestGetSenderByID_GetConfigDBClientError() {
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 	res, err := suite.store.getSenderByID("s1")
 	suite.Error(err)
 	suite.Nil(res)
 }
 
-func (suite *StoreTestSuite) TestGetSenderByName_GetDBClientError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(nil, errors.New("db err")).Once()
+func (suite *StoreTestSuite) TestGetSenderByName_GetConfigDBClientError() {
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 	res, err := suite.store.getSenderByName("n1")
 	suite.Error(err)
 	suite.Nil(res)
@@ -277,7 +277,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 		{
 			name: "query error",
 			setup: func(t *testing.T) {
-				suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 				suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s1").
 					Return(nil, errors.New("query fail")).Once()
 			},
@@ -293,7 +293,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 					"type":        "message",
 					"provider":    "twilio",
 				}
-				suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 				suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s1").
 					Return([]map[string]interface{}{row, row}, nil).Once()
 			},
@@ -303,7 +303,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 			name: "build error",
 			setup: func(t *testing.T) {
 				badRow := map[string]interface{}{"name": "n1"}
-				suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 				suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s1").
 					Return([]map[string]interface{}{badRow}, nil).Once()
 			},
@@ -320,7 +320,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 					"provider":    "twilio",
 					"properties":  "not-json",
 				}
-				suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 				suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s1").
 					Return([]map[string]interface{}{row}, nil).Once()
 			},
@@ -353,7 +353,7 @@ func (suite *StoreTestSuite) TestGetSender_WithProperties() {
 		"provider":    "twilio",
 		"properties":  propsJSON,
 	}
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Query(queryGetNotificationSenderByID, "s1").Return(
 		[]map[string]interface{}{row}, nil).Once()
 
@@ -366,7 +366,7 @@ func (suite *StoreTestSuite) TestGetSender_WithProperties() {
 func (suite *StoreTestSuite) TestUpdateSender() {
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.MessageProviderTypeTwilio}
 
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Execute(queryUpdateNotificationSender, sender.Name, sender.Description,
 		string(sender.Provider), "", "s1", string(sender.Type)).Return(int64(1), nil).Once()
 
@@ -380,7 +380,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithProperties() {
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1",
 		Provider: common.MessageProviderTypeTwilio, Properties: []cmodels.Property{*p}}
 
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	propsJSON, err := cmodels.SerializePropertiesToJSONArray([]cmodels.Property{*p})
 	suite.NoError(err)
 	suite.mockDBClient.EXPECT().Execute(queryUpdateNotificationSender, sender.Name, sender.Description,
@@ -390,8 +390,8 @@ func (suite *StoreTestSuite) TestUpdateSender_WithProperties() {
 	suite.NoError(err)
 }
 
-func (suite *StoreTestSuite) TestUpdateSender_GetDBClientError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(nil, errors.New("db err")).Once()
+func (suite *StoreTestSuite) TestUpdateSender_GetConfigDBClientError() {
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 	err := suite.store.updateSender("s1", common.NotificationSenderDTO{})
 	suite.Error(err)
 }
@@ -405,7 +405,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 		{
 			name: "get db client error",
 			setup: func(t *testing.T) {
-				suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(nil, errors.New("db err")).Once()
+				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 			},
 			wantErr: "failed to get database client",
 		},
@@ -413,7 +413,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 			name: "execute error",
 			setup: func(t *testing.T) {
 				sender := common.NotificationSenderDTO{Name: "n1", Provider: common.MessageProviderTypeTwilio}
-				suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 				suite.mockDBClient.EXPECT().Execute(queryUpdateNotificationSender, sender.Name,
 					sender.Description, string(sender.Provider), "", "s1", string(sender.Type)).
 					Return(int64(0), errors.New("exec fail")).Once()
@@ -437,7 +437,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 
 func (suite *StoreTestSuite) TestUpdateSender_ExecuteError() {
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.MessageProviderTypeTwilio}
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Execute(queryUpdateNotificationSender, sender.Name, sender.Description,
 		string(sender.Provider), "", "s1", string(sender.Type)).Return(int64(0), errors.New("exec fail")).Once()
 
@@ -458,7 +458,7 @@ func (suite *StoreTestSuite) TestUpdateSender_SerializeError() {
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1",
 		Provider: common.MessageProviderTypeTwilio, Properties: []cmodels.Property{*p}}
 
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 
 	err = suite.store.updateSender("s1", sender)
 	suite.Error(err)
@@ -467,21 +467,21 @@ func (suite *StoreTestSuite) TestUpdateSender_SerializeError() {
 
 func (suite *StoreTestSuite) TestDeleteSender_NoRows() {
 	// delete with 0 rows affected (should not return error)
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Execute(queryDeleteNotificationSender, "s1").Return(int64(0), nil).Once()
 
 	err := suite.store.deleteSender("s1")
 	suite.NoError(err)
 }
 
-func (suite *StoreTestSuite) TestDeleteSender_GetDBClientError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(nil, errors.New("db err")).Once()
+func (suite *StoreTestSuite) TestDeleteSender_GetConfigDBClientError() {
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 	err := suite.store.deleteSender("s1")
 	suite.Error(err)
 }
 
 func (suite *StoreTestSuite) TestDeleteSender_ExecuteError() {
-	suite.mockDBProvider.EXPECT().GetDBClient("identity").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	suite.mockDBClient.EXPECT().Execute(queryDeleteNotificationSender, "s1").Return(
 		int64(0), errors.New("exec fail")).Once()
 

--- a/backend/internal/oauth/oauth2/authz/store.go
+++ b/backend/internal/oauth/oauth2/authz/store.go
@@ -55,7 +55,7 @@ func newAuthorizationCodeStore() AuthorizationCodeStoreInterface {
 func (acs *authorizationCodeStore) InsertAuthorizationCode(authzCode AuthorizationCode) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, storeLoggerComponentName))
 
-	dbClient, err := acs.dbProvider.GetDBClient("runtime")
+	dbClient, err := acs.dbProvider.GetRuntimeDBClient()
 	if err != nil {
 		logger.Error("Failed to get database client", log.Error(err))
 		return err
@@ -105,7 +105,7 @@ func (acs *authorizationCodeStore) InsertAuthorizationCode(authzCode Authorizati
 func (acs *authorizationCodeStore) GetAuthorizationCode(clientID, authCode string) (AuthorizationCode, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, storeLoggerComponentName))
 
-	dbClient, err := acs.dbProvider.GetDBClient("runtime")
+	dbClient, err := acs.dbProvider.GetRuntimeDBClient()
 	if err != nil {
 		logger.Error("Failed to get database client", log.Error(err))
 		return AuthorizationCode{}, err
@@ -199,7 +199,7 @@ func (acs *authorizationCodeStore) updateAuthorizationCodeState(authzCode Author
 	newState string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, storeLoggerComponentName))
 
-	dbClient, err := acs.dbProvider.GetDBClient("runtime")
+	dbClient, err := acs.dbProvider.GetRuntimeDBClient()
 	if err != nil {
 		logger.Error("Failed to get database client", log.Error(err))
 		return err

--- a/backend/internal/oauth/oauth2/authz/store_test.go
+++ b/backend/internal/oauth/oauth2/authz/store_test.go
@@ -90,7 +90,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestnewAuthorizationCodeStore() {
 func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_Success() {
 	mockTx := &modelmock.TxInterfaceMock{}
 
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(mockTx, nil)
 
 	mockTx.On("Exec", queryInsertAuthorizationCode.Query,
@@ -115,7 +115,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_Succes
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_DBClientError() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(nil, errors.New("db client error"))
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db client error"))
 
 	err := suite.store.InsertAuthorizationCode(suite.testAuthzCode)
 	assert.Error(suite.T(), err)
@@ -125,7 +125,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_DBClie
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_BeginTxError() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(nil, errors.New("tx error"))
 
 	err := suite.store.InsertAuthorizationCode(suite.testAuthzCode)
@@ -139,7 +139,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_BeginT
 func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_ExecError() {
 	mockTx := &modelmock.TxInterfaceMock{}
 
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(mockTx, nil)
 
 	mockTx.On("Exec", queryInsertAuthorizationCode.Query,
@@ -163,7 +163,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_ExecEr
 func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_ScopeExecError() {
 	mockTx := &modelmock.TxInterfaceMock{}
 
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(mockTx, nil)
 
 	mockTx.On("Exec", queryInsertAuthorizationCode.Query,
@@ -191,7 +191,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_ScopeE
 func (suite *AuthorizationCodeStoreTestSuite) TestInsertAuthorizationCode_CommitError() {
 	mockTx := &modelmock.TxInterfaceMock{}
 
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(mockTx, nil)
 
 	mockTx.On("Exec", queryInsertAuthorizationCode.Query,
@@ -236,7 +236,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_Success()
 		{"scope": "read write"},
 	}
 
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetAuthorizationCode, "test-client-id", "test-code").
 		Return(queryResults, nil)
 	suite.mockDBClient.On("Query", queryGetAuthorizationCodeScopes, "test-code-id").
@@ -259,7 +259,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_Success()
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_DBClientError() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(nil, errors.New("db client error"))
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db client error"))
 
 	result, err := suite.store.GetAuthorizationCode("test-client-id", "test-code")
 	assert.Error(suite.T(), err)
@@ -269,7 +269,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_DBClientE
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_QueryError() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetAuthorizationCode, "test-client-id", "test-code").
 		Return(nil, errors.New("query error"))
 
@@ -285,7 +285,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_QueryErro
 func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_NoResults() {
 	queryResults := []map[string]interface{}{}
 
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetAuthorizationCode, "test-client-id", "test-code").
 		Return(queryResults, nil)
 
@@ -305,7 +305,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_EmptyCode
 		},
 	}
 
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetAuthorizationCode, "test-client-id", "test-code").
 		Return(queryResults, nil)
 
@@ -319,7 +319,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_EmptyCode
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestDeactivateAuthorizationCode_Success() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState,
 		AuthCodeStateInactive, suite.testAuthzCode.CodeID).Return(int64(1), nil)
 
@@ -331,7 +331,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestDeactivateAuthorizationCode_Su
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestRevokeAuthorizationCode_Success() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState,
 		AuthCodeStateRevoked, suite.testAuthzCode.CodeID).Return(int64(1), nil)
 
@@ -343,7 +343,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestRevokeAuthorizationCode_Succes
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestExpireAuthorizationCode_Success() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(suite.mockDBClient, nil)
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState,
 		AuthCodeStateExpired, suite.testAuthzCode.CodeID).Return(int64(1), nil)
 
@@ -355,7 +355,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestExpireAuthorizationCode_Succes
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestUpdateAuthorizationCodeState_Error() {
-	suite.mockdbProvider.On("GetDBClient", "runtime").Return(nil, errors.New("db client error"))
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db client error"))
 
 	err := suite.store.DeactivateAuthorizationCode(suite.testAuthzCode)
 	assert.Error(suite.T(), err)

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -63,7 +63,7 @@ func newOrganizationUnitStore() organizationUnitStoreInterface {
 
 // GetOrganizationUnitListCount retrieves the total count of organization units.
 func (s *organizationUnitStore) GetOrganizationUnitListCount() (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -87,7 +87,7 @@ func (s *organizationUnitStore) GetOrganizationUnitListCount() (int, error) {
 
 // GetOrganizationUnitList retrieves organization units with pagination.
 func (s *organizationUnitStore) GetOrganizationUnitList(limit, offset int) ([]OrganizationUnitBasic, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -111,7 +111,7 @@ func (s *organizationUnitStore) GetOrganizationUnitList(limit, offset int) ([]Or
 
 // CreateOrganizationUnit creates a new organization unit in the database.
 func (s *organizationUnitStore) CreateOrganizationUnit(ou OrganizationUnit) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -133,7 +133,7 @@ func (s *organizationUnitStore) CreateOrganizationUnit(ou OrganizationUnit) erro
 
 // GetOrganizationUnit retrieves an organization unit by its id.
 func (s *organizationUnitStore) GetOrganizationUnit(id string) (OrganizationUnit, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return OrganizationUnit{}, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -163,7 +163,7 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(handlePath []string) (
 		return OrganizationUnit{}, ErrOrganizationUnitNotFound
 	}
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return OrganizationUnit{}, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -207,7 +207,7 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(handlePath []string) (
 
 // IsOrganizationUnitExists checks if an organization unit exists by ID.
 func (s *organizationUnitStore) IsOrganizationUnitExists(id string) (bool, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -232,7 +232,7 @@ func (s *organizationUnitStore) IsOrganizationUnitExists(id string) (bool, error
 
 // UpdateOrganizationUnit updates an existing organization unit.
 func (s *organizationUnitStore) UpdateOrganizationUnit(ou OrganizationUnit) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -254,7 +254,7 @@ func (s *organizationUnitStore) UpdateOrganizationUnit(ou OrganizationUnit) erro
 
 // DeleteOrganizationUnit deletes an organization unit.
 func (s *organizationUnitStore) DeleteOrganizationUnit(id string) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -269,7 +269,7 @@ func (s *organizationUnitStore) DeleteOrganizationUnit(id string) error {
 
 // GetOrganizationUnitChildrenCount retrieves the total count of child organization units for a given parent ID.
 func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(parentID string) (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -296,7 +296,7 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(parentID string
 func (s *organizationUnitStore) GetOrganizationUnitChildrenList(
 	parentID string, limit, offset int,
 ) ([]OrganizationUnitBasic, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -320,7 +320,7 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenList(
 
 // GetOrganizationUnitUsersCount retrieves the total count of users in a given organization unit.
 func (s *organizationUnitStore) GetOrganizationUnitUsersCount(ouID string) (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -345,7 +345,7 @@ func (s *organizationUnitStore) GetOrganizationUnitUsersCount(ouID string) (int,
 
 // GetOrganizationUnitUsersList retrieves a paginated list of users in a given organization unit.
 func (s *organizationUnitStore) GetOrganizationUnitUsersList(ouID string, limit, offset int) ([]User, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -371,7 +371,7 @@ func (s *organizationUnitStore) GetOrganizationUnitUsersList(ouID string, limit,
 
 // GetOrganizationUnitGroupsCount retrieves the total count of groups in a given organization unit.
 func (s *organizationUnitStore) GetOrganizationUnitGroupsCount(ouID string) (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -396,7 +396,7 @@ func (s *organizationUnitStore) GetOrganizationUnitGroupsCount(ouID string) (int
 
 // GetOrganizationUnitGroupsList retrieves a paginated list of groups in a given organization unit.
 func (s *organizationUnitStore) GetOrganizationUnitGroupsList(ouID string, limit, offset int) ([]Group, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -454,7 +454,7 @@ func (s *organizationUnitStore) CheckOrganizationUnitHandleConflict(handle strin
 
 // CheckOrganizationUnitHasChildResources checks if an organization unit has users groups or sub-ous.
 func (s *organizationUnitStore) CheckOrganizationUnitHasChildResources(ouID string) (bool, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -539,7 +539,7 @@ func (s *organizationUnitStore) checkConflict(
 	parentID *string,
 	extraArgs ...interface{},
 ) (bool, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/ou/store_test.go
+++ b/backend/internal/ou/store_test.go
@@ -50,7 +50,7 @@ func (suite *OrganizationUnitStoreTestSuite) SetupTest() {
 }
 
 func (suite *OrganizationUnitStoreTestSuite) expectDBClient() {
-	suite.providerMock.On("GetDBClient", "identity").Return(suite.dbClientMock, nil)
+	suite.providerMock.On("GetConfigDBClient").Return(suite.dbClientMock, nil)
 }
 
 type conflictTestCase struct {
@@ -188,7 +188,7 @@ func (suite *OrganizationUnitStoreTestSuite) runConflictQueryScenario(
 				name: "db client error",
 				setup: func(_ *string) {
 					suite.providerMock.
-						On("GetDBClient", "identity").
+						On("GetConfigDBClient").
 						Return(nil, errors.New("db err")).
 						Once()
 				},
@@ -254,7 +254,7 @@ func (suite *OrganizationUnitStoreTestSuite) runCountQueryScenario(
 				name: "db client error",
 				setup: func() {
 					suite.providerMock.
-						On("GetDBClient", "identity").
+						On("GetConfigDBClient").
 						Return(nil, errors.New("db err")).
 						Once()
 				},
@@ -426,7 +426,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitHa
 			name: "db client error",
 			setup: func() {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -535,7 +535,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			name: "db client error",
 			setup: func() {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -641,7 +641,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			offset: 0,
 			setup: func(limit, offset int) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -744,7 +744,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitUser
 			offset: 0,
 			setup: func(limit, offset int) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -850,7 +850,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 			offset: 0,
 			setup: func(parent string, limit, offset int) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -940,7 +940,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_UpdateOrganizationUnit(
 			ou:   OrganizationUnit{ID: "ou1"},
 			setup: func(ou OrganizationUnit) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -998,7 +998,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_DeleteOrganizationUnit(
 			name: "db client error",
 			setup: func() {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -1091,7 +1091,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitExist
 			name: "db client error",
 			setup: func() {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db fail")).
 					Once()
 			},
@@ -1160,7 +1160,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 			path:    []string{},
 			wantErr: ErrOrganizationUnitNotFound,
 			after: func() {
-				suite.providerMock.AssertNotCalled(suite.T(), "GetDBClient", mock.Anything)
+				suite.providerMock.AssertNotCalled(suite.T(), "GetConfigDBClient", mock.Anything)
 			},
 		},
 		{
@@ -1168,7 +1168,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 			path: []string{"root"},
 			setup: func(_ []string) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -1327,7 +1327,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnit() {
 			id:   "ou1",
 			setup: func(id string) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -1420,7 +1420,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CreateOrganizationUnit(
 			ou:   OrganizationUnit{ID: "ou1"},
 			setup: func(ou OrganizationUnit) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db init failed")).
 					Once()
 			},
@@ -1511,7 +1511,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			offset: 0,
 			setup: func(limit, offset int) {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("db err")).
 					Once()
 			},
@@ -1586,7 +1586,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			name: "db client error",
 			setup: func() {
 				suite.providerMock.
-					On("GetDBClient", "identity").
+					On("GetConfigDBClient").
 					Return(nil, errors.New("no db")).
 					Once()
 			},

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -468,7 +468,7 @@ func (s *roleStore) GetAuthorizedPermissions(
 
 // getIdentityDBClient is a helper method to get the database client for the identity database.
 func (s *roleStore) getIdentityDBClient() (provider.DBClientInterface, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/role/store_test.go
+++ b/backend/internal/role/store_test.go
@@ -73,7 +73,7 @@ func (suite *RoleStoreTestSuite) SetupTest() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRoleListCount_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleListCount).Return([]map[string]interface{}{
 		{"total": int64(10)},
 	}, nil)
@@ -86,7 +86,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleListCount_Success() {
 
 func (suite *RoleStoreTestSuite) TestGetRoleListCount_QueryError() {
 	queryError := errors.New("query error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleListCount).Return(nil, queryError)
 
 	count, err := suite.store.GetRoleListCount()
@@ -97,7 +97,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleListCount_QueryError() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRoleList_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleList, 10, 0).Return([]map[string]interface{}{
 		{"role_id": "role1", "name": "Admin", "description": "Admin role", "ou_id": "ou1"},
 		{"role_id": "role2", "name": "User", "description": "User role", "ou_id": "ou1"},
@@ -113,7 +113,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleList_Success() {
 
 func (suite *RoleStoreTestSuite) TestGetRoleList_QueryError() {
 	queryError := errors.New("query error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleList, 10, 0).Return(nil, queryError)
 
 	roles, err := suite.store.GetRoleList(10, 0)
@@ -123,7 +123,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleList_QueryError() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRoleList_InvalidRowData() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleList, 10, 0).Return([]map[string]interface{}{
 		{"role_id": 123, "name": "Admin", "description": "Admin role", "ou_id": "ou1"}, // Invalid role_id type
 	}, nil)
@@ -144,7 +144,7 @@ func (suite *RoleStoreTestSuite) TestCreateRole_Success() {
 		Assignments:        []RoleAssignment{{ID: "user1", Type: AssigneeTypeUser}},
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
 	suite.mockTx.On("Exec", queryCreateRole.Query, mock.Anything, "ou1", "Test Role", "Test Description").
 		Return(&mockResult{}, nil)
@@ -169,7 +169,7 @@ func (suite *RoleStoreTestSuite) TestCreateRole_ExecError() {
 	}
 
 	execError := errors.New("insert failed")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
 	suite.mockTx.On("Exec", queryCreateRole.Query, mock.Anything, "ou1", "Test Role", "Test Description").
 		Return(nil, execError)
@@ -182,7 +182,7 @@ func (suite *RoleStoreTestSuite) TestCreateRole_ExecError() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRole_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleByID, "role1").Return([]map[string]interface{}{
 		{"role_id": "role1", "name": "Admin", "description": "Admin role", "ou_id": "ou1"},
 	}, nil)
@@ -200,7 +200,7 @@ func (suite *RoleStoreTestSuite) TestGetRole_Success() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRole_NotFound() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleByID, "nonexistent").Return([]map[string]interface{}{}, nil)
 
 	role, err := suite.store.GetRole("nonexistent")
@@ -211,7 +211,7 @@ func (suite *RoleStoreTestSuite) TestGetRole_NotFound() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRole_MultipleResults() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleByID, "role1").Return([]map[string]interface{}{
 		{"role_id": "role1", "name": "Admin", "description": "Admin role", "ou_id": "ou1"},
 		{"role_id": "role1", "name": "Admin", "description": "Admin role", "ou_id": "ou1"},
@@ -225,7 +225,7 @@ func (suite *RoleStoreTestSuite) TestGetRole_MultipleResults() {
 }
 
 func (suite *RoleStoreTestSuite) TestIsRoleExist_Exists() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckRoleExists, "role1").Return([]map[string]interface{}{
 		{"count": int64(1)},
 	}, nil)
@@ -237,7 +237,7 @@ func (suite *RoleStoreTestSuite) TestIsRoleExist_Exists() {
 }
 
 func (suite *RoleStoreTestSuite) TestIsRoleExist_DoesNotExist() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckRoleExists, "nonexistent").Return([]map[string]interface{}{
 		{"count": int64(0)},
 	}, nil)
@@ -249,7 +249,7 @@ func (suite *RoleStoreTestSuite) TestIsRoleExist_DoesNotExist() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRoleAssignments_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleAssignments, "role1", 10, 0).Return([]map[string]interface{}{
 		{"assignee_id": "user1", "assignee_type": "user"},
 		{"assignee_id": "group1", "assignee_type": "group"},
@@ -264,7 +264,7 @@ func (suite *RoleStoreTestSuite) TestGetRoleAssignments_Success() {
 }
 
 func (suite *RoleStoreTestSuite) TestGetRoleAssignmentsCount_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryGetRoleAssignmentsCount, "role1").Return([]map[string]interface{}{
 		{"total": int64(5)},
 	}, nil)
@@ -283,7 +283,7 @@ func (suite *RoleStoreTestSuite) TestUpdateRole_Success() {
 		Permissions:        []string{"perm1"},
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
 	suite.mockTx.On("Exec", queryUpdateRole.Query, "ou1", "Updated Role", "Updated Description", "role1").
 		Return(&mockResult{rowsAffected: 1}, nil)
@@ -304,7 +304,7 @@ func (suite *RoleStoreTestSuite) TestUpdateRole_NotFound() {
 		Permissions:        []string{},
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
 	suite.mockTx.On("Exec", queryUpdateRole.Query, "ou1", "Updated Role", "Updated Description", "nonexistent").
 		Return(&mockResult{rowsAffected: 0}, nil)
@@ -317,7 +317,7 @@ func (suite *RoleStoreTestSuite) TestUpdateRole_NotFound() {
 }
 
 func (suite *RoleStoreTestSuite) TestDeleteRole_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryDeleteRole, "role1").Return(int64(1), nil)
 
 	err := suite.store.DeleteRole("role1")
@@ -327,7 +327,7 @@ func (suite *RoleStoreTestSuite) TestDeleteRole_Success() {
 
 func (suite *RoleStoreTestSuite) TestDeleteRole_ExecuteError() {
 	execError := errors.New("delete failed")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Execute", queryDeleteRole, "role1").Return(int64(0), execError)
 
 	err := suite.store.DeleteRole("role1")
@@ -340,7 +340,7 @@ func (suite *RoleStoreTestSuite) TestAddAssignments_Success() {
 		{ID: "user1", Type: AssigneeTypeUser},
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
 	suite.mockTx.On("Exec", queryCreateRoleAssignment.Query, "role1", AssigneeTypeUser, "user1").
 		Return(&mockResult{}, nil)
@@ -356,7 +356,7 @@ func (suite *RoleStoreTestSuite) TestRemoveAssignments_Success() {
 		{ID: "user1", Type: AssigneeTypeUser},
 	}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
 	suite.mockTx.On("Exec", queryDeleteRoleAssignmentsByIDs.Query, "role1", AssigneeTypeUser, "user1").
 		Return(&mockResult{}, nil)
@@ -368,7 +368,7 @@ func (suite *RoleStoreTestSuite) TestRemoveAssignments_Success() {
 }
 
 func (suite *RoleStoreTestSuite) TestCheckRoleNameExists_Exists() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckRoleNameExists, "ou1", "Admin").Return([]map[string]interface{}{
 		{"count": int64(1)},
 	}, nil)
@@ -380,7 +380,7 @@ func (suite *RoleStoreTestSuite) TestCheckRoleNameExists_Exists() {
 }
 
 func (suite *RoleStoreTestSuite) TestCheckRoleNameExistsExcludingID_DoesNotExist() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", queryCheckRoleNameExistsExcludingID, "ou1", "Admin", "role1").
 		Return([]map[string]interface{}{
 			{"count": int64(0)},
@@ -397,7 +397,7 @@ func (suite *RoleStoreTestSuite) TestGetAuthorizedPermissions_Success() {
 	groupIDs := []string{"group1"}
 	requestedPermissions := []string{"perm1", "perm2"}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		[]map[string]interface{}{
 			{"permission": "perm1"},
@@ -414,7 +414,7 @@ func (suite *RoleStoreTestSuite) TestGetAuthorizedPermissions_NilGroupsHandled()
 	userID := "user1"
 	requestedPermissions := []string{"perm1"}
 
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Return([]map[string]interface{}{
 		{"permission": "perm1"},
 	}, nil)
@@ -461,7 +461,7 @@ func (suite *RoleStoreTestSuite) TestBuildRoleBasicInfoFromResultRow_InvalidData
 // Test Helper Functions
 
 func (suite *RoleStoreTestSuite) TestGetIdentityDBClient_Success() {
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(suite.mockDBClient, nil)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 
 	client, err := suite.store.getIdentityDBClient()
 
@@ -472,7 +472,7 @@ func (suite *RoleStoreTestSuite) TestGetIdentityDBClient_Success() {
 
 func (suite *RoleStoreTestSuite) TestGetIdentityDBClient_Error() {
 	dbError := errors.New("database connection error")
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, dbError)
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
 
 	client, err := suite.store.getIdentityDBClient()
 

--- a/backend/internal/system/database/provider/dbprovider.go
+++ b/backend/internal/system/database/provider/dbprovider.go
@@ -44,7 +44,8 @@ type dbConfig struct {
 
 // DBProviderInterface defines the interface for getting database clients.
 type DBProviderInterface interface {
-	GetDBClient(dbName string) (DBClientInterface, error)
+	GetConfigDBClient() (DBClientInterface, error)
+	GetRuntimeDBClient() (DBClientInterface, error)
 }
 
 // DBProviderCloser is a separate interface for closing the provider.
@@ -87,19 +88,18 @@ func GetDBProviderCloser() DBProviderCloser {
 	return instance
 }
 
-// GetDBClient returns a database client based on the provided database name.
+// GetConfigDBClient returns a database client for config datasource.
 // Not required to close the returned client manually since it manages its own connection pool.
-func (d *dbProvider) GetDBClient(dbName string) (DBClientInterface, error) {
-	switch dbName {
-	case "identity":
-		identityDBConfig := config.GetThunderRuntime().Config.Database.Identity
-		return d.getOrInitClient(&d.identityClient, &d.identityMutex, identityDBConfig)
-	case "runtime":
-		runtimeDBConfig := config.GetThunderRuntime().Config.Database.Runtime
-		return d.getOrInitClient(&d.runtimeClient, &d.runtimeMutex, runtimeDBConfig)
-	default:
-		return nil, fmt.Errorf("unsupported database name: %s", dbName)
-	}
+func (d *dbProvider) GetConfigDBClient() (DBClientInterface, error) {
+	identityDBConfig := config.GetThunderRuntime().Config.Database.Identity
+	return d.getOrInitClient(&d.identityClient, &d.identityMutex, identityDBConfig)
+}
+
+// GetRuntimeDBClient returns a database client for runtime datasource.
+// Not required to close the returned client manually since it manages its own connection pool.
+func (d *dbProvider) GetRuntimeDBClient() (DBClientInterface, error) {
+	runtimeDBConfig := config.GetThunderRuntime().Config.Database.Runtime
+	return d.getOrInitClient(&d.runtimeClient, &d.runtimeMutex, runtimeDBConfig)
 }
 
 // initializeAllClients initializes both identity and runtime clients at startup.

--- a/backend/internal/system/healthcheck/service/healthcheckservice_test.go
+++ b/backend/internal/system/healthcheck/service/healthcheckservice_test.go
@@ -72,8 +72,8 @@ func (suite *HealthCheckServiceTestSuite) BeforeTest(suiteName, testName string)
 	suite.mockRuntimeDB = dbClientRuntime
 
 	dbProvider := &dbprovidermock.DBProviderInterfaceMock{}
-	dbProvider.On("GetDBClient", "identity").Return(dbClientIdentity, nil)
-	dbProvider.On("GetDBClient", "runtime").Return(dbClientRuntime, nil)
+	dbProvider.On("GetConfigDBClient").Return(dbClientIdentity, nil)
+	dbProvider.On("GetRuntimeDBClient").Return(dbClientRuntime, nil)
 	suite.mockDBProvider = dbProvider
 	suite.service.(*HealthCheckService).DBProvider = dbProvider
 }
@@ -193,8 +193,8 @@ func (suite *HealthCheckServiceTestSuite) TestCheckReadiness() {
 
 func (suite *HealthCheckServiceTestSuite) TestCheckReadiness_DBRetrievalError() {
 	suite.mockDBProvider.ExpectedCalls = nil
-	suite.mockDBProvider.On("GetDBClient", "identity").Return(nil, errors.New("failed to get identity DB client"))
-	suite.mockDBProvider.On("GetDBClient", "runtime").Return(nil, errors.New("failed to get runtime DB client"))
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("failed to get identity DB client"))
+	suite.mockDBProvider.On("GetRuntimeDBClient").Return(nil, errors.New("failed to get runtime DB client"))
 
 	// Execute the method being tested
 	serverStatus := suite.service.CheckReadiness()

--- a/backend/internal/user/store.go
+++ b/backend/internal/user/store.go
@@ -51,7 +51,7 @@ func newUserStore() userStoreInterface {
 
 // GetUserListCount retrieves the total count of users.
 func (us *userStore) GetUserListCount(filters map[string]interface{}) (int, error) {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -80,7 +80,7 @@ func (us *userStore) GetUserListCount(filters map[string]interface{}) (int, erro
 
 // GetUserList retrieves a list of users from the database.
 func (us *userStore) GetUserList(limit, offset int, filters map[string]interface{}) ([]User, error) {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -110,7 +110,7 @@ func (us *userStore) GetUserList(limit, offset int, filters map[string]interface
 
 // CreateUser handles the user creation in the database.
 func (us *userStore) CreateUser(user User, credentials []Credential) error {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -150,7 +150,7 @@ func (us *userStore) CreateUser(user User, credentials []Credential) error {
 
 // GetUser retrieves a specific user by its ID from the database.
 func (us *userStore) GetUser(id string) (User, error) {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return User{}, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -179,7 +179,7 @@ func (us *userStore) GetUser(id string) (User, error) {
 
 // UpdateUser updates the user in the database.
 func (us *userStore) UpdateUser(user *User) error {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -207,7 +207,7 @@ func (us *userStore) UpdateUser(user *User) error {
 func (us *userStore) DeleteUser(id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -228,7 +228,7 @@ func (us *userStore) DeleteUser(id string) error {
 func (us *userStore) IdentifyUser(filters map[string]interface{}) (*string, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserStore"))
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -274,7 +274,7 @@ func (us *userStore) IdentifyUser(filters map[string]interface{}) (*string, erro
 
 // VerifyUser validate the user specified user using the given credentials from the database.
 func (us *userStore) VerifyUser(id string) (User, []Credential, error) {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return User{}, []Credential{}, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -324,7 +324,7 @@ func (us *userStore) ValidateUserIDs(userIDs []string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -358,7 +358,7 @@ func (us *userStore) ValidateUserIDs(userIDs []string) ([]string, error) {
 
 // GetGroupCountForUser retrieves the total count of groups a user belongs to.
 func (us *userStore) GetGroupCountForUser(userID string) (int, error) {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -380,7 +380,7 @@ func (us *userStore) GetGroupCountForUser(userID string) (int, error) {
 
 // GetUserGroups retrieves groups that a user belongs to with pagination.
 func (us *userStore) GetUserGroups(userID string, limit, offset int) ([]UserGroup, error) {
-	dbClient, err := provider.GetDBProvider().GetDBClient("identity")
+	dbClient, err := provider.GetDBProvider().GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/internal/userschema/store.go
+++ b/backend/internal/userschema/store.go
@@ -52,7 +52,7 @@ func newUserSchemaStore() userSchemaStoreInterface {
 
 // GetUserSchemaListCount retrieves the total count of user schemas.
 func (s *userSchemaStore) GetUserSchemaListCount() (int, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -78,7 +78,7 @@ func (s *userSchemaStore) GetUserSchemaListCount() (int, error) {
 func (s *userSchemaStore) GetUserSchemaList(limit, offset int) ([]UserSchemaListItem, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -103,7 +103,7 @@ func (s *userSchemaStore) GetUserSchemaList(limit, offset int) ([]UserSchemaList
 
 // CreateUserSchema creates a new user schema.
 func (s *userSchemaStore) CreateUserSchema(userSchema UserSchema) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -125,7 +125,7 @@ func (s *userSchemaStore) CreateUserSchema(userSchema UserSchema) error {
 
 // GetUserSchemaByID retrieves a user schema by its ID.
 func (s *userSchemaStore) GetUserSchemaByID(schemaID string) (UserSchema, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return UserSchema{}, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -144,7 +144,7 @@ func (s *userSchemaStore) GetUserSchemaByID(schemaID string) (UserSchema, error)
 
 // GetUserSchemaByName retrieves a user schema by its name.
 func (s *userSchemaStore) GetUserSchemaByName(name string) (UserSchema, error) {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return UserSchema{}, fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -163,7 +163,7 @@ func (s *userSchemaStore) GetUserSchemaByName(name string) (UserSchema, error) {
 
 // UpdateUserSchemaByID updates a user schema by its ID.
 func (s *userSchemaStore) UpdateUserSchemaByID(schemaID string, userSchema UserSchema) error {
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
@@ -187,7 +187,7 @@ func (s *userSchemaStore) UpdateUserSchemaByID(schemaID string, userSchema UserS
 func (s *userSchemaStore) DeleteUserSchemaByID(schemaID string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserSchemaPersistence"))
 
-	dbClient, err := s.dbProvider.GetDBClient("identity")
+	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}

--- a/backend/tests/mocks/database/providermock/DBProviderInterface_mock.go
+++ b/backend/tests/mocks/database/providermock/DBProviderInterface_mock.go
@@ -36,64 +36,112 @@ func (_m *DBProviderInterfaceMock) EXPECT() *DBProviderInterfaceMock_Expecter {
 	return &DBProviderInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
-// GetDBClient provides a mock function for the type DBProviderInterfaceMock
-func (_mock *DBProviderInterfaceMock) GetDBClient(dbName string) (provider.DBClientInterface, error) {
-	ret := _mock.Called(dbName)
+// GetConfigDBClient provides a mock function for the type DBProviderInterfaceMock
+func (_mock *DBProviderInterfaceMock) GetConfigDBClient() (provider.DBClientInterface, error) {
+	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDBClient")
+		panic("no return value specified for GetConfigDBClient")
 	}
 
 	var r0 provider.DBClientInterface
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (provider.DBClientInterface, error)); ok {
-		return returnFunc(dbName)
+	if returnFunc, ok := ret.Get(0).(func() (provider.DBClientInterface, error)); ok {
+		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) provider.DBClientInterface); ok {
-		r0 = returnFunc(dbName)
+	if returnFunc, ok := ret.Get(0).(func() provider.DBClientInterface); ok {
+		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(provider.DBClientInterface)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(dbName)
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// DBProviderInterfaceMock_GetDBClient_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDBClient'
-type DBProviderInterfaceMock_GetDBClient_Call struct {
+// DBProviderInterfaceMock_GetConfigDBClient_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfigDBClient'
+type DBProviderInterfaceMock_GetConfigDBClient_Call struct {
 	*mock.Call
 }
 
-// GetDBClient is a helper method to define mock.On call
-//   - dbName string
-func (_e *DBProviderInterfaceMock_Expecter) GetDBClient(dbName interface{}) *DBProviderInterfaceMock_GetDBClient_Call {
-	return &DBProviderInterfaceMock_GetDBClient_Call{Call: _e.mock.On("GetDBClient", dbName)}
+// GetConfigDBClient is a helper method to define mock.On call
+func (_e *DBProviderInterfaceMock_Expecter) GetConfigDBClient() *DBProviderInterfaceMock_GetConfigDBClient_Call {
+	return &DBProviderInterfaceMock_GetConfigDBClient_Call{Call: _e.mock.On("GetConfigDBClient")}
 }
 
-func (_c *DBProviderInterfaceMock_GetDBClient_Call) Run(run func(dbName string)) *DBProviderInterfaceMock_GetDBClient_Call {
+func (_c *DBProviderInterfaceMock_GetConfigDBClient_Call) Run(run func()) *DBProviderInterfaceMock_GetConfigDBClient_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run()
 	})
 	return _c
 }
 
-func (_c *DBProviderInterfaceMock_GetDBClient_Call) Return(dBClientInterface provider.DBClientInterface, err error) *DBProviderInterfaceMock_GetDBClient_Call {
+func (_c *DBProviderInterfaceMock_GetConfigDBClient_Call) Return(dBClientInterface provider.DBClientInterface, err error) *DBProviderInterfaceMock_GetConfigDBClient_Call {
 	_c.Call.Return(dBClientInterface, err)
 	return _c
 }
 
-func (_c *DBProviderInterfaceMock_GetDBClient_Call) RunAndReturn(run func(dbName string) (provider.DBClientInterface, error)) *DBProviderInterfaceMock_GetDBClient_Call {
+func (_c *DBProviderInterfaceMock_GetConfigDBClient_Call) RunAndReturn(run func() (provider.DBClientInterface, error)) *DBProviderInterfaceMock_GetConfigDBClient_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRuntimeDBClient provides a mock function for the type DBProviderInterfaceMock
+func (_mock *DBProviderInterfaceMock) GetRuntimeDBClient() (provider.DBClientInterface, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRuntimeDBClient")
+	}
+
+	var r0 provider.DBClientInterface
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (provider.DBClientInterface, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() provider.DBClientInterface); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(provider.DBClientInterface)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// DBProviderInterfaceMock_GetRuntimeDBClient_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRuntimeDBClient'
+type DBProviderInterfaceMock_GetRuntimeDBClient_Call struct {
+	*mock.Call
+}
+
+// GetRuntimeDBClient is a helper method to define mock.On call
+func (_e *DBProviderInterfaceMock_Expecter) GetRuntimeDBClient() *DBProviderInterfaceMock_GetRuntimeDBClient_Call {
+	return &DBProviderInterfaceMock_GetRuntimeDBClient_Call{Call: _e.mock.On("GetRuntimeDBClient")}
+}
+
+func (_c *DBProviderInterfaceMock_GetRuntimeDBClient_Call) Run(run func()) *DBProviderInterfaceMock_GetRuntimeDBClient_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *DBProviderInterfaceMock_GetRuntimeDBClient_Call) Return(dBClientInterface provider.DBClientInterface, err error) *DBProviderInterfaceMock_GetRuntimeDBClient_Call {
+	_c.Call.Return(dBClientInterface, err)
+	return _c
+}
+
+func (_c *DBProviderInterfaceMock_GetRuntimeDBClient_Call) RunAndReturn(run func() (provider.DBClientInterface, error)) *DBProviderInterfaceMock_GetRuntimeDBClient_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request refactors database client retrieval throughout the code base. The main change is replacing usage of the generic `GetDBClient("identity")` method with a more specific `GetConfigDBClient()` or `GetRuntimeDBClient()` methods, improving clarity and consistency in how the database clients are obtained. This update is applied across both production code and associated unit tests.

### Approach
* Replaced all calls to `provider.GetDBProvider().GetDBClient("identity")` with `provider.GetDBProvider().GetConfigDBClient()` in `backend/internal/application/store.go`, affecting methods such as `CreateApplication`, `GetTotalApplicationCount`, `GetApplicationList`, `GetOAuthApplication`, `getApplicationByQuery`, `UpdateApplication`, `DeleteApplication`, and `executeTransaction`. [[1]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L117-R117) [[2]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L143-R143) [[3]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L173-R173) [[4]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L292-R292) [[5]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L364-R364) [[6]](diffhunk://#diff-02b4c03eb801e3aa8b5711076afc7cb63e519d2f1cfcbace0815d149cd854810L825-R825)
* Updated `backend/internal/branding/store.go` to use `GetConfigDBClient()` in the helper and all relevant methods.
* Refactored all branding store unit tests in `backend/internal/branding/store_test.go` to mock and expect `GetConfigDBClient()` instead of `GetDBClient("identity")`, ensuring test coverage matches the new implementation. [[1]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL54-R54) [[2]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL66-R66) [[3]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL77-R77) [[4]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL88-R88) [[5]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL99-R99) [[6]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL113-R113) [[7]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL136-R136) [[8]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL147-R147) [[9]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL158-R158) [[10]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL169-R169) [[11]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL183-R183) [[12]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL207-R207) [[13]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL224-R224) [[14]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL240-R240) [[15]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL253-R253) [[16]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL270-R270) [[17]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL281-R281) [[18]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL296-R296) [[19]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL307-R307) [[20]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL319-R319) [[21]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL331-R331) [[22]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL343-R343) [[23]](diffhunk://#diff-be7596449164b01e0309e8be6cb46690fa47b6f735c2fdbb78fd88ba8821ba8bL353-R353)

This change improves maintainability by centralizing and clarifying how the configuration database client is acquired, reducing the risk of errors and making future updates easier.

### Related Issues
- https://github.com/asgardeo/thunder/issues/396

### Related PRs
- https://github.com/asgardeo/thunder/pull/677

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
