### PR TITLE
Improve user type UIs to indicate OU name instead of OU ID

### DIFF
--- a/frontend/apps/thunder-develop/src/features/organization-units/api/useGetOrganizationUnits.ts
+++ b/frontend/apps/thunder-develop/src/features/organization-units/api/useGetOrganizationUnits.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/commons-contexts';
+import type {
+  ApiError,
+  OrganizationUnitListParams,
+  OrganizationUnitListResponse,
+} from '../types/organization-units';
+
+/**
+ * Fetches organization units list with optional pagination.
+ */
+export default function useGetOrganizationUnits(params?: OrganizationUnitListParams) {
+  const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
+  const [data, setData] = useState<OrganizationUnitListResponse | null>(null);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [loading, setLoading] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const API_BASE_URL: string = useMemo(
+    () => getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string),
+    [getServerUrl],
+  );
+  const paramsKey = useMemo(() => JSON.stringify(params ?? {}), [params]);
+
+  const executeFetch = useCallback(
+    async (finalParams?: OrganizationUnitListParams): Promise<void> => {
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = new AbortController();
+
+      try {
+        setLoading(true);
+        setError(null);
+
+        const searchParams = new URLSearchParams();
+        const resolvedParams = finalParams ?? params;
+
+        if (resolvedParams?.limit !== undefined) {
+          searchParams.append('limit', String(resolvedParams.limit));
+        }
+        if (resolvedParams?.offset !== undefined) {
+          searchParams.append('offset', String(resolvedParams.offset));
+        }
+
+        const queryString = searchParams.toString();
+
+        const response = await http.request({
+          url: `${API_BASE_URL}/organization-units${queryString ? `?${queryString}` : ''}`,
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          signal: abortControllerRef.current?.signal,
+        } as unknown as Parameters<typeof http.request>[0]);
+
+        setData(response.data as OrganizationUnitListResponse);
+        setError(null);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          return;
+        }
+
+        const apiError: ApiError = {
+          code: 'FETCH_ERROR',
+          message: err instanceof Error ? err.message : 'An unknown error occurred',
+          description: 'Failed to fetch organization units',
+        };
+        setError(apiError);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [API_BASE_URL, http, params],
+  );
+
+  useEffect(() => {
+    executeFetch().catch(() => {
+      // Error already handled
+    });
+
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, [executeFetch, paramsKey]);
+
+  const refetch = async (newParams?: OrganizationUnitListParams): Promise<void> => {
+    await executeFetch(newParams).catch((err) => {
+      // propagate errors except abort to match previous behavior
+      if (!(err instanceof Error && err.name === 'AbortError')) {
+        throw err;
+      }
+    });
+  };
+
+  return {
+    data,
+    loading,
+    error,
+    refetch,
+  };
+}

--- a/frontend/apps/thunder-develop/src/features/organization-units/types/organization-units.ts
+++ b/frontend/apps/thunder-develop/src/features/organization-units/types/organization-units.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Organization Unit type definition
+ */
+export interface OrganizationUnit {
+  id: string;
+  handle: string;
+  name: string;
+  description?: string | null;
+  parent?: string | null;
+}
+
+/**
+ * List response for organization units
+ */
+export interface OrganizationUnitListResponse {
+  totalResults: number;
+  startIndex: number;
+  count: number;
+  organizationUnits: OrganizationUnit[];
+  links?: {
+    rel: string;
+    href: string;
+  }[];
+}
+
+/**
+ * Query parameters for listing organization units
+ */
+export interface OrganizationUnitListParams {
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Standard API error structure
+ */
+export interface ApiError {
+  code: string;
+  message: string;
+  description: string;
+}

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/UserTypesListPage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/UserTypesListPage.test.tsx
@@ -36,7 +36,11 @@ vi.mock('react-router', async () => {
 
 // Mock the UserTypesList component
 vi.mock('../../components/UserTypesList', () => ({
-  default: () => <div data-testid="user-types-list">User Types List Component</div>,
+  default: () => (
+    <div data-testid="user-types-list">
+      <span>Organization Unit: Root Organization</span>
+    </div>
+  ),
 }));
 
 describe('UserTypesListPage', () => {
@@ -71,6 +75,12 @@ describe('UserTypesListPage', () => {
     render(<UserTypesListPage />);
 
     expect(screen.getByTestId('user-types-list')).toBeInTheDocument();
+  });
+
+  it('shows organization unit name within the list component', () => {
+    render(<UserTypesListPage />);
+
+    expect(screen.getByText('Organization Unit: Root Organization')).toBeInTheDocument();
   });
 
   it('navigates to create page when create button is clicked', async () => {

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -352,8 +352,8 @@ const translations = {
     userTypeDetails: 'User Type Details',
     typeName: 'Type Name',
     typeNamePlaceholder: 'e.g., Employee, Customer, Partner',
-    ouId: 'Organization Unit ID',
-    ouIdPlaceholder: 'e.g., f47ac10b-58cc-4b77-9c42-1b48f9871f0b',
+    organizationUnit: 'Organization Unit',
+    ouSelectPlaceholder: 'Select an organization unit',
     allowSelfRegistration: 'Allow Self Registration',
     description: 'Description',
     createDescription: 'Define a new user type schema for your organization',
@@ -382,7 +382,11 @@ const translations = {
       propertiesRequired: 'Please add at least one property',
       duplicateProperties: 'Duplicate property names found: {{duplicates}}',
     },
+    errors: {
+      organizationUnitsFailedTitle: 'Failed to load organization units',
+    },
     noUserTypes: 'No user types found',
+    noOrganizationUnits: 'No organization units available',
     confirmDeleteUserType: 'Are you sure you want to delete this user type?',
   },
 


### PR DESCRIPTION
### Purpose
$subject. This is primarily improve the add user type experience, since now it shows the dropdown with OU names, rather user to enter the OU ID in a text box. Aligning to that, every other place in user type flows improved to show the OU name, instead of the OU ID.

### Approach
This pull request introduces organization unit support for user type management features. The main changes include a new hook for fetching organization units, updates to the user type creation and listing pages to display and select organization units, and corresponding type definitions and tests. These improvements ensure that user types can be associated with organization units, and users can view and select organization units in the UI.

**Organization Unit Integration**

* Added a new hook `useGetOrganizationUnits` to fetch organization units from the backend, including error handling and pagination support. (`frontend/apps/thunder-develop/src/features/organization-units/api/useGetOrganizationUnits.ts`)
* Defined new TypeScript interfaces for organization unit data, API responses, query parameters, and errors in `organization-units.ts`. (`frontend/apps/thunder-develop/src/features/organization-units/types/organization-units.ts`)

**User Type Listing and Display**

* Updated `UserTypesList` to fetch organization units and display their names in the user type list, replacing the previous organization unit ID column. Handles loading, error, and missing data states. (`frontend/apps/thunder-develop/src/features/user-types/components/UserTypesList.tsx`) [[1]](diffhunk://#diff-d64e8385cd877c3d9daa31bb3b027ec934441dd526bd7188d094e7a422a74a62L19-R19) [[2]](diffhunk://#diff-d64e8385cd877c3d9daa31bb3b027ec934441dd526bd7188d094e7a422a74a62R45) [[3]](diffhunk://#diff-d64e8385cd877c3d9daa31bb3b027ec934441dd526bd7188d094e7a422a74a62R64-R79) [[4]](diffhunk://#diff-d64e8385cd877c3d9daa31bb3b027ec934441dd526bd7188d094e7a422a74a62L148-R190)

**User Type Creation and Editing**

* Modified `CreateUserTypePage` to provide a dropdown for selecting an organization unit when creating a user type, with improved loading and error states and default selection logic. (`frontend/apps/thunder-develop/src/features/user-types/pages/CreateUserTypePage.tsx`) [[1]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aL20-R20) [[2]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aR41) [[3]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aR54-R58) [[4]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aR77-R83) [[5]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aL293-R350)
* Updated `ViewUserTypePage` to fetch organization units for display and editing purposes. (`frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx`) [[1]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3L20-R20) [[2]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R56) [[3]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R70-R74)

**Testing**

* Extended tests for `UserTypesList` to mock organization unit data and verify correct display of organization unit names. (`frontend/apps/thunder-develop/src/features/user-types/components/__tests__/UserTypesList.test.tsx`) [[1]](diffhunk://#diff-9b0a313f5a5f8d33c6cf96bfde708fd85a23782f2ac53aa38c004295b78870c4R28) [[2]](diffhunk://#diff-9b0a313f5a5f8d33c6cf96bfde708fd85a23782f2ac53aa38c004295b78870c4R128-R133) [[3]](diffhunk://#diff-9b0a313f5a5f8d33c6cf96bfde708fd85a23782f2ac53aa38c004295b78870c4R143-R146) [[4]](diffhunk://#diff-9b0a313f5a5f8d33c6cf96bfde708fd85a23782f2ac53aa38c004295b78870c4R158-R167) [[5]](diffhunk://#diff-9b0a313f5a5f8d33c6cf96bfde708fd85a23782f2ac53aa38c004295b78870c4R182-R187) [[6]](diffhunk://#diff-9b0a313f5a5f8d33c6cf96bfde708fd85a23782f2ac53aa38c004295b78870c4R197-R203)