### PR TITLE
Preserve THUNDER_SKIP_SECURITY env var in build scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1032,7 +1032,8 @@ function Run {
     Write-Host "Running frontend apps..."
     Run-Frontend
 
-    # Start backend with security disabled to set up
+    # Save original THUNDER_SKIP_SECURITY value and temporarily set to true
+    $script:ORIGINAL_THUNDER_SKIP_SECURITY = $env:THUNDER_SKIP_SECURITY
     $env:THUNDER_SKIP_SECURITY = "true"
     Run-Backend -ShowFinalOutput $false
     
@@ -1054,9 +1055,14 @@ function Run {
         exit 1
     }
 
-    Write-Host "🔒 Enabling security and restarting backend..."
-    # Reset backend to enable security
-    $env:THUNDER_SKIP_SECURITY = "false"
+    Write-Host "🔒 Restoring security setting and restarting backend..."
+    # Restore original THUNDER_SKIP_SECURITY value
+    if (![string]::IsNullOrEmpty($script:ORIGINAL_THUNDER_SKIP_SECURITY)) {
+        $env:THUNDER_SKIP_SECURITY = $script:ORIGINAL_THUNDER_SKIP_SECURITY
+    }
+    else {
+        Remove-Item Env:\THUNDER_SKIP_SECURITY -ErrorAction SilentlyContinue
+    }
     # Start backend with initial output but without final output/wait
     Start-Backend -ShowFinalOutput $false
 

--- a/build.sh
+++ b/build.sh
@@ -646,7 +646,8 @@ function run() {
     echo "Running frontend apps..."
     run_frontend
 
-    # Start backend with security disabled to set up
+    # Save original THUNDER_SKIP_SECURITY value and temporarily set to true
+    ORIGINAL_THUNDER_SKIP_SECURITY="${THUNDER_SKIP_SECURITY:-}"
     export THUNDER_SKIP_SECURITY=true
     run_backend false
     
@@ -693,9 +694,13 @@ function run() {
         exit 1
     fi
 
-    echo "🔒 Enabling security and restarting backend..."
-    # Reset backend to enable security
-    export THUNDER_SKIP_SECURITY=false
+    echo "🔒 Restoring security setting and restarting backend..."
+    # Restore original THUNDER_SKIP_SECURITY value
+    if [ -n "$ORIGINAL_THUNDER_SKIP_SECURITY" ]; then
+        export THUNDER_SKIP_SECURITY="$ORIGINAL_THUNDER_SKIP_SECURITY"
+    else
+        unset THUNDER_SKIP_SECURITY
+    fi
     # Start backend with initial output but without final output/wait
     start_backend false
 


### PR DESCRIPTION
### Purpose
  The setup and build scripts temporarily disable security during initial setup, but they were unconditionally changing the `THUNDER_SKIP_SECURITY` environment variable without preserving the original value. This meant any value set
  outside the scripts would be lost.

### Approach

This pull request updates both the PowerShell (`build.ps1`) and Bash (`build.sh`) build scripts to improve how the `THUNDER_SKIP_SECURITY` environment variable is managed when running the backend. Instead of always setting and unsetting the variable, the scripts now save the original value, set it temporarily, and restore it to its previous state afterwards. This ensures that any pre-existing configuration is preserved and avoids potential side effects.

**Environment variable management improvements:**

* Both `build.ps1` and `build.sh`: Save the original value of `THUNDER_SKIP_SECURITY` before temporarily setting it to disable security, and restore the original value (or unset it if it was not previously set) after the setup phase. This prevents accidental overwriting or leaking of environment variable changes. [[1]](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aL1035-R1036) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L649-R650) [[3]](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aL1057-R1065) [[4]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L696-R703)
### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
