### PR TITLE
Improve ou handle validation to restrict forward slash

### DIFF
--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -633,7 +633,12 @@ func (ous *organizationUnitService) validateOUName(name string) *serviceerror.Se
 
 // validateOUHandle validates organization unit handle.
 func (ous *organizationUnitService) validateOUHandle(handle string) *serviceerror.ServiceError {
-	if strings.TrimSpace(handle) == "" {
+	trimmed := strings.TrimSpace(handle)
+	if trimmed == "" {
+		return &ErrorInvalidRequestFormat
+	}
+
+	if strings.Contains(trimmed, "/") {
 		return &ErrorInvalidRequestFormat
 	}
 


### PR DESCRIPTION
### Purpose
$subject

### Approach
This pull request makes a small but important validation improvement to the organization unit handle logic. The change ensures that organization unit handles cannot contain the '/' character, which helps prevent invalid or potentially problematic handles.

* Updated `validateOUHandle` in `backend/internal/ou/service.go` to reject handles containing the '/' character, in addition to checking for empty or whitespace-only values.

### Related Issues
- https://github.com/asgardeo/thunder/issues/789

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
