### PR TITLE
Move the immutable resources configs to default.json

### DIFF
--- a/backend/cmd/server/repository/conf/deployment.yaml
+++ b/backend/cmd/server/repository/conf/deployment.yaml
@@ -27,9 +27,6 @@ cors:
   allowed_origins:
     - "https://localhost:3000"
 
-immutable_resources:
-  enabled: false
-
 observability:
   enabled: false
   output:

--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -72,5 +72,8 @@
   },
   "crypto": {
     "key": ""
+  },
+  "immutable_resources": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
### Purpose
Move the immutable resources configs to default.json

====
This pull request updates the configuration for immutable resources in the backend service. The main change is moving the `immutable_resources` setting from the deployment YAML file to the default JSON configuration file. This helps centralize configuration and maintain consistency.

**Configuration changes:**

* Removed the `immutable_resources` section from `deployment.yaml` to prevent duplicate or conflicting configuration.
* Added the `immutable_resources` section to `default.json`, setting `enabled` to `false` for default behavior.