### PR TITLE
Change Issuer as Refresh Token audience

### DIFF
--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -192,14 +192,14 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*model
 		Scopes:    ctx.Scopes,
 		ClientID:  ctx.ClientID,
 		Subject:   ctx.AccessTokenSubject,
-		Audience:  ctx.AccessTokenAudience,
+		Audience:  tokenConfig.Issuer,
 	}
 
 	tb.appendUserTypeAndOU(tokenDTO, claims, ctx.UserType, ctx.OuID, ctx.OuName, ctx.OuHandle)
 
 	token, iat, err := tb.jwtService.GenerateJWT(
 		ctx.ClientID,
-		ctx.ClientID,
+		tokenConfig.Issuer,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		claims,

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -410,7 +410,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"test-client",
+		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -431,6 +431,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 	assert.Equal(suite.T(), int64(3600), result.ExpiresIn)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
 	assert.Equal(suite.T(), "test-client", result.ClientID)
+	assert.Equal(suite.T(), "https://thunder.io", result.Audience)
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
@@ -450,7 +451,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"test-client",
+		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -482,7 +483,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"test-client",
+		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -514,7 +515,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() 
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"test-client",
+		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -556,7 +557,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_CustomIssuer()
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"test-client",
+		"https://custom.thunder.io",
 		"https://custom.thunder.io",
 		int64(3600),
 		mock.Anything,
@@ -593,7 +594,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"test-client",
+		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
@@ -630,7 +631,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFai
 
 	suite.mockJWTService.On("GenerateJWT",
 		"test-client",
-		"test-client",
+		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
 		mock.Anything,


### PR DESCRIPTION
### Purpose
Issue: https://github.com/asgardeo/thunder/issues/817

### Approach

This pull request updates the refresh token generation logic to use the token issuer as the audience instead of the client ID. The associated test has also been updated to reflect this new behavior.

**Refresh token audience update:**

* In `tokenservice/builder.go`, the `Audience` field in the refresh token payload is now set to `tokenConfig.Issuer` instead of `ctx.AccessTokenAudience`, and the JWT generation call uses `tokenConfig.Issuer` for the audience parameter.

Before
<img width="1399" height="672" alt="Screenshot 2025-11-20 at 13 50 44" src="https://github.com/user-attachments/assets/01e0ca2b-92dc-4767-980f-f83184491630" />

After 
<img width="1399" height="672" alt="Screenshot 2025-11-20 at 13 51 08" src="https://github.com/user-attachments/assets/3049419f-cb34-4571-9fc1-a38607b81779" />



### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
