### PR TITLE
Allow provisioning email address for federated users

### DIFF
--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -340,5 +340,15 @@ func getAuthenticatedUserForOIDC(o oidcAuthExecutorInterface, authService authno
 	//  when the support is implemented.
 	authenticatedUser.Attributes = userClaims
 
+	// Append email to runtime data if available.
+	if email, ok := userClaims["email"]; ok {
+		if emailStr, ok := email.(string); ok && emailStr != "" {
+			if execResp.RuntimeData == nil {
+				execResp.RuntimeData = make(map[string]string)
+			}
+			execResp.RuntimeData["email"] = emailStr
+		}
+	}
+
 	return &authenticatedUser, nil
 }


### PR DESCRIPTION
### Purpose
This pull request enhances the handling of user email attribute during authentication and registration flows for both OAuth and OIDC executors. Now, when an email is present and non-empty in user attributes or ID token claims, it is also added to the `RuntimeData` of the executor response, making it more accessible for downstream logic such as during user provisioning.

### Approach
* Updated `getUserAttributes` in `oAuthExecutor` to accept the executor response object and append the user's email to `RuntimeData` if available and non-empty. [[1]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3L363-R363) [[2]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3L403-R412) [[3]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R423-R432)
* Updated OIDC executor logic to similarly append email from user claims to `RuntimeData` when present and non-empty.

### Related Issues
- https://github.com/asgardeo/thunder/issues/822

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
