### PR TITLE
[Develop] Enable username/password login by default

### DIFF
--- a/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -54,13 +54,13 @@ export default function ApplicationCreatePage(): JSX.Element {
   const [selectedColor, setSelectedColor] = useState('#1976d2');
   const [appLogo, setAppLogo] = useState<string | null>(null);
   const [integrations, setIntegrations] = useState<Record<string, boolean>>({
-    // No default selections - user must select at least one option
+    [USERNAME_PASSWORD_AUTHENTICATION_OPTION_KEY]: true,
   });
   const [error, setError] = useState<string | null>(null);
   const [stepReady, setStepReady] = useState<Record<Step, boolean>>({
     name: false,
     design: true,
-    options: false, // Start as false since no options are selected by default
+    options: true, // Start as true since username/password is enabled by default
     configure: false, // Start as false since no redirect URIs are added by default
   });
   const [useDefaultBranding, setUseDefaultBranding] = useState<boolean>(false);

--- a/frontend/apps/thunder-develop/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -98,7 +98,7 @@ vi.mock('../../components/create-applications/ConfigureSignInOptions', () => ({
 
     return (
       <div data-testid="configure-sign-in">
-        <button type="button" data-testid="toggle-integration" onClick={() => onIntegrationToggle('test-integration')}>
+        <button type="button" data-testid="toggle-integration" onClick={() => onIntegrationToggle('basic_auth')}>
           Toggle Integration
         </button>
       </div>
@@ -371,10 +371,7 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 3: Sign In Options - select an integration
-      const toggleIntegrationButton = screen.queryByTestId('toggle-integration');
-      if (toggleIntegrationButton) {
-        await user.click(toggleIntegrationButton);
-      }
+
       await waitFor(() => {
         expect(screen.getByRole('button', {name: /continue/i})).not.toBeDisabled();
       });
@@ -538,10 +535,7 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 3: Sign In Options - select an integration
-      const toggleIntegrationButton = screen.queryByTestId('toggle-integration');
-      if (toggleIntegrationButton) {
-        await user.click(toggleIntegrationButton);
-      }
+
       await waitFor(() => {
         expect(screen.getByRole('button', {name: /continue/i})).not.toBeDisabled();
       });
@@ -591,10 +585,7 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 3: Sign In Options - select an integration
-      const toggleIntegrationButton = screen.queryByTestId('toggle-integration');
-      if (toggleIntegrationButton) {
-        await user.click(toggleIntegrationButton);
-      }
+
       await waitFor(() => {
         expect(screen.getByRole('button', {name: /continue/i})).not.toBeDisabled();
       });
@@ -640,10 +631,7 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 3: Sign In Options - need to select at least one integration
-      const toggleIntegrationButton = screen.queryByTestId('toggle-integration');
-      if (toggleIntegrationButton) {
-        await user.click(toggleIntegrationButton);
-      }
+
       await waitFor(() => {
         expect(screen.getByRole('button', {name: /continue/i})).not.toBeDisabled();
       });
@@ -689,10 +677,7 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
       // Step 3: Sign In Options - need to select at least one integration
-      const toggleIntegrationButton = screen.queryByTestId('toggle-integration');
-      if (toggleIntegrationButton) {
-        await user.click(toggleIntegrationButton);
-      }
+
       await waitFor(() => {
         expect(screen.getByRole('button', {name: /continue/i})).not.toBeDisabled();
       });
@@ -743,7 +728,7 @@ describe('ApplicationCreatePage', () => {
       expect(screen.getByTestId('configure-sign-in')).toBeInTheDocument();
     });
 
-    it('should start with no default selections (options step not ready)', async () => {
+    it('should start with default selections (options step ready)', async () => {
       renderWithProviders();
 
       // Navigate to options step
@@ -752,10 +737,10 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
-      // Options step should not be ready (no selections by default)
-      // Continue button should be disabled
+      // Options step should be ready (username/password selected by default)
+      // Continue button should be enabled
       const continueButton = screen.getByRole('button', {name: /continue/i});
-      expect(continueButton).toBeDisabled();
+      expect(continueButton).toBeEnabled();
     });
 
     it('should require at least one option to be selected before proceeding', async () => {
@@ -767,15 +752,24 @@ describe('ApplicationCreatePage', () => {
       await user.click(screen.getByRole('button', {name: /continue/i}));
       await user.click(screen.getByRole('button', {name: /continue/i}));
 
-      // Initially disabled
+      // Initially enabled (default selection)
       let continueButton = screen.getByRole('button', {name: /continue/i});
-      expect(continueButton).toBeDisabled();
+      expect(continueButton).toBeEnabled();
 
-      // Select an integration
+      // Deselect the default integration
       const toggleButton = screen.getByTestId('toggle-integration');
       await user.click(toggleButton);
 
-      // Now should be enabled
+      // Now should be disabled
+      await waitFor(() => {
+        continueButton = screen.getByRole('button', {name: /continue/i});
+        expect(continueButton).toBeDisabled();
+      });
+
+      // Select it again
+      await user.click(toggleButton);
+
+      // Now should be enabled again
       await waitFor(() => {
         continueButton = screen.getByRole('button', {name: /continue/i});
         expect(continueButton).not.toBeDisabled();


### PR DESCRIPTION
### Purpose
This pull request updates the default sign-in options selection logic and associated tests for the application creation flow. The main change is to enable the username/password authentication option by default, allowing users to proceed without making an explicit selection. The tests are updated to reflect this new behavior, ensuring that the continue button is enabled initially and properly toggles as integrations are selected or deselected.

![verify_signin_default_retry_1763700148914](https://github.com/user-attachments/assets/a12e9069-533c-4790-be63-19730dff789d)

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
