### PR TITLE
Improve global styling + bump oxygen-ui version

### DIFF
--- a/frontend/apps/thunder-develop/src/components/Navbar/AppNavbar.tsx
+++ b/frontend/apps/thunder-develop/src/components/Navbar/AppNavbar.tsx
@@ -80,7 +80,7 @@ export default function AppNavbar(): JSX.Element {
         >
           <Stack direction="row" spacing={1} sx={{justifyContent: 'center', mr: 'auto'}}>
             {/* <CustomIcon /> */}
-            <Typography variant="h4" component="h1" sx={{color: 'text.primary'}}>
+            <Typography variant="h1" sx={{color: 'text.primary'}}>
               Dashboard
             </Typography>
           </Stack>

--- a/frontend/apps/thunder-develop/src/features/applications/components/ApplicationsList.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/ApplicationsList.tsx
@@ -103,7 +103,7 @@ export default function ApplicationsList(): JSX.Element {
               slotProps={{
                 img: {
                   onError: (e: React.SyntheticEvent<HTMLImageElement>) => {
-                    e.currentTarget.style.display = 'none';
+                    e.currentTarget.src = '';
                   },
                 },
               }}

--- a/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureDesign.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureDesign.tsx
@@ -87,7 +87,7 @@ export default function ConfigureDesign({
   const theme = useTheme();
 
   const [logoSeed, setLogoSeed] = useState<number>(0);
-  const [customColor, setCustomColor] = useState<string>(theme?.vars?.palette.common.black ?? '#000000');
+  const [customColor, setCustomColor] = useState<string>('');
   const [showCustomColorInput, setShowCustomColorInput] = useState<boolean>(false);
   const [showColorOptions, setShowColorOptions] = useState<boolean>(false);
 
@@ -175,7 +175,7 @@ export default function ConfigureDesign({
   return (
     <Stack direction="column" spacing={4}>
       <Stack direction="column" spacing={1}>
-        <Typography variant="h4" component="h1" gutterBottom>
+        <Typography variant="h1" gutterBottom>
           {t('applications:onboarding.configure.design.title')}
         </Typography>
         <Stack direction="row" alignItems="center" spacing={1}>
@@ -218,7 +218,6 @@ export default function ConfigureDesign({
                     border: isSelected
                       ? `2px solid ${theme.vars?.palette.primary.main}`
                       : `1px solid ${theme.vars?.palette.divider}`,
-                    bgcolor: isSelected ? selectedColor : undefined,
                     p: 1,
                     '&:hover': {
                       transform: 'scale(1.1)',
@@ -226,6 +225,9 @@ export default function ConfigureDesign({
                     },
                     transition: 'all 0.2s ease-in-out',
                     ...theme.applyStyles('light', {
+                      backgroundColor: isSelected ? selectedColor : theme.vars?.palette.grey[600],
+                    }),
+                    ...theme.applyStyles('dark', {
                       backgroundColor: isSelected ? selectedColor : theme.vars?.palette.grey[600],
                     }),
                   }}
@@ -342,7 +344,7 @@ export default function ConfigureDesign({
                     width: 50,
                     height: 50,
                     borderRadius: '8px',
-                    border: `1px solid ${theme.vars?.palette.divider}`,
+                    border: 'none',
                     cursor: 'pointer',
                     opacity: customColor ? 1 : 0,
                     zIndex: customColor ? 1 : 0,
@@ -374,15 +376,23 @@ export default function ConfigureDesign({
                     width: 50,
                     height: 50,
                     borderRadius: '8px',
-                    border: `1px solid ${theme.vars?.palette.divider}`,
-                    bgcolor: 'background.paper',
+                    border: customColor ?
+                      `2px solid ${theme.vars?.palette.primary.main}` :
+                      `2px solid ${theme.vars?.palette.text.primary}`,
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
                     cursor: 'pointer',
                     fontSize: '1.5rem',
                     fontWeight: 300,
-                    color: 'text.secondary',
+                    ...theme.applyStyles('light', {
+                      color: customColor ? 
+                        theme.vars?.palette.background.default :
+                        theme.vars?.palette.text.primary,
+                    }),
+                    ...theme.applyStyles('dark', {
+                      color: theme.vars?.palette.text.primary,
+                    }),
                     zIndex: 2,
                     '&:hover': {
                       transform: 'scale(1.1)',

--- a/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureName.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureName.tsx
@@ -67,7 +67,7 @@ export default function ConfigureName({
 
   return (
     <Stack direction="column" spacing={4}>
-      <Typography variant="h4" component="h1" gutterBottom>
+      <Typography variant="h1" gutterBottom>
         {t('applications:onboarding.configure.name.title')}
       </Typography>
 

--- a/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureOAuth.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureOAuth.tsx
@@ -332,7 +332,7 @@ export default function ConfigureOAuth({
   return (
     <Stack direction="column" spacing={3}>
       <Stack direction="column" spacing={1}>
-        <Typography variant="h4" component="h1" gutterBottom>
+        <Typography variant="h1" gutterBottom>
           {t('applications:onboarding.configure.oauth.title')}
         </Typography>
         <Typography variant="body1" color="text.secondary">

--- a/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureSignInOptions.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/create-applications/ConfigureSignInOptions.tsx
@@ -112,7 +112,7 @@ export default function ConfigureSignInOptions({
   return (
     <Stack direction="column" spacing={4}>
       <Stack direction="column" spacing={1}>
-        <Typography variant="h4" component="h1" gutterBottom>
+        <Typography variant="h1" gutterBottom>
           {t('applications:onboarding.configure.SignInOptions.title')}
         </Typography>
         <Stack direction="row" alignItems="center" spacing={1}>

--- a/frontend/apps/thunder-develop/src/features/applications/components/create-applications/Preview.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/create-applications/Preview.tsx
@@ -144,8 +144,13 @@ export default function Preview({appName, appLogo, selectedColor, integrations}:
               sx={{
                 width: 64,
                 height: 64,
-                bgcolor: selectedColor,
                 p: 1,
+                ...theme.applyStyles('light', {
+                  backgroundColor: selectedColor,
+                }),
+                ...theme.applyStyles('dark', {
+                  backgroundColor: selectedColor,
+                })
               }}
             />
           </Box>
@@ -202,6 +207,7 @@ export default function Preview({appName, appLogo, selectedColor, integrations}:
                           variant="contained"
                           color="secondary"
                           sx={{
+                            color: '#fff',
                             backgroundColor: selectedColor,
                             '&:hover': {
                               backgroundColor: selectedColor,

--- a/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -491,7 +491,7 @@ export default function ApplicationCreatePage(): JSX.Element {
                     )}
 
                     {currentStep === 'configure' ? (
-                      <>
+                      <Stack direction="row" spacing={1}>
                         <Button
                           variant="outlined"
                           onClick={() => handleCreateApplication(true)}
@@ -512,7 +512,7 @@ export default function ApplicationCreatePage(): JSX.Element {
                             ? t('applications:onboarding.creating')
                             : t('applications:onboarding.createApplication')}
                         </Button>
-                      </>
+                      </Stack>
                     ) : (
                       <Button
                         variant="contained"

--- a/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationsListPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationsListPage.tsx
@@ -31,10 +31,10 @@ export default function ApplicationsListPage(): JSX.Element {
     <Box>
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={4} flexWrap="wrap" gap={2}>
         <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom>
             {t('applications:listing.title')}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle1" color="text.secondary">
             {t('applications:listing.subtitle')}
           </Typography>
         </Box>

--- a/frontend/apps/thunder-develop/src/features/integrations/pages/IntegrationsPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/integrations/pages/IntegrationsPage.tsx
@@ -25,10 +25,10 @@ export default function IntegrationsPage() {
   return (
     <Box>
       <Box mb={4}>
-        <Typography variant="h4" component="h1" gutterBottom>
+        <Typography variant="h1" gutterBottom>
           {t('integrations:title')}
         </Typography>
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="subtitle1" color="text.secondary">
           {t('integrations:subtitle')}
         </Typography>
       </Box>

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/CreateUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/CreateUserTypePage.tsx
@@ -272,10 +272,10 @@ export default function CreateUserTypePage() {
 
       <Stack direction="row" alignItems="flex-start" justifyContent="space-between" mb={4} gap={2}>
         <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom>
             {t('userTypes:addUserType')}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle1" color="text.secondary">
             {t('userTypes:createDescription')}
           </Typography>
         </Box>

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/UserTypesListPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/UserTypesListPage.tsx
@@ -30,10 +30,10 @@ export default function UserTypesListPage() {
     <Box>
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={4} flexWrap="wrap" gap={2}>
         <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom>
             {t('userTypes:title')}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle1" color="text.secondary">
             {t('userTypes:createDescription')}
           </Typography>
         </Box>

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
@@ -343,10 +343,10 @@ export default function ViewUserTypePage() {
 
       <Stack direction="row" alignItems="flex-start" justifyContent="space-between" mb={4} gap={2}>
         <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom>
             User Type Details
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle1" color="text.secondary">
             View and manage user type schema
           </Typography>
         </Box>

--- a/frontend/apps/thunder-develop/src/features/users/pages/CreateUserPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/CreateUserPage.tsx
@@ -143,10 +143,10 @@ export default function CreateUserPage() {
 
       <Stack direction="row" alignItems="flex-start" mb={4} gap={2}>
         <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom>
             Create User
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle1" color="text.secondary">
             Add a new user to your organization
           </Typography>
         </Box>

--- a/frontend/apps/thunder-develop/src/features/users/pages/UsersListPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/UsersListPage.tsx
@@ -47,10 +47,10 @@ export default function UsersListPage() {
     <Box>
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={4} flexWrap="wrap" gap={2}>
         <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom>
             {t('users:title')}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle1" color="text.secondary">
             {t('users:subtitle')}
           </Typography>
         </Box>

--- a/frontend/apps/thunder-develop/src/features/users/pages/ViewUserPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/ViewUserPage.tsx
@@ -230,10 +230,10 @@ export default function ViewUserPage() {
 
       <Stack direction="row" alignItems="flex-start" justifyContent="space-between" mb={4} gap={2}>
         <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h1" gutterBottom>
             User Profile
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle1" color="text.secondary">
             View and manage user information
           </Typography>
         </Box>

--- a/frontend/apps/thunder-gate/src/components/SignIn/SignInBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/SignInBox.tsx
@@ -125,7 +125,7 @@ export default function SignInBox(): JSX.Element {
         >
           {({onSubmit, isLoading, components, error, isInitialized}) => (
             <>
-              <Typography component="h1" variant="h5" sx={{width: '100%', mb: 2}}>
+              <Typography variant="h2" sx={{width: '100%', mb: 2}}>
                 Sign in
               </Typography>
 
@@ -419,35 +419,34 @@ export default function SignInBox(): JSX.Element {
                   })()}
                 </>
               )}
-
-              <Typography sx={{textAlign: 'center'}}>
-                Don&apos;t have an account?{' '}
-                <Button
-                  variant="text"
-                  onClick={() => {
-                    const currentParams = searchParams.toString();
-                    const createUrl = currentParams ? `${ROUTES.AUTH.SIGN_UP}?${currentParams}` : ROUTES.AUTH.SIGN_UP;
-                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    navigate(createUrl);
-                  }}
-                  sx={{
-                    p: 0,
-                    minWidth: 'auto',
-                    textTransform: 'none',
-                    color: 'primary.main',
-                    textDecoration: 'underline',
-                    '&:hover': {
-                      textDecoration: 'underline',
-                      backgroundColor: 'transparent',
-                    },
-                  }}
-                >
-                  Sign up
-                </Button>
-              </Typography>
             </>
           )}
         </SignIn>
+        <Typography sx={{textAlign: 'center'}}>
+          Don&apos;t have an account?{' '}
+          <Button
+            variant="text"
+            onClick={() => {
+              const currentParams = searchParams.toString();
+              const createUrl = currentParams ? `${ROUTES.AUTH.SIGN_UP}?${currentParams}` : ROUTES.AUTH.SIGN_UP;
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
+              navigate(createUrl);
+            }}
+            sx={{
+              p: 0,
+              minWidth: 'auto',
+              textTransform: 'none',
+              color: 'primary.main',
+              textDecoration: 'underline',
+              '&:hover': {
+                textDecoration: 'underline',
+                backgroundColor: 'transparent',
+              },
+            }}
+          >
+            Sign up
+          </Button>
+        </Typography>
       </StyledPaper>
     </Stack>
   );

--- a/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
@@ -92,7 +92,7 @@ export default function SignUpBox(): JSX.Element {
         >
           {({errors, handleSubmit, isLoading, components}) => (
             <>
-              <Typography component="h1" variant="h5" sx={{width: '100%', mb: 2}}>
+              <Typography variant="h2" sx={{width: '100%', mb: 2}}>
                 Create Account
               </Typography>
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -55,11 +55,11 @@ catalogs:
       specifier: ^3.2.4
       version: 3.2.4
     '@wso2/oxygen-ui':
-      specifier: 0.0.1-alpha.3
-      version: 0.0.1-alpha.3
+      specifier: 0.0.1-alpha.4
+      version: 0.0.1-alpha.4
     '@wso2/oxygen-ui-icons-react':
-      specifier: 0.0.1-alpha.1
-      version: 0.0.1-alpha.1
+      specifier: 0.0.1-alpha.4
+      version: 0.0.1-alpha.4
     babel-plugin-react-compiler:
       specifier: ^19.1.0-rc.3
       version: 19.1.0-rc.1-rc-af1b7da-20250421
@@ -196,10 +196,10 @@ importers:
         version: link:../../packages/thunder-i18n
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
-        version: 0.0.1-alpha.3(364b1f8ce18d8b166411506ae6acc263)
+        version: 0.0.1-alpha.4(a8eb6476bd4918c7e2bb0f3b093c822e)
       '@wso2/oxygen-ui-icons-react':
         specifier: 'catalog:'
-        version: 0.0.1-alpha.1(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)
+        version: 0.0.1-alpha.4(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -302,10 +302,10 @@ importers:
         version: link:../../packages/thunder-commons-contexts
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
-        version: 0.0.1-alpha.3(364b1f8ce18d8b166411506ae6acc263)
+        version: 0.0.1-alpha.4(a8eb6476bd4918c7e2bb0f3b093c822e)
       '@wso2/oxygen-ui-icons-react':
         specifier: 'catalog:'
-        version: 0.0.1-alpha.1(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)
+        version: 0.0.1-alpha.4(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.0
@@ -1553,9 +1553,6 @@ packages:
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
 
-  '@fontsource/inter@5.2.8':
-    resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
-
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1733,11 +1730,11 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/x-charts-vendor@8.18.0':
-    resolution: {integrity: sha512-NFbFMOR8tsa02C3+YKQOdbzPaDtZLJPprsySw9xVxJpcYw5y/v02TuV/yQCIE0Pk1dVGHW2yvCMBs8AS+irjLA==}
+  '@mui/x-charts-vendor@8.19.0':
+    resolution: {integrity: sha512-4wzlAf/Ym4HHDMGX8Iq4M1L2DCEDCS5l4SidUxauSM+4x+FPz8o/sVkmnh0hkQ995AzT2XTffjh/Nw8xm8aBcw==}
 
-  '@mui/x-charts@8.18.0':
-    resolution: {integrity: sha512-3ivGI//EKZaUFDbit85Z+3fM85kU4417uz7xULDO/BBxSHkwlowuHcb5EewDWFb2Rn2Nmstuv0bGYu5N8r6fvA==}
+  '@mui/x-charts@8.19.0':
+    resolution: {integrity: sha512-jQHk3F7bj7uWg+wz3qEra/unr1I60vBPuXZyMf0EOqRBHwgaB4hje8uvGSISCNpoll3gtBsyVLPGeO+nVBNCAw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -1752,8 +1749,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/x-data-grid@8.18.0':
-    resolution: {integrity: sha512-g8y5EI3TNqrimHpH/Hv6u6i04cbvsqh39Tg4bZEhGq+SDxWp42iABlUvB7p+gtXfyd+IbmpfzUQ1hOCsHlTMZw==}
+  '@mui/x-data-grid@8.19.0':
+    resolution: {integrity: sha512-jxt+d6Fms5Z/gPcSC6mpfCOsGw6YfKu7iiP8Q58RDPEh+I7C9XQfta7tPtNhcCNV1zJ7xBN7aQhslh8Rnadz5w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -1768,8 +1765,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/x-date-pickers@8.18.0':
-    resolution: {integrity: sha512-lgq60mOhOf5AKfiCl37eOVSkCZQo3sHhE6tbwbcS93aNkdtlsTQlqy/s6O89RoIi8QS3/7rgCKy+WuC6YzwZrA==}
+  '@mui/x-date-pickers@8.19.0':
+    resolution: {integrity: sha512-TQ4FsGUsiGJVs+Ie4q7nHXUmFqZADXL/1hVtZpOKsdr3WQXwpX7C5YmeakZGFR2NZnuv4snFj+WTee3kgyFbyQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -1805,17 +1802,17 @@ packages:
       moment-jalaali:
         optional: true
 
-  '@mui/x-internal-gestures@0.3.5':
-    resolution: {integrity: sha512-7G3ydqRdBT/mKRSiA/NLDvfmKo/oMN9PtXUv8CtNyEwzyXFWXiv1LvG1pIHS8xSk3lw5dL8tt0Vl4X0sTJMrgA==}
+  '@mui/x-internal-gestures@0.3.6':
+    resolution: {integrity: sha512-IDGCpitIwdBSJpp7wQ4f8C3IwB5u5Ru1fy88JMC4hCgwpUvtvUPyR4Ue5Xt3sbU2J0VEykRwi82h9gFFZeNF5A==}
 
-  '@mui/x-internals@8.18.0':
-    resolution: {integrity: sha512-iM2SJALLo4kNqxTel8lfjIymYV9MgTa6021/rAlfdh/vwPMglaKyXQHrxkkWs2Eu/JFKkCKr5Fd34Gsdp63wIg==}
+  '@mui/x-internals@8.19.0':
+    resolution: {integrity: sha512-mMmiyJAN5fW27srXJjhXhXJa+w2xGO45rwcjws6OQc9rdXGdJqRXhBwJd+OT7J1xwSdFIIUhjZRTz1KAfCSGBg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@mui/x-tree-view@8.18.0':
-    resolution: {integrity: sha512-lTz+irHHmNccs58Kto8h3EMuPfuGNuHECvRo4BIuqh0m1NHRd49y+8BiQjYtJpJMqRm5lbA5Vbku1UFKcL2TNg==}
+  '@mui/x-tree-view@8.19.0':
+    resolution: {integrity: sha512-1JPIczqK5qdDmo4p8KEpR4XZKxDHkw5dBoY1o+FNUdKmOipklQvg0+XL5wY75pjwzADngZR/6RYW08bhkt+Z3Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -1830,8 +1827,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/x-virtualizer@0.2.8':
-    resolution: {integrity: sha512-hCkhTg3BLLbf0SIw9Cx/NHTCUmbna+P5F2V+Bcv/9XiYhfzzmhYnm68+V6vOOhKVbV3j8JKsUEqcTC9K2Jpu8A==}
+  '@mui/x-virtualizer@0.2.9':
+    resolution: {integrity: sha512-++V8H8UQaDT2xsZn4eyNK4n55bsH9ncOuCatA238RptQa19uryLDVKqgSFhNbZ61aVUQ29Xel6q2rJVdS+J64Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2562,14 +2559,14 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@wso2/oxygen-ui-icons-react@0.0.1-alpha.1':
-    resolution: {integrity: sha512-jlC/uXoi5lpFBLK74XKlvtILOi5sYvsVGtnzcJod6MYy4/jAn4kz5XoFjBWB8iG16jr29rRFu+zamouP5VIKmg==}
+  '@wso2/oxygen-ui-icons-react@0.0.1-alpha.4':
+    resolution: {integrity: sha512-BBi0LqBEE1MnYWhsv9NVb1gKopbjVYq/I81DsMCXBXKeOKlDm+2jG0amMpAQ4M8apQaDB3F31r6JElL6AjDCJg==}
     peerDependencies:
       lucide-react: ^0.545.0
       react: ^19.2.0
 
-  '@wso2/oxygen-ui@0.0.1-alpha.3':
-    resolution: {integrity: sha512-G6tRyoD29OwPQi8oTM0Kx4tGS2J/16FMNrdAC/nNXHtgL7CD+fSt9I4ql3eyNKG6TLw/hsDq4pFQf1NbDjtwLg==}
+  '@wso2/oxygen-ui@0.0.1-alpha.4':
+    resolution: {integrity: sha512-gptOEiG9ZS0vFuuAaRD2EE+Mfs39hEEL7Dfgzi5HUQ6p0RaMScpaLVElvomNopVH5HLbFAWlt1pGIG5UhZXiwA==}
     peerDependencies:
       '@emotion/react': ^11.14.0
       '@emotion/styled': ^11.14.1
@@ -2578,7 +2575,7 @@ packages:
       '@mui/x-data-grid': ^8.16.0
       '@mui/x-date-pickers': ^8.17.0
       '@mui/x-tree-view': ^8.14.0
-      '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.1
+      '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.4
       date-fns: ^4.1.0
       react: ^19.2.0
       react-dom: ^19.2.0
@@ -6339,8 +6336,6 @@ snapshots:
 
   '@fontsource-variable/inter@5.2.8': {}
 
-  '@fontsource/inter@5.2.8': {}
-
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -6513,7 +6508,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
-  '@mui/x-charts-vendor@8.18.0':
+  '@mui/x-charts-vendor@8.19.0':
     dependencies:
       '@babel/runtime': 7.28.4
       '@types/d3-color': 3.1.3
@@ -6531,15 +6526,15 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  '@mui/x-charts@8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@mui/x-charts@8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@mui/system': 7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)
       '@mui/utils': 7.3.5(@types/react@19.2.2)(react@19.2.0)
-      '@mui/x-charts-vendor': 8.18.0
-      '@mui/x-internal-gestures': 0.3.5
-      '@mui/x-internals': 8.18.0(@types/react@19.2.2)(react@19.2.0)
+      '@mui/x-charts-vendor': 8.19.0
+      '@mui/x-internal-gestures': 0.3.6
+      '@mui/x-internals': 8.19.0(@types/react@19.2.2)(react@19.2.0)
       bezier-easing: 2.1.0
       clsx: 2.1.1
       flatqueue: 3.0.0
@@ -6554,14 +6549,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid@8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@mui/x-data-grid@8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@mui/system': 7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)
       '@mui/utils': 7.3.5(@types/react@19.2.2)(react@19.2.0)
-      '@mui/x-internals': 8.18.0(@types/react@19.2.2)(react@19.2.0)
-      '@mui/x-virtualizer': 0.2.8(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@mui/x-internals': 8.19.0(@types/react@19.2.2)(react@19.2.0)
+      '@mui/x-virtualizer': 0.2.9(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.0
@@ -6573,13 +6568,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers@8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(date-fns@4.1.0)(dayjs@1.11.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@mui/x-date-pickers@8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(date-fns@4.1.0)(dayjs@1.11.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@mui/system': 7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)
       '@mui/utils': 7.3.5(@types/react@19.2.2)(react@19.2.0)
-      '@mui/x-internals': 8.18.0(@types/react@19.2.2)(react@19.2.0)
+      '@mui/x-internals': 8.19.0(@types/react@19.2.2)(react@19.2.0)
       '@types/react-transition-group': 4.4.12(@types/react@19.2.2)
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -6594,11 +6589,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-internal-gestures@0.3.5':
+  '@mui/x-internal-gestures@0.3.6':
     dependencies:
       '@babel/runtime': 7.28.4
 
-  '@mui/x-internals@8.18.0(@types/react@19.2.2)(react@19.2.0)':
+  '@mui/x-internals@8.19.0(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/utils': 7.3.5(@types/react@19.2.2)(react@19.2.0)
@@ -6608,14 +6603,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-tree-view@8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@mui/x-tree-view@8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@base-ui-components/utils': 0.1.2(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@mui/system': 7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)
       '@mui/utils': 7.3.5(@types/react@19.2.2)(react@19.2.0)
-      '@mui/x-internals': 8.18.0(@types/react@19.2.2)(react@19.2.0)
+      '@mui/x-internals': 8.19.0(@types/react@19.2.2)(react@19.2.0)
       '@types/react-transition-group': 4.4.12(@types/react@19.2.2)
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -6628,11 +6623,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-virtualizer@0.2.8(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@mui/x-virtualizer@0.2.9(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/utils': 7.3.5(@types/react@19.2.2)(react@19.2.0)
-      '@mui/x-internals': 8.18.0(@types/react@19.2.2)(react@19.2.0)
+      '@mui/x-internals': 8.19.0(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
@@ -7342,22 +7337,22 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@wso2/oxygen-ui-icons-react@0.0.1-alpha.1(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)':
+  '@wso2/oxygen-ui-icons-react@0.0.1-alpha.4(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       lucide-react: 0.545.0(react@19.2.0)
       react: 19.2.0
 
-  '@wso2/oxygen-ui@0.0.1-alpha.3(364b1f8ce18d8b166411506ae6acc263)':
+  '@wso2/oxygen-ui@0.0.1-alpha.4(a8eb6476bd4918c7e2bb0f3b093c822e)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.2)(react@19.2.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)
-      '@fontsource/inter': 5.2.8
+      '@fontsource-variable/inter': 5.2.8
       '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@mui/x-charts': 8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@mui/x-data-grid': 8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@mui/x-date-pickers': 8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(date-fns@4.1.0)(dayjs@1.11.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@mui/x-tree-view': 8.18.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.1(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)
+      '@mui/x-charts': 8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@mui/x-data-grid': 8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@mui/x-date-pickers': 8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(date-fns@4.1.0)(dayjs@1.11.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@mui/x-tree-view': 8.19.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.3(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.4(lucide-react@0.545.0(react@19.2.0))(react@19.2.0)
       date-fns: 4.1.0
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -23,8 +23,8 @@ catalog:
   '@vitejs/plugin-basic-ssl': ^2.1.0
   '@vitejs/plugin-react': ^5.0.4
   '@vitest/coverage-istanbul': ^3.2.4
-  '@wso2/oxygen-ui': 0.0.1-alpha.3
-  '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.1
+  '@wso2/oxygen-ui': 0.0.1-alpha.4
+  '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.4
   babel-plugin-react-compiler: ^19.1.0-rc.3
   clsx: ^2.1.1
   dayjs: ^1.11.18


### PR DESCRIPTION
### Purpose

> - Bumped '@wso2/oxygen-ui' and '@wso2/oxygen-ui-icons-react' to `0.0.1-alpha.4`, to get latest styling fixes
> - Covert page heading to direct h1 variants
> - Fix some styling issues in application creation wizard