### PR TITLE
Bump @asgardeo/react version to 0.6.8

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.6.6
-      version: 0.6.6
+      specifier: 0.6.8
+      version: 0.6.8
     '@asgardeo/react-router':
       specifier: 1.0.6
       version: 1.0.6
@@ -169,10 +169,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.6.6(@types/react@19.2.2)(react@19.2.0)
+        version: 0.6.8(@types/react@19.2.2)(react@19.2.0)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 1.0.6(@asgardeo/react@0.6.6(@types/react@19.2.2)(react@19.2.0))(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 1.0.6(@asgardeo/react@0.6.8(@types/react@19.2.2)(react@19.2.0))(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@19.2.2)(react@19.2.0)
@@ -287,7 +287,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.6.6(@types/react@19.2.2)(react@19.2.0)
+        version: 0.6.8(@types/react@19.2.2)(react@19.2.0)
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@19.2.2)(react@19.2.0)
@@ -643,8 +643,8 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.0.0'
 
-  '@asgardeo/react@0.6.6':
-    resolution: {integrity: sha512-tkxFJXljzSDjky6MAq88F/i4I9zBfXsA4DjxRhkkOSJU8HAkgtHLbYzww1JZp4bcEecDwzWtaEZUi8Cj3nOKMg==}
+  '@asgardeo/react@0.6.8':
+    resolution: {integrity: sha512-V7c9V4qDBMEa7h41Ta/tz6knYJYjkTNtEPrts0hRBlisrLtwVZg4Ay3Y/b+ZN1naAinpBYMqvwLge8roZJEWOw==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -5227,14 +5227,14 @@ snapshots:
       '@asgardeo/i18n': 0.3.3
       tslib: 2.8.1
 
-  '@asgardeo/react-router@1.0.6(@asgardeo/react@0.6.6(@types/react@19.2.2)(react@19.2.0))(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@asgardeo/react-router@1.0.6(@asgardeo/react@0.6.8(@types/react@19.2.2)(react@19.2.0))(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@asgardeo/react': 0.6.6(@types/react@19.2.2)(react@19.2.0)
+      '@asgardeo/react': 0.6.8(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
       react-router: 7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.6.6(@types/react@19.2.2)(react@19.2.0)':
+  '@asgardeo/react@0.6.8(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@asgardeo/browser': 0.1.27(esbuild@0.25.12)
       '@asgardeo/i18n': 0.3.3

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  '@asgardeo/react': 0.6.6
+  '@asgardeo/react': 0.6.8
   '@asgardeo/react-router': 1.0.6
   '@emotion/react': ^11.14.0
   '@emotion/styled': ^11.14.1

--- a/samples/apps/react-sdk/package.json
+++ b/samples/apps/react-sdk/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@asgardeo/react": "^0.6.6",
+    "@asgardeo/react": "^0.6.8",
     "@wso2/oxygen-ui": "0.0.1-alpha.3",
     "jwt-decode": "^4.0.0",
     "react": "^19.2.0",

--- a/samples/apps/react-sdk/pnpm-lock.yaml
+++ b/samples/apps/react-sdk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@asgardeo/react':
-        specifier: ^0.6.6
-        version: 0.6.6(@types/react@19.2.6)(react@19.2.0)
+        specifier: ^0.6.8
+        version: 0.6.8(@types/react@19.2.6)(react@19.2.0)
       '@wso2/oxygen-ui':
         specifier: 0.0.1-alpha.3
         version: 0.0.1-alpha.3(0c7e0e06e579dc700ebe8f61b1456faf)
@@ -75,8 +75,8 @@ packages:
   '@asgardeo/javascript@0.2.2':
     resolution: {integrity: sha512-g0Xgc0KCHUXlffz5bZcMzadXCbwccPCDdM2kHXo1F2/ArR20SYPeYWyQZPD7fREOkjTY2Kud3xsILpAKSUOM0Q==}
 
-  '@asgardeo/react@0.6.6':
-    resolution: {integrity: sha512-tkxFJXljzSDjky6MAq88F/i4I9zBfXsA4DjxRhkkOSJU8HAkgtHLbYzww1JZp4bcEecDwzWtaEZUi8Cj3nOKMg==}
+  '@asgardeo/react@0.6.8':
+    resolution: {integrity: sha512-V7c9V4qDBMEa7h41Ta/tz6knYJYjkTNtEPrts0hRBlisrLtwVZg4Ay3Y/b+ZN1naAinpBYMqvwLge8roZJEWOw==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -2132,7 +2132,7 @@ snapshots:
       '@asgardeo/i18n': 0.3.3
       tslib: 2.8.1
 
-  '@asgardeo/react@0.6.6(@types/react@19.2.6)(react@19.2.0)':
+  '@asgardeo/react@0.6.8(@types/react@19.2.6)(react@19.2.0)':
     dependencies:
       '@asgardeo/browser': 0.1.27(esbuild@0.25.12)
       '@asgardeo/i18n': 0.3.3
@@ -3832,7 +3832,7 @@ snapshots:
 
   md5.js@1.3.5:
     dependencies:
-      hash-base: 3.0.5
+      hash-base: 3.1.2
       inherits: 2.0.4
       safe-buffer: 5.2.1
 


### PR DESCRIPTION
This pull request updates the `@asgardeo/react` dependency from version 0.6.6 to 0.6.8 across the codebase, including all relevant lock and workspace files. This ensures that all packages and sample applications use the latest compatible version of the SDK. There is also a minor update to the `hash-base` dependency in the sample app’s lock file.

**Dependency version updates:**

* Updated `@asgardeo/react` to version 0.6.8 in `frontend/pnpm-lock.yaml`, `frontend/pnpm-workspace.yaml`, `samples/apps/react-sdk/package.json`, and `samples/apps/react-sdk/pnpm-lock.yaml` to ensure consistency and use of the latest SDK features and fixes. [[1]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L10-R11) [[2]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L172-R175) [[3]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L290-R290) [[4]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L646-R647) [[5]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L5230-R5237) [[6]](diffhunk://#diff-f60c0ec3013027a039a8555f62dcdd071cf966ee68edeb1d64cf20267dba3411L6-R6) [[7]](diffhunk://#diff-02acf7e292137e4f489665b76e821e735b1bc2e51f202aa37d141a4d93a212bdL13-R13) [[8]](diffhunk://#diff-51274c3c1069f278315ac85055a48b743acad41a80ce3c16a82438ba75e040d9L15-R16) [[9]](diffhunk://#diff-51274c3c1069f278315ac85055a48b743acad41a80ce3c16a82438ba75e040d9L78-R79) [[10]](diffhunk://#diff-51274c3c1069f278315ac85055a48b743acad41a80ce3c16a82438ba75e040d9L2135-R2135)

**Other dependency updates:**

* Updated `hash-base` from version 3.0.5 to 3.1.2 in the sample app’s lock file to pull in the latest patch for this transitive dependency.