### PR TITLE
Add support for user provisioning in external IDP OAuth/OIDC authentication flows

### DIFF
--- a/backend/internal/flow/executor/github_auth_executor.go
+++ b/backend/internal/flow/executor/github_auth_executor.go
@@ -24,6 +24,8 @@ import (
 	flowcm "github.com/asgardeo/thunder/internal/flow/common"
 	flowcore "github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/idp"
+	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 // githubOAuthExecutor implements the OAuth authentication executor for GitHub.
@@ -39,6 +41,8 @@ func newGithubOAuthExecutor(
 	flowFactory flowcore.FlowFactoryInterface,
 	idpService idp.IDPServiceInterface,
 	authService authngithub.GithubOAuthAuthnServiceInterface,
+	userService user.UserServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 ) oAuthExecutorInterface {
 	oauthSvcCast, ok := authService.(authnoauth.OAuthAuthnCoreServiceInterface)
 	if !ok {
@@ -46,7 +50,7 @@ func newGithubOAuthExecutor(
 	}
 
 	base := newOAuthExecutor(ExecutorNameGitHubAuth, []flowcm.InputData{}, []flowcm.InputData{},
-		flowFactory, idpService, oauthSvcCast)
+		flowFactory, idpService, oauthSvcCast, userService, userSchemaService)
 
 	return &githubOAuthExecutor{
 		oAuthExecutorInterface: base,

--- a/backend/internal/flow/executor/github_auth_executor_test.go
+++ b/backend/internal/flow/executor/github_auth_executor_test.go
@@ -29,14 +29,18 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/authn/oauthmock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
 type GithubAuthExecutorTestSuite struct {
 	suite.Suite
-	mockFlowFactory   *coremock.FlowFactoryInterfaceMock
-	mockIDPService    *idpmock.IDPServiceInterfaceMock
-	mockGithubService *githubmock.GithubOAuthAuthnServiceInterfaceMock
-	mockOAuthService  *oauthmock.OAuthAuthnCoreServiceInterfaceMock
+	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockIDPService        *idpmock.IDPServiceInterfaceMock
+	mockGithubService     *githubmock.GithubOAuthAuthnServiceInterfaceMock
+	mockOAuthService      *oauthmock.OAuthAuthnCoreServiceInterfaceMock
+	mockUserService       *usermock.UserServiceInterfaceMock
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 }
 
 func TestGithubAuthExecutorTestSuite(t *testing.T) {
@@ -48,6 +52,8 @@ func (suite *GithubAuthExecutorTestSuite) SetupTest() {
 	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.mockGithubService = githubmock.NewGithubOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnCoreServiceInterfaceMock(suite.T())
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 }
 
 func (suite *GithubAuthExecutorTestSuite) TestNewGithubOAuthExecutor_Success() {
@@ -68,7 +74,8 @@ func (suite *GithubAuthExecutorTestSuite) TestNewGithubOAuthExecutor_Success() {
 		oauthService:                         suite.mockOAuthService,
 	}
 
-	executor := newGithubOAuthExecutor(suite.mockFlowFactory, suite.mockIDPService, mockGithubSvc)
+	executor := newGithubOAuthExecutor(suite.mockFlowFactory, suite.mockIDPService, mockGithubSvc,
+		suite.mockUserService, suite.mockUserSchemaService)
 
 	suite.NotNil(executor)
 	githubExec, ok := executor.(*githubOAuthExecutor)

--- a/backend/internal/flow/executor/google_auth_executor.go
+++ b/backend/internal/flow/executor/google_auth_executor.go
@@ -24,6 +24,8 @@ import (
 	flowcm "github.com/asgardeo/thunder/internal/flow/common"
 	flowcore "github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/idp"
+	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 // googleOIDCAuthExecutor implements the OIDC authentication executor for Google.
@@ -39,6 +41,8 @@ func newGoogleOIDCAuthExecutor(
 	flowFactory flowcore.FlowFactoryInterface,
 	idpService idp.IDPServiceInterface,
 	authService authngoogle.GoogleOIDCAuthnServiceInterface,
+	userService user.UserServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 ) oidcAuthExecutorInterface {
 	defaultInputs := []flowcm.InputData{
 		{
@@ -59,7 +63,7 @@ func newGoogleOIDCAuthExecutor(
 	}
 
 	base := newOIDCAuthExecutor(ExecutorNameGoogleAuth, defaultInputs, []flowcm.InputData{},
-		flowFactory, idpService, oidcSvcCast)
+		flowFactory, idpService, oidcSvcCast, userService, userSchemaService)
 
 	return &googleOIDCAuthExecutor{
 		oidcAuthExecutorInterface: base,

--- a/backend/internal/flow/executor/google_auth_executor_test.go
+++ b/backend/internal/flow/executor/google_auth_executor_test.go
@@ -29,14 +29,18 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/authn/oidcmock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
 type GoogleAuthExecutorTestSuite struct {
 	suite.Suite
-	mockFlowFactory   *coremock.FlowFactoryInterfaceMock
-	mockIDPService    *idpmock.IDPServiceInterfaceMock
-	mockGoogleService *googlemock.GoogleOIDCAuthnServiceInterfaceMock
-	mockOIDCService   *oidcmock.OIDCAuthnCoreServiceInterfaceMock
+	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockIDPService        *idpmock.IDPServiceInterfaceMock
+	mockGoogleService     *googlemock.GoogleOIDCAuthnServiceInterfaceMock
+	mockOIDCService       *oidcmock.OIDCAuthnCoreServiceInterfaceMock
+	mockUserService       *usermock.UserServiceInterfaceMock
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 }
 
 func TestGoogleAuthExecutorTestSuite(t *testing.T) {
@@ -48,6 +52,8 @@ func (suite *GoogleAuthExecutorTestSuite) SetupTest() {
 	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.mockGoogleService = googlemock.NewGoogleOIDCAuthnServiceInterfaceMock(suite.T())
 	suite.mockOIDCService = oidcmock.NewOIDCAuthnCoreServiceInterfaceMock(suite.T())
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 }
 
 func (suite *GoogleAuthExecutorTestSuite) TestNewGoogleOIDCAuthExecutor_Success() {
@@ -73,7 +79,8 @@ func (suite *GoogleAuthExecutorTestSuite) TestNewGoogleOIDCAuthExecutor_Success(
 		oidcService:                         suite.mockOIDCService,
 	}
 
-	executor := newGoogleOIDCAuthExecutor(suite.mockFlowFactory, suite.mockIDPService, mockGoogleSvc)
+	executor := newGoogleOIDCAuthExecutor(suite.mockFlowFactory, suite.mockIDPService, mockGoogleSvc,
+		suite.mockUserService, suite.mockUserSchemaService)
 
 	suite.NotNil(executor)
 	googleExec, ok := executor.(*googleOIDCAuthExecutor)

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -50,13 +50,15 @@ func Initialize(
 		flowFactory, userService, otpService))
 
 	reg.RegisterExecutor(ExecutorNameOAuth, newOAuthExecutor(
-		"", []flowcm.InputData{}, []flowcm.InputData{}, flowFactory, idpService, authRegistry.OAuthAuthnService))
+		"", []flowcm.InputData{}, []flowcm.InputData{}, flowFactory, idpService, authRegistry.OAuthAuthnService,
+		userService, userSchemaService))
 	reg.RegisterExecutor(ExecutorNameOIDCAuth, newOIDCAuthExecutor(
-		"", []flowcm.InputData{}, []flowcm.InputData{}, flowFactory, idpService, authRegistry.OIDCAuthnService))
+		"", []flowcm.InputData{}, []flowcm.InputData{}, flowFactory, idpService, authRegistry.OIDCAuthnService,
+		userService, userSchemaService))
 	reg.RegisterExecutor(ExecutorNameGitHubAuth, newGithubOAuthExecutor(
-		flowFactory, idpService, authRegistry.GithubOAuthAuthnService))
+		flowFactory, idpService, authRegistry.GithubOAuthAuthnService, userService, userSchemaService))
 	reg.RegisterExecutor(ExecutorNameGoogleAuth, newGoogleOIDCAuthExecutor(
-		flowFactory, idpService, authRegistry.GoogleOIDCAuthnService))
+		flowFactory, idpService, authRegistry.GoogleOIDCAuthnService, userService, userSchemaService))
 
 	reg.RegisterExecutor(ExecutorNameProvisioning, newProvisioningExecutor(flowFactory, userService))
 	reg.RegisterExecutor(ExecutorNameOUCreation, newOUExecutor(flowFactory, ouService))

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -30,10 +31,13 @@ import (
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	systemutils "github.com/asgardeo/thunder/internal/system/utils"
+	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 const (
 	oAuthLoggerComponentName = "OAuthExecutor"
+	subClaimKey              = "sub"
 )
 
 // OAuthTokenResponse represents the response from a OAuth token endpoint.
@@ -61,9 +65,11 @@ type oAuthExecutorInterface interface {
 // oAuthExecutor implements the OAuthExecutorInterface for handling generic OAuth authentication flows.
 type oAuthExecutor struct {
 	flowcore.ExecutorInterface
-	authService authnoauth.OAuthAuthnCoreServiceInterface
-	idpService  idp.IDPServiceInterface
-	logger      *log.Logger
+	authService       authnoauth.OAuthAuthnCoreServiceInterface
+	idpService        idp.IDPServiceInterface
+	userService       user.UserServiceInterface
+	userSchemaService userschema.UserSchemaServiceInterface
+	logger            *log.Logger
 }
 
 var _ flowcore.ExecutorInterface = (*oAuthExecutor)(nil)
@@ -75,6 +81,8 @@ func newOAuthExecutor(
 	flowFactory flowcore.FlowFactoryInterface,
 	idpService idp.IDPServiceInterface,
 	authService authnoauth.OAuthAuthnCoreServiceInterface,
+	userService user.UserServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 ) oAuthExecutorInterface {
 	if name == "" {
 		name = ExecutorNameOAuth
@@ -98,6 +106,8 @@ func newOAuthExecutor(
 		ExecutorInterface: base,
 		authService:       authService,
 		idpService:        idpService,
+		userService:       userService,
+		userSchemaService: userSchemaService,
 		logger:            logger,
 	}
 }
@@ -363,8 +373,26 @@ func (o *oAuthExecutor) getAuthenticatedUserWithAttributes(ctx *flowcore.NodeCon
 					Attributes:      o.getUserAttributes(userInfo, "", execResp),
 				}, nil
 			} else {
+				// Try to provision the user automatically if allowed user types are configured
+				provisionedUser, provisionErr := o.provisionUserOAuth(ctx, sub, userInfo, logger)
+				if provisionErr != nil {
+					logger.Error("Automatic user provisioning failed", log.Error(provisionErr), log.String("sub", sub))
+					execResp.Status = flowcm.ExecFailure
+					execResp.FailureReason = "User not found and automatic provisioning is not available"
+					return nil, nil
+				}
+				if provisionedUser != nil {
+					return &authncm.AuthenticatedUser{
+						IsAuthenticated:    true,
+						UserID:             provisionedUser.ID,
+						OrganizationUnitID: provisionedUser.OrganizationUnit,
+						UserType:           provisionedUser.Type,
+						Attributes:         o.getUserAttributes(userInfo, provisionedUser.ID, execResp),
+					}, nil
+				}
+				// Provisioning not possible, return failure
 				execResp.Status = flowcm.ExecFailure
-				execResp.FailureReason = "User not found"
+				execResp.FailureReason = failureReasonUserNotFound
 				return nil, nil
 			}
 		} else {
@@ -412,7 +440,7 @@ func (o *oAuthExecutor) getUserAttributes(userInfo map[string]string, userID str
 	execResp *flowcm.ExecutorResponse) map[string]interface{} {
 	attributes := make(map[string]interface{})
 	for key, value := range userInfo {
-		if key != "username" && key != "sub" {
+		if key != "username" && key != subClaimKey {
 			attributes[key] = value
 		}
 	}
@@ -431,4 +459,91 @@ func (o *oAuthExecutor) getUserAttributes(userInfo map[string]string, userID str
 	}
 
 	return attributes
+}
+
+// provisionUserOAuth attempts to automatically provision a user if allowed user types are configured.
+func (o *oAuthExecutor) provisionUserOAuth(ctx *flowcore.NodeContext,
+	sub string, userInfo map[string]string, logger *log.Logger) (*user.User, error) {
+	allowedUserTypes := ctx.Application.AllowedUserTypes
+	if len(allowedUserTypes) == 0 {
+		logger.Debug("No allowed user types configured, cannot provision user automatically",
+			log.String("sub", sub))
+		return nil, nil
+	}
+
+	if o.userService == nil || o.userSchemaService == nil {
+		return nil, fmt.Errorf("required services are not available for provisioning")
+	}
+
+	// Filter allowed user types to only those with self-registration enabled
+	selfRegEnabledUserTypes := make([]string, 0)
+	var selectedUserSchema *userschema.UserSchema
+	for _, userType := range allowedUserTypes {
+		userSchema, svcErr := o.userSchemaService.GetUserSchemaByName(userType)
+		if svcErr != nil {
+			logger.Debug("Failed to get user schema for user type, skipping",
+				log.String("userType", userType), log.String("errorCode", svcErr.Code))
+			continue
+		}
+		if userSchema.AllowSelfRegistration {
+			selfRegEnabledUserTypes = append(selfRegEnabledUserTypes, userType)
+			if selectedUserSchema == nil {
+				selectedUserSchema = userSchema
+			}
+		}
+	}
+
+	// Fail if no user types have self-registration enabled
+	if len(selfRegEnabledUserTypes) == 0 {
+		logger.Debug("No user types with self-registration enabled for automatic provisioning",
+			log.String("sub", sub))
+		return nil, fmt.Errorf("no user types with self-registration enabled")
+	}
+
+	// Fail if multiple user types have self-registration enabled
+	if len(selfRegEnabledUserTypes) > 1 {
+		logger.Debug("Multiple user types with self-registration enabled, cannot automatically provision",
+			log.String("sub", sub), log.Any("userTypes", selfRegEnabledUserTypes))
+		return nil, fmt.Errorf("multiple user types with self-registration enabled: %v", selfRegEnabledUserTypes)
+	}
+
+	// Exactly one user type with self-registration enabled
+	userType := selfRegEnabledUserTypes[0]
+	userSchema := selectedUserSchema
+
+	if userSchema.OrganizationUnitID == "" {
+		logger.Error("No organization unit found for user type", log.String("userType", userType))
+		return nil, fmt.Errorf("no organization unit found for user type: %s", userType)
+	}
+
+	userAttributes := make(map[string]interface{})
+	for key, value := range userInfo {
+		userAttributes[key] = value
+	}
+
+	// Convert attributes to JSON
+	attributesJSON, err := json.Marshal(userAttributes)
+	if err != nil {
+		logger.Error("Failed to marshal user attributes", log.Error(err))
+		return nil, fmt.Errorf("failed to marshal user attributes: %w", err)
+	}
+
+	newUser := &user.User{
+		OrganizationUnit: userSchema.OrganizationUnitID,
+		Type:             userType,
+		Attributes:       attributesJSON,
+	}
+
+	createdUser, svcErr := o.userService.CreateUser(newUser)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			return nil, fmt.Errorf("failed to create user: %s", svcErr.ErrorDescription)
+		}
+		logger.Error("Failed to create user during provisioning",
+			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription),
+			log.String("userType", userType), log.String("sub", sub))
+		return nil, fmt.Errorf("failed to create user: %s", svcErr.ErrorDescription)
+	}
+
+	return createdUser, nil
 }

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -22,8 +22,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	authnoauth "github.com/asgardeo/thunder/internal/authn/oauth"
 	flowcm "github.com/asgardeo/thunder/internal/flow/common"
@@ -31,18 +33,28 @@ import (
 	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 	"github.com/asgardeo/thunder/tests/mocks/authn/oauthmock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
 type OAuthExecutorTestSuite struct {
 	suite.Suite
-	mockOAuthService *oauthmock.OAuthAuthnCoreServiceInterfaceMock
-	mockIDPService   *idpmock.IDPServiceInterfaceMock
-	mockFlowFactory  *coremock.FlowFactoryInterfaceMock
-	executor         oAuthExecutorInterface
+	mockOAuthService      *oauthmock.OAuthAuthnCoreServiceInterfaceMock
+	mockIDPService        *idpmock.IDPServiceInterfaceMock
+	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockUserService       *usermock.UserServiceInterfaceMock
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
+	executor              oAuthExecutorInterface
 }
+
+const (
+	testOUID     = "ou-123"
+	testUserType = "employee"
+)
 
 func TestOAuthExecutorSuite(t *testing.T) {
 	suite.Run(t, new(OAuthExecutorTestSuite))
@@ -52,6 +64,8 @@ func (suite *OAuthExecutorTestSuite) SetupTest() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnCoreServiceInterfaceMock(suite.T())
 	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 
 	defaultInputs := []flowcm.InputData{{Name: "code", Type: "string", Required: true}}
 	mockExec := createMockAuthExecutor(suite.T(), ExecutorNameOAuth)
@@ -59,7 +73,8 @@ func (suite *OAuthExecutorTestSuite) SetupTest() {
 		defaultInputs, []flowcm.InputData{}).Return(mockExec)
 
 	suite.executor = newOAuthExecutor(ExecutorNameOAuth, defaultInputs, []flowcm.InputData{},
-		suite.mockFlowFactory, suite.mockIDPService, suite.mockOAuthService)
+		suite.mockFlowFactory, suite.mockIDPService, suite.mockOAuthService,
+		suite.mockUserService, suite.mockUserSchemaService)
 }
 
 func (suite *OAuthExecutorTestSuite) TestNewOAuthExecutor() {
@@ -121,7 +136,7 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser(
 
 	existingUser := &user.User{
 		ID:               "user-123",
-		OrganizationUnit: "ou-123",
+		OrganizationUnit: testOUID,
 		Type:             "INTERNAL",
 	}
 
@@ -139,7 +154,7 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser(
 	assert.Equal(suite.T(), flowcm.ExecComplete, resp.Status)
 	assert.True(suite.T(), resp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "user-123", resp.AuthenticatedUser.UserID)
-	assert.Equal(suite.T(), "ou-123", resp.AuthenticatedUser.OrganizationUnitID)
+	assert.Equal(suite.T(), testOUID, resp.AuthenticatedUser.OrganizationUnitID)
 	assert.Equal(suite.T(), "test@example.com", resp.RuntimeData["email"])
 	suite.mockOAuthService.AssertExpectations(suite.T())
 }
@@ -555,7 +570,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNo
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
-	assert.Equal(suite.T(), "User not found", execResp.FailureReason)
+	assert.Equal(suite.T(), failureReasonUserNotFound, execResp.FailureReason)
 	suite.mockOAuthService.AssertExpectations(suite.T())
 }
 
@@ -892,4 +907,497 @@ func (suite *OAuthExecutorTestSuite) TestGetUserAttributes_WithEmail_NilRuntimeD
 	assert.Equal(suite.T(), "user-123", attributes["user_id"])
 	assert.NotNil(suite.T(), execResp.RuntimeData, "RuntimeData should be initialized")
 	assert.Equal(suite.T(), "test@example.com", execResp.RuntimeData["email"])
+}
+
+// Test provisioning functionality
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_ProvisioningSucceeds() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{testUserType},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid profile",
+		ExpiresIn:   3600,
+	}
+
+	userInfo := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+		"name":  "New User",
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  testUserType,
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+
+	provisionedUser := &user.User{
+		ID:               "user-provisioned-123",
+		OrganizationUnit: testOUID,
+		Type:             testUserType,
+	}
+
+	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+		Return(userInfo, nil)
+	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockUserSchemaService.On("GetUserSchemaByName", testUserType).
+		Return(userSchema, nil)
+	suite.mockUserService.On("CreateUser", mock.MatchedBy(func(u *user.User) bool {
+		return u.Type == testUserType && u.OrganizationUnit == testOUID
+	})).Return(provisionedUser, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecComplete, execResp.Status)
+	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
+	assert.Equal(suite.T(), "user-provisioned-123", execResp.AuthenticatedUser.UserID)
+	assert.Equal(suite.T(), testOUID, execResp.AuthenticatedUser.OrganizationUnitID)
+	assert.Equal(suite.T(), testUserType, execResp.AuthenticatedUser.UserType)
+	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertExpectations(suite.T())
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_NoAllowedUserTypes() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid profile",
+		ExpiresIn:   3600,
+	}
+
+	userInfo := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+		Return(userInfo, nil)
+	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), failureReasonUserNotFound, execResp.FailureReason)
+	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertNotCalled(suite.T(), "GetUserSchemaByName")
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OAuthExecutorTestSuite) testUserNotFoundWithSchemaError(schemaError *serviceerror.ServiceError) {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{testUserType},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid profile",
+		ExpiresIn:   3600,
+	}
+
+	userInfo := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+		Return(userInfo, nil)
+	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockUserSchemaService.On("GetUserSchemaByName", testUserType).
+		Return(nil, schemaError)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_UserSchemaNotFound() {
+	suite.testUserNotFoundWithSchemaError(&serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "USRS-1002",
+		ErrorDescription: "User schema not found",
+	})
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_UserSchemaServiceError() {
+	suite.testUserNotFoundWithSchemaError(&serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "USRS-5000",
+		ErrorDescription: "Internal server error",
+	})
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_UserCreationFails() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{testUserType},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid profile",
+		ExpiresIn:   3600,
+	}
+
+	userInfo := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  testUserType,
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+
+	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+		Return(userInfo, nil)
+	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockUserSchemaService.On("GetUserSchemaByName", testUserType).
+		Return(userSchema, nil)
+	suite.mockUserService.On("CreateUser", mock.MatchedBy(func(u *user.User) bool {
+		return u.Type == testUserType && u.OrganizationUnit == testOUID
+	})).Return(nil, &serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "USR-1014",
+		ErrorDescription: "Attribute conflict",
+	})
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertExpectations(suite.T())
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_MultipleAllowedUserTypes() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid profile",
+		ExpiresIn:   3600,
+	}
+
+	userInfo := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	employeeSchema := &userschema.UserSchema{
+		ID:                    "schema-employee",
+		Name:                  "employee",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+	customerSchema := &userschema.UserSchema{
+		ID:                    "schema-customer",
+		Name:                  "customer",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+	partnerSchema := &userschema.UserSchema{
+		ID:                    "schema-partner",
+		Name:                  "partner",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+
+	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+		Return(userInfo, nil)
+	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	// All three user types have self-registration enabled, so should fail
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+		Return(customerSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "partner").
+		Return(partnerSchema, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_SelfRegistrationDisabled() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{testUserType},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid profile",
+		ExpiresIn:   3600,
+	}
+
+	userInfo := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  testUserType,
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: false,
+	}
+
+	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+		Return(userInfo, nil)
+	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockUserSchemaService.On("GetUserSchemaByName", testUserType).
+		Return(userSchema, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_MultipleTypes_OneWithSelfReg() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid profile",
+		ExpiresIn:   3600,
+	}
+
+	userInfo := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	employeeSchema := &userschema.UserSchema{
+		ID:                    "schema-employee",
+		Name:                  "employee",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+	customerSchema := &userschema.UserSchema{
+		ID:                    "schema-customer",
+		Name:                  "customer",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: false,
+	}
+	partnerSchema := &userschema.UserSchema{
+		ID:                    "schema-partner",
+		Name:                  "partner",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: false,
+	}
+
+	provisionedUser := &user.User{
+		ID:               "user-provisioned-123",
+		OrganizationUnit: testOUID,
+		Type:             "employee",
+	}
+
+	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+		Return(userInfo, nil)
+	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	// Only employee has self-registration enabled
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+		Return(customerSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "partner").
+		Return(partnerSchema, nil)
+	suite.mockUserService.On("CreateUser", mock.MatchedBy(func(u *user.User) bool {
+		return u.Type == "employee" && u.OrganizationUnit == testOUID
+	})).Return(provisionedUser, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecComplete, execResp.Status)
+	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
+	assert.Equal(suite.T(), "employee", execResp.AuthenticatedUser.UserType)
+	suite.mockOAuthService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertExpectations(suite.T())
 }

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -32,6 +33,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 const (
@@ -50,8 +52,10 @@ type oidcAuthExecutorInterface interface {
 // oidcAuthExecutor implements the OIDCAuthExecutorInterface for handling generic OIDC authentication flows.
 type oidcAuthExecutor struct {
 	oAuthExecutorInterface
-	authService authnoidc.OIDCAuthnCoreServiceInterface
-	logger      *log.Logger
+	authService       authnoidc.OIDCAuthnCoreServiceInterface
+	userService       user.UserServiceInterface
+	userSchemaService userschema.UserSchemaServiceInterface
+	logger            *log.Logger
 }
 
 var _ flowcore.ExecutorInterface = (*oidcAuthExecutor)(nil)
@@ -63,6 +67,8 @@ func newOIDCAuthExecutor(
 	flowFactory flowcore.FlowFactoryInterface,
 	idpService idp.IDPServiceInterface,
 	authService authnoidc.OIDCAuthnCoreServiceInterface,
+	userService user.UserServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 ) oidcAuthExecutorInterface {
 	if name == "" {
 		name = ExecutorNameOIDCAuth
@@ -76,11 +82,13 @@ func newOIDCAuthExecutor(
 	}
 
 	base := newOAuthExecutor(name, defaultInputs, prerequisites,
-		flowFactory, idpService, oauthSvcCast)
+		flowFactory, idpService, oauthSvcCast, userService, userSchemaService)
 
 	return &oidcAuthExecutor{
 		oAuthExecutorInterface: base,
 		authService:            authService,
+		userService:            userService,
+		userSchemaService:      userSchemaService,
 		logger:                 logger,
 	}
 }
@@ -166,7 +174,8 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *flowcore.NodeContext,
 			return nil
 		}
 
-		user, err := resolveUserForOIDC(o.authService, logger, parsedSub, ctx, execResp)
+		user, err := resolveUserForOIDC(o.authService, logger, parsedSub, ctx, execResp,
+			o.userService, o.userSchemaService, idTokenClaims)
 		if err != nil {
 			return err
 		}
@@ -224,8 +233,9 @@ func (o *oidcAuthExecutor) GetIDTokenClaims(execResp *flowcm.ExecutorResponse,
 
 // resolveUserForOIDC resolves the internal user based on the sub claim.
 func resolveUserForOIDC(authService authnoidc.OIDCAuthnCoreServiceInterface,
-	logger *log.Logger, sub string, ctx *flowcore.NodeContext, execResp *flowcm.ExecutorResponse) (
-	*user.User, error) {
+	logger *log.Logger, sub string, ctx *flowcore.NodeContext, execResp *flowcm.ExecutorResponse,
+	userService user.UserServiceInterface, userSchemaService userschema.UserSchemaServiceInterface,
+	idTokenClaims map[string]interface{}) (*user.User, error) {
 	user, svcErr := authService.GetInternalUser(sub)
 	if svcErr != nil {
 		if svcErr.Code == authncm.ErrorUserNotFound.Code {
@@ -241,6 +251,19 @@ func resolveUserForOIDC(authService authnoidc.OIDCAuthnCoreServiceInterface,
 
 				return nil, nil
 			} else {
+				// Provision the user automatically if allowed user types are configured
+				provisionedUser, provisionErr := provisionUserOIDC(ctx, sub, logger,
+					userService, userSchemaService, idTokenClaims)
+				if provisionErr != nil {
+					logger.Error("Automatic user provisioning failed", log.Error(provisionErr), log.String("sub", sub))
+					execResp.Status = flowcm.ExecFailure
+					execResp.FailureReason = "User not found and automatic provisioning is not available"
+					return nil, nil
+				}
+				if provisionedUser != nil {
+					return provisionedUser, nil
+				}
+				// Provisioning not possible, return failure
 				execResp.Status = flowcm.ExecFailure
 				execResp.FailureReason = failureReasonUserNotFound
 				return nil, nil
@@ -351,4 +374,98 @@ func getAuthenticatedUserForOIDC(o oidcAuthExecutorInterface, authService authno
 	}
 
 	return &authenticatedUser, nil
+}
+
+// provisionUserOIDC attempts to automatically provision a user if allowed user types are configured.
+func provisionUserOIDC(ctx *flowcore.NodeContext,
+	sub string, logger *log.Logger, userService user.UserServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface, idTokenClaims map[string]interface{}) (*user.User, error) {
+	allowedUserTypes := ctx.Application.AllowedUserTypes
+	if len(allowedUserTypes) == 0 {
+		logger.Debug("No allowed user types configured, cannot provision user automatically",
+			log.String("sub", sub))
+		return nil, nil
+	}
+
+	if userService == nil || userSchemaService == nil {
+		return nil, fmt.Errorf("required services are not available for provisioning")
+	}
+
+	// Filter allowed user types to only those with self-registration enabled
+	selfRegEnabledUserTypes := make([]string, 0)
+	var selectedUserSchema *userschema.UserSchema
+	for _, userType := range allowedUserTypes {
+		userSchema, svcErr := userSchemaService.GetUserSchemaByName(userType)
+		if svcErr != nil {
+			logger.Debug("Failed to get user schema for user type, skipping",
+				log.String("userType", userType), log.String("errorCode", svcErr.Code))
+			continue
+		}
+		if userSchema.AllowSelfRegistration {
+			selfRegEnabledUserTypes = append(selfRegEnabledUserTypes, userType)
+			if selectedUserSchema == nil {
+				selectedUserSchema = userSchema
+			}
+		}
+	}
+
+	// Fail if no user types have self-registration enabled
+	if len(selfRegEnabledUserTypes) == 0 {
+		logger.Debug("No user types with self-registration enabled for automatic provisioning",
+			log.String("sub", sub))
+		return nil, fmt.Errorf("no user types with self-registration enabled")
+	}
+
+	// Fail if multiple user types have self-registration enabled (ambiguous)
+	if len(selfRegEnabledUserTypes) > 1 {
+		logger.Debug("Multiple user types with self-registration enabled, cannot automatically provision",
+			log.String("sub", sub), log.Any("userTypes", selfRegEnabledUserTypes))
+		return nil, fmt.Errorf("multiple user types with self-registration enabled: %v", selfRegEnabledUserTypes)
+	}
+
+	// Exactly one user type with self-registration enabled
+	userType := selfRegEnabledUserTypes[0]
+	userSchema := selectedUserSchema
+
+	if userSchema.OrganizationUnitID == "" {
+		logger.Error("No organization unit found for user type", log.String("userType", userType))
+		return nil, fmt.Errorf("no organization unit found for user type: %s", userType)
+	}
+
+	// Extract user attributes from ID token claims
+	// We need to include 'sub' in attributes for user identification
+	userAttributes := make(map[string]interface{})
+	if len(idTokenClaims) != 0 {
+		for attr, val := range idTokenClaims {
+			if attr == "sub" || !slices.Contains(idTokenNonUserAttributes, attr) {
+				userAttributes[attr] = val
+			}
+		}
+	}
+
+	attributesJSON, err := json.Marshal(userAttributes)
+	if err != nil {
+		logger.Error("Failed to marshal user attributes", log.Error(err))
+		return nil, fmt.Errorf("failed to marshal user attributes: %w", err)
+	}
+
+	// Create the user
+	newUser := &user.User{
+		OrganizationUnit: userSchema.OrganizationUnitID,
+		Type:             userType,
+		Attributes:       attributesJSON,
+	}
+
+	createdUser, svcErr := userService.CreateUser(newUser)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			return nil, fmt.Errorf("failed to create user: %s", svcErr.ErrorDescription)
+		}
+		logger.Error("Failed to create user during provisioning",
+			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription),
+			log.String("userType", userType), log.String("sub", sub))
+		return nil, fmt.Errorf("failed to create user: %s", svcErr.ErrorDescription)
+	}
+
+	return createdUser, nil
 }

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -22,8 +22,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	authnoauth "github.com/asgardeo/thunder/internal/authn/oauth"
 	flowcm "github.com/asgardeo/thunder/internal/flow/common"
@@ -31,17 +33,22 @@ import (
 	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 	"github.com/asgardeo/thunder/tests/mocks/authn/oidcmock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
 type OIDCAuthExecutorTestSuite struct {
 	suite.Suite
-	mockOIDCService *oidcmock.OIDCAuthnCoreServiceInterfaceMock
-	mockIDPService  *idpmock.IDPServiceInterfaceMock
-	mockFlowFactory *coremock.FlowFactoryInterfaceMock
-	executor        oidcAuthExecutorInterface
+	mockOIDCService       *oidcmock.OIDCAuthnCoreServiceInterfaceMock
+	mockIDPService        *idpmock.IDPServiceInterfaceMock
+	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockUserService       *usermock.UserServiceInterfaceMock
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
+	executor              oidcAuthExecutorInterface
 }
 
 func TestOIDCAuthExecutorSuite(t *testing.T) {
@@ -52,6 +59,8 @@ func (suite *OIDCAuthExecutorTestSuite) SetupTest() {
 	suite.mockOIDCService = oidcmock.NewOIDCAuthnCoreServiceInterfaceMock(suite.T())
 	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 
 	defaultInputs := []flowcm.InputData{{Name: "code", Type: "string", Required: true}}
 	mockExec := createMockAuthExecutor(suite.T(), ExecutorNameOIDCAuth)
@@ -59,7 +68,8 @@ func (suite *OIDCAuthExecutorTestSuite) SetupTest() {
 		defaultInputs, []flowcm.InputData{}).Return(mockExec)
 
 	suite.executor = newOIDCAuthExecutor(ExecutorNameOIDCAuth, defaultInputs, []flowcm.InputData{},
-		suite.mockFlowFactory, suite.mockIDPService, suite.mockOIDCService)
+		suite.mockFlowFactory, suite.mockIDPService, suite.mockOIDCService,
+		suite.mockUserService, suite.mockUserSchemaService)
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestNewOIDCAuthExecutor() {
@@ -126,7 +136,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_Au
 
 	existingUser := &user.User{
 		ID:               "user-123",
-		OrganizationUnit: "ou-123",
+		OrganizationUnit: testOUID,
 		Type:             "INTERNAL",
 	}
 
@@ -150,7 +160,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_Au
 	assert.Equal(suite.T(), flowcm.ExecComplete, resp.Status)
 	assert.True(suite.T(), resp.AuthenticatedUser.IsAuthenticated)
 	assert.Equal(suite.T(), "user-123", resp.AuthenticatedUser.UserID)
-	assert.Equal(suite.T(), "ou-123", resp.AuthenticatedUser.OrganizationUnitID)
+	assert.Equal(suite.T(), testOUID, resp.AuthenticatedUser.OrganizationUnitID)
 	assert.Equal(suite.T(), "test@example.com", resp.RuntimeData["email"])
 	suite.mockOIDCService.AssertExpectations(suite.T())
 }
@@ -559,7 +569,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_WithAddition
 
 	existingUser := &user.User{
 		ID:               "user-123",
-		OrganizationUnit: "ou-123",
+		OrganizationUnit: testOUID,
 		Type:             "INTERNAL",
 	}
 
@@ -649,7 +659,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUs
 
 	existingUser := &user.User{
 		ID:               "user-123",
-		OrganizationUnit: "ou-123",
+		OrganizationUnit: testOUID,
 		Type:             "INTERNAL",
 	}
 
@@ -1054,4 +1064,503 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 	assert.Equal(suite.T(), "niltest@example.com", execResp.RuntimeData["email"])
 	assert.Equal(suite.T(), "niltest@example.com", execResp.AuthenticatedUser.Attributes["email"])
 	suite.mockOIDCService.AssertExpectations(suite.T())
+}
+
+// Test provisioning functionality
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_ProvisioningSucceeds() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid",
+		IDToken:     "id_token_jwt",
+		ExpiresIn:   3600,
+	}
+
+	idTokenClaims := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+		"name":  "New User",
+		"iss":   "https://provider.com",
+		"aud":   "client-id",
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+
+	provisionedUser := &user.User{
+		ID:               "user-provisioned-123",
+		OrganizationUnit: testOUID,
+		Type:             "employee",
+	}
+
+	oauthConfig := &authnoauth.OAuthClientConfig{
+		Scopes: []string{"openid"},
+	}
+
+	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
+		Return(idTokenClaims, nil)
+	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+		Return(oauthConfig, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+	suite.mockUserService.On("CreateUser", mock.MatchedBy(func(u *user.User) bool {
+		return u.Type == testUserType && u.OrganizationUnit == testOUID
+	})).Return(provisionedUser, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecComplete, execResp.Status)
+	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
+	assert.Equal(suite.T(), "user-provisioned-123", execResp.AuthenticatedUser.UserID)
+	assert.Equal(suite.T(), testOUID, execResp.AuthenticatedUser.OrganizationUnitID)
+	assert.Equal(suite.T(), "employee", execResp.AuthenticatedUser.UserType)
+	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertExpectations(suite.T())
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_NoAllowedUserTypes() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid",
+		IDToken:     "id_token_jwt",
+		ExpiresIn:   3600,
+	}
+
+	idTokenClaims := map[string]interface{}{
+		"sub": "new-user-sub",
+	}
+
+	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
+		Return(idTokenClaims, nil)
+	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), failureReasonUserNotFound, execResp.FailureReason)
+	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertNotCalled(suite.T(), "GetUserSchemaByName")
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_UserSchemaNotFound() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid",
+		IDToken:     "id_token_jwt",
+		ExpiresIn:   3600,
+	}
+
+	idTokenClaims := map[string]interface{}{
+		"sub": "new-user-sub",
+	}
+
+	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
+		Return(idTokenClaims, nil)
+	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			Code:             "USRS-1002",
+			ErrorDescription: "User schema not found",
+		})
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_UserCreationFails() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid",
+		IDToken:     "id_token_jwt",
+		ExpiresIn:   3600,
+	}
+
+	idTokenClaims := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+
+	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
+		Return(idTokenClaims, nil)
+	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+	suite.mockUserService.On("CreateUser", mock.MatchedBy(func(u *user.User) bool {
+		return u.Type == testUserType && u.OrganizationUnit == testOUID
+	})).Return(nil, &serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "USR-1014",
+		ErrorDescription: "Attribute conflict",
+	})
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertExpectations(suite.T())
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_MultipleAllowedUserTypes() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid",
+		IDToken:     "id_token_jwt",
+		ExpiresIn:   3600,
+	}
+
+	idTokenClaims := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	employeeSchema := &userschema.UserSchema{
+		ID:                    "schema-employee",
+		Name:                  "employee",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+	customerSchema := &userschema.UserSchema{
+		ID:                    "schema-customer",
+		Name:                  "customer",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+	partnerSchema := &userschema.UserSchema{
+		ID:                    "schema-partner",
+		Name:                  "partner",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+
+	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
+		Return(idTokenClaims, nil)
+	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	// All three user types have self-registration enabled, so should fail
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+		Return(customerSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "partner").
+		Return(partnerSchema, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_SelfRegistrationDisabled() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid",
+		IDToken:     "id_token_jwt",
+		ExpiresIn:   3600,
+	}
+
+	idTokenClaims := map[string]interface{}{
+		"sub": "new-user-sub",
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:                    "schema-123",
+		Name:                  "employee",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: false,
+	}
+
+	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
+		Return(idTokenClaims, nil)
+	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(userSchema, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User not found and automatic provisioning is not available", execResp.FailureReason)
+	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertNotCalled(suite.T(), "CreateUser")
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound_MultiTypes_OneWithSelfReg() {
+	ctx := &flowcore.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: flowcm.FlowTypeAuthentication,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputData: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &flowcm.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	tokenResp := &authnoauth.TokenResponse{
+		AccessToken: "access_token_123",
+		TokenType:   "Bearer",
+		Scope:       "openid",
+		IDToken:     "id_token_jwt",
+		ExpiresIn:   3600,
+	}
+
+	idTokenClaims := map[string]interface{}{
+		"sub":   "new-user-sub",
+		"email": "newuser@example.com",
+	}
+
+	employeeSchema := &userschema.UserSchema{
+		ID:                    "schema-employee",
+		Name:                  "employee",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: true,
+	}
+	customerSchema := &userschema.UserSchema{
+		ID:                    "schema-customer",
+		Name:                  "customer",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: false,
+	}
+	partnerSchema := &userschema.UserSchema{
+		ID:                    "schema-partner",
+		Name:                  "partner",
+		OrganizationUnitID:    testOUID,
+		AllowSelfRegistration: false,
+	}
+
+	provisionedUser := &user.User{
+		ID:               "user-provisioned-123",
+		OrganizationUnit: testOUID,
+		Type:             "employee",
+	}
+
+	oauthConfig := &authnoauth.OAuthClientConfig{
+		Scopes: []string{"openid"},
+	}
+
+	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+		Return(tokenResp, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
+		Return(idTokenClaims, nil)
+	suite.mockOIDCService.On("GetInternalUser", "new-user-sub").
+		Return(nil, &serviceerror.ServiceError{
+			Code: authncm.ErrorUserNotFound.Code,
+			Type: serviceerror.ClientErrorType,
+		})
+	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+		Return(oauthConfig, nil)
+	// Only employee has self-registration enabled
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+		Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+		Return(customerSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", "partner").
+		Return(partnerSchema, nil)
+	suite.mockUserService.On("CreateUser", mock.MatchedBy(func(u *user.User) bool {
+		return u.Type == "employee" && u.OrganizationUnit == testOUID
+	})).Return(provisionedUser, nil)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), flowcm.ExecComplete, execResp.Status)
+	assert.True(suite.T(), execResp.AuthenticatedUser.IsAuthenticated)
+	assert.Equal(suite.T(), "employee", execResp.AuthenticatedUser.UserType)
+	suite.mockOIDCService.AssertExpectations(suite.T())
+	suite.mockUserSchemaService.AssertExpectations(suite.T())
+	suite.mockUserService.AssertExpectations(suite.T())
 }


### PR DESCRIPTION
## Purpose

This pull request adds support for automatic user provisioning in OAuth and OIDC authentication flows. When a user authenticates via OAuth/OIDC and does not already exist in the system, the relevant executor will attempt to provision the user automatically if allowed user types are configured. The changes also ensure that the necessary user and user schema services are injected into the authentication executors and that tests are updated to mock these dependencies.

## Approach

**Automatic User Provisioning Enhancements:**

* Added logic to `oAuthExecutor` to automatically provision users during authentication if they do not exist and allowed user types are configured. This includes fetching the user schema, preparing attributes, and creating the user via the user service. [[1]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R375-R391) [[2]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R461-R530)

**Dependency Injection Updates:**

* Modified constructors for `OAuth`, `OIDC`, `GitHubOAuth`, and `GoogleOIDC` executors to accept `userService` and `userSchemaService` as additional dependencies, and updated executor registration in `init.go` to provide these services. [[1]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R69-R70) [[2]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R83-R84) [[3]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R108-R109) [[4]](diffhunk://#diff-f49db1386bfdc76a693337ca3a2d59e1b4d43926681b1a18b9c572d47175a59dR44-R53) [[5]](diffhunk://#diff-f49db1386bfdc76a693337ca3a2d59e1b4d43926681b1a18b9c572d47175a59dR27-R28) [[6]](diffhunk://#diff-052e066d8dbeb0ea9152f3a8cbb2f659515a0aa6f4a5bd8d643b29e9bc4be744R44-R45) [[7]](diffhunk://#diff-052e066d8dbeb0ea9152f3a8cbb2f659515a0aa6f4a5bd8d643b29e9bc4be744R27-R28) [[8]](diffhunk://#diff-052e066d8dbeb0ea9152f3a8cbb2f659515a0aa6f4a5bd8d643b29e9bc4be744L62-R66) [[9]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06L53-R61)

**Test Suite Improvements:**

* Updated test suites for OAuth, OIDC, GitHubOAuth, and GoogleOIDC executors to mock and inject `userService` and `userSchemaService`, ensuring coverage for the new provisioning logic. [[1]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R25-R50) [[2]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R62-R72) [[3]](diffhunk://#diff-b0580b9ed29205bd4180c7651589b418066cd92b98a240a1a80d3c0a503faab0R32-R33) [[4]](diffhunk://#diff-b0580b9ed29205bd4180c7651589b418066cd92b98a240a1a80d3c0a503faab0R42-R43) [[5]](diffhunk://#diff-b0580b9ed29205bd4180c7651589b418066cd92b98a240a1a80d3c0a503faab0R55-R56) [[6]](diffhunk://#diff-b0580b9ed29205bd4180c7651589b418066cd92b98a240a1a80d3c0a503faab0L71-R78) [[7]](diffhunk://#diff-e166913bce0345f5caf1deaff8162f1bdb90572cfcf82d3509df3ea6b223a74cR32-R33) [[8]](diffhunk://#diff-e166913bce0345f5caf1deaff8162f1bdb90572cfcf82d3509df3ea6b223a74cR42-R43) [[9]](diffhunk://#diff-e166913bce0345f5caf1deaff8162f1bdb90572cfcf82d3509df3ea6b223a74cR55-R56) [[10]](diffhunk://#diff-e166913bce0345f5caf1deaff8162f1bdb90572cfcf82d3509df3ea6b223a74cL76-R83)

**General Codebase Maintenance:**

* Added missing imports for `encoding/json`, `user`, and `userschema` in relevant files to support new provisioning features. [[1]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R22) [[2]](diffhunk://#diff-6f149d3cf105a09b95b320eb5aa82d89a0710e8b26ac6e6b718bff79bb2f7ce3R34-R35)

These changes collectively ensure that users can be provisioned automatically during OAuth/OIDC authentication, and the codebase and tests are updated to support this workflow.