### PR TITLE
Add common config to indicate gate app path

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -8,8 +8,7 @@
     "hostname": "localhost",
     "port": 8090,
     "scheme": "https",
-    "login_path": "/gate/signin",
-    "error_path": "/error"
+    "path": "/gate"
   },
   "security": {
     "cert_file": "repository/resources/security/server.cert",

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -22,6 +22,7 @@ package config
 import (
 	"encoding/json"
 	"os"
+	urlpath "path"
 	"path/filepath"
 	"reflect"
 
@@ -43,6 +44,7 @@ type GateClientConfig struct {
 	Hostname  string `yaml:"hostname" json:"hostname"`
 	Port      int    `yaml:"port" json:"port"`
 	Scheme    string `yaml:"scheme" json:"scheme"`
+	Path      string `yaml:"path" json:"path"`
 	LoginPath string `yaml:"login_path" json:"login_path"`
 	ErrorPath string `yaml:"error_path" json:"error_path"`
 }
@@ -209,6 +211,15 @@ func LoadConfig(path string, defaultsPath string) (*Config, error) {
 
 	// Merge user configuration with defaults
 	mergeConfigs(&cfg, &userCfg)
+	// Derive login_path and error_path from path if not explicitly set
+	if cfg.GateClient.Path != "" {
+		if cfg.GateClient.LoginPath == "" {
+			cfg.GateClient.LoginPath = urlpath.Join(cfg.GateClient.Path, "signin")
+		}
+		if cfg.GateClient.ErrorPath == "" {
+			cfg.GateClient.ErrorPath = urlpath.Join(cfg.GateClient.Path, "error")
+		}
+	}
 
 	return &cfg, nil
 }

--- a/backend/tests/resources/deployment.yaml
+++ b/backend/tests/resources/deployment.yaml
@@ -2,13 +2,6 @@ server:
   hostname: localhost
   port: 8080
 
-gate_client:
-  hostname: localhost
-  port: 8090
-  scheme: https
-  login_path: /gate/signin
-  error_path: /error
-
 security:
   cert_file: /path/to/cert.pem
   key_file: /path/to/key.pem

--- a/docs/contributing/3-development.md
+++ b/docs/contributing/3-development.md
@@ -84,8 +84,6 @@ cors:
 ```yaml
 gate_client:
   port: 5190
-  scheme: "https"
-  login_path: "/gate/signin"
 ```
 
 > [!TIP]
@@ -310,8 +308,6 @@ THUNDER_API_BASE="https://localhost:8090" \
 ```yaml
 gate_client:
   port: 5190
-  scheme: "https"
-  login_path: "/gate/signin"
 ```
 
 2. Add the local development origin of the Thunder Gate application (https://localhost:5190) to the CORS allowed origins in `<THUNDER_HOME>/repository/conf/deployment.yaml`.

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -161,8 +161,7 @@ The following table lists the configurable parameters of the Thunder chart and t
 | `configuration.gateClient.hostname`    | Gate client hostname                                            | `0.0.0.0`                    |
 | `configuration.gateClient.port`        | Gate client port                                                | `8090`                       |
 | `configuration.gateClient.scheme`      | Gate client scheme                                              | `https`                      |
-| `configuration.gateClient.loginPath`   | Gate client login path                                          | `/gate/signin`                     |
-| `configuration.gateClient.errorPath`   | Gate client error path                                          | `/error`                     |
+| `configuration.gateClient.path`        | Gate client base path                                           | `/gate`                      |
 | `configuration.security.certFile`      | Server certificate file path                                    | `repository/resources/security/server.cert` |
 | `configuration.security.keyFile`       | Server key file path                                            | `repository/resources/security/server.key`  |
 | `configuration.security.cryptoFile`    | Crypto key file path                                            | `repository/resources/security/crypto.key`  |

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -117,8 +117,7 @@ configuration:
     hostname: "0.0.0.0"
     port: 8090
     scheme: "https"
-    loginPath: "/gate/signin"
-    errorPath: "/error"
+    path: "/gate"
 
   # Security configuration
   security:


### PR DESCRIPTION
### Purpose
Currently there are two independent configs (`login_path` & `error_path`) are available to indicate the gate app's path. In case of the need of changing the gate app's path, it needs to change the both these configs, which can lead to user errors. 

In fact, the default values of these params was inconsistent (`/gate/signin` vs `error`) shows the example of the such user error.

Thus, introducing a config named `path` under the `gate_client` config, to give the ability to change the base path in one config, rather user having to change multiple places. In a case, user need to use different specific paths for specific gates, they can still use `login_path`, `error_path` configs and override the default behavior.

### Approach
This pull request improves the configuration of the Gate client by introducing a new `path` parameter, which serves as a base path for related endpoints. It also updates the logic to automatically derive the `login_path` and `error_path` from this base path if they are not explicitly set, ensuring consistency and simplifying configuration. Documentation and test cases are updated accordingly.

**Gate client configuration improvements:**

* Added a new `path` field to the Gate client configuration (`GateClientConfig` in `config.go`, `default.json`, `deployment.yaml`, Helm values, and documentation) to define a base path for endpoints. [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR47) [[2]](diffhunk://#diff-beec713bb8f44ef8633de8d745de6dcd555593b5cd0758d7788470fee3b2d974L11-R11) [[3]](diffhunk://#diff-4c1cde7cf666e68b1f32ef578db29763800843a2181e0e6ce66a6c3d6b416e62R9-R11) [[4]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eR119-R121) [[5]](diffhunk://#diff-3f767509b40f4f726a137cd616c967a47345b5cf0034ae6f4cc29fcd830f5096R163-R165)
* Updated the configuration loading logic to automatically set `login_path` and `error_path` based on the `path` value if they are not explicitly provided, ensuring derived paths follow the base path.

**Testing enhancements:**

* Added unit tests to verify that `login_path` and `error_path` are correctly derived from `path` when not set, and that explicit overrides work as expected.

**Documentation updates:**

* Updated configuration examples and documentation to reflect the new `path` parameter and the updated default values for `login_path` and `error_path`. [[1]](diffhunk://#diff-3e84d47c1f74e556e7712d01081df64ceff0a1116d082beb36987fdf3784abaaL87-L88) [[2]](diffhunk://#diff-3e84d47c1f74e556e7712d01081df64ceff0a1116d082beb36987fdf3784abaaL313-L314) [[3]](diffhunk://#diff-3f767509b40f4f726a137cd616c967a47345b5cf0034ae6f4cc29fcd830f5096R163-R165) [[4]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eR119-R121)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
