### PR TITLE
Fix SQLite Database Locking Issues Under Concurrent Load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.db
 */**/executables/*
 
+# sqlite database files
+*.db-shm
+*.db-wal
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/build.ps1
+++ b/build.ps1
@@ -366,6 +366,11 @@ function Initialize-Databases {
             if ($LASTEXITCODE -ne 0) {
                 throw "SQLite operation failed with exit code $LASTEXITCODE"
             }
+            Write-Host " - Enabling WAL mode for $db_file"
+            & sqlite3 $db_path "PRAGMA journal_mode=WAL;"
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to enable WAL mode with exit code $LASTEXITCODE"
+            }
         }
         else {
             Write-Host " ! Skipping $db_file : SQL script not found at $script_path"

--- a/build.sh
+++ b/build.sh
@@ -242,6 +242,11 @@ function initialize_databases() {
 
             echo " - Creating $db_file using $script_path"
             sqlite3 "$db_path" < "$script_path"
+            sqlite3 "$db_path" "PRAGMA journal_mode=WAL;"
+            if [ $? -ne 0 ]; then
+                echo "Failed to enable WAL mode for $db_file"
+                exit 1
+            fi
         else
             echo " ! Skipping $db_file: SQL script not found at $script_path"
         fi


### PR DESCRIPTION
### Issue
SQLite databases created during the build process were not initialized with WAL (Write-Ahead Logging) mode, despite the configuration specifying `_journal_mode=WAL`. This caused the databases to use the default `delete` journal mode, leading to database locking errors under concurrent load:
```
failed to update flow context in database: transaction failed: database is locked (5) (SQLITE_BUSY)
```
While the init_script.sh already correctly enables WAL mode when creating databases, the build scripts build.sh and build.ps1 did not perform this initialization step.

### Root Cause
When SQLite databases are created using the sqlite3 command to execute schema SQL scripts, they default to delete journal mode. The _journal_mode=WAL option in the connection string only takes effect when the database is opened by the application, but doesn't convert existing databases.

The build scripts were creating databases without explicitly enabling WAL mode:
- build.sh: Created databases but didn't run PRAGMA journal_mode=WAL;
- build.ps1: Created databases but didn't run PRAGMA journal_mode=WAL;
- [init_script.sh](https://github.com/asgardeo/thunder/blob/main/backend/scripts/init_script.sh#L145): ✅ Already correctly enabled WAL mode

This inconsistency meant that:

- Databases created via [init_script.sh](https://github.com/asgardeo/thunder/blob/main/backend/scripts/init_script.sh#L145) worked correctly with WAL mode
- Databases created during the build process started in delete mode, causing lock contention

### Solution

Updated both build scripts to enable WAL mode immediately after database creation:
This ensures all three database initialization paths (build.sh, build.ps1 and init_script.sh) create databases with WAL mode enabled from the start.

