### PR TITLE
Fix divider rendering in gate app

### DIFF
--- a/frontend/apps/thunder-gate/src/components/SignIn/SignInBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/SignInBox.tsx
@@ -237,8 +237,9 @@ export default function SignInBox(): JSX.Element {
                             </Box>
                           )}
 
-                          {/* Show divider if there are other auth options besides basic_auth */}
-                          {components.some((c) => c.type === 'BUTTON' && c.config?.actionId !== 'basic_auth') && (
+                          {/* Show divider only if basic_auth exists AND there are other auth options */}
+                          {components.some((c) => c.config?.actionId === 'basic_auth') &&
+                           components.some((c) => c.type === 'BUTTON' && c.config?.actionId !== 'basic_auth') && (
                             <Divider sx={{my: 2}}>OR</Divider>
                           )}
 


### PR DESCRIPTION
This pull request updates the logic for displaying the divider in the sign-in box to ensure it only appears when both the basic authentication option and at least one other authentication option are present.

Sign-in UI logic improvement:

* Modified the condition for rendering the divider in `SignInBox.tsx` so that the "OR" divider only shows if both a `basic_auth` option exists and there is at least one other authentication button. This prevents the divider from appearing when only one authentication method is available.