### PR TITLE
Fix Develop app menu overflow

### DIFF
--- a/frontend/apps/thunder-develop/src/components/Sidebar/SideMenu.tsx
+++ b/frontend/apps/thunder-develop/src/components/Sidebar/SideMenu.tsx
@@ -204,15 +204,34 @@ export default function SideMenu({
                 </Avatar>
                 {!mini && (
                   <>
-                    <Box sx={{mr: 'auto'}}>
-                      <Typography variant="body2" sx={{fontWeight: 500, lineHeight: '16px'}}>
+                    <Box sx={{mr: 'auto', minWidth: 0, flex: 1, overflow: 'hidden'}}>
+                      <Typography 
+                        variant="body2" 
+                        sx={{
+                          fontWeight: 500, 
+                          lineHeight: '16px',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
                         {user?.name}
                       </Typography>
-                      <Typography variant="caption" sx={{color: 'text.secondary'}}>
+                      <Typography 
+                        variant="caption" 
+                        sx={{
+                          color: 'text.secondary',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
                         {user?.email}
                       </Typography>
                     </Box>
+                    <Box sx={{flexShrink: 0}}>
                     <OptionsMenu />
+                    </Box>
                   </>
                 )}
               </>


### PR DESCRIPTION
This pull request improves the layout and usability of the user information section in the `SideMenu` component. The changes ensure that long user names and emails are properly truncated and do not overflow their container, maintaining a clean sidebar appearance.

**UI/UX improvements:**

<img width="260" height="1053" alt="image" src="https://github.com/user-attachments/assets/483a5546-ad9d-4c57-9f93-b48328df99c5" />

* Updated the `Box` containing user information to include `minWidth: 0`, `flex: 1`, and `overflow: 'hidden'` for better flexbox handling and to prevent overflow issues.
* Modified the `Typography` components for user name and email to use `overflow: 'hidden'`, `textOverflow: 'ellipsis'`, and `whiteSpace: 'nowrap'`, ensuring that long text is truncated with an ellipsis.
* Wrapped the `OptionsMenu` in a new `Box` with `flexShrink: 0` to prevent it from shrinking and to maintain consistent spacing next to the user info.
