### PR TITLE
Update lockfile of the react-sdk sample

### DIFF
--- a/samples/apps/react-sdk/pnpm-lock.yaml
+++ b/samples/apps/react-sdk/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.2
         version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-basic-ssl':
+        specifier: 2.1.0
+        version: 2.1.0(rolldown-vite@7.1.20(@types/node@20.19.24)(esbuild@0.25.9))
       '@vitejs/plugin-react':
         specifier: 5.1.0
         version: 5.1.0(rolldown-vite@7.1.20(@types/node@20.19.24)(esbuild@0.25.9))
@@ -941,6 +944,12 @@ packages:
   '@typescript-eslint/visitor-keys@8.46.2':
     resolution: {integrity: sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-basic-ssl@2.1.0':
+    resolution: {integrity: sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    peerDependencies:
+      vite: ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-react@5.1.0':
     resolution: {integrity: sha512-4LuWrg7EKWgQaMJfnN+wcmbAW+VSsCmqGohftWjuct47bv8uE4n/nPpq4XjJPsxgq00GGG5J8dvBczp8uxScew==}
@@ -3046,6 +3055,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.2
       eslint-visitor-keys: 4.2.1
+
+  '@vitejs/plugin-basic-ssl@2.1.0(rolldown-vite@7.1.20(@types/node@20.19.24)(esbuild@0.25.9))':
+    dependencies:
+      vite: rolldown-vite@7.1.20(@types/node@20.19.24)(esbuild@0.25.9)
 
   '@vitejs/plugin-react@5.1.0(rolldown-vite@7.1.20(@types/node@20.19.24)(esbuild@0.25.9))':
     dependencies:


### PR DESCRIPTION
### Purpose
This pull request updates the `pnpm-lock.yaml` file for the React SDK sample app to add support for SSL in Vite development environments. The main change is the addition of the `@vitejs/plugin-basic-ssl` dependency, which enables basic SSL configuration for local development.

**Dependency additions:**

* Added `@vitejs/plugin-basic-ssl@2.1.0` to the `importers` section, allowing the app to use SSL features during development.
* Included metadata for `@vitejs/plugin-basic-ssl@2.1.0` in the `packages` section, specifying integrity, engine requirements, and peer dependencies.
* Registered the plugin and its dependency on `vite` in the `snapshots` section to ensure proper resolution and installation.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
