### PR TITLE
Bump @asgardeo/react to version 0.6.11

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.6.10
-      version: 0.6.10
+      specifier: 0.6.11
+      version: 0.6.11
     '@asgardeo/react-router':
       specifier: 1.0.9
       version: 1.0.9
@@ -169,10 +169,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.6.10(@types/react@19.1.16)(react@19.1.1)
+        version: 0.6.11(@types/react@19.1.16)(react@19.1.1)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 1.0.9(@asgardeo/react@0.6.10(@types/react@19.1.16)(react@19.1.1))(react-router@7.9.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        version: 1.0.9(@asgardeo/react@0.6.11(@types/react@19.1.16)(react@19.1.1))(react-router@7.9.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@19.1.16)(react@19.1.1)
@@ -287,7 +287,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.6.10(@types/react@19.1.16)(react@19.1.1)
+        version: 0.6.11(@types/react@19.1.16)(react@19.1.1)
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@19.1.16)(react@19.1.1)
@@ -643,8 +643,8 @@ packages:
       react: 19.1.0
       react-router: 6.30.1
 
-  '@asgardeo/react@0.6.10':
-    resolution: {integrity: sha512-DfiCLHfxxU5Ytd3nKIgiIBkQjzismpwK0d6/MJE0MkEp8hsyRxq6IrjbS4YBooK8nbCT5V0npi3izr7/oGGOsg==}
+  '@asgardeo/react@0.6.11':
+    resolution: {integrity: sha512-d2W4C1COm4oOMc3mtUGwn+Kx4H644Jbly9TU4rMCwIJoejOKs+LVjZ3lMsleBCUU5VG/E7aEOvI8O1HMgWSJIw==}
     peerDependencies:
       '@types/react': 19.1.5
       react: 19.1.0
@@ -5367,14 +5367,14 @@ snapshots:
       '@asgardeo/i18n': 0.3.4
       tslib: 2.8.1
 
-  '@asgardeo/react-router@1.0.9(@asgardeo/react@0.6.10(@types/react@19.1.16)(react@19.1.1))(react-router@7.9.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+  '@asgardeo/react-router@1.0.9(@asgardeo/react@0.6.11(@types/react@19.1.16)(react@19.1.1))(react-router@7.9.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
     dependencies:
-      '@asgardeo/react': 0.6.10(@types/react@19.1.16)(react@19.1.1)
+      '@asgardeo/react': 0.6.11(@types/react@19.1.16)(react@19.1.1)
       react: 19.1.1
       react-router: 7.9.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.6.10(@types/react@19.1.16)(react@19.1.1)':
+  '@asgardeo/react@0.6.11(@types/react@19.1.16)(react@19.1.1)':
     dependencies:
       '@asgardeo/browser': 0.1.28(esbuild@0.25.9)
       '@asgardeo/i18n': 0.3.4

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  '@asgardeo/react': 0.6.10
+  '@asgardeo/react': 0.6.11
   '@asgardeo/react-router': 1.0.9
   '@emotion/react': 11.14.0
   '@emotion/styled': 11.14.1

--- a/samples/apps/react-sdk/package.json
+++ b/samples/apps/react-sdk/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@asgardeo/react": "0.6.10",
+    "@asgardeo/react": "0.6.11",
     "@wso2/oxygen-ui": "0.0.1-alpha.5",
     "jwt-decode": "4.0.0",
     "react": "19.2.0",

--- a/samples/apps/react-sdk/pnpm-lock.yaml
+++ b/samples/apps/react-sdk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@asgardeo/react':
-        specifier: 0.6.10
-        version: 0.6.10(@types/react@19.2.2)(react@19.2.0)
+        specifier: 0.6.11
+        version: 0.6.11(@types/react@19.2.2)(react@19.2.0)
       '@wso2/oxygen-ui':
         specifier: 0.0.1-alpha.5
         version: 0.0.1-alpha.5(8d577468a69b36e2afeab5b77df0ed32)
@@ -78,8 +78,8 @@ packages:
   '@asgardeo/javascript@0.2.3':
     resolution: {integrity: sha512-+4u+kDPg3pvldeql23qJvNLOnsDArrcYsIg2QXPFF7dYE638tjNe/z77Xmh96UBvrMa3O2ZIxxxfMfs5ejEo9g==}
 
-  '@asgardeo/react@0.6.10':
-    resolution: {integrity: sha512-DfiCLHfxxU5Ytd3nKIgiIBkQjzismpwK0d6/MJE0MkEp8hsyRxq6IrjbS4YBooK8nbCT5V0npi3izr7/oGGOsg==}
+  '@asgardeo/react@0.6.11':
+    resolution: {integrity: sha512-d2W4C1COm4oOMc3mtUGwn+Kx4H644Jbly9TU4rMCwIJoejOKs+LVjZ3lMsleBCUU5VG/E7aEOvI8O1HMgWSJIw==}
     peerDependencies:
       '@types/react': 19.1.5
       react: 19.1.0
@@ -2164,7 +2164,7 @@ snapshots:
       '@asgardeo/i18n': 0.3.4
       tslib: 2.8.1
 
-  '@asgardeo/react@0.6.10(@types/react@19.2.2)(react@19.2.0)':
+  '@asgardeo/react@0.6.11(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@asgardeo/browser': 0.1.28(esbuild@0.25.9)
       '@asgardeo/i18n': 0.3.4


### PR DESCRIPTION
This pull request updates the `@asgardeo/react` package from version 0.6.10 to 0.6.11 across the monorepo and sample application. The changes are focused on keeping dependencies consistent and up-to-date.

Dependency updates:

* Updated the `@asgardeo/react` version from 0.6.10 to 0.6.11 in `frontend/pnpm-lock.yaml`, `frontend/pnpm-workspace.yaml`, and `samples/apps/react-sdk/package.json` to ensure all packages use the latest release. [[1]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L10-R11) [[2]](diffhunk://#diff-f60c0ec3013027a039a8555f62dcdd071cf966ee68edeb1d64cf20267dba3411L6-R6) [[3]](diffhunk://#diff-02acf7e292137e4f489665b76e821e735b1bc2e51f202aa37d141a4d93a212bdL14-R14)
* Updated all references to `@asgardeo/react` in the lock files (`frontend/pnpm-lock.yaml` and `samples/apps/react-sdk/pnpm-lock.yaml`) to reflect the new version, including nested dependencies and integrity hashes. [[1]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L172-R175) [[2]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L290-R290) [[3]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L646-R647) [[4]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L5370-R5377) [[5]](diffhunk://#diff-51274c3c1069f278315ac85055a48b743acad41a80ce3c16a82438ba75e040d9L15-R16) [[6]](diffhunk://#diff-51274c3c1069f278315ac85055a48b743acad41a80ce3c16a82438ba75e040d9L81-R82) [[7]](diffhunk://#diff-51274c3c1069f278315ac85055a48b743acad41a80ce3c16a82438ba75e040d9L2167-R2167)