### PR TITLE
Update public url and add support to override app configs using helm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG KEY_FILE
 
 # Modify the hostname in the deployment configuration
 RUN sed -i 's/hostname: "localhost"/hostname: "0.0.0.0"/' backend/cmd/server/repository/conf/deployment.yaml && \
-    sed -i '/hostname: "0.0.0.0"/a\  public_hostname: "https://localhost:8090"' backend/cmd/server/repository/conf/deployment.yaml
+    sed -i '/hostname: "0.0.0.0"/a\  public_url: "https://localhost:8090"' backend/cmd/server/repository/conf/deployment.yaml
 
 # Handle shared certificates - use provided certificates or generate new ones
 RUN if [ -n "$CERT_FILE" ] && [ -n "$KEY_FILE" ] && [ -f "$CERT_FILE" ] && [ -f "$KEY_FILE" ]; then \

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -277,9 +277,9 @@ func (suite *DiscoveryTestSuite) TestGetBaseURL_WithPublicHostname() {
 	config.ResetThunderRuntime()
 	testConfig := &config.Config{
 		Server: config.ServerConfig{
-			PublicHostname: "https://public.thunder.io",
-			Hostname:       "localhost",
-			Port:           8080,
+			PublicURL: "https://public.thunder.io",
+			Hostname:  "localhost",
+			Port:      8080,
 		},
 		JWT: config.JWTConfig{
 			Issuer: "https://test.thunder.io",

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -76,8 +76,8 @@ func (ds *discoveryService) GetOIDCMetadata() *OIDCProviderMetadata {
 // Helper methods for building URLs and discovering capabilities
 func getBaseURL() string {
 	runtime := config.GetThunderRuntime()
-	if runtime.Config.Server.PublicHostname != "" {
-		return runtime.Config.Server.PublicHostname
+	if runtime.Config.Server.PublicURL != "" {
+		return runtime.Config.Server.PublicURL
 	}
 	scheme := "https"
 	if runtime.Config.Server.HTTPOnly {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -34,11 +34,11 @@ import (
 
 // ServerConfig holds the server configuration details.
 type ServerConfig struct {
-	Hostname       string `yaml:"hostname" json:"hostname"`
-	Port           int    `yaml:"port" json:"port"`
-	HTTPOnly       bool   `yaml:"http_only" json:"http_only"`
-	PublicHostname string `yaml:"public_hostname" json:"public_hostname"`
-	Identifier     string `yaml:"identifier" json:"identifier"`
+	Hostname   string `yaml:"hostname" json:"hostname"`
+	Port       int    `yaml:"port" json:"port"`
+	HTTPOnly   bool   `yaml:"http_only" json:"http_only"`
+	PublicURL  string `yaml:"public_url" json:"public_url"`
+	Identifier string `yaml:"identifier" json:"identifier"`
 }
 
 // GateClientConfig holds the client configuration details.

--- a/frontend/packages/thunder-commons-contexts/src/Config/ConfigProvider.tsx
+++ b/frontend/packages/thunder-commons-contexts/src/Config/ConfigProvider.tsx
@@ -87,6 +87,11 @@ export default function ConfigProvider({children}: ConfigProviderProps) {
     () => ({
       config,
       getServerUrl: () => {
+        // If public_url is provided, use it directly
+        if (config.server.public_url) {
+          return config.server.public_url;
+        }
+        // Otherwise, construct from hostname, port, and http_only
         const {hostname, port, http_only: httpOnly} = config.server;
         const protocol: string = httpOnly ? 'http' : 'https';
         return `${protocol}://${hostname}:${port}`;

--- a/frontend/packages/thunder-commons-contexts/src/Config/types.ts
+++ b/frontend/packages/thunder-commons-contexts/src/Config/types.ts
@@ -40,6 +40,13 @@ export interface ServerConfig {
    * When false, HTTPS will be used for secure connections.
    */
   http_only: boolean;
+
+  /**
+   * Optional public URL for the server. If provided, this will be used instead of
+   * constructing the URL from hostname, port, and http_only.
+   * @example "https://thunder.example.com", "https://api.thunder.local:8080"
+   */
+  public_url?: string;
 }
 
 /**

--- a/install/helm/Chart.yaml
+++ b/install/helm/Chart.yaml
@@ -18,5 +18,5 @@ apiVersion: v2
 name: thunder
 description: A Helm chart for WSO2 Thunder - Lightweight user and identity management system
 type: application
-version: 0.11.0
-appVersion: "0.11.0"
+version: 0.13.0
+appVersion: "0.13.0"

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -155,13 +155,16 @@ The following table lists the configurable parameters of the Thunder chart and t
 
 | Name                                   | Description                                                     | Default                      |
 | -------------------------------------- | --------------------------------------------------------------- | ---------------------------- |
-| `configuration.server.hostname`        | Thunder server hostname                                         | `0.0.0.0`                    |
 | `configuration.server.port`            | Thunder server port                                             | `8090`                       |
 | `configuration.server.httpOnly`        | Whether the server should run in HTTP-only mode                 | `false`                      |
-| `configuration.gateClient.hostname`    | Gate client hostname                                            | `0.0.0.0`                    |
-| `configuration.gateClient.port`        | Gate client port                                                | `8090`                       |
+| `configuration.server.publicURL`       | Public URL of the Thunder server                                | `https://thunder.local`      |
+| `configuration.gateClient.hostname`    | Gate client hostname                                            | `thunder.local`              |
+| `configuration.gateClient.port`        | Gate client port                                                | `443`                       |
 | `configuration.gateClient.scheme`      | Gate client scheme                                              | `https`                      |
 | `configuration.gateClient.path`        | Gate client base path                                           | `/gate`                      |
+| `configuration.developerClient.path`    | Developer client base path                                     | `/develop`                 |
+| `configuration.developerClient.clientId` | Developer client ID                                           | `DEVELOP`   |
+| `configuration.developerClient.scopes`   | Developer client scopes                                       | `['openid', 'profile', 'email', 'system']` |
 | `configuration.security.certFile`      | Server certificate file path                                    | `repository/resources/security/server.cert` |
 | `configuration.security.keyFile`       | Server key file path                                            | `repository/resources/security/server.key`  |
 | `configuration.security.cryptoFile`    | Crypto key file path                                            | `repository/resources/security/crypto.key`  |

--- a/install/helm/conf/apps/develop/config.js
+++ b/install/helm/conf/apps/develop/config.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable no-underscore-dangle */
+
+window.__THUNDER_RUNTIME_CONFIG__ = {
+  client: {
+    base: {{ .Values.configuration.developerClient.path | quote }},
+    client_id: {{ .Values.configuration.developerClient.clientId | quote }},
+    scopes: {{ .Values.configuration.developerClient.scopes }},
+  },
+  server: {
+    // Not used when public_url is set
+    hostname: "0.0.0.0",
+    port: {{ .Values.configuration.server.port }},
+    http_only: {{ .Values.configuration.server.httpOnly }},
+    {{- if .Values.configuration.server.publicUrl }}
+    public_url: {{ .Values.configuration.server.publicUrl | quote }},
+    {{- end }}
+  },
+};

--- a/install/helm/conf/apps/gate/config.js
+++ b/install/helm/conf/apps/gate/config.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable no-underscore-dangle */
+
+window.__THUNDER_RUNTIME_CONFIG__ = {
+  client: {
+    base: {{ .Values.configuration.gateClient.path | quote }},
+  },
+  server: {
+    // Not used when public_url is set
+    hostname: "0.0.0.0",
+    port: {{ .Values.configuration.server.port }},
+    http_only: {{ .Values.configuration.server.httpOnly }},
+    {{- if .Values.configuration.server.publicUrl }}
+    public_url: {{ .Values.configuration.server.publicUrl | quote }},
+    {{- end }}
+  },
+};

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -15,9 +15,10 @@
 # under the License.
 
 server:
-  hostname: {{ .Values.configuration.server.hostname | quote }}
+  hostname: "0.0.0.0"
   port: {{ .Values.configuration.server.port }}
   http_only: {{ .Values.configuration.server.httpOnly }}
+  public_url: {{ .Values.configuration.server.publicUrl | quote }}
 
 gate_client:
   hostname: {{ .Values.configuration.gateClient.hostname | quote }}

--- a/install/helm/templates/config-map.yaml
+++ b/install/helm/templates/config-map.yaml
@@ -23,3 +23,5 @@ metadata:
     {{- include "thunder.labels" . | nindent 4 }}
 data:
   deployment.yaml: {{ tpl (.Files.Get "conf/deployment.yaml") . | quote }}
+  gate-config.js: {{ tpl (.Files.Get "conf/apps/gate/config.js") . | quote }}
+  develop-config.js: {{ tpl (.Files.Get "conf/apps/develop/config.js") . | quote }}

--- a/install/helm/templates/setup-config-map.yaml
+++ b/install/helm/templates/setup-config-map.yaml
@@ -27,5 +27,5 @@ metadata:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-10"
 data:
-  deployment.yaml: {{ tpl (.Files.Get "conf/deployment.yaml") . | replace (.Values.configuration.server.hostname | quote) "\"0.0.0.0\"" | quote }}
+  deployment.yaml: {{ tpl (.Files.Get "conf/deployment.yaml") . | quote }}
 {{- end }}

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -122,7 +122,19 @@ spec:
             - name: deployment-yaml-volume
               mountPath: /opt/thunder/repository/conf/deployment.yaml
               subPath: deployment.yaml
+            - name: gate-config-volume
+              mountPath: /opt/thunder/apps/gate/config.js
+              subPath: gate-config.js
+            - name: develop-config-volume
+              mountPath: /opt/thunder/apps/develop/config.js
+              subPath: develop-config.js
       volumes:
         - name: deployment-yaml-volume
+          configMap:
+            name: {{ include "thunder.fullname" . }}-config-map
+        - name: gate-config-volume
+          configMap:
+            name: {{ include "thunder.fullname" . }}-config-map
+        - name: develop-config-volume
           configMap:
             name: {{ include "thunder.fullname" . }}-config-map

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -108,16 +108,22 @@ ingress:
 configuration:
   # Server configuration
   server:
-    hostname: "0.0.0.0"
     port: 8090
     httpOnly: false
+    publicUrl: "https://thunder.local"
 
   # Gate client configuration
   gateClient:
-    hostname: "0.0.0.0"
-    port: 8090
+    hostname: "thunder.local"
+    port: 443
     scheme: "https"
     path: "/gate"
+
+  # Developer client configuration
+  developerClient:
+    path: "/develop"
+    clientId: "DEVELOP"
+    scopes: "['openid', 'profile', 'email', 'system']"
 
   # Security configuration
   security:

--- a/setup.sh
+++ b/setup.sh
@@ -171,12 +171,12 @@ read_config() {
         HOSTNAME=$(yq eval '.server.hostname // "localhost"' "$config_file" 2>/dev/null)
         PORT=$(yq eval '.server.port // 8090' "$config_file" 2>/dev/null)
         HTTP_ONLY=$(yq eval '.server.http_only // false' "$config_file" 2>/dev/null)
-        PUBLIC_HOSTNAME=$(yq eval '.server.public_hostname // ""' "$config_file" 2>/dev/null)
+        PUBLIC_URL=$(yq eval '.server.public_url // ""' "$config_file" 2>/dev/null)
     else
         # Fallback: basic parsing with grep/awk
         HOSTNAME=$(grep -E '^\s*hostname:' "$config_file" | awk -F':' '{gsub(/[[:space:]"'\'']/,"",$2); print $2}' | head -1)
         PORT=$(grep -E '^\s*port:' "$config_file" | awk -F':' '{gsub(/[[:space:]]/,"",$2); print $2}' | head -1)
-        PUBLIC_HOSTNAME=$(grep -E '^\s*public_hostname:' "$config_file" | grep -o '"[^"]*"' | tr -d '"' | head -1)
+        PUBLIC_URL=$(grep -E '^\s*public_url:' "$config_file" | grep -o '"[^"]*"' | tr -d '"' | head -1)
 
         # Check for http_only
         if grep -q 'http_only.*true' "$config_file" 2>/dev/null; then
@@ -206,11 +206,7 @@ read_config
 BASE_URL="${PROTOCOL}://${HOSTNAME}:${PORT}"
 
 # Construct public URL (external/redirect URLs)
-if [ -n "$PUBLIC_HOSTNAME" ]; then
-    PUBLIC_URL="$PUBLIC_HOSTNAME"
-else
-    PUBLIC_URL="$BASE_URL"
-fi
+PUBLIC_URL="${PUBLIC_URL:-$BASE_URL}"
 
 echo ""
 echo "========================================="


### PR DESCRIPTION
### Purpose
This pull request introduces a new `public_url` field to replace the previous `public_hostname` setting throughout the Thunder project. The change standardizes how the public-facing URL for the server is configured and used across backend, frontend, Helm charts, and deployment scripts. Additionally, the Helm chart and values are updated to support new developer and gate client configurations, and the app version is bumped.

Key changes include:

**Breaking changes**

1. **Server hostname removed from values.yaml**: The `configuration.server.hostname` field has been removed from the default values as it's now hardcoded to `0.0.0.0` in the deployment template to ensure Kubernetes health probes work correctly.

2. **Public URL added**: New `configuration.server.publicUrl` field (default: `https://thunder.local`) allows specifying the external URL for OAuth redirects, frontend API calls, and discovery endpoints.

3. **Gate client configuration updated**: Changed from internal server binding (`0.0.0.0:8090`) to external ingress configuration (`thunder.local:443`) to properly route browser requests through the ingress controller.

**Public URL Standardization**

* Replaced all occurrences of `public_hostname` with `public_url` in backend config structs (`ServerConfig`), Dockerfile, and deployment YAML, ensuring consistent naming and usage. [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbL39-R39) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L41-R41) [[3]](diffhunk://#diff-f2cb3073a4637c871c6a543d4e76655f861053c8b63ebfc66ed958980466eb34L18-R21)
* Updated backend logic and frontend context/config code to use the new `public_url` field for constructing server URLs, falling back to hostname/port if not set. [[1]](diffhunk://#diff-13d4727b46aaf4ba9f5a45a059f5d1daafd0f659f5570502b4b9cb758c6737d6L79-R80) [[2]](diffhunk://#diff-6d4973e74c1df2a061bace6c36adf0eff10b960541c67810a86d6ad39b3e7cfdR90-R94) [[3]](diffhunk://#diff-85ea9d4ac2e82a5b5b7b0e900c69fd75e6da13a0afda7d69b62932675bb50ca9R43-R49)
* Modified setup scripts to parse and use `public_url` instead of `public_hostname`. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L174-R179) [[2]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L209-R210)

**Helm Chart and Configuration Enhancements**

* Updated Helm chart values, config maps, and deployment templates to support the new `public_url` field, and added configuration for new developer and gate clients. [[1]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eL111-R127) [[2]](diffhunk://#diff-f2cb3073a4637c871c6a543d4e76655f861053c8b63ebfc66ed958980466eb34L18-R21) [[3]](diffhunk://#diff-76afeee6c8cb8b18da66b79374dbfcdc9b5a67d25f2743f200d700333ddc8366R26-R27) [[4]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R125-R140)
* Added new runtime config files for gate and developer clients (`gate-config.js`, `develop-config.js`). [[1]](diffhunk://#diff-51e51c4acb3227ca6a7334b1654d934f84b5a77d1476e537729b837eb8b0343dR1-R33) [[2]](diffhunk://#diff-5cef443b362e947215ef044ce07b8bcb054f8da65689ef039f024a106c4f80d0R1-R35)

**Documentation and Versioning**

* Updated Helm chart documentation and bumped the app version to `0.13.0` to reflect these changes. [[1]](diffhunk://#diff-dbca42085fe854d0c2d5887fe2227967a2821e56b42c1fd0a47b9228ead6b34fL21-R22) [[2]](diffhunk://#diff-3f767509b40f4f726a137cd616c967a47345b5cf0034ae6f4cc29fcd830f5096L158-R167)

These updates make server configuration more flexible and future-proof, especially for deployments behind proxies or with custom public endpoints.

## Related Issues
- https://github.com/asgardeo/thunder/issues/871