### PR TITLE
Uses spans and traces properly with OpenTelemetry

### DIFF
--- a/backend/internal/observability/event/datakeys.go
+++ b/backend/internal/observability/event/datakeys.go
@@ -52,11 +52,12 @@ var DataKey = struct {
 	GrantType string
 
 	// Event Metadata Keys
-	Message    string
-	Error      string
-	ErrorCode  string
-	DurationMs string
-	LatencyUs  string
+	Message     string
+	Error       string
+	ErrorCode   string
+	DurationMs  string
+	LatencyUs   string
+	TraceParent string
 
 	// Testing Keys
 	Key   string
@@ -88,11 +89,12 @@ var DataKey = struct {
 	GrantType: "grant_type",
 
 	// Event Metadata Keys
-	Message:    "message",
-	Error:      "error",
-	ErrorCode:  "error_code",
-	DurationMs: "duration_ms",
-	LatencyUs:  "latency_us",
+	Message:     "message",
+	Error:       "error",
+	ErrorCode:   "error_code",
+	DurationMs:  "duration_ms",
+	LatencyUs:   "latency_us",
+	TraceParent: "trace_parent",
 
 	// Testing Keys
 	Key:   "key",


### PR DESCRIPTION
### Purpose
Earlier for each event we publish a different span from Thunder in oTel. But we should have group spans under traces for a single flow. With this PR, we are providing the capability publish spans under a single traces when the same trace id is being used

### Related Issues
- https://github.com/asgardeo/thunder/issues/695

### Related PRs
- https://github.com/asgardeo/thunder/pull/717