### PR TITLE
Comprehensive cleanup to use WriteSuccessResponse and WriteErrorResponse

### DIFF
--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -19,12 +19,10 @@
 package application
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/application/model"
 	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/apierror"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -48,18 +46,12 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 
 	appRequest, err := sysutils.DecodeJSONBody[model.ApplicationRequest](r)
 	if err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -84,7 +76,7 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 	// Create the app using the application service.
 	createdAppDTO, svcErr := ah.service.CreateApplication(&appDTO)
 	if svcErr != nil {
-		ah.handleError(w, logger, svcErr)
+		ah.handleError(w, svcErr)
 		return
 	}
 
@@ -110,50 +102,28 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 	if len(createdAppDTO.InboundAuthConfig) > 0 {
 		success := ah.processInboundAuthConfig(logger, createdAppDTO, &returnApp)
 		if !success {
-			w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-			w.WriteHeader(http.StatusInternalServerError)
-
 			errResp := apierror.ErrorResponse{
 				Code:        ErrorInternalServerError.Code,
 				Message:     ErrorInternalServerError.Error,
 				Description: ErrorInternalServerError.ErrorDescription,
 			}
-			if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-				logger.Error("Error encoding error response", log.Error(encodeErr))
-				http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-			}
+			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
 			return
 		}
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusCreated)
-
-	if encodeErr := json.NewEncoder(w).Encode(returnApp); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusCreated, returnApp)
 }
 
 // HandleApplicationListRequest handles the application request.
 func (ah *applicationHandler) HandleApplicationListRequest(w http.ResponseWriter, r *http.Request) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationHandler"))
-
 	listResponse, svcErr := ah.service.GetApplicationList()
 	if svcErr != nil {
-		ah.handleError(w, logger, svcErr)
+		ah.handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if encodeErr := json.NewEncoder(w).Encode(listResponse); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, listResponse)
 }
 
 // HandleApplicationGetRequest handles the application request.
@@ -162,24 +132,18 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 
 	id := r.PathValue("id")
 	if id == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidApplicationID.Code,
 			Message:     ErrorInvalidApplicationID.Error,
 			Description: ErrorInvalidApplicationID.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	appDTO, svcErr := ah.service.GetApplication(id)
 	if svcErr != nil {
-		ah.handleError(w, logger, svcErr)
+		ah.handleError(w, svcErr)
 		return
 	}
 
@@ -207,18 +171,12 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 			logger.Error("Unsupported inbound authentication type returned",
 				log.String("type", string(appDTO.InboundAuthConfig[0].Type)))
 
-			w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-			w.WriteHeader(http.StatusInternalServerError)
-
 			errResp := apierror.ErrorResponse{
 				Code:        ErrorInternalServerError.Code,
 				Message:     ErrorInternalServerError.Error,
 				Description: ErrorInternalServerError.ErrorDescription,
 			}
-			if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-				logger.Error("Error encoding error response", log.Error(encodeErr))
-				http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-			}
+			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
 			return
 		}
 
@@ -226,18 +184,12 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		if returnInboundAuthConfig.OAuthAppConfig == nil {
 			logger.Error("OAuth application configuration is nil")
 
-			w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-			w.WriteHeader(http.StatusInternalServerError)
-
 			errResp := apierror.ErrorResponse{
 				Code:        ErrorInternalServerError.Code,
 				Message:     ErrorInternalServerError.Error,
 				Description: ErrorInternalServerError.ErrorDescription,
 			}
-			if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-				logger.Error("Error encoding error response", log.Error(encodeErr))
-				http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-			}
+			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
 			return
 		}
 
@@ -277,14 +229,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		returnApp.ClientID = appDTO.InboundAuthConfig[0].OAuthAppConfig.ClientID
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if encodeErr := json.NewEncoder(w).Encode(returnApp); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, returnApp)
 }
 
 // HandleApplicationPutRequest handles the application request.
@@ -293,35 +238,23 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 
 	id := r.PathValue("id")
 	if id == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidApplicationID.Code,
 			Message:     ErrorInvalidApplicationID.Error,
 			Description: ErrorInvalidApplicationID.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	appRequest, err := sysutils.DecodeJSONBody[model.ApplicationRequest](r)
 	if err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -347,7 +280,7 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 	// Update the application using the application service.
 	updatedAppDTO, svcErr := ah.service.UpdateApplication(id, &updateReqAppDTO)
 	if svcErr != nil {
-		ah.handleError(w, logger, svcErr)
+		ah.handleError(w, svcErr)
 		return
 	}
 
@@ -373,60 +306,39 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 	if len(updatedAppDTO.InboundAuthConfig) > 0 {
 		success := ah.processInboundAuthConfig(logger, updatedAppDTO, &returnApp)
 		if !success {
-			w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-			w.WriteHeader(http.StatusInternalServerError)
-
 			errResp := apierror.ErrorResponse{
 				Code:        ErrorInternalServerError.Code,
 				Message:     ErrorInternalServerError.Error,
 				Description: ErrorInternalServerError.ErrorDescription,
 			}
-			if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-				logger.Error("Error encoding error response", log.Error(encodeErr))
-				http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-			}
+			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
 			return
 		}
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if encodeErr := json.NewEncoder(w).Encode(returnApp); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, returnApp)
 }
 
 // HandleApplicationDeleteRequest handles the application request.
 func (ah *applicationHandler) HandleApplicationDeleteRequest(w http.ResponseWriter, r *http.Request) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationHandler"))
-
 	id := r.PathValue("id")
 	if id == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidApplicationID.Code,
 			Message:     ErrorInvalidApplicationID.Error,
 			Description: ErrorInvalidApplicationID.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	svcErr := ah.service.DeleteApplication(id)
 	if svcErr != nil {
-		ah.handleError(w, logger, svcErr)
+		ah.handleError(w, svcErr)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 }
 
 // processInboundAuthConfig prepares the response for OAuth app configuration.
@@ -487,10 +399,8 @@ func (ah *applicationHandler) processInboundAuthConfig(logger *log.Logger, appDT
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func (ah *applicationHandler) handleError(w http.ResponseWriter, logger *log.Logger,
+func (ah *applicationHandler) handleError(w http.ResponseWriter,
 	svcErr *serviceerror.ServiceError) {
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
@@ -505,12 +415,8 @@ func (ah *applicationHandler) handleError(w http.ResponseWriter, logger *log.Log
 			statusCode = http.StatusBadRequest
 		}
 	}
-	w.WriteHeader(statusCode)
 
-	if err := json.NewEncoder(w).Encode(errResp); err != nil {
-		logger.Error("Error encoding error response", log.Error(err))
-		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-	}
+	sysutils.WriteErrorResponse(w, statusCode, errResp)
 }
 
 // processInboundAuthConfigFromRequest processes inbound auth config from request to DTO.

--- a/backend/internal/application/handler_test.go
+++ b/backend/internal/application/handler_test.go
@@ -745,7 +745,6 @@ func (suite *HandlerTestSuite) TestHandleApplicationDeleteRequest_ServiceError()
 func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_Success() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
-
 	logger := log.GetLogger()
 
 	appDTO := &model.ApplicationDTO{
@@ -782,7 +781,6 @@ func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_Success() {
 func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_EmptyRedirectURIs() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
-
 	logger := log.GetLogger()
 
 	appDTO := &model.ApplicationDTO{
@@ -818,7 +816,6 @@ func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_EmptyRedirectURIs() 
 func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_EmptyGrantTypes() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
-
 	logger := log.GetLogger()
 
 	appDTO := &model.ApplicationDTO{
@@ -854,7 +851,6 @@ func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_EmptyGrantTypes() {
 func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_UnsupportedType() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
-
 	logger := log.GetLogger()
 
 	appDTO := &model.ApplicationDTO{
@@ -881,7 +877,6 @@ func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_UnsupportedType() {
 func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_NilOAuthConfig() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
-
 	logger := log.GetLogger()
 
 	appDTO := &model.ApplicationDTO{
@@ -908,7 +903,6 @@ func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_NilOAuthConfig() {
 func (suite *HandlerTestSuite) TestProcessInboundAuthConfig_EmptyInboundAuthConfig() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
-
 	logger := log.GetLogger()
 
 	appDTO := &model.ApplicationDTO{
@@ -931,12 +925,11 @@ func (suite *HandlerTestSuite) TestHandleError_ClientError() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
 
-	logger := log.GetLogger()
 	w := httptest.NewRecorder()
 
 	svcErr := &ErrorInvalidApplicationName
 
-	handler.handleError(w, logger, svcErr)
+	handler.handleError(w, svcErr)
 
 	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
 	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
@@ -951,12 +944,11 @@ func (suite *HandlerTestSuite) TestHandleError_NotFoundError() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
 
-	logger := log.GetLogger()
 	w := httptest.NewRecorder()
 
 	svcErr := &ErrorApplicationNotFound
 
-	handler.handleError(w, logger, svcErr)
+	handler.handleError(w, svcErr)
 
 	assert.Equal(suite.T(), http.StatusNotFound, w.Code)
 	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
@@ -971,12 +963,11 @@ func (suite *HandlerTestSuite) TestHandleError_ServerError() {
 	mockService := NewApplicationServiceInterfaceMock(suite.T())
 	handler := newApplicationHandler(mockService)
 
-	logger := log.GetLogger()
 	w := httptest.NewRecorder()
 
 	svcErr := &ErrorInternalServerError
 
-	handler.handleError(w, logger, svcErr)
+	handler.handleError(w, svcErr)
 
 	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
 	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -19,7 +19,6 @@
 package authn
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/authn/common"
@@ -27,10 +26,8 @@ import (
 	"github.com/asgardeo/thunder/internal/authn/otp"
 	"github.com/asgardeo/thunder/internal/idp"
 	notifcommon "github.com/asgardeo/thunder/internal/notification/common"
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/apierror"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/system/log"
 	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
@@ -50,7 +47,7 @@ func newAuthenticationHandler(authnService AuthenticationServiceInterface) *auth
 func (ah *authenticationHandler) HandleCredentialsAuthRequest(w http.ResponseWriter, r *http.Request) {
 	authRequestPtr, err := sysutils.DecodeJSONBody[map[string]interface{}](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 	authRequest := *authRequestPtr
@@ -75,14 +72,14 @@ func (ah *authenticationHandler) HandleCredentialsAuthRequest(w http.ResponseWri
 	}
 
 	responseDTO := AuthenticationResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, responseDTO)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
 }
 
 // HandleSendSMSOTPRequest handles the send SMS OTP authentication request.
 func (ah *authenticationHandler) HandleSendSMSOTPRequest(w http.ResponseWriter, r *http.Request) {
 	otpRequest, err := sysutils.DecodeJSONBody[SendOTPAuthRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -97,14 +94,14 @@ func (ah *authenticationHandler) HandleSendSMSOTPRequest(w http.ResponseWriter, 
 		Status:       "SUCCESS",
 		SessionToken: sessionToken,
 	}
-	ah.writeSuccessResponse(w, response)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
 }
 
 // HandleVerifySMSOTPRequest handles the verify SMS OTP authentication request.
 func (ah *authenticationHandler) HandleVerifySMSOTPRequest(w http.ResponseWriter, r *http.Request) {
 	otpRequest, err := sysutils.DecodeJSONBody[VerifyOTPAuthRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -116,14 +113,14 @@ func (ah *authenticationHandler) HandleVerifySMSOTPRequest(w http.ResponseWriter
 	}
 
 	responseDTO := AuthenticationResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, responseDTO)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
 }
 
 // HandleGoogleAuthStartRequest handles the Google OAuth start authentication request.
 func (ah *authenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWriter, r *http.Request) {
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -134,14 +131,14 @@ func (ah *authenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWri
 	}
 
 	response := IDPAuthInitResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, response)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
 }
 
 // HandleGoogleAuthFinishRequest handles the Google OAuth finish authentication request.
 func (ah *authenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -153,14 +150,14 @@ func (ah *authenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWr
 	}
 
 	responseDTO := AuthenticationResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, responseDTO)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
 }
 
 // HandleGithubAuthStartRequest handles the GitHub OAuth start authentication request.
 func (ah *authenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWriter, r *http.Request) {
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -171,14 +168,14 @@ func (ah *authenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWri
 	}
 
 	responseDTO := IDPAuthInitResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, responseDTO)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
 }
 
 // HandleGithubAuthFinishRequest handles the GitHub OAuth finish authentication request.
 func (ah *authenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -190,14 +187,14 @@ func (ah *authenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWr
 	}
 
 	responseDTO := AuthenticationResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, responseDTO)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
 }
 
 // HandleStandardOAuthStartRequest handles the standard OAuth start authentication request.
 func (ah *authenticationHandler) HandleStandardOAuthStartRequest(w http.ResponseWriter, r *http.Request) {
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -208,14 +205,14 @@ func (ah *authenticationHandler) HandleStandardOAuthStartRequest(w http.Response
 	}
 
 	responseDTO := IDPAuthInitResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, responseDTO)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
 }
 
 // HandleStandardOAuthFinishRequest handles the standard OAuth finish authentication request.
 func (ah *authenticationHandler) HandleStandardOAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
-		ah.writeErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -227,7 +224,7 @@ func (ah *authenticationHandler) HandleStandardOAuthFinishRequest(w http.Respons
 	}
 
 	responseDTO := AuthenticationResponseDTO(*authResponse)
-	ah.writeSuccessResponse(w, responseDTO)
+	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
 }
 
 // handleServiceError converts service errors to appropriate HTTP responses.
@@ -249,32 +246,5 @@ func (ah *authenticationHandler) handleServiceError(w http.ResponseWriter, svcEr
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
 	}
-	ah.writeErrorResponse(w, status, errorResp)
-}
-
-// writeSuccessResponse writes a successful JSON response.
-func (ah *authenticationHandler) writeSuccessResponse(w http.ResponseWriter, data interface{}) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthenticationHandler"))
-
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		logger.Error("Failed to encode response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-	}
-}
-
-// writeErrorResponse writes an error response.
-func (ah *authenticationHandler) writeErrorResponse(w http.ResponseWriter,
-	statusCode int, errorResp apierror.ErrorResponse) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthenticationHandler"))
-
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(statusCode)
-
-	if err := json.NewEncoder(w).Encode(errorResp); err != nil {
-		logger.Error("Failed to encode error response", log.Error(err))
-		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-	}
+	sysutils.WriteErrorResponse(w, status, errorResp)
 }

--- a/backend/internal/authn/handler_test.go
+++ b/backend/internal/authn/handler_test.go
@@ -53,6 +53,15 @@ func (suite *AuthenticationHandlerTestSuite) SetupTest() {
 	}
 }
 
+func (suite *AuthenticationHandlerTestSuite) TestNewAuthenticationHandler() {
+	mockService := NewAuthenticationServiceInterfaceMock(suite.T())
+
+	handler := newAuthenticationHandler(mockService)
+
+	suite.NotNil(handler)
+	suite.Equal(mockService, handler.authService)
+}
+
 func (suite *AuthenticationHandlerTestSuite) testIDPAuthFinishSuccess(
 	idpType idp.IDPType, endpoint string, handlerFunc func(http.ResponseWriter, *http.Request)) {
 	authRequest := IDPAuthFinishRequestDTO{

--- a/backend/internal/branding/mgt/handler_test.go
+++ b/backend/internal/branding/mgt/handler_test.go
@@ -21,7 +21,6 @@ package brandingmgt
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,7 +29,6 @@ import (
 
 	"github.com/asgardeo/thunder/internal/branding/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/system/log"
 )
 
 type BrandingHandlerTestSuite struct {
@@ -495,26 +493,6 @@ func (suite *BrandingHandlerTestSuite) TestToHTTPLinks_Empty() {
 	suite.Len(httpLinks, 0)
 }
 
-// Test handleEncodingError
-func (suite *BrandingHandlerTestSuite) TestHandleEncodingError() {
-	w := httptest.NewRecorder()
-	handleEncodingError(w)
-	suite.Equal(http.StatusInternalServerError, w.Code)
-	suite.Equal("application/json", w.Header().Get("Content-Type"))
-}
-
-// Test writeToResponse error path
-func (suite *BrandingHandlerTestSuite) TestWriteToResponse_Error() {
-	// Create a response writer that will fail on Write
-	w := &failingResponseWriter{ResponseWriter: httptest.NewRecorder()}
-	logger := log.GetLogger()
-
-	// Use a type that cannot be encoded (channel)
-	response := make(chan int)
-	isErr := writeToResponse(w, response, logger)
-	suite.True(isErr)
-}
-
 // Test handleError default case
 func (suite *BrandingHandlerTestSuite) TestHandleError_DefaultCase() {
 	// Create an error with unknown code
@@ -526,21 +504,6 @@ func (suite *BrandingHandlerTestSuite) TestHandleError_DefaultCase() {
 	}
 
 	w := httptest.NewRecorder()
-	logger := log.GetLogger()
-	handleError(w, logger, unknownError)
+	handleError(w, unknownError)
 	suite.Equal(http.StatusBadRequest, w.Code)
-}
-
-// failingResponseWriter is a ResponseWriter that fails on Write
-type failingResponseWriter struct {
-	http.ResponseWriter
-	writeError error
-}
-
-func (w *failingResponseWriter) Write(p []byte) (int, error) {
-	if w.writeError != nil {
-		return 0, w.writeError
-	}
-	// Make Write fail by returning an error
-	return 0, errors.New("write failed")
 }

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -19,10 +19,8 @@
 package flowexec
 
 import (
-	"encoding/json"
 	"net/http"
 
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/apierror"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -46,14 +44,7 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 
 	flowR, err := sysutils.DecodeJSONBody[FlowRequest](r)
 	if err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
-		if err := json.NewEncoder(w).Encode(APIErrorFlowRequestJSONDecodeError); err != nil {
-			logger.Error("Error encoding error response", log.Error(err))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
-
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, APIErrorFlowRequestJSONDecodeError)
 		return
 	}
 
@@ -67,7 +58,7 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 	flowStep, flowErr := h.flowExecService.Execute(appID, flowID, actionID, flowTypeStr, inputs)
 
 	if flowErr != nil {
-		handleFlowError(w, logger, flowErr)
+		handleFlowError(w, flowErr)
 		return
 	}
 
@@ -81,37 +72,23 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 		FailureReason: flowStep.FailureReason,
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	err = json.NewEncoder(w).Encode(flowResp)
-	if err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, flowResp)
 
 	logger.Debug("Flow execution request handled successfully", log.String("flowID", flowResp.FlowID))
 }
 
 // handleFlowError handles errors that occur during flow execution as an API error response.
-func handleFlowError(w http.ResponseWriter, logger *log.Logger, flowErr *serviceerror.ServiceError) {
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-
+func handleFlowError(w http.ResponseWriter, flowErr *serviceerror.ServiceError) {
 	errResp := apierror.ErrorResponse{
 		Code:        flowErr.Code,
 		Message:     flowErr.Error,
 		Description: flowErr.ErrorDescription,
 	}
 
+	statusCode := http.StatusInternalServerError
 	if flowErr.Type == serviceerror.ClientErrorType {
-		w.WriteHeader(http.StatusBadRequest)
-	} else {
-		w.WriteHeader(http.StatusInternalServerError)
+		statusCode = http.StatusBadRequest
 	}
 
-	if err := json.NewEncoder(w).Encode(errResp); err != nil {
-		logger.Error("Error encoding error response", log.Error(err))
-		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-	}
+	sysutils.WriteErrorResponse(w, statusCode, errResp)
 }

--- a/backend/internal/group/handler_test.go
+++ b/backend/internal/group/handler_test.go
@@ -333,7 +333,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			},
 			assertBody: func(recorder *httptest.ResponseRecorder) {
 				suite.Require().Equal(http.StatusOK, recorder.Code)
-				suite.Require().Equal("Failed to encode response\n", recorder.Body.String())
+				suite.Require().Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
 			},
 		},
 		{
@@ -342,7 +342,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			useFlaky:    true,
 			assertBody: func(recorder *httptest.ResponseRecorder) {
 				suite.Require().Equal(http.StatusBadRequest, recorder.Code)
-				suite.Require().Equal("Failed to encode error response\n", recorder.Body.String())
+				suite.Require().Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
 			},
 			assertSvc: func(svc *GroupServiceInterfaceMock) {
 				svc.AssertNotCalled(suite.T(), "GetGroupList", mock.Anything, mock.Anything)
@@ -491,7 +491,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), "Failed to encode response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 		},
 	}
@@ -604,7 +604,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusCreated, rr.Code)
-				require.Equal(suite.T(), "Failed to encode response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 		},
 		{
@@ -613,7 +613,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), "Failed to encode error response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "CreateGroup", mock.Anything)
@@ -749,7 +749,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusCreated, rr.Code)
-				require.Equal(suite.T(), "Failed to encode response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 		},
 		{
@@ -763,7 +763,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			setJSONHeader:  true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), "Failed to encode error response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "CreateGroupByPath", mock.Anything, mock.Anything)
@@ -849,7 +849,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), "Failed to encode response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 		},
 		{
@@ -859,7 +859,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), "Failed to encode error response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "GetGroup", mock.Anything)
@@ -977,7 +977,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), "Failed to encode response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 		},
 		{
@@ -1010,7 +1010,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader:  true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), "Failed to encode error response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
@@ -1042,7 +1042,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), "Failed to encode error response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
@@ -1078,7 +1078,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), "Failed to encode error response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "DeleteGroup", mock.Anything)
@@ -1221,7 +1221,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), "Failed to encode response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 		},
 		{
@@ -1231,7 +1231,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), "Failed to encode error response\n", rr.Body.String())
+				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers", mock.Anything, mock.Anything, mock.Anything)
@@ -1289,14 +1289,13 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_ExtractAndValidatePathEncod
 	t := suite.T()
 	writer := newFlakyResponseWriter()
 	req := httptest.NewRequest(http.MethodGet, "/ous//groups", nil)
-	logger := log.GetLogger().With(log.String("component", "test"))
 
-	path, failed := extractAndValidatePath(writer, req, logger)
+	path, failed := extractAndValidatePath(writer, req)
 
 	require.True(t, failed)
 	require.Equal(t, "", path)
 	require.Equal(t, http.StatusBadRequest, writer.Code)
-	require.Equal(t, "Failed to encode error response\n", writer.Body.String())
+	require.Equal(t, serviceerror.ErrorEncodingError+"\n", writer.Body.String())
 }
 
 func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleErrorInternalServer() {

--- a/backend/internal/idp/handler.go
+++ b/backend/internal/idp/handler.go
@@ -19,13 +19,11 @@
 package idp
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/asgardeo/thunder/internal/system/cmodels"
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/apierror"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -50,25 +48,19 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 
 	createRequest, err := sysutils.DecodeJSONBody[idpRequest](r)
 	if err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	properties, err := getSanitizedProperties(createRequest.Properties)
 	if err != nil {
 		logger.Error("Failed to sanitize properties", log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError, logger)
+		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
 
@@ -80,34 +72,25 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 	}
 	createdIDP, svcErr := ih.idpService.CreateIdentityProvider(idpDTO)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr, logger)
+		writeServiceErrorResponse(w, svcErr)
 		return
 	}
 
 	idpResponse, err := getIDPResponse(*createdIDP)
 	if err != nil {
 		logger.Error("Failed to convert IDP to response", log.String("idp", createdIDP.Name), log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError, logger)
+		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusCreated)
-
-	if encodeErr := json.NewEncoder(w).Encode(idpResponse); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusCreated, idpResponse)
 }
 
 // HandleIDPListRequest handles the list identity providers request.
 func (ih *idpHandler) HandleIDPListRequest(w http.ResponseWriter, r *http.Request) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IDPHandler"))
-
 	idpList, svcErr := ih.idpService.GetIdentityProviderList()
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr, logger)
+		writeServiceErrorResponse(w, svcErr)
 		return
 	}
 
@@ -121,14 +104,7 @@ func (ih *idpHandler) HandleIDPListRequest(w http.ResponseWriter, r *http.Reques
 		})
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if encodeErr := json.NewEncoder(w).Encode(idpListResponse); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, idpListResponse)
 }
 
 // HandleIDPGetRequest handles the get identity provider request.
@@ -137,86 +113,60 @@ func (ih *idpHandler) HandleIDPGetRequest(w http.ResponseWriter, r *http.Request
 
 	id := r.PathValue("id")
 	if strings.TrimSpace(id) == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidIDPID.Code,
 			Message:     ErrorInvalidIDPID.Error,
 			Description: ErrorInvalidIDPID.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	idp, svcErr := ih.idpService.GetIdentityProvider(id)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr, logger)
+		writeServiceErrorResponse(w, svcErr)
 		return
 	}
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
 		logger.Error("Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError, logger)
+		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if encodeErr := json.NewEncoder(w).Encode(idpResponse); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, idpResponse)
 }
 
 // HandleIDPPutRequest handles the update identity provider request.
 func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IDPHandler"))
-
 	id := r.PathValue("id")
 	if strings.TrimSpace(id) == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidIDPID.Code,
 			Message:     ErrorInvalidIDPID.Error,
 			Description: ErrorInvalidIDPID.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	updateRequest, err := sysutils.DecodeJSONBody[idpRequest](r)
 	if err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	properties, err := getSanitizedProperties(updateRequest.Properties)
 	if err != nil {
 		logger.Error("Failed to sanitize properties", log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError, logger)
+		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
 
@@ -230,68 +180,50 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 
 	idp, svcErr := ih.idpService.UpdateIdentityProvider(id, idpDTO)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr, logger)
+		writeServiceErrorResponse(w, svcErr)
 		return
 	}
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
 		logger.Error("Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError, logger)
+		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if encodeErr := json.NewEncoder(w).Encode(idpResponse); encodeErr != nil {
-		logger.Error("Error encoding response", log.Error(encodeErr))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, idpResponse)
 }
 
 // HandleIDPDeleteRequest handles the delete identity provider request.
 func (ih *idpHandler) HandleIDPDeleteRequest(w http.ResponseWriter, r *http.Request) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IDPHandler"))
-
 	id := r.PathValue("id")
 	if strings.TrimSpace(id) == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidIDPID.Code,
 			Message:     ErrorInvalidIDPID.Error,
 			Description: ErrorInvalidIDPID.ErrorDescription,
 		}
-		if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-			logger.Error("Error encoding error response", log.Error(encodeErr))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	svcErr := ih.idpService.DeleteIdentityProvider(id)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr, logger)
+		writeServiceErrorResponse(w, svcErr)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 }
 
 // writeServiceErrorResponse writes the appropriate HTTP error response based on the service error.
-func writeServiceErrorResponse(w http.ResponseWriter, svcErr *serviceerror.ServiceError, logger *log.Logger) {
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-
+func writeServiceErrorResponse(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	var statusCode int
 	if svcErr.Type == serviceerror.ClientErrorType {
 		statusCode = getClientErrorStatusCode(svcErr.Code)
 	} else {
 		statusCode = http.StatusInternalServerError
 	}
-	w.WriteHeader(statusCode)
 
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
@@ -299,10 +231,7 @@ func writeServiceErrorResponse(w http.ResponseWriter, svcErr *serviceerror.Servi
 		Description: svcErr.ErrorDescription,
 	}
 
-	if encodeErr := json.NewEncoder(w).Encode(errResp); encodeErr != nil {
-		logger.Error("Error encoding error response", log.Error(encodeErr))
-		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-	}
+	sysutils.WriteErrorResponse(w, statusCode, errResp)
 }
 
 // getClientErrorStatusCode returns the appropriate HTTP status code for client errors.

--- a/backend/internal/idp/handler_test.go
+++ b/backend/internal/idp/handler_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/system/log"
 )
 
 const (
@@ -479,8 +478,7 @@ func (s *IDPHandlerTestSuite) TestWriteServiceErrorResponse() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			rr := httptest.NewRecorder()
-			logger := log.GetLogger()
-			writeServiceErrorResponse(rr, &tc.serviceError, logger)
+			writeServiceErrorResponse(rr, &tc.serviceError)
 
 			s.Equal(tc.expectedStatus, rr.Code)
 		})

--- a/backend/internal/notification/message_handler_test.go
+++ b/backend/internal/notification/message_handler_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/apierror"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/system/log"
 )
 
 type MessageHandlerTestSuite struct {
@@ -376,7 +375,6 @@ func (suite *MessageHandlerTestSuite) TestValidateSenderID_NonEmptyID() {
 
 func (suite *MessageHandlerTestSuite) TestHandleError() {
 	handler := newMessageNotificationSenderHandler(nil, nil)
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandlerTest"))
 
 	cases := []struct {
 		name          string
@@ -422,7 +420,7 @@ func (suite *MessageHandlerTestSuite) TestHandleError() {
 
 	for _, tc := range cases {
 		rr := httptest.NewRecorder()
-		handler.handleError(rr, logger, tc.svcErr, tc.customDesc)
+		handler.handleError(rr, tc.svcErr, tc.customDesc)
 
 		suite.Equal(tc.expectedCode, rr.Code, tc.name)
 
@@ -447,9 +445,8 @@ func (e *errWriter) WriteHeader(statusCode int) {}
 
 func (suite *MessageHandlerTestSuite) TestHandleError_EncodeFailure() {
 	handler := newMessageNotificationSenderHandler(nil, nil)
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandlerTest"))
 	ew := &errWriter{}
-	handler.handleError(ew, logger, &ErrorInternalServerError, "boom")
+	handler.handleError(ew, &ErrorInternalServerError, "boom")
 }
 
 func (suite *MessageHandlerTestSuite) TestGetDTOFromSenderRequest() {

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -19,7 +19,6 @@
 package authz
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -33,7 +32,6 @@ import (
 	oauth2model "github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	oauth2utils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
 	"github.com/asgardeo/thunder/internal/system/config"
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
@@ -463,31 +461,18 @@ func (ah *authorizeHandler) redirectToErrorPage(w http.ResponseWriter, r *http.R
 
 // writeAuthZResponse writes the authorization response to the HTTP response writer.
 func (ah *authorizeHandler) writeAuthZResponse(w http.ResponseWriter, redirectURI string) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
 	authZResp := AuthZPostResponse{
 		RedirectURI: redirectURI,
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	err := json.NewEncoder(w).Encode(authZResp)
-	if err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	utils.WriteSuccessResponse(w, http.StatusOK, authZResp)
 }
 
 // writeAuthZResponseToErrorPage writes the authorization response to the error page.
 func (ah *authorizeHandler) writeAuthZResponseToErrorPage(w http.ResponseWriter, code, msg string,
 	authRequestCtx *authRequestContext) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
 	redirectURI, err := getErrorPageRedirectURL(code, msg)
 	if err != nil {
-		logger.Error("Failed to construct error page URL: " + err.Error())
 		http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
 		return
 	}
@@ -498,7 +483,6 @@ func (ah *authorizeHandler) writeAuthZResponseToErrorPage(w http.ResponseWriter,
 		}
 		redirectURI, err = oauth2utils.GetURIWithQueryParams(redirectURI, queryParams)
 		if err != nil {
-			logger.Error("Failed to add state to error page URL: " + err.Error())
 			http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
 			return
 		}

--- a/backend/internal/oauth/oauth2/dcr/handler.go
+++ b/backend/internal/oauth/oauth2/dcr/handler.go
@@ -19,12 +19,9 @@
 package dcr
 
 import (
-	"encoding/json"
 	"net/http"
 
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/system/log"
 	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
@@ -42,8 +39,6 @@ func newDCRHandler(dcrService DCRServiceInterface) *dcrHandler {
 
 // HandleDCRRegistration handles the DCR client registration request.
 func (dh *dcrHandler) HandleDCRRegistration(w http.ResponseWriter, r *http.Request) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DCRHandler"))
-
 	dcrRequest, err := sysutils.DecodeJSONBody[DCRRegistrationRequest](r)
 	if err != nil {
 		sysutils.WriteJSONError(w, ErrorInvalidRequestFormat.Code,
@@ -57,14 +52,7 @@ func (dh *dcrHandler) HandleDCRRegistration(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusCreated)
-
-	if encodeErr := json.NewEncoder(w).Encode(dcrResponse); encodeErr != nil {
-		logger.Error("Error encoding DCR response", log.Error(encodeErr))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusCreated, dcrResponse)
 }
 
 // writeServiceErrorResponse writes a service error response.

--- a/backend/internal/oauth/oauth2/discovery/handler.go
+++ b/backend/internal/oauth/oauth2/discovery/handler.go
@@ -19,11 +19,10 @@
 package discovery
 
 import (
-	"encoding/json"
 	"net/http"
 
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // DiscoveryHandlerInterface defines the interface for discovery handlers
@@ -50,14 +49,8 @@ func (dh *discoveryHandler) HandleOAuth2AuthorizationServerMetadata(w http.Respo
 
 	metadata := dh.discoveryService.GetOAuth2AuthorizationServerMetadata()
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(metadata); err != nil {
-		logger.Error("Failed to encode OAuth 2.0 Authorization Server Metadata response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
+	logger.Debug("OAuth 2.0 Authorization Server Metadata response sent successfully")
 }
 
 // HandleOIDCDiscovery handles OpenID Connect Discovery requests
@@ -66,12 +59,6 @@ func (dh *discoveryHandler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.R
 
 	metadata := dh.discoveryService.GetOIDCMetadata()
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(metadata); err != nil {
-		logger.Error("Failed to encode OIDC discovery response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
+	logger.Debug("OIDC discovery response sent successfully")
 }

--- a/backend/internal/oauth/oauth2/introspect/handler.go
+++ b/backend/internal/oauth/oauth2/introspect/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // tokenIntrospectionHandler handles OAuth 2.0 token introspection requests.
@@ -47,7 +48,6 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 	if err := r.ParseForm(); err != nil {
 		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
 		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,
 			ErrorDescription: "Failed to decode request body",
@@ -64,7 +64,6 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 	if token == "" {
 		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
 		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,
 			ErrorDescription: "Token parameter is required",
@@ -82,7 +81,6 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 	if err != nil {
 		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
 		w.WriteHeader(http.StatusInternalServerError)
-
 		errResp := model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Server error while introspecting token",
@@ -94,11 +92,5 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
 }

--- a/backend/internal/oauth/oauth2/introspect/service_test.go
+++ b/backend/internal/oauth/oauth2/introspect/service_test.go
@@ -121,6 +121,20 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_InvalidSignatur
 	s.jwtServiceMock.AssertExpectations(s.T())
 }
 
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_DecodeFailsAfterVerify() {
+	// Test case where VerifyJWT succeeds but DecodeJWT fails
+	// This can happen with a malformed JWT structure (e.g., missing dots or invalid base64)
+	malformedToken := "header.payload" // Missing signature part
+
+	s.jwtServiceMock.On("VerifyJWT", malformedToken, "", "").Return(nil)
+
+	response, err := s.introspectService.IntrospectToken(malformedToken, "")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), response)
+	assert.False(s.T(), response.Active)
+	s.jwtServiceMock.AssertExpectations(s.T())
+}
+
 func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 	testCases := []struct {
 		name           string

--- a/backend/internal/oauth/oauth2/token/token_handler.go
+++ b/backend/internal/oauth/oauth2/token/token_handler.go
@@ -20,20 +20,18 @@
 package token
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/asgardeo/thunder/internal/application"
-	"github.com/asgardeo/thunder/internal/system/utils"
-
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/clientauth"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/granthandlers"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/scope"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // TokenHandlerInterface defines the interface for handling OAuth 2.0 token requests.
@@ -221,17 +219,11 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 		log.String("grant_type", grantTypeStr))
 
 	// Set the response headers.
-	w.Header().Set("Content-Type", "application/json")
 	// Must include the following headers when sensitive data is returned.
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
 
 	// Write the token response.
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(tokenResponse); err != nil {
-		logger.Error("Failed to write token response", log.Error(err))
-		http.Error(w, "Failed to write token response", http.StatusInternalServerError)
-		return
-	}
+	utils.WriteSuccessResponse(w, http.StatusOK, tokenResponse)
 	logger.Debug("Token response sent", log.String("client_id", clientID), log.String("grant_type", grantTypeStr))
 }

--- a/backend/internal/oauth/oauth2/userinfo/handler.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler.go
@@ -19,8 +19,6 @@
 package userinfo
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
@@ -63,25 +61,12 @@ func (h *userInfoHandler) HandleUserInfo(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
 	w.Header().Set(serverconst.CacheControlHeaderName, serverconst.CacheControlNoStore)
 	w.Header().Set(serverconst.PragmaHeaderName, serverconst.PragmaNoCache)
 
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(userInfo); err != nil {
-		h.logger.Error("Error encoding user info response", log.Error(err))
-		handleEncodingError(w)
-		return
-	}
+	utils.WriteSuccessResponse(w, http.StatusOK, userInfo)
 
 	h.logger.Debug("UserInfo response sent successfully")
-}
-
-// handleEncodingError handles errors that occur during response encoding.
-func handleEncodingError(w http.ResponseWriter) {
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusInternalServerError)
-	_, _ = fmt.Fprintln(w, serviceerror.ErrorEncodingError)
 }
 
 // writeServiceErrorResponse writes a service error response.

--- a/backend/internal/oauth/oauth2/userinfo/handler_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler_test.go
@@ -286,9 +286,9 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_EncodingError() {
 
 	s.handler.HandleUserInfo(rr, req)
 
-	// The handler should detect the encoding error and call handleEncodingError
-	assert.Equal(s.T(), "application/json", rr.Header().Get("Content-Type"))
-	// Verify that handleEncodingError was called by checking for the error message
+	// The handler should detect the encoding error - the utility logs the error and returns text/plain
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+	// Verify that encoding error message is returned
 	assert.Contains(s.T(), rr.Body.String(), serviceerror.ErrorEncodingError)
 	s.mockService.AssertExpectations(s.T())
 }

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -19,8 +19,6 @@
 package role
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -52,13 +50,13 @@ func (rh *roleHandler) HandleRoleListRequest(w http.ResponseWriter, r *http.Requ
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
 	roleList, svcErr := rh.roleService.GetRoleList(limit, offset)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
@@ -76,13 +74,7 @@ func (rh *roleHandler) HandleRoleListRequest(w http.ResponseWriter, r *http.Requ
 		Links:        toHTTPLinks(roleList.Links),
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	isErr := writeToResponse(w, roleListResponse, logger)
-	if isErr {
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, roleListResponse)
 
 	logger.Debug("Successfully listed roles with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -96,7 +88,7 @@ func (rh *roleHandler) HandleRolePostRequest(w http.ResponseWriter, r *http.Requ
 
 	createRequest, err := sysutils.DecodeJSONBody[CreateRoleRequest](r)
 	if err != nil {
-		handleError(w, logger, &ErrorInvalidRequestFormat)
+		handleError(w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -107,20 +99,14 @@ func (rh *roleHandler) HandleRolePostRequest(w http.ResponseWriter, r *http.Requ
 
 	serviceRole, svcErr := rh.roleService.CreateRole(serviceRequest)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
 	// Convert service response to HTTP response
 	createdRole := rh.toHTTPCreateRoleResponse(serviceRole)
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusCreated)
-
-	isErr := writeToResponse(w, createdRole, logger)
-	if isErr {
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdRole)
 
 	logger.Debug("Successfully created role", log.String("roleId", createdRole.ID))
 }
@@ -132,20 +118,14 @@ func (rh *roleHandler) HandleRoleGetRequest(w http.ResponseWriter, r *http.Reque
 	id := r.PathValue("id")
 	serviceRole, svcErr := rh.roleService.GetRoleWithPermissions(id)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
 	// Convert service response to HTTP response
 	role := rh.toHTTPRoleResponse(serviceRole)
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	isErr := writeToResponse(w, role, logger)
-	if isErr {
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, role)
 
 	logger.Debug("Successfully retrieved role", log.String("role id", id))
 }
@@ -157,7 +137,7 @@ func (rh *roleHandler) HandleRolePutRequest(w http.ResponseWriter, r *http.Reque
 	id := r.PathValue("id")
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateRoleRequest](r)
 	if err != nil {
-		handleError(w, logger, &ErrorInvalidRequestFormat)
+		handleError(w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -168,20 +148,14 @@ func (rh *roleHandler) HandleRolePutRequest(w http.ResponseWriter, r *http.Reque
 
 	serviceRole, svcErr := rh.roleService.UpdateRoleWithPermissions(id, serviceRequest)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
 	// Convert service response to HTTP response
 	role := rh.toHTTPRoleResponse(serviceRole)
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	isErr := writeToResponse(w, role, logger)
-	if isErr {
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, role)
 
 	logger.Debug("Successfully updated role", log.String("role id", id))
 }
@@ -193,11 +167,11 @@ func (rh *roleHandler) HandleRoleDeleteRequest(w http.ResponseWriter, r *http.Re
 	id := r.PathValue("id")
 	svcErr := rh.roleService.DeleteRole(id)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 	logger.Debug("Successfully deleted role", log.String("role id", id))
 }
 
@@ -208,7 +182,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 	id := r.PathValue("id")
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
@@ -217,7 +191,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 
 	serviceResponse, svcErr := rh.roleService.GetRoleAssignments(id, limit, offset, includeDisplay)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
@@ -235,13 +209,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 		Links:        toHTTPLinks(serviceResponse.Links),
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	isErr := writeToResponse(w, assignmentListResponse, logger)
-	if isErr {
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, assignmentListResponse)
 
 	logger.Debug("Successfully retrieved role assignments", log.String("role id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -257,7 +225,7 @@ func (rh *roleHandler) HandleRoleAddAssignmentsRequest(w http.ResponseWriter, r 
 	id := r.PathValue("id")
 	assignmentsRequest, err := sysutils.DecodeJSONBody[AssignmentsRequest](r)
 	if err != nil {
-		handleError(w, logger, &ErrorInvalidRequestFormat)
+		handleError(w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -268,11 +236,11 @@ func (rh *roleHandler) HandleRoleAddAssignmentsRequest(w http.ResponseWriter, r 
 
 	svcErr := rh.roleService.AddAssignments(id, serviceRequest)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 	logger.Debug("Successfully added assignments to role", log.String("role id", id))
 }
 
@@ -283,7 +251,7 @@ func (rh *roleHandler) HandleRoleRemoveAssignmentsRequest(w http.ResponseWriter,
 	id := r.PathValue("id")
 	assignmentsRequest, err := sysutils.DecodeJSONBody[AssignmentsRequest](r)
 	if err != nil {
-		handleError(w, logger, &ErrorInvalidRequestFormat)
+		handleError(w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -294,26 +262,16 @@ func (rh *roleHandler) HandleRoleRemoveAssignmentsRequest(w http.ResponseWriter,
 
 	svcErr := rh.roleService.RemoveAssignments(id, serviceRequest)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 	logger.Debug("Successfully removed assignments from role", log.String("role id", id))
 }
 
-// writeToResponse encodes the response as JSON and writes it to the ResponseWriter.
-func writeToResponse(w http.ResponseWriter, response any, logger *log.Logger) bool {
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		handleEncodingError(w)
-		return true
-	}
-	return false
-}
-
 // handleError handles service errors and returns appropriate HTTP responses.
-func handleError(w http.ResponseWriter, logger *log.Logger,
+func handleError(w http.ResponseWriter,
 	svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
@@ -333,27 +291,13 @@ func handleError(w http.ResponseWriter, logger *log.Logger,
 		}
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(statusCode)
-
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
 	}
 
-	if err := json.NewEncoder(w).Encode(errResp); err != nil {
-		logger.Error("Error encoding error response", log.Error(err))
-		handleEncodingError(w)
-		return
-	}
-}
-
-// handleEncodingError handles errors that occur during response encoding.
-func handleEncodingError(w http.ResponseWriter) {
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusInternalServerError)
-	_, _ = fmt.Fprintln(w, serviceerror.ErrorEncodingError)
+	sysutils.WriteErrorResponse(w, statusCode, errResp)
 }
 
 // sanitizeCreateRoleRequest sanitizes the create role request input.

--- a/backend/internal/system/export/handler_test.go
+++ b/backend/internal/system/export/handler_test.go
@@ -340,6 +340,7 @@ func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_DeepFolderStructur
 
 // TestGenerateAndSendZipResponse_Standalone tests the function without suite dependencies.
 func TestGenerateAndSendZipResponse_Standalone(t *testing.T) {
+	logger := log.GetLogger()
 	// Setup config
 	config.ResetThunderRuntime()
 	testConfig := &config.Config{
@@ -375,7 +376,6 @@ func TestGenerateAndSendZipResponse_Standalone(t *testing.T) {
 
 	// Execute
 	w := httptest.NewRecorder()
-	logger := log.GetLogger()
 	err = handler.generateAndSendZipResponse(w, logger, exportResponse)
 
 	// Assert
@@ -684,13 +684,12 @@ func (suite *HandlerTestSuite) TestHandleExportZipRequest_ServiceError() {
 // TestHandleError_ClientError tests error handling for client errors.
 func (suite *HandlerTestSuite) TestHandleError_ClientError() {
 	w := httptest.NewRecorder()
-	logger := log.GetLogger()
 
 	// Create client error
 	clientErr := &ErrorNoResourcesFound
 
 	// Execute
-	suite.handler.handleError(w, logger, clientErr)
+	suite.handler.handleError(w, clientErr)
 
 	// Assert response
 	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
@@ -707,13 +706,12 @@ func (suite *HandlerTestSuite) TestHandleError_ClientError() {
 // TestHandleError_ServerError tests error handling for server errors.
 func (suite *HandlerTestSuite) TestHandleError_ServerError() {
 	w := httptest.NewRecorder()
-	logger := log.GetLogger()
 
 	// Create server error
 	serverErr := &ErrorInternalServerError
 
 	// Execute
-	suite.handler.handleError(w, logger, serverErr)
+	suite.handler.handleError(w, serverErr)
 
 	// Assert response
 	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
@@ -802,6 +800,7 @@ func (suite *HandlerTestSuite) TestHandleExportJSONRequest_EmptyFiles() {
 
 // BenchmarkGenerateAndSendZipResponse benchmarks ZIP generation performance.
 func BenchmarkGenerateAndSendZipResponse(b *testing.B) {
+	logger := log.GetLogger()
 	// Setup
 	config.ResetThunderRuntime()
 	testConfig := &config.Config{}
@@ -827,8 +826,6 @@ func BenchmarkGenerateAndSendZipResponse(b *testing.B) {
 			},
 		},
 	}
-
-	logger := log.GetLogger()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -19,7 +19,6 @@
 package user
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -55,7 +54,7 @@ func (uh *userHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
@@ -65,25 +64,18 @@ func (uh *userHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 
 	filters, svcErr := parseFilterParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
 	// Get the user list using the user service.
 	userListResponse, svcErr := uh.userService.GetUserList(limit, offset, filters)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(userListResponse); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, userListResponse)
 
 	logger.Debug("Successfully listed users with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -98,25 +90,23 @@ func (uh *userHandler) HandleUserPostRequest(w http.ResponseWriter, r *http.Requ
 
 	createRequest, err := sysutils.DecodeJSONBody[User](r)
 	if err != nil {
-		http.Error(w, "Bad Request: The request body is malformed or contains invalid data.", http.StatusBadRequest)
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorInvalidRequestFormat.Code,
+			Message:     ErrorInvalidRequestFormat.Error,
+			Description: ErrorInvalidRequestFormat.ErrorDescription,
+		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	// Create the user using the user service.
 	createdUser, svcErr := uh.userService.CreateUser(createRequest)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-
-	if err := json.NewEncoder(w).Encode(createdUser); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdUser)
 
 	// Log the user creation response.
 	logger.Debug("User POST response sent", log.String("user id", createdUser.ID))
@@ -128,23 +118,23 @@ func (uh *userHandler) HandleUserGetRequest(w http.ResponseWriter, r *http.Reque
 
 	id := r.PathValue("id")
 	if id == "" {
-		http.Error(w, "Bad Request: Missing user id.", http.StatusBadRequest)
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorMissingUserID.Code,
+			Message:     ErrorMissingUserID.Error,
+			Description: ErrorMissingUserID.ErrorDescription,
+		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	// Get the user using the user service.
 	user, svcErr := uh.userService.GetUser(id)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(user); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
 
 	// Log the user response.
 	logger.Debug("User GET response sent", log.String("user id", id))
@@ -156,13 +146,13 @@ func (ah *userHandler) HandleUserGroupsGetRequest(w http.ResponseWriter, r *http
 
 	id := r.PathValue("id")
 	if id == "" {
-		handleError(w, logger, &ErrorMissingUserID)
+		handleError(w, &ErrorMissingUserID)
 		return
 	}
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
@@ -172,18 +162,11 @@ func (ah *userHandler) HandleUserGroupsGetRequest(w http.ResponseWriter, r *http
 
 	groupListResponse, svcErr := ah.userService.GetUserGroups(id, limit, offset)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(groupListResponse); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, groupListResponse)
 
 	logger.Debug("Successfully retrieved user groups", log.String("user id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -197,13 +180,23 @@ func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Reque
 
 	id := strings.TrimPrefix(r.URL.Path, "/users/")
 	if id == "" {
-		http.Error(w, "Bad Request: Missing user id.", http.StatusBadRequest)
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorMissingUserID.Code,
+			Message:     ErrorMissingUserID.Error,
+			Description: ErrorMissingUserID.ErrorDescription,
+		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	updateRequest, err := sysutils.DecodeJSONBody[User](r)
 	if err != nil {
-		http.Error(w, "Bad Request: The request body is malformed or contains invalid data.", http.StatusBadRequest)
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorInvalidRequestFormat.Code,
+			Message:     ErrorInvalidRequestFormat.Error,
+			Description: ErrorInvalidRequestFormat.ErrorDescription,
+		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 	updateRequest.ID = id
@@ -211,16 +204,11 @@ func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Reque
 	// Update the user using the user service.
 	user, svcErr := uh.userService.UpdateUser(id, updateRequest)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(user); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
 
 	// Log the user response.
 	logger.Debug("User PUT response sent", log.String("user id", id))
@@ -232,18 +220,23 @@ func (uh *userHandler) HandleUserDeleteRequest(w http.ResponseWriter, r *http.Re
 
 	id := strings.TrimPrefix(r.URL.Path, "/users/")
 	if id == "" {
-		http.Error(w, "Bad Request: Missing user id.", http.StatusBadRequest)
+		errResp := apierror.ErrorResponse{
+			Code:        ErrorMissingUserID.Code,
+			Message:     ErrorMissingUserID.Error,
+			Description: ErrorMissingUserID.ErrorDescription,
+		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	// Delete the user using the user service.
 	svcErr := uh.userService.DeleteUser(id)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 
 	// Log the user response.
 	logger.Debug("User DELETE response sent", log.String("user id", id))
@@ -253,14 +246,14 @@ func (uh *userHandler) HandleUserDeleteRequest(w http.ResponseWriter, r *http.Re
 func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
-	path, pathValidationFailed := extractAndValidatePath(w, r, logger)
+	path, pathValidationFailed := extractAndValidatePath(w, r)
 	if pathValidationFailed {
 		return
 	}
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
@@ -270,24 +263,17 @@ func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *htt
 
 	filters, svcErr := parseFilterParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
 	userListResponse, svcErr := uh.userService.GetUsersByPath(path, limit, offset, filters)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(userListResponse); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, userListResponse)
 
 	logger.Debug("Successfully listed users by path", log.String("path", path),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -300,43 +286,29 @@ func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *htt
 func (uh *userHandler) HandleUserPostByPathRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
-	path, pathValidationFailed := extractAndValidatePath(w, r, logger)
+	path, pathValidationFailed := extractAndValidatePath(w, r)
 	if pathValidationFailed {
 		return
 	}
 
 	createRequest, err := sysutils.DecodeJSONBody[CreateUserByPathRequest](r)
 	if err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: "Failed to parse request body: " + err.Error(),
 		}
-
-		if err := json.NewEncoder(w).Encode(errResp); err != nil {
-			logger.Error("Error encoding error response", log.Error(err))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	user, svcErr := uh.userService.CreateUserByPath(path, *createRequest)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusCreated)
-
-	if err := json.NewEncoder(w).Encode(user); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusCreated, user)
 
 	logger.Debug("Successfully created user by path", log.String("path", path), log.String("userType", user.Type))
 }
@@ -347,24 +319,17 @@ func (uh *userHandler) HandleSelfUserGetRequest(w http.ResponseWriter, r *http.R
 
 	userID := syscontext.GetUserID(r.Context())
 	if strings.TrimSpace(userID) == "" {
-		handleError(w, logger, &ErrorAuthenticationFailed)
+		handleError(w, &ErrorAuthenticationFailed)
 		return
 	}
 
 	user, svcErr := uh.userService.GetUser(userID)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(user); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
 
 	logger.Debug("Self user GET response sent", log.String("user id", userID))
 }
@@ -375,35 +340,28 @@ func (uh *userHandler) HandleSelfUserPutRequest(w http.ResponseWriter, r *http.R
 
 	userID := syscontext.GetUserID(r.Context())
 	if strings.TrimSpace(userID) == "" {
-		handleError(w, logger, &ErrorAuthenticationFailed)
+		handleError(w, &ErrorAuthenticationFailed)
 		return
 	}
 
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateSelfUserRequest](r)
 	if err != nil {
-		handleError(w, logger, &ErrorInvalidRequestFormat)
+		handleError(w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	if updateRequest == nil || len(updateRequest.Attributes) == 0 {
-		handleError(w, logger, &ErrorInvalidRequestFormat)
+		handleError(w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	updatedUser, svcErr := uh.userService.UpdateUserAttributes(userID, updateRequest.Attributes)
 	if svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(updatedUser); err != nil {
-		logger.Error("Error encoding response", log.Error(err))
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
-	}
+	sysutils.WriteSuccessResponse(w, http.StatusOK, updatedUser)
 
 	logger.Debug("Self user PUT response sent", log.String("user id", userID))
 }
@@ -414,27 +372,27 @@ func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWrit
 
 	userID := syscontext.GetUserID(r.Context())
 	if strings.TrimSpace(userID) == "" {
-		handleError(w, logger, &ErrorAuthenticationFailed)
+		handleError(w, &ErrorAuthenticationFailed)
 		return
 	}
 
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateSelfUserRequest](r)
 	if err != nil {
-		handleError(w, logger, &ErrorInvalidRequestFormat)
+		handleError(w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	if updateRequest == nil || len(updateRequest.Attributes) == 0 {
-		handleError(w, logger, &ErrorMissingCredentials)
+		handleError(w, &ErrorMissingCredentials)
 		return
 	}
 
 	if svcErr := uh.userService.UpdateUserCredentials(userID, updateRequest.Attributes); svcErr != nil {
-		handleError(w, logger, svcErr)
+		handleError(w, svcErr)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 	logger.Debug("Self user credential update response sent", log.String("user id", userID))
 }
 
@@ -467,9 +425,7 @@ func parsePaginationParams(query url.Values) (int, int, *serviceerror.ServiceErr
 }
 
 // handleError handles service errors and writes appropriate HTTP responses.
-func handleError(w http.ResponseWriter, logger *log.Logger, svcErr *serviceerror.ServiceError) {
-	w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-
+func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	var statusCode int
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -494,35 +450,25 @@ func handleError(w http.ResponseWriter, logger *log.Logger, svcErr *serviceerror
 		statusCode = http.StatusInternalServerError
 	}
 
-	w.WriteHeader(statusCode)
-
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
 	}
 
-	if err := json.NewEncoder(w).Encode(errResp); err != nil {
-		logger.Error("Error encoding error response", log.Error(err))
-		http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-	}
+	sysutils.WriteErrorResponse(w, statusCode, errResp)
 }
 
 // extractAndValidatePath extracts and validates the path parameter from the request.
-func extractAndValidatePath(w http.ResponseWriter, r *http.Request, logger *log.Logger) (string, bool) {
+func extractAndValidatePath(w http.ResponseWriter, r *http.Request) (string, bool) {
 	path := r.PathValue("path")
 	if path == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorHandlePathRequired.Code,
 			Message:     ErrorHandlePathRequired.Error,
 			Description: ErrorHandlePathRequired.ErrorDescription,
 		}
-		if err := json.NewEncoder(w).Encode(errResp); err != nil {
-			logger.Error("Error encoding error response", log.Error(err))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
 		return "", true
 	}
 	return path, false


### PR DESCRIPTION
With [1] we have introduced WriteSuccessResponse and WriteErrorResponse helper methods. In this PR we are modifying all the places with references to use this newly introduced until methods.

[1] https://github.com/asgardeo/thunder/pull/845 


### Related Issues
- https://github.com/asgardeo/thunder/issues/442