### PR TITLE
Add persistence layer for Sqlite databases

### DIFF
--- a/install/helm/templates/pvc.yaml
+++ b/install/helm/templates/pvc.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- $usingSqlite := or (eq .Values.configuration.database.identity.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
+{{- if or .Values.persistence.enabled $usingSqlite }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "thunder.fullname" . }}-database-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-15"
+    {{- with .Values.persistence.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -15,6 +15,7 @@
 # under the License.
 
 {{- if .Values.setup.enabled }}
+{{- $usingSqlite := or (eq .Values.configuration.database.identity.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -53,6 +54,40 @@ spec:
       {{- if .Values.deployment.image.imagePullSecret }}
       imagePullSecrets:
         - name: {{ .Values.deployment.image.imagePullSecret }}
+      {{- end }}
+      {{- if or .Values.persistence.enabled $usingSqlite }}
+      initContainers:
+        - name: init-database
+          {{- if .Values.deployment.image.digest }}
+          image: {{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}@{{ .Values.deployment.image.digest }}
+          {{- else }}
+          image: {{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ default "latest" .Values.deployment.image.tag }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            {{- if .Values.deployment.securityContext.enableRunAsUser }}
+            runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.deployment.securityContext.runAsUser }}
+            {{- end }}
+            capabilities:
+              drop:
+                - ALL
+          command: ['sh', '-c']
+          args:
+            - |
+              if [ ! -f /data/.initialized ]; then
+                echo "Copying database directory from image..."
+                cp -r /opt/thunder/repository/database/* /data/
+                touch /data/.initialized
+                echo "Database initialization complete"
+              else
+                echo "Database already initialized"
+              fi
+          volumeMounts:
+            - name: database-storage
+              mountPath: /data
       {{- end }}
       containers:
         - name: setup
@@ -93,6 +128,10 @@ spec:
               drop:
                 - all
           volumeMounts:
+            {{- if or .Values.persistence.enabled $usingSqlite }}
+            - name: database-storage
+              mountPath: /opt/thunder/repository/database
+            {{- end }}
             - name: deployment-yaml-volume
               mountPath: /opt/thunder/repository/conf/deployment.yaml
               subPath: deployment.yaml
@@ -131,6 +170,11 @@ spec:
             {{- toYaml .Values.setup.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
+        {{- if or .Values.persistence.enabled $usingSqlite }}
+        - name: database-storage
+          persistentVolumeClaim:
+            claimName: {{ include "thunder.fullname" . }}-database-pvc
+        {{- end }}
         - name: deployment-yaml-volume
           configMap:
             name: {{ include "thunder.fullname" . }}-setup-config-map

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+{{- $usingSqlite := or (eq .Values.configuration.database.identity.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -119,6 +120,10 @@ spec:
             - containerPort: {{ .Values.deployment.container.port }}
               protocol: TCP
           volumeMounts:
+            {{- if or .Values.persistence.enabled $usingSqlite }}
+            - name: database-storage
+              mountPath: /opt/thunder/repository/database
+            {{- end }}
             - name: deployment-yaml-volume
               mountPath: /opt/thunder/repository/conf/deployment.yaml
               subPath: deployment.yaml
@@ -129,6 +134,11 @@ spec:
               mountPath: /opt/thunder/apps/develop/config.js
               subPath: develop-config.js
       volumes:
+        {{- if or .Values.persistence.enabled $usingSqlite }}
+        - name: database-storage
+          persistentVolumeClaim:
+            claimName: {{ include "thunder.fullname" . }}-database-pvc
+        {{- end }}
         - name: deployment-yaml-volume
           configMap:
             name: {{ include "thunder.fullname" . }}-config-map

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -215,6 +215,15 @@ configuration:
     allowedOrigins:
       - "https://localhost:3000"
 
+# Persistence configuration for SQLite databases
+# Only relevant when using SQLite as the database type
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+
 # Setup Job configuration
 # Runs setup.sh as a one-time initialization job during Helm install
 setup:


### PR DESCRIPTION
### Purpose
This pull request adds support for automatic persistent storage when deploying Thunder with SQLite databases using Helm. Now, when any Thunder database is configured to use SQLite, a PersistentVolumeClaim (PVC) is created and an init container copies the database files from the image to the PVC, ensuring database files persist across pod restarts. The documentation and Helm chart values have been updated to reflect these changes and allow customization of persistence settings.

**SQLite Persistence Support:**

* Added automatic PVC creation for SQLite databases by introducing a new template file `pvc.yaml` and updating deployment and setup-job templates to mount the persistent volume when SQLite is used or persistence is enabled. [[1]](diffhunk://#diff-0ed46295ccfa302650f2d2e8a8aaa7f6c506c04a875216bcd6252d432af8374cR1-R47) [[2]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R17) [[3]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R123-R126) [[4]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R137-R141) [[5]](diffhunk://#diff-347defecc78c600bb09918a1ffee9bb8844c401332830dfb0b49d594e6d79b4bR18) [[6]](diffhunk://#diff-347defecc78c600bb09918a1ffee9bb8844c401332830dfb0b49d594e6d79b4bR58-R92) [[7]](diffhunk://#diff-347defecc78c600bb09918a1ffee9bb8844c401332830dfb0b49d594e6d79b4bR132-R135) [[8]](diffhunk://#diff-347defecc78c600bb09918a1ffee9bb8844c401332830dfb0b49d594e6d79b4bR174-R178)
* Added an init container to the setup job that copies SQLite database files from the image to the PVC, initializing the database on first run.
* Updated `values.yaml` to include new persistence configuration options (`persistence.enabled`, `storageClass`, etc.) for customizing storage behavior.

**Documentation Updates:**

* Updated `README.md` to document how to install Thunder with SQLite, explain automatic persistence behavior, and describe new persistence parameters. [[1]](diffhunk://#diff-3f767509b40f4f726a137cd616c967a47345b5cf0034ae6f4cc29fcd830f5096R47-R60) [[2]](diffhunk://#diff-3f767509b40f4f726a137cd616c967a47345b5cf0034ae6f4cc29fcd830f5096R227-R243)

## Related Issues
- https://github.com/asgardeo/thunder/issues/714
