### PR TITLE
Add http server support for helm chart

### DIFF
--- a/install/helm/templates/ingress.yaml
+++ b/install/helm/templates/ingress.yaml
@@ -18,7 +18,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- toYaml .Values.ingress.combinedAnnotations | nindent 4 }}
+    {{- $annotations := deepCopy .Values.ingress.combinedAnnotations }}
+    {{- if .Values.configuration.server.httpOnly }}
+    {{- $_ := set $annotations "nginx.ingress.kubernetes.io/backend-protocol" "HTTP" }}
+    {{- $_ := unset $annotations "nginx.ingress.kubernetes.io/force-ssl-redirect" }}
+    {{- end }}
+    {{- toYaml $annotations | nindent 4 }}
   name: {{ include "thunder.fullname" . }}-ingress
   namespace: {{ .Release.Namespace }}
   labels:
@@ -36,7 +41,9 @@ spec:
                 name: {{ include "thunder.fullname" .  }}-service
                 port:
                   number: {{ .Values.service.port }}
+  {{- if not .Values.configuration.server.httpOnly }}
   tls:
   - hosts:
     - {{ .Values.ingress.hostname | quote }}
     secretName: {{ .Values.ingress.tlsSecretsName  }}
+  {{- end }}

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -90,13 +90,13 @@ spec:
             httpGet:
               path: /health/liveness
               port: {{ .Values.deployment.container.port }}
-              scheme: HTTPS
+              scheme: {{ if .Values.configuration.server.httpOnly }}HTTP{{ else }}HTTPS{{ end }}
             periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
               path: /health/readiness
               port: {{ .Values.deployment.container.port }}
-              scheme: HTTPS
+              scheme: {{ if .Values.configuration.server.httpOnly }}HTTP{{ else }}HTTPS{{ end }}
             initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
           resources:


### PR DESCRIPTION
### Purpose
This pull request introduces conditional support for HTTP-only mode across the Helm chart templates, allowing deployments to optionally disable HTTPS and related TLS settings based on the `configuration.server.httpOnly` value. The changes ensure that annotations, probes, and TLS configuration are correctly set depending on this flag.

**Ingress configuration improvements:**

* The `ingress.yaml` annotations now dynamically set `nginx.ingress.kubernetes.io/backend-protocol` to `HTTP` and remove `nginx.ingress.kubernetes.io/force-ssl-redirect` when HTTP-only mode is enabled.
* The TLS block in `ingress.yaml` is conditionally included only if HTTP-only mode is not enabled, preventing unnecessary TLS configuration for HTTP-only deployments.

**Deployment probe adjustments:**

* The liveness and readiness probes in `thunder-deployment.yaml` now use either `HTTP` or `HTTPS` for the scheme, depending on the HTTP-only configuration, ensuring health checks work correctly in both modes.

## Related Issues
- https://github.com/asgardeo/thunder/issues/882