### PR TITLE
Remove depricated nginx annotations

### DIFF
--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -82,7 +82,6 @@ service:
 ingress:
   className: "nginx"
   commonAnnotations: &commonAnnotations
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"


### PR DESCRIPTION
### Purpose
This pull request makes a small configuration adjustment to the ingress annotations in the Helm values file. The change removes the redundant `kubernetes.io/ingress.class: nginx` annotation, which is already specified by the `className` field.

[1] https://kubernetes.io/docs/concepts/services-networking/ingress/