### PR TITLE
Update ingress and bootstrap configurations

### DIFF
--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -249,7 +249,8 @@ The setup job runs `setup.sh` as a one-time Helm pre-install hook to initialize 
 | -------------------------------------- | --------------------------------------------------------------- | ---------------------------- |
 | `setup.enabled`                        | Enable setup job (runs on install via Helm hook)                | `true`                       |
 | `setup.backoffLimit`                   | Number of retries if setup fails                                | `3`                          |
-| `setup.ttlSecondsAfterFinished`        | Time to keep job after completion (0 = indefinite)              | `86400` (24 hours)           |
+| `setup.preserveJob`                    | Preserve job after completion (false = delete on success)       | `false`                      |
+| `setup.ttlSecondsAfterFinished`        | Time to keep failed jobs (only if preserveJob=false)            | `86400` (24 hours)           |
 | `setup.debug`                          | Enable debug mode for setup                                     | `false`                      |
 | `setup.args`                           | Additional command-line arguments for setup.sh                  | `[]`                         |
 | `setup.env`                            | Additional environment variables for setup job                  | `[]`                         |
@@ -259,6 +260,10 @@ The setup job runs `setup.sh` as a one-time Helm pre-install hook to initialize 
 | `setup.resources.limits.memory`        | Memory limit for setup job                                      | `256Mi`                      |
 | `setup.extraVolumeMounts`              | Additional volume mounts for setup job                          | `[]`                         |
 | `setup.extraVolumes`                   | Additional volumes for setup job                                | `[]`                         |
+
+**Job Retention Behavior:**
+- When `preserveJob=false` (default): Successful jobs are deleted immediately. Failed jobs are kept for `ttlSecondsAfterFinished` (24 hours) to allow debugging.
+- When `preserveJob=true`: Job is kept indefinitely regardless of success/failure status. Use this for troubleshooting or audit purposes.
 
 ### Bootstrap Script Parameters
 

--- a/install/helm/templates/ingress.yaml
+++ b/install/helm/templates/ingress.yaml
@@ -18,12 +18,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    {{- if eq .Values.ingress.className "nginx" }}
     {{- $annotations := deepCopy .Values.ingress.combinedAnnotations }}
     {{- if .Values.configuration.server.httpOnly }}
     {{- $_ := set $annotations "nginx.ingress.kubernetes.io/backend-protocol" "HTTP" }}
     {{- $_ := unset $annotations "nginx.ingress.kubernetes.io/force-ssl-redirect" }}
     {{- end }}
     {{- toYaml $annotations | nindent 4 }}
+    {{- else }}
+    {{- toYaml .Values.ingress.customAnnotations | nindent 4 }}
+    {{- end }}
   name: {{ include "thunder.fullname" . }}-ingress
   namespace: {{ .Release.Namespace }}
   labels:

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -27,12 +27,16 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
+    {{- if not .Values.setup.preserveJob }}
     "helm.sh/hook-delete-policy": hook-succeeded
+    {{- end }}
 spec:
   completions: 1
   parallelism: 1
   backoffLimit: {{ .Values.setup.backoffLimit }}
+  {{- if not .Values.setup.preserveJob }}
   ttlSecondsAfterFinished: {{ .Values.setup.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -230,7 +230,12 @@ setup:
   enabled: true
   # Number of retries if setup fails
   backoffLimit: 3
-  # Time to keep job after completion (seconds, 0 = indefinite)
+  # Whether to preserve the setup job after completion
+  # When false: Job is deleted immediately on success, and after ttlSecondsAfterFinished on failure
+  # When true: Job is kept indefinitely (ttlSecondsAfterFinished is not applied)
+  preserveJob: false
+  # Time to keep failed jobs after completion (seconds, 0 = indefinite)
+  # Only applies when preserveJob=false. Successful jobs are deleted immediately via hook-delete-policy.
   ttlSecondsAfterFinished: 86400  # 24 hours
   # Enable debug mode for setup
   debug: false


### PR DESCRIPTION
### Purpose
This pull request introduces an option to control whether the Helm setup job is preserved after completion, and improves how Ingress annotations are applied based on the selected Ingress class. The main changes are grouped below:

Helm setup job enhancements:

* Added a new `setup.preserveJob` value to control whether the setup job is deleted after completion. The default is `false`, meaning the job will be deleted unless this is set to `true`. This option is documented in both `values.yaml` and `README.md`. [[1]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eR233-R234) [[2]](diffhunk://#diff-3f767509b40f4f726a137cd616c967a47345b5cf0034ae6f4cc29fcd830f5096R252)
* Updated the `setup-job.yaml` Helm template to conditionally set the `helm.sh/hook-delete-policy` annotation based on the `setup.preserveJob` value, allowing users to preserve the setup job if desired.

Ingress annotation improvements:

* Modified the `ingress.yaml` Helm template to apply different sets of annotations depending on whether the Ingress class is `nginx` or another value, allowing for more flexible and correct configuration of Ingress resources.