### PR TITLE
Set linter line length tab-width to 4

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -77,6 +77,7 @@ linters-settings:
       - cancelled
   lll:
     line-length: 120
+    tab-width: 4
   revive:
     rules:
       - name: struct-tag

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -86,7 +86,8 @@ func registerServices(
 	}
 	certservice := cert.Initialize()
 	brandingMgtService := brandingmgt.Initialize(mux)
-	applicationService := application.Initialize(mux, certservice, flowMgtService, brandingMgtService, userSchemaService)
+	applicationService := application.Initialize(mux, certservice, flowMgtService,
+		brandingMgtService, userSchemaService)
 	_ = brandingresolve.Initialize(mux, brandingMgtService, applicationService)
 
 	// Initialize export service with application and IDP service dependencies

--- a/backend/internal/application/cache_backed_store_test.go
+++ b/backend/internal/application/cache_backed_store_test.go
@@ -461,7 +461,8 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByName_CacheMiss() {
 
 func (suite *CacheBackedStoreTestSuite) TestGetApplicationByName_StoreError() {
 	storeErr := errors.New("store error")
-	suite.mockStore.On("GetApplicationByName", "test-name").Return((*model.ApplicationProcessedDTO)(nil), storeErr).Once()
+	suite.mockStore.On("GetApplicationByName", "test-name").
+		Return((*model.ApplicationProcessedDTO)(nil), storeErr).Once()
 
 	result, err := suite.cachedStore.GetApplicationByName("test-name")
 	suite.Equal(storeErr, err)

--- a/backend/internal/application/init_test.go
+++ b/backend/internal/application/init_test.go
@@ -336,7 +336,8 @@ inbound_auth_config:
 	assert.Contains(suite.T(), oauthConfig.GrantTypes, oauth2const.GrantType("refresh_token"))
 	assert.Contains(suite.T(), oauthConfig.ResponseTypes, oauth2const.ResponseType("code"))
 	assert.Contains(suite.T(), oauthConfig.ResponseTypes, oauth2const.ResponseType("token"))
-	assert.Equal(suite.T(), oauth2const.TokenEndpointAuthMethod("client_secret_post"), oauthConfig.TokenEndpointAuthMethod)
+	assert.Equal(suite.T(), oauth2const.TokenEndpointAuthMethod("client_secret_post"),
+		oauthConfig.TokenEndpointAuthMethod)
 	assert.False(suite.T(), oauthConfig.PKCERequired)
 	assert.True(suite.T(), oauthConfig.PublicClient)
 

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -915,7 +915,8 @@ func (suite *ServiceTestSuite) TestDeleteApplication_Success() {
 	service, mockStore, mockCertService, _ := suite.setupTestService()
 
 	mockStore.On("DeleteApplication", "app123").Return(nil)
-	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").Return(nil)
+	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication,
+		"app123").Return(nil)
 
 	svcErr := service.DeleteApplication("app123")
 
@@ -964,7 +965,8 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_NotFound() {
 func (suite *ServiceTestSuite) TestGetApplicationCertificate_NilCertificate() {
 	service, _, mockCertService, _ := suite.setupTestService()
 
-	mockCertService.EXPECT().GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").Return(nil, nil)
+	mockCertService.EXPECT().GetCertificateByReference(cert.CertificateReferenceTypeApplication,
+		"app123").Return(nil, nil)
 
 	result, err := service.getApplicationCertificate("app123")
 
@@ -1043,7 +1045,8 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_ClientError() {
 func (suite *ServiceTestSuite) TestRollbackAppCertificateCreation_Success() {
 	service, _, mockCertService, _ := suite.setupTestService()
 
-	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").Return(nil)
+	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication,
+		"app123").Return(nil)
 
 	svcErr := service.rollbackAppCertificateCreation("app123")
 
@@ -1369,7 +1372,8 @@ func (suite *ServiceTestSuite) TestGetValidatedCertificateForCreate_JWKSURI_Inva
 func (suite *ServiceTestSuite) TestDeleteApplicationCertificate_Success() {
 	service, _, mockCertService, _ := suite.setupTestService()
 
-	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").Return(nil)
+	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication,
+		"app123").Return(nil)
 
 	svcErr := service.deleteApplicationCertificate("app123")
 

--- a/backend/internal/application/store.go
+++ b/backend/internal/application/store.go
@@ -750,7 +750,8 @@ func buildOAuthInboundAuthConfig(row map[string]interface{}, basicApp model.Basi
 	} else if v, ok := row["oauth_config_json"].([]byte); ok {
 		oauthConfigJSON = string(v)
 	} else {
-		return model.InboundAuthConfigProcessedDTO{}, fmt.Errorf("failed to parse oauth_config_json as string or []byte")
+		return model.InboundAuthConfigProcessedDTO{},
+			fmt.Errorf("failed to parse oauth_config_json as string or []byte")
 	}
 
 	var oauthConfig oAuthConfig

--- a/backend/internal/application/store_constants.go
+++ b/backend/internal/application/store_constants.go
@@ -24,9 +24,9 @@ var (
 	// QueryCreateApplication is the query to create a new application with basic details.
 	QueryCreateApplication = dbmodel.DBQuery{
 		ID: "ASQ-APP_MGT-01",
-		Query: "INSERT INTO SP_APP (APP_ID, APP_NAME, DESCRIPTION, AUTH_FLOW_GRAPH_ID, REGISTRATION_FLOW_GRAPH_ID, " +
-			"IS_REGISTRATION_FLOW_ENABLED, BRANDING_ID, APP_JSON, DEPLOYMENT_ID) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, " +
-			"$9)",
+		Query: "INSERT INTO SP_APP (APP_ID, APP_NAME, DESCRIPTION, AUTH_FLOW_GRAPH_ID, " +
+			"REGISTRATION_FLOW_GRAPH_ID, IS_REGISTRATION_FLOW_ENABLED, BRANDING_ID, APP_JSON, DEPLOYMENT_ID) " +
+			"VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 	}
 	// QueryCreateOAuthApplication is the query to create a new OAuth application.
 	QueryCreateOAuthApplication = dbmodel.DBQuery{
@@ -40,8 +40,9 @@ var (
 		Query: "SELECT sp.APP_ID, sp.APP_NAME, sp.DESCRIPTION, sp.AUTH_FLOW_GRAPH_ID, " +
 			"sp.REGISTRATION_FLOW_GRAPH_ID, sp.IS_REGISTRATION_FLOW_ENABLED, sp.BRANDING_ID, sp.APP_JSON, " +
 			"oauth.CONSUMER_KEY, oauth.CONSUMER_SECRET, oauth.OAUTH_CONFIG_JSON " +
-			"FROM SP_APP sp LEFT JOIN IDN_OAUTH_CONSUMER_APPS oauth ON sp.APP_ID = oauth.APP_ID AND sp.DEPLOYMENT_ID = $2 " +
-			"AND oauth.DEPLOYMENT_ID = $2 WHERE sp.APP_ID = $1 AND sp.DEPLOYMENT_ID = $2",
+			"FROM SP_APP sp LEFT JOIN IDN_OAUTH_CONSUMER_APPS oauth " +
+			"ON sp.APP_ID = oauth.APP_ID AND sp.DEPLOYMENT_ID = $2 AND oauth.DEPLOYMENT_ID = $2 " +
+			"WHERE sp.APP_ID = $1 AND sp.DEPLOYMENT_ID = $2",
 	}
 	// QueryGetApplicationByName is the query to retrieve application details by name.
 	QueryGetApplicationByName = dbmodel.DBQuery{
@@ -49,8 +50,9 @@ var (
 		Query: "SELECT sp.APP_ID, sp.APP_NAME, sp.DESCRIPTION, sp.AUTH_FLOW_GRAPH_ID, " +
 			"sp.REGISTRATION_FLOW_GRAPH_ID, sp.IS_REGISTRATION_FLOW_ENABLED, sp.BRANDING_ID, sp.APP_JSON, " +
 			"oauth.CONSUMER_KEY, oauth.CONSUMER_SECRET, oauth.OAUTH_CONFIG_JSON " +
-			"FROM SP_APP sp LEFT JOIN IDN_OAUTH_CONSUMER_APPS oauth ON sp.APP_ID = oauth.APP_ID AND sp.DEPLOYMENT_ID = $2 " +
-			"AND oauth.DEPLOYMENT_ID = $2 WHERE sp.APP_NAME = $1 AND sp.DEPLOYMENT_ID = $2",
+			"FROM SP_APP sp LEFT JOIN IDN_OAUTH_CONSUMER_APPS oauth " +
+			"ON sp.APP_ID = oauth.APP_ID AND sp.DEPLOYMENT_ID = $2 AND oauth.DEPLOYMENT_ID = $2 " +
+			"WHERE sp.APP_NAME = $1 AND sp.DEPLOYMENT_ID = $2",
 	}
 	// QueryGetOAuthApplicationByClientID is the query to retrieve oauth application details by client ID.
 	QueryGetOAuthApplicationByClientID = dbmodel.DBQuery{

--- a/backend/internal/authn/handler_test.go
+++ b/backend/internal/authn/handler_test.go
@@ -256,7 +256,8 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleCredentialsAuthRequestSer
 	for _, tc := range cases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			m := NewAuthenticationServiceInterfaceMock(t)
-			m.On("AuthenticateWithCredentials", mock.Anything, mock.Anything, mock.Anything).Return(nil, tc.serviceError)
+			m.On("AuthenticateWithCredentials", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil, tc.serviceError)
 			h := &authenticationHandler{authService: m}
 
 			body, _ := json.Marshal(tc.authRequest)
@@ -390,7 +391,8 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleVerifySMSOTPRequestServic
 	}
 	serviceError := &otp.ErrorIncorrectOTP
 
-	suite.mockService.On("VerifyOTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, serviceError)
+	suite.mockService.On("VerifyOTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, serviceError)
 
 	body, _ := json.Marshal(otpRequest)
 	req := httptest.NewRequest(http.MethodPost, "/authenticate/otp/verify", bytes.NewReader(body))

--- a/backend/internal/authn/oauth/service_test.go
+++ b/backend/internal/authn/oauth/service_test.go
@@ -248,7 +248,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccessWithAdditio
 			clientSecretProp, _ := cmodels.NewProperty("client_secret", "test_client_secret", false)
 			redirectURIProp, _ := cmodels.NewProperty("redirect_uri", "https://app.example.com/callback", false)
 			scopesProp, _ := cmodels.NewProperty("scopes", "openid profile", false)
-			authzEndpointProp, _ := cmodels.NewProperty("authorization_endpoint", "https://example.com/oauth/authorize", false)
+			authzEndpointProp, _ := cmodels.NewProperty("authorization_endpoint",
+				"https://example.com/oauth/authorize", false)
 
 			idpDTO := &idp.IDPDTO{
 				ID:   testIDPID,

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -739,7 +739,8 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 			setupMocks: func() {
 				sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
-				suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil).Once()
+				suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).
+					Return(tokenResp, nil).Once()
 				suite.mockOAuthService.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil).Once()
 				suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
 				suite.mockAssertGenerator.On("GenerateAssertion", mock.Anything).Return(
@@ -749,8 +750,8 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 							IAL: assert.IALLevel1,
 						},
 					}, nil).Once()
-				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything, mock.Anything).
-					Return(testJWTToken, int64(3600), nil).Once()
+				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything,
+					mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -765,7 +766,8 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 				existingAssertion := suite.createTestAssertion(testUserID)
 				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
 				suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil).Once()
-				suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil).Once()
+				suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).
+					Return(tokenResp, nil).Once()
 				suite.mockOAuthService.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil).Once()
 				suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
 				suite.mockAssertGenerator.On("UpdateAssertion", mock.Anything, mock.Anything).Return(

--- a/backend/internal/branding/common/error_constants.go
+++ b/backend/internal/branding/common/error_constants.go
@@ -49,10 +49,11 @@ var (
 	}
 	// ErrorCannotDeleteBranding is the error returned when branding cannot be deleted.
 	ErrorCannotDeleteBranding = serviceerror.ServiceError{
-		Type:             serviceerror.ClientErrorType,
-		Code:             "BRD-1004",
-		Error:            "Cannot delete branding",
-		ErrorDescription: "Cannot delete branding configuration that is currently associated with one or more applications",
+		Type:  serviceerror.ClientErrorType,
+		Code:  "BRD-1004",
+		Error: "Cannot delete branding",
+		ErrorDescription: "Cannot delete branding configuration that is currently associated with " +
+			"one or more applications",
 	}
 	// ErrorMissingDisplayName is the error returned when displayName field is missing.
 	ErrorMissingDisplayName = serviceerror.ServiceError{

--- a/backend/internal/branding/mgt/store.go
+++ b/backend/internal/branding/mgt/store.go
@@ -165,7 +165,8 @@ func (s *brandingMgtStore) UpdateBranding(id string, branding UpdateBrandingRequ
 		return fmt.Errorf("failed to marshal preferences: %w", err)
 	}
 
-	rowsAffected, err := dbClient.Execute(queryUpdateBranding, branding.DisplayName, preferencesJSON, id, s.deploymentID)
+	rowsAffected, err := dbClient.Execute(queryUpdateBranding, branding.DisplayName, preferencesJSON, id,
+		s.deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/backend/internal/branding/mgt/store_constants.go
+++ b/backend/internal/branding/mgt/store_constants.go
@@ -29,8 +29,9 @@ var (
 
 	// queryGetBrandingByID retrieves a branding configuration by ID.
 	queryGetBrandingByID = dbmodel.DBQuery{
-		ID:    "BRQ-BRANDING_MGT-02",
-		Query: "SELECT BRANDING_ID, DISPLAY_NAME, PREFERENCES FROM BRANDING WHERE BRANDING_ID = $1 AND DEPLOYMENT_ID = $2",
+		ID: "BRQ-BRANDING_MGT-02",
+		Query: "SELECT BRANDING_ID, DISPLAY_NAME, PREFERENCES FROM BRANDING " +
+			"WHERE BRANDING_ID = $1 AND DEPLOYMENT_ID = $2",
 	}
 
 	// queryGetBrandingList retrieves a list of branding configurations with pagination.

--- a/backend/internal/branding/mgt/store_test.go
+++ b/backend/internal/branding/mgt/store_test.go
@@ -545,7 +545,8 @@ func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_DBClie
 func (suite *BrandingStoreTestSuite) TestGetApplicationsCountByBrandingID_QueryError() {
 	queryError := errors.New("query error")
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetApplicationsCountByBrandingID, "brand1", mock.Anything).Return(nil, queryError)
+	suite.mockDBClient.On("Query", queryGetApplicationsCountByBrandingID, "brand1", mock.Anything).
+		Return(nil, queryError)
 
 	count, err := suite.store.GetApplicationsCountByBrandingID("brand1")
 

--- a/backend/internal/branding/resolve/handler_test.go
+++ b/backend/internal/branding/resolve/handler_test.go
@@ -170,7 +170,8 @@ func (suite *BrandingResolveHandlerTestSuite) TestHandleResolveRequest_MissingTy
 }
 
 func (suite *BrandingResolveHandlerTestSuite) TestHandleResolveRequest_MissingID() {
-	suite.mockService.On("ResolveBranding", common.BrandingResolveTypeAPP, "").Return(nil, &common.ErrorMissingResolveID)
+	suite.mockService.On("ResolveBranding", common.BrandingResolveTypeAPP,
+		"").Return(nil, &common.ErrorMissingResolveID)
 
 	req := httptest.NewRequest(http.MethodGet, "/branding/resolve?type=APP", nil)
 	w := httptest.NewRecorder()

--- a/backend/internal/cert/store_constants.go
+++ b/backend/internal/cert/store_constants.go
@@ -23,8 +23,9 @@ import dbmodel "github.com/asgardeo/thunder/internal/system/database/model"
 var (
 	// queryGetCertificateByID retrieves a certificate by its ID.
 	queryGetCertificateByID = dbmodel.DBQuery{
-		ID:    "CER_MGT-01",
-		Query: "SELECT CERT_ID, REF_TYPE, REF_ID, TYPE, VALUE FROM CERTIFICATE WHERE CERT_ID = $1 AND DEPLOYMENT_ID = $2",
+		ID: "CER_MGT-01",
+		Query: "SELECT CERT_ID, REF_TYPE, REF_ID, TYPE, VALUE FROM CERTIFICATE " +
+			"WHERE CERT_ID = $1 AND DEPLOYMENT_ID = $2",
 	}
 	// queryGetCertificateByReference retrieves a certificate based on its reference type and ID.
 	queryGetCertificateByReference = dbmodel.DBQuery{
@@ -45,8 +46,9 @@ var (
 	}
 	// queryUpdateCertificateByReference updates a certificate based on its reference type and ID.
 	queryUpdateCertificateByReference = dbmodel.DBQuery{
-		ID:    "CER_MGT-05",
-		Query: "UPDATE CERTIFICATE SET TYPE = $3, VALUE = $4 WHERE REF_TYPE = $1 AND REF_ID = $2 AND DEPLOYMENT_ID = $5",
+		ID: "CER_MGT-05",
+		Query: "UPDATE CERTIFICATE SET TYPE = $3, VALUE = $4 " +
+			"WHERE REF_TYPE = $1 AND REF_ID = $2 AND DEPLOYMENT_ID = $5",
 	}
 	// queryDeleteCertificateByID deletes a certificate by its ID.
 	queryDeleteCertificateByID = dbmodel.DBQuery{

--- a/backend/internal/group/handler_test.go
+++ b/backend/internal/group/handler_test.go
@@ -293,7 +293,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			},
 			assertBody: func(recorder *httptest.ResponseRecorder) {
 				suite.Require().Equal(http.StatusOK, recorder.Code)
-				suite.Require().Equal(serverconst.ContentTypeJSON, recorder.Header().Get(serverconst.ContentTypeHeaderName))
+				suite.Require().Equal(serverconst.ContentTypeJSON,
+					recorder.Header().Get(serverconst.ContentTypeHeaderName))
 
 				var body GroupListResponse
 				suite.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &body))
@@ -308,7 +309,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			requestPath: "/groups?limit=invalid",
 			assertBody: func(recorder *httptest.ResponseRecorder) {
 				suite.Require().Equal(http.StatusBadRequest, recorder.Code)
-				suite.Require().Equal(serverconst.ContentTypeJSON, recorder.Header().Get(serverconst.ContentTypeHeaderName))
+				suite.Require().Equal(serverconst.ContentTypeJSON,
+					recorder.Header().Get(serverconst.ContentTypeHeaderName))
 
 				var body apierror.ErrorResponse
 				suite.Require().NoError(json.Unmarshal(recorder.Body.Bytes(), &body))
@@ -513,7 +515,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			body: "{invalid json",
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serverconst.ContentTypeJSON, rr.Header().Get(serverconst.ContentTypeHeaderName))
+				require.Equal(suite.T(), serverconst.ContentTypeJSON,
+					rr.Header().Get(serverconst.ContentTypeHeaderName))
 				var body apierror.ErrorResponse
 				require.NoError(suite.T(), json.Unmarshal(rr.Body.Bytes(), &body))
 				require.Equal(suite.T(), ErrorInvalidRequestFormat.Code, body.Code)
@@ -543,12 +546,14 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 							request.Members[0].ID == "member-1" &&
 							request.Members[0].Type == MemberTypeUser
 					})).
-					Return(&Group{ID: "grp-001", Name: "Team &lt;script&gt;", OrganizationUnitID: testOrganizationUnitID}, nil).
+					Return(&Group{ID: "grp-001", Name: "Team &lt;script&gt;",
+						OrganizationUnitID: testOrganizationUnitID}, nil).
 					Once()
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusCreated, rr.Code)
-				require.Equal(suite.T(), serverconst.ContentTypeJSON, rr.Header().Get(serverconst.ContentTypeHeaderName))
+				require.Equal(suite.T(), serverconst.ContentTypeJSON,
+					rr.Header().Get(serverconst.ContentTypeHeaderName))
 				var body Group
 				require.NoError(suite.T(), json.Unmarshal(rr.Body.Bytes(), &body))
 				require.Equal(suite.T(), "grp-001", body.ID)
@@ -1163,7 +1168,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), serverconst.ContentTypeJSON, rr.Header().Get(serverconst.ContentTypeHeaderName))
+				require.Equal(suite.T(), serverconst.ContentTypeJSON,
+					rr.Header().Get(serverconst.ContentTypeHeaderName))
 				var body MemberListResponse
 				require.NoError(suite.T(), json.Unmarshal(rr.Body.Bytes(), &body))
 				require.Equal(suite.T(), 3, body.TotalResults)

--- a/backend/internal/group/service_test.go
+++ b/backend/internal/group/service_test.go
@@ -123,7 +123,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupList() {
 				startIndex:   2,
 				groupNames:   []string{"group-1", "group-2"},
 				linkRels:     []string{"first", "prev", "last"},
-				linkHrefs:    []string{"/groups?offset=0&limit=2", "/groups?offset=0&limit=2", "/groups?offset=2&limit=2"},
+				linkHrefs: []string{"/groups?offset=0&limit=2", "/groups?offset=0&limit=2",
+					"/groups?offset=2&limit=2"},
 			},
 		},
 		{
@@ -330,7 +331,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupsByPath() {
 			},
 			wantErr: &ErrorInternalServerError,
 			assertStoreCalls: func(storeMock *groupStoreInterfaceMock) {
-				storeMock.AssertNotCalled(suite.T(), "GetGroupsByOrganizationUnit", mock.Anything, mock.Anything, mock.Anything)
+				storeMock.AssertNotCalled(suite.T(), "GetGroupsByOrganizationUnit",
+					mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -565,7 +567,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 			},
 			setup: func(args *setupArgs) {
 				args.ou.On("GetOrganizationUnit", "ou-001").
-					Return(oupkg.OrganizationUnit{}, &serviceerror.ServiceError{Code: "OU-5000", Type: serviceerror.ServerErrorType}).
+					Return(oupkg.OrganizationUnit{},
+						&serviceerror.ServiceError{Code: "OU-5000", Type: serviceerror.ServerErrorType}).
 					Once()
 			},
 			expectErr: &ErrorInternalServerError,
@@ -812,7 +815,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 			},
 			setup: func(args *setupArgs) {
 				args.store.On("GetGroup", "grp-001").
-					Return(GroupDAO{ID: "grp-001", Name: "old", Description: "legacy", OrganizationUnitID: "ou-old"}, nil).
+					Return(GroupDAO{ID: "grp-001", Name: "old", Description: "legacy",
+						OrganizationUnitID: "ou-old"}, nil).
 					Once()
 				args.store.On("CheckGroupNameConflictForUpdate", "new-name", "ou-new", "grp-001").
 					Return(nil).

--- a/backend/internal/group/store_test.go
+++ b/backend/internal/group/store_test.go
@@ -448,9 +448,10 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 	}
 
 	testCases := []struct {
-		name      string
-		group     GroupDAO
-		setup     func(*providermock.DBProviderInterfaceMock, *clientmock.DBClientInterfaceMock, *modelmock.TxInterfaceMock)
+		name  string
+		group GroupDAO
+		setup func(*providermock.DBProviderInterfaceMock, *clientmock.DBClientInterfaceMock,
+			*modelmock.TxInterfaceMock)
 		expectErr string
 		needsTx   bool
 		verifyTx  func(*modelmock.TxInterfaceMock)
@@ -1217,9 +1218,10 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 	groupMinimal := GroupDAO{ID: "grp-001"}
 
 	testCases := []struct {
-		name        string
-		group       GroupDAO
-		setup       func(*providermock.DBProviderInterfaceMock, *clientmock.DBClientInterfaceMock, *modelmock.TxInterfaceMock)
+		name  string
+		group GroupDAO
+		setup func(*providermock.DBProviderInterfaceMock, *clientmock.DBClientInterfaceMock,
+			*modelmock.TxInterfaceMock)
 		expectErr   string
 		expectErrIs error
 		needsTx     bool
@@ -1679,9 +1681,10 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 
 func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 	testCases := []struct {
-		name      string
-		groupID   string
-		setup     func(*providermock.DBProviderInterfaceMock, *clientmock.DBClientInterfaceMock, *modelmock.TxInterfaceMock)
+		name    string
+		groupID string
+		setup   func(*providermock.DBProviderInterfaceMock, *clientmock.DBClientInterfaceMock,
+			*modelmock.TxInterfaceMock)
 		expectErr string
 		needsTx   bool
 		verifyTx  func(*modelmock.TxInterfaceMock)
@@ -2537,7 +2540,10 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CheckGroupNameConflictForCreate
 		},
 		{
 			name: "database client error",
-			setupProvider: func(providerMock *providermock.DBProviderInterfaceMock, _ *clientmock.DBClientInterfaceMock) {
+			setupProvider: func(
+				providerMock *providermock.DBProviderInterfaceMock,
+				_ *clientmock.DBClientInterfaceMock,
+			) {
 				providerMock.
 					On("GetUserDBClient").
 					Return(nil, errors.New("client fail")).
@@ -2595,7 +2601,10 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CheckGroupNameConflictForUpdate
 		},
 		{
 			name: "database client error",
-			setupProvider: func(providerMock *providermock.DBProviderInterfaceMock, _ *clientmock.DBClientInterfaceMock) {
+			setupProvider: func(
+				providerMock *providermock.DBProviderInterfaceMock,
+				_ *clientmock.DBClientInterfaceMock,
+			) {
 				providerMock.
 					On("GetUserDBClient").
 					Return(nil, errors.New("client fail")).

--- a/backend/internal/group/storeconstants.go
+++ b/backend/internal/group/storeconstants.go
@@ -84,8 +84,9 @@ var (
 
 	// QueryAddMemberToGroup is the query to assign member to a group.
 	QueryAddMemberToGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-10",
-		Query: `INSERT INTO GROUP_MEMBER_REFERENCE (GROUP_ID, MEMBER_TYPE, MEMBER_ID, DEPLOYMENT_ID) VALUES ($1, $2, $3, $4)`,
+		ID: "GRQ-GROUP_MGT-10",
+		Query: `INSERT INTO GROUP_MEMBER_REFERENCE (GROUP_ID, MEMBER_TYPE, MEMBER_ID, DEPLOYMENT_ID) ` +
+			`VALUES ($1, $2, $3, $4)`,
 	}
 
 	// QueryCheckGroupNameConflict is the query to check if a group name conflicts within the same organization unit.

--- a/backend/internal/idp/store_constants.go
+++ b/backend/internal/idp/store_constants.go
@@ -23,8 +23,9 @@ import "github.com/asgardeo/thunder/internal/system/database/model"
 var (
 	// queryCreateIdentityProvider is the query to create a new IdP.
 	queryCreateIdentityProvider = model.DBQuery{
-		ID:    "IPQ-IDP_MGT-01",
-		Query: "INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, TYPE, PROPERTIES, DEPLOYMENT_ID) VALUES ($1, $2, $3, $4, $5, $6)",
+		ID: "IPQ-IDP_MGT-01",
+		Query: "INSERT INTO IDP (IDP_ID, NAME, DESCRIPTION, TYPE, PROPERTIES, DEPLOYMENT_ID) " +
+			"VALUES ($1, $2, $3, $4, $5, $6)",
 	}
 	// queryGetIdentityProviderByID is the query to get a IdP by IdP ID.
 	queryGetIdentityProviderByID = model.DBQuery{

--- a/backend/internal/notification/message_handler.go
+++ b/backend/internal/notification/message_handler.go
@@ -406,7 +406,8 @@ func getSenderResponseFromDTO(sender *common.NotificationSenderDTO) (common.Noti
 		} else {
 			propertyDTO, err := property.ToPropertyDTO()
 			if err != nil {
-				return common.NotificationSenderResponse{}, fmt.Errorf("failed to convert property %s: %w", property.GetName(), err)
+				return common.NotificationSenderResponse{},
+					fmt.Errorf("failed to convert property %s: %w", property.GetName(), err)
 			}
 			senderProperties = append(senderProperties, *propertyDTO)
 		}

--- a/backend/internal/notification/store_constants.go
+++ b/backend/internal/notification/store_constants.go
@@ -24,7 +24,8 @@ var (
 	// queryCreateNotificationSender is the query to create a new notification sender.
 	queryCreateNotificationSender = dbmodel.DBQuery{
 		ID: "NMQ-SM-01",
-		Query: "INSERT INTO NOTIFICATION_SENDER (NAME, SENDER_ID, DESCRIPTION, TYPE, PROVIDER, PROPERTIES, DEPLOYMENT_ID) " +
+		Query: "INSERT INTO NOTIFICATION_SENDER " +
+			"(NAME, SENDER_ID, DESCRIPTION, TYPE, PROVIDER, PROPERTIES, DEPLOYMENT_ID) " +
 			"VALUES ($1, $2, $3, $4, $5, $6, $7)",
 	}
 

--- a/backend/internal/notification/store_test.go
+++ b/backend/internal/notification/store_test.go
@@ -493,7 +493,8 @@ func (suite *StoreTestSuite) TestUpdateSender_SerializeError() {
 func (suite *StoreTestSuite) TestDeleteSender_NoRows() {
 	// delete with 0 rows affected (should not return error)
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().Execute(queryDeleteNotificationSender, "s1", testDeploymentID).Return(int64(0), nil).Once()
+	suite.mockDBClient.EXPECT().Execute(queryDeleteNotificationSender, "s1", testDeploymentID).
+		Return(int64(0), nil).Once()
 
 	err := suite.store.deleteSender("s1")
 	suite.NoError(err)

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -1023,7 +1023,8 @@ func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_Invali
 		jwt   string
 	}{
 		{"InvalidOUID", "ouId", "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJvdUlkIjoxMjM0NX0."},
-		{"InvalidOUName", "ouName", "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJvdU5hbWUiOjEyMzQ1fQ."},
+		{"InvalidOUName", "ouName",
+			"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJvdU5hbWUiOjEyMzQ1fQ."},
 		{"InvalidOUHandle", "ouHandle",
 			"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJvdUhhbmRsZSI6MTIzNDV9."},
 	}

--- a/backend/internal/oauth/oauth2/authz/store.go
+++ b/backend/internal/oauth/oauth2/authz/store.go
@@ -85,7 +85,8 @@ func (acs *authorizationCodeStore) InsertAuthorizationCode(authzCode Authorizati
 	}
 
 	_, err = dbClient.Execute(queryInsertAuthorizationCode, authzCode.CodeID, authzCode.Code,
-		authzCode.ClientID, authzCode.State, jsonDataBytes, authzCode.TimeCreated, authzCode.ExpiryTime, acs.deploymentID)
+		authzCode.ClientID, authzCode.State, jsonDataBytes, authzCode.TimeCreated, authzCode.ExpiryTime,
+		acs.deploymentID)
 	if err != nil {
 		return fmt.Errorf("error inserting authorization code: %w", err)
 	}

--- a/backend/internal/oauth/oauth2/authz/store_test.go
+++ b/backend/internal/oauth/oauth2/authz/store_test.go
@@ -673,8 +673,8 @@ func (suite *AuthorizationCodeStoreTestSuite) TestParseTimeField_InvalidStringFo
 
 func (suite *AuthorizationCodeStoreTestSuite) TestUpdateAuthorizationCodeState_ExecuteError() {
 	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState,
-		AuthCodeStateInactive, suite.testAuthzCode.CodeID, testDeploymentID).Return(int64(0), errors.New("execute error"))
+	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState, AuthCodeStateInactive,
+		suite.testAuthzCode.CodeID, testDeploymentID).Return(int64(0), errors.New("execute error"))
 
 	err := suite.store.DeactivateAuthorizationCode(suite.testAuthzCode)
 	assert.Error(suite.T(), err)

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -567,20 +567,21 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 			var capturedIDTokenClaims map[string]interface{}
 
 			// Mock access token generation - use function return to access context at call time
-			suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-				// Capture user attributes and groups (simulate filtering that happens in BuildAccessToken)
-				capturedAccessTokenClaims = make(map[string]interface{})
-				for k, v := range ctx.UserAttributes {
-					capturedAccessTokenClaims[k] = v
-				}
-				// Add groups if configured in app (simulate BuildAccessToken filtering)
-				if len(ctx.UserGroups) > 0 &&
-					slices.Contains(ctx.OAuthApp.Token.AccessToken.UserAttributes, constants.UserAttributeGroups) {
-					capturedAccessTokenClaims[constants.UserAttributeGroups] = ctx.UserGroups
-				}
-				// Verify GrantType is authorization_code
-				return ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
-			})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
+			suite.mockTokenBuilder.On("BuildAccessToken",
+				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+					// Capture user attributes and groups (simulate filtering that happens in BuildAccessToken)
+					capturedAccessTokenClaims = make(map[string]interface{})
+					for k, v := range ctx.UserAttributes {
+						capturedAccessTokenClaims[k] = v
+					}
+					// Add groups if configured in app (simulate BuildAccessToken filtering)
+					if len(ctx.UserGroups) > 0 &&
+						slices.Contains(ctx.OAuthApp.Token.AccessToken.UserAttributes, constants.UserAttributeGroups) {
+						capturedAccessTokenClaims[constants.UserAttributeGroups] = ctx.UserGroups
+					}
+					// Verify GrantType is authorization_code
+					return ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
+				})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
 				// Simulate filtering that happens in BuildAccessToken
 				userAttrs := make(map[string]interface{})
 				for k, v := range ctx.UserAttributes {
@@ -604,21 +605,23 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 
 			// Mock ID token generation if openid scope is present
 			if tc.includeOpenIDScope {
-				suite.mockTokenBuilder.On("BuildIDToken", mock.MatchedBy(func(ctx *tokenservice.IDTokenBuildContext) bool {
-					// Capture ID token claims
-					capturedIDTokenClaims = make(map[string]interface{})
-					for k, v := range ctx.UserAttributes {
-						capturedIDTokenClaims[k] = v
-					}
-					// Add groups if configured in ID token user attributes
-					if ctx.OAuthApp != nil && ctx.OAuthApp.Token != nil && ctx.OAuthApp.Token.IDToken != nil {
-						idTokenUserAttributes := ctx.OAuthApp.Token.IDToken.UserAttributes
-						if len(ctx.UserGroups) > 0 && slices.Contains(idTokenUserAttributes, constants.UserAttributeGroups) {
-							capturedIDTokenClaims[constants.UserAttributeGroups] = ctx.UserGroups
+				suite.mockTokenBuilder.On("BuildIDToken",
+					mock.MatchedBy(func(ctx *tokenservice.IDTokenBuildContext) bool {
+						// Capture ID token claims
+						capturedIDTokenClaims = make(map[string]interface{})
+						for k, v := range ctx.UserAttributes {
+							capturedIDTokenClaims[k] = v
 						}
-					}
-					return true
-				})).Return(&model.TokenDTO{
+						// Add groups if configured in ID token user attributes
+						if ctx.OAuthApp != nil && ctx.OAuthApp.Token != nil && ctx.OAuthApp.Token.IDToken != nil {
+							idTokenUserAttributes := ctx.OAuthApp.Token.IDToken.UserAttributes
+							if len(ctx.UserGroups) > 0 && slices.Contains(idTokenUserAttributes,
+								constants.UserAttributeGroups) {
+								capturedIDTokenClaims[constants.UserAttributeGroups] = ctx.UserGroups
+							}
+						}
+						return true
+					})).Return(&model.TokenDTO{
 					Token:     "test-id-token",
 					TokenType: "",
 					IssuedAt:  time.Now().Unix(),
@@ -640,7 +643,8 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 				assert.True(suite.T(), ok, tc.description)
 				assert.Equal(suite.T(), tc.expectedGroups, groupsInClaims, tc.description)
 
-				assert.NotNil(suite.T(), result.AccessToken.UserAttributes[constants.UserAttributeGroups], tc.description)
+				assert.NotNil(suite.T(),
+					result.AccessToken.UserAttributes[constants.UserAttributeGroups], tc.description)
 				groupsInAttrs, ok := result.AccessToken.UserAttributes[constants.UserAttributeGroups].([]string)
 				assert.True(suite.T(), ok, tc.description)
 				assert.Equal(suite.T(), tc.expectedGroups, groupsInAttrs, tc.description)
@@ -770,15 +774,16 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 			var capturedIDTokenClaims map[string]interface{}
 
 			// Mock access token generation - use function return to access context at call time
-			suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-				// Capture user attributes which contain groups
-				capturedAccessTokenClaims = make(map[string]interface{})
-				for k, v := range ctx.UserAttributes {
-					capturedAccessTokenClaims[k] = v
-				}
-				// Verify GrantType is authorization_code
-				return ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
-			})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
+			suite.mockTokenBuilder.On("BuildAccessToken",
+				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+					// Capture user attributes which contain groups
+					capturedAccessTokenClaims = make(map[string]interface{})
+					for k, v := range ctx.UserAttributes {
+						capturedAccessTokenClaims[k] = v
+					}
+					// Verify GrantType is authorization_code
+					return ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
+				})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
 				// Return user attributes from the actual call context
 				userAttrs := make(map[string]interface{})
 				for k, v := range ctx.UserAttributes {
@@ -797,11 +802,12 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 
 			// Mock ID token generation if openid scope is present
 			if tc.includeOpenIDScope {
-				suite.mockTokenBuilder.On("BuildIDToken", mock.MatchedBy(func(ctx *tokenservice.IDTokenBuildContext) bool {
-					// Capture ID token claims from user attributes
-					capturedIDTokenClaims = ctx.UserAttributes
-					return true
-				})).Return(&model.TokenDTO{
+				suite.mockTokenBuilder.On("BuildIDToken",
+					mock.MatchedBy(func(ctx *tokenservice.IDTokenBuildContext) bool {
+						// Capture ID token claims from user attributes
+						capturedIDTokenClaims = ctx.UserAttributes
+						return true
+					})).Return(&model.TokenDTO{
 					Token:     "test-id-token",
 					TokenType: "",
 					IssuedAt:  time.Now().Unix(),
@@ -934,7 +940,8 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_NoResourceP
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_FetchUserOUFailed() {
-	suite.T().Skip("OU service is no longer used - OU details are retrieved from authz code which comes from JWT claims")
+	suite.T().Skip("OU service is no longer used - OU details are retrieved from authz code " +
+		"which comes from JWT claims")
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerationFailed() {

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -190,12 +190,13 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 			}
 
 			expectedToken := testJWTToken
-			suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-				return ctx.Subject == testClientID &&
-					ctx.Audience == testClientID &&
-					ctx.ClientID == testClientID &&
-					tokenservice.JoinScopes(ctx.Scopes) == tokenservice.JoinScopes(tc.expectedScopes)
-			})).Return(&model.TokenDTO{
+			suite.mockTokenBuilder.On("BuildAccessToken",
+				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+					return ctx.Subject == testClientID &&
+						ctx.Audience == testClientID &&
+						ctx.ClientID == testClientID &&
+						tokenservice.JoinScopes(ctx.Scopes) == tokenservice.JoinScopes(tc.expectedScopes)
+				})).Return(&model.TokenDTO{
 				Token:     expectedToken,
 				TokenType: constants.TokenTypeBearer,
 				IssuedAt:  int64(1234567890),

--- a/backend/internal/oauth/oauth2/pkce/pkce_test.go
+++ b/backend/internal/oauth/oauth2/pkce/pkce_test.go
@@ -131,7 +131,8 @@ func (suite *PKCETestSuite) TestValidatePKCE() {
 			if tt.expectError {
 				assert.Error(t, err, "Expected error but got none")
 				if tt.expectedError != nil {
-					assert.ErrorIs(t, err, tt.expectedError, "Expected specific error: %v, got: %v", tt.expectedError, err)
+					assert.ErrorIs(t, err, tt.expectedError,
+						"Expected specific error: %v, got: %v", tt.expectedError, err)
 				}
 			} else {
 				assert.NoError(t, err, "Expected no error but got: %v", err)
@@ -193,7 +194,8 @@ func (suite *PKCETestSuite) TestGenerateCodeChallenge() {
 				assert.Error(t, err, "Expected error but got none")
 				assert.Empty(t, challenge, "Challenge should be empty on error")
 				if tt.expectedError != nil {
-					assert.ErrorIs(t, err, tt.expectedError, "Expected specific error: %v, got: %v", tt.expectedError, err)
+					assert.ErrorIs(t, err, tt.expectedError,
+						"Expected specific error: %v, got: %v", tt.expectedError, err)
 				}
 			} else {
 				assert.NoError(t, err, "Expected no error but got: %v", err)
@@ -293,7 +295,8 @@ func (suite *PKCETestSuite) TestValidateCodeChallenge() {
 			if tt.expectError {
 				assert.Error(t, err, "Expected error but got none")
 				if tt.expectedError != nil {
-					assert.ErrorIs(t, err, tt.expectedError, "Expected specific error: %v, got: %v", tt.expectedError, err)
+					assert.ErrorIs(t, err, tt.expectedError,
+						"Expected specific error: %v, got: %v", tt.expectedError, err)
 				}
 			} else {
 				assert.NoError(t, err, "Expected no error but got: %v", err)

--- a/backend/internal/observability/adapter/file_adapter.go
+++ b/backend/internal/observability/adapter/file_adapter.go
@@ -306,7 +306,8 @@ func (fa *FileAdapter) compressFile(filePath string) {
 
 	// Remove original file
 	if err := os.Remove(filePath); err != nil {
-		logger.Error("Failed to remove original file after compression", log.String("filePath", filePath), log.Error(err))
+		logger.Error("Failed to remove original file after compression",
+			log.String("filePath", filePath), log.Error(err))
 		return
 	}
 

--- a/backend/internal/ou/handler.go
+++ b/backend/internal/ou/handler.go
@@ -438,8 +438,9 @@ func (ouh *organizationUnitHandler) handleResourceListByPathRequest(
 			count = resp.Count
 		}
 
-		logger.Debug("Successfully listed resources in organization unit by path", log.String("resourceType", resourceType),
-			log.String("path", path), log.Int("limit", limit), log.Int("offset", offset),
+		logger.Debug("Successfully listed resources in organization unit by path",
+			log.String("resourceType", resourceType), log.String("path", path),
+			log.Int("limit", limit), log.Int("offset", offset),
 			log.Int("totalResults", totalResults), log.Int("count", count))
 	}
 }

--- a/backend/internal/ou/handler_test.go
+++ b/backend/internal/ou/handler_test.go
@@ -1154,7 +1154,8 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutByPathRe
 			pathParamValue: defaultOUPath,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("UpdateOrganizationUnitByPath", defaultOUPath, mock.AnythingOfType("ou.OrganizationUnitRequest")).
+					On("UpdateOrganizationUnitByPath", defaultOUPath,
+						mock.AnythingOfType("ou.OrganizationUnitRequest")).
 					Return(OrganizationUnit{}, &ErrorInternalServerError).
 					Once()
 			},
@@ -1176,7 +1177,8 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutByPathRe
 			useFlaky:       true,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("UpdateOrganizationUnitByPath", defaultOUPath, mock.AnythingOfType("ou.OrganizationUnitRequest")).
+					On("UpdateOrganizationUnitByPath", defaultOUPath,
+						mock.AnythingOfType("ou.OrganizationUnitRequest")).
 					Return(OrganizationUnit{ID: defaultOURequestID}, nil).
 					Once()
 			},
@@ -1195,7 +1197,8 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutByPathRe
 			pathParamValue: defaultOUPath,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("UpdateOrganizationUnitByPath", defaultOUPath, mock.AnythingOfType("ou.OrganizationUnitRequest")).
+					On("UpdateOrganizationUnitByPath", defaultOUPath,
+						mock.AnythingOfType("ou.OrganizationUnitRequest")).
 					Return(OrganizationUnit{ID: defaultOURequestID}, nil).
 					Once()
 			},

--- a/backend/internal/ou/storeconstants.go
+++ b/backend/internal/ou/storeconstants.go
@@ -90,8 +90,8 @@ var (
 	// queryGetOrganizationUnitChildrenList is the query to get child organization units with pagination.
 	queryGetOrganizationUnitChildrenList = dbmodel.DBQuery{
 		ID: "OUQ-OU_MGT-11",
-		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION FROM ORGANIZATION_UNIT WHERE PARENT_ID = $1 AND DEPLOYMENT_ID = $4 ` +
-			`ORDER BY NAME LIMIT $2 OFFSET $3`,
+		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION FROM ORGANIZATION_UNIT ` +
+			`WHERE PARENT_ID = $1 AND DEPLOYMENT_ID = $4 ORDER BY NAME LIMIT $2 OFFSET $3`,
 	}
 
 	// queryGetOrganizationUnitUsersCount is the query to get total count of users in an organization unit.
@@ -114,29 +114,33 @@ var (
 
 	// queryGetOrganizationUnitGroupsList is the query to get groups in an organization unit with pagination.
 	queryGetOrganizationUnitGroupsList = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-15",
-		Query: `SELECT GROUP_ID, NAME FROM "GROUP" WHERE OU_ID = $1 AND DEPLOYMENT_ID = $4 ORDER BY NAME LIMIT $2 OFFSET $3`,
+		ID: "OUQ-OU_MGT-15",
+		Query: `SELECT GROUP_ID, NAME FROM "GROUP" WHERE OU_ID = $1 AND DEPLOYMENT_ID = $4 ` +
+			`ORDER BY NAME LIMIT $2 OFFSET $3`,
 	}
 
 	// queryCheckOrganizationUnitNameConflict is the query to check if an organization
 	// unit name conflicts under the same parent.
 	queryCheckOrganizationUnitNameConflict = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-16",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE NAME = $1 AND PARENT_ID = $2 AND DEPLOYMENT_ID = $3`,
+		ID: "OUQ-OU_MGT-16",
+		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT ` +
+			`WHERE NAME = $1 AND PARENT_ID = $2 AND DEPLOYMENT_ID = $3`,
 	}
 
 	// queryCheckOrganizationUnitNameConflictRoot is the query to check if an organization
 	// unit name conflicts at root level.
 	queryCheckOrganizationUnitNameConflictRoot = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-17",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE NAME = $1 AND PARENT_ID IS NULL AND DEPLOYMENT_ID = $2`,
+		ID: "OUQ-OU_MGT-17",
+		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT ` +
+			`WHERE NAME = $1 AND PARENT_ID IS NULL AND DEPLOYMENT_ID = $2`,
 	}
 
 	// queryCheckOrganizationUnitHandleConflict is the query to check if an organization
 	// unit handle conflicts under the same parent.
 	queryCheckOrganizationUnitHandleConflict = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-18",
-		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT WHERE HANDLE = $1 AND PARENT_ID = $2 AND DEPLOYMENT_ID = $3`,
+		ID: "OUQ-OU_MGT-18",
+		Query: `SELECT COUNT(*) as count FROM ORGANIZATION_UNIT ` +
+			`WHERE HANDLE = $1 AND PARENT_ID = $2 AND DEPLOYMENT_ID = $3`,
 	}
 
 	// queryCheckOrganizationUnitHandleConflictRoot is the query to check if an organization

--- a/backend/internal/resource/handler_test.go
+++ b/backend/internal/resource/handler_test.go
@@ -868,7 +868,8 @@ func (suite *HandlerTestSuite) TestHandleResourceListRequest_InvalidLimit() {
 }
 
 func (suite *HandlerTestSuite) TestHandleResourceListRequest_ServiceError() {
-	suite.mockService.On("GetResourceList", "rs-123", (*string)(nil), 30, 0).Return(nil, &serviceerror.InternalServerError)
+	suite.mockService.On("GetResourceList", "rs-123", (*string)(nil), 30, 0).
+		Return(nil, &serviceerror.InternalServerError)
 
 	req := httptest.NewRequest("GET", "/resource-servers/rs-123/resources", nil)
 	req.SetPathValue("rsId", "rs-123")
@@ -1095,7 +1096,8 @@ func (suite *HandlerTestSuite) TestHandleActionPutAtResourceServerRequest_Servic
 
 func (suite *HandlerTestSuite) TestHandleActionDeleteAtResourceServerRequest_ServiceError() {
 	var nilResourceID *string
-	suite.mockService.On("DeleteAction", "rs-123", nilResourceID, "action-123").Return(&serviceerror.InternalServerError)
+	suite.mockService.On("DeleteAction", "rs-123", nilResourceID, "action-123").
+		Return(&serviceerror.InternalServerError)
 
 	req := httptest.NewRequest("DELETE", "/resource-servers/rs-123/actions/action-123", nil)
 	req.SetPathValue("rsId", "rs-123")

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -53,7 +53,9 @@ type ResourceServiceInterface interface {
 	// Action operations
 	CreateAction(resourceServerID string, resourceID *string, action Action) (*Action, *serviceerror.ServiceError)
 	GetAction(resourceServerID string, resourceID *string, id string) (*Action, *serviceerror.ServiceError)
-	GetActionList(resourceServerID string, resourceID *string, limit, offset int) (*ActionList, *serviceerror.ServiceError)
+	GetActionList(
+		resourceServerID string, resourceID *string, limit, offset int,
+	) (*ActionList, *serviceerror.ServiceError)
 	UpdateAction(
 		resourceServerID string, resourceID *string, id string, action Action,
 	) (*Action, *serviceerror.ServiceError)
@@ -121,7 +123,8 @@ func (rs *resourceService) CreateResourceServer(
 			return nil, &serviceerror.InternalServerError
 		}
 		if identifierExists {
-			rs.logger.Debug("Resource server identifier already exists", log.String("identifier", resourceServer.Identifier))
+			rs.logger.Debug("Resource server identifier already exists",
+				log.String("identifier", resourceServer.Identifier))
 			return nil, &ErrorIdentifierConflict
 		}
 	}
@@ -247,7 +250,8 @@ func (rs *resourceService) UpdateResourceServer(
 			return nil, &serviceerror.InternalServerError
 		}
 		if identifierExists {
-			rs.logger.Debug("Resource server identifier already exists", log.String("identifier", resourceServer.Identifier))
+			rs.logger.Debug("Resource server identifier already exists",
+				log.String("identifier", resourceServer.Identifier))
 			return nil, &ErrorIdentifierConflict
 		}
 	}

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -764,7 +764,8 @@ func (suite *ResourceServiceTestSuite) TestCreateResource_MultiLevelHierarchy() 
 	suite.mockStore.On("CheckResourceExistAndGetInternalID", rootID, 123).Return(100, nil).Once()
 	rootInternalID := 100
 	suite.mockStore.On("CheckResourceHandleExists", 123, "child", &rootInternalID).Return(false, nil).Once()
-	suite.mockStore.On("CreateResource", mock.AnythingOfType("string"), 123, &rootInternalID, childRes).Return(nil).Once()
+	suite.mockStore.On("CreateResource", mock.AnythingOfType("string"), 123, &rootInternalID, childRes).
+		Return(nil).Once()
 
 	result2, err2 := suite.service.CreateResource("rs-123", childRes)
 	suite.Nil(err2)
@@ -993,7 +994,8 @@ func (suite *ResourceServiceTestSuite) TestCreateResource_SameHandleDifferentPar
 	suite.mockStore.On("CheckResourceExistAndGetInternalID", "parent-a", 123).Return(100, nil).Once()
 	parentAInternalID := 100
 	suite.mockStore.On("CheckResourceHandleExists", 123, "users", &parentAInternalID).Return(false, nil).Once()
-	suite.mockStore.On("CreateResource", mock.AnythingOfType("string"), 123, &parentAInternalID, res1).Return(nil).Once()
+	suite.mockStore.On("CreateResource", mock.AnythingOfType("string"), 123, &parentAInternalID, res1).
+		Return(nil).Once()
 
 	result1, err1 := suite.service.CreateResource("rs-123", res1)
 
@@ -1005,7 +1007,8 @@ func (suite *ResourceServiceTestSuite) TestCreateResource_SameHandleDifferentPar
 	suite.mockStore.On("CheckResourceExistAndGetInternalID", "parent-b", 123).Return(200, nil).Once()
 	parentBInternalID := 200
 	suite.mockStore.On("CheckResourceHandleExists", 123, "users", &parentBInternalID).Return(false, nil).Once()
-	suite.mockStore.On("CreateResource", mock.AnythingOfType("string"), 123, &parentBInternalID, res2).Return(nil).Once()
+	suite.mockStore.On("CreateResource", mock.AnythingOfType("string"), 123, &parentBInternalID, res2).
+		Return(nil).Once()
 
 	result2, err2 := suite.service.CreateResource("rs-123", res2)
 
@@ -1715,7 +1718,8 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errResourceServerNotFound)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errResourceServerNotFound)
 			},
 			expectedError: &ErrorResourceServerNotFound,
 		},
@@ -1727,7 +1731,8 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 			offset:           0,
 			setupMocks: func() {
 				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("CheckResourceExistAndGetInternalID", testParentResourceID, 123).Return(0, errResourceNotFound)
+				suite.mockStore.On("CheckResourceExistAndGetInternalID", testParentResourceID, 123).
+					Return(0, errResourceNotFound)
 			},
 			expectedError: &ErrorResourceNotFound,
 		},
@@ -1738,7 +1743,8 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errors.New("database error"))
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -1762,8 +1768,10 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("GetResourceListCountByParent", 123, (*int)(nil)).Return(0, errors.New("database error"))
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("GetResourceListCountByParent", 123, (*int)(nil)).
+					Return(0, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -1774,9 +1782,12 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("GetResourceListCountByParent", 123, (*int)(nil)).Return(10, nil)
-				suite.mockStore.On("GetResourceListByParent", 123, (*int)(nil), 30, 0).Return(nil, errors.New("database error"))
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("GetResourceListCountByParent", 123, (*int)(nil)).
+					Return(10, nil)
+				suite.mockStore.On("GetResourceListByParent", 123, (*int)(nil), 30, 0).
+					Return(nil, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -2183,7 +2194,8 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResourceServer() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errResourceServerNotFound)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errResourceServerNotFound)
 			},
 			expectedError: &ErrorResourceServerNotFound,
 		},
@@ -2194,7 +2206,8 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResourceServer() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errors.New("database error"))
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -2318,11 +2331,17 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 					Handle:      testOriginalHandle,
 					Description: "old description",
 				}
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("GetAction", "action-123", 123, (*int)(nil)).Return(currentAction, nil)
-				suite.mockStore.On("UpdateAction", "action-123", 123, (*int)(nil), mock.MatchedBy(func(a Action) bool {
-					return a.Name == testUpdatedName && a.Handle == testOriginalHandle && a.Description == testNewDescription
-				})).Return(nil)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("GetAction", "action-123", 123, (*int)(nil)).
+					Return(currentAction, nil)
+				suite.mockStore.On(
+					"UpdateAction", "action-123", 123, (*int)(nil),
+					mock.MatchedBy(func(a Action) bool {
+						return a.Name == testUpdatedName &&
+							a.Handle == testOriginalHandle &&
+							a.Description == testNewDescription
+					})).Return(nil)
 			},
 			expectedError: nil,
 			validateResponse: func(result *Action) {
@@ -2347,13 +2366,19 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 					Handle:      testOriginalHandle,
 					Description: "old description",
 				}
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(456, nil)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+					Return(456, nil)
 				resInternalID := 456
-				suite.mockStore.On("GetAction", "action-123", 123, &resInternalID).Return(currentAction, nil)
-				suite.mockStore.On("UpdateAction", "action-123", 123, &resInternalID, mock.MatchedBy(func(a Action) bool {
-					return a.Name == testUpdatedName && a.Handle == testOriginalHandle && a.Description == testNewDescription
-				})).Return(nil)
+				suite.mockStore.On("GetAction", "action-123", 123, &resInternalID).
+					Return(currentAction, nil)
+				suite.mockStore.On("UpdateAction", "action-123", 123, &resInternalID,
+					mock.MatchedBy(func(a Action) bool {
+						return a.Name == testUpdatedName &&
+							a.Handle == testOriginalHandle &&
+							a.Description == testNewDescription
+					})).Return(nil)
 			},
 			expectedError: nil,
 			validateResponse: func(result *Action) {
@@ -2396,7 +2421,8 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errResourceServerNotFound)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errResourceServerNotFound)
 			},
 			expectedError: &ErrorResourceServerNotFound,
 		},
@@ -2407,8 +2433,10 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(0, errResourceNotFound)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+					Return(0, errResourceNotFound)
 			},
 			expectedError: &ErrorResourceNotFound,
 		},
@@ -2431,10 +2459,13 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(456, nil)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+					Return(456, nil)
 				resInternalID := 456
-				suite.mockStore.On("GetAction", "action-123", 123, &resInternalID).Return(Action{}, errActionNotFound)
+				suite.mockStore.On("GetAction", "action-123", 123, &resInternalID).
+					Return(Action{}, errActionNotFound)
 			},
 			expectedError: &ErrorActionNotFound,
 		},
@@ -2445,7 +2476,8 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errors.New("database error"))
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -2456,7 +2488,8 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
 				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
 					Return(0, errors.New("database error"))
 			},
@@ -2469,8 +2502,10 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("GetAction", "action-123", 123, (*int)(nil)).Return(Action{}, errors.New("database error"))
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("GetAction", "action-123", 123, (*int)(nil)).
+					Return(Action{}, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -2652,7 +2687,8 @@ func (suite *ResourceServiceTestSuite) TestDeleteActionAtResource_StoreError() {
 }
 
 func (suite *ResourceServiceTestSuite) TestDeleteActionAtResource_CheckServerError() {
-	suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errors.New("database error"))
+	suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+		Return(0, errors.New("database error"))
 
 	resID := testResourceID
 	err := suite.service.DeleteAction("rs-123", &resID, "action-123")
@@ -2663,7 +2699,8 @@ func (suite *ResourceServiceTestSuite) TestDeleteActionAtResource_CheckServerErr
 
 func (suite *ResourceServiceTestSuite) TestDeleteActionAtResource_CheckResourceError() {
 	suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-	suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(0, errors.New("database error"))
+	suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+		Return(0, errors.New("database error"))
 
 	resID := testResourceID
 	err := suite.service.DeleteAction("rs-123", &resID, "action-123")
@@ -2792,7 +2829,8 @@ func (suite *ResourceServiceTestSuite) TestGetActionAtResource_StoreError() {
 }
 
 func (suite *ResourceServiceTestSuite) TestGetActionAtResource_CheckServerError() {
-	suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errors.New("database error"))
+	suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+		Return(0, errors.New("database error"))
 
 	resID := testResourceID
 	result, err := suite.service.GetAction("rs-123", &resID, "action-123")
@@ -2804,7 +2842,8 @@ func (suite *ResourceServiceTestSuite) TestGetActionAtResource_CheckServerError(
 
 func (suite *ResourceServiceTestSuite) TestGetActionAtResource_CheckResourceError() {
 	suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-	suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(0, errors.New("database error"))
+	suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+		Return(0, errors.New("database error"))
 
 	resID := testResourceID
 	result, err := suite.service.GetAction("rs-123", &resID, "action-123")
@@ -2968,7 +3007,8 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errResourceServerNotFound)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errResourceServerNotFound)
 			},
 			expectedError: &ErrorResourceServerNotFound,
 		},
@@ -2979,8 +3019,10 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(0, errResourceNotFound)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+					Return(0, errResourceNotFound)
 			},
 			expectedError: &ErrorResourceNotFound,
 		},
@@ -2991,7 +3033,8 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(0, errors.New("database error"))
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(0, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -3015,10 +3058,13 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(456, nil)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+					Return(456, nil)
 				resInternalID := 456
-				suite.mockStore.On("GetActionListCount", 123, &resInternalID).Return(0, errors.New("database error"))
+				suite.mockStore.On("GetActionListCount", 123, &resInternalID).
+					Return(0, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},
@@ -3029,11 +3075,14 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
-				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").Return(123, nil)
-				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).Return(456, nil)
+				suite.mockStore.On("CheckResourceServerExistAndGetInternalID", "rs-123").
+					Return(123, nil)
+				suite.mockStore.On("CheckResourceExistAndGetInternalID", testResourceID, 123).
+					Return(456, nil)
 				resInternalID := 456
 				suite.mockStore.On("GetActionListCount", 123, &resInternalID).Return(2, nil)
-				suite.mockStore.On("GetActionList", 123, &resInternalID, 30, 0).Return(nil, errors.New("database error"))
+				suite.mockStore.On("GetActionList", 123, &resInternalID, 30, 0).
+					Return(nil, errors.New("database error"))
 			},
 			expectedError: &serviceerror.InternalServerError,
 		},

--- a/backend/internal/resource/store.go
+++ b/backend/internal/resource/store.go
@@ -455,7 +455,8 @@ func (s *resourceStore) CheckResourceHandleExists(
 			)
 		} else {
 			results, err = dbClient.Query(
-				queryCheckResourceHandleExistsUnderParent, resServerInternalID, handle, *parentInternalID, s.deploymentID,
+				queryCheckResourceHandleExistsUnderParent, resServerInternalID, handle, *parentInternalID,
+				s.deploymentID,
 			)
 		}
 
@@ -575,7 +576,8 @@ func (s *resourceStore) GetActionList(
 ) ([]Action, error) {
 	var actions []Action
 	err := s.withDBClient(func(dbClient provider.DBClientInterface) error {
-		results, err := dbClient.Query(queryGetActionList, resServerInternalID, resInternalID, limit, offset, s.deploymentID)
+		results, err := dbClient.Query(queryGetActionList, resServerInternalID, resInternalID, limit, offset,
+			s.deploymentID)
 		if err != nil {
 			return fmt.Errorf("failed to get action list: %w", err)
 		}

--- a/backend/internal/resource/store_constants.go
+++ b/backend/internal/resource/store_constants.go
@@ -108,7 +108,8 @@ var (
 	queryCreateResource = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-11",
 		Query: `INSERT INTO RESOURCE
-		        (RESOURCE_ID, RESOURCE_SERVER_ID, NAME, HANDLE, DESCRIPTION, PROPERTIES, PARENT_RESOURCE_ID, DEPLOYMENT_ID)
+		        (RESOURCE_ID, RESOURCE_SERVER_ID, NAME, HANDLE, DESCRIPTION, PROPERTIES,
+				PARENT_RESOURCE_ID, DEPLOYMENT_ID)
 		        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 	}
 
@@ -204,16 +205,16 @@ var (
 	queryCheckResourceHandleExistsUnderParent = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-21",
 		Query: `SELECT COUNT(*) as count
-		        FROM RESOURCE r
-		        WHERE r.RESOURCE_SERVER_ID = $1 AND r.HANDLE = $2 AND r.PARENT_RESOURCE_ID = $3 AND r.DEPLOYMENT_ID = $4`,
+		        FROM RESOURCE r WHERE r.RESOURCE_SERVER_ID = $1 AND r.HANDLE = $2
+				AND r.PARENT_RESOURCE_ID = $3 AND r.DEPLOYMENT_ID = $4`,
 	}
 
 	// queryCheckResourceHandleExistsUnderNullParent checks if resource handle exists at top level.
 	queryCheckResourceHandleExistsUnderNullParent = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-22",
 		Query: `SELECT COUNT(*) as count
-		        FROM RESOURCE r
-		        WHERE r.RESOURCE_SERVER_ID = $1 AND r.HANDLE = $2 AND r.PARENT_RESOURCE_ID IS NULL AND r.DEPLOYMENT_ID = $3`,
+		        FROM RESOURCE r WHERE r.RESOURCE_SERVER_ID = $1 AND r.HANDLE = $2
+				AND r.PARENT_RESOURCE_ID IS NULL AND r.DEPLOYMENT_ID = $3`,
 	}
 
 	// queryCheckResourceHasDependencies checks if resource has sub-resources or actions.
@@ -234,7 +235,8 @@ var (
 	queryCheckCircularDependency = dbmodel.DBQuery{
 		ID: "RSQ-RES_MGT-24",
 		Query: `WITH RECURSIVE parent_hierarchy AS (
-			SELECT ID, RESOURCE_ID, PARENT_RESOURCE_ID, DEPLOYMENT_ID FROM RESOURCE WHERE RESOURCE_ID = $1 AND DEPLOYMENT_ID = $3
+			SELECT ID, RESOURCE_ID, PARENT_RESOURCE_ID, DEPLOYMENT_ID FROM RESOURCE 
+			WHERE RESOURCE_ID = $1 AND DEPLOYMENT_ID = $3
 			UNION ALL
 			SELECT r.ID, r.RESOURCE_ID, r.PARENT_RESOURCE_ID, r.DEPLOYMENT_ID
 			FROM RESOURCE r

--- a/backend/internal/resource/store_test.go
+++ b/backend/internal/resource/store_test.go
@@ -121,15 +121,16 @@ func (suite *ResourceStoreTestSuite) TestCreateResourceServer_DBClientError() {
 
 func (suite *ResourceStoreTestSuite) TestGetResourceServer_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetResourceServerByID, "rs1", "test-deployment").Return([]map[string]interface{}{
-		{
-			"resource_server_id": "rs1",
-			"ou_id":              "ou1",
-			"name":               "Test Server",
-			"description":        "Test Description",
-			"identifier":         "test-identifier",
-		},
-	}, nil)
+	suite.mockDBClient.On("Query", queryGetResourceServerByID, "rs1", "test-deployment").
+		Return([]map[string]interface{}{
+			{
+				"resource_server_id": "rs1",
+				"ou_id":              "ou1",
+				"name":               "Test Server",
+				"description":        "Test Description",
+				"identifier":         "test-identifier",
+			},
+		}, nil)
 
 	rs, err := suite.store.GetResourceServer("rs1")
 
@@ -167,22 +168,23 @@ func (suite *ResourceStoreTestSuite) TestGetResourceServer_QueryError() {
 
 func (suite *ResourceStoreTestSuite) TestGetResourceServerList_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetResourceServerList, 10, 0, "test-deployment").Return([]map[string]interface{}{
-		{
-			"resource_server_id": "rs1",
-			"ou_id":              "ou1",
-			"name":               "Server 1",
-			"description":        "Description 1",
-			"identifier":         "identifier-1",
-		},
-		{
-			"resource_server_id": "rs2",
-			"ou_id":              "ou1",
-			"name":               "Server 2",
-			"description":        "Description 2",
-			"identifier":         "identifier-2",
-		},
-	}, nil)
+	suite.mockDBClient.On("Query", queryGetResourceServerList, 10, 0, "test-deployment").
+		Return([]map[string]interface{}{
+			{
+				"resource_server_id": "rs1",
+				"ou_id":              "ou1",
+				"name":               "Server 1",
+				"description":        "Description 1",
+				"identifier":         "identifier-1",
+			},
+			{
+				"resource_server_id": "rs2",
+				"ou_id":              "ou1",
+				"name":               "Server 2",
+				"description":        "Description 2",
+				"identifier":         "identifier-2",
+			},
+		}, nil)
 
 	servers, err := suite.store.GetResourceServerList(10, 0)
 
@@ -205,13 +207,14 @@ func (suite *ResourceStoreTestSuite) TestGetResourceServerList_QueryError() {
 
 func (suite *ResourceStoreTestSuite) TestGetResourceServerList_InvalidRowData() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetResourceServerList, 10, 0, "test-deployment").Return([]map[string]interface{}{
-		{
-			"resource_server_id": 123, // Invalid type
-			"ou_id":              "ou1",
-			"name":               "Server 1",
-		},
-	}, nil)
+	suite.mockDBClient.On("Query", queryGetResourceServerList, 10, 0, "test-deployment").
+		Return([]map[string]interface{}{
+			{
+				"resource_server_id": 123, // Invalid type
+				"ou_id":              "ou1",
+				"name":               "Server 1",
+			},
+		}, nil)
 
 	servers, err := suite.store.GetResourceServerList(10, 0)
 

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -161,7 +161,8 @@ func (suite *RoleServiceTestSuite) TestCreateRole_Success() {
 	suite.mockOUService.On("GetOrganizationUnit", "ou1").Return(ou, nil)
 	suite.mockStore.On("CheckRoleNameExists", "ou1", "Test Role").Return(false, nil)
 	suite.mockUserService.On("ValidateUserIDs", []string{testUserID1}).Return([]string{}, nil)
-	suite.mockStore.On("CreateRole", mock.AnythingOfType("string"), mock.AnythingOfType("RoleCreationDetail")).Return(nil)
+	suite.mockStore.On("CreateRole", mock.AnythingOfType("string"),
+		mock.AnythingOfType("RoleCreationDetail")).Return(nil)
 
 	result, err := suite.service.CreateRole(request)
 

--- a/backend/internal/role/store_test.go
+++ b/backend/internal/role/store_test.go
@@ -155,8 +155,8 @@ func (suite *RoleStoreTestSuite) TestCreateRole_Success() {
 		Return(&mockResult{}, nil)
 	suite.mockTx.On("Exec", queryCreateRolePermission.Query, mock.Anything, "perm2", testDeploymentID).
 		Return(&mockResult{}, nil)
-	suite.mockTx.On("Exec", queryCreateRoleAssignment.Query, mock.Anything, AssigneeTypeUser, "user1", testDeploymentID).
-		Return(&mockResult{}, nil)
+	suite.mockTx.On("Exec", queryCreateRoleAssignment.Query, mock.Anything, AssigneeTypeUser, "user1",
+		testDeploymentID).Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(nil)
 
 	err := suite.store.CreateRole("role1", roleDetail)
@@ -244,9 +244,10 @@ func (suite *RoleStoreTestSuite) TestIsRoleExist_Exists() {
 
 func (suite *RoleStoreTestSuite) TestIsRoleExist_DoesNotExist() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryCheckRoleExists, "nonexistent", testDeploymentID).Return([]map[string]interface{}{
-		{"count": int64(0)},
-	}, nil)
+	suite.mockDBClient.On("Query", queryCheckRoleExists, "nonexistent", testDeploymentID).
+		Return([]map[string]interface{}{
+			{"count": int64(0)},
+		}, nil)
 
 	exists, err := suite.store.IsRoleExist("nonexistent")
 
@@ -296,7 +297,8 @@ func (suite *RoleStoreTestSuite) TestUpdateRole_Success() {
 	suite.mockTx.On("Exec", queryUpdateRole.Query, "ou1", "Updated Role", "Updated Description", "role1",
 		testDeploymentID).Return(&mockResult{rowsAffected: 1}, nil)
 	suite.mockTx.On("Exec", queryDeleteRolePermissions.Query, "role1", testDeploymentID).Return(&mockResult{}, nil)
-	suite.mockTx.On("Exec", queryCreateRolePermission.Query, "role1", "perm1", testDeploymentID).Return(&mockResult{}, nil)
+	suite.mockTx.On("Exec", queryCreateRolePermission.Query, "role1", "perm1", testDeploymentID).
+		Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(nil)
 
 	err := suite.store.UpdateRole("role1", roleDetail)
@@ -367,8 +369,8 @@ func (suite *RoleStoreTestSuite) TestRemoveAssignments_Success() {
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
-	suite.mockTx.On("Exec", queryDeleteRoleAssignmentsByIDs.Query, "role1", AssigneeTypeUser, "user1", testDeploymentID).
-		Return(&mockResult{}, nil)
+	suite.mockTx.On("Exec", queryDeleteRoleAssignmentsByIDs.Query, "role1", AssigneeTypeUser, "user1",
+		testDeploymentID).Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(nil)
 
 	err := suite.store.RemoveAssignments("role1", assignments)

--- a/backend/internal/role/storeconstants.go
+++ b/backend/internal/role/storeconstants.go
@@ -85,8 +85,9 @@ var (
 
 	// queryCreateRoleAssignment creates a new role assignment.
 	queryCreateRoleAssignment = dbmodel.DBQuery{
-		ID:    "RLQ-ROLE_MGT-10",
-		Query: `INSERT INTO ROLE_ASSIGNMENT (ROLE_ID, ASSIGNEE_TYPE, ASSIGNEE_ID, DEPLOYMENT_ID) VALUES ($1, $2, $3, $4)`,
+		ID: "RLQ-ROLE_MGT-10",
+		Query: `INSERT INTO ROLE_ASSIGNMENT (ROLE_ID, ASSIGNEE_TYPE, ASSIGNEE_ID, DEPLOYMENT_ID) 
+			VALUES ($1, $2, $3, $4)`,
 	}
 
 	// queryGetRoleAssignments retrieves all assignments for a role with pagination.
@@ -117,8 +118,9 @@ var (
 
 	// queryCheckRoleNameExistsExcludingID checks if a role name exists for an OU excluding a specific role ID.
 	queryCheckRoleNameExistsExcludingID = dbmodel.DBQuery{
-		ID:    "RLQ-ROLE_MGT-15",
-		Query: `SELECT COUNT(*) as count FROM "ROLE" WHERE OU_ID = $1 AND NAME = $2 AND ROLE_ID != $3 AND DEPLOYMENT_ID = $4`,
+		ID: "RLQ-ROLE_MGT-15",
+		Query: `SELECT COUNT(*) as count FROM "ROLE" 
+			WHERE OU_ID = $1 AND NAME = $2 AND ROLE_ID != $3 AND DEPLOYMENT_ID = $4`,
 	}
 
 	// queryCheckRoleExists checks if a role exists by its ID.

--- a/backend/internal/system/crypto/hash/utils.go
+++ b/backend/internal/system/crypto/hash/utils.go
@@ -99,7 +99,8 @@ func verifySHA256Credential(credentialValueToVerify []byte, referenceCredential 
 func newPBKDF2Credential(credentialValue []byte) Credential {
 	credSalt, _ := generateSalt()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "PBKDF2HashProvider"))
-	hash, err := pbkdf2.Key(sha256.New, string(credentialValue), credSalt, defaultPBKDF2Iterations, defaultPBKDF2KeyLength)
+	hash, err := pbkdf2.Key(sha256.New, string(credentialValue), credSalt, defaultPBKDF2Iterations,
+		defaultPBKDF2KeyLength)
 	if err != nil {
 		logger.Error("Error hashing data with PBKDF2: %v", log.Error(err))
 		return Credential{}

--- a/backend/internal/system/export/handler_test.go
+++ b/backend/internal/system/export/handler_test.go
@@ -199,7 +199,8 @@ func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_SingleFileNoFolder
 		},
 	}
 
-	suite.testZipResponse(exportResponse, "standalone.yaml", "name: standalone-app\ndescription: Standalone Application")
+	suite.testZipResponse(exportResponse, "standalone.yaml",
+		"name: standalone-app\ndescription: Standalone Application")
 }
 
 // TestGenerateAndSendZipResponse_EmptyFiles tests ZIP generation with empty files list.

--- a/backend/internal/system/middleware/correlationid_test.go
+++ b/backend/internal/system/middleware/correlationid_test.go
@@ -166,7 +166,8 @@ func TestCorrelationIDMiddleware_XRequestIDPriorityOverXTraceID(t *testing.T) {
 	middleware.ServeHTTP(w, req)
 
 	if actualID != expectedID {
-		t.Errorf("Expected trace ID %s (X-Request-ID should take priority over X-Trace-ID), got %s", expectedID, actualID)
+		t.Errorf("Expected trace ID %s (X-Request-ID should take priority over X-Trace-ID), got %s",
+			expectedID, actualID)
 	}
 }
 

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -434,7 +434,8 @@ func (us *userService) UpdateUserAttributes(
 			logger.Debug("User not found", log.String("id", userID))
 			return nil, &ErrorUserNotFound
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to update user attributes", err, log.String("id", userID))
+		return nil, logErrorAndReturnServerError(logger, "Failed to update user attributes", err,
+			log.String("id", userID))
 	}
 
 	logger.Debug("Successfully updated user attributes", log.String("id", userID))
@@ -675,7 +676,8 @@ func (us *userService) VerifyUser(
 		}
 
 		if matchingCredential == nil {
-			logger.Debug("No stored credential found for type", log.String("userID", userID), log.String("credType", credType))
+			logger.Debug("No stored credential found for type",
+				log.String("userID", userID), log.String("credType", credType))
 			return nil, &ErrorAuthenticationFailed
 		}
 
@@ -687,9 +689,11 @@ func (us *userService) VerifyUser(
 		hashVerified := hash.Verify([]byte(credValue), verifyingCredential)
 
 		if hashVerified {
-			logger.Debug("Credential verified successfully", log.String("userID", userID), log.String("credType", credType))
+			logger.Debug("Credential verified successfully",
+				log.String("userID", userID), log.String("credType", credType))
 		} else {
-			logger.Debug("Credential verification failed", log.String("userID", userID), log.String("credType", credType))
+			logger.Debug("Credential verification failed",
+				log.String("userID", userID), log.String("credType", credType))
 			return nil, &ErrorAuthenticationFailed
 		}
 	}

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -74,7 +74,8 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
 				require.NotNil(t, err)
 				require.Equal(t, ErrorInternalServerError.Code, err.Code)
-				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness",
+					mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -94,7 +95,8 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
 				require.NotNil(t, err)
 				require.Equal(t, ErrorUserSchemaNotFound, *err)
-				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness",
+					mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -118,7 +120,8 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
 				require.NotNil(t, err)
 				require.Equal(t, ErrorInternalServerError, *err)
-				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness",
+					mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -138,7 +141,8 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			assert: func(t *testing.T, err *serviceerror.ServiceError, mocks testMocks) {
 				require.NotNil(t, err)
 				require.Equal(t, ErrorSchemaValidationFailed, *err)
-				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything)
+				mocks.schemaService.AssertNotCalled(t, "ValidateUserUniqueness",
+					mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{

--- a/backend/internal/user/storeconstants.go
+++ b/backend/internal/user/storeconstants.go
@@ -71,8 +71,9 @@ var (
 	}
 	// QueryValidateUserWithCredentials is the query to validate the user with the give credentials.
 	QueryValidateUserWithCredentials = model.DBQuery{
-		ID:    "ASQ-USER_MGT-07",
-		Query: "SELECT USER_ID, OU_ID, TYPE, ATTRIBUTES, CREDENTIALS FROM \"USER\" WHERE USER_ID = $1 AND DEPLOYMENT_ID = $2",
+		ID: "ASQ-USER_MGT-07",
+		Query: "SELECT USER_ID, OU_ID, TYPE, ATTRIBUTES, CREDENTIALS FROM \"USER\" " +
+			"WHERE USER_ID = $1 AND DEPLOYMENT_ID = $2",
 	}
 	// QueryGetGroupCountForUser is the query to get the count of groups for a given user.
 	QueryGetGroupCountForUser = model.DBQuery{

--- a/backend/internal/userschema/model/number.go
+++ b/backend/internal/userschema/model/number.go
@@ -45,7 +45,8 @@ func (p *number) validateValue(value interface{}, path string, logger *log.Logge
 
 	if p.enum != nil {
 		if _, exists := p.enum[numberValue]; !exists {
-			logger.Debug("Value not in enum", log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
+			logger.Debug("Value not in enum", log.String("property", path),
+				log.String("value", fmt.Sprintf("%v", value)))
 			return false, nil
 		}
 	}


### PR DESCRIPTION
### Purpose
Currently there are some line which are longer than 120 character. Even though we have configured the line length as 120 in linter config. This is because the lll (line length) linter, when used as part of golangci-lint, counts a tab character (\t) as a single character by default, not four. That's why those are not detected by linter checks. We can override the tab width. 

With this PR, the tab-width is set to 4
```
lll:
  line-length: 120
  tab-width: 4
```

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
