### PR TITLE
Add config for auth code expiry time

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -78,6 +78,9 @@
     "refresh_token": {
       "renew_on_grant": false,
       "validity_period": 86400
+    },
+    "authorization_code": {
+      "validity_period": 600
     }
   },
   "flow": {

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -535,8 +535,9 @@ func createAuthorizationCode(
 	allScopes := append(append([]string{}, StandardScopes...), permissionScopes...)
 	resource := authRequestCtx.OAuthParameters.Resource
 
-	// TODO: Add expiry time logic.
-	expiryTime := authTime.Add(10 * time.Minute)
+	oauthConfig := config.GetThunderRuntime().Config.OAuth
+	validityPeriod := oauthConfig.AuthorizationCode.ValidityPeriod
+	expiryTime := authTime.Add(time.Duration(validityPeriod) * time.Second)
 
 	return AuthorizationCode{
 		CodeID:              utils.GenerateUUID(),

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -86,6 +86,11 @@ func (suite *AuthorizeHandlerTestSuite) BeforeTest(suiteName, testName string) {
 				Path: ":memory:",
 			},
 		},
+		OAuth: config.OAuthConfig{
+			AuthorizationCode: config.AuthorizationCodeConfig{
+				ValidityPeriod: 600,
+			},
+		},
 	}
 	_ = config.InitializeThunderRuntime("test", testConfig)
 }

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -114,9 +114,15 @@ type RefreshTokenConfig struct {
 	ValidityPeriod int64 `yaml:"validity_period" json:"validity_period"`
 }
 
+// AuthorizationCodeConfig holds the authorization code configuration details.
+type AuthorizationCodeConfig struct {
+	ValidityPeriod int64 `yaml:"validity_period" json:"validity_period"`
+}
+
 // OAuthConfig holds the OAuth configuration details.
 type OAuthConfig struct {
-	RefreshToken RefreshTokenConfig `yaml:"refresh_token" json:"refresh_token"`
+	RefreshToken      RefreshTokenConfig      `yaml:"refresh_token" json:"refresh_token"`
+	AuthorizationCode AuthorizationCodeConfig `yaml:"authorization_code" json:"authorization_code"`
 }
 
 // FlowAuthnConfig holds the configuration details for the authentication flows.

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -90,6 +90,8 @@ oauth:
   refresh_token:
     renew_on_grant: {{ .Values.configuration.oauth.refreshToken.renewOnGrant }}
     validity_period: {{ .Values.configuration.oauth.refreshToken.validityPeriod }}
+  authorization_code:
+    validity_period: {{ .Values.configuration.oauth.authorizationCode.validityPeriod }}
 
 flow:
   graph_directory: {{ .Values.configuration.flow.graphDirectory | quote }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -202,6 +202,8 @@ configuration:
     refreshToken:
       renewOnGrant: false
       validityPeriod: 86400
+    authorizationCode:
+      validityPeriod: 600
 
   # Flow configuration
   flow:


### PR DESCRIPTION
This pull request introduces configurable validity periods for OAuth authorization codes, allowing their expiration time to be set via configuration files and Helm charts. The changes ensure that the authorization code lifetime is no longer hardcoded and can be easily managed through deployment configuration. The most important changes are grouped below:

**OAuth Authorization Code Validity Configuration:**

* Added a new `authorization_code` section with a `validity_period` field to the default OAuth configuration in `default.json`, enabling explicit configuration of authorization code lifetimes.
* Updated the `OAuthConfig` struct and related configuration structs in `config.go` to include `AuthorizationCodeConfig` with a `ValidityPeriod` field, supporting the new configuration option in code.
* Modified the authorization code creation logic in `handler.go` to use the configured validity period (in seconds) when calculating the expiry time, replacing the previously hardcoded 10-minute duration.

**Helm Chart and Test Configuration:**

* Extended Helm chart templates (`deployment.yaml` and `values.yaml`) to support the new `authorizationCode.validityPeriod` setting, ensuring the configuration is customizable during deployment. [[1]](diffhunk://#diff-f2cb3073a4637c871c6a543d4e76655f861053c8b63ebfc66ed958980466eb34R93-R94) [[2]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eR205-R206)
* Updated OAuth-related test setup to include the new `AuthorizationCode` configuration, ensuring tests reflect the new configuration-driven behavior.