### PR TITLE
Improve IDP property validations/ handling default properties

### DIFF
--- a/backend/internal/authn/oauth/model.go
+++ b/backend/internal/authn/oauth/model.go
@@ -23,6 +23,7 @@ type OAuthEndpoints struct {
 	AuthorizationEndpoint string
 	TokenEndpoint         string
 	UserInfoEndpoint      string
+	UserEmailEndpoint     string
 	LogoutEndpoint        string
 	JwksEndpoint          string
 }

--- a/backend/internal/authn/oauth/utils.go
+++ b/backend/internal/authn/oauth/utils.go
@@ -65,6 +65,8 @@ func parseIDPConfig(idp *idp.IDPDTO) (*OAuthClientConfig, error) {
 			oAuthClientConfig.OAuthEndpoints.TokenEndpoint = value
 		case "userinfo_endpoint":
 			oAuthClientConfig.OAuthEndpoints.UserInfoEndpoint = value
+		case "user_email_endpoint":
+			oAuthClientConfig.OAuthEndpoints.UserEmailEndpoint = value
 		case "logout_endpoint":
 			oAuthClientConfig.OAuthEndpoints.LogoutEndpoint = value
 		case "jwks_endpoint":

--- a/backend/internal/idp/constants.go
+++ b/backend/internal/idp/constants.go
@@ -40,16 +40,122 @@ var supportedIDPTypes = []IDPType{
 	IDPTypeGitHub,
 }
 
-// supportedIDPProperties lists all the supported identity provider properties.
-var supportedIDPProperties = []string{
-	"client_id",
-	"client_secret",
-	"redirect_uri",
-	"scopes",
-	"authorization_endpoint",
-	"token_endpoint",
-	"userinfo_endpoint",
-	"logout_endpoint",
-	"jwks_endpoint",
-	"prompt",
+// IDP property names.
+const (
+	PropClientID              = "client_id"
+	PropClientSecret          = "client_secret"
+	PropRedirectURI           = "redirect_uri"
+	PropScopes                = "scopes"
+	PropAuthorizationEndpoint = "authorization_endpoint"
+	PropTokenEndpoint         = "token_endpoint"
+	PropUserInfoEndpoint      = "userinfo_endpoint"
+	PropUserEmailEndpoint     = "user_email_endpoint"
+	PropLogoutEndpoint        = "logout_endpoint"
+	PropJwksEndpoint          = "jwks_endpoint"
+	PropPrompt                = "prompt"
+)
+
+// Known endpoints for Google OAuth2/OIDC.
+const (
+	googleAuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+	googleTokenEndpoint         = "https://oauth2.googleapis.com/token" // #nosec G101
+	googleUserInfoEndpoint      = "https://openidconnect.googleapis.com/v1/userinfo"
+	googleJwksEndpoint          = "https://www.googleapis.com/oauth2/v3/certs"
+)
+
+// Known endpoints for GitHub OAuth.
+const (
+	gitHubAuthorizationEndpoint = "https://github.com/login/oauth/authorize"
+	gitHubTokenEndpoint         = "https://github.com/login/oauth/access_token" // #nosec G101
+	gitHubUserInfoEndpoint      = "https://api.github.com/user"
+	gitHubUserEmailEndpoint     = "https://api.github.com/user/emails"
+)
+
+// idpPropertyConfig defines the required and optional properties for an IDP type,
+// along with any default values.
+type idpPropertyConfig struct {
+	Required []string
+	Optional []string
+	Defaults map[string]string
+}
+
+// idpPropertyConfigs maps each IDP type to its property configuration.
+var idpPropertyConfigs = map[IDPType]idpPropertyConfig{
+	IDPTypeOAuth: {
+		Required: []string{
+			PropClientID,
+			PropClientSecret,
+			PropRedirectURI,
+			PropAuthorizationEndpoint,
+			PropTokenEndpoint,
+			PropUserInfoEndpoint,
+		},
+		Optional: []string{
+			PropScopes,
+			PropLogoutEndpoint,
+			PropPrompt,
+		},
+		Defaults: map[string]string{},
+	},
+	IDPTypeOIDC: {
+		Required: []string{
+			PropClientID,
+			PropClientSecret,
+			PropRedirectURI,
+			PropAuthorizationEndpoint,
+			PropTokenEndpoint,
+		},
+		Optional: []string{
+			PropScopes,
+			PropUserInfoEndpoint,
+			PropLogoutEndpoint,
+			PropJwksEndpoint,
+			PropPrompt,
+		},
+		Defaults: map[string]string{},
+	},
+	IDPTypeGoogle: {
+		Required: []string{
+			PropClientID,
+			PropClientSecret,
+			PropRedirectURI,
+		},
+		Optional: []string{
+			PropAuthorizationEndpoint,
+			PropTokenEndpoint,
+			PropScopes,
+			PropUserInfoEndpoint,
+			PropLogoutEndpoint,
+			PropJwksEndpoint,
+			PropPrompt,
+		},
+		Defaults: map[string]string{
+			PropAuthorizationEndpoint: googleAuthorizationEndpoint,
+			PropTokenEndpoint:         googleTokenEndpoint,
+			PropUserInfoEndpoint:      googleUserInfoEndpoint,
+			PropJwksEndpoint:          googleJwksEndpoint,
+		},
+	},
+	IDPTypeGitHub: {
+		Required: []string{
+			PropClientID,
+			PropClientSecret,
+			PropRedirectURI,
+		},
+		Optional: []string{
+			PropAuthorizationEndpoint,
+			PropTokenEndpoint,
+			PropUserInfoEndpoint,
+			PropUserEmailEndpoint,
+			PropScopes,
+			PropLogoutEndpoint,
+			PropPrompt,
+		},
+		Defaults: map[string]string{
+			PropAuthorizationEndpoint: gitHubAuthorizationEndpoint,
+			PropTokenEndpoint:         gitHubTokenEndpoint,
+			PropUserInfoEndpoint:      gitHubUserInfoEndpoint,
+			PropUserEmailEndpoint:     gitHubUserEmailEndpoint,
+		},
+	},
 }

--- a/backend/internal/idp/init.go
+++ b/backend/internal/idp/init.go
@@ -22,12 +22,10 @@ package idp
 import (
 	"fmt"
 	"net/http"
-	"slices"
 	"strings"
 
 	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/config"
-	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	filebasedruntime "github.com/asgardeo/thunder/internal/system/file_based_runtime"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/middleware"
@@ -57,7 +55,7 @@ func Initialize(mux *http.ServeMux) IDPServiceInterface {
 			if err != nil {
 				logger.Fatal("Error parsing identity provider config", log.Error(err))
 			}
-			svcErr := validateIDPForInit(idpDTO)
+			svcErr := validateIDP(idpDTO, logger)
 			if svcErr != nil {
 				logger.Fatal("Error validating identity provider",
 					log.String("idpName", idpDTO.Name), log.Any("serviceError", svcErr))
@@ -124,26 +122,6 @@ func parseIDPType(typeStr string) (IDPType, error) {
 	}
 
 	return "", fmt.Errorf("unsupported IDP type: %s", typeStr)
-}
-
-func validateIDPForInit(idp *IDPDTO) *serviceerror.ServiceError {
-	if idp == nil {
-		return &ErrorIDPNil
-	}
-	if strings.TrimSpace(idp.Name) == "" {
-		return &ErrorInvalidIDPName
-	}
-
-	// Validate identity provider type
-	if strings.TrimSpace(string(idp.Type)) == "" {
-		return &ErrorInvalidIDPType
-	}
-	isValidType := slices.Contains(supportedIDPTypes, idp.Type)
-	if !isValidType {
-		return &ErrorInvalidIDPType
-	}
-
-	return validateIDPProperties(idp.Properties)
 }
 
 // RegisterRoutes registers the routes for identity provider operations.

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -21,11 +21,8 @@ package idp
 
 import (
 	"errors"
-	"fmt"
-	"slices"
 	"strings"
 
-	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	filebasedruntime "github.com/asgardeo/thunder/internal/system/file_based_runtime"
@@ -46,23 +43,25 @@ type IDPServiceInterface interface {
 // idpService is the default implementation of the IdPServiceInterface.
 type idpService struct {
 	idpStore idpStoreInterface
+	logger   *log.Logger
 }
 
 // newIDPService creates a new instance of IdPService.
 func newIDPService(idpStore idpStoreInterface) IDPServiceInterface {
 	return &idpService{
 		idpStore: idpStore,
+		logger:   log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService")),
 	}
 }
 
 // CreateIdentityProvider creates a new Identity Provider.
 func (is *idpService) CreateIdentityProvider(idp *IDPDTO) (*IDPDTO, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService"))
+	logger := is.logger
 	if config.GetThunderRuntime().Config.ImmutableResources.Enabled {
 		return nil, &filebasedruntime.ErrorImmutableResourceCreateOperation
 	}
 
-	if svcErr := is.validateIDP(idp); svcErr != nil {
+	if svcErr := validateIDP(idp, logger); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -90,8 +89,7 @@ func (is *idpService) CreateIdentityProvider(idp *IDPDTO) (*IDPDTO, *serviceerro
 
 // GetIdentityProviderList retrieves the list of all Identity Providers.
 func (is *idpService) GetIdentityProviderList() ([]BasicIDPDTO, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService"))
-
+	logger := is.logger
 	idps, err := is.idpStore.GetIdentityProviderList()
 	if err != nil {
 		logger.Error("Failed to get identity provider list", log.Error(err))
@@ -103,8 +101,7 @@ func (is *idpService) GetIdentityProviderList() ([]BasicIDPDTO, *serviceerror.Se
 
 // GetIdentityProvider retrieves an identity provider by its ID.
 func (is *idpService) GetIdentityProvider(idpID string) (*IDPDTO, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService"))
-
+	logger := is.logger
 	if strings.TrimSpace(idpID) == "" {
 		return nil, &ErrorInvalidIDPID
 	}
@@ -123,8 +120,7 @@ func (is *idpService) GetIdentityProvider(idpID string) (*IDPDTO, *serviceerror.
 
 // GetIdentityProviderByName retrieves an identity provider by its name.
 func (is *idpService) GetIdentityProviderByName(idpName string) (*IDPDTO, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService"))
-
+	logger := is.logger
 	if strings.TrimSpace(idpName) == "" {
 		return nil, &ErrorInvalidIDPName
 	}
@@ -144,7 +140,7 @@ func (is *idpService) GetIdentityProviderByName(idpName string) (*IDPDTO, *servi
 // UpdateIdentityProvider updates an existing Identity Provider.
 func (is *idpService) UpdateIdentityProvider(idpID string, idp *IDPDTO) (*IDPDTO,
 	*serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService"))
+	logger := is.logger
 	if config.GetThunderRuntime().Config.ImmutableResources.Enabled {
 		return nil, &filebasedruntime.ErrorImmutableResourceUpdateOperation
 	}
@@ -152,7 +148,7 @@ func (is *idpService) UpdateIdentityProvider(idpID string, idp *IDPDTO) (*IDPDTO
 	if strings.TrimSpace(idpID) == "" {
 		return nil, &ErrorInvalidIDPID
 	}
-	if svcErr := is.validateIDP(idp); svcErr != nil {
+	if svcErr := validateIDP(idp, logger); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -194,7 +190,7 @@ func (is *idpService) UpdateIdentityProvider(idpID string, idp *IDPDTO) (*IDPDTO
 
 // DeleteIdentityProvider deletes an Identity Provider by its ID.
 func (is *idpService) DeleteIdentityProvider(idpID string) *serviceerror.ServiceError {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService"))
+	logger := is.logger
 	if config.GetThunderRuntime().Config.ImmutableResources.Enabled {
 		return &filebasedruntime.ErrorImmutableResourceDeleteOperation
 	}
@@ -219,53 +215,5 @@ func (is *idpService) DeleteIdentityProvider(idpID string) *serviceerror.Service
 		return &serviceerror.InternalServerError
 	}
 
-	return nil
-}
-
-// validateIDP validates the identity provider details.
-func (is *idpService) validateIDP(idp *IDPDTO) *serviceerror.ServiceError {
-	if idp == nil {
-		return &ErrorIDPNil
-	}
-	if strings.TrimSpace(idp.Name) == "" {
-		return &ErrorInvalidIDPName
-	}
-
-	// Validate identity provider type
-	if strings.TrimSpace(string(idp.Type)) == "" {
-		return &ErrorInvalidIDPType
-	}
-	isValidType := slices.Contains(supportedIDPTypes, idp.Type)
-	if !isValidType {
-		return &ErrorInvalidIDPType
-	}
-
-	return validateIDPProperties(idp.Properties)
-}
-
-// validateIDPProperties validates the identity provider properties.
-func validateIDPProperties(properties []cmodels.Property) *serviceerror.ServiceError {
-	if len(properties) == 0 {
-		return nil
-	}
-	for _, property := range properties {
-		if strings.TrimSpace(property.GetName()) == "" {
-			return serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
-				"property names cannot be empty")
-		}
-		propertyValue, err := property.GetValue()
-		if err != nil {
-			return serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
-				fmt.Sprintf("failed to get value for property '%s': %v", property.GetName(), err))
-		}
-		if strings.TrimSpace(propertyValue) == "" {
-			return serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
-				fmt.Sprintf("property value cannot be empty for property '%s'", property.GetName()))
-		}
-		if !slices.Contains(supportedIDPProperties, property.GetName()) {
-			return serviceerror.CustomServiceError(ErrorUnsupportedIDPProperty,
-				fmt.Sprintf("property '%s' is not supported", property.GetName()))
-		}
-	}
 	return nil
 }

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/asgardeo/thunder/internal/system/cmodels"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
+)
+
+// validateIDP validates the identity provider details.
+func validateIDP(idp *IDPDTO, logger *log.Logger) *serviceerror.ServiceError {
+	if idp == nil {
+		return &ErrorIDPNil
+	}
+	if strings.TrimSpace(idp.Name) == "" {
+		return &ErrorInvalidIDPName
+	}
+
+	// Validate identity provider type
+	if strings.TrimSpace(string(idp.Type)) == "" {
+		return &ErrorInvalidIDPType
+	}
+	isValidType := slices.Contains(supportedIDPTypes, idp.Type)
+	if !isValidType {
+		return &ErrorInvalidIDPType
+	}
+
+	// Validate and apply default properties based on IDP type
+	updatedProperties, svcErr := validateIDPProperties(idp.Type, idp.Properties, logger)
+	if svcErr != nil {
+		return svcErr
+	}
+	idp.Properties = updatedProperties
+
+	return nil
+}
+
+// validateIDPProperties validates the properties of the identity provider based on its type.
+func validateIDPProperties(idpType IDPType, properties []cmodels.Property, logger *log.Logger) (
+	[]cmodels.Property, *serviceerror.ServiceError) {
+	config, exists := idpPropertyConfigs[idpType]
+	if !exists {
+		logger.Error("No property configuration found for IDP type", log.String("idpType", string(idpType)))
+		return nil, &serviceerror.InternalServerError
+	}
+
+	allowedProps := make([]string, 0, len(config.Required)+len(config.Optional))
+	allowedProps = append(allowedProps, config.Required...)
+	allowedProps = append(allowedProps, config.Optional...)
+
+	// Filter and validate provided properties
+	filteredPropsMap := make(map[string]cmodels.Property)
+	filteredPropKeys := []string{}
+	for _, prop := range properties {
+		propName := prop.GetName()
+		if strings.TrimSpace(propName) == "" {
+			return nil, serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
+				"property names cannot be empty")
+		}
+		if !slices.Contains(allowedProps, propName) {
+			return nil, serviceerror.CustomServiceError(ErrorUnsupportedIDPProperty,
+				fmt.Sprintf("property '%s' is not supported for IDP type '%s'", propName, idpType))
+		}
+
+		propertyValue, err := prop.GetValue()
+		if err != nil {
+			return nil, serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
+				fmt.Sprintf("failed to get value for property '%s': %v", propName, err))
+		}
+		if strings.TrimSpace(propertyValue) == "" {
+			return nil, serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
+				fmt.Sprintf("value cannot be empty for property '%s'", propName))
+		}
+
+		filteredPropsMap[propName] = prop
+		filteredPropKeys = append(filteredPropKeys, propName)
+	}
+
+	// Check for required properties
+	for _, requiredProp := range config.Required {
+		if !slices.Contains(filteredPropKeys, requiredProp) {
+			return nil, serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
+				fmt.Sprintf("required property '%s' is missing for IDP type '%s'", requiredProp, idpType))
+		}
+	}
+
+	// Apply default properties
+	for propName, defaultValue := range config.Defaults {
+		if _, exists := filteredPropsMap[propName]; !exists {
+			if err := createAndAppendProperty(filteredPropsMap, propName, defaultValue, false, logger); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Ensure openid scope for OIDC and Google IDPs
+	if idpType == IDPTypeOIDC || idpType == IDPTypeGoogle {
+		if err := ensureOpenIDScope(filteredPropsMap, logger); err != nil {
+			return nil, err
+		}
+	}
+
+	return propertyMapToSlice(filteredPropsMap), nil
+}
+
+// ensureOpenIDScope ensures that the openid scope is present in the scopes property.
+func ensureOpenIDScope(propertyMap map[string]cmodels.Property, logger *log.Logger) *serviceerror.ServiceError {
+	scopesProp, exists := propertyMap[PropScopes]
+	if !exists {
+		err := createAndAppendProperty(propertyMap, PropScopes, "openid", false, logger)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	scopesValue, err := scopesProp.GetValue()
+	if err != nil {
+		return serviceerror.CustomServiceError(ErrorInvalidIDPProperty,
+			fmt.Sprintf("failed to get scopes value: %v", err))
+	}
+
+	scopes := sysutils.ParseStringArray(scopesValue, ",")
+	filteredScopes := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		if scope != "" {
+			filteredScopes = append(filteredScopes, scope)
+		}
+	}
+	scopes = filteredScopes
+
+	if len(scopes) == 0 {
+		err := createAndAppendProperty(propertyMap, PropScopes, "openid", false, logger)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	if !slices.Contains(scopes, "openid") {
+		scopes = append(scopes, "openid")
+		updatedScopes := sysutils.StringifyStringArray(scopes, ",")
+		if err := createAndAppendProperty(
+			propertyMap, PropScopes, updatedScopes, scopesProp.IsSecret(), logger); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createAndAppendProperty creates a new property and appends it to the property map.
+func createAndAppendProperty(propertyMap map[string]cmodels.Property,
+	name, value string, isSecret bool, logger *log.Logger,
+) *serviceerror.ServiceError {
+	prop, err := cmodels.NewProperty(name, value, isSecret)
+	if err != nil {
+		logger.Error("Failed to create property", log.String("propertyName", name), log.Error(err))
+		return &serviceerror.InternalServerError
+	}
+	propertyMap[name] = *prop
+	return nil
+}
+
+// propertyMapToSlice converts a property map to a slice.
+func propertyMapToSlice(propertyMap map[string]cmodels.Property) []cmodels.Property {
+	properties := make([]cmodels.Property, 0, len(propertyMap))
+	for _, prop := range propertyMap {
+		properties = append(properties, prop)
+	}
+	return properties
+}

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -1,0 +1,604 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/system/cmodels"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+type IDPUtilsTestSuite struct {
+	suite.Suite
+	logger *log.Logger
+}
+
+func TestIDPUtilsTestSuite(t *testing.T) {
+	suite.Run(t, new(IDPUtilsTestSuite))
+}
+
+func (s *IDPUtilsTestSuite) SetupTest() {
+	s.logger = log.GetLogger()
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OAuth_AllRequired() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+	prop6, _ := cmodels.NewProperty(PropUserInfoEndpoint, "http://idp/userinfo", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.Len(result, 6)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OAuth_WithOptional() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+	prop6, _ := cmodels.NewProperty(PropUserInfoEndpoint, "http://idp/userinfo", false)
+	prop7, _ := cmodels.NewProperty(PropScopes, "profile,email", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6, *prop7}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.Len(result, 7)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OAuth_MissingRequired() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+
+	properties := []cmodels.Property{*prop1, *prop2}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription, "required property")
+	s.Contains(err.ErrorDescription, "missing")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDC_AllRequired() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.GreaterOrEqual(len(result), 6)
+
+	hasOpenIDScope := false
+	for _, prop := range result {
+		if prop.GetName() == PropScopes {
+			value, _ := prop.GetValue()
+			s.Contains(value, "openid")
+			hasOpenIDScope = true
+		}
+	}
+	s.True(hasOpenIDScope, "OIDC should have openid scope added")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDC_WithExistingScopes() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+	prop6, _ := cmodels.NewProperty(PropScopes, "profile,email", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+
+	for _, prop := range result {
+		if prop.GetName() == PropScopes {
+			value, _ := prop.GetValue()
+			s.Contains(value, "openid")
+			s.Contains(value, "profile")
+			s.Contains(value, "email")
+		}
+	}
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDC_ScopesAlreadyHasOpenID() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+	prop6, _ := cmodels.NewProperty(PropScopes, "openid,profile,email", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6}
+
+	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+
+	for _, prop := range result {
+		if prop.GetName() == PropScopes {
+			value, _ := prop.GetValue()
+			s.Contains(value, "openid")
+		}
+	}
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_Google_WithDefaults() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(IDPTypeGoogle, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.GreaterOrEqual(len(result), 7)
+
+	foundProperties := make(map[string]string)
+	for _, prop := range result {
+		value, _ := prop.GetValue()
+		foundProperties[prop.GetName()] = value
+	}
+
+	s.Equal(googleAuthorizationEndpoint, foundProperties[PropAuthorizationEndpoint])
+	s.Equal(googleTokenEndpoint, foundProperties[PropTokenEndpoint])
+	s.Equal(googleUserInfoEndpoint, foundProperties[PropUserInfoEndpoint])
+	s.Equal(googleJwksEndpoint, foundProperties[PropJwksEndpoint])
+	s.Contains(foundProperties[PropScopes], "openid")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_Google_WithCustomEndpoints() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://custom/auth", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(IDPTypeGoogle, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+
+	foundProperties := make(map[string]string)
+	for _, prop := range result {
+		value, _ := prop.GetValue()
+		foundProperties[prop.GetName()] = value
+	}
+
+	s.Equal("http://custom/auth", foundProperties[PropAuthorizationEndpoint])
+	s.Equal(googleTokenEndpoint, foundProperties[PropTokenEndpoint])
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_WithDefaults() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(IDPTypeGitHub, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.GreaterOrEqual(len(result), 6)
+
+	foundProperties := make(map[string]string)
+	for _, prop := range result {
+		value, _ := prop.GetValue()
+		foundProperties[prop.GetName()] = value
+	}
+
+	s.Equal(gitHubAuthorizationEndpoint, foundProperties[PropAuthorizationEndpoint])
+	s.Equal(gitHubTokenEndpoint, foundProperties[PropTokenEndpoint])
+	s.Equal(gitHubUserInfoEndpoint, foundProperties[PropUserInfoEndpoint])
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_WithCustomEndpoints() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropTokenEndpoint, "http://custom/token", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(IDPTypeGitHub, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+
+	foundProperties := make(map[string]string)
+	for _, prop := range result {
+		value, _ := prop.GetValue()
+		foundProperties[prop.GetName()] = value
+	}
+
+	s.Equal("http://custom/token", foundProperties[PropTokenEndpoint])
+	s.Equal(gitHubAuthorizationEndpoint, foundProperties[PropAuthorizationEndpoint])
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_EmptyPropertyName() {
+	prop1, _ := cmodels.NewProperty("", "test-value", false)
+
+	properties := []cmodels.Property{*prop1}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription, "property names cannot be empty")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_EmptyPropertyValue() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "", false)
+
+	properties := []cmodels.Property{*prop1}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription, "value cannot be empty")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_UnsupportedProperty() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty("unsupported_prop", "value", false)
+
+	properties := []cmodels.Property{*prop1, *prop2}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorUnsupportedIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription, "unsupported_prop")
+	s.Contains(err.ErrorDescription, "not supported")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_InvalidIDPType() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+
+	properties := []cmodels.Property{*prop1}
+
+	result, err := validateIDPProperties(IDPType("INVALID"), properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestPropertyMapToSlice() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+
+	propertyMap := map[string]cmodels.Property{
+		PropClientID:     *prop1,
+		PropClientSecret: *prop2,
+	}
+
+	result := propertyMapToSlice(propertyMap)
+
+	s.NotNil(result)
+	s.Len(result, 2)
+
+	names := make([]string, 0)
+	for _, prop := range result {
+		names = append(names, prop.GetName())
+	}
+	s.Contains(names, PropClientID)
+	s.Contains(names, PropClientSecret)
+}
+
+func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_NoExistingScopes() {
+	propertyMap := make(map[string]cmodels.Property)
+
+	err := ensureOpenIDScope(propertyMap, s.logger)
+
+	s.Nil(err)
+	s.Contains(propertyMap, PropScopes)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	s.Equal("openid", value)
+}
+
+func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithExistingScopes() {
+	prop, _ := cmodels.NewProperty(PropScopes, "profile,email", false)
+	propertyMap := map[string]cmodels.Property{
+		PropScopes: *prop,
+	}
+
+	err := ensureOpenIDScope(propertyMap, s.logger)
+
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	s.Contains(value, "openid")
+	s.Contains(value, "profile")
+	s.Contains(value, "email")
+}
+
+func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_AlreadyHasOpenID() {
+	prop, _ := cmodels.NewProperty(PropScopes, "openid,profile", false)
+	propertyMap := map[string]cmodels.Property{
+		PropScopes: *prop,
+	}
+
+	err := ensureOpenIDScope(propertyMap, s.logger)
+
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	s.Contains(value, "openid")
+	s.Contains(value, "profile")
+}
+
+func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_EmptyScopesValue() {
+	prop, _ := cmodels.NewProperty(PropScopes, "", false)
+	propertyMap := map[string]cmodels.Property{
+		PropScopes: *prop,
+	}
+
+	err := ensureOpenIDScope(propertyMap, s.logger)
+
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	s.Equal("openid", value)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_ValidOAuth() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+	prop6, _ := cmodels.NewProperty(PropUserInfoEndpoint, "http://idp/userinfo", false)
+
+	idp := &IDPDTO{
+		Name:       "Test OAuth IDP",
+		Type:       IDPTypeOAuth,
+		Properties: []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6},
+	}
+
+	err := validateIDP(idp, s.logger)
+
+	s.Nil(err)
+	s.NotNil(idp.Properties)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_NilIDP() {
+	err := validateIDP(nil, s.logger)
+
+	s.NotNil(err)
+	s.Equal(ErrorIDPNil.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_EmptyName() {
+	idp := &IDPDTO{
+		Name: "",
+		Type: IDPTypeOAuth,
+	}
+
+	err := validateIDP(idp, s.logger)
+
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPName.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_EmptyType() {
+	idp := &IDPDTO{
+		Name: "Test IDP",
+		Type: "",
+	}
+
+	err := validateIDP(idp, s.logger)
+
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPType.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_InvalidType() {
+	idp := &IDPDTO{
+		Name: "Test IDP",
+		Type: "INVALID",
+	}
+
+	err := validateIDP(idp, s.logger)
+
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPType.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_WithWhitespaceName() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+	prop6, _ := cmodels.NewProperty(PropUserInfoEndpoint, "http://idp/userinfo", false)
+
+	idp := &IDPDTO{
+		Name:       "   ",
+		Type:       IDPTypeOAuth,
+		Properties: []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6},
+	}
+
+	err := validateIDP(idp, s.logger)
+
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPName.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_WithWhitespaceType() {
+	idp := &IDPDTO{
+		Name: "Test IDP",
+		Type: "   ",
+	}
+
+	err := validateIDP(idp, s.logger)
+
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPType.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_WithWhitespacePropertyName() {
+	prop1, _ := cmodels.NewProperty("   ", "test-value", false)
+
+	properties := []cmodels.Property{*prop1}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription, "property names cannot be empty")
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_WithWhitespacePropertyValue() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "   ", false)
+
+	properties := []cmodels.Property{*prop1}
+
+	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription, "value cannot be empty")
+}
+
+func (s *IDPUtilsTestSuite) TestCreateAndAppendProperty_Success() {
+	propertyMap := make(map[string]cmodels.Property)
+
+	err := createAndAppendProperty(propertyMap, "test_prop", "test_value", false, s.logger)
+
+	s.Nil(err)
+	s.Contains(propertyMap, "test_prop")
+
+	prop := propertyMap["test_prop"]
+	value, _ := prop.GetValue()
+	s.Equal("test_value", value)
+	s.False(prop.IsSecret())
+}
+
+func (s *IDPUtilsTestSuite) TestCreateAndAppendProperty_OverwriteExisting() {
+	prop1, _ := cmodels.NewProperty("test_prop", "old_value", false)
+	propertyMap := map[string]cmodels.Property{
+		"test_prop": *prop1,
+	}
+
+	err := createAndAppendProperty(propertyMap, "test_prop", "new_value", false, s.logger)
+
+	s.Nil(err)
+	s.Contains(propertyMap, "test_prop")
+
+	prop := propertyMap["test_prop"]
+	value, _ := prop.GetValue()
+	s.Equal("new_value", value)
+}
+
+func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithWhitespaceScopes() {
+	prop, _ := cmodels.NewProperty(PropScopes, "   ", false)
+	propertyMap := map[string]cmodels.Property{
+		PropScopes: *prop,
+	}
+
+	err := ensureOpenIDScope(propertyMap, s.logger)
+
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	s.Equal("openid", value)
+}
+
+func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_CommaSeparatedScopes() {
+	prop, _ := cmodels.NewProperty(PropScopes, "profile,email,address", false)
+	propertyMap := map[string]cmodels.Property{
+		PropScopes: *prop,
+	}
+
+	err := ensureOpenIDScope(propertyMap, s.logger)
+
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	// Should have openid added
+	s.Contains(value, "openid")
+	s.Contains(value, "profile")
+	s.Contains(value, "email")
+	s.Contains(value, "address")
+	// Verify comma separation
+	s.NotContains(value, " ")
+}
+
+func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithEmptyStringInScopes() {
+	prop, _ := cmodels.NewProperty(PropScopes, "profile,,email,,", false)
+	propertyMap := map[string]cmodels.Property{
+		PropScopes: *prop,
+	}
+
+	err := ensureOpenIDScope(propertyMap, s.logger)
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	// Should have openid added and empty strings filtered out
+	s.Contains(value, "openid")
+	s.Contains(value, "profile")
+	s.Contains(value, "email")
+	// Should not have consecutive commas
+	s.NotContains(value, ",,")
+}

--- a/tests/integration/export/export_api_test.go
+++ b/tests/integration/export/export_api_test.go
@@ -164,6 +164,21 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportYAML() {
 				Value:    "https://localhost:3000/oauth/callback",
 				IsSecret: false,
 			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://export-test-idp.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://export-test-idp.example.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://export-test-idp.example.com/userinfo",
+				IsSecret: false,
+			},
 		},
 	}
 
@@ -211,6 +226,26 @@ func (ts *ExportAPITestSuite) TestMultipleIdentityProvidersExportYAML() {
 				Value:    "github_export_secret",
 				IsSecret: true,
 			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:3000/github/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://github-export.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://github-export.example.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://github-export.example.com/userinfo",
+				IsSecret: false,
+			},
 		},
 	}
 
@@ -233,6 +268,21 @@ func (ts *ExportAPITestSuite) TestMultipleIdentityProvidersExportYAML() {
 				Name:     "client_secret",
 				Value:    "google_export_secret",
 				IsSecret: true,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:3000/google/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://google-export.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://google-export.example.com/token",
+				IsSecret: false,
 			},
 		},
 	}
@@ -308,6 +358,26 @@ func (ts *ExportAPITestSuite) TestMixedResourcesExportYAML() {
 				Value:    "mixed_idp_secret",
 				IsSecret: true,
 			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:3000/mixed/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://mixed-export.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://mixed-export.example.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://mixed-export.example.com/userinfo",
+				IsSecret: false,
+			},
 		},
 	}
 
@@ -343,6 +413,31 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportWithWildcard() {
 			{
 				Name:     "client_id",
 				Value:    "wildcard_test_client",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "wildcard_test_secret",
+				IsSecret: true,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:3000/wildcard/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://wildcard-test.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://wildcard-test.example.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://wildcard-test.example.com/userinfo",
 				IsSecret: false,
 			},
 		},
@@ -386,6 +481,16 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportWithProperties() {
 			{
 				Name:     "redirect_uri",
 				Value:    "https://localhost:3000/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://props-test.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://props-test.example.com/token",
 				IsSecret: false,
 			},
 			{

--- a/tests/integration/idp/idp_api_test.go
+++ b/tests/integration/idp/idp_api_test.go
@@ -61,6 +61,22 @@ var (
 				Value:    "user:email,read:user",
 				IsSecret: false,
 			},
+			// Default endpoints added by server
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://github.com/login/oauth/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://github.com/login/oauth/access_token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://api.github.com/user",
+				IsSecret: false,
+			},
 		},
 	}
 	testGoogleIdp = testutils.IDP{
@@ -88,6 +104,27 @@ var (
 				Value:    "openid,email,profile",
 				IsSecret: false,
 			},
+			// Default endpoints added by server
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://accounts.google.com/o/oauth2/v2/auth",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://oauth2.googleapis.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "jwks_endpoint",
+				Value:    "https://www.googleapis.com/oauth2/v3/certs",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://openidconnect.googleapis.com/v1/userinfo",
+				IsSecret: false,
+			},
 		},
 	}
 	idpToCreate = testutils.IDP{
@@ -108,6 +145,21 @@ var (
 			{
 				Name:     "redirect_uri",
 				Value:    "https://localhost:3000/oidc/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://test-idp.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://test-idp.example.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://test-idp.example.com/userinfo",
 				IsSecret: false,
 			},
 			{
@@ -135,6 +187,21 @@ var (
 			{
 				Name:     "redirect_uri",
 				Value:    "https://localhost:3000/updated/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://updated-idp.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://updated-idp.example.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    "https://updated-idp.example.com/userinfo",
 				IsSecret: false,
 			},
 			{
@@ -277,11 +344,6 @@ var (
 			{
 				Name:     "logout_endpoint",
 				Value:    "https://provider.com/oauth/logout",
-				IsSecret: false,
-			},
-			{
-				Name:     "jwks_endpoint",
-				Value:    "https://provider.com/.well-known/jwks.json",
 				IsSecret: false,
 			},
 			{
@@ -447,6 +509,26 @@ func (ts *IdpAPITestSuite) TestCreateIdpSuccess() {
 						Value:    "test_success_secret",
 						IsSecret: true,
 					},
+					{
+						Name:     "redirect_uri",
+						Value:    "https://localhost:3000/oauth/callback",
+						IsSecret: false,
+					},
+					{
+						Name:     "authorization_endpoint",
+						Value:    "https://test-oauth.example.com/authorize",
+						IsSecret: false,
+					},
+					{
+						Name:     "token_endpoint",
+						Value:    "https://test-oauth.example.com/token",
+						IsSecret: false,
+					},
+					{
+						Name:     "userinfo_endpoint",
+						Value:    "https://test-oauth.example.com/userinfo",
+						IsSecret: false,
+					},
 				},
 			},
 			description: "Should successfully create basic OAuth IDP",
@@ -467,6 +549,11 @@ func (ts *IdpAPITestSuite) TestCreateIdpSuccess() {
 						Name:     "client_secret",
 						Value:    "test_google_success_secret",
 						IsSecret: true,
+					},
+					{
+						Name:     "redirect_uri",
+						Value:    "https://localhost:3000/google/callback",
+						IsSecret: false,
 					},
 				},
 			},
@@ -489,6 +576,11 @@ func (ts *IdpAPITestSuite) TestCreateIdpSuccess() {
 						Value:    "test_github_success_secret",
 						IsSecret: true,
 					},
+					{
+						Name:     "redirect_uri",
+						Value:    "https://localhost:3000/github/callback",
+						IsSecret: false,
+					},
 				},
 			},
 			description: "Should successfully create basic Github IDP",
@@ -503,13 +595,32 @@ func (ts *IdpAPITestSuite) TestCreateIdpSuccess() {
 				t.Fatalf("Failed to create IDP for test case %s: %v", tc.name, err)
 			}
 
+			// For Google and GitHub types, add expected default properties
+			expectedProps := tc.idp.Properties
+			if tc.idp.Type == "GOOGLE" {
+				expectedProps = append(expectedProps,
+					testutils.IDPProperty{Name: "authorization_endpoint", Value: "https://accounts.google.com/o/oauth2/v2/auth", IsSecret: false},
+					testutils.IDPProperty{Name: "token_endpoint", Value: "https://oauth2.googleapis.com/token", IsSecret: false},
+					testutils.IDPProperty{Name: "jwks_endpoint", Value: "https://www.googleapis.com/oauth2/v3/certs", IsSecret: false},
+					testutils.IDPProperty{Name: "userinfo_endpoint", Value: "https://openidconnect.googleapis.com/v1/userinfo", IsSecret: false},
+					testutils.IDPProperty{Name: "scopes", Value: "openid", IsSecret: false},
+				)
+			} else if tc.idp.Type == "GITHUB" {
+				expectedProps = append(expectedProps,
+					testutils.IDPProperty{Name: "authorization_endpoint", Value: "https://github.com/login/oauth/authorize", IsSecret: false},
+					testutils.IDPProperty{Name: "token_endpoint", Value: "https://github.com/login/oauth/access_token", IsSecret: false},
+					testutils.IDPProperty{Name: "userinfo_endpoint", Value: "https://api.github.com/user", IsSecret: false},
+					testutils.IDPProperty{Name: "user_email_endpoint", Value: "https://api.github.com/user/emails", IsSecret: false},
+				)
+			}
+
 			// Validate that the IDP was created correctly
 			retrieveAndValidateIdpDetails(ts, testutils.IDP{
 				ID:          idpID,
 				Name:        tc.idp.Name,
 				Description: tc.idp.Description,
 				Type:        tc.idp.Type,
-				Properties:  tc.idp.Properties,
+				Properties:  expectedProps,
 			})
 
 			// Clean up
@@ -703,22 +814,50 @@ func (ts *IdpAPITestSuite) TestSupportedIdpTypes() {
 	supportedTypes := []string{"OAUTH", "GOOGLE", "GITHUB"}
 
 	for _, idpType := range supportedTypes {
+		properties := []testutils.IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    fmt.Sprintf("test_%s_client", strings.ToLower(idpType)),
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    fmt.Sprintf("test_%s_secret", strings.ToLower(idpType)),
+				IsSecret: true,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    fmt.Sprintf("https://localhost:3000/%s/callback", strings.ToLower(idpType)),
+				IsSecret: false,
+			},
+		}
+
+		// Add required endpoints for OAuth type
+		if idpType == "OAUTH" {
+			properties = append(properties,
+				testutils.IDPProperty{
+					Name:     "authorization_endpoint",
+					Value:    "https://test-oauth.example.com/authorize",
+					IsSecret: false,
+				},
+				testutils.IDPProperty{
+					Name:     "token_endpoint",
+					Value:    "https://test-oauth.example.com/token",
+					IsSecret: false,
+				},
+				testutils.IDPProperty{
+					Name:     "userinfo_endpoint",
+					Value:    "https://test-oauth.example.com/userinfo",
+					IsSecret: false,
+				},
+			)
+		}
+
 		testIDP := testutils.IDP{
 			Name:        fmt.Sprintf("Test %s IDP", idpType),
 			Description: fmt.Sprintf("%s identity provider for testing", idpType),
 			Type:        idpType,
-			Properties: []testutils.IDPProperty{
-				{
-					Name:     "client_id",
-					Value:    fmt.Sprintf("test_%s_client", strings.ToLower(idpType)),
-					IsSecret: false,
-				},
-				{
-					Name:     "client_secret",
-					Value:    fmt.Sprintf("test_%s_secret", strings.ToLower(idpType)),
-					IsSecret: true,
-				},
-			},
+			Properties:  properties,
 		}
 
 		// Create IDP with the supported type
@@ -727,13 +866,32 @@ func (ts *IdpAPITestSuite) TestSupportedIdpTypes() {
 			ts.T().Fatalf("Failed to create IDP with type %s: %v", idpType, err)
 		}
 
+		// For Google and GitHub types, add expected default properties
+		expectedProps := testIDP.Properties
+		if idpType == "GOOGLE" {
+			expectedProps = append(expectedProps,
+				testutils.IDPProperty{Name: "authorization_endpoint", Value: "https://accounts.google.com/o/oauth2/v2/auth", IsSecret: false},
+				testutils.IDPProperty{Name: "token_endpoint", Value: "https://oauth2.googleapis.com/token", IsSecret: false},
+				testutils.IDPProperty{Name: "jwks_endpoint", Value: "https://www.googleapis.com/oauth2/v3/certs", IsSecret: false},
+				testutils.IDPProperty{Name: "userinfo_endpoint", Value: "https://openidconnect.googleapis.com/v1/userinfo", IsSecret: false},
+				testutils.IDPProperty{Name: "scopes", Value: "openid", IsSecret: false},
+			)
+		} else if idpType == "GITHUB" {
+			expectedProps = append(expectedProps,
+				testutils.IDPProperty{Name: "authorization_endpoint", Value: "https://github.com/login/oauth/authorize", IsSecret: false},
+				testutils.IDPProperty{Name: "token_endpoint", Value: "https://github.com/login/oauth/access_token", IsSecret: false},
+				testutils.IDPProperty{Name: "userinfo_endpoint", Value: "https://api.github.com/user", IsSecret: false},
+				testutils.IDPProperty{Name: "user_email_endpoint", Value: "https://api.github.com/user/emails", IsSecret: false},
+			)
+		}
+
 		// Validate type is correctly stored
 		retrieveAndValidateIdpDetails(ts, testutils.IDP{
 			ID:          idpID,
 			Name:        testIDP.Name,
 			Description: testIDP.Description,
 			Type:        testIDP.Type,
-			Properties:  testIDP.Properties,
+			Properties:  expectedProps,
 		})
 
 		// Clean up
@@ -745,24 +903,51 @@ func (ts *IdpAPITestSuite) TestSupportedIdpTypes() {
 }
 
 func (ts *IdpAPITestSuite) TestSupportedPropertyNames() {
+	// Test with OIDC type since it supports more optional properties
 	supportedProperties := []string{
-		"client_id", "client_secret", "redirect_uri", "scopes",
-		"authorization_endpoint", "token_endpoint", "userinfo_endpoint",
-		"logout_endpoint", "jwks_endpoint", "prompt",
+		"scopes", "logout_endpoint", "jwks_endpoint", "prompt",
 	}
 
 	for _, propertyName := range supportedProperties {
+		// Start with required OIDC properties
+		properties := []testutils.IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "test_client",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "test_secret",
+				IsSecret: true,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "https://localhost:3000/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    "https://test.example.com/authorize",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    "https://test.example.com/token",
+				IsSecret: false,
+			},
+			{
+				Name:     propertyName,
+				Value:    fmt.Sprintf("test_%s_value", strings.ReplaceAll(propertyName, "_", "")),
+				IsSecret: false,
+			},
+		}
+
 		testIDP := testutils.IDP{
 			Name:        fmt.Sprintf("Test IDP with %s", propertyName),
 			Description: fmt.Sprintf("Testing %s property", propertyName),
-			Type:        "OAUTH",
-			Properties: []testutils.IDPProperty{
-				{
-					Name:     propertyName,
-					Value:    fmt.Sprintf("test_%s_value", strings.ReplaceAll(propertyName, "_", "")),
-					IsSecret: propertyName == "client_secret",
-				},
-			},
+			Type:        "OIDC",
+			Properties:  properties,
 		}
 
 		// Create IDP with the supported property


### PR DESCRIPTION
### Purpose
This pull request updates the property handling logic of the IDP service. This enables a more robust IDP type based property validation as well introduces the capability to apply known properties to the creating/ updating IDP.

### Approach
- Improve IDP property validations to validate properties based on the IDP type
- Implement logic to apply default properties for known IDP types such as Google and Github (Previously this was handled during runtime in auth services and executors. That will no longer be required and will be removed with a separate PR)

### Related Issues
- https://github.com/asgardeo/thunder/issues/891

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
