### PR TITLE
Use docker compose in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,58 +100,34 @@ Follow these steps to download the latest release of WSO2 Thunder and run it loc
 
     The product will start on `https://localhost:8090`.
 
-#### Option 2: Run with Docker
+#### Option 2: Run with Docker Compose
 
-Follow these steps to run WSO2 Thunder using Docker.
+Follow these steps to run WSO2 Thunder using Docker Compose.
 
-1. **Pull the Docker image**
+1. **Download the Docker Compose file**
 
-    ```bash
-    docker pull ghcr.io/asgardeo/thunder:latest
-    ```
-
-2. **Setup the product**
-
-    You need to setup the server with the initial configurations and data before starting the server for the first time.
+    Download the `docker-compose.yml` file using the following command:
 
     ```bash
-        docker run -it --rm \
-            ghcr.io/asgardeo/thunder:latest \
-            ./setup.sh
+    curl -o docker-compose.yml https://raw.githubusercontent.com/asgardeo/thunder/v0.14.0/install/quick-start/docker-compose.yml
     ```
 
-    **Note the id of the sample app indicated with the log line `[INFO] Sample App ID: <id>`.** You'll need it for the sample app configuration.
+2. **Start Thunder**
 
-    > [!NOTE]
-    > This will shut down the container after the setup is complete. You need to start the container again using the command in step 3. If you are using sqlite as the database, then you need to mount a volume to persist the database file and share it between the setup and server run containers.
-
-3. **Run the container**
+    Run the following command in the directory where you downloaded the `docker-compose.yml` file:
 
     ```bash
-    docker run --rm \
-      -p 8090:8090 \
-      ghcr.io/asgardeo/thunder:latest
+    docker compose up
     ```
 
-    Optionally if you want to modify the server configurations, you can mount a custom `deployment.yaml` file. Create a `deployment.yaml` file in your working directory similar to the [deployment.yaml](https://github.com/asgardeo/thunder/blob/main/backend/cmd/server/repository/conf/deployment.yaml), and mount it as below:
+    This will automatically:
+    - Initialize the database
+    - Run the setup process
+    - Start the Thunder server
 
-    ```bash
-    docker run --rm \
-      -p 8090:8090 \
-      -v $(pwd)/deployment.yaml:/opt/thunder/repository/conf/deployment.yaml \
-      ghcr.io/asgardeo/thunder:latest
-    ```
+    **Note the id of the sample app indicated with the log line `[INFO] Sample App ID: <id>` in the setup logs.** You'll need it for the sample app configuration.
 
-    Optionally if you want to use custom configurations or certificates, you can mount them as follows:
-
-    ```bash
-    docker run --rm \
-      -p 8090:8090 \
-      -v $(pwd)/deployment.yaml:/opt/thunder/repository/conf/deployment.yaml \
-      -v $(pwd)/certs/server.cert:/opt/thunder/repository/resources/security/server.cert \
-      -v $(pwd)/certs/server.key:/opt/thunder/repository/resources/security/server.key \
-      ghcr.io/asgardeo/thunder:latest
-    ```
+    The product will start on `https://localhost:8090`.
 
 ### Try Out the Product
 

--- a/install/quick-start/docker-compose.yml
+++ b/install/quick-start/docker-compose.yml
@@ -1,0 +1,50 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+services:
+  # Initialize database from the image
+  thunder-db-init:
+    image: ghcr.io/asgardeo/thunder:0.14.0
+    command: sh -c "cp -r /opt/thunder/repository/database/* /data/"
+    volumes:
+      - thunder-db:/data
+    restart: "no"
+
+  # Run setup once with the shared database
+  thunder-setup:
+    image: ghcr.io/asgardeo/thunder:0.14.0
+    command: ./setup.sh
+    volumes:
+      - thunder-db:/opt/thunder/repository/database
+    depends_on:
+      thunder-db-init:
+        condition: service_completed_successfully
+    restart: "no"
+
+  # Run Thunder server with the shared database
+  thunder:
+    image: ghcr.io/asgardeo/thunder:0.14.0
+    depends_on:
+      thunder-setup:
+        condition: service_completed_successfully
+    ports:
+      - "8090:8090"
+    volumes:
+      - thunder-db:/opt/thunder/repository/database
+
+volumes:
+  thunder-db:
+    driver: local


### PR DESCRIPTION
### Purpose
This pull request updates the documentation and adds a new `docker-compose.yml` file to simplify running WSO2 Thunder using Docker Compose. The main improvements are a streamlined setup process and clearer instructions for users who want to get started quickly with Docker Compose instead of manual Docker commands.

**Docker Compose support and documentation improvements:**

* Added a new `docker-compose.yml` file that automates database initialization, setup, and server startup for WSO2 Thunder, using dedicated services and a shared volume for persistent data.
* Updated the `README.md` to provide step-by-step instructions for running WSO2 Thunder with Docker Compose, replacing the previous manual Docker command workflow with a simpler and more automated process.
### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
