### PR TITLE
Add refresh token expiry time config

### DIFF
--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -63,28 +63,28 @@ func resolveTokenConfig(oauthApp *appmodel.OAuthAppConfigProcessedDTO, tokenType
 		ValidityPeriod: conf.JWT.ValidityPeriod,
 	}
 
-	if oauthApp == nil || oauthApp.Token == nil {
-		return tokenConfig
-	}
-
-	// Use OAuth-level issuer for all token types
-	if oauthApp.Token.Issuer != "" {
+	// Use OAuth-level issuer for all token types if app config is available
+	if oauthApp != nil && oauthApp.Token != nil && oauthApp.Token.Issuer != "" {
 		tokenConfig.Issuer = oauthApp.Token.Issuer
 	}
 
 	// Override with token-type specific configuration if available
 	switch tokenType {
 	case TokenTypeAccess:
-		if oauthApp.Token.AccessToken != nil {
+		if oauthApp != nil && oauthApp.Token != nil && oauthApp.Token.AccessToken != nil {
 			if oauthApp.Token.AccessToken.ValidityPeriod > 0 {
 				tokenConfig.ValidityPeriod = oauthApp.Token.AccessToken.ValidityPeriod
 			}
 		}
 	case TokenTypeID:
-		if oauthApp.Token.IDToken != nil {
+		if oauthApp != nil && oauthApp.Token != nil && oauthApp.Token.IDToken != nil {
 			if oauthApp.Token.IDToken.ValidityPeriod > 0 {
 				tokenConfig.ValidityPeriod = oauthApp.Token.IDToken.ValidityPeriod
 			}
+		}
+	case TokenTypeRefresh:
+		if conf.OAuth.RefreshToken.ValidityPeriod > 0 {
+			tokenConfig.ValidityPeriod = conf.OAuth.RefreshToken.ValidityPeriod
 		}
 	}
 


### PR DESCRIPTION
This pull request refines the logic for resolving token configuration in the OAuth2 token service utility. The main focus is on improving the handling of issuer and validity period overrides based on the provided app configuration and token type.

Improvements to token configuration logic:

* Added explicit checks for `oauthApp` and its nested fields before overriding the issuer and validity period, ensuring safer and more predictable behavior when app configuration is missing or incomplete.
* Introduced handling for `TokenTypeRefresh`, allowing the validity period for refresh tokens to be set from the global OAuth configuration if specified.