### PR TITLE
Add dynamic token issuer resolution

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -70,7 +70,6 @@
     "properties": []
   },
   "jwt": {
-    "issuer": "thunder",
     "validity_period": 3600,
     "audience": "application"
   },

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -19,8 +19,6 @@
 package discovery
 
 import (
-	"fmt"
-
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/pkce"
 	"github.com/asgardeo/thunder/internal/system/config"
@@ -39,8 +37,9 @@ type discoveryService struct {
 
 // NewDiscoveryService creates a new discovery service instance
 func newDiscoveryService() DiscoveryServiceInterface {
+	runtime := config.GetThunderRuntime()
 	ds := &discoveryService{}
-	ds.baseURL = getBaseURL()
+	ds.baseURL = config.GetServerURL(&runtime.Config.Server)
 	return ds
 }
 
@@ -71,22 +70,6 @@ func (ds *discoveryService) GetOIDCMetadata() *OIDCProviderMetadata {
 		IDTokenSigningAlgValuesSupported:  ds.getSupportedIDTokenSigningAlgorithms(),
 		ClaimsSupported:                   ds.getSupportedClaims(),
 	}
-}
-
-// Helper methods for building URLs and discovering capabilities
-func getBaseURL() string {
-	runtime := config.GetThunderRuntime()
-	if runtime.Config.Server.PublicURL != "" {
-		return runtime.Config.Server.PublicURL
-	}
-	scheme := "https"
-	if runtime.Config.Server.HTTPOnly {
-		scheme = "http"
-	}
-	return fmt.Sprintf("%s://%s:%d",
-		scheme,
-		runtime.Config.Server.Hostname,
-		runtime.Config.Server.Port)
 }
 
 func (ds *discoveryService) getIssuer() string {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -21,6 +21,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	urlpath "path"
 	"path/filepath"
@@ -275,6 +276,11 @@ func LoadConfig(path string, defaultsPath string) (*Config, error) {
 		}
 	}
 
+	// Derive JWT issuer from server config if not set
+	if cfg.JWT.Issuer == "" {
+		cfg.JWT.Issuer = GetServerURL(&cfg.Server)
+	}
+
 	return &cfg, nil
 }
 
@@ -298,6 +304,19 @@ func loadDefaultConfig(path string) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// GetServerURL constructs the server URL from the server configuration.
+// It uses PublicURL if set, otherwise constructs from hostname, port, and scheme.
+func GetServerURL(server *ServerConfig) string {
+	if server.PublicURL != "" {
+		return server.PublicURL
+	}
+	scheme := "https"
+	if server.HTTPOnly {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s:%d", scheme, server.Hostname, server.Port)
 }
 
 // mergeConfigs merges user configuration into the base configuration.

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -215,7 +215,7 @@ The following table lists the configurable parameters of the Thunder chart and t
 | `configuration.cache.ttl`              | Cache TTL in seconds                                            | `3600`                       |
 | `configuration.cache.evictionPolicy`   | Cache eviction policy                                           | `LRU`                        |
 | `configuration.cache.cleanupInterval`  | Cache cleanup interval in seconds                               | `300`                        |
-| `configuration.jwt.issuer`             | JWT issuer                                                      | `thunder`                    |
+| `configuration.jwt.issuer`             | JWT issuer (derived from server.publicUrl if not set)           | derived                      |
 | `configuration.jwt.validityPeriod`     | JWT validity period in seconds                                  | `3600`                       |
 | `configuration.jwt.audience`           | Default audience for auth assertions                            | `application`                |
 | `configuration.oauth.refreshToken.renewOnGrant` | Renew refresh token on grant                           | `false`                      |

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -193,7 +193,6 @@ configuration:
 
   # Token Configuration
   jwt:
-    issuer: "thunder"
     validityPeriod: 3600
     audience: "application"
 

--- a/install/openchoreo/helm/README.md
+++ b/install/openchoreo/helm/README.md
@@ -85,7 +85,7 @@ The chart creates the following OpenChoreo resources:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `jwt.issuer` | JWT token issuer identifier | `thunder` |
+| `jwt.issuer` | JWT token issuer identifier (derived from server URL if not set) | derived |
 | `jwt.validity` | JWT token validity in seconds | `3600` (1 hour) |
 | `oauth.refresh_token_validity` | Refresh token validity in seconds | `86400` (24 hours) |
 | `cors.allowed_origins` | List of allowed CORS origins | See values.yaml |

--- a/install/openchoreo/helm/values.yaml
+++ b/install/openchoreo/helm/values.yaml
@@ -60,7 +60,6 @@ database:
     sslmode: disable          # SSL mode: disable, require, verify-ca, verify-full
 
 jwt:
-  issuer: thunder     # JWT token issuer identifier
   validity: 3600      # JWT token validity in seconds (default: 1 hour)
 
 oauth:


### PR DESCRIPTION
This pull request updates the configuration logic for the JWT issuer, making it dynamically derived from the server configuration if not explicitly set. This change improves flexibility and ensures the JWT issuer matches the deployment environment. The default value for the issuer is removed from configuration files and documentation is updated to reflect the new behavior. Tests are added to verify the derivation logic.

**Configuration logic improvements:**

* The JWT issuer is now automatically derived from the server configuration (using `server.publicUrl` or constructed from hostname, port, and protocol) if not explicitly set in the config. (`backend/internal/system/config/config.go`, [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR279-R283) [[2]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR309-R320)
* Added comprehensive tests to verify issuer derivation logic under various scenarios, including explicit issuer, public URL, HTTP/HTTPS, and default behavior. (`backend/internal/system/config/config_test.go`, [backend/internal/system/config/config_test.goR606-R697](diffhunk://#diff-101c5403b01dad29943210a884b9a908df1009633a0718fd8a9f0eb234460434R606-R697))

**Configuration and documentation updates:**

* Removed the default `"issuer": "thunder"` value from `default.json`, Helm values, and OpenChoreo values files to avoid hardcoded issuer. (`backend/cmd/server/repository/resources/conf/default.json`, [[1]](diffhunk://#diff-beec713bb8f44ef8633de8d745de6dcd555593b5cd0758d7788470fee3b2d974L73); `install/helm/values.yaml`, [[2]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eL196); `install/openchoreo/helm/values.yaml`, [[3]](diffhunk://#diff-ee1431b12d650f30611fc35e0f2d5884e91c36bfe1e97b7699f34881b9880aa3L63)
* Updated documentation in Helm and OpenChoreo README files to explain that the JWT issuer is derived from the server URL if not set. (`install/helm/README.md`, [[1]](diffhunk://#diff-3f767509b40f4f726a137cd616c967a47345b5cf0034ae6f4cc29fcd830f5096L218-R218); `install/openchoreo/helm/README.md`, [[2]](diffhunk://#diff-e5b014a7f2d8bd4d353015e4ed0e5045aced5c5ca5f511bf989415c395a29ad7L88-R88)

**Codebase maintenance:**

* Minor import cleanup in `config.go` to support new logic. (`backend/internal/system/config/config.go`, [backend/internal/system/config/config.goR24](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR24))


### Related issue

- https://github.com/asgardeo/thunder/issues/815