### PR TITLE
Buffer encode HTTP responses before sending headers

### DIFF
--- a/backend/internal/group/handler_test.go
+++ b/backend/internal/group/handler_test.go
@@ -322,7 +322,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			},
 		},
 		{
-			name:        "encode error",
+			name:        "response write error",
 			requestPath: "/groups",
 			useFlaky:    true,
 			setup: func(svc *GroupServiceInterfaceMock) {
@@ -333,16 +333,16 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			},
 			assertBody: func(recorder *httptest.ResponseRecorder) {
 				suite.Require().Equal(http.StatusOK, recorder.Code)
-				suite.Require().Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Require().Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
-			name:        "client error encode failure",
+			name:        "client error response write failure",
 			requestPath: "/groups?limit=invalid",
 			useFlaky:    true,
 			assertBody: func(recorder *httptest.ResponseRecorder) {
 				suite.Require().Equal(http.StatusBadRequest, recorder.Code)
-				suite.Require().Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Require().Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 			assertSvc: func(svc *GroupServiceInterfaceMock) {
 				svc.AssertNotCalled(suite.T(), "GetGroupList", mock.Anything, mock.Anything)
@@ -477,7 +477,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			method:         http.MethodGet,
 			url:            "/ous/root/groups",
 			pathParamKey:   "path",
@@ -491,7 +491,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 		},
 	}
@@ -591,7 +591,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			},
 		},
 		{
-			name:     "encode error",
+			name:     "response write error",
 			body:     `{"name":"team","organizationUnitId":"ou"}`,
 			useFlaky: true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
@@ -604,16 +604,16 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusCreated, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
-			name:     "error response encode failure",
+			name:     "error response write failure",
 			body:     "{",
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "CreateGroup", mock.Anything)
@@ -733,7 +733,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			method:         http.MethodPost,
 			url:            "/ous/root/groups",
 			pathParamKey:   "path",
@@ -749,11 +749,11 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusCreated, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
-			name:           "error response encode failure",
+			name:           "error response write failure",
 			method:         http.MethodPost,
 			url:            "/ous/root/groups",
 			pathParamKey:   "path",
@@ -763,7 +763,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			setJSONHeader:  true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "CreateGroupByPath", mock.Anything, mock.Anything)
@@ -835,7 +835,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			method:         http.MethodGet,
 			url:            "/groups/grp-001",
 			pathParamKey:   "id",
@@ -849,17 +849,17 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
-			name:     "error response encode failure",
+			name:     "error response write failure",
 			method:   http.MethodGet,
 			url:      "/groups/",
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "GetGroup", mock.Anything)
@@ -961,7 +961,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			method:         http.MethodPut,
 			url:            "/groups/grp-001",
 			pathParamKey:   "id",
@@ -977,7 +977,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
@@ -1000,7 +1000,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			},
 		},
 		{
-			name:           "invalid json encode failure",
+			name:           "invalid json response write failure",
 			method:         http.MethodPut,
 			url:            "/groups/grp-001",
 			pathParamKey:   "id",
@@ -1010,7 +1010,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader:  true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
@@ -1034,7 +1034,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			},
 		},
 		{
-			name:          "missing id encode failure",
+			name:          "missing id response write failure",
 			method:        http.MethodPut,
 			url:           "/groups/",
 			body:          "{}",
@@ -1042,7 +1042,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
@@ -1072,13 +1072,13 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 			},
 		},
 		{
-			name:     "error response encode failure",
+			name:     "error response write failure",
 			method:   http.MethodDelete,
 			url:      "/groups/",
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "DeleteGroup", mock.Anything)
@@ -1207,7 +1207,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			method:         http.MethodGet,
 			url:            "/groups/grp-001/members",
 			pathParamKey:   "id",
@@ -1221,17 +1221,17 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			},
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusOK, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
-			name:     "error response encode failure",
+			name:     "error response write failure",
 			method:   http.MethodGet,
 			url:      "/groups//members",
 			useFlaky: true,
 			assert: func(rr *httptest.ResponseRecorder) {
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				require.Equal(suite.T(), serviceerror.ErrorEncodingError+"\n", rr.Body.String())
+				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers", mock.Anything, mock.Anything, mock.Anything)
@@ -1295,7 +1295,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_ExtractAndValidatePathEncod
 	require.True(t, failed)
 	require.Equal(t, "", path)
 	require.Equal(t, http.StatusBadRequest, writer.Code)
-	require.Equal(t, serviceerror.ErrorEncodingError+"\n", writer.Body.String())
+	require.Equal(t, "", writer.Body.String()) // Write fails, body remains empty
 }
 
 func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleErrorInternalServer() {

--- a/backend/internal/oauth/oauth2/userinfo/handler_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler_test.go
@@ -286,8 +286,8 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_EncodingError() {
 
 	s.handler.HandleUserInfo(rr, req)
 
-	// The handler should detect the encoding error - the utility logs the error and returns text/plain
-	assert.Equal(s.T(), http.StatusOK, rr.Code)
+	// With buffer approach, encoding fails BEFORE headers are sent, so we get HTTP 500
+	assert.Equal(s.T(), http.StatusInternalServerError, rr.Code)
 	// Verify that encoding error message is returned
 	assert.Contains(s.T(), rr.Body.String(), serviceerror.ErrorEncodingError)
 	s.mockService.AssertExpectations(s.T())

--- a/backend/internal/ou/handler_test.go
+++ b/backend/internal/ou/handler_test.go
@@ -345,7 +345,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 			},
 		},
 		{
-			name:     "encode error",
+			name:     "response write error",
 			url:      "/organization-units",
 			useFlaky: true,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
@@ -356,7 +356,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 	}
@@ -423,12 +423,12 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPostRequest
 			},
 		},
 		{
-			name:     "invalid json encode error",
+			name:     "invalid json response write error",
 			body:     "{invalid",
 			useFlaky: true,
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusBadRequest, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "CreateOrganizationUnit", mock.Anything)
@@ -491,7 +491,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPostRequest
 			},
 		},
 		{
-			name:     "service error encode failure",
+			name:     "service error response write failure",
 			body:     `{"handle":"finance","name":"Finance"}`,
 			useFlaky: true,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
@@ -502,11 +502,11 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPostRequest
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusInternalServerError, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
-			name:     "encode error",
+			name:     "response write error",
 			body:     `{"handle":"finance","name":"Finance"}`,
 			useFlaky: true,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
@@ -517,7 +517,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPostRequest
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusCreated, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 	}
@@ -577,12 +577,12 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUGetRequest(
 			},
 		},
 		{
-			name:     "missing id encode error",
+			name:     "missing id response write error",
 			url:      "/organization-units/" + defaultOURequestID,
 			useFlaky: true,
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusBadRequest, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "GetOrganizationUnit", mock.Anything)
@@ -607,7 +607,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUGetRequest(
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			url:            "/organization-units/" + defaultOURequestID,
 			pathParamKey:   "id",
 			pathParamValue: defaultOURequestID,
@@ -620,7 +620,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUGetRequest(
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
@@ -685,7 +685,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 			},
 		},
 		{
-			name:           "invalid json encode error",
+			name:           "invalid json response write error",
 			method:         http.MethodPut,
 			url:            "/organization-units/" + defaultOURequestID,
 			body:           "{invalid",
@@ -695,7 +695,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 			useFlaky:       true,
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusBadRequest, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
@@ -749,7 +749,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			method:         http.MethodPut,
 			url:            "/organization-units/" + defaultOURequestID,
 			body:           bodyValid,
@@ -765,7 +765,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 	}
@@ -935,7 +935,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			url:            "/organization-units/" + defaultOURequestID + "/ous",
 			pathParamKey:   "id",
 			pathParamValue: defaultOURequestID,
@@ -948,7 +948,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
@@ -1039,12 +1039,12 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUGetByPathRe
 			},
 		},
 		{
-			name:     "missing path encode error",
+			name:     "missing path response write error",
 			url:      "/organization-units/tree/" + defaultOUPath,
 			useFlaky: true,
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusBadRequest, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.AssertNotCalled(suite.T(), "GetOrganizationUnitByPath", mock.Anything)
@@ -1069,7 +1069,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUGetByPathRe
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			url:            "/organization-units/tree/" + defaultOUPath,
 			pathParamKey:   "path",
 			pathParamValue: defaultOUPath,
@@ -1082,7 +1082,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUGetByPathRe
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
@@ -1167,7 +1167,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutByPathRe
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			method:         http.MethodPut,
 			url:            "/organization-units/tree/" + defaultOUPath,
 			body:           `{"handle":"finance","name":"Finance"}`,
@@ -1184,7 +1184,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutByPathRe
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{
@@ -1342,7 +1342,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUUsersListBy
 			},
 		},
 		{
-			name:           "encode error",
+			name:           "response write error",
 			url:            "/organization-units/tree/" + defaultOUPath + "/users",
 			pathParamKey:   "path",
 			pathParamValue: defaultOUPath,
@@ -1355,7 +1355,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUUsersListBy
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
-				suite.Equal(serviceerror.ErrorEncodingError+"\n", recorder.Body.String())
+				suite.Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 		},
 		{

--- a/backend/internal/system/utils/httputil_test.go
+++ b/backend/internal/system/utils/httputil_test.go
@@ -578,8 +578,9 @@ func (suite *HTTPUtilTestSuite) TestWriteSuccessResponse_EncodingError() {
 
 		WriteSuccessResponse(w, http.StatusOK, unserializableData)
 
-		// The function should have attempted to write status code
-		assert.Equal(t, http.StatusOK, w.Code)
+		// With buffer approach, encoding fails BEFORE headers are sent
+		// So we get HTTP 500 instead of the intended 200
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
 
 		// After encoding fails, http.Error() is called which writes the predefined error message
 		responseBody := w.Body.String()


### PR DESCRIPTION
### Purpose
After w.WriteHeader(statusCode) is called, calling http.Error() when encoding fails will not properly set the HTTP status to 500. Once WriteHeader is called, the status code cannot be changed. With the previous implementation, the error message will be written to the response body but the status code will remain as statusCode instead of 500. Ref [1]. This is resolved with the PR.

### Related Issues
- https://github.com/asgardeo/thunder/issues/442

### Related PRs
- https://github.com/asgardeo/thunder/pull/845
- https://github.com/asgardeo/thunder/pull/878

[1] https://github.com/asgardeo/thunder/pull/845#discussion_r2559422923
