### PR TITLE
Define a generic `START` node for all flows

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -302,6 +302,7 @@ RESPONSE=$(thunder_api_call POST "/applications" "{
   \"auth_flow_graph_id\": \"auth_flow_config_basic\",
   \"registration_flow_graph_id\": \"registration_flow_config_basic\",
   \"is_registration_flow_enabled\": true,
+  \"allowed_user_types\": [\"Person\"],
   \"user_attributes\": [\"given_name\",\"family_name\",\"email\",\"groups\", \"name\"],
   \"inbound_auth_config\": [{
     \"type\": \"oauth2\",

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "basic_auth"
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "inputs": [

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "choose_auth"
+        },
+        {
             "id": "choose_auth",
             "type": "PROMPT",
             "actions": [

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "choose_auth"
+        },
+        {
             "id": "choose_auth",
             "type": "PROMPT",
             "actions": [

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_google_github_sms.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "choose_auth"
+        },
+        {
             "id": "choose_auth",
             "type": "PROMPT",
             "actions": [

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_with_prompt.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_with_prompt.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "prompt_username"
+        },
+        {
             "id": "prompt_username",
             "type": "PROMPT",
             "inputs": [

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_github.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "github_auth"
+        },
+        {
             "id": "github_auth",
             "type": "TASK_EXECUTION",
             "properties": {

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_google.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "google_auth"
+        },
+        {
             "id": "google_auth",
             "type": "TASK_EXECUTION",
             "properties": {

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_sms.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "prompt_mobile"
+        },
+        {
             "id": "prompt_mobile",
             "type": "PROMPT",
             "inputs": [

--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_sms_with_username.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_sms_with_username.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "mobile_prompt_username"
+        },
+        {
             "id": "mobile_prompt_username",
             "type": "PROMPT",
             "inputs": [

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "basic_auth"
         },
         {

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "choose_auth"
         },
         {

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github_sms.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "choose_auth"
         },
         {

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_sms.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "prompt_mobile"
         },
         {

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -59,8 +59,8 @@ type NodeType string
 const (
 	// NodeTypeAuthSuccess represents a node that does auth assertion
 	NodeTypeAuthSuccess NodeType = "AUTHENTICATION_SUCCESS"
-	// NodeTypeRegistrationStart represents the beginning of a registration flow
-	NodeTypeRegistrationStart NodeType = "REGISTRATION_START"
+	// NodeTypeStart represents the beginning of a flow
+	NodeTypeStart NodeType = "START"
 	// NodeTypeTaskExecution represents a task execution node
 	NodeTypeTaskExecution NodeType = "TASK_EXECUTION"
 	// NodeTypePrompt represents a prompt node

--- a/backend/internal/flow/core/factory.go
+++ b/backend/internal/flow/core/factory.go
@@ -64,7 +64,7 @@ func (f *flowFactory) CreateNode(id, _type string, properties map[string]interfa
 		return newPromptNode(id, properties, isStartNode, isFinalNode), nil
 	case common.NodeTypeAuthSuccess:
 		return newTaskExecutionNode(id, properties, isStartNode, isFinalNode), nil
-	case common.NodeTypeRegistrationStart:
+	case common.NodeTypeStart:
 		return newTaskExecutionNode(id, properties, isStartNode, isFinalNode), nil
 	default:
 		return nil, errors.New("unsupported node type: " + _type)

--- a/tests/integration/flowauthn/attribute_collect_test.go
+++ b/tests/integration/flowauthn/attribute_collect_test.go
@@ -40,6 +40,7 @@ var (
 		ClientID:                  "attr_collect_flow_test_client",
 		ClientSecret:              "attr_collect_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"attr_collect_flow_user"},
 	}
 
 	attrCollectTestOU = testutils.OrganizationUnit{
@@ -50,7 +51,7 @@ var (
 	}
 
 	attrCollectUserSchema = testutils.UserSchema{
-		Name: "attr_collect_user",
+		Name: "attr_collect_flow_user",
 		Schema: map[string]interface{}{
 			"username": map[string]interface{}{
 				"type": "string",
@@ -148,19 +149,20 @@ func (ts *AttributeCollectFlowTestSuite) SetupSuite() {
 	}
 	attrCollectTestOUID = ouID
 
-	// Create test application for attribute collect tests
-	appID, err := testutils.CreateApplication(attrCollectTestApp)
-	if err != nil {
-		ts.T().Fatalf("Failed to create test application during setup: %v", err)
-	}
-	attrCollectTestAppID = appID
-
+	// Create test user schema within the OU
 	attrCollectUserSchema.OrganizationUnitId = attrCollectTestOUID
 	schemaID, err := testutils.CreateUserType(attrCollectUserSchema)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)
 	}
 	attrCollectUserSchemaID = schemaID
+
+	// Create test application for attribute collect tests
+	appID, err := testutils.CreateApplication(attrCollectTestApp)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test application during setup: %v", err)
+	}
+	attrCollectTestAppID = appID
 
 	// Store original app config (this will be the created app config)
 	ts.config.OriginalAppConfig, err = getAppConfig(attrCollectTestAppID)

--- a/tests/integration/flowauthn/authz_test.go
+++ b/tests/integration/flowauthn/authz_test.go
@@ -65,6 +65,7 @@ var (
 		ClientID:                  "authz_flow_test_client",
 		ClientSecret:              "authz_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"authz-test-person"},
 	}
 
 	userWithRole = testutils.User{

--- a/tests/integration/flowauthn/basic_auth_test.go
+++ b/tests/integration/flowauthn/basic_auth_test.go
@@ -43,6 +43,7 @@ var (
 		ClientID:                  "flow_test_client",
 		ClientSecret:              "flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"basic_auth_user"},
 	}
 
 	testUserSchema = testutils.UserSchema{
@@ -102,13 +103,6 @@ func (ts *BasicAuthFlowTestSuite) SetupSuite() {
 	ts.Require().NoError(err, "Failed to create test organization unit")
 	ts.ouID = ouID
 
-	// Create test application
-	appID, err := testutils.CreateApplication(testApp)
-	if err != nil {
-		ts.T().Fatalf("Failed to create test application during setup: %v", err)
-	}
-	testAppID = appID
-
 	// Create test user schema
 	testUserSchema.OrganizationUnitId = ts.ouID
 	schemaID, err := testutils.CreateUserType(testUserSchema)
@@ -116,6 +110,13 @@ func (ts *BasicAuthFlowTestSuite) SetupSuite() {
 		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)
 	}
 	userSchemaID = schemaID
+
+	// Create test application
+	appID, err := testutils.CreateApplication(testApp)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test application during setup: %v", err)
+	}
+	testAppID = appID
 
 	// Create test user with the created OU
 	testUser := testUser

--- a/tests/integration/flowauthn/github_auth_test.go
+++ b/tests/integration/flowauthn/github_auth_test.go
@@ -39,12 +39,13 @@ var (
 		ClientID:                  "github_auth_flow_test_client",
 		ClientSecret:              "github_auth_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"github_auth_user"},
 	}
 )
 
 var (
 	githubAuthTestAppID string
-	githubAuthTestOU = testutils.OrganizationUnit{
+	githubAuthTestOU    = testutils.OrganizationUnit{
 		Handle:      "github-auth-flow-test-ou",
 		Name:        "GitHub Auth Flow Test OU",
 		Description: "Organization unit for GitHub authentication flow tests",
@@ -56,7 +57,7 @@ const (
 )
 
 var githubUserSchema = testutils.UserSchema{
-	Name: "github_flow_user",
+	Name: "github_auth_user",
 	Schema: map[string]interface{}{
 		"username": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/flowauthn/google_auth_test.go
+++ b/tests/integration/flowauthn/google_auth_test.go
@@ -39,12 +39,13 @@ var (
 		ClientID:                  "google_auth_flow_test_client",
 		ClientSecret:              "google_auth_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"google_auth_user"},
 	}
 )
 
 var (
 	googleAuthTestAppID string
-	googleAuthTestOU = testutils.OrganizationUnit{
+	googleAuthTestOU    = testutils.OrganizationUnit{
 		Handle:      "google-auth-flow-test-ou",
 		Name:        "Google Auth Flow Test OU",
 		Description: "Organization unit for Google authentication flow tests",
@@ -56,7 +57,7 @@ const (
 )
 
 var googleUserSchema = testutils.UserSchema{
-	Name: "google_flow_user",
+	Name: "google_auth_user",
 	Schema: map[string]interface{}{
 		"username": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/flowauthn/http_request_executor_test.go
+++ b/tests/integration/flowauthn/http_request_executor_test.go
@@ -38,6 +38,7 @@ var (
 		AuthFlowGraphID:           "auth_flow_config_basic_http_request",
 		RegistrationFlowGraphID:   "registration_flow_config_basic",
 		IsRegistrationFlowEnabled: false,
+		AllowedUserTypes:          []string{"http_request_test_person"},
 	}
 
 	httpRequestTestOU = testutils.OrganizationUnit{

--- a/tests/integration/flowauthn/prompt_actions_test.go
+++ b/tests/integration/flowauthn/prompt_actions_test.go
@@ -41,6 +41,7 @@ var (
 		ClientID:                  "prompt_actions_flow_test_client",
 		ClientSecret:              "prompt_actions_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"prompt_actions_test_person"},
 	}
 
 	promptActionsTestOU = testutils.OrganizationUnit{
@@ -51,7 +52,7 @@ var (
 	}
 
 	promptActionsUserSchema = testutils.UserSchema{
-		Name: "prompt_actions_user",
+		Name: "prompt_actions_test_person",
 		Schema: map[string]interface{}{
 			"username": map[string]interface{}{
 				"type": "string",
@@ -125,19 +126,20 @@ func (ts *PromptActionsAndMFAFlowTestSuite) SetupSuite() {
 	}
 	promptActionsTestOUID = ouID
 
-	// Create test application for prompt actions tests
-	appID, err := testutils.CreateApplication(promptActionsTestApp)
-	if err != nil {
-		ts.T().Fatalf("Failed to create test application during setup: %v", err)
-	}
-	promptActionsTestAppID = appID
-
+	// Create test user schema within the OU
 	promptActionsUserSchema.OrganizationUnitId = promptActionsTestOUID
 	schemaID, err := testutils.CreateUserType(promptActionsUserSchema)
 	if err != nil {
 		ts.T().Fatalf("Failed to create test user schema during setup: %v", err)
 	}
 	promptActionsUserSchemaID = schemaID
+
+	// Create test application for prompt actions tests
+	appID, err := testutils.CreateApplication(promptActionsTestApp)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test application during setup: %v", err)
+	}
+	promptActionsTestAppID = appID
 
 	// Start mock notification server
 	ts.mockServer = testutils.NewMockNotificationServer(mockPromptActionsNotificationServerPort)

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -347,6 +347,7 @@ func (ts *OAuthAuthzScopeTestSuite) createOAuthApplication() (string, error) {
 		"auth_flow_graph_id":           "auth_flow_config_basic",
 		"registration_flow_graph_id":   "registration_flow_config_basic",
 		"is_registration_flow_enabled": false,
+		"allowed_user_types":           []string{"authz-test-person"},
 		"inbound_auth_config": []map[string]interface{}{
 			{
 				"type": "oauth2",

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -119,6 +119,7 @@ func (ts *AuthzTestSuite) SetupSuite() {
 		"auth_flow_graph_id":           "auth_flow_config_basic",
 		"registration_flow_graph_id":   "registration_flow_config_basic",
 		"is_registration_flow_enabled": true,
+		"allowed_user_types":           []string{"authz-test-person"},
 		"inbound_auth_config": []map[string]interface{}{
 			{
 				"type": "oauth2",

--- a/tests/integration/oauth/token/tokenexchange_test.go
+++ b/tests/integration/oauth/token/tokenexchange_test.go
@@ -204,6 +204,7 @@ func (ts *TokenExchangeTestSuite) createTestApplication() string {
 		"auth_flow_graph_id":           "auth_flow_config_basic",
 		"registration_flow_graph_id":   "registration_flow_config_basic",
 		"is_registration_flow_enabled": true,
+		"allowed_user_types":           []string{"token-test-person"},
 		"inbound_auth_config": []map[string]interface{}{
 			{
 				"type": "oauth2",
@@ -508,6 +509,7 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_ApplicationNotRegisteredForG
 		"auth_flow_graph_id":           "auth_flow_config_basic",
 		"registration_flow_graph_id":   "registration_flow_config_basic",
 		"is_registration_flow_enabled": true,
+		"allowed_user_types":           []string{"token-test-person"},
 		"inbound_auth_config": []map[string]interface{}{
 			{
 				"type": "oauth2",

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -160,6 +160,7 @@ func (ts *UserInfoTestSuite) createTestApplication() string {
 		"auth_flow_graph_id":           "auth_flow_config_basic",
 		"registration_flow_graph_id":   "registration_flow_config_basic",
 		"is_registration_flow_enabled": true,
+		"allowed_user_types":           []string{"userinfo-person"},
 		"inbound_auth_config": []map[string]interface{}{
 			{
 				"type": "oauth2",

--- a/tests/integration/resources/graphs/auth_flow_config_basic_attr_collect_test_1.json
+++ b/tests/integration/resources/graphs/auth_flow_config_basic_attr_collect_test_1.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "basic_auth"
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "inputs": [

--- a/tests/integration/resources/graphs/auth_flow_config_basic_http_request.json
+++ b/tests/integration/resources/graphs/auth_flow_config_basic_http_request.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "basic_auth"
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "executor": {

--- a/tests/integration/resources/graphs/auth_flow_config_decision_and_mfa_test_1.json
+++ b/tests/integration/resources/graphs/auth_flow_config_decision_and_mfa_test_1.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "choose_auth"
+        },
+        {
             "id": "choose_auth",
             "type": "PROMPT",
             "actions": [

--- a/tests/integration/resources/graphs/auth_flow_config_github.json
+++ b/tests/integration/resources/graphs/auth_flow_config_github.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "github_auth"
+        },
+        {
             "id": "github_auth",
             "type": "TASK_EXECUTION",
             "properties": {

--- a/tests/integration/resources/graphs/auth_flow_config_google.json
+++ b/tests/integration/resources/graphs/auth_flow_config_google.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "google_auth"
+        },
+        {
             "id": "google_auth",
             "type": "TASK_EXECUTION",
             "properties": {

--- a/tests/integration/resources/graphs/auth_flow_config_google_conditional_ou.json
+++ b/tests/integration/resources/graphs/auth_flow_config_google_conditional_ou.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "google_auth"
+        },
+        {
             "id": "google_auth",
             "type": "TASK_EXECUTION",
             "properties": {

--- a/tests/integration/resources/graphs/auth_flow_config_http_request_error_continue.json
+++ b/tests/integration/resources/graphs/auth_flow_config_http_request_error_continue.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "basic_auth"
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "executor": {

--- a/tests/integration/resources/graphs/auth_flow_config_http_request_error_fail.json
+++ b/tests/integration/resources/graphs/auth_flow_config_http_request_error_fail.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "basic_auth"
+        },
+        {
             "id": "basic_auth",
             "type": "TASK_EXECUTION",
             "executor": {

--- a/tests/integration/resources/graphs/auth_flow_config_sms.json
+++ b/tests/integration/resources/graphs/auth_flow_config_sms.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "prompt_mobile"
+        },
+        {
             "id": "prompt_mobile",
             "type": "PROMPT",
             "inputs": [

--- a/tests/integration/resources/graphs/auth_flow_config_sms_with_username.json
+++ b/tests/integration/resources/graphs/auth_flow_config_sms_with_username.json
@@ -3,6 +3,11 @@
     "type": "AUTHENTICATION",
     "nodes": [
         {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "mobile_prompt_username"
+        },
+        {
             "id": "mobile_prompt_username",
             "type": "PROMPT",
             "inputs": [

--- a/tests/integration/resources/graphs/registration_flow_config_basic.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "basic_auth"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_basic_http_request.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic_http_request.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "provision_user"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_basic_with_ou.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic_with_ou.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "basic_auth"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_github.json
+++ b/tests/integration/resources/graphs/registration_flow_config_github.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "github_auth"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_google.json
+++ b/tests/integration/resources/graphs/registration_flow_config_google.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "google_auth"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_google_with_existing_user.json
+++ b/tests/integration/resources/graphs/registration_flow_config_google_with_existing_user.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "google_auth"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_sms.json
+++ b/tests/integration/resources/graphs/registration_flow_config_sms.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "prompt_mobile"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_sms_with_ou.json
+++ b/tests/integration/resources/graphs/registration_flow_config_sms_with_ou.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "sms_auth"
         },
         {

--- a/tests/integration/resources/graphs/registration_flow_config_sms_with_username.json
+++ b/tests/integration/resources/graphs/registration_flow_config_sms_with_username.json
@@ -3,8 +3,8 @@
     "type": "REGISTRATION",
     "nodes": [
         {
-            "id": "registration_start",
-            "type": "REGISTRATION_START",
+            "id": "start",
+            "type": "START",
             "onSuccess": "mobile_prompt_username"
         },
         {


### PR DESCRIPTION
### Purpose
This PR defines a generic `START` node type for all the flows including authentication and registration. This replaces the previously existing `REGISTRATION_START` node with the new `START` node.

---
### ⚠️ Breaking Changes

This PR introduces breaking changes that require updates to the existing flow definitions.

#### 🔧 Summary of Breaking Changes

**1. 🆕 Introduction of a new `START` node

A new `START` node type has been introduced to signify the beginning of a flow. Existing flows that do not define a starting point must be updated to include a `START` node. The `START` node does not require any inputs or actions.

Here is an example of how to define a `START` node in your flow definition:

```json
{
    "id": "start",
    "type": "START",
}
```

**2. 🔄 Replace `REGISTRATION_START` with the new `START` node

Flows that previously used the `REGISTRATION_START` node should be updated to use the new `START` node. The functionality remains the same, but the node type has been standardized.

---

### Approach
This PR introduces the following changes to the flow definitions.
- Introduce a generic `START` node type that will gets an executor attached underline
- Replace the `REGISTRATION_START` node with the new `START` node
- Improve `UserTypeResolver` executor to be used in authentication flows. In authentication flows, it validates whether the application has any user types attached

### Related Issues
- https://github.com/asgardeo/thunder/issues/919

### Related PRs
- https://github.com/asgardeo/thunder/pull/920

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
