### PR TITLE
Add fsGroup and runAsGroup support

### DIFF
--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -120,8 +120,13 @@ The following table lists the configurable parameters of the Thunder chart and t
 | `deployment.resources.limits.memory`    | Memory resource limits                                                                  | `512Mi`                        |
 | `deployment.resources.requests.cpu`     | CPU resource requests                                                                   | `1`                            |
 | `deployment.resources.requests.memory`  | Memory resource requests                                                                | `256Mi`                        |
+| `deployment.securityContext.readOnlyRootFilesystem` | Enable read-only root filesystem (must be false for SQLite)                     | `true`                         |
 | `deployment.securityContext.enableRunAsUser` | Enable running as non-root user                                                    | `true`                         |
 | `deployment.securityContext.runAsUser`  | User ID to run the container                                                            | `802`                          |
+| `deployment.securityContext.enableRunAsGroup` | Enable setting group ID for the container process                                 | `true`                         |
+| `deployment.securityContext.runAsGroup` | Group ID to run the container                                                           | `802`                          |
+| `deployment.securityContext.enableFsGroup` | Enable setting fsGroup for volume ownership                                          | `true`                         |
+| `deployment.securityContext.fsGroup`    | Group ID for mounted volumes (fixes SQLite permission issues on cloud platforms)        | `802`                          |
 | `deployment.securityContext.seccompProfile.enabled` | Enable seccomp profile                                                      | `false`                        |
 | `deployment.securityContext.seccompProfile.type` | Seccomp profile type                                                           | `RuntimeDefault`               |
 

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -51,6 +51,12 @@ spec:
         {{- if .Values.deployment.securityContext.enableRunAsUser }}
         runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
         {{- end }}
+        {{- if .Values.deployment.securityContext.enableRunAsGroup }}
+        runAsGroup: {{ .Values.deployment.securityContext.runAsGroup }}
+        {{- end }}
+        {{- if .Values.deployment.securityContext.enableFsGroup }}
+        fsGroup: {{ .Values.deployment.securityContext.fsGroup }}
+        {{- end }}
         {{- if .Values.deployment.securityContext.seccompProfile.enabled }}
         seccompProfile:
           type: {{ .Values.deployment.securityContext.seccompProfile.type }}

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -44,6 +44,12 @@ spec:
         {{- if .Values.deployment.securityContext.enableRunAsUser }}
         runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
         {{- end }}
+        {{- if .Values.deployment.securityContext.enableRunAsGroup }}
+        runAsGroup: {{ .Values.deployment.securityContext.runAsGroup }}
+        {{- end }}
+        {{- if .Values.deployment.securityContext.enableFsGroup }}
+        fsGroup: {{ .Values.deployment.securityContext.fsGroup }}
+        {{- end }}
         {{- if .Values.deployment.securityContext.seccompProfile.enabled }}
         seccompProfile:
           type: {{ .Values.deployment.securityContext.seccompProfile.type }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -24,6 +24,10 @@ deployment:
     readOnlyRootFilesystem: true # This must be false if sqlite is used as the database
     enableRunAsUser: true
     runAsUser: 802
+    enableRunAsGroup: true
+    runAsGroup: 802
+    enableFsGroup: true
+    fsGroup: 802
     seccompProfile:
       enabled: false
       type: "RuntimeDefault"


### PR DESCRIPTION
### Purpose
This pull request adds new configurable options to the Helm chart for controlling container and volume security context, specifically around group permissions and filesystem ownership. These changes improve flexibility and compatibility, especially when deploying with SQLite or on cloud platforms.

### Helm Chart Security Context Enhancements

* Added support for configuring `runAsGroup` and `fsGroup` in the deployment and setup job templates, allowing containers and volumes to run with specific group IDs for improved permission management. [[1]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R47-R52) [[2]](diffhunk://#diff-347defecc78c600bb09918a1ffee9bb8844c401332830dfb0b49d594e6d79b4bR54-R59)
* Updated `values.yaml` to expose new parameters: `enableRunAsGroup`, `runAsGroup`, `enableFsGroup`, and `fsGroup`, making it easier to set group ownership for processes and mounted volumes.

### Documentation Updates

* Expanded the Helm chart documentation table in `README.md` to describe the new security context options, including notes about compatibility with SQLite and cloud platforms.

### Related Issues
- https://github.com/asgardeo/thunder/issues/932