### PR TITLE
Fix db type issue and add Query method to Tx

### DIFF
--- a/backend/internal/application/store.go
+++ b/backend/internal/application/store.go
@@ -104,7 +104,7 @@ func (st *applicationStore) CreateApplication(app model.ApplicationProcessedDTO)
 			} else {
 				brandingID = nil
 			}
-			_, err := tx.Exec(QueryCreateApplication.Query, app.ID, app.Name, app.Description,
+			_, err := tx.Exec(QueryCreateApplication, app.ID, app.Name, app.Description,
 				app.AuthFlowGraphID, app.RegistrationFlowGraphID, isRegistrationEnabledStr, brandingID,
 				jsonDataBytes, st.deploymentID)
 			return err
@@ -341,7 +341,7 @@ func (st *applicationStore) UpdateApplication(existingApp, updatedApp *model.App
 			} else {
 				brandingID = nil
 			}
-			_, err := tx.Exec(QueryUpdateApplicationByAppID.Query, updatedApp.ID, updatedApp.Name,
+			_, err := tx.Exec(QueryUpdateApplicationByAppID, updatedApp.ID, updatedApp.Name,
 				updatedApp.Description, updatedApp.AuthFlowGraphID, updatedApp.RegistrationFlowGraphID,
 				isRegistrationEnabledStr, brandingID, jsonDataBytes, st.deploymentID)
 			return err
@@ -481,7 +481,7 @@ func createOAuthAppQuery(app *model.ApplicationProcessedDTO,
 	}
 
 	return func(tx dbmodel.TxInterface) error {
-		_, err := tx.Exec(oauthAppMgtQuery.Query, app.ID, clientID, clientSecret, oauthConfigJSON, deploymentID)
+		_, err := tx.Exec(oauthAppMgtQuery, app.ID, clientID, clientSecret, oauthConfigJSON, deploymentID)
 		return err
 	}
 }
@@ -489,7 +489,7 @@ func createOAuthAppQuery(app *model.ApplicationProcessedDTO,
 // deleteOAuthAppQuery creates a query function for deleting an OAuth application by client ID.
 func deleteOAuthAppQuery(clientID string, deploymentID string) func(tx dbmodel.TxInterface) error {
 	return func(tx dbmodel.TxInterface) error {
-		_, err := tx.Exec(QueryDeleteOAuthApplicationByClientID.Query, clientID, deploymentID)
+		_, err := tx.Exec(QueryDeleteOAuthApplicationByClientID, clientID, deploymentID)
 		return err
 	}
 }

--- a/backend/internal/application/store_test.go
+++ b/backend/internal/application/store_test.go
@@ -1704,7 +1704,7 @@ func TestCreateOAuthAppQuery_ExecError(t *testing.T) {
 
 	mockTx := modelmock.NewTxInterfaceMock(t)
 	mockTx.
-		On("Exec", QueryCreateOAuthApplication.Query, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		On("Exec", QueryCreateOAuthApplication, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			testServerID).
 		Return(nil, errors.New("database exec error")).
 		Once()
@@ -1722,7 +1722,7 @@ func TestDeleteOAuthAppQuery_ExecError(t *testing.T) {
 
 	mockTx := modelmock.NewTxInterfaceMock(t)
 	mockTx.
-		On("Exec", QueryDeleteOAuthApplicationByClientID.Query, mock.Anything, testServerID).
+		On("Exec", QueryDeleteOAuthApplicationByClientID, mock.Anything, testServerID).
 		Return(nil, errors.New("database delete error")).
 		Once()
 

--- a/backend/internal/flow/flowexec/store.go
+++ b/backend/internal/flow/flowexec/store.go
@@ -59,13 +59,13 @@ func (s *flowStore) StoreFlowContext(ctx EngineContext) error {
 
 	queries := []func(tx dbmodel.TxInterface) error{
 		func(tx dbmodel.TxInterface) error {
-			_, err := tx.Exec(QueryCreateFlowContext.Query, dbModel.FlowID, dbModel.AppID,
+			_, err := tx.Exec(QueryCreateFlowContext, dbModel.FlowID, dbModel.AppID,
 				dbModel.CurrentNodeID, dbModel.CurrentActionID, dbModel.GraphID,
 				dbModel.RuntimeData, dbModel.ExecutionHistory, s.deploymentID)
 			return err
 		},
 		func(tx dbmodel.TxInterface) error {
-			_, err := tx.Exec(QueryCreateFlowUserData.Query, dbModel.FlowID,
+			_, err := tx.Exec(QueryCreateFlowUserData, dbModel.FlowID,
 				dbModel.IsAuthenticated, dbModel.UserID, dbModel.OrganizationUnitID,
 				dbModel.UserType, dbModel.UserInputs, dbModel.UserAttributes, s.deploymentID)
 			return err
@@ -109,13 +109,13 @@ func (s *flowStore) UpdateFlowContext(ctx EngineContext) error {
 
 	queries := []func(tx dbmodel.TxInterface) error{
 		func(tx dbmodel.TxInterface) error {
-			_, err := tx.Exec(QueryUpdateFlowContext.Query, dbModel.FlowID,
+			_, err := tx.Exec(QueryUpdateFlowContext, dbModel.FlowID,
 				dbModel.CurrentNodeID, dbModel.CurrentActionID, dbModel.RuntimeData, dbModel.ExecutionHistory,
 				s.deploymentID)
 			return err
 		},
 		func(tx dbmodel.TxInterface) error {
-			_, err := tx.Exec(QueryUpdateFlowUserData.Query, dbModel.FlowID, dbModel.IsAuthenticated,
+			_, err := tx.Exec(QueryUpdateFlowUserData, dbModel.FlowID, dbModel.IsAuthenticated,
 				dbModel.UserID, dbModel.OrganizationUnitID, dbModel.UserType,
 				dbModel.UserInputs, dbModel.UserAttributes, s.deploymentID)
 			return err
@@ -129,11 +129,11 @@ func (s *flowStore) UpdateFlowContext(ctx EngineContext) error {
 func (s *flowStore) DeleteFlowContext(flowID string) error {
 	queries := []func(tx dbmodel.TxInterface) error{
 		func(tx dbmodel.TxInterface) error {
-			_, err := tx.Exec(QueryDeleteFlowUserData.Query, flowID, s.deploymentID)
+			_, err := tx.Exec(QueryDeleteFlowUserData, flowID, s.deploymentID)
 			return err
 		},
 		func(tx dbmodel.TxInterface) error {
-			_, err := tx.Exec(QueryDeleteFlowContext.Query, flowID, s.deploymentID)
+			_, err := tx.Exec(QueryDeleteFlowContext, flowID, s.deploymentID)
 			return err
 		},
 	}

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -130,7 +130,7 @@ func (s *groupStore) CreateGroup(group GroupDAO) error {
 	}
 
 	_, err = tx.Exec(
-		QueryCreateGroup.Query,
+		QueryCreateGroup,
 		group.ID,
 		group.OrganizationUnitID,
 		group.Name,
@@ -251,7 +251,7 @@ func (s *groupStore) UpdateGroup(group GroupDAO) error {
 	}
 
 	result, err := tx.Exec(
-		QueryUpdateGroup.Query,
+		QueryUpdateGroup,
 		group.ID,
 		group.OrganizationUnitID,
 		group.Name,
@@ -309,7 +309,7 @@ func (s *groupStore) DeleteGroup(id string) error {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	_, err = tx.Exec(QueryDeleteGroupMembers.Query, id, s.deploymentID)
+	_, err = tx.Exec(QueryDeleteGroupMembers, id, s.deploymentID)
 	if err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
 			err = errors.Join(err, fmt.Errorf("failed to rollback transaction: %w", rollbackErr))
@@ -317,7 +317,7 @@ func (s *groupStore) DeleteGroup(id string) error {
 		return fmt.Errorf("failed to delete group members: %w", err)
 	}
 
-	result, err := tx.Exec(QueryDeleteGroup.Query, id, s.deploymentID)
+	result, err := tx.Exec(QueryDeleteGroup, id, s.deploymentID)
 	if err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
 			err = errors.Join(err, fmt.Errorf("failed to rollback transaction: %w", rollbackErr))
@@ -494,7 +494,7 @@ func addMembersToGroup(
 	deploymentID string,
 ) error {
 	for _, member := range members {
-		_, err := tx.Exec(QueryAddMemberToGroup.Query, groupID, member.Type, member.ID, deploymentID)
+		_, err := tx.Exec(QueryAddMemberToGroup, groupID, member.Type, member.ID, deploymentID)
 		if err != nil {
 			return fmt.Errorf("failed to add member to group: %w", err)
 		}
@@ -510,7 +510,7 @@ func updateGroupMembers(
 	members []Member,
 	deploymentID string,
 ) error {
-	_, err := tx.Exec(QueryDeleteGroupMembers.Query, groupID, deploymentID)
+	_, err := tx.Exec(QueryDeleteGroupMembers, groupID, deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing group member assignments: %w", err)
 	}

--- a/backend/internal/group/store_test.go
+++ b/backend/internal/group/store_test.go
@@ -145,7 +145,7 @@ func (suite *GroupStoreTestSuite) runGroupNameConflictTestCases(testCases []grou
 }
 
 // testExecRollbackError is a helper function to test rollback errors during database operations.
-func testExecRollbackError(t *testing.T, query string, operation func(*groupStore, GroupDAO) error) {
+func testExecRollbackError(t *testing.T, query dbmodel.DBQuery, operation func(*groupStore, GroupDAO) error) {
 	providerMock := providermock.NewDBProviderInterfaceMock(t)
 	dbClientMock := clientmock.NewDBClientInterfaceMock(t)
 	txMock := modelmock.NewTxInterfaceMock(t)
@@ -480,7 +480,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryCreateGroup.Query,
+						QueryCreateGroup,
 						groupWithMember.ID,
 						groupWithMember.OrganizationUnitID,
 						groupWithMember.Name,
@@ -493,7 +493,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						groupWithMember.ID,
 						MemberTypeUser,
 						"user-1",
@@ -533,7 +533,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryCreateGroup.Query,
+						QueryCreateGroup,
 						groupNoMembers.ID,
 						groupNoMembers.OrganizationUnitID,
 						groupNoMembers.Name,
@@ -570,7 +570,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 			name:      "insert rollback failure",
 			useHelper: true,
 			helper: func() {
-				testExecRollbackError(suite.T(), QueryCreateGroup.Query, func(store *groupStore, group GroupDAO) error {
+				testExecRollbackError(suite.T(), QueryCreateGroup, func(store *groupStore, group GroupDAO) error {
 					return store.CreateGroup(group)
 				})
 			},
@@ -597,7 +597,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryCreateGroup.Query,
+						QueryCreateGroup,
 						groupMemberOnly.ID,
 						groupMemberOnly.OrganizationUnitID,
 						groupMemberOnly.Name,
@@ -610,7 +610,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						groupMemberOnly.ID,
 						MemberTypeUser,
 						"usr-1",
@@ -648,7 +648,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryCreateGroup.Query,
+						QueryCreateGroup,
 						groupMemberOnly.ID,
 						groupMemberOnly.OrganizationUnitID,
 						groupMemberOnly.Name,
@@ -661,7 +661,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						groupMemberOnly.ID,
 						MemberTypeUser,
 						"usr-1",
@@ -720,7 +720,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryCreateGroup.Query,
+						QueryCreateGroup,
 						groupWithMember.ID,
 						groupWithMember.OrganizationUnitID,
 						groupWithMember.Name,
@@ -733,7 +733,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_CreateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						groupWithMember.ID,
 						MemberTypeUser,
 						"user-1",
@@ -1249,7 +1249,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						groupWithMembers.ID,
 						groupWithMembers.OrganizationUnitID,
 						groupWithMembers.Name,
@@ -1284,7 +1284,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 			name:      "exec rollback helper",
 			useHelper: true,
 			helper: func() {
-				testExecRollbackError(suite.T(), QueryUpdateGroup.Query, func(store *groupStore, group GroupDAO) error {
+				testExecRollbackError(suite.T(), QueryUpdateGroup, func(store *groupStore, group GroupDAO) error {
 					return store.UpdateGroup(group)
 				})
 			},
@@ -1309,7 +1309,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						groupMinimal.ID,
 						groupMinimal.OrganizationUnitID,
 						groupMinimal.Name,
@@ -1345,7 +1345,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						groupMinimal.ID,
 						groupMinimal.OrganizationUnitID,
 						groupMinimal.Name,
@@ -1381,7 +1381,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						"grp-001",
 						"",
 						"",
@@ -1393,7 +1393,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1402,7 +1402,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						"grp-001",
 						MemberTypeUser,
 						"usr-1",
@@ -1437,7 +1437,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						groupMinimal.ID,
 						groupMinimal.OrganizationUnitID,
 						groupMinimal.Name,
@@ -1449,7 +1449,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						groupMinimal.ID,
 						testDeploymentID,
 					).
@@ -1458,7 +1458,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						groupMinimal.ID,
 						mock.Anything,
 						mock.Anything,
@@ -1512,7 +1512,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						groupMinimal.ID,
 						groupMinimal.OrganizationUnitID,
 						groupMinimal.Name,
@@ -1548,7 +1548,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						groupWithoutMembers.ID,
 						groupWithoutMembers.OrganizationUnitID,
 						groupWithoutMembers.Name,
@@ -1560,7 +1560,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						groupWithoutMembers.ID,
 						testDeploymentID,
 					).
@@ -1593,7 +1593,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryUpdateGroup.Query,
+						QueryUpdateGroup,
 						groupWithMembers.ID,
 						groupWithMembers.OrganizationUnitID,
 						groupWithMembers.Name,
@@ -1605,7 +1605,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						groupWithMembers.ID,
 						testDeploymentID,
 					).
@@ -1614,7 +1614,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						groupWithMembers.ID,
 						MemberTypeUser,
 						"user-1",
@@ -1731,7 +1731,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1767,7 +1767,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1777,7 +1777,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroup.Query,
+						QueryDeleteGroup,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1813,7 +1813,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1823,7 +1823,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroup.Query,
+						QueryDeleteGroup,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1859,7 +1859,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1869,7 +1869,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroup.Query,
+						QueryDeleteGroup,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1905,7 +1905,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1915,7 +1915,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroup.Query,
+						QueryDeleteGroup,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -1967,7 +1967,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2003,7 +2003,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2013,7 +2013,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroup.Query,
+						QueryDeleteGroup,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2049,7 +2049,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2059,7 +2059,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_DeleteGroup() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroup.Query,
+						QueryDeleteGroup,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2681,7 +2681,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_AddMembersToGroupReturnsError()
 	txMock.
 		On(
 			"Exec",
-			QueryAddMemberToGroup.Query,
+			QueryAddMemberToGroup,
 			"grp-001",
 			MemberTypeUser,
 			"usr-1",
@@ -2711,7 +2711,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroupMembers() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2721,7 +2721,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroupMembers() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						"grp-001",
 						MemberTypeUser,
 						"usr-1",
@@ -2740,7 +2740,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroupMembers() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2757,7 +2757,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroupMembers() {
 				txMock.
 					On(
 						"Exec",
-						QueryDeleteGroupMembers.Query,
+						QueryDeleteGroupMembers,
 						"grp-001",
 						testDeploymentID,
 					).
@@ -2767,7 +2767,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_UpdateGroupMembers() {
 				txMock.
 					On(
 						"Exec",
-						QueryAddMemberToGroup.Query,
+						QueryAddMemberToGroup,
 						"grp-001",
 						MemberTypeUser,
 						"usr-1",

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -110,7 +110,7 @@ func (s *roleStore) CreateRole(id string, role RoleCreationDetail) error {
 
 	return s.executeInTransaction(dbClient, func(tx dbmodel.TxInterface) error {
 		_, err := tx.Exec(
-			queryCreateRole.Query,
+			queryCreateRole,
 			id,
 			role.OrganizationUnitID,
 			role.Name,
@@ -243,7 +243,7 @@ func (s *roleStore) UpdateRole(id string, role RoleUpdateDetail) error {
 
 	return s.executeInTransaction(dbClient, func(tx dbmodel.TxInterface) error {
 		result, err := tx.Exec(
-			queryUpdateRole.Query,
+			queryUpdateRole,
 			role.OrganizationUnitID,
 			role.Name,
 			role.Description,
@@ -313,7 +313,7 @@ func (s *roleStore) RemoveAssignments(id string, assignments []RoleAssignment) e
 
 	return s.executeInTransaction(dbClient, func(tx dbmodel.TxInterface) error {
 		for _, assignment := range assignments {
-			_, err := tx.Exec(queryDeleteRoleAssignmentsByIDs.Query, id, assignment.Type, assignment.ID, s.deploymentID)
+			_, err := tx.Exec(queryDeleteRoleAssignmentsByIDs, id, assignment.Type, assignment.ID, s.deploymentID)
 			if err != nil {
 				return fmt.Errorf("failed to remove assignment from role: %w", err)
 			}
@@ -364,7 +364,7 @@ func addPermissionsToRole(
 	deploymentID string,
 ) error {
 	for _, permission := range permissions {
-		_, err := tx.Exec(queryCreateRolePermission.Query, id, permission, deploymentID)
+		_, err := tx.Exec(queryCreateRolePermission, id, permission, deploymentID)
 		if err != nil {
 			return fmt.Errorf("failed to add permission to role: %w", err)
 		}
@@ -380,7 +380,7 @@ func addAssignmentsToRole(
 	deploymentID string,
 ) error {
 	for _, assignment := range assignments {
-		_, err := tx.Exec(queryCreateRoleAssignment.Query, id, assignment.Type, assignment.ID, deploymentID)
+		_, err := tx.Exec(queryCreateRoleAssignment, id, assignment.Type, assignment.ID, deploymentID)
 		if err != nil {
 			return fmt.Errorf("failed to add assignment to role: %w", err)
 		}
@@ -396,7 +396,7 @@ func updateRolePermissions(
 	permissions []string,
 	deploymentID string,
 ) error {
-	_, err := tx.Exec(queryDeleteRolePermissions.Query, id, deploymentID)
+	_, err := tx.Exec(queryDeleteRolePermissions, id, deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing role permissions: %w", err)
 	}

--- a/backend/internal/role/store_test.go
+++ b/backend/internal/role/store_test.go
@@ -149,13 +149,13 @@ func (suite *RoleStoreTestSuite) TestCreateRole_Success() {
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
-	suite.mockTx.On("Exec", queryCreateRole.Query, mock.Anything, "ou1", "Test Role", "Test Description",
+	suite.mockTx.On("Exec", queryCreateRole, mock.Anything, "ou1", "Test Role", "Test Description",
 		testDeploymentID).Return(&mockResult{}, nil)
-	suite.mockTx.On("Exec", queryCreateRolePermission.Query, mock.Anything, "perm1", testDeploymentID).
+	suite.mockTx.On("Exec", queryCreateRolePermission, mock.Anything, "perm1", testDeploymentID).
 		Return(&mockResult{}, nil)
-	suite.mockTx.On("Exec", queryCreateRolePermission.Query, mock.Anything, "perm2", testDeploymentID).
+	suite.mockTx.On("Exec", queryCreateRolePermission, mock.Anything, "perm2", testDeploymentID).
 		Return(&mockResult{}, nil)
-	suite.mockTx.On("Exec", queryCreateRoleAssignment.Query, mock.Anything, AssigneeTypeUser, "user1",
+	suite.mockTx.On("Exec", queryCreateRoleAssignment, mock.Anything, AssigneeTypeUser, "user1",
 		testDeploymentID).Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(nil)
 
@@ -176,7 +176,7 @@ func (suite *RoleStoreTestSuite) TestCreateRole_ExecError() {
 	execError := errors.New("insert failed")
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
-	suite.mockTx.On("Exec", queryCreateRole.Query, mock.Anything, "ou1", "Test Role", "Test Description",
+	suite.mockTx.On("Exec", queryCreateRole, mock.Anything, "ou1", "Test Role", "Test Description",
 		testDeploymentID).Return(nil, execError)
 	suite.mockTx.On("Rollback").Return(nil)
 
@@ -294,10 +294,10 @@ func (suite *RoleStoreTestSuite) TestUpdateRole_Success() {
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
-	suite.mockTx.On("Exec", queryUpdateRole.Query, "ou1", "Updated Role", "Updated Description", "role1",
+	suite.mockTx.On("Exec", queryUpdateRole, "ou1", "Updated Role", "Updated Description", "role1",
 		testDeploymentID).Return(&mockResult{rowsAffected: 1}, nil)
-	suite.mockTx.On("Exec", queryDeleteRolePermissions.Query, "role1", testDeploymentID).Return(&mockResult{}, nil)
-	suite.mockTx.On("Exec", queryCreateRolePermission.Query, "role1", "perm1", testDeploymentID).
+	suite.mockTx.On("Exec", queryDeleteRolePermissions, "role1", testDeploymentID).Return(&mockResult{}, nil)
+	suite.mockTx.On("Exec", queryCreateRolePermission, "role1", "perm1", testDeploymentID).
 		Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(nil)
 
@@ -317,7 +317,7 @@ func (suite *RoleStoreTestSuite) TestUpdateRole_NotFound() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
 	suite.mockTx.On(
-		"Exec", queryUpdateRole.Query, "ou1", "Updated Role", "Updated Description", "nonexistent", testDeploymentID,
+		"Exec", queryUpdateRole, "ou1", "Updated Role", "Updated Description", "nonexistent", testDeploymentID,
 	).Return(&mockResult{rowsAffected: 0}, nil)
 	suite.mockTx.On("Rollback").Return(nil)
 
@@ -353,7 +353,7 @@ func (suite *RoleStoreTestSuite) TestAddAssignments_Success() {
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
-	suite.mockTx.On("Exec", queryCreateRoleAssignment.Query, "role1", AssigneeTypeUser, "user1", testDeploymentID).
+	suite.mockTx.On("Exec", queryCreateRoleAssignment, "role1", AssigneeTypeUser, "user1", testDeploymentID).
 		Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(nil)
 
@@ -369,7 +369,7 @@ func (suite *RoleStoreTestSuite) TestRemoveAssignments_Success() {
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
 	suite.mockDBClient.On("BeginTx").Return(suite.mockTx, nil)
-	suite.mockTx.On("Exec", queryDeleteRoleAssignmentsByIDs.Query, "role1", AssigneeTypeUser, "user1",
+	suite.mockTx.On("Exec", queryDeleteRoleAssignmentsByIDs, "role1", AssigneeTypeUser, "user1",
 		testDeploymentID).Return(&mockResult{}, nil)
 	suite.mockTx.On("Commit").Return(nil)
 

--- a/backend/internal/system/database/model/dbquery_test.go
+++ b/backend/internal/system/database/model/dbquery_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type DBQueryTestSuite struct {
+	suite.Suite
+}
+
+func TestDBQueryTestSuite(t *testing.T) {
+	suite.Run(t, new(DBQueryTestSuite))
+}
+
+func (suite *DBQueryTestSuite) TestGetID() {
+	query := DBQuery{
+		ID:    "TEST-001",
+		Query: "SELECT * FROM users",
+	}
+
+	suite.Equal("TEST-001", query.GetID())
+}
+
+func (suite *DBQueryTestSuite) TestGetQuery_DefaultQuery() {
+	query := DBQuery{
+		ID:    "TEST-002",
+		Query: "SELECT * FROM users",
+	}
+
+	suite.Equal("SELECT * FROM users", query.GetQuery("postgres"))
+	suite.Equal("SELECT * FROM users", query.GetQuery("sqlite"))
+	suite.Equal("SELECT * FROM users", query.GetQuery("mysql"))
+}
+
+func (suite *DBQueryTestSuite) TestGetQuery_PostgresQuery() {
+	query := DBQuery{
+		ID:            "TEST-003",
+		Query:         "SELECT * FROM users WHERE id = ?",
+		PostgresQuery: "SELECT * FROM users WHERE id = $1",
+	}
+
+	suite.Equal("SELECT * FROM users WHERE id = $1", query.GetQuery("postgres"))
+	suite.Equal("SELECT * FROM users WHERE id = ?", query.GetQuery("sqlite"))
+}
+
+func (suite *DBQueryTestSuite) TestGetQuery_SQLiteQuery() {
+	query := DBQuery{
+		ID:          "TEST-004",
+		Query:       "SELECT * FROM users WHERE id = $1",
+		SQLiteQuery: "SELECT * FROM users WHERE id = ?",
+	}
+
+	suite.Equal("SELECT * FROM users WHERE id = $1", query.GetQuery("postgres"))
+	suite.Equal("SELECT * FROM users WHERE id = ?", query.GetQuery("sqlite"))
+}
+
+func (suite *DBQueryTestSuite) TestGetQuery_BothSpecificQueries() {
+	query := DBQuery{
+		ID:            "TEST-005",
+		Query:         "SELECT * FROM users",
+		PostgresQuery: "SELECT * FROM users WHERE id = $1",
+		SQLiteQuery:   "SELECT * FROM users WHERE id = ?",
+	}
+
+	suite.Equal("SELECT * FROM users WHERE id = $1", query.GetQuery("postgres"))
+	suite.Equal("SELECT * FROM users WHERE id = ?", query.GetQuery("sqlite"))
+	suite.Equal("SELECT * FROM users", query.GetQuery("mysql"))
+}
+
+func (suite *DBQueryTestSuite) TestGetQuery_EmptySpecificQueries() {
+	query := DBQuery{
+		ID:            "TEST-006",
+		Query:         "SELECT * FROM users",
+		PostgresQuery: "",
+		SQLiteQuery:   "",
+	}
+
+	suite.Equal("SELECT * FROM users", query.GetQuery("postgres"))
+	suite.Equal("SELECT * FROM users", query.GetQuery("sqlite"))
+}
+
+func (suite *DBQueryTestSuite) TestGetQuery_UnknownDBType() {
+	query := DBQuery{
+		ID:            "TEST-007",
+		Query:         "SELECT * FROM users",
+		PostgresQuery: "SELECT * FROM users WHERE id = $1",
+		SQLiteQuery:   "SELECT * FROM users WHERE id = ?",
+	}
+
+	suite.Equal("SELECT * FROM users", query.GetQuery("unknown"))
+	suite.Equal("SELECT * FROM users", query.GetQuery(""))
+}
+
+func (suite *DBQueryTestSuite) TestDBQuery_ImplementsInterface() {
+	var _ DBQueryInterface = (*DBQuery)(nil)
+}

--- a/backend/internal/system/database/model/model_test.go
+++ b/backend/internal/system/database/model/model_test.go
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/suite"
+)
+
+type DBTestSuite struct {
+	suite.Suite
+	db     *sql.DB
+	mock   sqlmock.Sqlmock
+	dbImpl DBInterface
+}
+
+func TestDBTestSuite(t *testing.T) {
+	suite.Run(t, new(DBTestSuite))
+}
+
+func (suite *DBTestSuite) SetupTest() {
+	var err error
+	suite.db, suite.mock, err = sqlmock.New()
+	suite.Require().NoError(err)
+	suite.dbImpl = NewDB(suite.db)
+}
+
+func (suite *DBTestSuite) TearDownTest() {
+	_ = suite.db.Close()
+}
+
+func (suite *DBTestSuite) TestNewDB() {
+	db := NewDB(suite.db)
+	suite.NotNil(db)
+	suite.IsType(&DB{}, db)
+}
+
+func (suite *DBTestSuite) TestDB_Query_Success() {
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "test")
+	suite.mock.ExpectQuery("SELECT \\* FROM users WHERE id = \\$1").
+		WithArgs(1).
+		WillReturnRows(rows)
+
+	result, err := suite.dbImpl.Query("SELECT * FROM users WHERE id = $1", 1)
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *DBTestSuite) TestDB_Query_Error() {
+	suite.mock.ExpectQuery("SELECT \\* FROM users").
+		WillReturnError(errors.New("query error"))
+
+	result, err := suite.dbImpl.Query("SELECT * FROM users")
+	suite.Error(err)
+	suite.Nil(result)
+	suite.Equal("query error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *DBTestSuite) TestDB_Exec_Success() {
+	suite.mock.ExpectExec("INSERT INTO users").
+		WithArgs("john", "john@example.com").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	result, err := suite.dbImpl.Exec("INSERT INTO users (name, email) VALUES ($1, $2)", "john", "john@example.com")
+	suite.NoError(err)
+	suite.NotNil(result)
+
+	rowsAffected, err := result.RowsAffected()
+	suite.NoError(err)
+	suite.Equal(int64(1), rowsAffected)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *DBTestSuite) TestDB_Exec_Error() {
+	suite.mock.ExpectExec("INSERT INTO users").
+		WillReturnError(errors.New("exec error"))
+
+	result, err := suite.dbImpl.Exec("INSERT INTO users (name) VALUES ($1)", "john")
+	suite.Error(err)
+	suite.Nil(result)
+	suite.Equal("exec error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *DBTestSuite) TestDB_Begin_Success() {
+	suite.mock.ExpectBegin()
+
+	tx, err := suite.dbImpl.Begin()
+	suite.NoError(err)
+	suite.NotNil(tx)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *DBTestSuite) TestDB_Begin_Error() {
+	suite.mock.ExpectBegin().WillReturnError(errors.New("begin error"))
+
+	tx, err := suite.dbImpl.Begin()
+	suite.Error(err)
+	suite.Nil(tx)
+	suite.Equal("begin error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *DBTestSuite) TestDB_Close_Success() {
+	suite.mock.ExpectClose()
+
+	err := suite.dbImpl.Close()
+	suite.NoError(err)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *DBTestSuite) TestDB_Close_Error() {
+	suite.mock.ExpectClose().WillReturnError(errors.New("close error"))
+
+	err := suite.dbImpl.Close()
+	suite.Error(err)
+	suite.Equal("close error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+type TxTestSuite struct {
+	suite.Suite
+	db     *sql.DB
+	mock   sqlmock.Sqlmock
+	tx     *sql.Tx
+	txImpl TxInterface
+}
+
+func TestTxTestSuite(t *testing.T) {
+	suite.Run(t, new(TxTestSuite))
+}
+
+func (suite *TxTestSuite) SetupTest() {
+	var err error
+	suite.db, suite.mock, err = sqlmock.New()
+	suite.Require().NoError(err)
+
+	suite.mock.ExpectBegin()
+	suite.tx, err = suite.db.Begin()
+	suite.Require().NoError(err)
+
+	suite.txImpl = NewTx(suite.tx, "postgres")
+}
+
+func (suite *TxTestSuite) TearDownTest() {
+	_ = suite.db.Close()
+}
+
+func (suite *TxTestSuite) TestNewTx() {
+	tx := NewTx(suite.tx, "postgres")
+	suite.NotNil(tx)
+	suite.IsType(&Tx{}, tx)
+}
+
+func (suite *TxTestSuite) TestTx_Commit_Success() {
+	suite.mock.ExpectCommit()
+
+	err := suite.txImpl.Commit()
+	suite.NoError(err)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Commit_Error() {
+	suite.mock.ExpectCommit().WillReturnError(errors.New("commit error"))
+
+	err := suite.txImpl.Commit()
+	suite.Error(err)
+	suite.Equal("commit error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Rollback_Success() {
+	suite.mock.ExpectRollback()
+
+	err := suite.txImpl.Rollback()
+	suite.NoError(err)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Rollback_Error() {
+	suite.mock.ExpectRollback().WillReturnError(errors.New("rollback error"))
+
+	err := suite.txImpl.Rollback()
+	suite.Error(err)
+	suite.Equal("rollback error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Exec_Success_DefaultQuery() {
+	query := DBQuery{
+		ID:    "TEST-001",
+		Query: "INSERT INTO users (name) VALUES ($1)",
+	}
+
+	suite.mock.ExpectExec("INSERT INTO users").
+		WithArgs("john").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	result, err := suite.txImpl.Exec(query, "john")
+	suite.NoError(err)
+	suite.NotNil(result)
+
+	rowsAffected, err := result.RowsAffected()
+	suite.NoError(err)
+	suite.Equal(int64(1), rowsAffected)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Exec_Success_PostgresQuery() {
+	suite.txImpl = NewTx(suite.tx, "postgres")
+
+	query := DBQuery{
+		ID:            "TEST-002",
+		Query:         "INSERT INTO users (name) VALUES (?)",
+		PostgresQuery: "INSERT INTO users (name) VALUES ($1)",
+	}
+
+	suite.mock.ExpectExec("INSERT INTO users").
+		WithArgs("john").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	result, err := suite.txImpl.Exec(query, "john")
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Exec_Success_SQLiteQuery() {
+	suite.mock.ExpectBegin()
+	tx, err := suite.db.Begin()
+	suite.Require().NoError(err)
+	suite.txImpl = NewTx(tx, "sqlite")
+
+	query := DBQuery{
+		ID:          "TEST-003",
+		Query:       "INSERT INTO users (name) VALUES ($1)",
+		SQLiteQuery: "INSERT INTO users (name) VALUES (?)",
+	}
+
+	suite.mock.ExpectExec("INSERT INTO users").
+		WithArgs("john").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	result, err := suite.txImpl.Exec(query, "john")
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Exec_Error() {
+	query := DBQuery{
+		ID:    "TEST-004",
+		Query: "INSERT INTO users (name) VALUES ($1)",
+	}
+
+	suite.mock.ExpectExec("INSERT INTO users").
+		WillReturnError(errors.New("exec error"))
+
+	result, err := suite.txImpl.Exec(query, "john")
+	suite.Error(err)
+	suite.Nil(result)
+	suite.Equal("exec error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Query_Success_DefaultQuery() {
+	query := DBQuery{
+		ID:    "TEST-005",
+		Query: "SELECT * FROM users WHERE id = $1",
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "john")
+	suite.mock.ExpectQuery("SELECT \\* FROM users WHERE id = \\$1").
+		WithArgs(1).
+		WillReturnRows(rows)
+
+	result, err := suite.txImpl.Query(query, 1)
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Query_Success_PostgresQuery() {
+	suite.txImpl = NewTx(suite.tx, "postgres")
+
+	query := DBQuery{
+		ID:            "TEST-006",
+		Query:         "SELECT * FROM users WHERE id = ?",
+		PostgresQuery: "SELECT * FROM users WHERE id = $1",
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "john")
+	suite.mock.ExpectQuery("SELECT \\* FROM users WHERE id = \\$1").
+		WithArgs(1).
+		WillReturnRows(rows)
+
+	result, err := suite.txImpl.Query(query, 1)
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Query_Success_SQLiteQuery() {
+	suite.mock.ExpectBegin()
+	tx, err := suite.db.Begin()
+	suite.Require().NoError(err)
+	suite.txImpl = NewTx(tx, "sqlite")
+
+	query := DBQuery{
+		ID:          "TEST-007",
+		Query:       "SELECT * FROM users WHERE id = $1",
+		SQLiteQuery: "SELECT * FROM users WHERE id = ?",
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "john")
+	suite.mock.ExpectQuery("SELECT \\* FROM users WHERE id = \\?").
+		WithArgs(1).
+		WillReturnRows(rows)
+
+	result, err := suite.txImpl.Query(query, 1)
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}
+
+func (suite *TxTestSuite) TestTx_Query_Error() {
+	query := DBQuery{
+		ID:    "TEST-008",
+		Query: "SELECT * FROM users",
+	}
+
+	suite.mock.ExpectQuery("SELECT \\* FROM users").
+		WillReturnError(errors.New("query error"))
+
+	result, err := suite.txImpl.Query(query)
+	suite.Error(err)
+	suite.Nil(result)
+	suite.Equal("query error", err.Error())
+	suite.NoError(suite.mock.ExpectationsWereMet())
+}

--- a/backend/internal/system/database/provider/dbclient.go
+++ b/backend/internal/system/database/provider/dbclient.go
@@ -126,7 +126,7 @@ func (client *DBClient) BeginTx() (model.TxInterface, error) {
 	if err != nil {
 		return nil, err
 	}
-	return model.NewTx(tx), nil
+	return model.NewTx(tx, client.dbType), nil
 }
 
 // Close closes the database connection.

--- a/backend/internal/user/store.go
+++ b/backend/internal/user/store.go
@@ -166,7 +166,7 @@ func (us *userStore) CreateUser(user User, credentials []Credential) error {
 
 	// Insert user
 	_, err = tx.Exec(
-		QueryCreateUser.Query,
+		QueryCreateUser,
 		user.ID,
 		user.OrganizationUnit,
 		user.Type,
@@ -247,8 +247,7 @@ func (us *userStore) UpdateUser(user *User) error {
 
 	// Update user
 	result, err := tx.Exec(
-		QueryUpdateUserByUserID.Query,
-		user.ID, user.OrganizationUnit, user.Type, string(attributes), us.deploymentID)
+		QueryUpdateUserByUserID, user.ID, user.OrganizationUnit, user.Type, string(attributes), us.deploymentID)
 	if err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
 			err = errors.Join(err, fmt.Errorf("failed to rollback transaction: %w", rollbackErr))
@@ -273,7 +272,7 @@ func (us *userStore) UpdateUser(user *User) error {
 
 	// Delete existing indexed attributes
 	_, err = tx.Exec(
-		QueryDeleteIndexedAttributesByUser.Query,
+		QueryDeleteIndexedAttributesByUser,
 		user.ID,
 		us.deploymentID,
 	)
@@ -698,7 +697,11 @@ func (us *userStore) syncIndexedAttributesWithTx(
 	}
 
 	// Construct the complete query with dynamic VALUES placeholders
-	query := QueryBatchInsertIndexedAttributes.Query + strings.Join(valuePlaceholders, ", ")
+	queryStr := QueryBatchInsertIndexedAttributes.Query + strings.Join(valuePlaceholders, ", ")
+	query := dbmodel.DBQuery{
+		ID:    QueryBatchInsertIndexedAttributes.ID,
+		Query: queryStr,
+	}
 
 	// Execute batch insert
 	_, err := tx.Exec(query, args...)

--- a/backend/internal/user/store_test.go
+++ b/backend/internal/user/store_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	dbmodel "github.com/asgardeo/thunder/internal/system/database/model"
 	"github.com/asgardeo/thunder/tests/mocks/database/modelmock"
 )
 
@@ -74,12 +75,12 @@ func (suite *UserStoreTestSuite) TestSyncIndexedAttributesWithTx_Success_StringV
 	}`)
 
 	// Expect batch insert with all indexed attributes
-	suite.mockTx.On("Exec", mock.MatchedBy(func(query string) bool {
-		return strings.Contains(query, "INSERT INTO USER_INDEXED_ATTRIBUTES") &&
-			strings.Contains(query, "USER_ID") &&
-			strings.Contains(query, "ATTRIBUTE_NAME") &&
-			strings.Contains(query, "ATTRIBUTE_VALUE") &&
-			strings.Contains(query, "DEPLOYMENT_ID")
+	suite.mockTx.On("Exec", mock.MatchedBy(func(query dbmodel.DBQuery) bool {
+		return strings.Contains(query.Query, "INSERT INTO USER_INDEXED_ATTRIBUTES") &&
+			strings.Contains(query.Query, "USER_ID") &&
+			strings.Contains(query.Query, "ATTRIBUTE_NAME") &&
+			strings.Contains(query.Query, "ATTRIBUTE_VALUE") &&
+			strings.Contains(query.Query, "DEPLOYMENT_ID")
 	}), mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
@@ -105,12 +106,12 @@ func (suite *UserStoreTestSuite) TestSyncIndexedAttributesWithTx_Success_MixedTy
 
 	// Expect batch insert with only indexed attributes (username, email)
 	// age, active, score should be converted to strings
-	suite.mockTx.On("Exec", mock.MatchedBy(func(query string) bool {
-		return strings.Contains(query, "INSERT INTO USER_INDEXED_ATTRIBUTES") &&
-			strings.Contains(query, "USER_ID") &&
-			strings.Contains(query, "ATTRIBUTE_NAME") &&
-			strings.Contains(query, "ATTRIBUTE_VALUE") &&
-			strings.Contains(query, "DEPLOYMENT_ID")
+	suite.mockTx.On("Exec", mock.MatchedBy(func(query dbmodel.DBQuery) bool {
+		return strings.Contains(query.Query, "INSERT INTO USER_INDEXED_ATTRIBUTES") &&
+			strings.Contains(query.Query, "USER_ID") &&
+			strings.Contains(query.Query, "ATTRIBUTE_NAME") &&
+			strings.Contains(query.Query, "ATTRIBUTE_VALUE") &&
+			strings.Contains(query.Query, "DEPLOYMENT_ID")
 	}), mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)

--- a/backend/tests/mocks/database/modelmock/TxInterface_mock.go
+++ b/backend/tests/mocks/database/modelmock/TxInterface_mock.go
@@ -7,6 +7,7 @@ package modelmock
 import (
 	"database/sql"
 
+	"github.com/asgardeo/thunder/internal/system/database/model"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -82,7 +83,7 @@ func (_c *TxInterfaceMock_Commit_Call) RunAndReturn(run func() error) *TxInterfa
 }
 
 // Exec provides a mock function for the type TxInterfaceMock
-func (_mock *TxInterfaceMock) Exec(query string, args ...any) (sql.Result, error) {
+func (_mock *TxInterfaceMock) Exec(query model.DBQuery, args ...any) (sql.Result, error) {
 	var _ca []interface{}
 	_ca = append(_ca, query)
 	_ca = append(_ca, args...)
@@ -94,17 +95,17 @@ func (_mock *TxInterfaceMock) Exec(query string, args ...any) (sql.Result, error
 
 	var r0 sql.Result
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, ...any) (sql.Result, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(model.DBQuery, ...any) (sql.Result, error)); ok {
 		return returnFunc(query, args...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, ...any) sql.Result); ok {
+	if returnFunc, ok := ret.Get(0).(func(model.DBQuery, ...any) sql.Result); ok {
 		r0 = returnFunc(query, args...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(sql.Result)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, ...any) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(model.DBQuery, ...any) error); ok {
 		r1 = returnFunc(query, args...)
 	} else {
 		r1 = ret.Error(1)
@@ -118,18 +119,18 @@ type TxInterfaceMock_Exec_Call struct {
 }
 
 // Exec is a helper method to define mock.On call
-//   - query string
+//   - query model.DBQuery
 //   - args ...any
 func (_e *TxInterfaceMock_Expecter) Exec(query interface{}, args ...interface{}) *TxInterfaceMock_Exec_Call {
 	return &TxInterfaceMock_Exec_Call{Call: _e.mock.On("Exec",
 		append([]interface{}{query}, args...)...)}
 }
 
-func (_c *TxInterfaceMock_Exec_Call) Run(run func(query string, args ...any)) *TxInterfaceMock_Exec_Call {
+func (_c *TxInterfaceMock_Exec_Call) Run(run func(query model.DBQuery, args ...any)) *TxInterfaceMock_Exec_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 model.DBQuery
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(model.DBQuery)
 		}
 		var arg1 []any
 		variadicArgs := make([]any, len(args)-1)
@@ -152,7 +153,83 @@ func (_c *TxInterfaceMock_Exec_Call) Return(result sql.Result, err error) *TxInt
 	return _c
 }
 
-func (_c *TxInterfaceMock_Exec_Call) RunAndReturn(run func(query string, args ...any) (sql.Result, error)) *TxInterfaceMock_Exec_Call {
+func (_c *TxInterfaceMock_Exec_Call) RunAndReturn(run func(query model.DBQuery, args ...any) (sql.Result, error)) *TxInterfaceMock_Exec_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Query provides a mock function for the type TxInterfaceMock
+func (_mock *TxInterfaceMock) Query(query model.DBQuery, args ...any) (*sql.Rows, error) {
+	var _ca []interface{}
+	_ca = append(_ca, query)
+	_ca = append(_ca, args...)
+	ret := _mock.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
+
+	var r0 *sql.Rows
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(model.DBQuery, ...any) (*sql.Rows, error)); ok {
+		return returnFunc(query, args...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(model.DBQuery, ...any) *sql.Rows); ok {
+		r0 = returnFunc(query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.Rows)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(model.DBQuery, ...any) error); ok {
+		r1 = returnFunc(query, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// TxInterfaceMock_Query_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Query'
+type TxInterfaceMock_Query_Call struct {
+	*mock.Call
+}
+
+// Query is a helper method to define mock.On call
+//   - query model.DBQuery
+//   - args ...any
+func (_e *TxInterfaceMock_Expecter) Query(query interface{}, args ...interface{}) *TxInterfaceMock_Query_Call {
+	return &TxInterfaceMock_Query_Call{Call: _e.mock.On("Query",
+		append([]interface{}{query}, args...)...)}
+}
+
+func (_c *TxInterfaceMock_Query_Call) Run(run func(query model.DBQuery, args ...any)) *TxInterfaceMock_Query_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 model.DBQuery
+		if args[0] != nil {
+			arg0 = args[0].(model.DBQuery)
+		}
+		var arg1 []any
+		variadicArgs := make([]any, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
+	})
+	return _c
+}
+
+func (_c *TxInterfaceMock_Query_Call) Return(rows *sql.Rows, err error) *TxInterfaceMock_Query_Call {
+	_c.Call.Return(rows, err)
+	return _c
+}
+
+func (_c *TxInterfaceMock_Query_Call) RunAndReturn(run func(query model.DBQuery, args ...any) (*sql.Rows, error)) *TxInterfaceMock_Query_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request refactors how SQL queries are executed with transactions by updating transaction interfaces and usage to improve database abstraction and flexibility. Instead of passing raw query strings to transaction methods, the code now consistently uses the `DBQuery` struct, which supports database-specific query variants. Additionally, a comprehensive test suite for `DBQuery` has been added. These changes enhance maintainability and make it easier to support multiple database engines.

Additionally this fixes the bug of not picking the database specific queries when executing a transaction.

### Approach
- Modify Exec method in Tx to accept the `DBQuery` struct instead of the string query
- Introduce Query method to the Tx interface

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
