### PR TITLE
Allow basic auth executor to be used with any attribute

### DIFF
--- a/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_with_prompt.json
+++ b/backend/cmd/server/repository/resources/graphs/auth_flow_config_basic_with_prompt.json
@@ -21,8 +21,13 @@
             "type": "TASK_EXECUTION",
             "inputData": [
                 {
-                    "name": "password",
+                    "name": "username",
                     "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "password",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 }
             ],

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic.json
@@ -28,7 +28,7 @@
                 },
                 {
                     "name": "password",
-                    "type": "string",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 },
                 {

--- a/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github_sms.json
+++ b/backend/cmd/server/repository/resources/graphs/registration_flow_config_basic_google_github_sms.json
@@ -104,7 +104,7 @@
                 },
                 {
                     "name": "password",
-                    "type": "string",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 },
                 {

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -152,31 +152,14 @@ func (e *executor) GetUserIDFromContext(ctx *NodeContext) string {
 }
 
 // GetRequiredData returns the required input data for the executor.
-// It combines the default executor inputs with the node input data, ensuring no duplicates.
 func (e *executor) GetRequiredData(ctx *NodeContext) []common.InputData {
-	executorReqData := e.GetDefaultExecutorInputs()
 	requiredData := ctx.NodeInputData
 
-	if len(requiredData) == 0 {
-		requiredData = executorReqData
-	} else {
-		// Append the default required data if not already present.
-		for _, inputData := range executorReqData {
-			exists := false
-			for _, existingInputData := range requiredData {
-				if existingInputData.Name == inputData.Name {
-					exists = true
-					break
-				}
-			}
-			// If the input data already exists, skip adding it again.
-			if !exists {
-				requiredData = append(requiredData, inputData)
-			}
-		}
+	if len(requiredData) > 0 {
+		return requiredData
 	}
 
-	return requiredData
+	return e.GetDefaultExecutorInputs()
 }
 
 // appendRequiredData appends the required input data to the executor response if not present

--- a/backend/internal/flow/core/executor_test.go
+++ b/backend/internal/flow/core/executor_test.go
@@ -337,14 +337,14 @@ func (s *ExecutorTestSuite) TestGetRequiredData() {
 			[]string{testInputName},
 		},
 		{
-			"Node input provided, merge with default",
+			"Node input provided, use node input only",
 			[]common.InputData{{Name: testInputName, Required: true}},
 			[]common.InputData{{Name: "email", Required: true}},
-			2,
-			[]string{testInputName, "email"},
+			1,
+			[]string{"email"},
 		},
 		{
-			"Duplicate in node input, no duplication in result",
+			"Node input with same name as default, use node input",
 			[]common.InputData{{Name: testInputName, Required: true}},
 			[]common.InputData{{Name: testInputName, Required: true}},
 			1,
@@ -356,6 +356,20 @@ func (s *ExecutorTestSuite) TestGetRequiredData() {
 			[]common.InputData{{Name: "custom", Required: false}},
 			1,
 			[]string{"custom"},
+		},
+		{
+			"Multiple node inputs, use all node inputs",
+			[]common.InputData{{Name: testInputName, Required: true}},
+			[]common.InputData{{Name: "email", Required: true}, {Name: "phone", Required: true}},
+			2,
+			[]string{"email", "phone"},
+		},
+		{
+			"No default and no node input, return empty",
+			[]common.InputData{},
+			[]common.InputData{},
+			0,
+			[]string{},
 		},
 	}
 
@@ -375,7 +389,7 @@ func (s *ExecutorTestSuite) TestGetRequiredData() {
 						break
 					}
 				}
-				s.True(found)
+				s.True(found, "Expected to find input name: %s", name)
 			}
 		})
 	}

--- a/tests/integration/flowauthn/attribute_collect_test.go
+++ b/tests/integration/flowauthn/attribute_collect_test.go
@@ -388,7 +388,12 @@ func (ts *AttributeCollectFlowTestSuite) validateRequiredInputs(actualInputs []I
 	for _, expectedName := range expectedInputNames {
 		input, exists := actualInputMap[expectedName]
 		ts.Require().True(exists, "Expected input '%s' not found", expectedName)
-		ts.Require().Equal("string", input.Type, "Expected input '%s' to be of type string", expectedName)
+
+		if expectedName == "password" {
+			ts.Require().Equal("PASSWORD_INPUT", input.Type, "Expected input password to be of type PASSWORD_INPUT")
+		} else {
+			ts.Require().Equal("string", input.Type, "Expected input '%s' to be of type string", expectedName)
+		}
 
 		// Check if required field is set correctly based on the flow definition
 		if expectedName == "mobileNumber" {

--- a/tests/integration/flowregistration/basic_registration_test.go
+++ b/tests/integration/flowregistration/basic_registration_test.go
@@ -276,7 +276,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowDuplicateUser
 	ts.Require().Equal("ERROR", completeFlowStep.FlowStatus, "Expected flow status to be ERROR")
 	ts.Require().Empty(completeFlowStep.Assertion, "No JWT assertion should be returned for failed registration")
 	ts.Require().NotEmpty(completeFlowStep.FailureReason, "Failure reason should be provided for duplicate user")
-	ts.Equal("User already exists with the provided username.", completeFlowStep.FailureReason,
+	ts.Equal("User already exists with the provided attributes.", completeFlowStep.FailureReason,
 		"Failure reason should indicate duplicate username")
 }
 

--- a/tests/integration/resources/graphs/auth_flow_config_basic_attr_collect_test_1.json
+++ b/tests/integration/resources/graphs/auth_flow_config_basic_attr_collect_test_1.json
@@ -13,7 +13,7 @@
                 },
                 {
                     "name": "password",
-                    "type": "string",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 }
             ],

--- a/tests/integration/resources/graphs/auth_flow_config_decision_and_mfa_test_1.json
+++ b/tests/integration/resources/graphs/auth_flow_config_decision_and_mfa_test_1.json
@@ -21,7 +21,7 @@
                 },
                 {
                     "name": "password",
-                    "type": "string",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 }
             ],

--- a/tests/integration/resources/graphs/registration_flow_config_basic.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic.json
@@ -30,7 +30,7 @@
                 },
                 {
                     "name": "password",
-                    "type": "string",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 },
                 {

--- a/tests/integration/resources/graphs/registration_flow_config_basic_http_request.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic_http_request.json
@@ -20,7 +20,7 @@
                 },
                 {
                     "name": "password",
-                    "type": "string",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 },
                 {

--- a/tests/integration/resources/graphs/registration_flow_config_basic_with_ou.json
+++ b/tests/integration/resources/graphs/registration_flow_config_basic_with_ou.json
@@ -40,7 +40,7 @@
                 },
                 {
                     "name": "password",
-                    "type": "string",
+                    "type": "PASSWORD_INPUT",
                     "required": true
                 },
                 {


### PR DESCRIPTION
### Purpose
This PR allows Basic Auth Executor to be used with any user attributes by eliminating the previous restriction of sticking to username/password. Additionally to cater the above requirement, this also improves the way required input data is handled by executors by only appending default inputs if inputs are not defined in the flow definition.

### Approach
* Simplified the `GetRequiredData` method in `executor.go` to return node input data if provided, otherwise fall back to default executor inputs. This removes the previous logic that merged node and default inputs, ensuring only node-specified inputs are used when present.
* Refactored the authentication logic in `basicAuthExecutor` to support identifying and authenticating users based on arbitrary sets of attributes (not just username/password). The executor now dynamically builds the set of user-identifying and authentication attributes from the required inputs, enabling support for flows that use attributes like email or phone for authentication.
* Introduced a new input data type `PASSWORD_INPUT` for password fields, and updated all references to use this constant for clarity and consistency in `basic_auth_executor.go` and its tests.

### Related Issues
- https://github.com/asgardeo/thunder/issues/942

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
