### PR TITLE
Add layout information to the flow definition

### DIFF
--- a/api/flow-management.yaml
+++ b/api/flow-management.yaml
@@ -620,9 +620,23 @@ components:
         nodes: &authFlowNodes
           - id: node_000
             type: START
+            layout:
+              size:
+                width: 180
+                height: 80
+              position:
+                x: 50
+                y: 50
             onSuccess: node_001
           - id: node_001
             type: PROMPT
+            layout:
+              size:
+                width: 320
+                height: 450
+              position:
+                x: 50
+                y: 180
             meta:
               components:
                 - type: TEXT
@@ -667,6 +681,13 @@ components:
                 nextNode: node_002
           - id: node_002
             type: TASK_EXECUTION
+            layout:
+              size:
+                width: 200
+                height: 120
+              position:
+                x: 450
+                y: 300
             executor:
               name: SendSMSExecutor
             properties:
@@ -675,6 +696,13 @@ components:
             onFailure: node_007
           - id: node_003
             type: PROMPT
+            layout:
+              size:
+                width: 320
+                height: 380
+              position:
+                x: 700
+                y: 280
             meta:
               components:
                 - type: HEADING
@@ -707,6 +735,13 @@ components:
                 nextNode: node_002
           - id: node_004
             type: TASK_EXECUTION
+            layout:
+              size:
+                width: 200
+                height: 140
+              position:
+                x: 450
+                y: 100
             executor:
               name: BasicAuthExecutor
             inputs:
@@ -721,6 +756,13 @@ components:
             onSuccess: node_008
           - id: node_005
             type: TASK_EXECUTION
+            layout:
+              size:
+                width: 200
+                height: 140
+              position:
+                x: 1100
+                y: 320
             executor:
               name: VerifyOTPExecutor
             properties:
@@ -733,6 +775,13 @@ components:
             onSuccess: node_008
           - id: node_007
             type: PROMPT
+            layout:
+              size:
+                width: 300
+                height: 280
+              position:
+                x: 450
+                y: 480
             meta:
               components:
                 - type: HEADING
@@ -749,6 +798,13 @@ components:
                 nextNode: node_002
           - id: node_008
             type: END
+            layout:
+              size:
+                width: 180
+                height: 80
+              position:
+                x: 1400
+                y: 200
 
     FlowDefinitionResponse:
       type: object
@@ -878,6 +934,9 @@ components:
           description: |
             Type of node
           example: PROMPT
+        layout:
+          allOf:
+            - $ref: '#/components/schemas/NodeLayout'
         meta:
           description: Optional UI metadata for PROMPT nodes (verbose mode)
           allOf:
@@ -914,6 +973,50 @@ components:
           type: string
           description: Next node ID on failed execution (TASK_EXECUTION nodes)
           example: node_007
+
+    NodeLayout:
+      type: object
+      description: |
+        Layout information for the flow composer UI. This metadata is used 
+        only by the visual flow composer to position and size nodes on the canvas. 
+      properties:
+        size:
+          type: object
+          description: Dimensions of the node in the flow composer canvas
+          required:
+            - width
+            - height
+          properties:
+            width:
+              type: number
+              description: Width of the node in pixels
+              example: 200
+            height:
+              type: number
+              description: Height of the node in pixels
+              example: 150
+        position:
+          type: object
+          description: Position of the node in the flow composer canvas
+          required:
+            - x
+            - y
+          properties:
+            x:
+              type: number
+              description: X-coordinate of the node
+              example: 100
+            y:
+              type: number
+              description: Y-coordinate of the node
+              example: 100
+      example:
+        size:
+          width: 200
+          height: 150
+        position:
+          x: 100
+          y: 100
 
     NodeMeta:
       type: object

--- a/backend/internal/flow/mgt/constants.go
+++ b/backend/internal/flow/mgt/constants.go
@@ -34,4 +34,12 @@ const (
 	provisioningNodeID = "prov_node"
 	// userTypeResolverNodeID is the node ID for the inferred user type resolver node
 	userTypeResolverNodeID = "ut_res_node"
+	// defaultNodeWidth is the default width for a node layout
+	defaultNodeWidth = 100
+	// defaultNodeHeight is the default height for a node layout
+	defaultNodeHeight = 120
+	// defaultNodeXPos is the default X position for a node layout
+	defaultNodeXPos = 0
+	// defaultNodeYPos is the default Y position for a node layout
+	defaultNodeYPos = 0
 )

--- a/backend/internal/flow/mgt/model.go
+++ b/backend/internal/flow/mgt/model.go
@@ -94,10 +94,29 @@ type Link struct {
 	Rel  string `json:"rel"`
 }
 
+// NodeLayout represents the layout information for a node in the flow composer UI.
+type NodeLayout struct {
+	Size     *NodeSize     `json:"size,omitempty"`
+	Position *NodePosition `json:"position,omitempty"`
+}
+
+// NodeSize represents the dimensions of a node.
+type NodeSize struct {
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+}
+
+// NodePosition represents the position of a node on the canvas.
+type NodePosition struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
 // NodeDefinition represents a single node in a flow definition.
 type NodeDefinition struct {
 	ID         string                 `json:"id"`
 	Type       string                 `json:"type"`
+	Layout     *NodeLayout            `json:"layout,omitempty"`
 	Meta       interface{}            `json:"meta,omitempty"`
 	Inputs     []InputDefinition      `json:"inputs,omitempty"`
 	Actions    []ActionDefinition     `json:"actions,omitempty"`

--- a/tests/integration/flow/mgt/flow_mgt_api_test.go
+++ b/tests/integration/flow/mgt/flow_mgt_api_test.go
@@ -205,6 +205,114 @@ func (suite *FlowMgtAPITestSuite) TestCreateFlow_Success() {
 	}
 }
 
+func (suite *FlowMgtAPITestSuite) TestCreateFlow_WithLayout() {
+	// Create a flow with layout information
+	flowWithLayout := FlowDefinition{
+		Name:     "Flow with Layout",
+		FlowType: "AUTHENTICATION",
+		Nodes: []NodeDefinition{
+			{
+				ID:   "START",
+				Type: "START",
+				Layout: &NodeLayout{
+					Size: &NodeSize{
+						Width:  180,
+						Height: 80,
+					},
+					Position: &NodePosition{
+						X: 50,
+						Y: 50,
+					},
+				},
+			},
+			{
+				ID:   "basic_auth",
+				Type: "TASK_EXECUTION",
+				Layout: &NodeLayout{
+					Size: &NodeSize{
+						Width:  200,
+						Height: 120,
+					},
+					Position: &NodePosition{
+						X: 300,
+						Y: 50,
+					},
+				},
+				Executor: &ExecutorDefinition{
+					Name: "BasicAuthExecutor",
+				},
+				OnSuccess: "END",
+				OnFailure: "END",
+			},
+			{
+				ID:   "END",
+				Type: "END",
+				Layout: &NodeLayout{
+					Size: &NodeSize{
+						Width:  180,
+						Height: 80,
+					},
+					Position: &NodePosition{
+						X: 550,
+						Y: 50,
+					},
+				},
+			},
+		},
+	}
+
+	// Create the flow
+	response := suite.createFlow(flowWithLayout)
+	suite.trackFlow(response.ID)
+
+	// Verify layout is preserved in the response
+	suite.NotEmpty(response.ID)
+	suite.Equal(flowWithLayout.Name, response.Name)
+	suite.Len(response.Nodes, 3)
+
+	// Verify START node layout
+	startNode := response.Nodes[0]
+	suite.Equal("START", startNode.ID)
+	suite.NotNil(startNode.Layout)
+	suite.NotNil(startNode.Layout.Size)
+	suite.Equal(180.0, startNode.Layout.Size.Width)
+	suite.Equal(80.0, startNode.Layout.Size.Height)
+	suite.NotNil(startNode.Layout.Position)
+	suite.Equal(50.0, startNode.Layout.Position.X)
+	suite.Equal(50.0, startNode.Layout.Position.Y)
+
+	// Verify basic_auth node layout
+	authNode := response.Nodes[1]
+	suite.Equal("basic_auth", authNode.ID)
+	suite.NotNil(authNode.Layout)
+	suite.NotNil(authNode.Layout.Size)
+	suite.Equal(200.0, authNode.Layout.Size.Width)
+	suite.Equal(120.0, authNode.Layout.Size.Height)
+	suite.NotNil(authNode.Layout.Position)
+	suite.Equal(300.0, authNode.Layout.Position.X)
+	suite.Equal(50.0, authNode.Layout.Position.Y)
+
+	// Verify END node layout
+	endNode := response.Nodes[2]
+	suite.Equal("END", endNode.ID)
+	suite.NotNil(endNode.Layout)
+	suite.NotNil(endNode.Layout.Size)
+	suite.Equal(180.0, endNode.Layout.Size.Width)
+	suite.Equal(80.0, endNode.Layout.Size.Height)
+	suite.NotNil(endNode.Layout.Position)
+	suite.Equal(550.0, endNode.Layout.Position.X)
+	suite.Equal(50.0, endNode.Layout.Position.Y)
+
+	// Retrieve the flow by ID and verify layout is persisted
+	retrievedFlow := suite.getFlow(response.ID)
+	suite.Len(retrievedFlow.Nodes, 3)
+
+	// Verify layout is preserved after retrieval
+	suite.NotNil(retrievedFlow.Nodes[0].Layout)
+	suite.Equal(180.0, retrievedFlow.Nodes[0].Layout.Size.Width)
+	suite.Equal(50.0, retrievedFlow.Nodes[0].Layout.Position.X)
+}
+
 func (suite *FlowMgtAPITestSuite) TestCreateFlow_ValidationErrors() {
 	testCases := []struct {
 		name           string

--- a/tests/integration/flow/mgt/model.go
+++ b/tests/integration/flow/mgt/model.go
@@ -81,9 +81,25 @@ type Link struct {
 	Rel  string `json:"rel"`
 }
 
+type NodeLayout struct {
+	Size     *NodeSize     `json:"size,omitempty"`
+	Position *NodePosition `json:"position,omitempty"`
+}
+
+type NodeSize struct {
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+}
+
+type NodePosition struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
 type NodeDefinition struct {
 	ID         string                 `json:"id"`
 	Type       string                 `json:"type"`
+	Layout     *NodeLayout            `json:"layout,omitempty"`
 	Meta       interface{}            `json:"meta,omitempty"`
 	Inputs     []InputDefinition      `json:"inputs,omitempty"`
 	Actions    []ActionDefinition     `json:"actions,omitempty"`


### PR DESCRIPTION
### Purpose
This pull request introduces support for node layout metadata in flow definitions, enabling nodes to specify their size and position to be use in the visual flow composer UI. The changes ensure that layout information can be defined in the API schema, handled in backend models, and preserved or generated as appropriate in flow inference logic.

Related Discussion: [[Design Discussion] Flow composer layouts in graph definition](https://github.com/asgardeo/thunder/discussions/872)

### Approach

* Added a `layout` field to node definitions in the OpenAPI spec (`api/flow-management.yaml`), defining a new `NodeLayout` schema with `size` and `position` properties for use in the visual flow composer.
* Introduced new Go structs (`NodeLayout`, `NodeSize`, `NodePosition`) and added a `Layout` field to `NodeDefinition` to represent layout metadata in backend models.
* Updated flow inference logic to detect if any node has layout information and, if so, to add default layout to newly generated nodes (such as provisioning and user type resolver nodes).

### Related Issues
- https://github.com/asgardeo/thunder/issues/945

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
