### PR TITLE
Add immutable config support for OU

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -65,7 +65,12 @@ func registerServices(
 	// List to collect exporters from each package
 	var exporters []immutableresource.ResourceExporter
 
-	ouService := ou.Initialize(mux)
+	ouService, ouExporter, err := ou.Initialize(mux)
+	if err != nil {
+		logger.Fatal("Failed to initialize OrganizationUnitService", log.Error(err))
+	}
+	exporters = append(exporters, ouExporter)
+
 	hashService := hash.Initialize()
 	userSchemaService, userSchemaExporter, err := userschema.Initialize(mux, ouService)
 	if err != nil {

--- a/backend/internal/ou/file_based_store.go
+++ b/backend/internal/ou/file_based_store.go
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"errors"
+
+	immutableresource "github.com/asgardeo/thunder/internal/system/immutable_resource"
+	"github.com/asgardeo/thunder/internal/system/immutable_resource/entity"
+)
+
+type fileBasedStore struct {
+	*immutableresource.GenericFileBasedStore
+}
+
+// newFileBasedStore creates a new instance of a file-based store.
+func newFileBasedStore() organizationUnitStoreInterface {
+	genericStore := immutableresource.NewGenericFileBasedStore(entity.KeyTypeOU)
+	return &fileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+}
+
+// Create implements immutableresource.Storer interface for resource loader
+func (f *fileBasedStore) Create(id string, data interface{}) error {
+	ou := data.(*OrganizationUnit)
+	return f.CreateOrganizationUnit(*ou)
+}
+
+// CreateOrganizationUnit implements organizationUnitStoreInterface.
+func (f *fileBasedStore) CreateOrganizationUnit(ou OrganizationUnit) error {
+	return f.GenericFileBasedStore.Create(ou.ID, &ou)
+}
+
+// DeleteOrganizationUnit implements organizationUnitStoreInterface.
+func (f *fileBasedStore) DeleteOrganizationUnit(id string) error {
+	return errors.New("DeleteOrganizationUnit is not supported in file-based store")
+}
+
+// GetOrganizationUnit implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnit(id string) (OrganizationUnit, error) {
+	data, err := f.GenericFileBasedStore.Get(id)
+	if err != nil {
+		return OrganizationUnit{}, ErrOrganizationUnitNotFound
+	}
+	ou, ok := data.(*OrganizationUnit)
+	if !ok {
+		immutableresource.LogTypeAssertionError("organization unit", id)
+		return OrganizationUnit{}, errors.New("organization unit data corrupted")
+	}
+	return *ou, nil
+}
+
+// GetOrganizationUnitByPath implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitByPath(handles []string) (OrganizationUnit, error) {
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return OrganizationUnit{}, err
+	}
+
+	// Build the path by traversing the hierarchy
+	var currentOU *OrganizationUnit
+	var currentParent *string
+
+	for _, handle := range handles {
+		found := false
+		for _, item := range list {
+			if ou, ok := item.Data.(*OrganizationUnit); ok {
+				// Check if this OU has the right handle and parent
+				parentMatch := (currentParent == nil && ou.Parent == nil) ||
+					(currentParent != nil && ou.Parent != nil && *currentParent == *ou.Parent)
+
+				if ou.Handle == handle && parentMatch {
+					currentOU = ou
+					currentParent = &ou.ID
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return OrganizationUnit{}, ErrOrganizationUnitNotFound
+		}
+	}
+
+	if currentOU == nil {
+		return OrganizationUnit{}, ErrOrganizationUnitNotFound
+	}
+
+	return *currentOU, nil
+}
+
+// GetOrganizationUnitList implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitList(limit, offset int) ([]OrganizationUnitBasic, error) {
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var ouList []OrganizationUnitBasic
+	for _, item := range list {
+		if ou, ok := item.Data.(*OrganizationUnit); ok {
+			// Only include root OUs (those without a parent)
+			if ou.Parent == nil {
+				basicOU := OrganizationUnitBasic{
+					ID:          ou.ID,
+					Handle:      ou.Handle,
+					Name:        ou.Name,
+					Description: ou.Description,
+				}
+				ouList = append(ouList, basicOU)
+			}
+		}
+	}
+
+	// Apply pagination
+	start := offset
+	if start > len(ouList) {
+		return []OrganizationUnitBasic{}, nil
+	}
+	end := start + limit
+	if end > len(ouList) {
+		end = len(ouList)
+	}
+
+	return ouList[start:end], nil
+}
+
+// GetOrganizationUnitListCount implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitListCount() (int, error) {
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, item := range list {
+		if ou, ok := item.Data.(*OrganizationUnit); ok {
+			// Only count root OUs (those without a parent)
+			if ou.Parent == nil {
+				count++
+			}
+		}
+	}
+
+	return count, nil
+}
+
+// IsOrganizationUnitExists implements organizationUnitStoreInterface.
+func (f *fileBasedStore) IsOrganizationUnitExists(id string) (bool, error) {
+	_, err := f.GetOrganizationUnit(id)
+	if err != nil {
+		if errors.Is(err, ErrOrganizationUnitNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// CheckOrganizationUnitNameConflict implements organizationUnitStoreInterface.
+func (f *fileBasedStore) CheckOrganizationUnitNameConflict(name string, parent *string) (bool, error) {
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list {
+		if ou, ok := item.Data.(*OrganizationUnit); ok {
+			parentMatch := (parent == nil && ou.Parent == nil) ||
+				(parent != nil && ou.Parent != nil && *parent == *ou.Parent)
+
+			if ou.Name == name && parentMatch {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// CheckOrganizationUnitHandleConflict implements organizationUnitStoreInterface.
+func (f *fileBasedStore) CheckOrganizationUnitHandleConflict(handle string, parent *string) (bool, error) {
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list {
+		if ou, ok := item.Data.(*OrganizationUnit); ok {
+			parentMatch := (parent == nil && ou.Parent == nil) ||
+				(parent != nil && ou.Parent != nil && *parent == *ou.Parent)
+
+			if ou.Handle == handle && parentMatch {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// UpdateOrganizationUnit implements organizationUnitStoreInterface.
+func (f *fileBasedStore) UpdateOrganizationUnit(ou OrganizationUnit) error {
+	return errors.New("UpdateOrganizationUnit is not supported in file-based store")
+}
+
+// CheckOrganizationUnitHasChildResources implements organizationUnitStoreInterface.
+func (f *fileBasedStore) CheckOrganizationUnitHasChildResources(id string) (bool, error) {
+	// In file-based mode, we check if there are any child OUs
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list {
+		if ou, ok := item.Data.(*OrganizationUnit); ok {
+			if ou.Parent != nil && *ou.Parent == id {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// GetOrganizationUnitChildrenCount implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitChildrenCount(id string) (int, error) {
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, item := range list {
+		if ou, ok := item.Data.(*OrganizationUnit); ok {
+			if ou.Parent != nil && *ou.Parent == id {
+				count++
+			}
+		}
+	}
+
+	return count, nil
+}
+
+// GetOrganizationUnitChildrenList implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitChildrenList(
+	id string, limit, offset int) ([]OrganizationUnitBasic, error) {
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var children []OrganizationUnitBasic
+	for _, item := range list {
+		if ou, ok := item.Data.(*OrganizationUnit); ok {
+			if ou.Parent != nil && *ou.Parent == id {
+				basicOU := OrganizationUnitBasic{
+					ID:          ou.ID,
+					Handle:      ou.Handle,
+					Name:        ou.Name,
+					Description: ou.Description,
+				}
+				children = append(children, basicOU)
+			}
+		}
+	}
+
+	// Apply pagination
+	start := offset
+	if start > len(children) {
+		return []OrganizationUnitBasic{}, nil
+	}
+	end := start + limit
+	if end > len(children) {
+		end = len(children)
+	}
+
+	return children[start:end], nil
+}
+
+// GetOrganizationUnitUsersCount implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitUsersCount(id string) (int, error) {
+	// In file-based mode, users are not stored with OUs
+	return 0, nil
+}
+
+// GetOrganizationUnitUsersList implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitUsersList(id string, limit, offset int) ([]User, error) {
+	// In file-based mode, users are not stored with OUs
+	return []User{}, nil
+}
+
+// GetOrganizationUnitGroupsCount implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitGroupsCount(id string) (int, error) {
+	// In file-based mode, groups are not stored with OUs
+	return 0, nil
+}
+
+// GetOrganizationUnitGroupsList implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitGroupsList(id string, limit, offset int) ([]Group, error) {
+	// In file-based mode, groups are not stored with OUs
+	return []Group{}, nil
+}

--- a/backend/internal/ou/file_based_store_test.go
+++ b/backend/internal/ou/file_based_store_test.go
@@ -1,0 +1,572 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"strconv"
+	"testing"
+
+	immutableresource "github.com/asgardeo/thunder/internal/system/immutable_resource"
+	"github.com/asgardeo/thunder/internal/system/immutable_resource/entity"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testParentOUID = "parent-1"
+	testRootOUID   = "root-1"
+)
+
+type FileBasedStoreTestSuite struct {
+	suite.Suite
+	store *fileBasedStore
+}
+
+func TestFileBasedStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(FileBasedStoreTestSuite))
+}
+
+func (s *FileBasedStoreTestSuite) SetupTest() {
+	// Create a file-based store with test instance
+	genericStore := immutableresource.NewGenericFileBasedStoreForTest(entity.KeyTypeOU)
+	s.store = &fileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+}
+
+func (s *FileBasedStoreTestSuite) TestCreateOrganizationUnit() {
+	ou := OrganizationUnit{
+		ID:          "test-ou-1",
+		Handle:      "test",
+		Name:        "Test OU",
+		Description: "Test organization unit",
+		Parent:      nil,
+	}
+
+	err := s.store.CreateOrganizationUnit(ou)
+	assert.NoError(s.T(), err)
+
+	// Verify it was created
+	retrieved, err := s.store.GetOrganizationUnit("test-ou-1")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), ou.ID, retrieved.ID)
+	assert.Equal(s.T(), ou.Name, retrieved.Name)
+	assert.Equal(s.T(), ou.Handle, retrieved.Handle)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitNotFound() {
+	_, err := s.store.GetOrganizationUnit("non-existent")
+	assert.Error(s.T(), err)
+	assert.ErrorIs(s.T(), err, ErrOrganizationUnitNotFound)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitList() {
+	// Create root OUs
+	ou1 := OrganizationUnit{
+		ID:     "root-1",
+		Handle: "root1",
+		Name:   "Root 1",
+		Parent: nil,
+	}
+	ou2 := OrganizationUnit{
+		ID:     "root-2",
+		Handle: "root2",
+		Name:   "Root 2",
+		Parent: nil,
+	}
+
+	err := s.store.CreateOrganizationUnit(ou1)
+	assert.NoError(s.T(), err)
+	err = s.store.CreateOrganizationUnit(ou2)
+	assert.NoError(s.T(), err)
+
+	// Create child OU (should not be in root list)
+	parentID := testRootOUID
+	child := OrganizationUnit{
+		ID:     "child-1",
+		Handle: "child1",
+		Name:   "Child 1",
+		Parent: &parentID,
+	}
+	err = s.store.CreateOrganizationUnit(child)
+	assert.NoError(s.T(), err)
+
+	// Get list should only return root OUs
+	list, err := s.store.GetOrganizationUnitList(10, 0)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), list, 2)
+}
+
+func (s *FileBasedStoreTestSuite) TestUpdateNotSupported() {
+	ou := OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test",
+		Name:   "Test OU",
+	}
+
+	err := s.store.UpdateOrganizationUnit(ou)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "not supported")
+}
+
+func (s *FileBasedStoreTestSuite) TestDeleteNotSupported() {
+	err := s.store.DeleteOrganizationUnit("test-ou-1")
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "not supported")
+}
+
+func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitNameConflict() {
+	ou := OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test",
+		Name:   "Test OU",
+		Parent: nil,
+	}
+
+	err := s.store.CreateOrganizationUnit(ou)
+	assert.NoError(s.T(), err)
+
+	// Check for conflict with same name and parent
+	conflict, err := s.store.CheckOrganizationUnitNameConflict("Test OU", nil)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), conflict)
+
+	// No conflict with different name
+	conflict, err = s.store.CheckOrganizationUnitNameConflict("Different Name", nil)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), conflict)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildren() {
+	// Create parent
+	parent := OrganizationUnit{
+		ID:     testParentOUID,
+		Handle: "parent",
+		Name:   "Parent OU",
+		Parent: nil,
+	}
+	err := s.store.CreateOrganizationUnit(parent)
+	assert.NoError(s.T(), err)
+
+	// Create children
+	parentID := testParentOUID
+	child1 := OrganizationUnit{
+		ID:     "child-1",
+		Handle: "child1",
+		Name:   "Child 1",
+		Parent: &parentID,
+	}
+	child2 := OrganizationUnit{
+		ID:     "child-2",
+		Handle: "child2",
+		Name:   "Child 2",
+		Parent: &parentID,
+	}
+
+	err = s.store.CreateOrganizationUnit(child1)
+	assert.NoError(s.T(), err)
+	err = s.store.CreateOrganizationUnit(child2)
+	assert.NoError(s.T(), err)
+
+	// Get children
+	children, err := s.store.GetOrganizationUnitChildrenList(testParentOUID, 10, 0)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), children, 2)
+
+	// Get children count
+	count, err := s.store.GetOrganizationUnitChildrenCount(testParentOUID)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 2, count)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitByPath() {
+	// Create hierarchy: root -> engineering -> backend
+	root := OrganizationUnit{
+		ID:     "root-1",
+		Handle: "root",
+		Name:   "Root",
+		Parent: nil,
+	}
+	rootID := "root-1"
+	engineering := OrganizationUnit{
+		ID:     "eng-1",
+		Handle: "engineering",
+		Name:   "Engineering",
+		Parent: &rootID,
+	}
+	engID := "eng-1"
+	backend := OrganizationUnit{
+		ID:     "backend-1",
+		Handle: "backend",
+		Name:   "Backend",
+		Parent: &engID,
+	}
+
+	err := s.store.CreateOrganizationUnit(root)
+	assert.NoError(s.T(), err)
+	err = s.store.CreateOrganizationUnit(engineering)
+	assert.NoError(s.T(), err)
+	err = s.store.CreateOrganizationUnit(backend)
+	assert.NoError(s.T(), err)
+
+	// Test getting by path
+	ou, err := s.store.GetOrganizationUnitByPath([]string{"root"})
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "root-1", ou.ID)
+
+	ou, err = s.store.GetOrganizationUnitByPath([]string{"root", "engineering"})
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "eng-1", ou.ID)
+
+	ou, err = s.store.GetOrganizationUnitByPath([]string{"root", "engineering", "backend"})
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "backend-1", ou.ID)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitByPath_NotFound() {
+	root := OrganizationUnit{
+		ID:     "root-1",
+		Handle: "root",
+		Name:   "Root",
+		Parent: nil,
+	}
+	err := s.store.CreateOrganizationUnit(root)
+	assert.NoError(s.T(), err)
+
+	// Test invalid path
+	_, err = s.store.GetOrganizationUnitByPath([]string{"root", "nonexistent"})
+	assert.Error(s.T(), err)
+	assert.ErrorIs(s.T(), err, ErrOrganizationUnitNotFound)
+
+	// Test completely invalid path
+	_, err = s.store.GetOrganizationUnitByPath([]string{"invalid"})
+	assert.Error(s.T(), err)
+	assert.ErrorIs(s.T(), err, ErrOrganizationUnitNotFound)
+}
+
+func (s *FileBasedStoreTestSuite) TestIsOrganizationUnitExists() {
+	ou := OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test",
+		Name:   "Test OU",
+		Parent: nil,
+	}
+	err := s.store.CreateOrganizationUnit(ou)
+	assert.NoError(s.T(), err)
+
+	// Test existing OU
+	exists, err := s.store.IsOrganizationUnitExists("test-ou-1")
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), exists)
+
+	// Test non-existent OU
+	exists, err = s.store.IsOrganizationUnitExists("non-existent")
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), exists)
+}
+
+func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitHandleConflict() {
+	ou := OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test-handle",
+		Name:   "Test OU",
+		Parent: nil,
+	}
+	err := s.store.CreateOrganizationUnit(ou)
+	assert.NoError(s.T(), err)
+
+	// Check for conflict with same handle and parent
+	conflict, err := s.store.CheckOrganizationUnitHandleConflict("test-handle", nil)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), conflict)
+
+	// No conflict with different handle
+	conflict, err = s.store.CheckOrganizationUnitHandleConflict("different-handle", nil)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), conflict)
+
+	// Test with parent context
+	parentID := testParentOUID
+	child := OrganizationUnit{
+		ID:     "child-1",
+		Handle: "child-handle",
+		Name:   "Child",
+		Parent: &parentID,
+	}
+	err = s.store.CreateOrganizationUnit(child)
+	assert.NoError(s.T(), err)
+
+	conflict, err = s.store.CheckOrganizationUnitHandleConflict("child-handle", &parentID)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), conflict)
+
+	// Different parent, same handle should not conflict
+	differentParent := "different-parent"
+	conflict, err = s.store.CheckOrganizationUnitHandleConflict("child-handle", &differentParent)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), conflict)
+}
+
+func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitNameConflict_WithParent() {
+	parentID := testParentOUID
+	parent := OrganizationUnit{
+		ID:     parentID,
+		Handle: "parent",
+		Name:   "Parent",
+		Parent: nil,
+	}
+	err := s.store.CreateOrganizationUnit(parent)
+	assert.NoError(s.T(), err)
+
+	child := OrganizationUnit{
+		ID:     "child-1",
+		Handle: "child",
+		Name:   "Child Name",
+		Parent: &parentID,
+	}
+	err = s.store.CreateOrganizationUnit(child)
+	assert.NoError(s.T(), err)
+
+	// Same name, same parent - should conflict
+	conflict, err := s.store.CheckOrganizationUnitNameConflict("Child Name", &parentID)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), conflict)
+
+	// Same name, different parent - should not conflict
+	differentParent := "different-parent"
+	conflict, err = s.store.CheckOrganizationUnitNameConflict("Child Name", &differentParent)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), conflict)
+
+	// Same name, nil parent vs actual parent - should not conflict
+	conflict, err = s.store.CheckOrganizationUnitNameConflict("Child Name", nil)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), conflict)
+}
+
+func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitHasChildResources() {
+	parent := OrganizationUnit{
+		ID:     testParentOUID,
+		Handle: "parent",
+		Name:   "Parent",
+		Parent: nil,
+	}
+	err := s.store.CreateOrganizationUnit(parent)
+	assert.NoError(s.T(), err)
+
+	// No children initially
+	hasChildren, err := s.store.CheckOrganizationUnitHasChildResources(testParentOUID)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), hasChildren)
+
+	// Add a child
+	parentID := testParentOUID
+	child := OrganizationUnit{
+		ID:     "child-1",
+		Handle: "child",
+		Name:   "Child",
+		Parent: &parentID,
+	}
+	err = s.store.CreateOrganizationUnit(child)
+	assert.NoError(s.T(), err)
+
+	// Should have children now
+	hasChildren, err = s.store.CheckOrganizationUnitHasChildResources(testParentOUID)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), hasChildren)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitListCount() {
+	// Initially empty
+	count, err := s.store.GetOrganizationUnitListCount()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, count)
+
+	// Add root OUs
+	root1 := OrganizationUnit{
+		ID:     "root-1",
+		Handle: "root1",
+		Name:   "Root 1",
+		Parent: nil,
+	}
+	root2 := OrganizationUnit{
+		ID:     "root-2",
+		Handle: "root2",
+		Name:   "Root 2",
+		Parent: nil,
+	}
+	err = s.store.CreateOrganizationUnit(root1)
+	assert.NoError(s.T(), err)
+	err = s.store.CreateOrganizationUnit(root2)
+	assert.NoError(s.T(), err)
+
+	// Should count only root OUs
+	count, err = s.store.GetOrganizationUnitListCount()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 2, count)
+
+	// Add child OU (should not be counted)
+	parentID := "root-1"
+	child := OrganizationUnit{
+		ID:     "child-1",
+		Handle: "child",
+		Name:   "Child",
+		Parent: &parentID,
+	}
+	err = s.store.CreateOrganizationUnit(child)
+	assert.NoError(s.T(), err)
+
+	// Count should still be 2
+	count, err = s.store.GetOrganizationUnitListCount()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 2, count)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitList_Pagination() {
+	// Create multiple root OUs
+	for i := 1; i <= 5; i++ {
+		iStr := strconv.Itoa(i)
+		ou := OrganizationUnit{
+			ID:     "root-" + iStr,
+			Handle: "root" + iStr,
+			Name:   "Root " + iStr,
+			Parent: nil,
+		}
+		err := s.store.CreateOrganizationUnit(ou)
+		assert.NoError(s.T(), err)
+	}
+
+	// Test pagination - first page
+	list, err := s.store.GetOrganizationUnitList(2, 0)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), list, 2)
+
+	// Test pagination - second page
+	list, err = s.store.GetOrganizationUnitList(2, 2)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), list, 2)
+
+	// Test pagination - last page
+	list, err = s.store.GetOrganizationUnitList(2, 4)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), list, 1)
+
+	// Test offset beyond range
+	list, err = s.store.GetOrganizationUnitList(10, 100)
+	assert.NoError(s.T(), err)
+	assert.Empty(s.T(), list)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildrenList_Pagination() {
+	// Create parent
+	parent := OrganizationUnit{
+		ID:     testParentOUID,
+		Handle: "parent",
+		Name:   "Parent",
+		Parent: nil,
+	}
+	err := s.store.CreateOrganizationUnit(parent)
+	assert.NoError(s.T(), err)
+
+	// Create multiple children
+	parentID := testParentOUID
+	for i := 1; i <= 5; i++ {
+		iStr := strconv.Itoa(i)
+		child := OrganizationUnit{
+			ID:     "child-" + iStr,
+			Handle: "child" + iStr,
+			Name:   "Child " + iStr,
+			Parent: &parentID,
+		}
+		err := s.store.CreateOrganizationUnit(child)
+		assert.NoError(s.T(), err)
+	}
+
+	// Test pagination
+	children, err := s.store.GetOrganizationUnitChildrenList(testParentOUID, 2, 0)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), children, 2)
+
+	children, err = s.store.GetOrganizationUnitChildrenList(testParentOUID, 2, 2)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), children, 2)
+
+	// Test offset beyond range
+	children, err = s.store.GetOrganizationUnitChildrenList(testParentOUID, 10, 100)
+	assert.NoError(s.T(), err)
+	assert.Empty(s.T(), children)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitUsersCount() {
+	// Users are not stored in file-based mode
+	count, err := s.store.GetOrganizationUnitUsersCount("any-id")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, count)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitUsersList() {
+	// Users are not stored in file-based mode
+	users, err := s.store.GetOrganizationUnitUsersList("any-id", 10, 0)
+	assert.NoError(s.T(), err)
+	assert.Empty(s.T(), users)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitGroupsCount() {
+	// Groups are not stored in file-based mode
+	count, err := s.store.GetOrganizationUnitGroupsCount("any-id")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, count)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitGroupsList() {
+	// Groups are not stored in file-based mode
+	groups, err := s.store.GetOrganizationUnitGroupsList("any-id", 10, 0)
+	assert.NoError(s.T(), err)
+	assert.Empty(s.T(), groups)
+}
+
+func (s *FileBasedStoreTestSuite) TestCreate_StorerInterface() {
+	ou := &OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test",
+		Name:   "Test OU",
+		Parent: nil,
+	}
+
+	// Test the Create method from Storer interface
+	err := s.store.Create("test-ou-1", ou)
+	assert.NoError(s.T(), err)
+
+	// Verify it was created
+	retrieved, err := s.store.GetOrganizationUnit("test-ou-1")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), ou.ID, retrieved.ID)
+}
+
+func (s *FileBasedStoreTestSuite) TestNewFileBasedStore() {
+	// Test that newFileBasedStore creates a valid store
+	store := newFileBasedStore()
+	assert.NotNil(s.T(), store)
+
+	// Verify it implements the interface by using it
+	fbStore, ok := store.(*fileBasedStore)
+	assert.True(s.T(), ok)
+	assert.NotNil(s.T(), fbStore.GenericFileBasedStore)
+}

--- a/backend/internal/ou/immutable_resource.go
+++ b/backend/internal/ou/immutable_resource.go
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	immutableresource "github.com/asgardeo/thunder/internal/system/immutable_resource"
+	"github.com/asgardeo/thunder/internal/system/log"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	resourceTypeOU = "organization_unit"
+	paramTypeOU    = "OrganizationUnit"
+)
+
+// OUExporter implements immutableresource.ResourceExporter for organization units.
+type OUExporter struct {
+	service OrganizationUnitServiceInterface
+}
+
+// newOUExporter creates a new OU exporter.
+func newOUExporter(service OrganizationUnitServiceInterface) *OUExporter {
+	return &OUExporter{service: service}
+}
+
+// NewOUExporterForTest creates a new OU exporter for testing purposes.
+func NewOUExporterForTest(service OrganizationUnitServiceInterface) *OUExporter {
+	if !testing.Testing() {
+		panic("only for tests!")
+	}
+	return newOUExporter(service)
+}
+
+// GetResourceType returns the resource type for organization units.
+func (e *OUExporter) GetResourceType() string {
+	return resourceTypeOU
+}
+
+// GetParameterizerType returns the parameterizer type for organization units.
+func (e *OUExporter) GetParameterizerType() string {
+	return paramTypeOU
+}
+
+// GetAllResourceIDs retrieves all organization unit IDs.
+func (e *OUExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+	// Get all OUs by requesting a large limit
+	ous, err := e.service.GetOrganizationUnitList(1000, 0)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(ous.OrganizationUnits))
+	for _, ou := range ous.OrganizationUnits {
+		ids = append(ids, ou.ID)
+	}
+
+	// Also get all child OUs recursively
+	allIDs := make(map[string]bool)
+	for _, id := range ids {
+		allIDs[id] = true
+		childIDs, err := e.getAllChildIDs(id)
+		if err != nil {
+			return nil, err
+		}
+		for _, childID := range childIDs {
+			allIDs[childID] = true
+		}
+	}
+
+	result := make([]string, 0, len(allIDs))
+	for id := range allIDs {
+		result = append(result, id)
+	}
+
+	return result, nil
+}
+
+// getAllChildIDs recursively retrieves all child OU IDs.
+func (e *OUExporter) getAllChildIDs(parentID string) ([]string, *serviceerror.ServiceError) {
+	children, err := e.service.GetOrganizationUnitChildren(parentID, 1000, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	allIDs := []string{}
+	for _, child := range children.OrganizationUnits {
+		allIDs = append(allIDs, child.ID)
+		grandchildIDs, err := e.getAllChildIDs(child.ID)
+		if err != nil {
+			return nil, err
+		}
+		allIDs = append(allIDs, grandchildIDs...)
+	}
+
+	return allIDs, nil
+}
+
+// GetResourceByID retrieves an organization unit by its ID.
+func (e *OUExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+	ou, err := e.service.GetOrganizationUnit(id)
+	if err != nil {
+		return nil, "", err
+	}
+	return &ou, ou.Name, nil
+}
+
+// ValidateResource validates an organization unit resource.
+func (e *OUExporter) ValidateResource(
+	resource interface{}, id string, logger *log.Logger,
+) (string, *immutableresource.ExportError) {
+	ou, ok := resource.(*OrganizationUnit)
+	if !ok {
+		return "", immutableresource.CreateTypeError(resourceTypeOU, id)
+	}
+
+	if err := immutableresource.ValidateResourceName(
+		ou.Name, resourceTypeOU, id, "OU_VALIDATION_ERROR", logger); err != nil {
+		return "", err
+	}
+
+	return ou.Name, nil
+}
+
+// GetResourceRules returns the parameterization rules for organization units.
+func (e *OUExporter) GetResourceRules() *immutableresource.ResourceRules {
+	// OUs typically don't have parameterizable fields
+	return &immutableresource.ResourceRules{
+		Variables:      []string{},
+		ArrayVariables: []string{},
+	}
+}
+
+// loadImmutableResources loads immutable organization unit resources from files.
+func loadImmutableResources(ouStore organizationUnitStoreInterface) error {
+	// Type assert to access Storer interface for resource loading
+	fileBasedStore, ok := ouStore.(*fileBasedStore)
+	if !ok {
+		return fmt.Errorf("failed to assert ouStore to *fileBasedStore")
+	}
+
+	resourceConfig := immutableresource.ResourceConfig{
+		ResourceType:  "OrganizationUnit",
+		DirectoryName: "organizational_units",
+		Parser:        parseToOUWrapper,
+		Validator:     validateOUWrapper,
+		IDExtractor: func(data interface{}) string {
+			return data.(*OrganizationUnit).ID
+		},
+	}
+
+	loader := immutableresource.NewResourceLoader(resourceConfig, fileBasedStore)
+	if err := loader.LoadResources(); err != nil {
+		return fmt.Errorf("failed to load organization unit resources: %w", err)
+	}
+
+	return nil
+}
+
+// parseToOUWrapper wraps parseToOU to match the expected signature.
+func parseToOUWrapper(data []byte) (interface{}, error) {
+	return parseToOU(data)
+}
+
+// parseToOU parses YAML data to OrganizationUnit.
+func parseToOU(data []byte) (*OrganizationUnit, error) {
+	var ouRequest struct {
+		ID          string  `yaml:"id"`
+		Handle      string  `yaml:"handle"`
+		Name        string  `yaml:"name"`
+		Description string  `yaml:"description,omitempty"`
+		Parent      *string `yaml:"parent,omitempty"`
+	}
+
+	err := yaml.Unmarshal(data, &ouRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	ou := &OrganizationUnit{
+		ID:          ouRequest.ID,
+		Handle:      ouRequest.Handle,
+		Name:        ouRequest.Name,
+		Description: ouRequest.Description,
+		Parent:      ouRequest.Parent,
+	}
+
+	return ou, nil
+}
+
+// validateOUWrapper wraps validateOU to match ResourceConfig.Validator signature.
+func validateOUWrapper(data interface{}) error {
+	ou, ok := data.(*OrganizationUnit)
+	if !ok {
+		return fmt.Errorf("invalid type: expected *OrganizationUnit")
+	}
+
+	if ou.ID == "" {
+		return fmt.Errorf("organization unit ID is required")
+	}
+
+	if ou.Name == "" {
+		return fmt.Errorf("organization unit name is required")
+	}
+
+	if ou.Handle == "" {
+		return fmt.Errorf("organization unit handle is required")
+	}
+
+	return nil
+}

--- a/backend/internal/ou/immutable_resource_test.go
+++ b/backend/internal/ou/immutable_resource_test.go
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ImmutableResourceTestSuite struct {
+	suite.Suite
+	mockService *OrganizationUnitServiceInterfaceMock
+	exporter    *OUExporter
+}
+
+func TestImmutableResourceTestSuite(t *testing.T) {
+	suite.Run(t, new(ImmutableResourceTestSuite))
+}
+
+func (s *ImmutableResourceTestSuite) SetupTest() {
+	s.mockService = NewOrganizationUnitServiceInterfaceMock(s.T())
+	s.exporter = NewOUExporterForTest(s.mockService)
+}
+
+func (s *ImmutableResourceTestSuite) TestGetResourceType() {
+	resourceType := s.exporter.GetResourceType()
+	assert.Equal(s.T(), "organization_unit", resourceType)
+}
+
+func (s *ImmutableResourceTestSuite) TestGetParameterizerType() {
+	paramType := s.exporter.GetParameterizerType()
+	assert.Equal(s.T(), "OrganizationUnit", paramType)
+}
+
+func (s *ImmutableResourceTestSuite) TestGetResourceByID() {
+	ou := OrganizationUnit{
+		ID:          "test-ou-1",
+		Handle:      "test",
+		Name:        "Test OU",
+		Description: "Test organization unit",
+		Parent:      nil,
+	}
+
+	s.mockService.EXPECT().GetOrganizationUnit("test-ou-1").Return(ou, (*serviceerror.ServiceError)(nil))
+
+	resource, name, err := s.exporter.GetResourceByID("test-ou-1")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), "Test OU", name)
+	assert.NotNil(s.T(), resource)
+
+	retrievedOU, ok := resource.(*OrganizationUnit)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), "test-ou-1", retrievedOU.ID)
+}
+
+func (s *ImmutableResourceTestSuite) TestValidateResource() {
+	ou := &OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test",
+		Name:   "Test OU",
+	}
+
+	name, err := s.exporter.ValidateResource(ou, "test-ou-1", nil)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), "Test OU", name)
+}
+
+func (s *ImmutableResourceTestSuite) TestValidateResourceInvalidType() {
+	invalidResource := "not an OU"
+
+	name, err := s.exporter.ValidateResource(invalidResource, "test-id", nil)
+	assert.NotNil(s.T(), err)
+	assert.Empty(s.T(), name)
+	assert.Equal(s.T(), "INVALID_TYPE", err.Code)
+}
+
+func (s *ImmutableResourceTestSuite) TestParseToOU() {
+	yamlData := []byte(`
+id: test-ou-1
+handle: test
+name: Test OU
+description: Test organization unit
+parent: parent-id
+`)
+
+	ou, err := parseToOU(yamlData)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), ou)
+	assert.Equal(s.T(), "test-ou-1", ou.ID)
+	assert.Equal(s.T(), "test", ou.Handle)
+	assert.Equal(s.T(), "Test OU", ou.Name)
+	assert.Equal(s.T(), "Test organization unit", ou.Description)
+	assert.NotNil(s.T(), ou.Parent)
+	assert.Equal(s.T(), "parent-id", *ou.Parent)
+}
+
+func (s *ImmutableResourceTestSuite) TestParseToOUWithoutParent() {
+	yamlData := []byte(`
+id: root-ou
+handle: root
+name: Root OU
+description: Root organization unit
+`)
+
+	ou, err := parseToOU(yamlData)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), ou)
+	assert.Equal(s.T(), "root-ou", ou.ID)
+	assert.Equal(s.T(), "root", ou.Handle)
+	assert.Equal(s.T(), "Root OU", ou.Name)
+	assert.Nil(s.T(), ou.Parent)
+}
+
+func (s *ImmutableResourceTestSuite) TestValidateOUWrapper() {
+	ou := &OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test",
+		Name:   "Test OU",
+	}
+
+	err := validateOUWrapper(ou)
+	assert.NoError(s.T(), err)
+}
+
+func (s *ImmutableResourceTestSuite) TestValidateOUWrapperMissingID() {
+	ou := &OrganizationUnit{
+		Handle: "test",
+		Name:   "Test OU",
+	}
+
+	err := validateOUWrapper(ou)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "ID is required")
+}
+
+func (s *ImmutableResourceTestSuite) TestValidateOUWrapperMissingName() {
+	ou := &OrganizationUnit{
+		ID:     "test-ou-1",
+		Handle: "test",
+	}
+
+	err := validateOUWrapper(ou)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "name is required")
+}
+
+func (s *ImmutableResourceTestSuite) TestValidateOUWrapperMissingHandle() {
+	ou := &OrganizationUnit{
+		ID:   "test-ou-1",
+		Name: "Test OU",
+	}
+
+	err := validateOUWrapper(ou)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "handle is required")
+}
+
+func (s *ImmutableResourceTestSuite) TestGetResourceRules() {
+	rules := s.exporter.GetResourceRules()
+	assert.NotNil(s.T(), rules)
+	assert.Empty(s.T(), rules.Variables)
+	assert.Empty(s.T(), rules.ArrayVariables)
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_NoOUs() {
+	// Test with empty result
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.Nil(s.T(), err)
+	assert.Empty(s.T(), ids)
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_RootOUsOnly() {
+	// Test with only root OUs (no children)
+	rootOU1 := OrganizationUnitBasic{
+		ID:     "root-1",
+		Handle: "root1",
+		Name:   "Root 1",
+	}
+	rootOU2 := OrganizationUnitBasic{
+		ID:     "root-2",
+		Handle: "root2",
+		Name:   "Root 2",
+	}
+
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
+	}, (*serviceerror.ServiceError)(nil))
+
+	// Mock GetOrganizationUnitChildren to return empty lists for both roots
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-2", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 2)
+	assert.Contains(s.T(), ids, "root-1")
+	assert.Contains(s.T(), ids, "root-2")
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_WithChildren() {
+	// Test with nested OUs
+	rootOU := OrganizationUnitBasic{
+		ID:     "root-1",
+		Handle: "root",
+		Name:   "Root OU",
+	}
+	childOU := OrganizationUnitBasic{
+		ID:     "child-1",
+		Handle: "child",
+		Name:   "Child OU",
+	}
+	grandchildOU := OrganizationUnitBasic{
+		ID:     "grandchild-1",
+		Handle: "grandchild",
+		Name:   "Grandchild OU",
+	}
+
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{rootOU},
+	}, (*serviceerror.ServiceError)(nil))
+
+	// Mock children at each level
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{childOU},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{grandchildOU},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("grandchild-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 3)
+	assert.Contains(s.T(), ids, "root-1")
+	assert.Contains(s.T(), ids, "child-1")
+	assert.Contains(s.T(), ids, "grandchild-1")
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithChildren() {
+	// Test with multiple root OUs each having children
+	rootOU1 := OrganizationUnitBasic{
+		ID:     "root-1",
+		Handle: "root1",
+		Name:   "Root 1",
+	}
+	rootOU2 := OrganizationUnitBasic{
+		ID:     "root-2",
+		Handle: "root2",
+		Name:   "Root 2",
+	}
+	child1 := OrganizationUnitBasic{
+		ID:     "child-1",
+		Handle: "child1",
+		Name:   "Child 1",
+	}
+	child2 := OrganizationUnitBasic{
+		ID:     "child-2",
+		Handle: "child2",
+		Name:   "Child 2",
+	}
+
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{child1},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-2", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{child2},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-2", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 4)
+	assert.Contains(s.T(), ids, "root-1")
+	assert.Contains(s.T(), ids, "root-2")
+	assert.Contains(s.T(), ids, "child-1")
+	assert.Contains(s.T(), ids, "child-2")
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_ErrorGettingList() {
+	// Test error handling when getting the OU list fails
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(
+		(*OrganizationUnitListResponse)(nil),
+		&serviceerror.InternalServerError,
+	)
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), ids)
+	assert.Equal(s.T(), serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_ErrorGettingChildren() {
+	// Test error handling when getting children fails
+	rootOU := OrganizationUnitBasic{
+		ID:     "root-1",
+		Handle: "root",
+		Name:   "Root OU",
+	}
+
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{rootOU},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(
+		(*OrganizationUnitListResponse)(nil),
+		&serviceerror.InternalServerError,
+	)
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), ids)
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_DeepNesting() {
+	// Test with deeply nested hierarchy (5 levels)
+	level1 := OrganizationUnitBasic{ID: "level-1", Handle: "l1", Name: "Level 1"}
+	level2 := OrganizationUnitBasic{ID: "level-2", Handle: "l2", Name: "Level 2"}
+	level3 := OrganizationUnitBasic{ID: "level-3", Handle: "l3", Name: "Level 3"}
+	level4 := OrganizationUnitBasic{ID: "level-4", Handle: "l4", Name: "Level 4"}
+	level5 := OrganizationUnitBasic{ID: "level-5", Handle: "l5", Name: "Level 5"}
+
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{level1},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{level2},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-2", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{level3},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-3", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{level4},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-4", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{level5},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-5", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 5)
+	for i := 1; i <= 5; i++ {
+		assert.Contains(s.T(), ids, "level-"+strconv.Itoa(i))
+	}
+}
+
+func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPerLevel() {
+	// Test with multiple children at same level
+	rootOU := OrganizationUnitBasic{
+		ID:     "root-1",
+		Handle: "root",
+		Name:   "Root OU",
+	}
+	child1 := OrganizationUnitBasic{
+		ID:     "child-1",
+		Handle: "child1",
+		Name:   "Child 1",
+	}
+	child2 := OrganizationUnitBasic{
+		ID:     "child-2",
+		Handle: "child2",
+		Name:   "Child 2",
+	}
+	child3 := OrganizationUnitBasic{
+		ID:     "child-3",
+		Handle: "child3",
+		Name:   "Child 3",
+	}
+
+	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{rootOU},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{child1, child2, child3},
+	}, (*serviceerror.ServiceError)(nil))
+
+	// Each child has no children
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-2", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-3", 1000, 0).Return(&OrganizationUnitListResponse{
+		OrganizationUnits: []OrganizationUnitBasic{},
+	}, (*serviceerror.ServiceError)(nil))
+
+	ids, err := s.exporter.GetAllResourceIDs()
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 4)
+	assert.Contains(s.T(), ids, "root-1")
+	assert.Contains(s.T(), ids, "child-1")
+	assert.Contains(s.T(), ids, "child-2")
+	assert.Contains(s.T(), ids, "child-3")
+}

--- a/backend/internal/ou/init_test.go
+++ b/backend/internal/ou/init_test.go
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	immutableresource "github.com/asgardeo/thunder/internal/system/immutable_resource"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type InitTestSuite struct {
+	suite.Suite
+}
+
+func TestInitTestSuite(t *testing.T) {
+	suite.Run(t, new(InitTestSuite))
+}
+
+func (suite *InitTestSuite) SetupTest() {
+	// Initialize ThunderRuntime for each test
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		ImmutableResources: config.ImmutableResources{
+			Enabled: false,
+		},
+	}
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+}
+
+func (suite *InitTestSuite) TearDownTest() {
+	// Clean up after each test
+	config.ResetThunderRuntime()
+}
+
+func (suite *InitTestSuite) TestInitialize_WithImmutableResourcesDisabled() {
+	// Setup: Disable immutable resources
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = false
+
+	mux := http.NewServeMux()
+
+	// Execute
+	service, exporter, err := Initialize(mux)
+
+	// Assert
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), exporter)
+
+	// Verify exporter is properly created
+	assert.Equal(suite.T(), "organization_unit", exporter.GetResourceType())
+	assert.Equal(suite.T(), "OrganizationUnit", exporter.GetParameterizerType())
+}
+
+func (suite *InitTestSuite) TestInitialize_WithImmutableResourcesEnabled() {
+	// Setup: Enable immutable resources
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = true
+
+	mux := http.NewServeMux()
+
+	// Execute
+	service, exporter, err := Initialize(mux)
+
+	// Assert
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), exporter)
+
+	// Verify exporter is properly created
+	assert.Equal(suite.T(), "organization_unit", exporter.GetResourceType())
+	assert.Equal(suite.T(), "OrganizationUnit", exporter.GetParameterizerType())
+}
+
+func (suite *InitTestSuite) TestInitialize_FileBasedStoreCreation() {
+	// Setup: Enable immutable resources
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = true
+
+	mux := http.NewServeMux()
+
+	// Execute
+	service, exporter, err := Initialize(mux)
+
+	// Assert
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), exporter)
+
+	// Test that the service works (would use file-based store)
+	// We can't directly verify the store type, but we can check the service is functional
+	assert.NotNil(suite.T(), service)
+}
+
+func (suite *InitTestSuite) TestInitialize_DatabaseStoreCreation() {
+	// Setup: Disable immutable resources (uses database store)
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = false
+
+	mux := http.NewServeMux()
+
+	// Execute
+	service, exporter, err := Initialize(mux)
+
+	// Assert
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), exporter)
+}
+
+func (suite *InitTestSuite) TestInitialize_RoutesRegistered() {
+	// Setup
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = false
+
+	mux := http.NewServeMux()
+
+	// Execute
+	service, exporter, err := Initialize(mux)
+
+	// Assert
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), exporter)
+
+	// Verify routes are registered by checking if requests can be matched
+	// Note: We can't easily verify all routes without making actual HTTP requests,
+	// but we can verify the function completed successfully
+}
+
+func (suite *InitTestSuite) TestInitialize_ExporterInterfaceCompliance() {
+	// Setup
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = false
+
+	mux := http.NewServeMux()
+
+	// Execute
+	service, exporter, err := Initialize(mux)
+
+	// Assert
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), service)
+
+	// Verify exporter implements ResourceExporter interface
+	var _ immutableresource.ResourceExporter = exporter
+
+	// Test exporter methods
+	assert.Equal(suite.T(), "organization_unit", exporter.GetResourceType())
+	assert.Equal(suite.T(), "OrganizationUnit", exporter.GetParameterizerType())
+
+	rules := exporter.GetResourceRules()
+	assert.NotNil(suite.T(), rules)
+	assert.Empty(suite.T(), rules.Variables)
+	assert.Empty(suite.T(), rules.ArrayVariables)
+}
+
+func (suite *InitTestSuite) TestInitialize_ServiceInterfaceCompliance() {
+	// Setup
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = false
+
+	mux := http.NewServeMux()
+
+	// Execute
+	service, exporter, err := Initialize(mux)
+
+	// Assert
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), exporter)
+
+	// Verify service implements OrganizationUnitServiceInterface
+	var _ OrganizationUnitServiceInterface = service
+}
+
+func (suite *InitTestSuite) TestInitialize_MultipleInitializations() {
+	// Test that multiple initializations work (e.g., for testing scenarios)
+	runtime := config.GetThunderRuntime()
+	runtime.Config.ImmutableResources.Enabled = false
+
+	mux1 := http.NewServeMux()
+	service1, exporter1, err1 := Initialize(mux1)
+	assert.NoError(suite.T(), err1)
+	assert.NotNil(suite.T(), service1)
+	assert.NotNil(suite.T(), exporter1)
+
+	mux2 := http.NewServeMux()
+	service2, exporter2, err2 := Initialize(mux2)
+	assert.NoError(suite.T(), err2)
+	assert.NotNil(suite.T(), service2)
+	assert.NotNil(suite.T(), exporter2)
+
+	// Services should be different instances
+	assert.NotSame(suite.T(), service1, service2)
+	assert.NotSame(suite.T(), exporter1, exporter2)
+}

--- a/backend/internal/ou/service_test.go
+++ b/backend/internal/ou/service_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/asgardeo/thunder/internal/system/config"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
@@ -38,6 +39,21 @@ const testParentID = "parent"
 
 func TestOUService_OrganizationUnitServiceTestSuite_Run(t *testing.T) {
 	suite.Run(t, new(OrganizationUnitServiceTestSuite))
+}
+
+func (suite *OrganizationUnitServiceTestSuite) SetupTest() {
+	// Initialize ThunderRuntime with immutable mode disabled by default
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		ImmutableResources: config.ImmutableResources{
+			Enabled: false,
+		},
+	}
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+}
+
+func (suite *OrganizationUnitServiceTestSuite) TearDownTest() {
+	config.ResetThunderRuntime()
 }
 
 type ouListExpectations struct {

--- a/backend/internal/system/export/model.go
+++ b/backend/internal/system/export/model.go
@@ -26,6 +26,7 @@ type ExportRequest struct {
 	IdentityProviders   []string `json:"identity_providers,omitempty"`
 	NotificationSenders []string `json:"notification_senders,omitempty"`
 	UserSchemas         []string `json:"user_schemas,omitempty"`
+	OrganizationUnits   []string `json:"organization_units,omitempty"`
 
 	Options *ExportOptions `json:"options,omitempty"`
 }

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -35,6 +35,7 @@ const (
 	resourceTypeIdentityProvider   = "identity_provider"
 	resourceTypeNotificationSender = "notification_sender"
 	resourceTypeUserSchema         = "user_schema"
+	resourceTypeOU                 = "organization_unit"
 )
 
 // parameterizerInterface defines the interface for template parameterization.
@@ -100,6 +101,7 @@ func (es *exportService) ExportResources(request *ExportRequest) (*ExportRespons
 		resourceTypeIdentityProvider:   request.IdentityProviders,
 		resourceTypeNotificationSender: request.NotificationSenders,
 		resourceTypeUserSchema:         request.UserSchemas,
+		resourceTypeOU:                 request.OrganizationUnits,
 	}
 
 	// Export resources using the registry

--- a/backend/internal/system/immutable_resource/entity/entity_store.go
+++ b/backend/internal/system/immutable_resource/entity/entity_store.go
@@ -34,6 +34,7 @@ const (
 	KeyTypeIDP                KeyType = "idp"
 	KeyTypeNotificationSender KeyType = "notification-sender"
 	KeyTypeUserSchema         KeyType = "user-schema"
+	KeyTypeOU                 KeyType = "ou"
 )
 
 // String returns the string representation of KeyType
@@ -44,7 +45,7 @@ func (kt KeyType) String() string {
 // IsValid checks if the KeyType is one of the predefined types
 func (kt KeyType) IsValid() bool {
 	switch kt {
-	case KeyTypeApplication, KeyTypeNotification, KeyTypeIDP, KeyTypeNotificationSender, KeyTypeUserSchema:
+	case KeyTypeApplication, KeyTypeNotification, KeyTypeIDP, KeyTypeNotificationSender, KeyTypeUserSchema, KeyTypeOU:
 		return true
 	default:
 		return false


### PR DESCRIPTION
### Purpose
Add immutable config support for OU

### Issue
- https://github.com/asgardeo/thunder/issues/923

====
This pull request introduces file-based storage and export functionality for Organization Units (OUs), along with comprehensive tests. The changes add a new file-based store implementation for OUs, integrate it into the service registration, and provide an exporter for immutable resource management. Extensive unit tests ensure the correctness of the new file-based logic.

**File-based Organization Unit storage:**

* Added a new `fileBasedStore` in `file_based_store.go` implementing the OU store interface, supporting creation, retrieval, listing, and various checks for OUs, while explicitly not supporting update and delete operations in file-based mode.
* Provided a factory function to create a new file-based store and implemented all necessary methods for OU hierarchy and conflict checks.

**Immutable resource export and loading:**

* Introduced `OUExporter` in `immutable_resource.go`, implementing the `ResourceExporter` interface for OUs, enabling export, validation, and loading of OU resources from files.
* Added logic to recursively collect all OU IDs, parse and validate YAML resource files, and integrate with the generic immutable resource loader.

**Integration and service registration:**

* Updated `registerServices` in `servicemanager.go` to initialize the OU service with file-based storage and register the OU exporter for resource export.

**Testing:**

* Added comprehensive tests in `file_based_store_test.go` covering creation, retrieval, listing, conflict detection, and unsupported operations for the file-based OU store.