### PR TITLE
Change OU immutable config directory name

### DIFF
--- a/backend/internal/ou/immutable_resource.go
+++ b/backend/internal/ou/immutable_resource.go
@@ -173,7 +173,7 @@ func loadImmutableResources(fileStore organizationUnitStoreInterface, dbStore or
 
 	resourceConfig := immutableresource.ResourceConfig{
 		ResourceType:  "OrganizationUnit",
-		DirectoryName: "organizational_units",
+		DirectoryName: "organization_units",
 		Parser:        parseToOUWrapper,
 		Validator: func(data interface{}) error {
 			return validateOUWrapper(data, store, dbStore)

--- a/docs/guides/immutable-configurations/immutable-configuration.md
+++ b/docs/guides/immutable-configurations/immutable-configuration.md
@@ -136,7 +136,7 @@ organization_unit:
 
 ```
 repository/conf/immutable_resources/
-└── organizational_units/
+└── organization_units/
     ├── production.yaml      # Immutable OU from YAML
     ├── staging.yaml         # Immutable OU from YAML
     └── development.yaml     # Immutable OU from YAML
@@ -175,7 +175,7 @@ repository/conf/immutable_resources/
 |---------------|-----------|-------------|--------|
 | Applications | `applications/` | Global only | ✅ Supported |
 | Identity Providers | `identity-providers/` | Global only | ✅ Supported |
-| Organization Units | `organizational_units/` | mutable / immutable / composite | ✅ Supported |
+| Organization Units | `organization_units/` | mutable / immutable / composite | ✅ Supported |
 | Notification Senders | `notification-senders/` | Global only | 🔜 Coming Soon |
 | Groups | `groups/` | TBD | 🔜 Coming Soon |
 | Roles | `roles/` | TBD | 🔜 Coming Soon |


### PR DESCRIPTION
### Purpose
Change OU immutable config directory name from `organizational_units` to `organization_units`

### Approach
This pull request standardizes the directory naming convention for organization units by updating references from `organizational_units` to `organization_units` across both the backend code and documentation. This change ensures consistency and prevents confusion when managing immutable resources.

**Directory naming consistency:**

* Updated the `DirectoryName` in the `ResourceConfig` for organization units from `organizational_units` to `organization_units` in `immutable_resource.go` to match the intended convention.

**Documentation updates:**

* Changed all references to the organization units directory from `organizational_units/` to `organization_units/` in the immutable configuration guide, including directory structures and feature support tables. [[1]](diffhunk://#diff-84adb385dc520e84e94d2a804d8da5d0d31a3389cde60cc0da797699f6d1ae77L139-R139) [[2]](diffhunk://#diff-84adb385dc520e84e94d2a804d8da5d0d31a3389cde60cc0da797699f6d1ae77L178-R178)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
