### PR TITLE
Fix immutable configuration documentation

### DIFF
--- a/docs/guides/immutable-configurations/immutable-configuration.md
+++ b/docs/guides/immutable-configurations/immutable-configuration.md
@@ -161,7 +161,7 @@ repository/conf/immutable_resources/
 │   ├── google-idp.yaml
 │   ├── github-idp.yaml
 │   └── oidc-idp.yaml
-├── organizational_units/
+├── organization_units/
 │   ├── production.yaml
 │   ├── staging.yaml
 │   └── development.yaml
@@ -174,11 +174,9 @@ repository/conf/immutable_resources/
 | Resource Type | Directory | Store Modes | Status |
 |---------------|-----------|-------------|--------|
 | Applications | `applications/` | Global only | ✅ Supported |
-| Identity Providers | `identity-providers/` | Global only | ✅ Supported |
+| Identity Providers | `identity_providers/` | Global only | ✅ Supported |
 | Organization Units | `organization_units/` | mutable / immutable / composite | ✅ Supported |
-| Notification Senders | `notification-senders/` | Global only | 🔜 Coming Soon |
-| Groups | `groups/` | TBD | 🔜 Coming Soon |
-| Roles | `roles/` | TBD | 🔜 Coming Soon |
+| Notification Senders | `notification_senders/` | Global only | ✅ Supported |
 
 ## Creating Configuration Files
 


### PR DESCRIPTION
### Purpose
Fix immutable configuration documentation


### Approach
This pull request updates the documentation for immutable configuration resources to ensure consistency in naming conventions and clarify support status for certain resource types.

**Directory naming consistency:**

* Renamed the `organizational_units/` directory to `organization_units/` in the example file structure to match the resource type naming convention.
* Updated the directory name for identity providers from `identity-providers/` to `identity_providers/` in the resource type table for consistency.
* Changed the directory name for notification senders from `notification-senders/` to `notification_senders/` in the resource type table.

**Support status updates:**

* Marked `notification_senders/` as "✅ Supported" instead of "🔜 Coming Soon" in the resource type table.
* Removed "Groups" and "Roles" from the resource type table, as their support status is no longer listed.

### Related Issues
- https://github.com/asgardeo/thunder/issues/478

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
