### PR TITLE
Change Immutable resource directory

### DIFF
--- a/backend/internal/application/init_test.go
+++ b/backend/internal/application/init_test.go
@@ -499,7 +499,7 @@ func TestInitialize_WithImmutableResources_Standalone(t *testing.T) {
 
 	// Create a temporary directory structure for file-based runtime
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	appDir := confDir + "/applications"
 
 	// Create the directory structure

--- a/backend/internal/idp/init_test.go
+++ b/backend/internal/idp/init_test.go
@@ -312,8 +312,8 @@ func TestInitialize_WithImmutableResourcesEnabled_EmptyDirectory(t *testing.T) {
 
 	// Create a temporary directory structure for file-based runtime
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
-	idpDir := confDir + "/identity-providers"
+	confDir := tmpDir + "/repository/resources"
+	idpDir := confDir + "/identity_providers"
 
 	// Create the directory structure
 	err := os.MkdirAll(idpDir, 0750)
@@ -347,7 +347,7 @@ func TestInitialize_WithImmutableResourcesEnabled_EmptyDirectory(t *testing.T) {
 func TestInitialize_WithImmutableResourcesEnabled_ValidConfigs(t *testing.T) {
 	// Create a temporary directory structure for file-based runtime
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	idpDir := confDir + "/identity_providers"
 
 	// Create the directory structure
@@ -355,6 +355,9 @@ func TestInitialize_WithImmutableResourcesEnabled_ValidConfigs(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create crypto key file for encryption (relative to tmpDir)
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
+	assert.NoError(t, err)
 	cryptoFilePath := tmpDir + "/repository/conf/crypto.key"
 	err = os.WriteFile(cryptoFilePath, []byte(testCryptoKey), 0600)
 	assert.NoError(t, err)
@@ -471,7 +474,7 @@ properties:
 //nolint:dupl // Similar test setup required for different error scenarios
 func TestInitialize_WithImmutableResourcesEnabled_InvalidYAML(t *testing.T) {
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	idpDir := confDir + "/identity_providers"
 
 	err := os.MkdirAll(idpDir, 0750)
@@ -485,6 +488,9 @@ func TestInitialize_WithImmutableResourcesEnabled_InvalidYAML(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Setup config
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
+	assert.NoError(t, err)
 	cryptoFilePath := tmpDir + "/repository/conf/crypto.key"
 	// Use testCryptoKey constant
 	err = os.WriteFile(cryptoFilePath, []byte(testCryptoKey), 0600)
@@ -517,7 +523,7 @@ func TestInitialize_WithImmutableResourcesEnabled_InvalidYAML(t *testing.T) {
 //nolint:dupl // Similar test setup required for different error scenarios
 func TestInitialize_WithImmutableResourcesEnabled_ValidationFailure(t *testing.T) {
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	idpDir := confDir + "/identity_providers"
 
 	err := os.MkdirAll(idpDir, 0750)
@@ -536,6 +542,9 @@ properties:
 	assert.NoError(t, err)
 
 	// Setup config
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
+	assert.NoError(t, err)
 	cryptoFilePath := tmpDir + "/repository/conf/crypto.key"
 	// Use testCryptoKey constant
 	err = os.WriteFile(cryptoFilePath, []byte(testCryptoKey), 0600)
@@ -568,7 +577,7 @@ properties:
 //nolint:dupl // Similar test setup required for different error scenarios
 func TestInitialize_WithImmutableResourcesEnabled_InvalidIDPType(t *testing.T) {
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	idpDir := confDir + "/identity_providers"
 
 	err := os.MkdirAll(idpDir, 0750)
@@ -587,6 +596,9 @@ properties:
 	assert.NoError(t, err)
 
 	// Setup config
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
+	assert.NoError(t, err)
 	cryptoFilePath := tmpDir + "/repository/conf/crypto.key"
 	// Use testCryptoKey constant
 	err = os.WriteFile(cryptoFilePath, []byte(testCryptoKey), 0600)

--- a/backend/internal/notification/init_test.go
+++ b/backend/internal/notification/init_test.go
@@ -91,7 +91,7 @@ func (suite *InitTestSuite) TestInitialize() {
 func (suite *InitTestSuite) TestInitialize_WithImmutableResourcesEnabled_FileLoading() {
 	// Create a temporary directory for immutable resources
 	tmpDir := suite.T().TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	senderDir := confDir + "/notification_senders"
 
 	// Create the directory structure
@@ -463,7 +463,7 @@ func (suite *InitTestSuite) TestParseProviderType_CaseSensitivity() {
 //nolint:dupl // Similar test setup required for different error scenarios
 func (suite *InitTestSuite) TestInitialize_WithImmutableResourcesEnabled_InvalidYAML() {
 	tmpDir := suite.T().TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	senderDir := confDir + "/notification_senders"
 
 	err := os.MkdirAll(senderDir, 0750)
@@ -534,7 +534,7 @@ func (suite *InitTestSuite) TestInitialize_WithImmutableResourcesEnabled_Invalid
 //nolint:dupl // Similar test setup required for different error scenarios
 func (suite *InitTestSuite) TestInitialize_WithImmutableResourcesEnabled_ValidationFailure() {
 	tmpDir := suite.T().TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	senderDir := confDir + "/notification_senders"
 
 	err := os.MkdirAll(senderDir, 0750)

--- a/backend/internal/system/immutable_resource/loader_test.go
+++ b/backend/internal/system/immutable_resource/loader_test.go
@@ -92,8 +92,8 @@ func (suite *ResourceLoaderTestSuite) SetupSuite() {
 	err := config.InitializeThunderRuntime(tempThunderHome, testConfig)
 	suite.Require().NoError(err, "Failed to initialize ThunderRuntime")
 
-	// Create the immutable_resources directory structure
-	suite.resourcesDir = filepath.Join(tempThunderHome, "repository", "conf", "immutable_resources")
+	// Create the resources directory structure
+	suite.resourcesDir = filepath.Join(tempThunderHome, "repository", "resources")
 	err = os.MkdirAll(suite.resourcesDir, 0750)
 	suite.Require().NoError(err)
 }
@@ -103,7 +103,7 @@ func (suite *ResourceLoaderTestSuite) TearDownSuite() {
 	// Temp directory cleanup is handled automatically by suite.T().TempDir()
 }
 
-// Helper function to create YAML file in immutable_resources directory
+// Helper function to create YAML file in resources directory
 func (suite *ResourceLoaderTestSuite) createYAMLFile(subdir, filename, content string) {
 	dirPath := filepath.Join(suite.resourcesDir, subdir)
 	err := os.MkdirAll(dirPath, 0750)
@@ -113,7 +113,7 @@ func (suite *ResourceLoaderTestSuite) createYAMLFile(subdir, filename, content s
 	suite.Require().NoError(err)
 }
 
-// Helper function to create resource directory in immutable_resources
+// Helper function to create resource directory in resources
 func (suite *ResourceLoaderTestSuite) createResourceDir(subdir string) string {
 	dirPath := filepath.Join(suite.resourcesDir, subdir)
 	err := os.MkdirAll(dirPath, 0750)

--- a/backend/internal/system/immutable_resource/manager.go
+++ b/backend/internal/system/immutable_resource/manager.go
@@ -118,11 +118,11 @@ func substituteEnvironmentVariables(content []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// GetConfigs reads all configuration files from the specified directory within the immutable_resources directory.
+// GetConfigs reads all configuration files from the specified directory within the resources directory.
 func GetConfigs(configDirectoryPath string) ([][]byte, error) {
 	logger := log.GetLogger().With(log.String("component", "FileBasedRuntime"))
 	thunderHome := config.GetThunderRuntime().ThunderHome
-	immutableConfigFilePath := path.Join(thunderHome, "repository/conf/immutable_resources/")
+	immutableConfigFilePath := path.Join(thunderHome, "repository/resources/")
 	absoluteDirectoryPath := filepath.Join(immutableConfigFilePath, configDirectoryPath)
 	files, err := os.ReadDir(absoluteDirectoryPath)
 	if err != nil {

--- a/backend/internal/system/immutable_resource/manager_test.go
+++ b/backend/internal/system/immutable_resource/manager_test.go
@@ -104,7 +104,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) setEnvVar(key, value string) {
 // Helper function to create test files in the immutable resources directory
 func (suite *FileBasedRuntimeManagerTestSuite) createTestFile(configDir, filename, content string) string {
 	thunderHome := config.GetThunderRuntime().ThunderHome
-	immutableDir := filepath.Join(thunderHome, "repository", "conf", "immutable_resources", configDir)
+	immutableDir := filepath.Join(thunderHome, "repository", "resources", configDir)
 	err := os.MkdirAll(immutableDir, 0750)
 	suite.Require().NoError(err)
 
@@ -375,7 +375,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigs_EmptyDirectory() {
 	configDir := "empty-configs"
 	// Create empty directory
 	thunderHome := config.GetThunderRuntime().ThunderHome
-	immutableDir := filepath.Join(thunderHome, "repository", "conf", "immutable_resources", configDir)
+	immutableDir := filepath.Join(thunderHome, "repository", "resources", configDir)
 	err := os.MkdirAll(immutableDir, 0750)
 	suite.Require().NoError(err)
 
@@ -393,7 +393,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigs_DirectoryWithSubdi
 
 	// Create a subdirectory
 	thunderHome := config.GetThunderRuntime().ThunderHome
-	immutableDir := filepath.Join(thunderHome, "repository", "conf", "immutable_resources", configDir)
+	immutableDir := filepath.Join(thunderHome, "repository", "resources", configDir)
 	subDir := filepath.Join(immutableDir, "subdir")
 	err := os.MkdirAll(subDir, 0750)
 	suite.Require().NoError(err)
@@ -531,7 +531,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigs_DirectoryReadPermi
 
 	// Get the directory path and remove read permissions
 	thunderHome := config.GetThunderRuntime().ThunderHome
-	immutableDir := filepath.Join(thunderHome, "repository", "conf", "immutable_resources", configDir)
+	immutableDir := filepath.Join(thunderHome, "repository", "resources", configDir)
 
 	err := os.Chmod(immutableDir, 0000)
 	suite.NoError(err)
@@ -554,7 +554,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigs_CorruptedFile() {
 
 	// Create a file with invalid UTF-8 sequences using the file system directly
 	thunderHome := config.GetThunderRuntime().ThunderHome
-	immutableDir := filepath.Join(thunderHome, "repository", "conf", "immutable_resources", configDir)
+	immutableDir := filepath.Join(thunderHome, "repository", "resources", configDir)
 	err := os.MkdirAll(immutableDir, 0750)
 	suite.Require().NoError(err)
 
@@ -704,7 +704,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigs_BinaryFiles() {
 	// Create a binary file (non-text content)
 	binaryContent := []byte{0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE, 0xFD}
 	thunderHome := config.GetThunderRuntime().ThunderHome
-	immutableDir := filepath.Join(thunderHome, "repository", "conf", "immutable_resources", configDir)
+	immutableDir := filepath.Join(thunderHome, "repository", "resources", configDir)
 	err := os.MkdirAll(immutableDir, 0750)
 	suite.Require().NoError(err)
 

--- a/backend/internal/userschema/init_test.go
+++ b/backend/internal/userschema/init_test.go
@@ -722,7 +722,7 @@ this is not valid yaml:
 //nolint:dupl // Similar test setup required for different error scenarios
 func TestInitialize_WithImmutableResourcesEnabled_InvalidYAML(t *testing.T) {
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	schemaDir := confDir + "/user_schemas"
 
 	err := os.MkdirAll(schemaDir, 0750)
@@ -736,6 +736,9 @@ func TestInitialize_WithImmutableResourcesEnabled_InvalidYAML(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Setup config
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
+	assert.NoError(t, err)
 	cryptoFilePath := tmpDir + "/repository/conf/crypto.key"
 	// Use testCryptoKey constant
 	err = os.WriteFile(cryptoFilePath, []byte(testCryptoKey), 0600)
@@ -769,10 +772,15 @@ func TestInitialize_WithImmutableResourcesEnabled_InvalidYAML(t *testing.T) {
 //nolint:dupl // Similar test setup required for different error scenarios
 func TestInitialize_WithImmutableResourcesEnabled_ValidationFailure(t *testing.T) {
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	schemaDir := confDir + "/user_schemas"
 
 	err := os.MkdirAll(schemaDir, 0750)
+	assert.NoError(t, err)
+
+	// Create crypto directory
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
 	assert.NoError(t, err)
 
 	// Create a YAML file with invalid configuration (empty name)
@@ -819,10 +827,15 @@ schema: |
 // TestInitialize_WithImmutableResourcesEnabled_OUServiceError tests Initialize when OU service fails
 func TestInitialize_WithImmutableResourcesEnabled_OUServiceError(t *testing.T) {
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	schemaDir := confDir + "/user_schemas"
 
 	err := os.MkdirAll(schemaDir, 0750)
+	assert.NoError(t, err)
+
+	// Create crypto directory
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
 	assert.NoError(t, err)
 
 	// Create a valid YAML file
@@ -883,10 +896,15 @@ schema: |
 //nolint:dupl // Similar test setup required for different error scenarios
 func TestInitialize_WithImmutableResourcesEnabled_InvalidJSONSchema(t *testing.T) {
 	tmpDir := t.TempDir()
-	confDir := tmpDir + "/repository/conf/immutable_resources"
+	confDir := tmpDir + "/repository/resources"
 	schemaDir := confDir + "/user_schemas"
 
 	err := os.MkdirAll(schemaDir, 0750)
+	assert.NoError(t, err)
+
+	// Create crypto directory
+	cryptoDir := tmpDir + "/repository/conf"
+	err = os.MkdirAll(cryptoDir, 0750)
 	assert.NoError(t, err)
 
 	// Create a YAML file with invalid JSON in schema field

--- a/docs/guides/immutable-configurations/export-configurations.md
+++ b/docs/guides/immutable-configurations/export-configurations.md
@@ -564,7 +564,7 @@ docker run \
   -e MY_APP_CLIENT_SECRET=prod-secret \
   -e MY_APP_REDIRECT_URIS_0=https://app.example.com/callback \
   -e MY_APP_REDIRECT_URIS_1=https://app.example.com/logout \
-  -v $(pwd)/configs:/app/repository/conf/immutable_resources \
+  -v $(pwd)/configs:/app/repository/resources \
   thunder:latest
 ```
 
@@ -572,7 +572,7 @@ Or use an environment file:
 
 ```bash
 docker run --env-file production.env \
-  -v $(pwd)/configs:/app/repository/conf/immutable_resources \
+  -v $(pwd)/configs:/app/repository/resources \
   thunder:latest
 ```
 

--- a/docs/guides/immutable-configurations/immutable-configuration.md
+++ b/docs/guides/immutable-configurations/immutable-configuration.md
@@ -16,7 +16,7 @@ Immutable Configuration Mode allows Thunder to load resource configurations from
 
 When immutable configuration mode is enabled:
 
-1. Thunder starts and reads YAML files from `repository/conf/immutable_resources/`
+1. Thunder starts and reads YAML files from `repository/resources/`
 2. Configurations are loaded into memory (not the database)
 3. Create, Update, and Delete operations are **disabled** via API
 4. Applications use the file-based configurations
@@ -135,7 +135,7 @@ organization_unit:
 ```
 
 ```
-repository/conf/immutable_resources/
+repository/resources/
 └── organization_units/
     ├── production.yaml      # Immutable OU from YAML
     ├── staging.yaml         # Immutable OU from YAML
@@ -149,10 +149,10 @@ At runtime:
 
 ## Directory Structure
 
-Place configuration files in the `repository/conf/immutable_resources/` directory:
+Place configuration files in the `repository/resources/` directory:
 
 ```
-repository/conf/immutable_resources/
+repository/resources/
 ├── applications/
 │   ├── my-web-app.yaml
 │   ├── mobile-app.yaml
@@ -190,14 +190,14 @@ curl -X POST https://localhost:8090/export \
   -H "Content-Type: application/json" \
   -d '{
     "applications": ["<application-id>"]
-  }' > repository/conf/immutable_resources/applications/my-app.yaml
+  }' > repository/resources/applications/my-app.yaml
 
 # Export an identity provider
 curl -X POST https://localhost:8090/export \
   -H "Content-Type: application/json" \
   -d '{
     "identity_providers": ["<idp-id>"]
-  }' > repository/conf/immutable_resources/identity-providers/google-idp.yaml
+  }' > repository/resources/identity_providers/google-idp.yaml
 ```
 
 See the [Export Configurations Guide](./export-configurations.md) for detailed export instructions.
@@ -207,7 +207,7 @@ See the [Export Configurations Guide](./export-configurations.md) for detailed e
 You can also create YAML files manually. Here's an example application configuration:
 
 ```yaml
-# repository/conf/immutable_resources/applications/my-app.yaml
+# repository/resources/applications/my-app.yaml
 name: My Application
 description: Production web application
 url: https://myapp.example.com
@@ -356,7 +356,7 @@ docker run \
   -e MY_APP_CLIENT_ID=client-id \
   -e MY_APP_CLIENT_SECRET=secret \
   -e MY_APP_REDIRECT_URIS_0=https://app.example.com/callback \
-  -v $(pwd)/immutable_resources:/app/repository/conf/immutable_resources \
+  -v $(pwd)/immutable_resources:/app/repository/resources \
   thunder:latest
 ```
 
@@ -364,7 +364,7 @@ Or use an env file:
 
 ```bash
 docker run --env-file production.env \
-  -v $(pwd)/immutable_resources:/app/repository/conf/immutable_resources \
+  -v $(pwd)/immutable_resources:/app/repository/resources \
   thunder:latest
 ```
 
@@ -446,7 +446,7 @@ When immutable configuration mode is enabled:
 Store configuration files in git:
 
 ```bash
-git add repository/conf/immutable_resources/
+git add repository/resources/
 git commit -m "Add production application configs"
 git tag v1.0.0
 ```
@@ -482,7 +482,7 @@ Validate configurations before deployment:
 
 ```bash
 # Check for syntax errors
-yamllint repository/conf/immutable_resources/**/*.yaml
+yamllint repository/resources/**/*.yaml
 
 # Verify all variables are set
 ./scripts/validate-env.sh production.env
@@ -529,7 +529,7 @@ export MY_APP_REDIRECT_URIS_1=https://example.com/logout
 **Cause:** File not in correct directory or invalid YAML.
 
 **Solution:**
-1. Verify file location: `repository/conf/immutable_resources/applications/`
+1. Verify file location: `repository/resources/applications/`
 2. Check YAML syntax: `yamllint my-app.yaml`
 3. Check server logs for parsing errors
 
@@ -541,7 +541,7 @@ export MY_APP_REDIRECT_URIS_1=https://example.com/logout
 
 **Solution:**
 This is expected behavior. To add new applications:
-1. Create a new YAML file in `immutable_resources/applications/`
+1. Create a new YAML file in `repository/resources/applications/`
 2. Restart Thunder
 3. Or disable immutable mode to use API
 
@@ -566,7 +566,7 @@ This is expected behavior. To add new applications:
 3. **Restrict file permissions:**
    ```bash
    chmod 600 environments/*.env
-   chmod 700 repository/conf/immutable_resources/
+   chmod 700 repository/resources/
    ```
 
 4. **Rotate secrets regularly:**


### PR DESCRIPTION
### Purpose
Change immutable resource directory to repository/resources. This includes tests and documentation changes as well.

With this PR the directory used for immutable configuration changes. 
- Current directory : `repository/conf/resources`
- New directory: `repository/resources`

For those who uses existing immutable configuration enabled, those configurations needs to be moved to the new directory mentioned above.


### Approach
This pull request updates the directory structure for storing immutable resource configurations across the codebase and documentation. The main change is moving all references from `repository/conf/immutable_resources` to `repository/resources`. This affects test setups, helper functions, file loading logic, and user documentation to ensure consistency and clarity in where resource files are located.

**Directory structure and file path updates:**

**Documentation updates:**

* All relevant documentation, including guides for exporting and using immutable configurations, now instruct users to mount or place files under `repository/resources` rather than `repository/conf/immutable_resources`. [[1]](diffhunk://#diff-6840a08a871f7bccfa7dd2f0630d184e18682bbace09308fedffb7a988d1f9abL567-R575) [[2]](diffhunk://#diff-84adb385dc520e84e94d2a804d8da5d0d31a3389cde60cc0da797699f6d1ae77L19-R19)

These changes ensure a unified and simplified directory structure for resource configurations, making it easier for both developers and users to manage configuration files.

### Related Issues
- https://github.com/asgardeo/thunder/issues/478

### Related PRs
- https://github.com/asgardeo/thunder/pull/969

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
