### PR TITLE
Allow provisioning executor to perform group and role assignment

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -109,7 +109,8 @@ func registerServices(
 	// Initialize flow and executor services.
 	flowFactory, graphCache := flowcore.Initialize()
 	execRegistry := executor.Initialize(flowFactory, userService, ouService,
-		idpService, otpService, jwtService, authSvcRegistry, authZService, userSchemaService, observabilitySvc)
+		idpService, otpService, jwtService, authSvcRegistry, authZService, userSchemaService, observabilitySvc,
+		groupService, roleService)
 
 	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(mux, flowFactory, execRegistry, graphCache)
 	if err != nil {

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -61,6 +61,12 @@ const (
 	dataValueTrue = "true"
 )
 
+// Executor property keys
+const (
+	propertyKeyAssignGroup = "assignGroup"
+	propertyKeyAssignRole  = "assignRole"
+)
+
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.
 var nonSearchableInputs = []string{"password", "code", "nonce", "otp"}
 

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -23,10 +23,12 @@ import (
 	"github.com/asgardeo/thunder/internal/authz"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/group"
 	"github.com/asgardeo/thunder/internal/idp"
 	"github.com/asgardeo/thunder/internal/notification"
 	"github.com/asgardeo/thunder/internal/observability"
 	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/role"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/user"
 	"github.com/asgardeo/thunder/internal/userschema"
@@ -44,6 +46,8 @@ func Initialize(
 	authZService authz.AuthorizationServiceInterface,
 	userSchemaService userschema.UserSchemaServiceInterface,
 	observabilitySvc observability.ObservabilityServiceInterface,
+	groupService group.GroupServiceInterface,
+	roleService role.RoleServiceInterface,
 ) ExecutorRegistryInterface {
 	reg := newExecutorRegistry()
 	reg.RegisterExecutor(ExecutorNameBasicAuth, newBasicAuthExecutor(
@@ -62,7 +66,8 @@ func Initialize(
 	reg.RegisterExecutor(ExecutorNameGoogleAuth, newGoogleOIDCAuthExecutor(
 		flowFactory, idpService, userSchemaService, authRegistry.GoogleOIDCAuthnService))
 
-	reg.RegisterExecutor(ExecutorNameProvisioning, newProvisioningExecutor(flowFactory, userService))
+	reg.RegisterExecutor(ExecutorNameProvisioning, newProvisioningExecutor(flowFactory, userService,
+		groupService, roleService))
 	reg.RegisterExecutor(ExecutorNameOUCreation, newOUExecutor(flowFactory, ouService))
 
 	reg.RegisterExecutor(ExecutorNameAttributeCollect, newAttributeCollector(flowFactory, userService))

--- a/tests/integration/flow/common/model.go
+++ b/tests/integration/flow/common/model.go
@@ -24,6 +24,8 @@ type TestSuiteConfig struct {
 	CreatedFlowIDs    []string
 	CreatedIdpIDs     []string
 	CreatedSenderIDs  []string
+	CreatedGroupIDs   []string
+	CreatedRoleIDs    []string
 	OriginalAppConfig map[string]interface{}
 	MockServer        interface{} // Can be cast to specific mock server type
 }

--- a/tests/integration/flow/registration/google_registration_with_role_group_test.go
+++ b/tests/integration/flow/registration/google_registration_with_role_group_test.go
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package registration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asgardeo/thunder/tests/integration/flow/common"
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+var (
+	googleRegGroupRoleFlow = testutils.Flow{
+		Name:     "Google Registration with Group and Role Assignment",
+		FlowType: "REGISTRATION",
+		Handle:   "registration_flow_google_group_role_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "user_type_resolver",
+			},
+			{
+				"id":   "user_type_resolver",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "UserTypeResolver",
+				},
+				"onSuccess": "google_auth",
+			},
+			{
+				"id":   "google_auth",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"idpId": "placeholder-idp-id",
+				},
+				"executor": map[string]interface{}{
+					"name": "GoogleOIDCAuthExecutor",
+				},
+				"onSuccess": "provisioning",
+			},
+			{
+				"id":   "provisioning",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"assignGroup": "placeholder-group-id",
+					"assignRole":  "placeholder-role-id",
+				},
+				"executor": map[string]interface{}{
+					"name": "ProvisioningExecutor",
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	googleRegGroupRoleTestOU = testutils.OrganizationUnit{
+		Handle:      "google-reg-group-role-test-ou",
+		Name:        "Google Registration Group/Role Test OU",
+		Description: "Organization unit for testing Google registration with group/role assignment",
+		Parent:      nil,
+	}
+
+	googleRegGroupRoleUserSchema = testutils.UserSchema{
+		Name: "google_reg_group_role_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"sub": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"givenName": map[string]interface{}{
+				"type": "string",
+			},
+			"familyName": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	googleRegGroupRoleTestApp = testutils.Application{
+		Name:                      "Google Registration Group/Role Test App",
+		Description:               "Application for testing Google registration with group/role assignment",
+		IsRegistrationFlowEnabled: true,
+		ClientID:                  "google_reg_group_role_test_client",
+		ClientSecret:              "google_reg_group_role_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{googleRegGroupRoleUserSchema.Name},
+	}
+)
+
+var (
+	googleRegGroupRoleTestAppID string
+	googleRegGroupRoleTestOUID  string
+)
+
+const (
+	mockGoogleRegGroupRoleFlowPort = 8094
+)
+
+type GoogleRegistrationGroupRoleTestSuite struct {
+	suite.Suite
+	mockGoogleServer *testutils.MockGoogleOIDCServer
+	idpID            string
+	userSchemaID     string
+	groupID          string
+	roleID           string
+	config           *common.TestSuiteConfig
+}
+
+func TestGoogleRegistrationGroupRoleTestSuite(t *testing.T) {
+	suite.Run(t, new(GoogleRegistrationGroupRoleTestSuite))
+}
+
+func (ts *GoogleRegistrationGroupRoleTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	// Start mock Google server
+	mockServer, err := testutils.NewMockGoogleOIDCServer(mockGoogleRegGroupRoleFlowPort,
+		"test_google_client", "test_google_secret")
+	ts.Require().NoError(err, "Failed to create mock Google server")
+	ts.mockGoogleServer = mockServer
+
+	ts.mockGoogleServer.AddUser(&testutils.GoogleUserInfo{
+		Sub:           "google-group-role-user-789",
+		Email:         "grouproleuser@gmail.com",
+		EmailVerified: true,
+		Name:          "Group Role User",
+		GivenName:     "GroupRole",
+		FamilyName:    "User",
+		Picture:       "https://example.com/grouprolepicture.jpg",
+		Locale:        "en",
+	})
+
+	err = ts.mockGoogleServer.Start()
+	ts.Require().NoError(err, "Failed to start mock Google server")
+
+	// Create test organization unit
+	ouID, err := testutils.CreateOrganizationUnit(googleRegGroupRoleTestOU)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test organization unit during setup: %v", err)
+	}
+	googleRegGroupRoleTestOUID = ouID
+
+	// Create user schema
+	googleRegGroupRoleUserSchema.OrganizationUnitId = googleRegGroupRoleTestOUID
+	googleRegGroupRoleUserSchema.AllowSelfRegistration = true
+	schemaID, err := testutils.CreateUserType(googleRegGroupRoleUserSchema)
+	ts.Require().NoError(err, "Failed to create user schema")
+	ts.userSchemaID = schemaID
+
+	// Create test group
+	testGroup := testutils.Group{
+		Name:               "Provisioned Users Group",
+		Description:        "Group for testing user provisioning with group assignment",
+		OrganizationUnitId: googleRegGroupRoleTestOUID,
+	}
+	groupID, err := testutils.CreateGroup(testGroup)
+	ts.Require().NoError(err, "Failed to create test group")
+	ts.groupID = groupID
+	ts.config.CreatedGroupIDs = append(ts.config.CreatedGroupIDs, groupID)
+
+	// Create test role
+	testRole := testutils.Role{
+		Name:               "Provisioned Users Role",
+		Description:        "Role for testing user provisioning with role assignment",
+		OrganizationUnitID: googleRegGroupRoleTestOUID,
+		Permissions:        []testutils.ResourcePermissions{},
+	}
+	roleID, err := testutils.CreateRole(testRole)
+	ts.Require().NoError(err, "Failed to create test role")
+	ts.roleID = roleID
+	ts.config.CreatedRoleIDs = append(ts.config.CreatedRoleIDs, roleID)
+
+	// Create Google IDP
+	googleIDP := testutils.IDP{
+		Name:        "Google Group/Role Test IDP",
+		Description: "Google IDP for testing registration with group/role assignment",
+		Type:        "GOOGLE",
+		Properties: []testutils.IDPProperty{
+			{
+				Name:     "client_id",
+				Value:    "test_google_client",
+				IsSecret: false,
+			},
+			{
+				Name:     "client_secret",
+				Value:    "test_google_secret",
+				IsSecret: true,
+			},
+			{
+				Name:     "redirect_uri",
+				Value:    "http://localhost:3000/callback",
+				IsSecret: false,
+			},
+			{
+				Name:     "scopes",
+				Value:    "openid email profile",
+				IsSecret: false,
+			},
+			{
+				Name:     "authorization_endpoint",
+				Value:    ts.mockGoogleServer.GetURL() + "/o/oauth2/v2/auth",
+				IsSecret: false,
+			},
+			{
+				Name:     "token_endpoint",
+				Value:    ts.mockGoogleServer.GetURL() + "/token",
+				IsSecret: false,
+			},
+			{
+				Name:     "userinfo_endpoint",
+				Value:    ts.mockGoogleServer.GetURL() + "/v1/userinfo",
+				IsSecret: false,
+			},
+			{
+				Name:     "jwks_endpoint",
+				Value:    ts.mockGoogleServer.GetURL() + "/oauth2/v3/certs",
+				IsSecret: false,
+			},
+		},
+	}
+
+	idpID, err := testutils.CreateIDP(googleIDP)
+	ts.Require().NoError(err, "Failed to create Google IDP")
+	ts.idpID = idpID
+	ts.config.CreatedIdpIDs = append(ts.config.CreatedIdpIDs, idpID)
+
+	// Update flow definition with created IDs
+	nodes := googleRegGroupRoleFlow.Nodes.([]map[string]interface{})
+	nodes[2]["properties"].(map[string]interface{})["idpId"] = idpID
+	nodes[3]["properties"].(map[string]interface{})["assignGroup"] = groupID
+	nodes[3]["properties"].(map[string]interface{})["assignRole"] = roleID
+	googleRegGroupRoleFlow.Nodes = nodes
+
+	// Create registration flow
+	flowID, err := testutils.CreateFlow(googleRegGroupRoleFlow)
+	ts.Require().NoError(err, "Failed to create registration flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+	googleRegGroupRoleTestApp.RegistrationFlowGraphID = flowID
+
+	// Create test application
+	appID, err := testutils.CreateApplication(googleRegGroupRoleTestApp)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test application during setup: %v", err)
+	}
+	googleRegGroupRoleTestAppID = appID
+}
+
+func (ts *GoogleRegistrationGroupRoleTestSuite) TearDownTest() {
+	// Clean up users created during each test
+	if len(ts.config.CreatedUserIDs) > 0 {
+		if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+			ts.T().Logf("Failed to cleanup users after test: %v", err)
+		}
+		// Reset the list for the next test
+		ts.config.CreatedUserIDs = []string{}
+	}
+}
+
+func (ts *GoogleRegistrationGroupRoleTestSuite) TearDownSuite() {
+	// Delete test application
+	if googleRegGroupRoleTestAppID != "" {
+		if err := testutils.DeleteApplication(googleRegGroupRoleTestAppID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+
+	// Delete test flows
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+
+	// Delete test IDPs
+	for _, idpID := range ts.config.CreatedIdpIDs {
+		if err := testutils.DeleteIDP(idpID); err != nil {
+			ts.T().Logf("Failed to delete test IDP during teardown: %v", err)
+		}
+	}
+
+	// Delete test groups
+	for _, groupID := range ts.config.CreatedGroupIDs {
+		if err := testutils.DeleteGroup(groupID); err != nil {
+			ts.T().Logf("Failed to delete test group during teardown: %v", err)
+		}
+	}
+
+	// Delete test roles
+	for _, roleID := range ts.config.CreatedRoleIDs {
+		if err := testutils.DeleteRole(roleID); err != nil {
+			ts.T().Logf("Failed to delete test role during teardown: %v", err)
+		}
+	}
+
+	// Delete test organization unit
+	if googleRegGroupRoleTestOUID != "" {
+		if err := testutils.DeleteOrganizationUnit(googleRegGroupRoleTestOUID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+
+	// Clean up any remaining users
+	if len(ts.config.CreatedUserIDs) > 0 {
+		if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+			ts.T().Logf("Failed to cleanup users during teardown: %v", err)
+		}
+	}
+
+	if ts.userSchemaID != "" {
+		_ = testutils.DeleteUserType(ts.userSchemaID)
+	}
+
+	// Stop mock server
+	if ts.mockGoogleServer != nil {
+		_ = ts.mockGoogleServer.Stop()
+		// Wait for port to be released
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (ts *GoogleRegistrationGroupRoleTestSuite) TestGoogleRegistrationWithGroupAndRoleAssignment() {
+	// Step 1: Initiate the flow
+	flowStep, err := common.InitiateRegistrationFlow(googleRegGroupRoleTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+
+	// Verify flow status and type
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
+	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
+	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+
+	redirectURLStr := flowStep.Data.RedirectURL
+	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
+
+	// Step 2: Simulate OAuth flow
+	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURLStr)
+	ts.Require().NoError(err, "Failed to simulate OAuth flow")
+	ts.Require().NotEmpty(authCode, "Authorization code should not be empty")
+
+	// Step 3: Complete the flow
+	inputs := map[string]string{"code": authCode}
+	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "")
+	ts.Require().NoError(err, "Failed to complete flow")
+
+	// Verify flow completion
+	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be COMPLETE")
+	ts.Require().NotEmpty(completeFlowStep.Assertion, "Assertion token should be present")
+
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+	ts.Require().Equal(googleRegGroupRoleUserSchema.Name, jwtClaims.UserType, "Expected userType to match")
+	ts.Require().Equal(googleRegGroupRoleTestAppID, jwtClaims.Aud, "Expected aud to match application ID")
+
+	// Step 4: Verify user was created
+	user, err := testutils.FindUserByAttribute("sub", "google-group-role-user-789")
+	ts.Require().NoError(err, "Failed to retrieve user by sub")
+	ts.Require().NotNil(user, "User should be found after registration")
+
+	// Store the created user for cleanup
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+
+	// Step 5: Verify user was added to the group
+	groupMembers, err := testutils.GetGroupMembers(ts.groupID)
+	ts.Require().NoError(err, "Failed to retrieve group members")
+	ts.Require().NotNil(groupMembers, "Group members should be found")
+
+	// Check if user is in the group members
+	hasUser := false
+	for _, member := range groupMembers {
+		if member.ID == user.ID && member.Type == "user" {
+			hasUser = true
+			break
+		}
+	}
+	ts.Require().True(hasUser, "User should be a member of the group after provisioning")
+
+	// Step 6: Verify user was assigned the role
+	roleAssignments, err := testutils.GetRoleAssignments(ts.roleID)
+	ts.Require().NoError(err, "Failed to retrieve role assignments")
+
+	// Check if user has the role assignment
+	hasRoleAssignment := false
+	for _, assignment := range roleAssignments {
+		if assignment.ID == user.ID && assignment.Type == "user" {
+			hasRoleAssignment = true
+			break
+		}
+	}
+	ts.Require().True(hasRoleAssignment, "User should have the role assigned after provisioning")
+}

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -111,6 +111,13 @@ type AuthenticationResponse struct {
 	Assertion        string `json:"assertion,omitempty"`
 }
 
+// GroupMember represents a member of a group
+type GroupMember struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Display string `json:"display,omitempty"`
+}
+
 // Group represents a group in the system
 type Group struct {
 	ID                 string `json:"id,omitempty"`


### PR DESCRIPTION
### Purpose
Allow provisioning executor to perform group and role assignment ProvisioningExecutor node

This can be configured as follows in the ProvisioningExecutor, then the self signed up user will be assigned to the provided role or group
```
            {
				"id":   "provisioning",
				"type": "TASK_EXECUTION",
				"properties": {
					"assignGroup": "<placeholder-group-id>",
					"assignRole":  "<placeholder-role-id>",
				},
				"executor": {
					"name": "ProvisioningExecutor",
				},
				"onSuccess": "auth_assert",
			}
```


### Approach

This pull request enhances the user provisioning flow by adding support for automatically assigning newly provisioned users to specific groups and roles. The changes include updates to the provisioning executor to handle group and role assignment, as well as corresponding updates to dependency injection and unit tests.

**Provisioning Executor Enhancements:**

- Added logic to the `provisioningExecutor` to assign newly created users to groups and roles based on node properties. This includes new methods for retrieving assignment targets and performing the assignments, with appropriate error handling and logging. [[1]](diffhunk://#diff-8a20de7dc4bb45cd5a0961e2f54a45a2f799275c5ef52dc0c44d1d311a80439cR167-R176) [[2]](diffhunk://#diff-8a20de7dc4bb45cd5a0961e2f54a45a2f799275c5ef52dc0c44d1d311a80439cR374-R528)
- Updated the constructor for `provisioningExecutor` to accept `groupService` and `roleService` dependencies, and store them for use in group/role assignment. [[1]](diffhunk://#diff-8a20de7dc4bb45cd5a0961e2f54a45a2f799275c5ef52dc0c44d1d311a80439cR60-R61) [[2]](diffhunk://#diff-8a20de7dc4bb45cd5a0961e2f54a45a2f799275c5ef52dc0c44d1d311a80439cR76-R77)

**Dependency Injection Updates:**

- Modified the `executor.Initialize` function and its callers to accept and pass `groupService` and `roleService` as additional dependencies, ensuring these services are available to the provisioning executor. [[1]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06R49-R50) [[2]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06L65-R70) [[3]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L112-R113)
- Added imports for the group and role packages where needed to support the new dependencies. [[1]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06R26-R31) [[2]](diffhunk://#diff-8a20de7dc4bb45cd5a0961e2f54a45a2f799275c5ef52dc0c44d1d311a80439cR29-R49) [[3]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R32-R38)

**Testing Improvements:**

- Extended the provisioning executor test suite to include mocks for `groupService` and `roleService`, and added tests to verify that group and role assignments are performed correctly when specified, and skipped when not configured. [[1]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R47-R48) [[2]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R59-R60) [[3]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88L64-R73) [[4]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R142-R145) [[5]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R164-R187) [[6]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R196-R197) [[7]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R515) [[8]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R536-R537) [[9]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R547-R550)
### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
