### PR TITLE
Add glob-pattern-based public path matching

### DIFF
--- a/backend/internal/system/security/constants.go
+++ b/backend/internal/system/security/constants.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package security
+
+// maxPublicPathLength defines the maximum allowed length for a public path.
+// This prevents potential DoS attacks via excessively long paths (even with safe regex).
+const maxPublicPathLength = 4096
+
+// publicPaths defines the list of public paths using glob patterns.
+// - "*": Matches a single path segment (e.g., /a/*/b).
+// - "**": Matches zero or more path segments (subpaths) at the end of the path (e.g., /a/**).
+// Not allowed in the middle of the path (e.g., /a/**/b is invalid).
+var publicPaths = []string{
+	"/health/**",
+	"/auth/**",
+	"/flow/execute/**",
+	"/oauth2/**",
+	"/.well-known/openid-configuration/**",
+	"/.well-known/oauth-authorization-server/**",
+	"/gate/**",
+	"/develop/**",
+	"/error/**",
+	"/branding/resolve/**",
+	"/i18n/languages",
+	"/i18n/languages/*/translations/resolve",
+	"/i18n/languages/*/translations/ns/*/keys/*/resolve",
+}

--- a/backend/internal/system/security/init.go
+++ b/backend/internal/system/security/init.go
@@ -27,8 +27,9 @@ import (
 // Initialize creates and returns the security middleware with necessary authenticators.
 func Initialize(jwtService jwt.JWTServiceInterface) (func(http.Handler) http.Handler, error) {
 	jwtAuthenticator := newJWTAuthenticator(jwtService)
-	securityService := &securityService{
-		authenticators: []AuthenticatorInterface{jwtAuthenticator},
+	securityService, err := NewSecurityService([]AuthenticatorInterface{jwtAuthenticator}, publicPaths)
+	if err != nil {
+		return nil, err
 	}
 	return middleware(securityService)
 }

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -21,9 +21,15 @@ package security
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
+
+	"github.com/asgardeo/thunder/internal/system/log"
 )
+
+const loggerComponentName = "SecurityService"
 
 // SecurityServiceInterface defines the contract for security processing services.
 type SecurityServiceInterface interface {
@@ -33,6 +39,30 @@ type SecurityServiceInterface interface {
 // securityService orchestrates authentication and authorization for HTTP requests.
 type securityService struct {
 	authenticators []AuthenticatorInterface
+	logger         *log.Logger
+	compiledPaths  []*regexp.Regexp
+}
+
+// NewSecurityService creates a new instance of the security service.
+//
+// Parameters:
+//   - authenticators: A slice of AuthenticatorInterface implementations to handle request authentication.
+//   - publicPaths: A slice of string patterns representing paths that are exempt from authentication.
+//
+// Returns:
+//   - *securityService: A pointer to the created securityService instance.
+//   - error: An error if any of the provided public paths are invalid and cannot be compiled.
+func NewSecurityService(authenticators []AuthenticatorInterface, publicPaths []string) (*securityService, error) {
+	compiledPaths, err := compilePathPatterns(publicPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	return &securityService{
+		authenticators: authenticators,
+		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)),
+		compiledPaths:  compiledPaths,
+	}, nil
 }
 
 // Process handles the complete security flow: authentication and authorization.
@@ -82,30 +112,63 @@ func (s *securityService) Process(r *http.Request) (context.Context, error) {
 	return ctx, nil
 }
 
-// isPublicPath checks if the given path is a public endpoint that doesn't require authentication.
-func (s *securityService) isPublicPath(path string) bool {
-	publicPaths := []string{
-		"/health/",
-		"/auth/",
-		"/flow/execute",
-		"/oauth2/",
-		"/.well-known/openid-configuration",
-		"/.well-known/oauth-authorization-server",
-		"/gate/",    // Gate application (login UI)
-		"/develop/", // Develop application
-		"/error",
-		"/branding/resolve",
+// isPublicPath checks if the given request path matches any of the configured public path patterns.
+func (s *securityService) isPublicPath(requestPath string) bool {
+	if len(requestPath) > maxPublicPathLength {
+		s.logger.Warn("Path length exceeds maximum allowed length",
+			log.Int("limit", maxPublicPathLength),
+			log.Int("length", len(requestPath)))
+		return false
 	}
 
-	for _, publicPath := range publicPaths {
-		if strings.HasPrefix(path, publicPath) {
-			return true
-		}
-		// Exact match for paths without trailing slash
-		if path == strings.TrimSuffix(publicPath, "/") {
+	for _, regex := range s.compiledPaths {
+		if regex.MatchString(requestPath) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// compilePathPatterns compiles the path patterns into regular expressions safely.
+// It returns an error if any pattern is invalid.
+func compilePathPatterns(patterns []string) ([]*regexp.Regexp, error) {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		var regexPattern string
+
+		// Check for recursive wildcard usage
+		if strings.Contains(pattern, "**") {
+			// Ensure "**" is only used as a suffix "/**"
+			if !strings.HasSuffix(pattern, "/**") {
+				return nil,
+					fmt.Errorf("invalid pattern: recursive wildcard '**' is only allowed as a suffix: %s", pattern)
+			}
+
+			// Ensure "**" appears only once
+			if strings.Count(pattern, "**") > 1 {
+				return nil, fmt.Errorf("invalid pattern: recursive wildcard '**' can only appear once: %s", pattern)
+			}
+
+			base := strings.TrimSuffix(pattern, "/**")
+			baseRegex := regexp.QuoteMeta(base)
+			baseRegex = strings.ReplaceAll(baseRegex, "\\*", "[^/]+")
+			regexPattern = "^" + baseRegex + "(?:/.*)?$"
+		} else {
+			// Normal pattern (no recursive wildcards)
+			regexPattern = regexp.QuoteMeta(pattern)
+			regexPattern = strings.ReplaceAll(regexPattern, "\\*", "[^/]+")
+			regexPattern = "^" + regexPattern + "$"
+		}
+
+		re, err := regexp.Compile(regexPattern)
+		if err != nil {
+			return nil, fmt.Errorf("error compiling public path regex for pattern %s: %w", pattern, err)
+		}
+
+		compiled = append(compiled, re)
+	}
+
+	return compiled, nil
 }


### PR DESCRIPTION
### Purpose

This pull request refactors and enhances the public path matching logic in the security service, making it more flexible and robust. The main changes involve switching from simple prefix matching to glob-like pattern matching using regular expressions, and expanding the set of public paths to allow for more granular control.

### Approach

* Introduced glob pattern support for public paths, enabling single (`*`) and multi-segment (`**`) wildcards for endpoint matching in `service.go`. Patterns like `/i18n/languages/*/translations/resolve` and `/i18n/languages/*/translations/ns/*/keys/*/resolve` are now supported.
* Refactored the `isPublicPath` method to use precompiled regular expressions instead of simple string prefix checks, improving accuracy and flexibility in path matching.
* Added a `precompilePathRegexPatterns` function to convert glob patterns into regular expressions at initialization, optimizing runtime matching.

### Related Issues
- https://github.com/asgardeo/thunder/issues/983

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
