### PR TITLE
Fix issues in flow export function

### DIFF
--- a/backend/internal/flow/mgt/immutable_resource.go
+++ b/backend/internal/flow/mgt/immutable_resource.go
@@ -44,6 +44,11 @@ func newFlowGraphExporter(service FlowMgtServiceInterface) *FlowGraphExporter {
 	return &FlowGraphExporter{service: service}
 }
 
+// NewFlowGraphExporterForTest creates a new flow graph exporter for testing purposes.
+func NewFlowGraphExporterForTest(service FlowMgtServiceInterface) *FlowGraphExporter {
+	return newFlowGraphExporter(service)
+}
+
 // GetResourceType returns the resource type for flow graphs.
 func (e *FlowGraphExporter) GetResourceType() string {
 	return resourceTypeFlow

--- a/backend/internal/flow/mgt/immutable_resource_test.go
+++ b/backend/internal/flow/mgt/immutable_resource_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
 
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -634,6 +635,889 @@ func (s *ImmutableResourceTestSuite) TestLoadImmutableResources_InvalidStoreType
 	err := loadImmutableResources(mockStore)
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "failed to assert flowStore to *fileBasedStore")
+}
+
+// TestNodeDefinitionMarshalYAML_WithComplexMeta tests YAML marshaling with complex meta objects
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_WithComplexMeta() {
+	// Create a complex meta object similar to the test.yaml file
+	complexMeta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":      "text_001",
+				"label":   "{{ t(signin:heading) }}",
+				"type":    "TEXT",
+				"variant": "HEADING_1",
+			},
+			map[string]interface{}{
+				"id":   "block_001",
+				"type": "BLOCK",
+				"components": []interface{}{
+					map[string]interface{}{
+						"id":          "input_001",
+						"label":       "{{ t(elements:fields.username.label) }}",
+						"placeholder": "{{ t(elements:fields.username.placeholder) }}",
+						"ref":         "username",
+						"required":    true,
+						"type":        "TEXT_INPUT",
+					},
+					map[string]interface{}{
+						"id":          "input_002",
+						"label":       "{{ t(elements:fields.password.label) }}",
+						"placeholder": "{{ t(elements:fields.password.placeholder) }}",
+						"ref":         "password",
+						"required":    true,
+						"type":        "PASSWORD_INPUT",
+					},
+					map[string]interface{}{
+						"eventType": "SUBMIT",
+						"id":        "action_001",
+						"label":     "{{ t(elements:buttons.submit.text) }}",
+						"type":      "ACTION",
+						"variant":   "PRIMARY",
+					},
+				},
+			},
+		},
+	}
+
+	nodeDef := &NodeDefinition{
+		ID:   "prompt_credentials",
+		Type: "PROMPT",
+		Meta: complexMeta,
+		Inputs: []InputDefinition{
+			{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
+			{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
+		},
+		Actions: []ActionDefinition{
+			{Ref: "action_001", NextNode: "basic_auth"},
+		},
+	}
+
+	// Marshal to YAML
+	result, err := nodeDef.MarshalYAML()
+	require.NoError(s.T(), err)
+
+	// Verify the result
+	alias, ok := result.(nodeDefinitionAlias)
+	require.True(s.T(), ok, "result should be nodeDefinitionAlias")
+
+	// Verify Meta is now a JSON string
+	metaStr, ok := alias.Meta.(string)
+	require.True(s.T(), ok, "Meta should be converted to string")
+	assert.Contains(s.T(), metaStr, "components")
+	assert.Contains(s.T(), metaStr, "text_001")
+	assert.Contains(s.T(), metaStr, "block_001")
+}
+
+// TestNodeDefinitionMarshalYAML_WithNilMeta tests YAML marshaling with nil meta
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_WithNilMeta() {
+	nodeDef := &NodeDefinition{
+		ID:   "start",
+		Type: "START",
+		Meta: nil,
+	}
+
+	result, err := nodeDef.MarshalYAML()
+	require.NoError(s.T(), err)
+
+	alias, ok := result.(nodeDefinitionAlias)
+	require.True(s.T(), ok)
+	assert.Nil(s.T(), alias.Meta)
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithComplexMeta tests YAML unmarshaling with complex meta
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithComplexMeta() {
+	// Use a shorter meta string that still demonstrates the functionality
+	metaJSON := `{"components":[{"id":"text_001","type":"TEXT"},` +
+		`{"id":"block_001","type":"BLOCK","components":[{"id":"input_001","type":"TEXT_INPUT"}]}]}`
+
+	yamlData := []byte(fmt.Sprintf(`
+id: prompt_credentials
+type: PROMPT
+meta: '%s'
+inputs:
+  - ref: input_001
+    type: TEXT_INPUT
+    identifier: username
+    required: true
+actions:
+  - ref: action_001
+    nextNode: basic_auth
+`, metaJSON))
+
+	// Parse the actual YAML
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(yamlData, &nodeDef)
+	require.NoError(s.T(), err)
+
+	// Verify the Meta field is properly decoded
+	assert.NotNil(s.T(), nodeDef.Meta)
+	metaMap, ok := nodeDef.Meta.(map[string]interface{})
+	require.True(s.T(), ok, "Meta should be decoded to map[string]interface{}")
+
+	// Verify the structure
+	components, ok := metaMap["components"].([]interface{})
+	require.True(s.T(), ok)
+	assert.Len(s.T(), components, 2)
+
+	// Verify first component
+	firstComponent, ok := components[0].(map[string]interface{})
+	require.True(s.T(), ok)
+	assert.Equal(s.T(), "text_001", firstComponent["id"])
+	assert.Equal(s.T(), "TEXT", firstComponent["type"])
+
+	// Verify nested components
+	secondComponent, ok := components[1].(map[string]interface{})
+	require.True(s.T(), ok)
+	assert.Equal(s.T(), "block_001", secondComponent["id"])
+
+	nestedComponents, ok := secondComponent["components"].([]interface{})
+	require.True(s.T(), ok)
+	assert.Len(s.T(), nestedComponents, 1)
+}
+
+// TestCompleteFlowDefinition_MarshalUnmarshal_RoundTrip tests full round trip
+func (s *ImmutableResourceTestSuite) TestCompleteFlowDefinition_MarshalUnmarshal_RoundTrip() {
+	// Create a complete flow definition with complex meta
+	originalFlow := &CompleteFlowDefinition{
+		ID:            "019b4495-793d-7172-b3e5-ebc3d61afe36",
+		Handle:        "develop-app-flow",
+		Name:          "Develop App Authentication Flow",
+		FlowType:      "AUTHENTICATION",
+		ActiveVersion: 1,
+		Nodes: []NodeDefinition{
+			{
+				ID:        "start",
+				Type:      "START",
+				OnSuccess: "prompt_credentials",
+			},
+			{
+				ID:   "prompt_credentials",
+				Type: "PROMPT",
+				Meta: map[string]interface{}{
+					"components": []interface{}{
+						map[string]interface{}{
+							"id":      "text_001",
+							"label":   "{{ t(signin:heading) }}",
+							"type":    "TEXT",
+							"variant": "HEADING_1",
+						},
+						map[string]interface{}{
+							"id":   "block_001",
+							"type": "BLOCK",
+							"components": []interface{}{
+								map[string]interface{}{
+									"id":          "input_001",
+									"label":       "Username",
+									"placeholder": "Enter username",
+									"ref":         "username",
+									"required":    true,
+									"type":        "TEXT_INPUT",
+								},
+								map[string]interface{}{
+									"id":          "input_002",
+									"label":       "Password",
+									"placeholder": "Enter password",
+									"ref":         "password",
+									"required":    true,
+									"type":        "PASSWORD_INPUT",
+								},
+							},
+						},
+					},
+				},
+				Inputs: []InputDefinition{
+					{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
+					{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
+				},
+				Actions: []ActionDefinition{
+					{Ref: "action_001", NextNode: "basic_auth"},
+				},
+			},
+			{
+				ID:   "end",
+				Type: "END",
+			},
+		},
+		CreatedAt: "2025-12-22 05:43:25",
+		UpdatedAt: "2025-12-22 05:43:25",
+	}
+
+	// Marshal to YAML
+	yamlBytes, err := yaml.Marshal(originalFlow)
+	require.NoError(s.T(), err)
+
+	// The meta field should be present in the YAML
+	yamlStr := string(yamlBytes)
+	assert.Contains(s.T(), yamlStr, `meta:`)
+	// When using the custom MarshalYAML on NodeDefinition, meta will be present
+	// The structure may vary based on how yaml.v3 handles it
+
+	// Unmarshal back
+	var unmarshaledFlow CompleteFlowDefinition
+	err = yaml.Unmarshal(yamlBytes, &unmarshaledFlow)
+	require.NoError(s.T(), err)
+
+	// Verify the structure is preserved
+	assert.Equal(s.T(), originalFlow.ID, unmarshaledFlow.ID)
+	assert.Equal(s.T(), originalFlow.Handle, unmarshaledFlow.Handle)
+	assert.Equal(s.T(), originalFlow.Name, unmarshaledFlow.Name)
+	assert.Len(s.T(), unmarshaledFlow.Nodes, 3)
+
+	// Verify the meta is correctly decoded
+	promptNode := unmarshaledFlow.Nodes[1]
+	assert.NotNil(s.T(), promptNode.Meta)
+
+	metaMap, ok := promptNode.Meta.(map[string]interface{})
+	require.True(s.T(), ok, "Meta should be decoded to map")
+
+	components, ok := metaMap["components"].([]interface{})
+	require.True(s.T(), ok)
+	assert.Len(s.T(), components, 2)
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithInvalidJSON tests handling of invalid JSON in meta
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithInvalidJSON() {
+	yamlData := []byte(`
+id: test_node
+type: PROMPT
+meta: 'this is not valid json {}'
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(yamlData, &nodeDef)
+	require.NoError(s.T(), err)
+
+	// When JSON parsing fails, the string value should be kept
+	metaStr, ok := nodeDef.Meta.(string)
+	require.True(s.T(), ok, "Invalid JSON should be kept as string")
+	assert.Equal(s.T(), "this is not valid json {}", metaStr)
+}
+
+// TestFlowExport_WithComplexMeta tests exporting a flow with complex meta via the exporter
+func (s *ImmutableResourceTestSuite) TestFlowExport_WithComplexMeta() {
+	mockService := &FlowMgtServiceInterfaceMock{}
+
+	complexFlow := &CompleteFlowDefinition{
+		ID:            "test-flow-001",
+		Handle:        "test-flow",
+		Name:          "Test Flow with Complex Meta",
+		FlowType:      "AUTHENTICATION",
+		ActiveVersion: 1,
+		Nodes: []NodeDefinition{
+			{
+				ID:   "prompt",
+				Type: "PROMPT",
+				Meta: map[string]interface{}{
+					"title":       "Login Page",
+					"description": "Please enter your credentials",
+					"components": []interface{}{
+						map[string]interface{}{
+							"id":       "username_field",
+							"type":     "TEXT_INPUT",
+							"label":    "Username",
+							"required": true,
+						},
+						map[string]interface{}{
+							"id":       "password_field",
+							"type":     "PASSWORD_INPUT",
+							"label":    "Password",
+							"required": true,
+						},
+					},
+					"theme": map[string]interface{}{
+						"primaryColor":   "#0066cc",
+						"secondaryColor": "#6c757d",
+					},
+				},
+			},
+		},
+	}
+
+	mockService.EXPECT().GetFlow("test-flow-001").Return(complexFlow, nil)
+
+	exporter := newFlowGraphExporter(mockService)
+	resource, name, err := exporter.GetResourceByID("test-flow-001")
+
+	require.Nil(s.T(), err)
+	assert.Equal(s.T(), "Test Flow with Complex Meta", name)
+
+	flow, ok := resource.(*CompleteFlowDefinition)
+	require.True(s.T(), ok)
+
+	// Verify meta is preserved
+	assert.NotNil(s.T(), flow.Nodes[0].Meta)
+	metaMap, ok := flow.Nodes[0].Meta.(map[string]interface{})
+	require.True(s.T(), ok)
+	assert.Equal(s.T(), "Login Page", metaMap["title"])
+
+	// Marshal the flow to ensure meta serialization works
+	yamlBytes, marshalErr := yaml.Marshal(flow)
+	require.NoError(s.T(), marshalErr)
+	assert.Contains(s.T(), string(yamlBytes), "meta:")
+}
+
+// TestNodeDefinitionMarshalYAML_WithPrimitiveMeta tests marshaling with primitive meta values
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_WithPrimitiveMeta() {
+	testCases := []struct {
+		name      string
+		metaValue interface{}
+	}{
+		{
+			name:      "string meta",
+			metaValue: "simple string value",
+		},
+		{
+			name:      "integer meta",
+			metaValue: 42,
+		},
+		{
+			name:      "float meta",
+			metaValue: 3.14159,
+		},
+		{
+			name:      "boolean meta",
+			metaValue: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			nodeDef := NodeDefinition{
+				ID:   "test_node",
+				Type: "TEST",
+				Meta: tc.metaValue,
+			}
+
+			yamlBytes, err := yaml.Marshal(nodeDef)
+			require.NoError(t, err)
+			assert.Contains(t, string(yamlBytes), "meta:")
+
+			// Unmarshal and verify
+			var unmarshaled NodeDefinition
+			err = yaml.Unmarshal(yamlBytes, &unmarshaled)
+			require.NoError(t, err)
+
+			// For primitive types, verify the structure
+			assert.NotNil(t, unmarshaled.Meta)
+		})
+	}
+}
+
+// TestNodeDefinitionMarshalYAML_WithArrayMeta tests marshaling with array meta
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_WithArrayMeta() {
+	nodeDef := NodeDefinition{
+		ID:   "test_node",
+		Type: "TEST",
+		Meta: []interface{}{
+			"string element",
+			42,
+			true,
+			map[string]interface{}{
+				"nested": "value",
+			},
+		},
+	}
+
+	yamlBytes, err := yaml.Marshal(nodeDef)
+	require.NoError(s.T(), err)
+	assert.Contains(s.T(), string(yamlBytes), "meta:")
+
+	// Unmarshal and verify
+	var unmarshaled NodeDefinition
+	err = yaml.Unmarshal(yamlBytes, &unmarshaled)
+	require.NoError(s.T(), err)
+	assert.NotNil(s.T(), unmarshaled.Meta)
+
+	// Verify array structure is preserved
+	metaArray, ok := unmarshaled.Meta.([]interface{})
+	require.True(s.T(), ok)
+	assert.Len(s.T(), metaArray, 4)
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithEmptyMeta tests unmarshaling with empty meta string
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithEmptyMeta() {
+	yamlData := []byte(`
+id: test_node
+type: TEST
+meta: ''
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(yamlData, &nodeDef)
+	require.NoError(s.T(), err)
+
+	// Empty string should remain as empty string (not parsed)
+	assert.Equal(s.T(), "", nodeDef.Meta)
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithPartiallyInvalidJSON tests partial JSON parsing
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithPartiallyInvalidJSON() {
+	yamlData := []byte(`
+id: test_node
+type: TEST
+meta: '{"valid": "json", "incomplete":'
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(yamlData, &nodeDef)
+	require.NoError(s.T(), err)
+
+	// Invalid JSON should be kept as string
+	metaStr, ok := nodeDef.Meta.(string)
+	require.True(s.T(), ok)
+	assert.Equal(s.T(), `{"valid": "json", "incomplete":`, metaStr)
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithValidJSONArray tests unmarshaling with JSON array
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithValidJSONArray() {
+	yamlData := []byte(`
+id: test_node
+type: TEST
+meta: '["item1", "item2", "item3"]'
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(yamlData, &nodeDef)
+	require.NoError(s.T(), err)
+	assert.NotNil(s.T(), nodeDef.Meta)
+
+	// Should be parsed as array
+	metaArray, ok := nodeDef.Meta.([]interface{})
+	require.True(s.T(), ok)
+	assert.Len(s.T(), metaArray, 3)
+	assert.Equal(s.T(), "item1", metaArray[0])
+	assert.Equal(s.T(), "item2", metaArray[1])
+	assert.Equal(s.T(), "item3", metaArray[2])
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithNestedObjects tests deeply nested JSON objects
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithNestedObjects() {
+	yamlData := []byte(`
+id: test_node
+type: TEST
+meta: '{"level1":{"level2":{"level3":{"value":"deep"}}}}'
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(yamlData, &nodeDef)
+	require.NoError(s.T(), err)
+	assert.NotNil(s.T(), nodeDef.Meta)
+
+	// Navigate through nested structure
+	metaMap, ok := nodeDef.Meta.(map[string]interface{})
+	require.True(s.T(), ok)
+
+	level1, ok := metaMap["level1"].(map[string]interface{})
+	require.True(s.T(), ok)
+
+	level2, ok := level1["level2"].(map[string]interface{})
+	require.True(s.T(), ok)
+
+	level3, ok := level2["level3"].(map[string]interface{})
+	require.True(s.T(), ok)
+
+	assert.Equal(s.T(), "deep", level3["value"])
+}
+
+// TestCompleteFlowDefinition_WithMultipleNodesWithMeta tests multiple nodes with different meta types
+func (s *ImmutableResourceTestSuite) TestCompleteFlowDefinition_WithMultipleNodesWithMeta() {
+	flow := CompleteFlowDefinition{
+		ID:       "test-flow",
+		Handle:   "multi-meta-flow",
+		Name:     "Flow with Multiple Meta Types",
+		FlowType: "AUTHENTICATION",
+		Nodes: []NodeDefinition{
+			{
+				ID:   "node1",
+				Type: "TYPE1",
+				Meta: map[string]interface{}{"key": "value"},
+			},
+			{
+				ID:   "node2",
+				Type: "TYPE2",
+				Meta: []interface{}{"item1", "item2"},
+			},
+			{
+				ID:   "node3",
+				Type: "TYPE3",
+				Meta: "simple string",
+			},
+			{
+				ID:   "node4",
+				Type: "TYPE4",
+				Meta: nil,
+			},
+		},
+	}
+
+	// Marshal
+	yamlBytes, err := yaml.Marshal(flow)
+	require.NoError(s.T(), err)
+
+	// Unmarshal
+	var unmarshaled CompleteFlowDefinition
+	err = yaml.Unmarshal(yamlBytes, &unmarshaled)
+	require.NoError(s.T(), err)
+
+	// Verify each node's meta
+	require.Len(s.T(), unmarshaled.Nodes, 4)
+
+	// Node 1: map
+	metaMap, ok := unmarshaled.Nodes[0].Meta.(map[string]interface{})
+	require.True(s.T(), ok)
+	assert.Equal(s.T(), "value", metaMap["key"])
+
+	// Node 2: array
+	metaArray, ok := unmarshaled.Nodes[1].Meta.([]interface{})
+	require.True(s.T(), ok)
+	assert.Len(s.T(), metaArray, 2)
+
+	// Node 3: string
+	metaStr, ok := unmarshaled.Nodes[2].Meta.(string)
+	require.True(s.T(), ok)
+	assert.Equal(s.T(), "simple string", metaStr)
+
+	// Node 4: nil
+	assert.Nil(s.T(), unmarshaled.Nodes[3].Meta)
+}
+
+// TestNodeDefinitionMarshalYAML_WithSpecialCharacters tests meta with special characters
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_WithSpecialCharacters() {
+	nodeDef := NodeDefinition{
+		ID:   "test_node",
+		Type: "TEST",
+		Meta: map[string]interface{}{
+			"special":  "value with \"quotes\" and 'apostrophes'",
+			"newlines": "line1\nline2\nline3",
+			"unicode":  "emoji: 😀 中文",
+			"symbols":  "!@#$%^&*()_+-=[]{}|;:,.<>?",
+		},
+	}
+
+	// Marshal
+	yamlBytes, err := yaml.Marshal(nodeDef)
+	require.NoError(s.T(), err)
+
+	// Unmarshal
+	var unmarshaled NodeDefinition
+	err = yaml.Unmarshal(yamlBytes, &unmarshaled)
+	require.NoError(s.T(), err)
+
+	// Verify special characters are preserved
+	metaMap, ok := unmarshaled.Meta.(map[string]interface{})
+	require.True(s.T(), ok)
+	assert.Contains(s.T(), metaMap["special"], "quotes")
+	assert.Contains(s.T(), metaMap["newlines"], "\n")
+	assert.Contains(s.T(), metaMap["unicode"], "😀")
+	assert.Contains(s.T(), metaMap["symbols"], "!@#$")
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithMalformedYAML tests error handling for malformed YAML
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithMalformedYAML() {
+	malformedYAML := []byte(`
+id: test_node
+type: TEST
+meta: this is not properly quoted: {invalid
+inputs:
+  - malformed
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(malformedYAML, &nodeDef)
+	// Should return an error because the YAML is malformed
+	assert.Error(s.T(), err)
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithInvalidNodeStructure tests error when required fields are missing
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithInvalidNodeStructure() {
+	invalidYAML := []byte(`
+meta: '{"key": "value"}'
+# Missing required fields like id and type
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(invalidYAML, &nodeDef)
+	// Should succeed in unmarshaling but fields will be empty
+	require.NoError(s.T(), err)
+	assert.Empty(s.T(), nodeDef.ID)
+	assert.Empty(s.T(), nodeDef.Type)
+}
+
+// TestNodeDefinitionMarshalYAML_RoundTrip tests complete round-trip with various meta types
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_RoundTrip() {
+	testCases := []struct {
+		name     string
+		nodeDef  NodeDefinition
+		validate func(*testing.T, NodeDefinition)
+	}{
+		{
+			name: "complex nested structure",
+			nodeDef: NodeDefinition{
+				ID:   "node1",
+				Type: "PROMPT",
+				Meta: map[string]interface{}{
+					"level1": map[string]interface{}{
+						"level2": []interface{}{
+							map[string]interface{}{
+								"key": "value",
+								"num": float64(42),
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, nd NodeDefinition) {
+				metaMap := nd.Meta.(map[string]interface{})
+				level1 := metaMap["level1"].(map[string]interface{})
+				level2 := level1["level2"].([]interface{})
+				item := level2[0].(map[string]interface{})
+				assert.Equal(t, "value", item["key"])
+			},
+		},
+		{
+			name: "array of primitives",
+			nodeDef: NodeDefinition{
+				ID:   "node2",
+				Type: "TEST",
+				Meta: []interface{}{"string", float64(123), true, nil},
+			},
+			validate: func(t *testing.T, nd NodeDefinition) {
+				arr := nd.Meta.([]interface{})
+				assert.Len(t, arr, 4)
+				assert.Equal(t, "string", arr[0])
+				// After JSON marshal/unmarshal, numbers can be int or float64
+				// depending on the value. Check the numeric value instead.
+				switch v := arr[1].(type) {
+				case int:
+					assert.Equal(t, 123, v)
+				case float64:
+					assert.Equal(t, float64(123), v)
+				default:
+					t.Errorf("Expected numeric value, got %T", v)
+				}
+				assert.Equal(t, true, arr[2])
+				assert.Nil(t, arr[3])
+			},
+		},
+		{
+			name: "with all node fields",
+			nodeDef: NodeDefinition{
+				ID:   "node3",
+				Type: "EXECUTOR",
+				Meta: map[string]interface{}{"config": "value"},
+				Layout: &NodeLayout{
+					Position: &NodePosition{X: 100, Y: 200},
+					Size:     &NodeSize{Width: 300, Height: 400},
+				},
+				Inputs: []InputDefinition{
+					{Type: "TEXT", Identifier: "input1", Required: true},
+				},
+				Actions: []ActionDefinition{
+					{Ref: "action1", NextNode: "next"},
+				},
+				Properties: map[string]interface{}{
+					"prop1": "value1",
+				},
+				Executor:  &ExecutorDefinition{Name: "test-executor"},
+				OnSuccess: "success-node",
+				OnFailure: "failure-node",
+			},
+			validate: func(t *testing.T, nd NodeDefinition) {
+				assert.Equal(t, "node3", nd.ID)
+				assert.Equal(t, "EXECUTOR", nd.Type)
+				assert.NotNil(t, nd.Layout)
+				assert.Equal(t, float64(100), nd.Layout.Position.X)
+				assert.Len(t, nd.Inputs, 1)
+				assert.Len(t, nd.Actions, 1)
+				metaMap := nd.Meta.(map[string]interface{})
+				assert.Equal(t, "value", metaMap["config"])
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			// Marshal
+			yamlBytes, err := yaml.Marshal(tc.nodeDef)
+			require.NoError(t, err)
+
+			// Unmarshal
+			var unmarshaled NodeDefinition
+			err = yaml.Unmarshal(yamlBytes, &unmarshaled)
+			require.NoError(t, err)
+
+			// Validate
+			tc.validate(t, unmarshaled)
+		})
+	}
+}
+
+// TestNodeDefinitionMarshalYAML_WithJSONMarshallableTypes tests various JSON-marshallable types
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_WithJSONMarshallableTypes() {
+	testCases := []struct {
+		name        string
+		meta        interface{}
+		expectError bool
+	}{
+		{
+			name: "nested arrays and maps",
+			meta: []interface{}{
+				map[string]interface{}{
+					"nested": []interface{}{
+						map[string]interface{}{"deep": "value"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "numeric types",
+			meta: map[string]interface{}{
+				"int":      42,
+				"float":    3.14,
+				"negInt":   -100,
+				"negFloat": -2.5,
+				"zero":     0,
+			},
+			expectError: false,
+		},
+		{
+			name: "boolean and null",
+			meta: map[string]interface{}{
+				"true":  true,
+				"false": false,
+				"null":  nil,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			nodeDef := NodeDefinition{
+				ID:   "test",
+				Type: "TEST",
+				Meta: tc.meta,
+			}
+
+			result, err := nodeDef.MarshalYAML()
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				alias := result.(nodeDefinitionAlias)
+				assert.IsType(t, "", alias.Meta)
+			}
+		})
+	}
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithMixedMetaFormats tests unmarshaling different meta formats
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithMixedMetaFormats() {
+	testCases := []struct {
+		name     string
+		yaml     string
+		validate func(*testing.T, NodeDefinition)
+	}{
+		{
+			name: "JSON object string",
+			yaml: `
+id: test1
+type: TEST
+meta: '{"key":"value","num":42}'
+`,
+			validate: func(t *testing.T, nd NodeDefinition) {
+				metaMap, ok := nd.Meta.(map[string]interface{})
+				require.True(t, ok)
+				assert.Equal(t, "value", metaMap["key"])
+				assert.Equal(t, float64(42), metaMap["num"])
+			},
+		},
+		{
+			name: "JSON array string",
+			yaml: `
+id: test2
+type: TEST
+meta: '[1,2,3]'
+`,
+			validate: func(t *testing.T, nd NodeDefinition) {
+				metaArr, ok := nd.Meta.([]interface{})
+				require.True(t, ok)
+				assert.Len(t, metaArr, 3)
+			},
+		},
+		{
+			name: "plain string (backward compatibility)",
+			yaml: `
+id: test3
+type: TEST
+meta: 'just a plain string'
+`,
+			validate: func(t *testing.T, nd NodeDefinition) {
+				metaStr, ok := nd.Meta.(string)
+				require.True(t, ok)
+				assert.Equal(t, "just a plain string", metaStr)
+			},
+		},
+		{
+			name: "numeric meta",
+			yaml: `
+id: test4
+type: TEST
+meta: 42
+`,
+			validate: func(t *testing.T, nd NodeDefinition) {
+				// When meta is a number in YAML, it's unmarshaled as int
+				assert.Equal(t, 42, nd.Meta)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			var nodeDef NodeDefinition
+			err := yaml.Unmarshal([]byte(tc.yaml), &nodeDef)
+			require.NoError(t, err)
+			tc.validate(t, nodeDef)
+		})
+	}
+}
+
+// TestCompleteFlowDefinition_MarshalUnmarshal_WithErrors tests error propagation in complete flows
+func (s *ImmutableResourceTestSuite) TestCompleteFlowDefinition_MarshalUnmarshal_WithErrors() {
+	// Test that yaml.Unmarshal properly reports errors for invalid structure
+	invalidYAML := []byte(`
+id: "flow-001"
+handle: "test-flow"
+nodes:
+  - id: "node1"
+    type: "TEST"
+    meta: this is invalid: {no quotes
+`)
+
+	var flow CompleteFlowDefinition
+	err := yaml.Unmarshal(invalidYAML, &flow)
+	// Should return an error due to malformed YAML
+	assert.Error(s.T(), err)
+}
+
+// TestNodeDefinitionUnmarshalYAML_WithWhitespaceInMeta tests meta with whitespace
+func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithWhitespaceInMeta() {
+	yamlData := []byte(`
+id: test_node
+type: TEST
+meta: '{"key": "value with spaces", "multiline": "line1\nline2"}'
+`)
+
+	var nodeDef NodeDefinition
+	err := yaml.Unmarshal(yamlData, &nodeDef)
+	require.NoError(s.T(), err)
+
+	metaMap, ok := nodeDef.Meta.(map[string]interface{})
+	require.True(s.T(), ok)
+	assert.Equal(s.T(), "value with spaces", metaMap["key"])
+	assert.Contains(s.T(), metaMap["multiline"], "\n")
 }
 
 func TestImmutableResourceTestSuite(t *testing.T) {

--- a/backend/internal/ou/immutable_resource.go
+++ b/backend/internal/ou/immutable_resource.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	immutableresource "github.com/asgardeo/thunder/internal/system/immutable_resource"
 	"github.com/asgardeo/thunder/internal/system/log"
-
-	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/backend/internal/system/export/model.go
+++ b/backend/internal/system/export/model.go
@@ -27,6 +27,7 @@ type ExportRequest struct {
 	NotificationSenders []string `json:"notification_senders,omitempty"`
 	UserSchemas         []string `json:"user_schemas,omitempty"`
 	OrganizationUnits   []string `json:"organization_units,omitempty"`
+	Flows               []string `json:"flows,omitempty"`
 
 	Options *ExportOptions `json:"options,omitempty"`
 }

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -36,6 +36,7 @@ const (
 	resourceTypeNotificationSender = "notification_sender"
 	resourceTypeUserSchema         = "user_schema"
 	resourceTypeOU                 = "organization_unit"
+	resourceTypeFlow               = "flow"
 )
 
 // parameterizerInterface defines the interface for template parameterization.
@@ -102,6 +103,7 @@ func (es *exportService) ExportResources(request *ExportRequest) (*ExportRespons
 		resourceTypeNotificationSender: request.NotificationSenders,
 		resourceTypeUserSchema:         request.UserSchemas,
 		resourceTypeOU:                 request.OrganizationUnits,
+		resourceTypeFlow:               request.Flows,
 	}
 
 	// Export resources using the registry


### PR DESCRIPTION
### Purpose
This PR contains fixes for following issues
1. Flows were not exported as the request had not contained a parameter to specify flows
2. NodeDefinition contains the Meta as an interface, therefore the export function fails to properly marshall to yaml

### Approach
Fix for 1: Added the flows to the request
Fix for 2: Parsed the Meta as json when exporting and read the Meta object as json

====
This pull request introduces improvements to the export and serialization mechanisms for flow definitions and system resources, particularly focusing on handling the `Meta` field in `NodeDefinition` and supporting export of flows. The main changes include custom YAML marshaling/unmarshaling logic for complex fields, additional resource support in export models and services, and enhancements to serialization for interface types.

**Flow definition serialization improvements:**
- Added custom `MarshalYAML` and `UnmarshalYAML` methods for the `NodeDefinition` struct to ensure the `Meta` field (of type `interface{}`) is serialized as a JSON string in YAML, and correctly deserialized back to its original structure. This prevents infinite recursion and ensures consistent handling of arbitrary metadata.
- Imported `encoding/json` and `gopkg.in/yaml.v3` in `model.go` to support the new serialization logic.

**Export system enhancements:**
- Added a `Flows` field to the `ExportRequest` struct, enabling export operations to include flow resources.
- Registered the new `flow` resource type in the export service and updated the resource aggregation logic to support exporting flows. [[1]](diffhunk://#diff-11acb4a0c3686aa0fef583c77393c2e7c0635f7318664b30704d13962e4773eaR39) [[2]](diffhunk://#diff-11acb4a0c3686aa0fef583c77393c2e7c0635f7318664b30704d13962e4773eaR106)
- Improved the `parameterizer` logic to handle `interface{}` fields by JSON-encoding them when converting to YAML nodes, ensuring complex data structures are preserved during export. [[1]](diffhunk://#diff-f9a8b103b09beea98b5ca9ab140bb1e0643de52e7b8316eec76bcd52cb9c75f6R377-R409) [[2]](diffhunk://#diff-f9a8b103b09beea98b5ca9ab140bb1e0643de52e7b8316eec76bcd52cb9c75f6R23)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
