### PR TITLE
Update branding resolve API CORS

### DIFF
--- a/backend/internal/branding/resolve/init.go
+++ b/backend/internal/branding/resolve/init.go
@@ -42,8 +42,8 @@ func Initialize(
 func registerRoutes(mux *http.ServeMux, resolveHandler *brandingResolveHandler) {
 	opts := middleware.CORSOptions{
 		AllowedMethods:   "GET",
-		AllowedHeaders:   "Content-Type",
-		AllowCredentials: false,
+		AllowedHeaders:   "Content-Type, Authorization",
+		AllowCredentials: true,
 	}
 	mux.HandleFunc(middleware.WithCORS("GET /branding/resolve", resolveHandler.HandleResolveRequest, opts))
 	mux.HandleFunc(middleware.WithCORS("OPTIONS /branding/resolve", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This pull request makes a small update to the CORS middleware configuration for the branding resolve API endpoint. The change allows requests with the `Authorization` header and enables credentialed requests (such as those with cookies or HTTP authentication).

- CORS configuration for the `/branding/resolve` endpoint now allows the `Authorization` header and sets `AllowCredentials` to `true` in `init.go`.