### PR TITLE
Update notification-senders options

### DIFF
--- a/backend/internal/notification/init.go
+++ b/backend/internal/notification/init.go
@@ -65,6 +65,10 @@ func registerRoutes(mux *http.ServeMux, handler *messageNotificationSenderHandle
 		handler.HandleSenderListRequest, opts1))
 	mux.HandleFunc(middleware.WithCORS("POST /notification-senders/message",
 		handler.HandleSenderCreateRequest, opts1))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /notification-senders/message",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}, opts1))
 
 	opts2 := middleware.CORSOptions{
 		AllowedMethods:   "GET, PUT, DELETE",
@@ -77,6 +81,10 @@ func registerRoutes(mux *http.ServeMux, handler *messageNotificationSenderHandle
 		handler.HandleSenderUpdateRequest, opts2))
 	mux.HandleFunc(middleware.WithCORS("DELETE /notification-senders/message/{id}",
 		handler.HandleSenderDeleteRequest, opts2))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /notification-senders/message/{id}",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}, opts2))
 
 	opts3 := middleware.CORSOptions{
 		AllowedMethods:   "POST",
@@ -85,6 +93,14 @@ func registerRoutes(mux *http.ServeMux, handler *messageNotificationSenderHandle
 	}
 	mux.HandleFunc(middleware.WithCORS("POST /notification-senders/otp/send",
 		handler.HandleOTPSendRequest, opts3))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /notification-senders/otp/send",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}, opts3))
 	mux.HandleFunc(middleware.WithCORS("POST /notification-senders/otp/verify",
 		handler.HandleOTPVerifyRequest, opts3))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /notification-senders/otp/verify",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}, opts3))
 }

--- a/backend/internal/notification/init_test.go
+++ b/backend/internal/notification/init_test.go
@@ -285,12 +285,21 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflight() {
 	_, _, _, err := Initialize(suite.mux, suite.mockJWTService)
 	suite.NoError(err)
 
-	req := httptest.NewRequest(http.MethodOptions, "/notification-senders/message", nil)
-	w := httptest.NewRecorder()
+	paths := []string{
+		"/notification-senders/message",
+		"/notification-senders/message/test-id",
+		"/notification-senders/otp/send",
+		"/notification-senders/otp/verify",
+	}
 
-	suite.mux.ServeHTTP(w, req)
+	for _, path := range paths {
+		req := httptest.NewRequest(http.MethodOptions, path, nil)
+		w := httptest.NewRecorder()
 
-	suite.NotEqual(http.StatusNotFound, w.Code)
+		suite.mux.ServeHTTP(w, req)
+
+		suite.NotEqual(http.StatusNotFound, w.Code)
+	}
 }
 
 // TestParseToNotificationSenderDTO_ValidYAML tests parsing a valid YAML configuration.


### PR DESCRIPTION
This pull request adds explicit handling for HTTP OPTIONS requests to several notification sender routes in the backend. This improves CORS (Cross-Origin Resource Sharing) support by ensuring that preflight requests receive the correct response, which is important for browser-based clients.

**CORS and Preflight Request Handling Improvements:**

* Added explicit `OPTIONS` handlers for the `/notification-senders/message` and `/notification-senders/message/{id}` endpoints to respond with HTTP 204 No Content, ensuring proper CORS preflight support. [[1]](diffhunk://#diff-40c4098e994917a09f4e449c9eb32c898a0fe98590537afd3b0f342dbb87a812R68-R71) [[2]](diffhunk://#diff-40c4098e994917a09f4e449c9eb32c898a0fe98590537afd3b0f342dbb87a812R84-R87)
* Added explicit `OPTIONS` handlers for the `/notification-senders/otp/send` and `/notification-senders/otp/verify` endpoints to respond with HTTP 204 No Content, further improving CORS compliance for OTP-related routes.