### PR TITLE
Fix wildcard export for user-schemas and ou

### DIFF
--- a/backend/internal/ou/immutable_resource.go
+++ b/backend/internal/ou/immutable_resource.go
@@ -24,6 +24,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	immutableresource "github.com/asgardeo/thunder/internal/system/immutable_resource"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -68,7 +69,7 @@ func (e *OUExporter) GetParameterizerType() string {
 func (e *OUExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
 	// Get all OUs by requesting a large limit from the service
 	// In composite mode, this returns OUs from both file-based and database stores
-	ous, err := e.service.GetOrganizationUnitList(1000, 0)
+	ous, err := e.service.GetOrganizationUnitList(serverconst.MaxPageSize, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (e *OUExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) 
 
 // getAllChildIDs recursively retrieves all child OU IDs (excluding immutable ones).
 func (e *OUExporter) getAllChildIDs(parentID string) ([]string, *serviceerror.ServiceError) {
-	children, err := e.service.GetOrganizationUnitChildren(parentID, 1000, 0)
+	children, err := e.service.GetOrganizationUnitChildren(parentID, serverconst.MaxPageSize, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/ou/immutable_resource_test.go
+++ b/backend/internal/ou/immutable_resource_test.go
@@ -263,7 +263,7 @@ func (s *ImmutableResourceTestSuite) TestGetResourceRules() {
 
 func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_NoOUs() {
 	// Test with empty result
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -285,7 +285,7 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_RootOUsOnly() {
 		Name:   "Root 2",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -294,11 +294,11 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_RootOUsOnly() {
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("root-2").Return(false)
 
 	// Mock GetOrganizationUnitChildren to return empty lists for both roots
-	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("root-2", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-2", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -327,7 +327,7 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_WithChildren() {
 		Name:   "Grandchild OU",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{rootOU},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -335,19 +335,19 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_WithChildren() {
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("root-1").Return(false)
 
 	// Mock children at each level
-	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{childOU},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("child-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{grandchildOU},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("grandchild-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("grandchild-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("grandchild-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -382,7 +382,7 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithChil
 		Name:   "Child 2",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -390,23 +390,23 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithChil
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("root-1").Return(false)
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("root-2").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{child1},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("child-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("root-2", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-2", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{child2},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("child-2").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("child-2", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-2", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -421,7 +421,7 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithChil
 
 func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_ErrorGettingList() {
 	// Test error handling when getting the OU list fails
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(
 		(*OrganizationUnitListResponse)(nil),
 		&serviceerror.InternalServerError,
 	)
@@ -440,14 +440,14 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_ErrorGettingChildren(
 		Name:   "Root OU",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{rootOU},
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitImmutable to indicate this is a mutable OU
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("root-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 100, 0).Return(
 		(*OrganizationUnitListResponse)(nil),
 		&serviceerror.InternalServerError,
 	)
@@ -465,38 +465,38 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_DeepNesting() {
 	level4 := OrganizationUnitBasic{ID: "level-4", Handle: "l4", Name: "Level 4"}
 	level5 := OrganizationUnitBasic{ID: "level-5", Handle: "l5", Name: "Level 5"}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level1},
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitImmutable for all levels
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("level-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("level-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level2},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("level-2").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("level-2", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-2", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level3},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("level-3").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("level-3", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-3", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level4},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("level-4").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("level-4", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-4", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level5},
 	}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("level-5").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("level-5", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("level-5", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -531,14 +531,14 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPerLe
 		Name:   "Child 3",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitList(100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{rootOU},
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitImmutable for root
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("root-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("root-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{child1, child2, child3},
 	}, (*serviceerror.ServiceError)(nil))
 
@@ -548,15 +548,15 @@ func (s *ImmutableResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPerLe
 	s.mockService.EXPECT().IsOrganizationUnitImmutable("child-3").Return(false)
 
 	// Each child has no children
-	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("child-2", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-2", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren("child-3", 1000, 0).Return(&OrganizationUnitListResponse{
+	s.mockService.EXPECT().GetOrganizationUnitChildren("child-3", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -1588,7 +1588,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_Wildcard() {
 		},
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(0, 1000).Return(mockSchemaList, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(100, 0).Return(mockSchemaList, nil)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema1").Return(mockSchema1, nil)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema2").Return(mockSchema2, nil)
 
@@ -1718,7 +1718,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_WildcardPartialFailur
 		Error: "User schema not found",
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(0, 1000).Return(mockSchemaList, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(100, 0).Return(mockSchemaList, nil)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema1").Return(mockSchema1, nil)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema2").Return(nil, schemaError)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema3").Return(mockSchema3, nil)

--- a/backend/internal/userschema/immutable_resource.go
+++ b/backend/internal/userschema/immutable_resource.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	oupkg "github.com/asgardeo/thunder/internal/ou"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	immutableresource "github.com/asgardeo/thunder/internal/system/immutable_resource"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -63,7 +64,7 @@ func (e *UserSchemaExporter) GetParameterizerType() string {
 
 // GetAllResourceIDs retrieves all user schema IDs.
 func (e *UserSchemaExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
-	response, err := e.service.GetUserSchemaList(0, 1000)
+	response, err := e.service.GetUserSchemaList(serverconst.MaxPageSize, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/userschema/immutable_resource_test.go
+++ b/backend/internal/userschema/immutable_resource_test.go
@@ -70,7 +70,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_Success() {
 		},
 	}
 
-	s.mockService.EXPECT().GetUserSchemaList(0, 1000).Return(expectedResponse, nil)
+	s.mockService.EXPECT().GetUserSchemaList(100, 0).Return(expectedResponse, nil)
 
 	ids, err := s.exporter.GetAllResourceIDs()
 
@@ -86,7 +86,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_Error() {
 		Error: "test error",
 	}
 
-	s.mockService.EXPECT().GetUserSchemaList(0, 1000).Return(nil, expectedError)
+	s.mockService.EXPECT().GetUserSchemaList(100, 0).Return(nil, expectedError)
 
 	ids, err := s.exporter.GetAllResourceIDs()
 
@@ -99,7 +99,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
 		Schemas: []userschema.UserSchemaListItem{},
 	}
 
-	s.mockService.EXPECT().GetUserSchemaList(0, 1000).Return(expectedResponse, nil)
+	s.mockService.EXPECT().GetUserSchemaList(100, 0).Return(expectedResponse, nil)
 
 	ids, err := s.exporter.GetAllResourceIDs()
 

--- a/docs/guides/immutable-configurations/immutable-configuration.md
+++ b/docs/guides/immutable-configurations/immutable-configuration.md
@@ -203,9 +203,25 @@ curl -X POST https://localhost:8090/export \
   -d '{
     "identity_providers": ["<idp-id>"]
   }' > repository/resources/identity_providers/google-idp.yaml
+
+# Export specific organization units
+curl -X POST https://localhost:8090/export \
+  -H "Content-Type: application/json" \
+  -d '{
+    "organization_units": ["<ou-id-1>", "<ou-id-2>"]
+  }' > repository/resources/organization_units/my-ous.yaml
 ```
 
 See the [Export Configurations Guide](./export-configurations.md) for detailed export instructions.
+
+**⚠️ Organization Units Export Limitation:**
+
+When using wildcard export for organization units (`"organization_units": ["*"]`), only the first 100 organization units will be retrieved due to pagination limits. If you have more than 100 OUs at the root level, they will not be included in the export. 
+
+To export all organization units:
+- Export specific OUs by ID rather than using wildcards
+- Make multiple export requests with specific OU IDs
+- Consider implementing pagination loop logic in your export script to fetch all pages
 
 ### Manual Creation
 


### PR DESCRIPTION
### Purpose
Fix wildcard export for user-schemas and ou

### Approach
There is a validation for limit which cannot exceed 99

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
