### PR TITLE
Fix setup.sh to run with bash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,16 @@
 # 3. Stops Thunder server
 # 4. Exits cleanly
 
+# Ensure the script runs with Bash even if invoked via `sh`
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec /usr/bin/env bash "$0" "$@"
+fi
+
+# Guard against Bash POSIX mode (happens when running `sh setup.sh`)
+if set -o | grep -q 'posix[[:space:]]\+on'; then
+    exec /usr/bin/env bash "$0" "$@"
+fi
+
 set -e
 
 # Default settings


### PR DESCRIPTION
### Purpose
This pull request improves the robustness of the `setup.sh` script by ensuring it always runs under Bash, regardless of how it is invoked. This prevents issues that can arise if the script is run with `sh` or in POSIX mode, which may not support all Bash features.

Shell compatibility improvements:

* Added checks at the top of `setup.sh` to re-execute the script with Bash if it is not already running under Bash, or if Bash is running in POSIX mode. This ensures consistent behavior and avoids subtle bugs when the script is started with `sh` or in environments where Bash defaults to POSIX mode.