### PR TITLE
Fix system token generation in readme to match flow execution changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,21 +216,34 @@ The React Vanilla sample supports user self-registration and login:
 
 3. Upon successful login, you'll see the home page with your access token.
 
-#### Try Out Client Credentials Flow
 
-To try out the Client Credentials flow, you first need to obtain a token to access the System APIs of Thunder. Follow these steps:
+#### Obtain System API Token
 
-Replace `<application_id>` with the sample app ID generated during "Setup the product."
+To access the system APIs of Thunder, you need a token with system permissions. Follow the steps below to obtain a system API token.
+
+1. Run the following command, replacing `<application_id>` with the sample app ID generated during "Setup the product."
 
 ```bash
 curl -k -X POST 'https://localhost:8090/flow/execute' \
-  -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION", "inputs":{"username":"admin","password":"admin", "requested_permissions":"system"}}'
+  -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}'
+```
+2. Extract the `flowId` value from the response.
+```json
+{"flowId":"<flow_id>","flowStatus":"INCOMPLETE", ...}
 ```
 
-The response will contain an `assertion` field.
+3. Run the following command, replacing `<flow_id>` with the `flowId` value you extracted above.
+```bash
+curl -k -X POST 'https://localhost:8090/flow/execute' \
+  -d '{"flowId":"<flow_id>", "inputs":{"username":"admin","password":"admin", "requested_permissions":"system"},"action": "action_001"}'
+```
+
+4. Obtain the system API token by extracting the `assertion` value from the response.
 ```json
 {"flowId":"<flow_id>","flowStatus":"COMPLETE","data":{},"assertion":"<assertion>"}
 ```
+
+#### Try Out Client Credentials Flow
 
 The Client Credentials flow is used to obtain an access token for machine-to-machine communication. This flow does not require user interaction and is typically used for server-to-server communication.
 
@@ -238,7 +251,9 @@ To try out the Client Credentials flow, follow these steps:
 
 1. Create a Client Application
 
-   Create a client application in the system to use for the Client Credentials flow. You can use the following cURL command to create a new application. Replace `<assertion>` with the assertion value obtained from the previous step.
+   Application creation is secured functionality, so you first need to obtain a system API token as mentioned in the "Obtaining System API Token" section above.
+
+   Run the following command, replacing `<assertion>` with the assertion value obtained from the previous step.
 
     ```bash
     curl -kL -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' https://localhost:8090/applications \


### PR DESCRIPTION
### Purpose
This pull request updates the `README.md` to clarify the steps required for obtaining a system API token and trying out the Client Credentials flow. The documentation now provides a more detailed and sequential guide for users, making it easier to follow the process for system API access and application creation.

**Documentation improvements:**

* Renamed the section from "Try Out Client Credentials Flow" to "Obtain System API Token" and clarified that a system token with system permissions is required for accessing system APIs.
* Added step-by-step instructions for obtaining a system API token, including extracting the `flowId` and then the `assertion` from the API responses.

**Client Credentials flow clarification:**

* Updated the Client Credentials flow section to specify that application creation requires a system API token, referencing the new instructions above.
* Improved the flow by making the dependency between obtaining a system token and creating a client application explicit.