### PR TITLE
Fix duplicate SMS OTP issue in the assurance authenticator list

### DIFF
--- a/backend/internal/flow/common/model.go
+++ b/backend/internal/flow/common/model.go
@@ -71,6 +71,7 @@ type NodeExecutionRecord struct {
 	NodeType     string             `json:"node_type"`
 	ExecutorName string             `json:"executor_name,omitempty"`
 	ExecutorType ExecutorType       `json:"executor_type,omitempty"`
+	ExecutorMode string             `json:"executor_mode,omitempty"`
 	Step         int                `json:"step"`
 	Status       FlowStatus         `json:"status"`
 	Executions   []ExecutionAttempt `json:"executions"`

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -182,6 +182,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 func (a *authAssertExecutor) extractAuthenticatorReferences(
 	history map[string]*common.NodeExecutionRecord) []authncm.AuthenticatorReference {
 	refs := make([]authncm.AuthenticatorReference, 0)
+	seenAuthenticators := make(map[string]bool)
 
 	for _, record := range history {
 		if record.ExecutorType != common.ExecutorTypeAuthentication {
@@ -196,6 +197,12 @@ func (a *authAssertExecutor) extractAuthenticatorReferences(
 		if authnServiceName == "" {
 			continue
 		}
+
+		// Skip if we've already seen this authenticator
+		if seenAuthenticators[authnServiceName] {
+			continue
+		}
+		seenAuthenticators[authnServiceName] = true
 
 		refs = append(refs, authncm.AuthenticatorReference{
 			Authenticator: authnServiceName,

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -351,6 +351,34 @@ func (suite *AuthAssertExecutorTestSuite) TestExtractAuthenticatorReferences_Unk
 	assert.Empty(suite.T(), refs)
 }
 
+func (suite *AuthAssertExecutorTestSuite) TestExtractAuthenticatorReferences_SMSOTPSendVerifyMode() {
+	history := map[string]*common.NodeExecutionRecord{
+		"sms_send_node": {
+			ExecutorName: ExecutorNameSMSAuth,
+			ExecutorType: common.ExecutorTypeAuthentication,
+			ExecutorMode: "send",
+			Status:       common.FlowStatusComplete,
+			Step:         1,
+			EndTime:      1000,
+		},
+		"sms_verify_node": {
+			ExecutorName: ExecutorNameSMSAuth,
+			ExecutorType: common.ExecutorTypeAuthentication,
+			ExecutorMode: "verify",
+			Status:       common.FlowStatusComplete,
+			Step:         2,
+			EndTime:      2000,
+		},
+	}
+
+	refs := suite.executor.extractAuthenticatorReferences(history)
+
+	// Should only have one SMS OTP authenticator, not two
+	assert.Len(suite.T(), refs, 1)
+	assert.Equal(suite.T(), authncm.AuthenticatorSMSOTP, refs[0].Authenticator)
+	assert.Equal(suite.T(), 1, refs[0].Step)
+}
+
 func (suite *AuthAssertExecutorTestSuite) TestGetUserAttributes_Success() {
 	attrs := map[string]interface{}{"email": "test@example.com", "name": "Test User"}
 	attrsJSON, _ := json.Marshal(attrs)

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -607,6 +607,7 @@ func createExecutionRecord(node core.NodeInterface, step int) common.NodeExecuti
 				record.ExecutorName = executor.GetName()
 				record.ExecutorType = executor.GetType()
 			}
+			record.ExecutorMode = executableNode.GetMode()
 		}
 	}
 
@@ -674,17 +675,6 @@ func publishNodeExecutionStartedEvent(
 		WithData(event.DataKey.StepNumber, fmt.Sprintf("%d", stepNumber)).
 		WithData(event.DataKey.AttemptNumber, fmt.Sprintf("%d", attemptNumber)).
 		WithData(event.DataKey.AppID, ctx.AppID)
-
-	// Set executor details if applicable (only for executor-backed nodes)
-	if node.GetType() == common.NodeTypeTaskExecution {
-		if executableNode, ok := node.(core.ExecutorBackedNodeInterface); ok {
-			executor := executableNode.GetExecutor()
-			if executor != nil && record != nil {
-				record.ExecutorName = executor.GetName()
-				record.ExecutorType = executor.GetType()
-			}
-		}
-	}
 
 	obsSvc.PublishEvent(evt)
 }

--- a/tests/integration/flow/authentication/assurance_test.go
+++ b/tests/integration/flow/authentication/assurance_test.go
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/asgardeo/thunder/tests/integration/flow/common"
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	assuranceMockNotificationServerPort = 8099
+)
+
+// Authenticator names used in assurance
+const (
+	AuthenticatorCredentials = "CredentialsAuthenticator"
+	AuthenticatorSMSOTP      = "SMSOTPAuthenticator"
+)
+
+var (
+	// Flow for SMS OTP only authentication (AAL1)
+	assuranceSMSOnlyFlow = testutils.Flow{
+		Name:     "SMS Only Auth Flow for Assurance Test",
+		FlowType: "AUTHENTICATION",
+		Handle:   "assurance_test_sms_only_flow",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_mobile",
+			},
+			{
+				"id":   "prompt_mobile",
+				"type": "PROMPT",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_001",
+						"identifier": "mobileNumber",
+						"type":       "string",
+						"required":   true,
+					},
+				},
+				"actions": []map[string]interface{}{
+					{
+						"ref":      "action_001",
+						"nextNode": "sms_otp_send",
+					},
+				},
+			},
+			{
+				"id":   "sms_otp_send",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"senderId": "placeholder-sender-id",
+				},
+				"executor": map[string]interface{}{
+					"name": "SMSOTPAuthExecutor",
+					"mode": "send",
+				},
+				"onSuccess": "prompt_otp",
+			},
+			{
+				"id":   "prompt_otp",
+				"type": "PROMPT",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_002",
+						"identifier": "otp",
+						"type":       "string",
+						"required":   true,
+					},
+				},
+				"actions": []map[string]interface{}{
+					{
+						"ref":      "action_002",
+						"nextNode": "sms_otp_verify",
+					},
+				},
+			},
+			{
+				"id":   "sms_otp_verify",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"senderId": "placeholder-sender-id",
+				},
+				"executor": map[string]interface{}{
+					"name": "SMSOTPAuthExecutor",
+					"mode": "verify",
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	// Flow for Credentials + SMS OTP authentication (AAL2)
+	assuranceMFAFlow = testutils.Flow{
+		Name:     "MFA Auth Flow for Assurance Test",
+		FlowType: "AUTHENTICATION",
+		Handle:   "assurance_test_mfa_flow",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_001",
+						"identifier": "username",
+						"type":       "string",
+						"required":   true,
+					},
+					{
+						"ref":        "input_002",
+						"identifier": "password",
+						"type":       "string",
+						"required":   true,
+					},
+				},
+				"actions": []map[string]interface{}{
+					{
+						"ref":      "action_001",
+						"nextNode": "basic_auth",
+					},
+				},
+			},
+			{
+				"id":   "basic_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "BasicAuthExecutor",
+				},
+				"onSuccess": "sms_otp_send",
+			},
+			{
+				"id":   "sms_otp_send",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"senderId": "placeholder-sender-id",
+				},
+				"executor": map[string]interface{}{
+					"name": "SMSOTPAuthExecutor",
+					"mode": "send",
+				},
+				"onSuccess": "prompt_otp",
+			},
+			{
+				"id":   "prompt_otp",
+				"type": "PROMPT",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_003",
+						"identifier": "otp",
+						"type":       "string",
+						"required":   true,
+					},
+				},
+				"actions": []map[string]interface{}{
+					{
+						"ref":      "action_002",
+						"nextNode": "sms_otp_verify",
+					},
+				},
+			},
+			{
+				"id":   "sms_otp_verify",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"senderId": "placeholder-sender-id",
+				},
+				"executor": map[string]interface{}{
+					"name": "SMSOTPAuthExecutor",
+					"mode": "verify",
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	// Flow for Basic Auth only (AAL1)
+	assuranceBasicAuthFlow = testutils.Flow{
+		Name:     "Basic Auth Only Flow for Assurance Test",
+		FlowType: "AUTHENTICATION",
+		Handle:   "assurance_test_basic_auth_flow",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_001",
+						"identifier": "username",
+						"type":       "string",
+						"required":   true,
+					},
+					{
+						"ref":        "input_002",
+						"identifier": "password",
+						"type":       "string",
+						"required":   true,
+					},
+				},
+				"actions": []map[string]interface{}{
+					{
+						"ref":      "action_001",
+						"nextNode": "basic_auth",
+					},
+				},
+			},
+			{
+				"id":   "basic_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "BasicAuthExecutor",
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+)
+
+var (
+	assuranceTestApp = testutils.Application{
+		Name:                      "Assurance Test Application",
+		Description:               "Application for testing authentication assurance levels",
+		IsRegistrationFlowEnabled: false,
+		ClientID:                  "assurance_test_client",
+		ClientSecret:              "assurance_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"assurance_test_user"},
+	}
+
+	assuranceUserSchema = testutils.UserSchema{
+		Name: "assurance_test_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"mobileNumber": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	assuranceTestUser = testutils.User{
+		Type: assuranceUserSchema.Name,
+		Attributes: json.RawMessage(`{
+			"username": "assurance_user",
+			"password": "testpassword123",
+			"email": "assurance@example.com",
+			"mobileNumber": "+1987654321"
+		}`),
+	}
+)
+
+var (
+	assuranceTestAppID       string
+	assuranceUserSchemaID    string
+	assuranceTestSenderID    string
+	assuranceSMSOnlyFlowID   string
+	assuranceMFAFlowID       string
+	assuranceBasicAuthFlowID string
+	assuranceTestOU          = testutils.OrganizationUnit{
+		Handle:      "assurance-test-ou",
+		Name:        "Assurance Test OU",
+		Description: "Organization unit for assurance testing",
+	}
+)
+
+type AssuranceTestSuite struct {
+	suite.Suite
+	config     *common.TestSuiteConfig
+	mockServer *testutils.MockNotificationServer
+}
+
+func TestAssuranceTestSuite(t *testing.T) {
+	suite.Run(t, new(AssuranceTestSuite))
+}
+
+func (ts *AssuranceTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	// Create test organization unit
+	ouID, err := testutils.CreateOrganizationUnit(assuranceTestOU)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test organization unit: %v", err)
+	}
+	assuranceTestOU.ID = ouID
+
+	// Create test user schema
+	assuranceUserSchema.OrganizationUnitId = ouID
+	schemaID, err := testutils.CreateUserType(assuranceUserSchema)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user schema: %v", err)
+	}
+	assuranceUserSchemaID = schemaID
+
+	// Start mock notification server
+	ts.mockServer = testutils.NewMockNotificationServer(assuranceMockNotificationServerPort)
+	err = ts.mockServer.Start()
+	if err != nil {
+		ts.T().Fatalf("Failed to start mock notification server: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Create test user
+	testUser := assuranceTestUser
+	testUser.OrganizationUnit = assuranceTestOU.ID
+	userIDs, err := testutils.CreateMultipleUsers(testUser)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user: %v", err)
+	}
+	ts.config.CreatedUserIDs = userIDs
+
+	// Create notification sender
+	customSender := testutils.NotificationSender{
+		Name:        "Assurance Test Sender",
+		Description: "Sender for assurance testing",
+		Provider:    "custom",
+		Properties: []testutils.SenderProperty{
+			{Name: "url", Value: ts.mockServer.GetSendSMSURL(), IsSecret: false},
+			{Name: "http_method", Value: "POST", IsSecret: false},
+			{Name: "content_type", Value: "JSON", IsSecret: false},
+		},
+	}
+	senderID, err := testutils.CreateNotificationSender(customSender)
+	ts.Require().NoError(err, "Failed to create notification sender")
+	assuranceTestSenderID = senderID
+	ts.config.CreatedSenderIDs = append(ts.config.CreatedSenderIDs, senderID)
+
+	// Update flow definitions with sender ID
+	smsOnlyNodes := assuranceSMSOnlyFlow.Nodes.([]map[string]interface{})
+	smsOnlyNodes[2]["properties"].(map[string]interface{})["senderId"] = senderID
+	smsOnlyNodes[4]["properties"].(map[string]interface{})["senderId"] = senderID
+	assuranceSMSOnlyFlow.Nodes = smsOnlyNodes
+
+	mfaNodes := assuranceMFAFlow.Nodes.([]map[string]interface{})
+	mfaNodes[3]["properties"].(map[string]interface{})["senderId"] = senderID
+	mfaNodes[5]["properties"].(map[string]interface{})["senderId"] = senderID
+	assuranceMFAFlow.Nodes = mfaNodes
+
+	// Create flows
+	smsOnlyFlowID, err := testutils.CreateFlow(assuranceSMSOnlyFlow)
+	ts.Require().NoError(err, "Failed to create SMS only flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, smsOnlyFlowID)
+	assuranceSMSOnlyFlowID = smsOnlyFlowID
+
+	mfaFlowID, err := testutils.CreateFlow(assuranceMFAFlow)
+	ts.Require().NoError(err, "Failed to create MFA flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, mfaFlowID)
+	assuranceMFAFlowID = mfaFlowID
+
+	basicAuthFlowID, err := testutils.CreateFlow(assuranceBasicAuthFlow)
+	ts.Require().NoError(err, "Failed to create basic auth flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, basicAuthFlowID)
+	assuranceBasicAuthFlowID = basicAuthFlowID
+
+	// Create test application
+	assuranceTestApp.AuthFlowID = smsOnlyFlowID
+	appID, err := testutils.CreateApplication(assuranceTestApp)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test application: %v", err)
+	}
+	assuranceTestAppID = appID
+}
+
+func (ts *AssuranceTestSuite) TearDownSuite() {
+	if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+		ts.T().Logf("Failed to cleanup users: %v", err)
+	}
+
+	if ts.mockServer != nil {
+		_ = ts.mockServer.Stop()
+	}
+
+	if assuranceTestAppID != "" {
+		_ = testutils.DeleteApplication(assuranceTestAppID)
+	}
+
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		_ = testutils.DeleteFlow(flowID)
+	}
+
+	for _, senderID := range ts.config.CreatedSenderIDs {
+		_ = testutils.DeleteNotificationSender(senderID)
+	}
+
+	if assuranceTestOU.ID != "" {
+		_ = testutils.DeleteOrganizationUnit(assuranceTestOU.ID)
+	}
+
+	if assuranceUserSchemaID != "" {
+		_ = testutils.DeleteUserType(assuranceUserSchemaID)
+	}
+}
+
+func (ts *AssuranceTestSuite) TestAssurance_SMSOTPOnly() {
+	// Ensure app is configured to use SMS only flow
+	err := common.UpdateAppConfig(assuranceTestAppID, assuranceSMSOnlyFlowID, "")
+	ts.Require().NoError(err)
+
+	// Step 1: Initiate flow
+	flowStep, err := common.InitiateAuthenticationFlow(assuranceTestAppID, false, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	// Clear messages
+	ts.mockServer.ClearMessages()
+
+	// Step 2: Submit mobile number
+	userAttrs, err := testutils.GetUserAttributes(assuranceTestUser)
+	ts.Require().NoError(err)
+
+	inputs := map[string]string{
+		"mobileNumber": userAttrs["mobileNumber"].(string),
+	}
+
+	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus)
+
+	// Wait for SMS
+	time.Sleep(500 * time.Millisecond)
+
+	// Get OTP
+	lastMessage := ts.mockServer.GetLastMessage()
+	ts.Require().NotNil(lastMessage)
+	ts.Require().NotEmpty(lastMessage.OTP)
+
+	// Step 3: Submit OTP
+	otpInputs := map[string]string{"otp": lastMessage.OTP}
+	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_002")
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
+	ts.Require().NotEmpty(completeFlowStep.Assertion)
+
+	// Validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err)
+
+	// Validate assurance block
+	err = testutils.ValidateAssurance(jwtClaims, testutils.AssuranceExpectation{
+		AAL:                    "AAL1",
+		IAL:                    "IAL1",
+		ExpectedAuthenticators: []string{AuthenticatorSMSOTP},
+	})
+	ts.Require().NoError(err, "Assurance validation failed")
+}
+
+func (ts *AssuranceTestSuite) TestAssurance_CredentialsPlusSMSOTP() {
+	// Update app to use MFA flow
+	err := common.UpdateAppConfig(assuranceTestAppID, assuranceMFAFlowID, "")
+	ts.Require().NoError(err)
+
+	// Step 1: Initiate flow
+	flowStep, err := common.InitiateAuthenticationFlow(assuranceTestAppID, false, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	// Clear messages
+	ts.mockServer.ClearMessages()
+
+	// Step 2: Submit credentials
+	userAttrs, err := testutils.GetUserAttributes(assuranceTestUser)
+	ts.Require().NoError(err)
+
+	credInputs := map[string]string{
+		"username": userAttrs["username"].(string),
+		"password": userAttrs["password"].(string),
+	}
+
+	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, credInputs, "action_001")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus)
+
+	// Wait for SMS
+	time.Sleep(500 * time.Millisecond)
+
+	// Get OTP
+	lastMessage := ts.mockServer.GetLastMessage()
+	ts.Require().NotNil(lastMessage)
+	ts.Require().NotEmpty(lastMessage.OTP)
+
+	// Step 3: Submit OTP
+	otpInputs := map[string]string{"otp": lastMessage.OTP}
+	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_002")
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
+	ts.Require().NotEmpty(completeFlowStep.Assertion)
+
+	// Validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err)
+
+	// Validate assurance block
+	err = testutils.ValidateAssurance(jwtClaims, testutils.AssuranceExpectation{
+		AAL:                    "AAL2",
+		IAL:                    "IAL1",
+		ExpectedAuthenticators: []string{AuthenticatorCredentials, AuthenticatorSMSOTP},
+	})
+	ts.Require().NoError(err, "Assurance validation failed")
+}
+
+func (ts *AssuranceTestSuite) TestAssurance_BasicAuthOnly() {
+	// Update app to use basic auth flow
+	err := common.UpdateAppConfig(assuranceTestAppID, assuranceBasicAuthFlowID, "")
+	ts.Require().NoError(err)
+
+	// Step 1: Initiate flow
+	flowStep, err := common.InitiateAuthenticationFlow(assuranceTestAppID, false, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	// Step 2: Submit credentials
+	userAttrs, err := testutils.GetUserAttributes(assuranceTestUser)
+	ts.Require().NoError(err)
+
+	credInputs := map[string]string{
+		"username": userAttrs["username"].(string),
+		"password": userAttrs["password"].(string),
+	}
+
+	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, credInputs, "action_001")
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
+	ts.Require().NotEmpty(completeFlowStep.Assertion)
+
+	// Validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(completeFlowStep.Assertion)
+	ts.Require().NoError(err)
+
+	// Validate assurance block
+	err = testutils.ValidateAssurance(jwtClaims, testutils.AssuranceExpectation{
+		AAL:                    "AAL1",
+		IAL:                    "IAL1",
+		ExpectedAuthenticators: []string{AuthenticatorCredentials},
+	})
+	ts.Require().NoError(err, "Assurance validation failed")
+}


### PR DESCRIPTION
### Purpose
This pull request fixes the issue of appending SMS OTP authenticator twice to the assurance's authenticator list. This introduces improvements to how authentication steps are tracked and validated in the flow execution system, with a focus on ensuring accurate recording and validation of authenticator usage and assurance levels. The main changes include adding an `ExecutorMode` field to node execution records, preventing duplicate authenticator references, and enhancing test coverage for authenticator extraction logic.

### Approach

### Authentication Step Tracking & Deduplication

* Added `ExecutorMode` field to the `NodeExecutionRecord` struct and ensured it is populated during execution record creation, allowing differentiation between authentication modes such as "send" and "verify".
* Updated authenticator reference extraction logic to skip duplicate authenticators, ensuring that each authenticator is only counted once per flow, regardless of mode.

### Test Coverage Improvements

* Added a new test case (`TestExtractAuthenticatorReferences_SMSOTPSendVerifyMode`) to verify that only one SMS OTP authenticator is recorded even if both "send" and "verify" modes are present, confirming correct deduplication behavior.

### Assurance Validation Utilities

* Introduced the `AssuranceExpectation` struct and the `ValidateAssurance` function in test utilities, enabling detailed validation of the assurance block in JWT claims, including AAL, IAL, and authenticators with step and timestamp checks.

No changes were made to the event publishing logic in `engine.go`, as some redundant executor detail assignment code was removed.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1028

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
