### PR TITLE
Update obtain Admin token documentation

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,18 +10,34 @@ Thunder is a modern, open-source identity management service designed for teams 
 
 System APIs of Thunder are secured by default. You need to obtain an access token with `system` scope by authenticating as an admin user. Follow these steps:
 
-1. **Authenticate and obtain an access token:**
+1. **Initiate the authentication flow:**
 
-   Replace `<application_id>` with the sample app ID generated during "Setup the product."
+   Run the following command, replacing `<application_id>` with the sample app ID generated during "Setup the product."
 
    ```bash
    curl -k -X POST 'https://localhost:8090/flow/execute' \
-     -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION", "inputs":{"username":"admin","password":"admin", "requested_permissions":"system"}}'
+     -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}'
    ```
 
-2. **Extract the assertion from the response:**
+2. **Extract the flowId from the response:**
 
-   The response will contain an `assertion` field:
+   ```json
+   {"flowId":"<flow_id>","flowStatus":"INCOMPLETE", ...}
+   ```
+
+3. **Submit credentials:**
+
+   Run the following command, replacing `<flow_id>` with the `flowId` value you extracted above.
+
+   ```bash
+   curl -k -X POST 'https://localhost:8090/flow/execute' \
+     -d '{"flowId":"<flow_id>", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}'
+   ```
+
+4. **Extract the assertion from the response:**
+
+   Obtain the system API token by extracting the `assertion` value from the response.
+
    ```json
    {"flowId":"<flow_id>","flowStatus":"COMPLETE","data":{},"assertion":"<assertion>"}
    ```

--- a/docs/guides/standards-based/oauth2-oidc/features/public-clients.md
+++ b/docs/guides/standards-based/oauth2-oidc/features/public-clients.md
@@ -19,19 +19,24 @@ Public clients are OAuth 2.0 applications that cannot securely store client secr
 
 ### Step 1: Obtain Admin Token
 
+#### 1.1: Initiate the Authentication Flow
+
+Run the following command, replacing `<application_id>` with your sample app ID (created during Thunder setup).
+
 ```bash
-# Replace <application_id> with your sample app ID (created during Thunder setup)
+FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
+  -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
+
+FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+```
+
+#### 1.2: Submit Admin Credentials
+
+Run the following command with the extracted `flowId`.
+
+```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "applicationId": "<application_id>",
-    "flowType": "AUTHENTICATION",
-    "inputs": {
-      "username": "admin",
-      "password": "admin",
-      "requested_permissions": "system"
-    }
-  }')
+  -d '{"flowId":"'$FLOW_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```

--- a/docs/guides/standards-based/oauth2-oidc/grant-types/authorization-code.md
+++ b/docs/guides/standards-based/oauth2-oidc/grant-types/authorization-code.md
@@ -28,21 +28,26 @@ The Authorization Code grant type is the recommended OAuth 2.0 grant type for ap
 
 ### Step 1: Obtain Admin Token
 
-First, obtain an admin token to create applications:
+First, obtain an admin token to create applications.
+
+#### 1.1: Initiate the Authentication Flow
+
+Run the following command, replacing `<application_id>` with your sample app ID (created during Thunder setup).
 
 ```bash
-# Replace <application_id> with your sample app ID (created during Thunder setup)
+FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
+  -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
+
+FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+```
+
+#### 1.2: Submit Admin Credentials
+
+Run the following command with the extracted `flowId`.
+
+```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "applicationId": "<application_id>",
-    "flowType": "AUTHENTICATION",
-    "inputs": {
-      "username": "admin",
-      "password": "admin",
-      "requested_permissions": "system"
-    }
-  }')
+  -d '{"flowId":"'$FLOW_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```

--- a/docs/guides/standards-based/oauth2-oidc/grant-types/client-credentials.md
+++ b/docs/guides/standards-based/oauth2-oidc/grant-types/client-credentials.md
@@ -27,21 +27,26 @@ The Client Credentials grant type allows applications to authenticate using thei
 
 ### Step 1: Obtain Admin Token
 
-First, obtain an admin token to create applications:
+First, obtain an admin token to create applications.
+
+#### 1.1: Initiate the Authentication Flow
+
+Run the following command, replacing `<application_id>` with your sample app ID (created during Thunder setup).
 
 ```bash
-# Replace <application_id> with your sample app ID (created during Thunder setup)
+FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
+  -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
+
+FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+```
+
+#### 1.2: Submit Admin Credentials
+
+Run the following command with the extracted `flowId`.
+
+```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "applicationId": "<application_id>",
-    "flowType": "AUTHENTICATION",
-    "inputs": {
-      "username": "admin",
-      "password": "admin",
-      "requested_permissions": "system"
-    }
-  }')
+  -d '{"flowId":"'$FLOW_ID'", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action": "action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```

--- a/docs/guides/standards-based/oauth2-oidc/grant-types/token-exchange.md
+++ b/docs/guides/standards-based/oauth2-oidc/grant-types/token-exchange.md
@@ -24,21 +24,26 @@ Token Exchange enables:
 
 ### Step 1: Obtain Admin Token
 
-First, obtain an admin token to create applications:
+First, obtain an admin token to create applications.
+
+#### 1.1: Initiate the Authentication Flow
+
+Run the following command, replacing `<application_id>` with your sample app ID (created during Thunder setup).
 
 ```bash
-# Replace <application_id> with your sample app ID (created during Thunder setup)
+FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
+  -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
+
+FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+```
+
+#### 1.2: Submit Admin Credentials
+
+Run the following command with the extracted `flowId`.
+
+```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "applicationId": "<application_id>",
-    "flowType": "AUTHENTICATION",
-    "inputs": {
-      "username": "admin",
-      "password": "admin",
-      "requested_permissions": "system"
-    }
-  }')
+  -d '{"flowId":"'$FLOW_ID'", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action": "action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```


### PR DESCRIPTION
### Purpose
The obtain system token docs needs to be updated as https://github.com/asgardeo/thunder/commit/1daed20a1027f78c24458385ac092ec1b7527f7d

====

This pull request updates the authentication flow documentation for obtaining an admin token across several guides. The new approach splits the process into two distinct steps: initiating the authentication flow to receive a `flowId`, and then submitting admin credentials using that `flowId`. This change improves clarity and aligns the documentation with the actual API flow.

**Authentication Flow Documentation Updates**

* All guides now instruct users to first initiate the authentication flow and extract the `flowId` before submitting credentials, providing a more accurate representation of the required API calls. [[1]](diffhunk://#diff-8d80745b4e642475274e1de3100d73869664e9ed435af8f839eff86b39acbbedL13-L24) [[2]](diffhunk://#diff-051c183d6dd9938f10e13f5f9886c2c0ba8af88e23a792722c0e74d68647b1d3R22-R39) [[3]](diffhunk://#diff-c470fb14275bb3e315b8d307f8853bd149a640d936b2bb93d257e6d679262271L31-R50) [[4]](diffhunk://#diff-b0b9148f9ccd153417b286a3f470e32ca7384b1c9c6dfedc97bf476aa403e072L30-R49) [[5]](diffhunk://#diff-1b65d51221293538b65475fbb9c74fa34c839f85c758c3f61c66d46b0d18b670L27-R46)

**Step-by-Step Instructions and Examples**

* The command examples have been updated to show both steps: initiating the flow and submitting credentials, including the extraction of `flowId` and use of the `action_001` parameter. [[1]](diffhunk://#diff-8d80745b4e642475274e1de3100d73869664e9ed435af8f839eff86b39acbbedL13-L24) [[2]](diffhunk://#diff-051c183d6dd9938f10e13f5f9886c2c0ba8af88e23a792722c0e74d68647b1d3R22-R39) [[3]](diffhunk://#diff-c470fb14275bb3e315b8d307f8853bd149a640d936b2bb93d257e6d679262271L31-R50) [[4]](diffhunk://#diff-b0b9148f9ccd153417b286a3f470e32ca7384b1c9c6dfedc97bf476aa403e072L30-R49) [[5]](diffhunk://#diff-1b65d51221293538b65475fbb9c74fa34c839f85c758c3f61c66d46b0d18b670L27-R46)

**Consistency Across Guides**

* The changes have been applied consistently to the main README and all OAuth2/OIDC grant type guides, ensuring unified onboarding and setup instructions. [[1]](diffhunk://#diff-8d80745b4e642475274e1de3100d73869664e9ed435af8f839eff86b39acbbedL13-L24) [[2]](diffhunk://#diff-051c183d6dd9938f10e13f5f9886c2c0ba8af88e23a792722c0e74d68647b1d3R22-R39) [[3]](diffhunk://#diff-c470fb14275bb3e315b8d307f8853bd149a640d936b2bb93d257e6d679262271L31-R50) [[4]](diffhunk://#diff-b0b9148f9ccd153417b286a3f470e32ca7384b1c9c6dfedc97bf476aa403e072L30-R49) [[5]](diffhunk://#diff-1b65d51221293538b65475fbb9c74fa34c839f85c758c3f61c66d46b0d18b670L27-R46)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
