### PR TITLE
Add config to change min TLS version

### DIFF
--- a/backend/cmd/server/repository/conf/deployment.yaml
+++ b/backend/cmd/server/repository/conf/deployment.yaml
@@ -2,7 +2,8 @@ server:
   hostname: "localhost"
   port: 8090
 
-security:
+tls:
+  min_version: "1.3"
   cert_file: "repository/resources/security/server.cert"
   key_file: "repository/resources/security/server.key"
 

--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -11,7 +11,8 @@
     "scheme": "https",
     "path": "/gate"
   },
-  "security": {
+  "tls": {
+    "min_version": "1.3",
     "cert_file": "repository/resources/security/server.cert",
     "key_file": "repository/resources/security/server.key"
   },

--- a/backend/internal/authn/github/service_test.go
+++ b/backend/internal/authn/github/service_test.go
@@ -26,12 +26,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/idp"
+	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/user"
@@ -69,6 +71,14 @@ func (suite *GithubOAuthAuthnServiceTestSuite) SetupTest() {
 		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "GithubAuthnService")),
 	}
 	suite.service = service
+
+	thunderConfig := &config.Config{
+		TLS: config.TLSConfig{
+			MinVersion: "1.3",
+		},
+	}
+	err := config.InitializeThunderRuntime("", thunderConfig)
+	assert.NoError(suite.T(), err)
 }
 
 func (suite *GithubOAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {

--- a/backend/internal/oauth/jwks/service_test.go
+++ b/backend/internal/oauth/jwks/service_test.go
@@ -51,7 +51,7 @@ func (suite *JWKSServiceTestSuite) SetupTest() {
 
 func (suite *JWKSServiceTestSuite) setupRuntimeConfig(tlsConfig *tls.Config, certKid string) error {
 	testConfig := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: "test-cert.pem",
 			KeyFile:  "test-key.pem",
 		},

--- a/backend/internal/system/cert/system_cert_service.go
+++ b/backend/internal/system/cert/system_cert_service.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/crypto/hash"
+	"github.com/asgardeo/thunder/internal/system/http"
 )
 
 // SystemCertificateServiceInterface defines the interface for system certificate operations.
@@ -46,8 +47,8 @@ func NewSystemCertificateService() SystemCertificateServiceInterface {
 
 // GetTLSConfig loads the TLS configuration from the certificate and key files.
 func (c *systemCertificateService) GetTLSConfig(cfg *config.Config, currentDirectory string) (*tls.Config, error) {
-	certFilePath := path.Join(currentDirectory, cfg.Security.CertFile)
-	keyFilePath := path.Join(currentDirectory, cfg.Security.KeyFile)
+	certFilePath := path.Join(currentDirectory, cfg.TLS.CertFile)
+	keyFilePath := path.Join(currentDirectory, cfg.TLS.KeyFile)
 
 	// Check if the certificate and key files exist.
 	if _, err := os.Stat(certFilePath); os.IsNotExist(err) {
@@ -63,10 +64,10 @@ func (c *systemCertificateService) GetTLSConfig(cfg *config.Config, currentDirec
 		return nil, err
 	}
 
-	// Return the TLS configuration.
+	// #nosec G402 -- Min TLS version is TLS 1.2 or higher based on config
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12, // Enforce minimum TLS version 1.2
+		MinVersion:   http.GetTLSVersion(*cfg),
 	}, nil
 }
 

--- a/backend/internal/system/cert/system_cert_service_test.go
+++ b/backend/internal/system/cert/system_cert_service_test.go
@@ -66,7 +66,7 @@ func (suite *SystemCertificateServiceTestSuite) SetupSuite() {
 
 	// Create test config
 	suite.testConfig = &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: suite.certFile,
 			KeyFile:  suite.keyFile,
 		},
@@ -153,12 +153,12 @@ func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_ValidCertificat
 	suite.NoError(err)
 	suite.NotNil(tlsConfig)
 	suite.Len(tlsConfig.Certificates, 1)
-	suite.Equal(uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+	suite.Equal(uint16(tls.VersionTLS13), tlsConfig.MinVersion)
 }
 
 func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_CertificateFileNotFound() {
 	config := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: "nonexistent.crt",
 			KeyFile:  suite.keyFile,
 		},
@@ -173,7 +173,7 @@ func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_CertificateFile
 
 func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_KeyFileNotFound() {
 	config := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: suite.certFile,
 			KeyFile:  "nonexistent.key",
 		},
@@ -193,7 +193,7 @@ func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_InvalidCertific
 	suite.Require().NoError(err)
 
 	config := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: "invalid.crt",
 			KeyFile:  suite.keyFile,
 		},
@@ -212,7 +212,7 @@ func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_InvalidKeyFile(
 	suite.Require().NoError(err)
 
 	config := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: suite.certFile,
 			KeyFile:  "invalid.key",
 		},
@@ -259,7 +259,7 @@ func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_DifferentDirect
 	suite.Require().NoError(err)
 
 	config := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: suite.certFile, // relative path
 			KeyFile:  suite.keyFile,  // relative path
 		},
@@ -275,7 +275,7 @@ func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_DifferentDirect
 func (suite *SystemCertificateServiceTestSuite) TestGetTLSConfig_RelativePaths() {
 	// Test with relative paths from the temp directory
 	relativeConfig := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			CertFile: "./test.crt",
 			KeyFile:  "./test.key",
 		},
@@ -382,7 +382,7 @@ func (suite *SystemCertificateServiceTestSuite) TestIntegration_GetTLSConfigAndK
 
 	// Verify the TLS config is actually usable
 	suite.Len(tlsConfig.Certificates, 1)
-	suite.Equal(uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+	suite.Equal(uint16(tls.VersionTLS13), tlsConfig.MinVersion)
 
 	// Verify certificate data is accessible
 	certData := tlsConfig.Certificates[0].Certificate[0]

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -53,10 +53,11 @@ type GateClientConfig struct {
 	ErrorPath string `yaml:"error_path" json:"error_path"`
 }
 
-// SecurityConfig holds the security configuration details.
-type SecurityConfig struct {
-	CertFile string `yaml:"cert_file" json:"cert_file"`
-	KeyFile  string `yaml:"key_file" json:"key_file"`
+// TLSConfig holds the TLS configuration details.
+type TLSConfig struct {
+	MinVersion string `yaml:"min_version" json:"min_version"`
+	CertFile   string `yaml:"cert_file" json:"cert_file"`
+	KeyFile    string `yaml:"key_file" json:"key_file"`
 }
 
 // DataSource holds the individual database connection details.
@@ -236,7 +237,7 @@ type OrganizationUnitConfig struct {
 type Config struct {
 	Server             ServerConfig           `yaml:"server" json:"server"`
 	GateClient         GateClientConfig       `yaml:"gate_client" json:"gate_client"`
-	Security           SecurityConfig         `yaml:"security" json:"security"`
+	TLS                TLSConfig              `yaml:"tls" json:"tls"`
 	Database           DatabaseConfig         `yaml:"database" json:"database"`
 	Cache              CacheConfig            `yaml:"cache" json:"cache"`
 	JWT                JWTConfig              `yaml:"jwt" json:"jwt"`

--- a/backend/internal/system/config/runtimeconfig_test.go
+++ b/backend/internal/system/config/runtimeconfig_test.go
@@ -45,7 +45,7 @@ func (suite *RuntimeConfigTestSuite) TestInitializeThunderRuntime() {
 			Hostname: "testhost",
 			Port:     9000,
 		},
-		Security: SecurityConfig{
+		TLS: TLSConfig{
 			CertFile: "test-cert.pem",
 			KeyFile:  "test-key.pem",
 		},
@@ -60,7 +60,7 @@ func (suite *RuntimeConfigTestSuite) TestInitializeThunderRuntime() {
 	assert.Equal(suite.T(), "/test/thunder/home", runtime.ThunderHome)
 	assert.Equal(suite.T(), config.Server.Hostname, runtime.Config.Server.Hostname)
 	assert.Equal(suite.T(), config.Server.Port, runtime.Config.Server.Port)
-	assert.Equal(suite.T(), config.Security.CertFile, runtime.Config.Security.CertFile)
+	assert.Equal(suite.T(), config.TLS.CertFile, runtime.Config.TLS.CertFile)
 }
 
 func (suite *RuntimeConfigTestSuite) TestInitializeThunderRuntimeOnlyOnce() {

--- a/backend/internal/system/http/httpclient.go
+++ b/backend/internal/system/http/httpclient.go
@@ -32,10 +32,13 @@
 package http
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/asgardeo/thunder/internal/system/config"
 )
 
 // HTTPClientInterface defines the interface for HTTP client operations.
@@ -60,11 +63,7 @@ type HTTPClient struct {
 // NewHTTPClient creates a new HTTPClient with default 30-second timeout.
 // This method provides complete abstraction over http.Client references.
 func NewHTTPClient() HTTPClientInterface {
-	return &HTTPClient{
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-	}
+	return NewHTTPClientWithTimeout(30 * time.Second)
 }
 
 // NewHTTPClientWithTimeout creates a new HTTPClient with a custom timeout.
@@ -73,6 +72,12 @@ func NewHTTPClientWithTimeout(timeout time.Duration) HTTPClientInterface {
 	return &HTTPClient{
 		client: &http.Client{
 			Timeout: timeout,
+			Transport: &http.Transport{
+				// #nosec G402 -- Min TLS version is TLS 1.2 or higher based on config
+				TLSClientConfig: &tls.Config{
+					MinVersion: GetTLSVersion(config.GetThunderRuntime().Config),
+				},
+			},
 		},
 	}
 }

--- a/backend/internal/system/http/httpclient_test.go
+++ b/backend/internal/system/http/httpclient_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/asgardeo/thunder/internal/system/config"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -39,6 +41,16 @@ type HTTPClientTestSuite struct {
 // TestHTTPClientSuite runs the HTTP client test suite.
 func TestHTTPClientSuite(t *testing.T) {
 	suite.Run(t, new(HTTPClientTestSuite))
+}
+
+func (suite *HTTPClientTestSuite) SetupSuite() {
+	thunderConfig := &config.Config{
+		TLS: config.TLSConfig{
+			MinVersion: "1.3",
+		},
+	}
+	err := config.InitializeThunderRuntime("", thunderConfig)
+	assert.NoError(suite.T(), err)
 }
 
 func (suite *HTTPClientTestSuite) TestNewHTTPClient() {

--- a/backend/internal/system/http/utils.go
+++ b/backend/internal/system/http/utils.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package http
+
+import (
+	"crypto/tls"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+)
+
+// GetTLSVersion returns the appropriate TLS version constant based on the provided
+// configuration. It defaults to TLS 1.3 if the configured version is not recognized
+// or empty.
+func GetTLSVersion(config config.Config) uint16 {
+	var minTLSVersion uint16
+	switch config.TLS.MinVersion {
+	case "1.2":
+		minTLSVersion = tls.VersionTLS12
+	case "1.3":
+		minTLSVersion = tls.VersionTLS13
+	default:
+		minTLSVersion = tls.VersionTLS13 // Default to TLS 1.3 for better security
+	}
+	return minTLSVersion
+}

--- a/backend/internal/system/http/utils_test.go
+++ b/backend/internal/system/http/utils_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package http
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// UtilsTestSuite defines the test suite for HTTP utils.
+type UtilsTestSuite struct {
+	suite.Suite
+}
+
+// TestUtilsSuite runs the HTTP utils test suite.
+func TestUtilsSuite(t *testing.T) {
+	suite.Run(t, new(UtilsTestSuite))
+}
+
+func (suite *UtilsTestSuite) TestGetTLSVersion_TLS12() {
+	cfg := config.Config{
+		TLS: config.TLSConfig{
+			MinVersion: "1.2",
+		},
+	}
+
+	version := GetTLSVersion(cfg)
+	assert.Equal(suite.T(), uint16(tls.VersionTLS12), version)
+}
+
+func (suite *UtilsTestSuite) TestGetTLSVersion_TLS13() {
+	cfg := config.Config{
+		TLS: config.TLSConfig{
+			MinVersion: "1.3",
+		},
+	}
+
+	version := GetTLSVersion(cfg)
+	assert.Equal(suite.T(), uint16(tls.VersionTLS13), version)
+}
+
+func (suite *UtilsTestSuite) TestGetTLSVersion_DefaultToTLS13() {
+	cfg := config.Config{
+		TLS: config.TLSConfig{
+			MinVersion: "",
+		},
+	}
+
+	version := GetTLSVersion(cfg)
+	assert.Equal(suite.T(), uint16(tls.VersionTLS13), version)
+}
+
+func (suite *UtilsTestSuite) TestGetTLSVersion_InvalidVersionDefaultsToTLS13() {
+	cfg := config.Config{
+		TLS: config.TLSConfig{
+			MinVersion: "1.1",
+		},
+	}
+
+	version := GetTLSVersion(cfg)
+	assert.Equal(suite.T(), uint16(tls.VersionTLS13), version)
+}
+
+func (suite *UtilsTestSuite) TestGetTLSVersion_UnknownVersionDefaultsToTLS13() {
+	cfg := config.Config{
+		TLS: config.TLSConfig{
+			MinVersion: "invalid",
+		},
+	}
+
+	version := GetTLSVersion(cfg)
+	assert.Equal(suite.T(), uint16(tls.VersionTLS13), version)
+}

--- a/backend/internal/system/jwt/service.go
+++ b/backend/internal/system/jwt/service.go
@@ -77,7 +77,7 @@ func GetJWTService() JWTServiceInterface {
 // Init loads the private key from the configured file path.
 func (js *JWTService) Init() error {
 	thunderRuntime := config.GetThunderRuntime()
-	keyFilePath := path.Join(thunderRuntime.ThunderHome, thunderRuntime.Config.Security.KeyFile)
+	keyFilePath := path.Join(thunderRuntime.ThunderHome, thunderRuntime.Config.TLS.KeyFile)
 	keyFilePath = filepath.Clean(keyFilePath)
 
 	// Check if the key file exists.

--- a/backend/internal/system/jwt/service_test.go
+++ b/backend/internal/system/jwt/service_test.go
@@ -115,7 +115,7 @@ func (suite *JWTServiceTestSuite) SetupTest() {
 	}
 
 	testConfig := &config.Config{
-		Security: config.SecurityConfig{
+		TLS: config.TLSConfig{
 			KeyFile: suite.testKeyPath,
 		},
 		JWT: config.JWTConfig{
@@ -297,14 +297,14 @@ func (suite *JWTServiceTestSuite) TestInitScenarios() {
 			jwtService := &JWTService{}
 
 			thunderRuntime := config.GetThunderRuntime()
-			originalKeyFile := thunderRuntime.Config.Security.KeyFile
+			originalKeyFile := thunderRuntime.Config.TLS.KeyFile
 
 			// Ensure original config is restored regardless of test outcome
 			defer func() {
-				thunderRuntime.Config.Security.KeyFile = originalKeyFile
+				thunderRuntime.Config.TLS.KeyFile = originalKeyFile
 			}()
 
-			thunderRuntime.Config.Security.KeyFile = tc.setupFunc()
+			thunderRuntime.Config.TLS.KeyFile = tc.setupFunc()
 
 			err := jwtService.Init()
 
@@ -1647,14 +1647,14 @@ func (suite *JWTServiceTestSuite) TestInitErrorConditions() {
 			jwtService := &JWTService{}
 
 			thunderRuntime := config.GetThunderRuntime()
-			originalKeyFile := thunderRuntime.Config.Security.KeyFile
-			thunderRuntime.Config.Security.KeyFile = tc.setupFunc()
+			originalKeyFile := thunderRuntime.Config.TLS.KeyFile
+			thunderRuntime.Config.TLS.KeyFile = tc.setupFunc()
 
 			err := jwtService.Init()
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tc.expectedErrMsg)
 
-			thunderRuntime.Config.Security.KeyFile = originalKeyFile
+			thunderRuntime.Config.TLS.KeyFile = originalKeyFile
 		})
 	}
 }

--- a/backend/tests/resources/deployment.yaml
+++ b/backend/tests/resources/deployment.yaml
@@ -2,7 +2,7 @@ server:
   hostname: localhost
   port: 8080
 
-security:
+tls:
   cert_file: /path/to/cert.pem
   key_file: /path/to/key.pem
 

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -27,7 +27,8 @@ gate_client:
   login_path: {{ .Values.configuration.gateClient.loginPath | quote }}
   error_path: {{ .Values.configuration.gateClient.errorPath | quote }}
 
-security:
+tls:
+  min_version: {{ .Values.configuration.tls.minVersion | quote }}
   cert_file: {{ .Values.configuration.security.certFile | quote }}
   key_file: {{ .Values.configuration.security.keyFile | quote }}
 

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -128,8 +128,9 @@ configuration:
     clientId: "DEVELOP"
     scopes: "['openid', 'profile', 'email', 'system']"
 
-  # Security configuration
-  security:
+  # TLS configuration
+  tls:
+    minVersion: "1.3"
     certFile: "repository/resources/security/server.cert"
     keyFile: "repository/resources/security/server.key"
 

--- a/install/openchoreo/helm/templates/thunder-component.yaml
+++ b/install/openchoreo/helm/templates/thunder-component.yaml
@@ -56,7 +56,8 @@ spec:
             login_path: "/login"
             error_path: "/error"
 
-          security:
+          tls:
+            min_version: "1.3"
             cert_file: "repository/resources/security/server.cert"
             key_file: "repository/resources/security/server.key"
 

--- a/tests/integration/resources/deployment.yaml
+++ b/tests/integration/resources/deployment.yaml
@@ -2,7 +2,7 @@ server:
   hostname: "localhost"
   port: 8095
 
-security:
+tls:
   cert_file: "repository/resources/security/server.cert"
   key_file: "repository/resources/security/server.key"
 

--- a/tests/integration/resources/scripts/setup-test-config.sh
+++ b/tests/integration/resources/scripts/setup-test-config.sh
@@ -8,7 +8,7 @@ server:
   port: 8095
 
 
-security:
+tls:
   cert_file: "repository/resources/security/server.cert"
   key_file: "repository/resources/security/server.key"
 


### PR DESCRIPTION
### Purpose
This pull request refactors the configuration for TLS across the backend, replacing the old `SecurityConfig` with a new `TLSConfig` structure and updating all relevant usages. It also enforces a minimum TLS version (defaulting to 1.3 for improved security), centralizes TLS version logic in a new utility, and ensures that all code and tests reflect these changes. The update enhances security and maintainability by standardizing TLS configuration and making the minimum version explicit and configurable.

**Configuration Refactor and Security Improvements**

* Replaced `SecurityConfig` with `TLSConfig` in the main configuration struct (`Config`), updating all references and usages throughout the codebase and configuration files to use the new structure and field names.
* Enforced a configurable minimum TLS version (defaulting to TLS 1.3) for both server and client connections, updating TLS initialization logic to use the new config value.
* Added a new utility function `GetTLSVersion` in `backend/internal/system/http/utils.go` to centralize and standardize TLS version selection based on configuration, with comprehensive unit tests in `utils_test.go`. 

**Test and Usage Updates**

* Updated all relevant tests and test setup to use `TLSConfig` instead of `SecurityConfig`, and verified that the correct minimum TLS version is enforced in both certificate and HTTP client tests.
* Refactored JWT and certificate service logic to use the new `TLSConfig` fields for key and certificate file paths, ensuring compatibility and correctness.

**Other Codebase Improvements**

* Updated HTTP client construction to use the new TLS version logic, ensuring all outgoing requests use at least the configured minimum TLS version.
* Added missing imports and setup logic in test files to support the new configuration structure and runtime initialization. 

---
### ⚠️ Breaking Changes

1. This PR introduces a **breaking change** by changing the config name related to TLS certificated.

- `security.cert_file` → `tls.cert_file`
- `security.key_file` → `tls.key_file`

2. This PR introduces a **breaking change** by changing the minimum TLS version to 1.3.

#### Impact

- **TLS certs** : Consumers must update the deployment configurations as mentioned above.
- **TLS version** : Add the following config to keep using TLS 1.2 as min version.

```yml
tls:
    min_version: "1.2"
``` 

---

### Approach
- Set default minimum TLS vetsion as 1.3
- Rename Security config to TLS

### Related Issues
- https://github.com/asgardeo/thunder/issues/473

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
