### PR TITLE
Fix i18n message overriding precedence

### DIFF
--- a/backend/internal/system/i18n/mgt/file_based_store.go
+++ b/backend/internal/system/i18n/mgt/file_based_store.go
@@ -147,10 +147,6 @@ func (f *fileBasedStore) GetTranslationsByKey(key string, namespace string) (map
 		}
 	}
 
-	if len(translations) == 0 {
-		return nil, nil // Return nil map if no translations found, matching db store behavior
-	}
-
 	return translations, nil
 }
 

--- a/backend/internal/system/i18n/mgt/file_based_store_test.go
+++ b/backend/internal/system/i18n/mgt/file_based_store_test.go
@@ -201,12 +201,14 @@ func (s *FileBasedStoreTestSuite) TestGetTranslationsByKey_NotFound() {
 	// Wrong key
 	translations, err := s.store.GetTranslationsByKey("key2", "ns1")
 	assert.NoError(s.T(), err)
-	assert.Nil(s.T(), translations)
+	assert.NotNil(s.T(), translations)
+	assert.Empty(s.T(), translations)
 
 	// Wrong namespace
 	translations, err = s.store.GetTranslationsByKey("key1", "ns2")
 	assert.NoError(s.T(), err)
-	assert.Nil(s.T(), translations)
+	assert.NotNil(s.T(), translations)
+	assert.Empty(s.T(), translations)
 }
 
 func (s *FileBasedStoreTestSuite) TestIsTranslationExists() {

--- a/backend/internal/system/i18n/mgt/store.go
+++ b/backend/internal/system/i18n/mgt/store.go
@@ -130,10 +130,6 @@ func (s *i18nStore) GetTranslationsByKey(key string, namespace string) (map[stri
 		return nil, fmt.Errorf("failed to get translation: %w", err)
 	}
 
-	if len(results) == 0 {
-		return nil, nil
-	}
-
 	return buildTranslationsMap(results)
 }
 

--- a/backend/internal/system/i18n/mgt/store_test.go
+++ b/backend/internal/system/i18n/mgt/store_test.go
@@ -150,9 +150,9 @@ func (suite *I18nStoreTestSuite) TestGetTranslationsByKey_NotFound() {
 		Return([]map[string]interface{}{}, nil)
 
 	trans, err := suite.store.GetTranslationsByKey("k1", "ns1")
-
 	suite.NoError(err)
-	suite.Nil(trans)
+	suite.NotNil(trans)
+	suite.Empty(trans)
 }
 
 // UpsertTranslation Tests


### PR DESCRIPTION
### Purpose

This pull request refactors how translations for i18n keys in system namespace are handled. 
System default translations are now set as fallbacks for system language when custom overrides in system language are missing, both for single-key and bulk translation resolution. 

### Approach

* In `ResolveTranslationsForKey`, if a custom override for the system language is missing and the namespace is `system`, the code now automatically falls back to the default system translation for that key. This replaces the previous approach, which checked for system defaults only after failing to find a translation in the database.
* In `ResolveTranslations`, system default translations are now merged into the result set for all keys when the namespace is empty or set to `system`, ensuring that any missing custom translations are filled in by the system defaults.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1022

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
