### PR TITLE
Add admin-initiated user registration flow support

### DIFF
--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -1,0 +1,207 @@
+{
+    "name": "User Onboarding Flow",
+    "handle": "default-user-onboarding",
+    "flowType": "USER_ONBOARDING",
+    "nodes": [
+        {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "permission_validator"
+        },
+        {
+            "id": "permission_validator",
+            "type": "TASK_EXECUTION",
+            "properties": {
+                "requiredScopes": [
+                    "system"
+                ]
+            },
+            "executor": {
+                "name": "PermissionValidator"
+            },
+            "onSuccess": "user_type_resolver"
+        },
+        {
+            "id": "user_type_resolver",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "UserTypeResolver"
+            },
+            "onSuccess": "prompt_user_details"
+        },
+        {
+            "id": "prompt_user_details",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "type": "TEXT",
+                        "id": "text_header_details",
+                        "label": "User Details",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "BLOCK",
+                        "id": "block_user_details",
+                        "components": [
+                            {
+                                "id": "input_prompt_001",
+                                "ref": "username",
+                                "type": "TEXT_INPUT",
+                                "label": "Username",
+                                "required": true,
+                                "placeholder": "Enter username"
+                            },
+                            {
+                                "id": "input_prompt_002",
+                                "ref": "email",
+                                "type": "EMAIL_INPUT",
+                                "label": "Email",
+                                "required": true,
+                                "placeholder": "Enter email"
+                            },
+                            {
+                                "type": "ACTION",
+                                "id": "action_submit_details",
+                                "label": "Next",
+                                "variant": "PRIMARY",
+                                "eventType": "SUBMIT"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "prompts": [
+                {
+                    "inputs": [
+                        {
+                            "ref": "input_prompt_001",
+                            "identifier": "username",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_prompt_002",
+                            "identifier": "email",
+                            "type": "EMAIL_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_submit_details",
+                        "nextNode": "provisioning"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "provisioning",
+            "type": "TASK_EXECUTION",
+            "inputs": [
+                {
+                    "ref": "input_001",
+                    "identifier": "username",
+                    "type": "TEXT_INPUT",
+                    "required": true
+                },
+                {
+                    "ref": "input_002",
+                    "identifier": "email",
+                    "type": "TEXT_INPUT",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "ProvisioningExecutor"
+            },
+            "onSuccess": "invite"
+        },
+        {
+            "id": "invite",
+            "type": "TASK_EXECUTION",
+            "inputs": [
+                {
+                    "ref": "input_003",
+                    "identifier": "inviteToken",
+                    "type": "HIDDEN",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "InviteExecutor"
+            },
+            "onSuccess": "prompt_credential"
+        },
+        {
+            "id": "prompt_credential",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "type": "TEXT",
+                        "id": "text_header_pwd",
+                        "label": "Set Password",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "BLOCK",
+                        "id": "block_pwd",
+                        "components": [
+                            {
+                                "id": "input_prompt_003",
+                                "ref": "password",
+                                "type": "PASSWORD_INPUT",
+                                "label": "Password",
+                                "required": true,
+                                "placeholder": "Enter password"
+                            },
+                            {
+                                "type": "ACTION",
+                                "id": "action_submit_pwd",
+                                "label": "Set Password",
+                                "variant": "PRIMARY",
+                                "eventType": "SUBMIT"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "prompts": [
+                {
+                    "inputs": [
+                        {
+                            "ref": "input_prompt_003",
+                            "identifier": "password",
+                            "type": "PASSWORD_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_submit_pwd",
+                        "nextNode": "credential_setter"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "credential_setter",
+            "type": "TASK_EXECUTION",
+            "inputs": [
+                {
+                    "ref": "input_004",
+                    "identifier": "password",
+                    "type": "PASSWORD_INPUT",
+                    "required": true
+                }
+            ],
+            "executor": {
+                "name": "CredentialSetter"
+            },
+            "onSuccess": "end"
+        },
+        {
+            "id": "end",
+            "type": "END"
+        }
+    ]
+}

--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -85,6 +85,7 @@
   },
   "flow": {
     "default_auth_flow_handle": "default-basic-flow",
+    "user_onboarding_flow_handle": "default-user-onboarding",
     "max_version_history": 10,
     "auto_infer_registration": true
   },

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -29,6 +29,8 @@ const (
 	FlowTypeAuthentication FlowType = "AUTHENTICATION"
 	// FlowTypeRegistration represents a flow execution for user registration.
 	FlowTypeRegistration FlowType = "REGISTRATION"
+	// FlowTypeUserOnboarding represents an admin-initiated user onboarding flow.
+	FlowTypeUserOnboarding FlowType = "USER_ONBOARDING"
 )
 
 // FlowStatus defines the status of a flow execution.

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -155,9 +155,6 @@ func (e *executor) GetUserIDFromContext(ctx *NodeContext) string {
 	if userID == "" {
 		userID = ctx.RuntimeData[userAttributeUserID]
 	}
-	if userID == "" {
-		userID = ctx.UserInputs[userAttributeUserID]
-	}
 
 	return userID
 }

--- a/backend/internal/flow/core/executor_test.go
+++ b/backend/internal/flow/core/executor_test.go
@@ -283,13 +283,6 @@ func (s *ExecutorTestSuite) TestGetUserIDFromContext() {
 			"user-456",
 		},
 		{
-			"UserID from user inputs",
-			authncm.AuthenticatedUser{},
-			map[string]string{},
-			map[string]string{userAttributeUserID: "user-789"},
-			"user-789",
-		},
-		{
 			"Priority: authenticated user over runtime data",
 			authncm.AuthenticatedUser{UserID: "user-auth"},
 			map[string]string{userAttributeUserID: "user-runtime"},

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -43,6 +43,7 @@ type NodeContext struct {
 	UserInputs     map[string]string
 	RuntimeData    map[string]string
 
+	HTTPContext       context.Context
 	Application       appmodel.Application
 	AuthenticatedUser authncm.AuthenticatedUser
 	ExecutionHistory  map[string]*common.NodeExecutionRecord

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -22,20 +22,23 @@ import "github.com/asgardeo/thunder/internal/flow/common"
 
 // Executor name constants
 const (
-	ExecutorNameBasicAuth        = "BasicAuthExecutor"
-	ExecutorNameSMSAuth          = "SMSOTPAuthExecutor"
-	ExecutorNameOAuth            = "OAuthExecutor"
-	ExecutorNameOIDCAuth         = "OIDCAuthExecutor"
-	ExecutorNameGitHubAuth       = "GithubOAuthExecutor"
-	ExecutorNameGoogleAuth       = "GoogleOIDCAuthExecutor"
-	ExecutorNameIdentifying      = "IdentifyingExecutor"
-	ExecutorNameAuthAssert       = "AuthAssertExecutor"
-	ExecutorNameProvisioning     = "ProvisioningExecutor"
-	ExecutorNameAttributeCollect = "AttributeCollector"
-	ExecutorNameAuthorization    = "AuthorizationExecutor"
-	ExecutorNameOUCreation       = "OUExecutor"
-	ExecutorNameHTTPRequest      = "HTTPRequestExecutor"
-	ExecutorNameUserTypeResolver = "UserTypeResolver"
+	ExecutorNameBasicAuth           = "BasicAuthExecutor"
+	ExecutorNameSMSAuth             = "SMSOTPAuthExecutor"
+	ExecutorNameOAuth               = "OAuthExecutor"
+	ExecutorNameOIDCAuth            = "OIDCAuthExecutor"
+	ExecutorNameGitHubAuth          = "GithubOAuthExecutor"
+	ExecutorNameGoogleAuth          = "GoogleOIDCAuthExecutor"
+	ExecutorNameIdentifying         = "IdentifyingExecutor"
+	ExecutorNameAuthAssert          = "AuthAssertExecutor"
+	ExecutorNameProvisioning        = "ProvisioningExecutor"
+	ExecutorNameAttributeCollect    = "AttributeCollector"
+	ExecutorNameAuthorization       = "AuthorizationExecutor"
+	ExecutorNamePermissionValidator = "PermissionValidator"
+	ExecutorNameOUCreation          = "OUExecutor"
+	ExecutorNameHTTPRequest         = "HTTPRequestExecutor"
+	ExecutorNameUserTypeResolver    = "UserTypeResolver"
+	ExecutorNameInviteExecutor      = "InviteExecutor"
+	ExecutorNameCredentialSetter    = "CredentialSetter"
 )
 
 // User attribute and input constants
@@ -48,11 +51,12 @@ const (
 	userAttributeGroups       = "groups"
 	userAttributeSub          = "sub"
 
-	userInputCode     = "code"
-	userInputNonce    = "nonce"
-	userInputOuName   = "ouName"
-	userInputOuHandle = "ouHandle"
-	userInputOuDesc   = "ouDescription"
+	userInputCode        = "code"
+	userInputNonce       = "nonce"
+	userInputOuName      = "ouName"
+	userInputOuHandle    = "ouHandle"
+	userInputOuDesc      = "ouDescription"
+	userInputInviteToken = "inviteToken"
 
 	ouIDKey        = "ouId"
 	defaultOUIDKey = "defaultOUID"
@@ -63,8 +67,9 @@ const (
 
 // Executor property keys
 const (
-	propertyKeyAssignGroup = "assignGroup"
-	propertyKeyAssignRole  = "assignRole"
+	propertyKeyAssignGroup    = "assignGroup"
+	propertyKeyAssignRole     = "assignRole"
+	propertyKeyRequiredScopes = "requiredScopes"
 )
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.
@@ -74,9 +79,11 @@ var nonSearchableInputs = []string{"password", "code", "nonce", "otp"}
 var nonUserAttributes = []string{"userID", "code", "nonce", "state", "flowID",
 	"otp", "attemptCount", "expiryTimeInMillis", "otpSessionToken", "value",
 	"authorized_permissions", "requested_permissions",
-	userTypeKey, ouIDKey, defaultOUIDKey, userInputOuName, userInputOuHandle, userInputOuDesc,
+	userTypeKey, ouIDKey, defaultOUIDKey, userInputOuName, userInputOuHandle, userInputOuDesc, userInputInviteToken,
 	common.RuntimeKeyUserEligibleForProvisioning, common.RuntimeKeySkipProvisioning,
-	common.RuntimeKeyUserAutoProvisioned}
+	common.RuntimeKeyUserAutoProvisioned, runtimeKeyStoredInviteToken}
+
+const runtimeKeyStoredInviteToken = "storedInviteToken"
 
 // Failure reason constants
 const (

--- a/backend/internal/flow/executor/credential_setter.go
+++ b/backend/internal/flow/executor/credential_setter.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"encoding/json"
+
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/user"
+)
+
+// credentialSetter allows users to set their credentials for an existing user account.
+type credentialSetter struct {
+	core.ExecutorInterface
+	userService user.UserServiceInterface
+	logger      *log.Logger
+}
+
+// newCredentialSetter creates a new instance of the credential setter executor.
+func newCredentialSetter(
+	flowFactory core.FlowFactoryInterface,
+	userService user.UserServiceInterface,
+) *credentialSetter {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CredentialSetter"))
+	base := flowFactory.CreateExecutor(
+		ExecutorNameCredentialSetter,
+		common.ExecutorTypeRegistration,
+		[]common.Input{
+			{
+				Identifier: userAttributePassword,
+				Type:       "PASSWORD_INPUT",
+				Required:   true,
+			},
+		},
+		[]common.Input{
+			{
+				Identifier: userAttributeUserID,
+				Type:       "TEXT",
+				Required:   true,
+			},
+		},
+	)
+	return &credentialSetter{
+		ExecutorInterface: base,
+		userService:       userService,
+		logger:            logger,
+	}
+}
+
+// Execute sets the password for the user identified by userID in RuntimeData.
+func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Executing credential set")
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// Check if password is provided
+	if !e.HasRequiredInputs(ctx, execResp) {
+		logger.Debug("Requested credentials not provided, requesting input")
+		execResp.Status = common.ExecUserInputRequired
+		return execResp, nil
+	}
+
+	// Validate prerequisites
+	if !e.ValidatePrerequisites(ctx, execResp) {
+		logger.Debug("Prerequisites not met for credential setter")
+		return execResp, nil
+	}
+
+	// Get userID from context
+	userID := e.GetUserIDFromContext(ctx)
+	if userID == "" {
+		logger.Debug("User ID not found in flow context")
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "User ID not found in flow context"
+		return execResp, nil
+	}
+
+	var credentialKey, credentialValue string
+	requiredInputs := e.GetRequiredInputs(ctx)
+	if len(requiredInputs) == 0 {
+		logger.Debug("No required inputs configured for credential setter")
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "No credential input configured for credential setter"
+		return execResp, nil
+	}
+
+	input := requiredInputs[0]
+	credentialKey = input.Identifier
+	if credentialKey == "" {
+		logger.Debug("Required input has empty identifier in credential setter")
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Invalid credential input configuration"
+		return execResp, nil
+	}
+	credentialValue = ctx.UserInputs[credentialKey]
+
+	if credentialValue == "" {
+		logger.Debug("Credential value is empty", log.String("credentialKey", credentialKey))
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Credential value cannot be empty"
+		return execResp, nil
+	}
+
+	// Build credentials
+	credentials, err := json.Marshal(map[string]string{
+		credentialKey: credentialValue,
+	})
+	if err != nil {
+		logger.Debug("Failed to marshal credentials", log.Error(err))
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Failed to process credentials"
+		return execResp, nil
+	}
+
+	// Update user credentials
+	svcErr := e.userService.UpdateUserCredentials(userID, credentials)
+	if svcErr != nil {
+		logger.Debug("Failed to update user credentials", log.String("userID", userID))
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Failed to set credentials"
+		return execResp, nil
+	}
+
+	logger.Debug("Successfully set credentials for user", log.String("userID", userID))
+	execResp.Status = common.ExecComplete
+	return execResp, nil
+}

--- a/backend/internal/flow/executor/credential_setter_test.go
+++ b/backend/internal/flow/executor/credential_setter_test.go
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+)
+
+type CredentialSetterTestSuite struct {
+	suite.Suite
+	mockFlowFactory  *coremock.FlowFactoryInterfaceMock
+	mockUserService  *usermock.UserServiceInterfaceMock
+	mockBaseExecutor *coremock.ExecutorInterfaceMock
+	executor         *credentialSetter
+}
+
+func (suite *CredentialSetterTestSuite) SetupTest() {
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockBaseExecutor = coremock.NewExecutorInterfaceMock(suite.T())
+
+	suite.mockFlowFactory.On("CreateExecutor",
+		ExecutorNameCredentialSetter,
+		common.ExecutorTypeRegistration,
+		mock.Anything,
+		[]common.Input{
+			{
+				Identifier: userAttributeUserID,
+				Type:       "TEXT",
+				Required:   true,
+			},
+		}).Return(suite.mockBaseExecutor)
+
+	suite.executor = newCredentialSetter(suite.mockFlowFactory, suite.mockUserService)
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_Success() {
+	userID := testUserID
+	password := "securePass123!"
+	ctx := &core.NodeContext{
+		FlowID: "test-flow",
+		UserInputs: map[string]string{
+			userAttributePassword: password,
+		},
+		RuntimeData: map[string]string{
+			"userID": userID,
+		},
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("ValidatePrerequisites", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("GetUserIDFromContext", ctx).Return(userID)
+	suite.mockBaseExecutor.On("GetRequiredInputs", ctx).Return([]common.Input{
+		{
+			Identifier: userAttributePassword,
+			Type:       "PASSWORD_INPUT",
+			Required:   true,
+		},
+	})
+
+	// Use mock.Anything for credentials JSON bytes to avoid strict byte checking
+	suite.mockUserService.On("UpdateUserCredentials", userID, mock.Anything).Return(nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_MissingInput() {
+	ctx := &core.NodeContext{
+		FlowID:     "test-flow",
+		UserInputs: make(map[string]string),
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(false)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_MissingUserID() {
+	ctx := &core.NodeContext{
+		FlowID: "test-flow",
+		UserInputs: map[string]string{
+			userAttributePassword: "password",
+		},
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("ValidatePrerequisites", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("GetUserIDFromContext", ctx).Return("")
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "User ID not found in flow context", resp.FailureReason)
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_EmptyPassword() {
+	userID := testUserID
+	ctx := &core.NodeContext{
+		FlowID: "test-flow",
+		UserInputs: map[string]string{
+			userAttributePassword: "",
+		},
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("ValidatePrerequisites", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("GetUserIDFromContext", ctx).Return(userID)
+	suite.mockBaseExecutor.On("GetRequiredInputs", ctx).Return([]common.Input{
+		{
+			Identifier: userAttributePassword,
+			Type:       "PASSWORD_INPUT",
+			Required:   true,
+		},
+	})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Credential value cannot be empty", resp.FailureReason)
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_ServiceError() {
+	userID := testUserID
+	password := "password"
+	ctx := &core.NodeContext{
+		FlowID: "test-flow",
+		UserInputs: map[string]string{
+			userAttributePassword: password,
+		},
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("ValidatePrerequisites", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("GetUserIDFromContext", ctx).Return(userID)
+	suite.mockBaseExecutor.On("GetRequiredInputs", ctx).Return([]common.Input{
+		{
+			Identifier: userAttributePassword,
+			Type:       "PASSWORD_INPUT",
+			Required:   true,
+		},
+	})
+
+	suite.mockUserService.On("UpdateUserCredentials", userID, mock.Anything).
+		Return(&serviceerror.ServiceError{Error: "db error"})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Failed to set credentials", resp.FailureReason)
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_CustomAttribute() {
+	userID := testUserID
+	customAttr := "pin"
+	pinValue := "1234"
+
+	ctx := &core.NodeContext{
+		FlowID: "test-flow",
+		UserInputs: map[string]string{
+			customAttr: pinValue,
+		},
+		RuntimeData: map[string]string{
+			"userID": userID,
+		},
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("ValidatePrerequisites", mock.Anything, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("GetUserIDFromContext", mock.Anything).Return(userID)
+
+	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{
+			Identifier: customAttr,
+			Required:   true,
+			Type:       "TEXT",
+		},
+	})
+
+	// Expect UpdateUserCredentials with custom attribute
+	expectedCredentialsJSON := `{"pin":"1234"}` //nolint:gosec // G101: This is test data, not a real credential
+	suite.mockUserService.On("UpdateUserCredentials", userID, mock.MatchedBy(func(data []byte) bool {
+		return string(data) == expectedCredentialsJSON
+	})).Return(nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_NoRequiredInputs() {
+	userID := testUserID
+	ctx := &core.NodeContext{
+		FlowID: "test-flow",
+		UserInputs: map[string]string{
+			userAttributePassword: "password",
+		},
+		RuntimeData: map[string]string{
+			"userID": userID,
+		},
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("ValidatePrerequisites", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("GetUserIDFromContext", ctx).Return(userID)
+	suite.mockBaseExecutor.On("GetRequiredInputs", ctx).Return([]common.Input{})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, "No credential input configured")
+}
+
+func (suite *CredentialSetterTestSuite) TestExecute_EmptyInputIdentifier() {
+	userID := testUserID
+	ctx := &core.NodeContext{
+		FlowID: "test-flow",
+		UserInputs: map[string]string{
+			userAttributePassword: "password",
+		},
+		RuntimeData: map[string]string{
+			"userID": userID,
+		},
+	}
+
+	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("ValidatePrerequisites", ctx, mock.Anything).Return(true)
+	suite.mockBaseExecutor.On("GetUserIDFromContext", ctx).Return(userID)
+	suite.mockBaseExecutor.On("GetRequiredInputs", ctx).Return([]common.Input{
+		{
+			Identifier: "",
+			Type:       "PASSWORD_INPUT",
+			Required:   true,
+		},
+	})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, "Invalid credential input configuration")
+}
+
+func TestCredentialSetterSuite(t *testing.T) {
+	suite.Run(t, new(CredentialSetterTestSuite))
+}

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -76,6 +76,9 @@ func Initialize(
 	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService))
 	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory))
 	reg.RegisterExecutor(ExecutorNameUserTypeResolver, newUserTypeResolver(flowFactory, userSchemaService))
+	reg.RegisterExecutor(ExecutorNameInviteExecutor, newInviteExecutor(flowFactory))
+	reg.RegisterExecutor(ExecutorNameCredentialSetter, newCredentialSetter(flowFactory, userService))
+	reg.RegisterExecutor(ExecutorNamePermissionValidator, newPermissionValidator(flowFactory))
 
 	return reg
 }

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"fmt"
+
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/utils"
+)
+
+// inviteExecutor generates an invite link for the user to complete registration.
+type inviteExecutor struct {
+	core.ExecutorInterface
+	logger *log.Logger
+}
+
+// newInviteExecutor creates a new instance of the invite executor.
+func newInviteExecutor(flowFactory core.FlowFactoryInterface) *inviteExecutor {
+	defaultInputs := []common.Input{
+		{
+			Identifier: userInputInviteToken,
+			Type:       "HIDDEN",
+			Required:   true,
+		},
+	}
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InviteExecutor"))
+	base := flowFactory.CreateExecutor(
+		ExecutorNameInviteExecutor,
+		common.ExecutorTypeUtility,
+		defaultInputs,
+		[]common.Input{},
+	)
+	return &inviteExecutor{
+		ExecutorInterface: base,
+		logger:            logger,
+	}
+}
+
+// Execute generates the invite link and returns it in AdditionalData.
+func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Executing invite executor")
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// Check if inviteToken is provided by the user
+	if !e.HasRequiredInputs(ctx, execResp) {
+		inviteToken, err := e.getOrGenerateToken(ctx)
+		if err != nil {
+			logger.Debug("Failed to get or generate invite token", log.Error(err))
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "Failed to generate invite token"
+			return execResp, nil
+		}
+
+		inviteLink := e.generateInviteLink(ctx, inviteToken)
+
+		// Store the token for validation and return the link
+		execResp.RuntimeData[runtimeKeyStoredInviteToken] = inviteToken
+		execResp.AdditionalData["inviteLink"] = inviteLink
+
+		execResp.Status = common.ExecUserInputRequired
+		return execResp, nil
+	}
+
+	// User has provided the invite token, validate it against stored token
+	inviteTokenInput := ctx.UserInputs[userInputInviteToken]
+	storedToken, hasStoredToken := ctx.RuntimeData[runtimeKeyStoredInviteToken]
+
+	if !hasStoredToken {
+		logger.Debug("No invite token found in runtime data")
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Invalid invite token"
+		return execResp, nil
+	}
+
+	if inviteTokenInput != storedToken {
+		logger.Debug("Invite token mismatch", log.String("flowId", ctx.FlowID))
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Invalid invite token"
+		return execResp, nil
+	}
+
+	logger.Debug("Invite token validated successfully")
+	execResp.Status = common.ExecComplete
+	return execResp, nil
+}
+
+// getOrGenerateToken retrieves the existing invite token from runtime data or generates a new one.
+func (e *inviteExecutor) getOrGenerateToken(ctx *core.NodeContext) (string, error) {
+	if storedToken, exists := ctx.RuntimeData[runtimeKeyStoredInviteToken]; exists && storedToken != "" {
+		return storedToken, nil
+	}
+
+	return utils.GenerateUUIDv7()
+}
+
+// generateInviteLink constructs the invite link using the GateClient configuration.
+func (e *inviteExecutor) generateInviteLink(ctx *core.NodeContext, inviteToken string) string {
+	gateConfig := config.GetThunderRuntime().Config.GateClient
+	gateAppURL := fmt.Sprintf("%s://%s:%d%s",
+		gateConfig.Scheme,
+		gateConfig.Hostname,
+		gateConfig.Port,
+		gateConfig.Path)
+
+	return fmt.Sprintf("%s?flowId=%s&inviteToken=%s", gateAppURL, ctx.FlowID, inviteToken)
+}

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+)
+
+type InviteExecutorTestSuite struct {
+	suite.Suite
+	mockFlowFactory *coremock.FlowFactoryInterfaceMock
+	executor        *inviteExecutor
+}
+
+func (suite *InviteExecutorTestSuite) SetupTest() {
+	// Initialize runtime config for tests
+	err := config.InitializeThunderRuntime(".", &config.Config{
+		GateClient: config.GateClientConfig{
+			Scheme:   "https",
+			Hostname: "localhost",
+			Port:     5190,
+			Path:     "/gate",
+		},
+	})
+	suite.Require().NoError(err)
+
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockBaseExecutor := coremock.NewExecutorInterfaceMock(suite.T())
+
+	// Set up expectations for CreateExecutor (called in constructor)
+	suite.mockFlowFactory.On("CreateExecutor",
+		ExecutorNameInviteExecutor,
+		common.ExecutorTypeUtility,
+		[]common.Input{
+			{
+				Identifier: userInputInviteToken,
+				Type:       "HIDDEN",
+				Required:   true,
+			},
+		},
+		[]common.Input{}).Return(mockBaseExecutor)
+
+	suite.executor = newInviteExecutor(suite.mockFlowFactory)
+}
+
+func (suite *InviteExecutorTestSuite) TearDownTest() {
+	config.ResetThunderRuntime()
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_GenerateToken_AdminPhase() {
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow-id",
+		UserInputs:  make(map[string]string),
+		RuntimeData: make(map[string]string),
+	}
+
+	mockExecutor := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(false)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.NotEmpty(suite.T(), resp.RuntimeData[runtimeKeyStoredInviteToken])
+	assert.Contains(suite.T(), resp.AdditionalData["inviteLink"], "inviteToken=")
+	assert.Contains(suite.T(), resp.AdditionalData["inviteLink"], "flowId=test-flow-id")
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_Idempotency_AdminRetry() {
+	existingToken := "existing-token-123"
+	ctx := &core.NodeContext{
+		FlowID:     "test-flow-id",
+		UserInputs: make(map[string]string),
+		RuntimeData: map[string]string{
+			runtimeKeyStoredInviteToken: existingToken,
+		},
+	}
+
+	mockExecutor := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(false)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), existingToken, resp.RuntimeData[runtimeKeyStoredInviteToken])
+	assert.Contains(suite.T(), resp.AdditionalData["inviteLink"], existingToken)
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_ValidationSuccess_UserPhase() {
+	token := "valid-token"
+	ctx := &core.NodeContext{
+		FlowID: "test-flow-id",
+		UserInputs: map[string]string{
+			userInputInviteToken: token,
+		},
+		RuntimeData: map[string]string{
+			runtimeKeyStoredInviteToken: token,
+		},
+	}
+
+	mockExecutor := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_ValidationFailure_Mismatch() {
+	ctx := &core.NodeContext{
+		FlowID: "test-flow-id",
+		UserInputs: map[string]string{
+			userInputInviteToken: "wrong-token",
+		},
+		RuntimeData: map[string]string{
+			runtimeKeyStoredInviteToken: "correct-token",
+		},
+	}
+
+	mockExecutor := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Invalid invite token", resp.FailureReason)
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_ValidationFailure_NoStoredToken() {
+	ctx := &core.NodeContext{
+		FlowID: "test-flow-id",
+		UserInputs: map[string]string{
+			userInputInviteToken: "some-token",
+		},
+		RuntimeData: make(map[string]string),
+	}
+
+	mockExecutor := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(true)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Invalid invite token", resp.FailureReason)
+}
+
+func TestInviteExecutorSuite(t *testing.T) {
+	suite.Run(t, new(InviteExecutorTestSuite))
+}

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/security"
+)
+
+const (
+	defaultRequiredScope = "system"
+)
+
+// permissionValidator validates that the request has the required permission/scope to access the next node.
+type permissionValidator struct {
+	core.ExecutorInterface
+	logger *log.Logger
+}
+
+// newPermissionValidator creates a new permission validator executor.
+func newPermissionValidator(flowFactory core.FlowFactoryInterface) *permissionValidator {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "PermissionValidator"))
+	base := flowFactory.CreateExecutor(
+		ExecutorNamePermissionValidator,
+		common.ExecutorTypeUtility,
+		[]common.Input{},
+		[]common.Input{},
+	)
+	return &permissionValidator{
+		ExecutorInterface: base,
+		logger:            logger,
+	}
+}
+
+// Execute validates that the request has the required permission/scope to access the next node.
+func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// Get required scopes from node properties.
+	requiredScopes := e.getRequiredScopes(ctx)
+
+	logger.Debug("Checking scope protection", log.Any("requiredScopes", requiredScopes))
+
+	// Check if HTTP context exists
+	if ctx.HTTPContext == nil {
+		logger.Debug("No HTTP context available - blocking access")
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Insufficient permissions"
+		return execResp, nil
+	}
+
+	// Extract scopes from HTTP request context
+	userScopes := extractScopesFromHTTPContext(ctx.HTTPContext)
+	logger.Debug("Extracted scopes from HTTP context",
+		log.Int("scopeCount", len(userScopes)),
+		log.String("scopes", strings.Join(userScopes, ", ")))
+
+	// Check if any of the required scopes are present
+	if !slices.ContainsFunc(requiredScopes, func(reqScope string) bool {
+		return slices.Contains(userScopes, reqScope)
+	}) {
+		logger.Debug("Request lacks required scope",
+			log.Any("requiredScopes", requiredScopes))
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Insufficient permissions"
+		return execResp, nil
+	}
+
+	logger.Debug("Scope protection passed", log.Any("requiredScopes", requiredScopes))
+	execResp.Status = common.ExecComplete
+	return execResp, nil
+}
+
+// getRequiredScopes retrieves the required scopes from the node context properties.
+func (e *permissionValidator) getRequiredScopes(ctx *core.NodeContext) []string {
+	requiredScopes := []string{defaultRequiredScope}
+
+	if ctx.NodeProperties != nil {
+		if val, exists := ctx.NodeProperties[propertyKeyRequiredScopes]; exists {
+			if v, ok := val.([]interface{}); ok {
+				scopes := make([]string, 0, len(v))
+				for _, item := range v {
+					if s, ok := item.(string); ok && s != "" {
+						scopes = append(scopes, s)
+					}
+				}
+
+				if len(scopes) > 0 {
+					requiredScopes = scopes
+				}
+			}
+		}
+	}
+
+	return requiredScopes
+}
+
+// extractScopesFromHTTPContext extracts scopes/permissions from the HTTP request context.
+// It checks for scope, scopes and authorized_permissions claims.
+func extractScopesFromHTTPContext(httpCtx context.Context) []string {
+	if scopeAttr := security.GetAttribute(httpCtx, "scope"); scopeAttr != nil {
+		if scopeStr, ok := scopeAttr.(string); ok && scopeStr != "" {
+			return strings.Fields(scopeStr)
+		}
+	}
+
+	if scopesAttr := security.GetAttribute(httpCtx, "scopes"); scopesAttr != nil {
+		if scopes, ok := scopesAttr.([]string); ok {
+			return scopes
+		}
+
+		if scopesInterface, ok := scopesAttr.([]interface{}); ok {
+			result := make([]string, 0, len(scopesInterface))
+			for _, s := range scopesInterface {
+				if str, ok := s.(string); ok {
+					result = append(result, str)
+				}
+			}
+			return result
+		}
+	}
+
+	if permsAttr := security.GetAttribute(httpCtx, "authorized_permissions"); permsAttr != nil {
+		if permsStr, ok := permsAttr.(string); ok && permsStr != "" {
+			return strings.Fields(permsStr)
+		}
+	}
+
+	return []string{}
+}

--- a/backend/internal/flow/executor/permission_validator_test.go
+++ b/backend/internal/flow/executor/permission_validator_test.go
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/security"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+)
+
+type PermissionValidatorTestSuite struct {
+	suite.Suite
+	mockFlowFactory *coremock.FlowFactoryInterfaceMock
+	executor        *permissionValidator
+}
+
+func (suite *PermissionValidatorTestSuite) SetupTest() {
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	mockBaseExecutor := coremock.NewExecutorInterfaceMock(suite.T())
+
+	suite.mockFlowFactory.On("CreateExecutor",
+		ExecutorNamePermissionValidator,
+		common.ExecutorTypeUtility,
+		[]common.Input{},
+		[]common.Input{}).Return(mockBaseExecutor)
+
+	suite.executor = newPermissionValidator(suite.mockFlowFactory)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_DefaultScopeCheck_Success() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "app1", "token",
+		map[string]interface{}{"scope": "system other"},
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: httpCtx,
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_DefaultScopeCheck_Failure() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "app1", "token",
+		map[string]interface{}{"scope": "other"},
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: httpCtx,
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Insufficient permissions", resp.FailureReason)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_CustomScopeCheck_Success() {
+	type testCase struct {
+		name           string
+		nodeProps      map[string]interface{}
+		contextScopes  []string
+		expectedStatus common.ExecutorStatus
+	}
+
+	testCases := []testCase{
+		{
+			name: "Success - Required scopes configured and present",
+			nodeProps: map[string]interface{}{
+				propertyKeyRequiredScopes: []interface{}{"scope1"},
+			},
+			contextScopes:  []string{"scope1"},
+			expectedStatus: common.ExecComplete,
+		},
+		{
+			name: "Failure - Required scopes configured but missing",
+			nodeProps: map[string]interface{}{
+				propertyKeyRequiredScopes: []interface{}{"scope1"},
+			},
+			contextScopes:  []string{"scope2"},
+			expectedStatus: common.ExecFailure,
+		},
+		{
+			name:           "Success - No required scopes configured (default system scope present)",
+			nodeProps:      nil,
+			contextScopes:  []string{"system"},
+			expectedStatus: common.ExecComplete,
+		},
+		{
+			name: "Success - Empty required scopes (default system scope present)",
+			nodeProps: map[string]interface{}{
+				propertyKeyRequiredScopes: []interface{}{},
+			},
+			contextScopes:  []string{"system"},
+			expectedStatus: common.ExecComplete,
+		},
+		{
+			name: "Success - Multiple required scopes configured (OR logic) - scope1 present",
+			nodeProps: map[string]interface{}{
+				propertyKeyRequiredScopes: []interface{}{"scope1", "scope2"},
+			},
+			contextScopes:  []string{"scope1"},
+			expectedStatus: common.ExecComplete,
+		},
+		{
+			name: "Success - Multiple required scopes configured (OR logic) - scope2 present",
+			nodeProps: map[string]interface{}{
+				propertyKeyRequiredScopes: []interface{}{"scope1", "scope2"},
+			},
+			contextScopes:  []string{"scope2"},
+			expectedStatus: common.ExecComplete,
+		},
+		{
+			name: "Failure - Multiple required scopes configured - none present",
+			nodeProps: map[string]interface{}{
+				propertyKeyRequiredScopes: []interface{}{"scope1", "scope2"},
+			},
+			contextScopes:  []string{"scope3"},
+			expectedStatus: common.ExecFailure,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			httpCtx := context.Background()
+			authCtx := security.NewSecurityContextForTest(
+				"user1", "ou1", "app1", "token",
+				map[string]interface{}{"scopes": tc.contextScopes},
+			)
+			httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+			ctx := &core.NodeContext{
+				FlowID:         "test-flow",
+				HTTPContext:    httpCtx,
+				NodeProperties: tc.nodeProps,
+			}
+
+			resp, err := suite.executor.Execute(ctx)
+
+			assert.NoError(suite.T(), err)
+			assert.Equal(suite.T(), tc.expectedStatus, resp.Status)
+		})
+	}
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_MultipleRequiredScopes_OR_Success() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "app1", "token",
+		map[string]interface{}{"scope": "scopeB"},
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: httpCtx,
+		NodeProperties: map[string]interface{}{
+			propertyKeyRequiredScopes: []interface{}{"scopeA", "scopeB"},
+		},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_AuthorizedPermissionsCheck_Success() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "app1", "token",
+		map[string]interface{}{"authorized_permissions": "read write admin"},
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: httpCtx,
+		NodeProperties: map[string]interface{}{
+			propertyKeyRequiredScopes: []interface{}{"admin"},
+		},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_NoHTTPContext() {
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: nil,
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Insufficient permissions", resp.FailureReason)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_EmptyScopes() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "app1", "token",
+		map[string]interface{}{"scope": ""},
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: httpCtx,
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Insufficient permissions", resp.FailureReason)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_NoScopesInContext() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "app1", "token",
+		map[string]interface{}{}, // No scope or authorized_permissions
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: httpCtx,
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Insufficient permissions", resp.FailureReason)
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_ScopesWithUnexpectedType() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "app1", "token",
+		map[string]interface{}{"scope": 123}, // Invalid type (int instead of string)
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow",
+		HTTPContext: httpCtx,
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), "Insufficient permissions", resp.FailureReason)
+}
+
+func TestPermissionValidatorSuite(t *testing.T) {
+	suite.Run(t, new(PermissionValidatorTestSuite))
+}

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -94,6 +94,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 			UserInputs:        ctx.UserInputs,
 			CurrentNodeID:     ctx.CurrentNode.GetID(),
 			RuntimeData:       ctx.RuntimeData,
+			HTTPContext:       ctx.HTTPContext,
 			Application:       ctx.Application,
 			AuthenticatedUser: ctx.AuthenticatedUser,
 			ExecutionHistory:  ctx.ExecutionHistory,
@@ -575,6 +576,16 @@ func (fe *flowEngine) resolveStepDetailsForPrompt(nodeResp *common.NodeResponse,
 	// Include meta in the flow step if present
 	if nodeResp.Meta != nil {
 		flowStep.Data.Meta = nodeResp.Meta
+	}
+
+	// Include additionalData in the flow step if present
+	if len(nodeResp.AdditionalData) > 0 {
+		if flowStep.Data.AdditionalData == nil {
+			flowStep.Data.AdditionalData = make(map[string]string)
+		}
+		for key, value := range nodeResp.AdditionalData {
+			flowStep.Data.AdditionalData[key] = value
+		}
 	}
 
 	// Set failure reason if present (e.g., when handling onFailure)

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -48,6 +48,7 @@ type EngineContext struct {
 	Graph       core.GraphInterface
 	Application appmodel.Application
 
+	HTTPContext       context.Context
 	AuthenticatedUser authncm.AuthenticatedUser
 	Assertion         string
 	ExecutionHistory  map[string]*common.NodeExecutionRecord

--- a/backend/internal/flow/mgt/service.go
+++ b/backend/internal/flow/mgt/service.go
@@ -437,7 +437,8 @@ func (s *flowMgtService) IsValidFlow(flowID string) bool {
 // isValidFlowType checks if the provided flow type is valid.
 func isValidFlowType(flowType common.FlowType) bool {
 	return flowType == common.FlowTypeAuthentication ||
-		flowType == common.FlowTypeRegistration
+		flowType == common.FlowTypeRegistration ||
+		flowType == common.FlowTypeUserOnboarding
 }
 
 // buildPaginationLinks constructs pagination links for the flow list response.

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -130,9 +130,10 @@ type OAuthConfig struct {
 
 // FlowConfig holds the configuration details for the flow service.
 type FlowConfig struct {
-	DefaultAuthFlowHandle string `yaml:"default_auth_flow_handle" json:"default_auth_flow_handle"`
-	MaxVersionHistory     int    `yaml:"max_version_history" json:"max_version_history"`
-	AutoInferRegistration bool   `yaml:"auto_infer_registration" json:"auto_infer_registration"`
+	DefaultAuthFlowHandle    string `yaml:"default_auth_flow_handle" json:"default_auth_flow_handle"`
+	UserOnboardingFlowHandle string `yaml:"user_onboarding_flow_handle" json:"user_onboarding_flow_handle"`
+	MaxVersionHistory        int    `yaml:"max_version_history" json:"max_version_history"`
+	AutoInferRegistration    bool   `yaml:"auto_infer_registration" json:"auto_infer_registration"`
 }
 
 // CryptoConfig holds the cryptographic configuration details.


### PR DESCRIPTION
This pull request introduces support for admin-initiated invite registration flows, enabling administrators to invite users and allowing those users to complete registration via a secure invite link. The changes span flow definitions, executor implementations, configuration updates, and test coverage.

### Flow

1. Admin initiates flow
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/5829d894-5f8b-4ad9-bdb2-cd990c5f4c24" />

2. Admin selects user type
<img width="600" height="500"  alt="image" src="https://github.com/user-attachments/assets/4933a065-0d2e-4e71-be1c-74839bd3e688" />

3. Admin provides required attributes
<img width="600" height="500"  alt="image" src="https://github.com/user-attachments/assets/f37fc76c-a05b-4df9-a2d5-26ef9597b627" />

4. User submits the invite token
<img width="600" height="500"  alt="image" src="https://github.com/user-attachments/assets/4eeceb1c-a95f-478a-9f9f-1eadbf2ac3fa" />

5. User sets password
<img width="600" height="500"  alt="image" src="https://github.com/user-attachments/assets/dbfbf34e-0f99-4485-956a-f41206744508" />


**Invite Registration Flow Implementation**

* Added the `INVITE_REGISTRATION` flow type to the system, including a default flow definition in `invite_registration_flow.json` with nodes for permission validation, user type resolution, provisioning, invite link generation, and credential setting. [[1]](diffhunk://#diff-c3956d0ab86bdd2ad4f57ed5806f6ecd78e4cb8ca9244b6eaab95642f850fabaR1-R78) [[2]](diffhunk://#diff-9efdd475ef67a1c9e9acb315486fdf7b3fdd9de00897898495ea69c599cbf79dR32-R33)
* Updated the bootstrap script (`01-default-resources.sh`) to process invite registration flows: it now loads, creates, or updates flows from the new `invite_registration` directory. [[1]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aR389) [[2]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aR521-R579)

**New Executors for Invite Registration**

* Implemented the `InviteExecutor` to generate secure invite links and validate invite tokens, and the `CredentialSetter` to allow invited users to set their credentials. Both executors are registered and integrated into the flow engine. [[1]](diffhunk://#diff-dccaf85100a16c4bdaed19f643df139636c702ce9658b627c9276a816bf32306R1-R130) [[2]](diffhunk://#diff-8444f53e556aa2e076637d299f96481b90fc84c21482c0ca08bab15f5670260fR1-R121) [[3]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06R79-R81) [[4]](diffhunk://#diff-82a5330129814e06de3d54d982ddd0ee9e70262be578aa6dcfbe0babfa628d4fR36-R41)
* Added comprehensive unit tests for the `CredentialSetter` executor to ensure correct behavior for success, missing input, missing user ID, empty password, and service errors.

**Configuration and Context Updates**

* Extended deployment configuration to support GateClient settings, which are used in invite link generation, and updated CORS settings to allow requests from new ports. [[1]](diffhunk://#diff-fb7b89dae773382f1ed4977c550448c9098477d2f747a254a3345d923c5e0eb8R10-R17) [[2]](diffhunk://#diff-fb7b89dae773382f1ed4977c550448c9098477d2f747a254a3345d923c5e0eb8R50-R52)
* Enhanced the `NodeContext` model to include an `HTTPContext` field, preparing the flow engine for future context-aware operations. [[1]](diffhunk://#diff-593404002fd7a4db7c4ca2b1e5774c1ef8622164090720d2b2e3922c5f33982fR22-R23) [[2]](diffhunk://#diff-593404002fd7a4db7c4ca2b1e5774c1ef8622164090720d2b2e3922c5f33982fR44)