### PR TITLE
Update dockerfile UID&GID to 10001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN apk add --no-cache \
     unzip
 
 # Create thunder user and group
-RUN addgroup -S thunder -g 802 && adduser -S thunder -u 802 -G thunder
+RUN addgroup -S thunder -g 10001 && adduser -S thunder -u 10001 -G thunder
 
 # Create application directory
 WORKDIR /opt/thunder

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -153,12 +153,12 @@ The following table lists the configurable parameters of the Thunder chart and t
 | `deployment.resources.requests.cpu`     | CPU resource requests                                                                   | `1`                            |
 | `deployment.resources.requests.memory`  | Memory resource requests                                                                | `256Mi`                        |
 | `deployment.securityContext.readOnlyRootFilesystem` | Enable read-only root filesystem (must be false for SQLite)                     | `true`                         |
-| `deployment.securityContext.enableRunAsUser` | Enable running as non-root user                                                    | `true`                         |
-| `deployment.securityContext.runAsUser`  | User ID to run the container                                                            | `802`                          |
+| `deployment.securityContext.enableRunAsUser` | Enforce user ID via pod security context                                               | `true`                         |
+| `deployment.securityContext.runAsUser`  | User ID to run the container                                                            | `10001`                        |
 | `deployment.securityContext.enableRunAsGroup` | Enable setting group ID for the container process                                 | `true`                         |
-| `deployment.securityContext.runAsGroup` | Group ID to run the container                                                           | `802`                          |
+| `deployment.securityContext.runAsGroup` | Group ID to run the container                                                           | `10001`                        |
 | `deployment.securityContext.enableFsGroup` | Enable setting fsGroup for volume ownership                                          | `true`                         |
-| `deployment.securityContext.fsGroup`    | Group ID for mounted volumes (fixes SQLite permission issues on cloud platforms)        | `802`                          |
+| `deployment.securityContext.fsGroup`    | Group ID for mounted volumes (fixes SQLite permission issues on cloud platforms)        | `10001`                        |
 | `deployment.securityContext.seccompProfile.enabled` | Enable seccomp profile                                                      | `false`                        |
 | `deployment.securityContext.seccompProfile.type` | Seccomp profile type                                                           | `RuntimeDefault`               |
 

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -23,11 +23,11 @@ deployment:
   securityContext:
     readOnlyRootFilesystem: true # This must be false if sqlite is used as the database
     enableRunAsUser: true
-    runAsUser: 802
+    runAsUser: 10001
     enableRunAsGroup: true
-    runAsGroup: 802
+    runAsGroup: 10001
     enableFsGroup: true
-    fsGroup: 802
+    fsGroup: 10001
     seccompProfile:
       enabled: false
       type: "RuntimeDefault"


### PR DESCRIPTION
### Purpose
This pull request updates the user and group IDs used by the Thunder application to improve security and consistency. The main change is switching from the previously used ID `802` to the more standard `10001` across the Dockerfile and Helm chart configuration. This impacts both the container runtime and the deployment configuration.

### Approach

**Security context and user/group ID updates:**

* Changed the user and group IDs from `802` to `10001` when creating the `thunder` user and group in the `Dockerfile` to align with best practices for non-root containers.
* Updated the default values for `runAsUser`, `runAsGroup`, and `fsGroup` from `802` to `10001` in `install/helm/values.yaml` to ensure the container runs with the correct user and group permissions.
* Modified the Helm chart documentation in `install/helm/README.md` to reflect the new user and group ID defaults and clarified the description for `enableRunAsUser`.


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
