### PR TITLE
Automate thunder release to run weekly at a fixed time

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -7,8 +7,8 @@ name: 🚀 Release Builder
 
 on:
   schedule:
-    # Runs every Thursday at 4:00 PM IST (10:30 AM UTC)
-    - cron: '40 15 * * *'
+    # Runs every Friday at 12:00 PM IST (6:30 AM UTC)
+    - cron: '30 6 * * 5'
   workflow_dispatch:
     inputs:
       version:
@@ -58,7 +58,11 @@ jobs:
             RUN_PERF_TEST="${{ github.event.inputs.run_performance_test }}"
           else
             # Scheduled run or manual run without version - read from version.txt
-            VERSION=$(cat version.txt)
+            if [ ! -f version.txt ] || [ -z "$(cat version.txt | tr -d '[:space:]')" ]; then
+              echo "❌ Error: version.txt not found or empty"
+              exit 1
+            fi
+            VERSION=$(tr -d '[:space:]' < version.txt)
             PRERELEASE="false"
             RUN_PERF_TEST="false"
           fi


### PR DESCRIPTION
### Purpose
This pull request updates the `release-builder.yml` workflow to improve how release versions are determined and propagated between jobs. The workflow now supports scheduled releases using `version.txt` and ensures consistent usage of the computed version, prerelease status, and performance test flags across all jobs.

**Enhancements to release version handling:**

* Added a scheduled trigger to run the release workflow every Friday at 12:00 PM IST, supporting automated releases.
* Introduced a new step (`get_version`) to determine the release version: uses manual input if provided, otherwise reads from `version.txt`, and sets outputs for version, prerelease, and performance test flags.

**Consistent propagation of release metadata:**

* Updated all downstream jobs and steps to use `${{ needs.build-thunder.outputs.version }}` and related outputs instead of `${{ github.event.inputs.version }}` for versioning, Docker/Helm tags, sample packaging, and release notes. [[1]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L175-R216) [[2]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L274-R315) [[3]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L313-R354) [[4]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L347-R388) [[5]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L379-R420) [[6]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L499-R540) [[7]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L589-R630) [[8]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L691-R740) [[9]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L778-R819) [[10]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L898-R939)
* Changed job dependencies to ensure all jobs needing the version wait for `build-thunder` to complete. [[1]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L468-R509) [[2]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L558-R599) [[3]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L640-R681)

**Performance test trigger improvements:**

* The performance test job now uses the output from `build-thunder` to conditionally run, supporting both manual and scheduled releases.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1045

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
