### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/tests/integration/testutils/mock_notification_server.go
+++ b/tests/integration/testutils/mock_notification_server.go
@@ -217,7 +217,6 @@ func extractOTPFromMessage(message string) string {
 		score := calculateOTPScore(currentNumber)
 		if score > bestScore {
 			bestSequence = currentNumber
-			bestScore = score
 		}
 	}
 


### PR DESCRIPTION
In general, a dead local assignment should be removed or its value should be used meaningfully. Here, the comparison logic already uses `bestScore` correctly inside the loop; only the last assignment in the post-loop check is redundant because no code reads `bestScore` afterward. The best fix is to remove that single assignment while keeping the rest of the scoring logic intact.

Concretely, in `tests/integration/testutils/mock_notification_server.go`, within `extractOTPFromMessage`, keep the condition and `bestSequence = currentNumber` assignment in the final block, but delete the `bestScore = score` line (line 220 in the snippet). No other changes, imports, or new methods are needed, since the algorithm still returns the same `bestSequence` and the now-removed value was not used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._