### PR TITLE
Get the current year dynamically when auto-fixing the license header ESLint warning

### DIFF
--- a/frontend/packages/thunder-eslint-plugin/src/rules/__tests__/copyright-header.test.ts
+++ b/frontend/packages/thunder-eslint-plugin/src/rules/__tests__/copyright-header.test.ts
@@ -27,8 +27,10 @@ const ruleTester = new RuleTester({
   },
 } as unknown as Linter.Config);
 
+const getCurrentYear = (): number => new Date().getFullYear();
+
 const VALID_COPYRIGHT = `/**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) ${getCurrentYear()}, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/frontend/packages/thunder-eslint-plugin/src/rules/copyright-header.ts
+++ b/frontend/packages/thunder-eslint-plugin/src/rules/copyright-header.ts
@@ -24,8 +24,10 @@ interface CopyrightHeaderOptions {
   template?: string;
 }
 
+const CURRENT_YEAR = new Date().getFullYear();
+
 const REQUIRED_COPYRIGHT_HEADER = `/**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) ${CURRENT_YEAR}, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
### Purpose

$subject

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
Use JS utils to get the current year.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
