### PR TITLE
Fix helm value key for TLS

### DIFF
--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -29,8 +29,8 @@ gate_client:
 
 tls:
   min_version: {{ .Values.configuration.tls.minVersion | quote }}
-  cert_file: {{ .Values.configuration.security.certFile | quote }}
-  key_file: {{ .Values.configuration.security.keyFile | quote }}
+  cert_file: {{ .Values.configuration.tls.certFile | quote }}
+  key_file: {{ .Values.configuration.tls.keyFile | quote }}
 
 crypto:
   encryption:


### PR DESCRIPTION
### Purpose

This pull request updates the TLS configuration in the `install/helm/conf/deployment.yaml` file to reference the correct values for certificate and key files. This ensures that the deployment uses the intended TLS settings.

### Approach

  * Changed `cert_file` and `key_file` in the `tls` section to use `.Values.configuration.tls.certFile` and `.Values.configuration.tls.keyFile` instead of referencing the `security` section which was removed.

### Related Issues
- N/A

### Related PRs
- https://github.com/asgardeo/thunder/pull/1038
