### PR TITLE
Introduce prompts to prompt nodes and improve input handling

### DIFF
--- a/backend/cmd/server/bootstrap/flows/apps/develop/auth_flow_develop.json
+++ b/backend/cmd/server/bootstrap/flows/apps/develop/auth_flow_develop.json
@@ -50,24 +50,26 @@
                     }
                 ]
             },
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "username",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_002",
+                            "identifier": "password",
+                            "type": "PASSWORD_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 }
             ]
         },

--- a/backend/cmd/server/bootstrap/flows/apps/develop/registration_flow_develop.json
+++ b/backend/cmd/server/bootstrap/flows/apps/develop/registration_flow_develop.json
@@ -82,42 +82,44 @@
                     }
                 ]
             },
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_003",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_004",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_005",
-                    "identifier": "email",
-                    "type": "EMAIL_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "username",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_002",
+                            "identifier": "password",
+                            "type": "PASSWORD_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_003",
+                            "identifier": "firstName",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_004",
+                            "identifier": "lastName",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_005",
+                            "identifier": "email",
+                            "type": "EMAIL_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 }
             ]
         },
@@ -132,40 +134,40 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_001",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_003",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_004",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_005",
-                    "identifier": "email",
-                    "type": "EMAIL_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "ProvisioningExecutor"
+                "name": "ProvisioningExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_001",
+                        "identifier": "username",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_002",
+                        "identifier": "password",
+                        "type": "PASSWORD_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_003",
+                        "identifier": "firstName",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_004",
+                        "identifier": "lastName",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_005",
+                        "identifier": "email",
+                        "type": "EMAIL_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic.json
@@ -50,24 +50,26 @@
                     }
                 ]
             },
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "username",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_002",
+                            "identifier": "password",
+                            "type": "PASSWORD_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 }
             ]
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_github.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_github.json
@@ -11,14 +11,18 @@
         {
             "id": "choose_auth",
             "type": "PROMPT",
-            "actions": [
+            "prompts": [
                 {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 },
                 {
-                    "ref": "action_002",
-                    "nextNode": "github_auth"
+                    "action": {
+                        "ref": "action_002",
+                        "nextNode": "github_auth"
+                    }
                 }
             ]
         },
@@ -36,16 +40,16 @@
             "properties": {
                 "idpId": "<github-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_003",
-                    "type": "TEXT_INPUT",
-                    "identifier": "code",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GithubOAuthExecutor"
+                "name": "GithubOAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_003",
+                        "type": "TEXT_INPUT",
+                        "identifier": "code",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_google.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_google.json
@@ -11,14 +11,18 @@
         {
             "id": "choose_auth",
             "type": "PROMPT",
-            "actions": [
+            "prompts": [
                 {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 },
                 {
-                    "ref": "action_002",
-                    "nextNode": "google_auth"
+                    "action": {
+                        "ref": "action_002",
+                        "nextNode": "google_auth"
+                    }
                 }
             ]
         },
@@ -36,16 +40,16 @@
             "properties": {
                 "idpId": "<google-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_003",
-                    "type": "TEXT_INPUT",
-                    "identifier": "code",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GoogleOIDCAuthExecutor"
+                "name": "GoogleOIDCAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_003",
+                        "type": "TEXT_INPUT",
+                        "identifier": "code",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_google_github.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_google_github.json
@@ -11,18 +11,24 @@
         {
             "id": "choose_auth",
             "type": "PROMPT",
-            "actions": [
+            "prompts": [
                 {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 },
                 {
-                    "ref": "action_002",
-                    "nextNode": "google_auth"
+                    "action": {
+                        "ref": "action_002",
+                        "nextNode": "google_auth"
+                    }
                 },
                 {
-                    "ref": "action_003",
-                    "nextNode": "github_auth"
+                    "action": {
+                        "ref": "action_003",
+                        "nextNode": "github_auth"
+                    }
                 }
             ]
         },
@@ -40,16 +46,16 @@
             "properties": {
                 "idpId": "<google-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_001",
-                    "identifier": "code",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GoogleOIDCAuthExecutor"
+                "name": "GoogleOIDCAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_001",
+                        "identifier": "code",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },
@@ -59,16 +65,16 @@
             "properties": {
                 "idpId": "<github-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_002",
-                    "identifier": "code",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GithubOAuthExecutor"
+                "name": "GithubOAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_002",
+                        "identifier": "code",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_google_github_sms.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_google_github_sms.json
@@ -11,22 +11,30 @@
         {
             "id": "choose_auth",
             "type": "PROMPT",
-            "actions": [
+            "prompts": [
                 {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 },
                 {
-                    "ref": "action_002",
-                    "nextNode": "google_auth"
+                    "action": {
+                        "ref": "action_002",
+                        "nextNode": "google_auth"
+                    }
                 },
                 {
-                    "ref": "action_003",
-                    "nextNode": "github_auth"
+                    "action": {
+                        "ref": "action_003",
+                        "nextNode": "github_auth"
+                    }
                 },
                 {
-                    "ref": "action_004",
-                    "nextNode": "prompt_mobile"
+                    "action": {
+                        "ref": "action_004",
+                        "nextNode": "prompt_mobile"
+                    }
                 }
             ]
         },
@@ -41,25 +49,22 @@
         {
             "id": "google_auth",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_001",
-                    "identifier": "code",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "nonce",
-                    "type": "TEXT_INPUT",
-                    "required": false
-                }
-            ],
-            "properties": {
-                "idpId": "<google-idp-id>"
-            },
             "executor": {
-                "name": "GoogleOIDCAuthExecutor"
+                "name": "GoogleOIDCAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_001",
+                        "identifier": "code",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_002",
+                        "identifier": "nonce",
+                        "type": "TEXT_INPUT",
+                        "required": false
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },
@@ -69,34 +74,36 @@
             "properties": {
                 "idpId": "<github-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_003",
-                    "identifier": "code",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GithubOAuthExecutor"
+                "name": "GithubOAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_003",
+                        "identifier": "code",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },
         {
             "id": "prompt_mobile",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_004",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "send_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_004",
+                            "identifier": "mobileNumber",
+                            "type": "PHONE_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "send_sms"
+                    }
                 }
             ]
         },
@@ -115,18 +122,20 @@
         {
             "id": "prompt_otp",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_005",
-                    "identifier": "otp",
-                    "type": "OTP_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "verify_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_005",
+                            "identifier": "otp",
+                            "type": "OTP_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "verify_sms"
+                    }
                 }
             ]
         },
@@ -145,16 +154,16 @@
         {
             "id": "attr_collector",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_005",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": false
-                }
-            ],
             "executor": {
-                "name": "AttributeCollector"
+                "name": "AttributeCollector",
+                "inputs": [
+                    {
+                        "ref": "input_005",
+                        "identifier": "mobileNumber",
+                        "type": "PHONE_INPUT",
+                        "required": false
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_github.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_github.json
@@ -14,16 +14,16 @@
             "properties": {
                 "idpId": "<github-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_001",
-                    "identifier": "code",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GithubOAuthExecutor"
+                "name": "GithubOAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_001",
+                        "identifier": "code",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_google.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_google.json
@@ -14,16 +14,16 @@
             "properties": {
                 "idpId": "<google-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_001",
-                    "identifier": "code",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GoogleOIDCAuthExecutor"
+                "name": "GoogleOIDCAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_001",
+                        "identifier": "code",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_google_github.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_google_github.json
@@ -11,14 +11,18 @@
         {
             "id": "choose_auth",
             "type": "PROMPT",
-            "actions": [
+            "prompts": [
                 {
-                    "ref": "action_001",
-                    "nextNode": "google_auth"
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "google_auth"
+                    }
                 },
                 {
-                    "ref": "action_002",
-                    "nextNode": "github_auth"
+                    "action": {
+                        "ref": "action_002",
+                        "nextNode": "github_auth"
+                    }
                 }
             ]
         },
@@ -28,16 +32,16 @@
             "properties": {
                 "idpId": "<google-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_003",
-                    "type": "TEXT_INPUT",
-                    "identifier": "code",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GoogleOIDCAuthExecutor"
+                "name": "GoogleOIDCAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_003",
+                        "type": "TEXT_INPUT",
+                        "identifier": "code",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },
@@ -47,16 +51,16 @@
             "properties": {
                 "idpId": "<github-idp-id>"
             },
-            "inputs": [
-                {
-                    "ref": "input_004",
-                    "type": "TEXT_INPUT",
-                    "identifier": "code",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "GithubOAuthExecutor"
+                "name": "GithubOAuthExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_004",
+                        "type": "TEXT_INPUT",
+                        "identifier": "code",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_sms.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_sms.json
@@ -11,18 +11,20 @@
         {
             "id": "prompt_mobile",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "send_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "mobileNumber",
+                            "type": "PHONE_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "send_sms"
+                    }
                 }
             ]
         },
@@ -41,18 +43,20 @@
         {
             "id": "prompt_otp",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_002",
-                    "identifier": "otp",
-                    "type": "OTP_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "verify_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_002",
+                            "identifier": "otp",
+                            "type": "OTP_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "verify_sms"
+                    }
                 }
             ]
         },

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic.json
@@ -27,40 +27,40 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_001",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_003",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_004",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_005",
-                    "identifier": "email",
-                    "type": "EMAIL_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "ProvisioningExecutor"
+                "name": "ProvisioningExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_001",
+                        "identifier": "username",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_002",
+                        "identifier": "password",
+                        "type": "PASSWORD_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_003",
+                        "identifier": "firstName",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_004",
+                        "identifier": "lastName",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_005",
+                        "identifier": "email",
+                        "type": "EMAIL_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_google_github.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_google_github.json
@@ -19,18 +19,24 @@
         {
             "id": "choose_auth",
             "type": "PROMPT",
-            "actions": [
+            "prompts": [
                 {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 },
                 {
-                    "ref": "action_002",
-                    "nextNode": "google_auth"
+                    "action": {
+                        "ref": "action_002",
+                        "nextNode": "google_auth"
+                    }
                 },
                 {
-                    "ref": "action_003",
-                    "nextNode": "github_auth"
+                    "action": {
+                        "ref": "action_003",
+                        "nextNode": "github_auth"
+                    }
                 }
             ]
         },

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_google_github_sms.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_google_github_sms.json
@@ -19,22 +19,30 @@
         {
             "id": "choose_auth",
             "type": "PROMPT",
-            "actions": [
+            "prompts": [
                 {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 },
                 {
-                    "ref": "action_002",
-                    "nextNode": "google_auth"
+                    "action": {
+                        "ref": "action_002",
+                        "nextNode": "google_auth"
+                    }
                 },
                 {
-                    "ref": "action_003",
-                    "nextNode": "github_auth"
+                    "action": {
+                        "ref": "action_003",
+                        "nextNode": "github_auth"
+                    }
                 },
                 {
-                    "ref": "action_004",
-                    "nextNode": "prompt_mobile"
+                    "action": {
+                        "ref": "action_004",
+                        "nextNode": "prompt_mobile"
+                    }
                 }
             ]
         },
@@ -71,18 +79,20 @@
         {
             "id": "prompt_mobile",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "send_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "mobileNumber",
+                            "type": "PHONE_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "send_sms"
+                    }
                 }
             ]
         },
@@ -101,18 +111,20 @@
         {
             "id": "prompt_otp",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_002",
-                    "identifier": "otp",
-                    "type": "OTP_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "verify_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_002",
+                            "identifier": "otp",
+                            "type": "OTP_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "verify_sms"
+                    }
                 }
             ]
         },
@@ -131,18 +143,20 @@
         {
             "id": "prompt_mobile_for_basic",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "send_sms_for_basic"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "mobileNumber",
+                            "type": "PHONE_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "send_sms_for_basic"
+                    }
                 }
             ]
         },
@@ -161,18 +175,20 @@
         {
             "id": "prompt_otp_for_basic",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_003",
-                    "identifier": "otp",
-                    "type": "OTP_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "verify_sms_for_basic"
+                    "inputs": [
+                        {
+                            "ref": "input_003",
+                            "identifier": "otp",
+                            "type": "OTP_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "verify_sms_for_basic"
+                    }
                 }
             ]
         },
@@ -191,68 +207,68 @@
         {
             "id": "provisioning_local_basic",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_002",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_003",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_004",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": false
-                },
-                {
-                    "ref": "input_005",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": false
-                },
-                {
-                    "ref": "input_006",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": false
-                }
-            ],
             "executor": {
-                "name": "ProvisioningExecutor"
+                "name": "ProvisioningExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_002",
+                        "identifier": "username",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_003",
+                        "identifier": "password",
+                        "type": "PASSWORD_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_004",
+                        "identifier": "firstName",
+                        "type": "TEXT_INPUT",
+                        "required": false
+                    },
+                    {
+                        "ref": "input_005",
+                        "identifier": "lastName",
+                        "type": "TEXT_INPUT",
+                        "required": false
+                    },
+                    {
+                        "ref": "input_006",
+                        "identifier": "mobileNumber",
+                        "type": "PHONE_INPUT",
+                        "required": false
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },
         {
             "id": "provisioning_local_sms",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_007",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": false
-                },
-                {
-                    "ref": "input_008",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": false
-                },
-                {
-                    "ref": "input_009",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "ProvisioningExecutor"
+                "name": "ProvisioningExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_007",
+                        "identifier": "firstName",
+                        "type": "TEXT_INPUT",
+                        "required": false
+                    },
+                    {
+                        "ref": "input_008",
+                        "identifier": "lastName",
+                        "type": "TEXT_INPUT",
+                        "required": false
+                    },
+                    {
+                        "ref": "input_009",
+                        "identifier": "mobileNumber",
+                        "type": "PHONE_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_with_prompt.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_with_prompt.json
@@ -82,42 +82,44 @@
                     }
                 ]
             },
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_003",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_004",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_005",
-                    "identifier": "email",
-                    "type": "EMAIL_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "basic_auth"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "username",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_002",
+                            "identifier": "password",
+                            "type": "PASSWORD_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_003",
+                            "identifier": "firstName",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_004",
+                            "identifier": "lastName",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_005",
+                            "identifier": "email",
+                            "type": "EMAIL_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "basic_auth"
+                    }
                 }
             ]
         },
@@ -132,40 +134,40 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_001",
-                    "identifier": "username",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_002",
-                    "identifier": "password",
-                    "type": "PASSWORD_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_003",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_004",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_005",
-                    "identifier": "email",
-                    "type": "EMAIL_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "ProvisioningExecutor"
+                "name": "ProvisioningExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_001",
+                        "identifier": "username",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_002",
+                        "identifier": "password",
+                        "type": "PASSWORD_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_003",
+                        "identifier": "firstName",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_004",
+                        "identifier": "lastName",
+                        "type": "TEXT_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_005",
+                        "identifier": "email",
+                        "type": "EMAIL_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_sms.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_sms.json
@@ -19,18 +19,20 @@
         {
             "id": "prompt_mobile",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_001",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "send_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "mobileNumber",
+                            "type": "PHONE_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "send_sms"
+                    }
                 }
             ]
         },
@@ -49,18 +51,20 @@
         {
             "id": "prompt_otp",
             "type": "PROMPT",
-            "inputs": [
+            "prompts": [
                 {
-                    "ref": "input_002",
-                    "identifier": "otp",
-                    "type": "OTP_INPUT",
-                    "required": true
-                }
-            ],
-            "actions": [
-                {
-                    "ref": "action_001",
-                    "nextNode": "verify_sms"
+                    "inputs": [
+                        {
+                            "ref": "input_002",
+                            "identifier": "otp",
+                            "type": "OTP_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "verify_sms"
+                    }
                 }
             ]
         },
@@ -79,34 +83,34 @@
         {
             "id": "provisioning",
             "type": "TASK_EXECUTION",
-            "inputs": [
-                {
-                    "ref": "input_002",
-                    "identifier": "firstName",
-                    "type": "TEXT_INPUT",
-                    "required": false
-                },
-                {
-                    "ref": "input_003",
-                    "identifier": "lastName",
-                    "type": "TEXT_INPUT",
-                    "required": false
-                },
-                {
-                    "ref": "input_004",
-                    "identifier": "email",
-                    "type": "EMAIL_INPUT",
-                    "required": true
-                },
-                {
-                    "ref": "input_005",
-                    "identifier": "mobileNumber",
-                    "type": "PHONE_INPUT",
-                    "required": true
-                }
-            ],
             "executor": {
-                "name": "ProvisioningExecutor"
+                "name": "ProvisioningExecutor",
+                "inputs": [
+                    {
+                        "ref": "input_002",
+                        "identifier": "firstName",
+                        "type": "TEXT_INPUT",
+                        "required": false
+                    },
+                    {
+                        "ref": "input_003",
+                        "identifier": "lastName",
+                        "type": "TEXT_INPUT",
+                        "required": false
+                    },
+                    {
+                        "ref": "input_004",
+                        "identifier": "email",
+                        "type": "EMAIL_INPUT",
+                        "required": true
+                    },
+                    {
+                        "ref": "input_005",
+                        "identifier": "mobileNumber",
+                        "type": "PHONE_INPUT",
+                        "required": true
+                    }
+                ]
             },
             "onSuccess": "auth_assert"
         },

--- a/backend/internal/flow/common/model.go
+++ b/backend/internal/flow/common/model.go
@@ -37,6 +37,12 @@ type Action struct {
 	NextNode string `json:"nextNode,omitempty"`
 }
 
+// Prompt groups inputs with an action for prompt nodes.
+type Prompt struct {
+	Inputs []Input `json:"inputs,omitempty"`
+	Action *Action `json:"action,omitempty"`
+}
+
 // NodeResponse represents the response from a node execution
 type NodeResponse struct {
 	Status            NodeStatus                `json:"status"`

--- a/backend/internal/flow/core/NodeInterface_mock_test.go
+++ b/backend/internal/flow/core/NodeInterface_mock_test.go
@@ -271,52 +271,6 @@ func (_c *NodeInterfaceMock_GetID_Call) RunAndReturn(run func() string) *NodeInt
 	return _c
 }
 
-// GetInputs provides a mock function for the type NodeInterfaceMock
-func (_mock *NodeInterfaceMock) GetInputs() []common.Input {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInputs")
-	}
-
-	var r0 []common.Input
-	if returnFunc, ok := ret.Get(0).(func() []common.Input); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Input)
-		}
-	}
-	return r0
-}
-
-// NodeInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
-type NodeInterfaceMock_GetInputs_Call struct {
-	*mock.Call
-}
-
-// GetInputs is a helper method to define mock.On call
-func (_e *NodeInterfaceMock_Expecter) GetInputs() *NodeInterfaceMock_GetInputs_Call {
-	return &NodeInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
-}
-
-func (_c *NodeInterfaceMock_GetInputs_Call) Run(run func()) *NodeInterfaceMock_GetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *NodeInterfaceMock_GetInputs_Call) Return(inputs []common.Input) *NodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(inputs)
-	return _c
-}
-
-func (_c *NodeInterfaceMock_GetInputs_Call) RunAndReturn(run func() []common.Input) *NodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetNextNodeList provides a mock function for the type NodeInterfaceMock
 func (_mock *NodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -769,46 +723,6 @@ func (_c *NodeInterfaceMock_SetCondition_Call) Return() *NodeInterfaceMock_SetCo
 }
 
 func (_c *NodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *NodeCondition)) *NodeInterfaceMock_SetCondition_Call {
-	_c.Run(run)
-	return _c
-}
-
-// SetInputs provides a mock function for the type NodeInterfaceMock
-func (_mock *NodeInterfaceMock) SetInputs(inputs []common.Input) {
-	_mock.Called(inputs)
-	return
-}
-
-// NodeInterfaceMock_SetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetInputs'
-type NodeInterfaceMock_SetInputs_Call struct {
-	*mock.Call
-}
-
-// SetInputs is a helper method to define mock.On call
-//   - inputs []common.Input
-func (_e *NodeInterfaceMock_Expecter) SetInputs(inputs interface{}) *NodeInterfaceMock_SetInputs_Call {
-	return &NodeInterfaceMock_SetInputs_Call{Call: _e.mock.On("SetInputs", inputs)}
-}
-
-func (_c *NodeInterfaceMock_SetInputs_Call) Run(run func(inputs []common.Input)) *NodeInterfaceMock_SetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Input
-		if args[0] != nil {
-			arg0 = args[0].([]common.Input)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *NodeInterfaceMock_SetInputs_Call) Return() *NodeInterfaceMock_SetInputs_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *NodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *NodeInterfaceMock_SetInputs_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/PromptNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/PromptNodeInterface_mock_test.go
@@ -181,52 +181,6 @@ func (_c *PromptNodeInterfaceMock_Execute_Call) RunAndReturn(run func(ctx *NodeC
 	return _c
 }
 
-// GetActions provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) GetActions() []common.Action {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetActions")
-	}
-
-	var r0 []common.Action
-	if returnFunc, ok := ret.Get(0).(func() []common.Action); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Action)
-		}
-	}
-	return r0
-}
-
-// PromptNodeInterfaceMock_GetActions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActions'
-type PromptNodeInterfaceMock_GetActions_Call struct {
-	*mock.Call
-}
-
-// GetActions is a helper method to define mock.On call
-func (_e *PromptNodeInterfaceMock_Expecter) GetActions() *PromptNodeInterfaceMock_GetActions_Call {
-	return &PromptNodeInterfaceMock_GetActions_Call{Call: _e.mock.On("GetActions")}
-}
-
-func (_c *PromptNodeInterfaceMock_GetActions_Call) Run(run func()) *PromptNodeInterfaceMock_GetActions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetActions_Call) Return(actions []common.Action) *PromptNodeInterfaceMock_GetActions_Call {
-	_c.Call.Return(actions)
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetActions_Call) RunAndReturn(run func() []common.Action) *PromptNodeInterfaceMock_GetActions_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetCondition provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) GetCondition() *NodeCondition {
 	ret := _mock.Called()
@@ -313,52 +267,6 @@ func (_c *PromptNodeInterfaceMock_GetID_Call) Return(s string) *PromptNodeInterf
 }
 
 func (_c *PromptNodeInterfaceMock_GetID_Call) RunAndReturn(run func() string) *PromptNodeInterfaceMock_GetID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetInputs provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) GetInputs() []common.Input {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInputs")
-	}
-
-	var r0 []common.Input
-	if returnFunc, ok := ret.Get(0).(func() []common.Input); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Input)
-		}
-	}
-	return r0
-}
-
-// PromptNodeInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
-type PromptNodeInterfaceMock_GetInputs_Call struct {
-	*mock.Call
-}
-
-// GetInputs is a helper method to define mock.On call
-func (_e *PromptNodeInterfaceMock_Expecter) GetInputs() *PromptNodeInterfaceMock_GetInputs_Call {
-	return &PromptNodeInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
-}
-
-func (_c *PromptNodeInterfaceMock_GetInputs_Call) Run(run func()) *PromptNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetInputs_Call) Return(inputs []common.Input) *PromptNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(inputs)
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetInputs_Call) RunAndReturn(run func() []common.Input) *PromptNodeInterfaceMock_GetInputs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -497,6 +405,52 @@ func (_c *PromptNodeInterfaceMock_GetPreviousNodeList_Call) Return(strings []str
 }
 
 func (_c *PromptNodeInterfaceMock_GetPreviousNodeList_Call) RunAndReturn(run func() []string) *PromptNodeInterfaceMock_GetPreviousNodeList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPrompts provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) GetPrompts() []common.Prompt {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPrompts")
+	}
+
+	var r0 []common.Prompt
+	if returnFunc, ok := ret.Get(0).(func() []common.Prompt); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.Prompt)
+		}
+	}
+	return r0
+}
+
+// PromptNodeInterfaceMock_GetPrompts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPrompts'
+type PromptNodeInterfaceMock_GetPrompts_Call struct {
+	*mock.Call
+}
+
+// GetPrompts is a helper method to define mock.On call
+func (_e *PromptNodeInterfaceMock_Expecter) GetPrompts() *PromptNodeInterfaceMock_GetPrompts_Call {
+	return &PromptNodeInterfaceMock_GetPrompts_Call{Call: _e.mock.On("GetPrompts")}
+}
+
+func (_c *PromptNodeInterfaceMock_GetPrompts_Call) Run(run func()) *PromptNodeInterfaceMock_GetPrompts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetPrompts_Call) Return(prompts []common.Prompt) *PromptNodeInterfaceMock_GetPrompts_Call {
+	_c.Call.Return(prompts)
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetPrompts_Call) RunAndReturn(run func() []common.Prompt) *PromptNodeInterfaceMock_GetPrompts_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -759,46 +713,6 @@ func (_c *PromptNodeInterfaceMock_RemovePreviousNode_Call) RunAndReturn(run func
 	return _c
 }
 
-// SetActions provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) SetActions(actions []common.Action) {
-	_mock.Called(actions)
-	return
-}
-
-// PromptNodeInterfaceMock_SetActions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetActions'
-type PromptNodeInterfaceMock_SetActions_Call struct {
-	*mock.Call
-}
-
-// SetActions is a helper method to define mock.On call
-//   - actions []common.Action
-func (_e *PromptNodeInterfaceMock_Expecter) SetActions(actions interface{}) *PromptNodeInterfaceMock_SetActions_Call {
-	return &PromptNodeInterfaceMock_SetActions_Call{Call: _e.mock.On("SetActions", actions)}
-}
-
-func (_c *PromptNodeInterfaceMock_SetActions_Call) Run(run func(actions []common.Action)) *PromptNodeInterfaceMock_SetActions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Action
-		if args[0] != nil {
-			arg0 = args[0].([]common.Action)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetActions_Call) Return() *PromptNodeInterfaceMock_SetActions_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetActions_Call) RunAndReturn(run func(actions []common.Action)) *PromptNodeInterfaceMock_SetActions_Call {
-	_c.Run(run)
-	return _c
-}
-
 // SetAsFinalNode provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) SetAsFinalNode() {
 	_mock.Called()
@@ -901,46 +815,6 @@ func (_c *PromptNodeInterfaceMock_SetCondition_Call) Return() *PromptNodeInterfa
 }
 
 func (_c *PromptNodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *NodeCondition)) *PromptNodeInterfaceMock_SetCondition_Call {
-	_c.Run(run)
-	return _c
-}
-
-// SetInputs provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) SetInputs(inputs []common.Input) {
-	_mock.Called(inputs)
-	return
-}
-
-// PromptNodeInterfaceMock_SetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetInputs'
-type PromptNodeInterfaceMock_SetInputs_Call struct {
-	*mock.Call
-}
-
-// SetInputs is a helper method to define mock.On call
-//   - inputs []common.Input
-func (_e *PromptNodeInterfaceMock_Expecter) SetInputs(inputs interface{}) *PromptNodeInterfaceMock_SetInputs_Call {
-	return &PromptNodeInterfaceMock_SetInputs_Call{Call: _e.mock.On("SetInputs", inputs)}
-}
-
-func (_c *PromptNodeInterfaceMock_SetInputs_Call) Run(run func(inputs []common.Input)) *PromptNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Input
-		if args[0] != nil {
-			arg0 = args[0].([]common.Input)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetInputs_Call) Return() *PromptNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *PromptNodeInterfaceMock_SetInputs_Call {
 	_c.Run(run)
 	return _c
 }
@@ -1061,6 +935,46 @@ func (_c *PromptNodeInterfaceMock_SetPreviousNodeList_Call) Return() *PromptNode
 }
 
 func (_c *PromptNodeInterfaceMock_SetPreviousNodeList_Call) RunAndReturn(run func(previousNodeIDList []string)) *PromptNodeInterfaceMock_SetPreviousNodeList_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetPrompts provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) SetPrompts(prompts []common.Prompt) {
+	_mock.Called(prompts)
+	return
+}
+
+// PromptNodeInterfaceMock_SetPrompts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetPrompts'
+type PromptNodeInterfaceMock_SetPrompts_Call struct {
+	*mock.Call
+}
+
+// SetPrompts is a helper method to define mock.On call
+//   - prompts []common.Prompt
+func (_e *PromptNodeInterfaceMock_Expecter) SetPrompts(prompts interface{}) *PromptNodeInterfaceMock_SetPrompts_Call {
+	return &PromptNodeInterfaceMock_SetPrompts_Call{Call: _e.mock.On("SetPrompts", prompts)}
+}
+
+func (_c *PromptNodeInterfaceMock_SetPrompts_Call) Run(run func(prompts []common.Prompt)) *PromptNodeInterfaceMock_SetPrompts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []common.Prompt
+		if args[0] != nil {
+			arg0 = args[0].([]common.Prompt)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetPrompts_Call) Return() *PromptNodeInterfaceMock_SetPrompts_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetPrompts_Call) RunAndReturn(run func(prompts []common.Prompt)) *PromptNodeInterfaceMock_SetPrompts_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/RepresentationNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/RepresentationNodeInterface_mock_test.go
@@ -271,52 +271,6 @@ func (_c *RepresentationNodeInterfaceMock_GetID_Call) RunAndReturn(run func() st
 	return _c
 }
 
-// GetInputs provides a mock function for the type RepresentationNodeInterfaceMock
-func (_mock *RepresentationNodeInterfaceMock) GetInputs() []common.Input {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInputs")
-	}
-
-	var r0 []common.Input
-	if returnFunc, ok := ret.Get(0).(func() []common.Input); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Input)
-		}
-	}
-	return r0
-}
-
-// RepresentationNodeInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
-type RepresentationNodeInterfaceMock_GetInputs_Call struct {
-	*mock.Call
-}
-
-// GetInputs is a helper method to define mock.On call
-func (_e *RepresentationNodeInterfaceMock_Expecter) GetInputs() *RepresentationNodeInterfaceMock_GetInputs_Call {
-	return &RepresentationNodeInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
-}
-
-func (_c *RepresentationNodeInterfaceMock_GetInputs_Call) Run(run func()) *RepresentationNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_GetInputs_Call) Return(inputs []common.Input) *RepresentationNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(inputs)
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_GetInputs_Call) RunAndReturn(run func() []common.Input) *RepresentationNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetNextNodeList provides a mock function for the type RepresentationNodeInterfaceMock
 func (_mock *RepresentationNodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -813,46 +767,6 @@ func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) Return() *Represent
 }
 
 func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *NodeCondition)) *RepresentationNodeInterfaceMock_SetCondition_Call {
-	_c.Run(run)
-	return _c
-}
-
-// SetInputs provides a mock function for the type RepresentationNodeInterfaceMock
-func (_mock *RepresentationNodeInterfaceMock) SetInputs(inputs []common.Input) {
-	_mock.Called(inputs)
-	return
-}
-
-// RepresentationNodeInterfaceMock_SetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetInputs'
-type RepresentationNodeInterfaceMock_SetInputs_Call struct {
-	*mock.Call
-}
-
-// SetInputs is a helper method to define mock.On call
-//   - inputs []common.Input
-func (_e *RepresentationNodeInterfaceMock_Expecter) SetInputs(inputs interface{}) *RepresentationNodeInterfaceMock_SetInputs_Call {
-	return &RepresentationNodeInterfaceMock_SetInputs_Call{Call: _e.mock.On("SetInputs", inputs)}
-}
-
-func (_c *RepresentationNodeInterfaceMock_SetInputs_Call) Run(run func(inputs []common.Input)) *RepresentationNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Input
-		if args[0] != nil {
-			arg0 = args[0].([]common.Input)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_SetInputs_Call) Return() *RepresentationNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *RepresentationNodeInterfaceMock_SetInputs_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/factory.go
+++ b/backend/internal/flow/core/factory.go
@@ -121,7 +121,6 @@ func (f *flowFactory) CloneNode(source NodeInterface) (NodeInterface, error) {
 	// Copy node connections and metadata
 	nodeCopy.SetNextNodeList(append([]string{}, source.GetNextNodeList()...))
 	nodeCopy.SetPreviousNodeList(append([]string{}, source.GetPreviousNodeList()...))
-	nodeCopy.SetInputs(append([]common.Input{}, source.GetInputs()...))
 
 	// Copy condition if present
 	if sourceCondition := source.GetCondition(); sourceCondition != nil {
@@ -138,10 +137,11 @@ func (f *flowFactory) CloneNode(source NodeInterface) (NodeInterface, error) {
 		}
 	}
 
-	// Copy executor name, onSuccess, and onFailure if the node is executor-backed
+	// Copy executor name, inputs, onSuccess, and onFailure if the node is executor-backed
 	if executableSource, ok := source.(ExecutorBackedNodeInterface); ok {
 		if executableCopy, ok := nodeCopy.(ExecutorBackedNodeInterface); ok {
 			executableCopy.SetExecutorName(executableSource.GetExecutorName())
+			executableCopy.SetInputs(append([]common.Input{}, executableSource.GetInputs()...))
 			executableCopy.SetOnSuccess(executableSource.GetOnSuccess())
 			executableCopy.SetOnFailure(executableSource.GetOnFailure())
 		} else {
@@ -149,10 +149,10 @@ func (f *flowFactory) CloneNode(source NodeInterface) (NodeInterface, error) {
 		}
 	}
 
-	// Copy actions and meta if the node is a prompt node
+	// Copy prompts and meta if the node is a prompt node
 	if promptSource, ok := source.(PromptNodeInterface); ok {
 		if promptCopy, ok := nodeCopy.(PromptNodeInterface); ok {
-			promptCopy.SetActions(append([]common.Action{}, promptSource.GetActions()...))
+			promptCopy.SetPrompts(append([]common.Prompt{}, promptSource.GetPrompts()...))
 			promptCopy.SetMeta(promptSource.GetMeta())
 		} else {
 			return nil, errors.New("mismatch in node types during cloning. copy is not a prompt node")

--- a/backend/internal/flow/core/factory_test.go
+++ b/backend/internal/flow/core/factory_test.go
@@ -188,11 +188,11 @@ func (s *FlowFactoryTestSuite) TestCreateExecutor() {
 func (s *FlowFactoryTestSuite) TestCloneNodeSuccess() {
 	node, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
 		map[string]interface{}{"key": "value"}, true, false)
-	node.SetInputs([]common.Input{{Identifier: "input1", Required: true}})
 	node.AddNextNode("next-1")
 	node.AddPreviousNode("prev-1")
 	if execNode, ok := node.(ExecutorBackedNodeInterface); ok {
 		execNode.SetExecutorName("test-executor")
+		execNode.SetInputs([]common.Input{{Identifier: "input1", Required: true}})
 	}
 
 	clonedNode, err := s.factory.CloneNode(node)
@@ -205,11 +205,11 @@ func (s *FlowFactoryTestSuite) TestCloneNodeSuccess() {
 	s.Equal(node.IsFinalNode(), clonedNode.IsFinalNode())
 	s.Equal(node.GetNextNodeList(), clonedNode.GetNextNodeList())
 	s.Equal(node.GetPreviousNodeList(), clonedNode.GetPreviousNodeList())
-	s.Len(clonedNode.GetInputs(), len(node.GetInputs()))
 
 	if sourceExecNode, ok := node.(ExecutorBackedNodeInterface); ok {
 		if clonedExecNode, ok := clonedNode.(ExecutorBackedNodeInterface); ok {
 			s.Equal(sourceExecNode.GetExecutorName(), clonedExecNode.GetExecutorName())
+			s.Len(clonedExecNode.GetInputs(), len(sourceExecNode.GetInputs()))
 		}
 	}
 

--- a/backend/internal/flow/core/graph.go
+++ b/backend/internal/flow/core/graph.go
@@ -242,19 +242,19 @@ func (g *graph) ToJSON() (string, error) {
 			PreviousNodeIDList: node.GetPreviousNodeList(),
 		}
 
-		// Set executor name if the node is executor-backed
+		// Set executor name and inputs if the node is executor-backed
 		if executableNode, ok := node.(ExecutorBackedNodeInterface); ok {
 			executorName := executableNode.GetExecutorName()
 			if executorName != "" {
 				jsonNode.Executor = executorName
 			}
-		}
 
-		inputs := node.GetInputs()
-		if len(inputs) > 0 {
-			jsonNode.Inputs = make([]JSONInputs, len(inputs))
-			for i, input := range inputs {
-				jsonNode.Inputs[i] = JSONInputs(input)
+			inputs := executableNode.GetInputs()
+			if len(inputs) > 0 {
+				jsonNode.Inputs = make([]JSONInputs, len(inputs))
+				for i, input := range inputs {
+					jsonNode.Inputs[i] = JSONInputs(input)
+				}
 			}
 		}
 

--- a/backend/internal/flow/core/graph_test.go
+++ b/backend/internal/flow/core/graph_test.go
@@ -299,9 +299,8 @@ func (s *GraphTestSuite) TestToJSON() {
 
 	if execNode, ok := node1.(ExecutorBackedNodeInterface); ok {
 		execNode.SetExecutorName("test-executor")
+		execNode.SetInputs([]common.Input{{Identifier: "username", Type: "string", Required: true}})
 	}
-
-	node1.SetInputs([]common.Input{{Identifier: "username", Type: "string", Required: true}})
 
 	_ = s.graph.AddNode(node1)
 	_ = s.graph.AddNode(node2)

--- a/backend/internal/flow/core/node.go
+++ b/backend/internal/flow/core/node.go
@@ -42,8 +42,6 @@ type NodeInterface interface {
 	SetPreviousNodeList(previousNodeIDList []string)
 	AddPreviousNode(previousNodeID string)
 	RemovePreviousNode(previousNodeID string)
-	GetInputs() []common.Input
-	SetInputs(inputs []common.Input)
 	GetCondition() *NodeCondition
 	SetCondition(condition *NodeCondition)
 }
@@ -64,6 +62,8 @@ type ExecutorBackedNodeInterface interface {
 	SetExecutorName(name string)
 	GetExecutor() ExecutorInterface
 	SetExecutor(executor ExecutorInterface)
+	GetInputs() []common.Input
+	SetInputs(inputs []common.Input)
 	GetOnSuccess() string
 	SetOnSuccess(nodeID string)
 	GetOnFailure() string
@@ -75,8 +75,8 @@ type ExecutorBackedNodeInterface interface {
 // PromptNodeInterface extends NodeInterface for nodes that require user interaction.
 type PromptNodeInterface interface {
 	NodeInterface
-	GetActions() []common.Action
-	SetActions(actions []common.Action)
+	GetPrompts() []common.Prompt
+	SetPrompts(prompts []common.Prompt)
 	GetMeta() interface{}
 	SetMeta(meta interface{})
 }
@@ -90,7 +90,6 @@ type node struct {
 	isFinalNode      bool
 	nextNodeList     []string
 	previousNodeList []string
-	inputs           []common.Input
 	condition        *NodeCondition
 }
 
@@ -241,16 +240,6 @@ func (n *node) RemovePreviousNode(previousNodeID string) {
 			return
 		}
 	}
-}
-
-// GetInputs returns the inputs required for the node
-func (n *node) GetInputs() []common.Input {
-	return n.inputs
-}
-
-// SetInputs sets the inputs required for the node
-func (n *node) SetInputs(inputs []common.Input) {
-	n.inputs = inputs
 }
 
 // GetCondition returns the execution condition for the node

--- a/backend/internal/flow/core/node_test.go
+++ b/backend/internal/flow/core/node_test.go
@@ -116,7 +116,11 @@ func (s *NodeTestSuite) TestInputsAndProperties() {
 
 	s.Equal(props, node.GetProperties())
 
+	// Cast to ExecutorBackedNodeInterface to access inputs
+	execNode, ok := node.(ExecutorBackedNodeInterface)
+	s.True(ok)
+
 	inputs := []common.Input{{Identifier: "i1", Required: true}}
-	node.SetInputs(inputs)
-	s.Equal(inputs, node.GetInputs())
+	execNode.SetInputs(inputs)
+	s.Equal(inputs, execNode.GetInputs())
 }

--- a/backend/internal/flow/core/representation_node.go
+++ b/backend/internal/flow/core/representation_node.go
@@ -47,7 +47,6 @@ func newRepresentationNode(id string, nodeType common.NodeType, properties map[s
 			isFinalNode:      isFinalNode,
 			nextNodeList:     []string{},
 			previousNodeList: []string{},
-			inputs:           []common.Input{},
 		},
 		onSuccess: "",
 	}

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -32,6 +32,7 @@ type taskExecutionNode struct {
 	executorName string
 	executor     ExecutorInterface
 	mode         string
+	inputs       []common.Input
 	onSuccess    string
 	onFailure    string
 }
@@ -51,10 +52,10 @@ func newTaskExecutionNode(id string, properties map[string]interface{}, isStartN
 			isFinalNode:      isFinalNode,
 			nextNodeList:     []string{},
 			previousNodeList: []string{},
-			inputs:           []common.Input{},
 		},
 		executorName: "",
 		executor:     nil,
+		inputs:       []common.Input{},
 	}
 }
 
@@ -222,4 +223,14 @@ func (n *taskExecutionNode) GetMode() string {
 // SetMode sets the mode for the executor that supports multi-step execution
 func (n *taskExecutionNode) SetMode(mode string) {
 	n.mode = mode
+}
+
+// GetInputs returns the inputs required for the task execution node
+func (n *taskExecutionNode) GetInputs() []common.Input {
+	return n.inputs
+}
+
+// SetInputs sets the inputs required for the task execution node
+func (n *taskExecutionNode) SetInputs(inputs []common.Input) {
+	n.inputs = inputs
 }

--- a/backend/internal/flow/mgt/immutable_resource_test.go
+++ b/backend/internal/flow/mgt/immutable_resource_test.go
@@ -684,12 +684,14 @@ func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_WithComplexMe
 		ID:   "prompt_credentials",
 		Type: "PROMPT",
 		Meta: complexMeta,
-		Inputs: []InputDefinition{
-			{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
-			{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
-		},
-		Actions: []ActionDefinition{
-			{Ref: "action_001", NextNode: "basic_auth"},
+		Prompts: []PromptDefinition{
+			{
+				Inputs: []InputDefinition{
+					{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
+					{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
+				},
+				Action: &ActionDefinition{Ref: "action_001", NextNode: "basic_auth"},
+			},
 		},
 	}
 
@@ -735,14 +737,15 @@ func (s *ImmutableResourceTestSuite) TestNodeDefinitionUnmarshalYAML_WithComplex
 id: prompt_credentials
 type: PROMPT
 meta: '%s'
-inputs:
-  - ref: input_001
-    type: TEXT_INPUT
-    identifier: username
-    required: true
-actions:
-  - ref: action_001
-    nextNode: basic_auth
+prompts:
+  - inputs:
+      - ref: input_001
+        type: TEXT_INPUT
+        identifier: username
+        required: true
+    action:
+      ref: action_001
+      nextNode: basic_auth
 `, metaJSON))
 
 	// Parse the actual YAML
@@ -826,12 +829,14 @@ func (s *ImmutableResourceTestSuite) TestCompleteFlowDefinition_MarshalUnmarshal
 						},
 					},
 				},
-				Inputs: []InputDefinition{
-					{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
-					{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
-				},
-				Actions: []ActionDefinition{
-					{Ref: "action_001", NextNode: "basic_auth"},
+				Prompts: []PromptDefinition{
+					{
+						Inputs: []InputDefinition{
+							{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
+							{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
+						},
+						Action: &ActionDefinition{Ref: "action_001", NextNode: "basic_auth"},
+					},
 				},
 			},
 			{
@@ -1310,16 +1315,21 @@ func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_RoundTrip() {
 					Position: &NodePosition{X: 100, Y: 200},
 					Size:     &NodeSize{Width: 300, Height: 400},
 				},
-				Inputs: []InputDefinition{
-					{Type: "TEXT", Identifier: "input1", Required: true},
+				Executor: &ExecutorDefinition{
+					Name: "test-executor",
+					Inputs: []InputDefinition{
+						{Type: "TEXT", Identifier: "input1", Required: true},
+					},
 				},
-				Actions: []ActionDefinition{
-					{Ref: "action1", NextNode: "next"},
+				Prompts: []PromptDefinition{
+					{
+						Action: &ActionDefinition{Ref: "action1", NextNode: "next"},
+					},
 				},
 				Properties: map[string]interface{}{
 					"prop1": "value1",
 				},
-				Executor:  &ExecutorDefinition{Name: "test-executor"},
+
 				OnSuccess: "success-node",
 				OnFailure: "failure-node",
 			},
@@ -1328,8 +1338,9 @@ func (s *ImmutableResourceTestSuite) TestNodeDefinitionMarshalYAML_RoundTrip() {
 				assert.Equal(t, "EXECUTOR", nd.Type)
 				assert.NotNil(t, nd.Layout)
 				assert.Equal(t, float64(100), nd.Layout.Position.X)
-				assert.Len(t, nd.Inputs, 1)
-				assert.Len(t, nd.Actions, 1)
+				assert.NotNil(t, nd.Executor)
+				assert.Len(t, nd.Executor.Inputs, 1)
+				assert.Len(t, nd.Prompts, 1)
 				metaMap := nd.Meta.(map[string]interface{})
 				assert.Equal(t, "value", metaMap["config"])
 			},

--- a/backend/internal/flow/mgt/inference.go
+++ b/backend/internal/flow/mgt/inference.go
@@ -297,10 +297,10 @@ func (s *flowInferenceService) insertNodeBefore(nodes *[]NodeDefinition,
 			modified = true
 		}
 
-		// Update actions that point to target
-		for j := range node.Actions {
-			if node.Actions[j].NextNode == targetNodeID {
-				node.Actions[j].NextNode = newNode.ID
+		// Update prompts that have actions pointing to target
+		for j := range node.Prompts {
+			if node.Prompts[j].Action != nil && node.Prompts[j].Action.NextNode == targetNodeID {
+				node.Prompts[j].Action.NextNode = newNode.ID
 				modified = true
 			}
 		}

--- a/backend/internal/flow/mgt/inference_test.go
+++ b/backend/internal/flow/mgt/inference_test.go
@@ -155,9 +155,9 @@ func (s *FlowInferenceServiceTestSuite) TestInferRegistrationFlow_WithAuthAssert
 			{
 				ID:   "decision",
 				Type: "DECISION",
-				Actions: []ActionDefinition{
-					{Ref: "path1", NextNode: "auth1"},
-					{Ref: "path2", NextNode: "auth2"},
+				Prompts: []PromptDefinition{
+					{Action: &ActionDefinition{Ref: "path1", NextNode: "auth1"}},
+					{Action: &ActionDefinition{Ref: "path2", NextNode: "auth2"}},
 				},
 			},
 			{
@@ -336,9 +336,9 @@ func (s *FlowInferenceServiceTestSuite) TestInferRegistrationFlow_WithActions() 
 			{
 				ID:   "prompt",
 				Type: "PROMPT",
-				Actions: []ActionDefinition{
-					{Ref: "login", NextNode: "end"},
-					{Ref: "signup", NextNode: "end"},
+				Prompts: []PromptDefinition{
+					{Action: &ActionDefinition{Ref: "login", NextNode: "end"}},
+					{Action: &ActionDefinition{Ref: "signup", NextNode: "end"}},
 				},
 			},
 			{ID: "end", Type: "END"},
@@ -349,10 +349,10 @@ func (s *FlowInferenceServiceTestSuite) TestInferRegistrationFlow_WithActions() 
 
 	s.NoError(err)
 	promptNode := s.getNode(regFlow.Nodes, "prompt")
-	s.Len(promptNode.Actions, 2)
+	s.Len(promptNode.Prompts, 2)
 	// Actions should now point to provisioning node instead of end (since no AuthAssert exists)
-	s.Equal(provisioningNodeID, promptNode.Actions[0].NextNode)
-	s.Equal(provisioningNodeID, promptNode.Actions[1].NextNode)
+	s.Equal(provisioningNodeID, promptNode.Prompts[0].Action.NextNode)
+	s.Equal(provisioningNodeID, promptNode.Prompts[1].Action.NextNode)
 }
 
 func (s *FlowInferenceServiceTestSuite) TestInferRegistrationFlow_WithOnFailure() {
@@ -907,9 +907,9 @@ func (s *FlowInferenceServiceTestSuite) TestInsertNodeBefore_WithActions() {
 		{
 			ID:   "prompt",
 			Type: "PROMPT",
-			Actions: []ActionDefinition{
-				{Ref: "action1", NextNode: "end"},
-				{Ref: "action2", NextNode: "task"},
+			Prompts: []PromptDefinition{
+				{Action: &ActionDefinition{Ref: "action1", NextNode: "end"}},
+				{Action: &ActionDefinition{Ref: "action2", NextNode: "task"}},
 			},
 		},
 		{ID: "task", Type: "TASK_EXECUTION"},
@@ -920,8 +920,8 @@ func (s *FlowInferenceServiceTestSuite) TestInsertNodeBefore_WithActions() {
 	err := service.insertNodeBefore(&nodes, newNode, "end")
 
 	s.NoError(err)
-	s.Equal("new", nodes[1].Actions[0].NextNode)
-	s.Equal("task", nodes[1].Actions[1].NextNode) // unchanged
+	s.Equal("new", nodes[1].Prompts[0].Action.NextNode)
+	s.Equal("task", nodes[1].Prompts[1].Action.NextNode) // unchanged
 }
 
 func (s *FlowInferenceServiceTestSuite) TestInsertNodeBefore_NoNodesPointingToTarget() {

--- a/backend/internal/flow/mgt/model.go
+++ b/backend/internal/flow/mgt/model.go
@@ -126,8 +126,7 @@ type NodeDefinition struct {
 	Type       string                 `json:"type" yaml:"type"`
 	Layout     *NodeLayout            `json:"layout,omitempty" yaml:"layout,omitempty"`
 	Meta       interface{}            `json:"meta,omitempty" yaml:"meta,omitempty"`
-	Inputs     []InputDefinition      `json:"inputs,omitempty" yaml:"inputs,omitempty"`
-	Actions    []ActionDefinition     `json:"actions,omitempty" yaml:"actions,omitempty"`
+	Prompts    []PromptDefinition     `json:"prompts,omitempty" yaml:"prompts,omitempty"`
 	Properties map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
 	Executor   *ExecutorDefinition    `json:"executor,omitempty" yaml:"executor,omitempty"`
 	OnSuccess  string                 `json:"onSuccess,omitempty" yaml:"onSuccess,omitempty"`
@@ -149,10 +148,17 @@ type ActionDefinition struct {
 	NextNode string `json:"nextNode" yaml:"nextNode"`
 }
 
+// PromptDefinition groups inputs with an action for prompt nodes.
+type PromptDefinition struct {
+	Inputs []InputDefinition `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Action *ActionDefinition `json:"action,omitempty" yaml:"action,omitempty"`
+}
+
 // ExecutorDefinition represents the executor configuration for a node.
 type ExecutorDefinition struct {
-	Name string `json:"name" yaml:"name"`
-	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"` // Execution mode for multi-step executors
+	Name   string            `json:"name" yaml:"name"`
+	Mode   string            `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Inputs []InputDefinition `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 }
 
 // ConditionDefinition represents a condition for node execution.

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -2231,12 +2231,14 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowWithCom
 				ID:   "prompt",
 				Type: "PROMPT",
 				Meta: complexMeta,
-				Inputs: []flowmgt.InputDefinition{
-					{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
-					{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
-				},
-				Actions: []flowmgt.ActionDefinition{
-					{Ref: "action_001", NextNode: "end"},
+				Prompts: []flowmgt.PromptDefinition{
+					{
+						Inputs: []flowmgt.InputDefinition{
+							{Ref: "input_001", Type: "TEXT_INPUT", Identifier: "username", Required: true},
+							{Ref: "input_002", Type: "PASSWORD_INPUT", Identifier: "password", Required: true},
+						},
+						Action: &flowmgt.ActionDefinition{Ref: "action_001", NextNode: "end"},
+					},
 				},
 			},
 			{

--- a/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
@@ -272,52 +272,6 @@ func (_c *NodeInterfaceMock_GetID_Call) RunAndReturn(run func() string) *NodeInt
 	return _c
 }
 
-// GetInputs provides a mock function for the type NodeInterfaceMock
-func (_mock *NodeInterfaceMock) GetInputs() []common.Input {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInputs")
-	}
-
-	var r0 []common.Input
-	if returnFunc, ok := ret.Get(0).(func() []common.Input); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Input)
-		}
-	}
-	return r0
-}
-
-// NodeInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
-type NodeInterfaceMock_GetInputs_Call struct {
-	*mock.Call
-}
-
-// GetInputs is a helper method to define mock.On call
-func (_e *NodeInterfaceMock_Expecter) GetInputs() *NodeInterfaceMock_GetInputs_Call {
-	return &NodeInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
-}
-
-func (_c *NodeInterfaceMock_GetInputs_Call) Run(run func()) *NodeInterfaceMock_GetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *NodeInterfaceMock_GetInputs_Call) Return(inputs []common.Input) *NodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(inputs)
-	return _c
-}
-
-func (_c *NodeInterfaceMock_GetInputs_Call) RunAndReturn(run func() []common.Input) *NodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetNextNodeList provides a mock function for the type NodeInterfaceMock
 func (_mock *NodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -770,46 +724,6 @@ func (_c *NodeInterfaceMock_SetCondition_Call) Return() *NodeInterfaceMock_SetCo
 }
 
 func (_c *NodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *core.NodeCondition)) *NodeInterfaceMock_SetCondition_Call {
-	_c.Run(run)
-	return _c
-}
-
-// SetInputs provides a mock function for the type NodeInterfaceMock
-func (_mock *NodeInterfaceMock) SetInputs(inputs []common.Input) {
-	_mock.Called(inputs)
-	return
-}
-
-// NodeInterfaceMock_SetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetInputs'
-type NodeInterfaceMock_SetInputs_Call struct {
-	*mock.Call
-}
-
-// SetInputs is a helper method to define mock.On call
-//   - inputs []common.Input
-func (_e *NodeInterfaceMock_Expecter) SetInputs(inputs interface{}) *NodeInterfaceMock_SetInputs_Call {
-	return &NodeInterfaceMock_SetInputs_Call{Call: _e.mock.On("SetInputs", inputs)}
-}
-
-func (_c *NodeInterfaceMock_SetInputs_Call) Run(run func(inputs []common.Input)) *NodeInterfaceMock_SetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Input
-		if args[0] != nil {
-			arg0 = args[0].([]common.Input)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *NodeInterfaceMock_SetInputs_Call) Return() *NodeInterfaceMock_SetInputs_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *NodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *NodeInterfaceMock_SetInputs_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/coremock/PromptNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/PromptNodeInterface_mock.go
@@ -182,52 +182,6 @@ func (_c *PromptNodeInterfaceMock_Execute_Call) RunAndReturn(run func(ctx *core.
 	return _c
 }
 
-// GetActions provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) GetActions() []common.Action {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetActions")
-	}
-
-	var r0 []common.Action
-	if returnFunc, ok := ret.Get(0).(func() []common.Action); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Action)
-		}
-	}
-	return r0
-}
-
-// PromptNodeInterfaceMock_GetActions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActions'
-type PromptNodeInterfaceMock_GetActions_Call struct {
-	*mock.Call
-}
-
-// GetActions is a helper method to define mock.On call
-func (_e *PromptNodeInterfaceMock_Expecter) GetActions() *PromptNodeInterfaceMock_GetActions_Call {
-	return &PromptNodeInterfaceMock_GetActions_Call{Call: _e.mock.On("GetActions")}
-}
-
-func (_c *PromptNodeInterfaceMock_GetActions_Call) Run(run func()) *PromptNodeInterfaceMock_GetActions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetActions_Call) Return(actions []common.Action) *PromptNodeInterfaceMock_GetActions_Call {
-	_c.Call.Return(actions)
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetActions_Call) RunAndReturn(run func() []common.Action) *PromptNodeInterfaceMock_GetActions_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetCondition provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) GetCondition() *core.NodeCondition {
 	ret := _mock.Called()
@@ -314,52 +268,6 @@ func (_c *PromptNodeInterfaceMock_GetID_Call) Return(s string) *PromptNodeInterf
 }
 
 func (_c *PromptNodeInterfaceMock_GetID_Call) RunAndReturn(run func() string) *PromptNodeInterfaceMock_GetID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetInputs provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) GetInputs() []common.Input {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInputs")
-	}
-
-	var r0 []common.Input
-	if returnFunc, ok := ret.Get(0).(func() []common.Input); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Input)
-		}
-	}
-	return r0
-}
-
-// PromptNodeInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
-type PromptNodeInterfaceMock_GetInputs_Call struct {
-	*mock.Call
-}
-
-// GetInputs is a helper method to define mock.On call
-func (_e *PromptNodeInterfaceMock_Expecter) GetInputs() *PromptNodeInterfaceMock_GetInputs_Call {
-	return &PromptNodeInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
-}
-
-func (_c *PromptNodeInterfaceMock_GetInputs_Call) Run(run func()) *PromptNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetInputs_Call) Return(inputs []common.Input) *PromptNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(inputs)
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_GetInputs_Call) RunAndReturn(run func() []common.Input) *PromptNodeInterfaceMock_GetInputs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -498,6 +406,52 @@ func (_c *PromptNodeInterfaceMock_GetPreviousNodeList_Call) Return(strings []str
 }
 
 func (_c *PromptNodeInterfaceMock_GetPreviousNodeList_Call) RunAndReturn(run func() []string) *PromptNodeInterfaceMock_GetPreviousNodeList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPrompts provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) GetPrompts() []common.Prompt {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPrompts")
+	}
+
+	var r0 []common.Prompt
+	if returnFunc, ok := ret.Get(0).(func() []common.Prompt); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.Prompt)
+		}
+	}
+	return r0
+}
+
+// PromptNodeInterfaceMock_GetPrompts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPrompts'
+type PromptNodeInterfaceMock_GetPrompts_Call struct {
+	*mock.Call
+}
+
+// GetPrompts is a helper method to define mock.On call
+func (_e *PromptNodeInterfaceMock_Expecter) GetPrompts() *PromptNodeInterfaceMock_GetPrompts_Call {
+	return &PromptNodeInterfaceMock_GetPrompts_Call{Call: _e.mock.On("GetPrompts")}
+}
+
+func (_c *PromptNodeInterfaceMock_GetPrompts_Call) Run(run func()) *PromptNodeInterfaceMock_GetPrompts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetPrompts_Call) Return(prompts []common.Prompt) *PromptNodeInterfaceMock_GetPrompts_Call {
+	_c.Call.Return(prompts)
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetPrompts_Call) RunAndReturn(run func() []common.Prompt) *PromptNodeInterfaceMock_GetPrompts_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -760,46 +714,6 @@ func (_c *PromptNodeInterfaceMock_RemovePreviousNode_Call) RunAndReturn(run func
 	return _c
 }
 
-// SetActions provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) SetActions(actions []common.Action) {
-	_mock.Called(actions)
-	return
-}
-
-// PromptNodeInterfaceMock_SetActions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetActions'
-type PromptNodeInterfaceMock_SetActions_Call struct {
-	*mock.Call
-}
-
-// SetActions is a helper method to define mock.On call
-//   - actions []common.Action
-func (_e *PromptNodeInterfaceMock_Expecter) SetActions(actions interface{}) *PromptNodeInterfaceMock_SetActions_Call {
-	return &PromptNodeInterfaceMock_SetActions_Call{Call: _e.mock.On("SetActions", actions)}
-}
-
-func (_c *PromptNodeInterfaceMock_SetActions_Call) Run(run func(actions []common.Action)) *PromptNodeInterfaceMock_SetActions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Action
-		if args[0] != nil {
-			arg0 = args[0].([]common.Action)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetActions_Call) Return() *PromptNodeInterfaceMock_SetActions_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetActions_Call) RunAndReturn(run func(actions []common.Action)) *PromptNodeInterfaceMock_SetActions_Call {
-	_c.Run(run)
-	return _c
-}
-
 // SetAsFinalNode provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) SetAsFinalNode() {
 	_mock.Called()
@@ -902,46 +816,6 @@ func (_c *PromptNodeInterfaceMock_SetCondition_Call) Return() *PromptNodeInterfa
 }
 
 func (_c *PromptNodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *core.NodeCondition)) *PromptNodeInterfaceMock_SetCondition_Call {
-	_c.Run(run)
-	return _c
-}
-
-// SetInputs provides a mock function for the type PromptNodeInterfaceMock
-func (_mock *PromptNodeInterfaceMock) SetInputs(inputs []common.Input) {
-	_mock.Called(inputs)
-	return
-}
-
-// PromptNodeInterfaceMock_SetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetInputs'
-type PromptNodeInterfaceMock_SetInputs_Call struct {
-	*mock.Call
-}
-
-// SetInputs is a helper method to define mock.On call
-//   - inputs []common.Input
-func (_e *PromptNodeInterfaceMock_Expecter) SetInputs(inputs interface{}) *PromptNodeInterfaceMock_SetInputs_Call {
-	return &PromptNodeInterfaceMock_SetInputs_Call{Call: _e.mock.On("SetInputs", inputs)}
-}
-
-func (_c *PromptNodeInterfaceMock_SetInputs_Call) Run(run func(inputs []common.Input)) *PromptNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Input
-		if args[0] != nil {
-			arg0 = args[0].([]common.Input)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetInputs_Call) Return() *PromptNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *PromptNodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *PromptNodeInterfaceMock_SetInputs_Call {
 	_c.Run(run)
 	return _c
 }
@@ -1062,6 +936,46 @@ func (_c *PromptNodeInterfaceMock_SetPreviousNodeList_Call) Return() *PromptNode
 }
 
 func (_c *PromptNodeInterfaceMock_SetPreviousNodeList_Call) RunAndReturn(run func(previousNodeIDList []string)) *PromptNodeInterfaceMock_SetPreviousNodeList_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetPrompts provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) SetPrompts(prompts []common.Prompt) {
+	_mock.Called(prompts)
+	return
+}
+
+// PromptNodeInterfaceMock_SetPrompts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetPrompts'
+type PromptNodeInterfaceMock_SetPrompts_Call struct {
+	*mock.Call
+}
+
+// SetPrompts is a helper method to define mock.On call
+//   - prompts []common.Prompt
+func (_e *PromptNodeInterfaceMock_Expecter) SetPrompts(prompts interface{}) *PromptNodeInterfaceMock_SetPrompts_Call {
+	return &PromptNodeInterfaceMock_SetPrompts_Call{Call: _e.mock.On("SetPrompts", prompts)}
+}
+
+func (_c *PromptNodeInterfaceMock_SetPrompts_Call) Run(run func(prompts []common.Prompt)) *PromptNodeInterfaceMock_SetPrompts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []common.Prompt
+		if args[0] != nil {
+			arg0 = args[0].([]common.Prompt)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetPrompts_Call) Return() *PromptNodeInterfaceMock_SetPrompts_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetPrompts_Call) RunAndReturn(run func(prompts []common.Prompt)) *PromptNodeInterfaceMock_SetPrompts_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/coremock/RepresentationNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/RepresentationNodeInterface_mock.go
@@ -272,52 +272,6 @@ func (_c *RepresentationNodeInterfaceMock_GetID_Call) RunAndReturn(run func() st
 	return _c
 }
 
-// GetInputs provides a mock function for the type RepresentationNodeInterfaceMock
-func (_mock *RepresentationNodeInterfaceMock) GetInputs() []common.Input {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInputs")
-	}
-
-	var r0 []common.Input
-	if returnFunc, ok := ret.Get(0).(func() []common.Input); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Input)
-		}
-	}
-	return r0
-}
-
-// RepresentationNodeInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
-type RepresentationNodeInterfaceMock_GetInputs_Call struct {
-	*mock.Call
-}
-
-// GetInputs is a helper method to define mock.On call
-func (_e *RepresentationNodeInterfaceMock_Expecter) GetInputs() *RepresentationNodeInterfaceMock_GetInputs_Call {
-	return &RepresentationNodeInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
-}
-
-func (_c *RepresentationNodeInterfaceMock_GetInputs_Call) Run(run func()) *RepresentationNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_GetInputs_Call) Return(inputs []common.Input) *RepresentationNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(inputs)
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_GetInputs_Call) RunAndReturn(run func() []common.Input) *RepresentationNodeInterfaceMock_GetInputs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetNextNodeList provides a mock function for the type RepresentationNodeInterfaceMock
 func (_mock *RepresentationNodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -814,46 +768,6 @@ func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) Return() *Represent
 }
 
 func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *core.NodeCondition)) *RepresentationNodeInterfaceMock_SetCondition_Call {
-	_c.Run(run)
-	return _c
-}
-
-// SetInputs provides a mock function for the type RepresentationNodeInterfaceMock
-func (_mock *RepresentationNodeInterfaceMock) SetInputs(inputs []common.Input) {
-	_mock.Called(inputs)
-	return
-}
-
-// RepresentationNodeInterfaceMock_SetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetInputs'
-type RepresentationNodeInterfaceMock_SetInputs_Call struct {
-	*mock.Call
-}
-
-// SetInputs is a helper method to define mock.On call
-//   - inputs []common.Input
-func (_e *RepresentationNodeInterfaceMock_Expecter) SetInputs(inputs interface{}) *RepresentationNodeInterfaceMock_SetInputs_Call {
-	return &RepresentationNodeInterfaceMock_SetInputs_Call{Call: _e.mock.On("SetInputs", inputs)}
-}
-
-func (_c *RepresentationNodeInterfaceMock_SetInputs_Call) Run(run func(inputs []common.Input)) *RepresentationNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []common.Input
-		if args[0] != nil {
-			arg0 = args[0].([]common.Input)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_SetInputs_Call) Return() *RepresentationNodeInterfaceMock_SetInputs_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *RepresentationNodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *RepresentationNodeInterfaceMock_SetInputs_Call {
 	_c.Run(run)
 	return _c
 }

--- a/tests/integration/flow/authentication/assurance_test.go
+++ b/tests/integration/flow/authentication/assurance_test.go
@@ -53,18 +53,20 @@ var (
 			{
 				"id":   "prompt_mobile",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "mobileNumber",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "sms_otp_send",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "mobileNumber",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "sms_otp_send",
+						},
 					},
 				},
 			},
@@ -83,18 +85,20 @@ var (
 			{
 				"id":   "prompt_otp",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_002",
-						"identifier": "otp",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_002",
-						"nextNode": "sms_otp_verify",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_002",
+								"identifier": "otp",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_002",
+							"nextNode": "sms_otp_verify",
+						},
 					},
 				},
 			},
@@ -139,24 +143,26 @@ var (
 			{
 				"id":   "prompt_credentials",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "string",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},
@@ -183,18 +189,20 @@ var (
 			{
 				"id":   "prompt_otp",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_003",
-						"identifier": "otp",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_002",
-						"nextNode": "sms_otp_verify",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_003",
+								"identifier": "otp",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_002",
+							"nextNode": "sms_otp_verify",
+						},
 					},
 				},
 			},
@@ -239,24 +247,26 @@ var (
 			{
 				"id":   "prompt_credentials",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "string",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},

--- a/tests/integration/flow/authentication/attribute_collect_test.go
+++ b/tests/integration/flow/authentication/attribute_collect_test.go
@@ -49,34 +49,34 @@ var (
 			{
 				"id":   "attribute_collect",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_003",
-						"identifier": "firstName",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_004",
-						"identifier": "lastName",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_005",
-						"identifier": "email",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_006",
-						"identifier": "mobileNumber",
-						"type":       "string",
-						"required":   false,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "AttributeCollector",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_003",
+							"identifier": "firstName",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_004",
+							"identifier": "lastName",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_005",
+							"identifier": "email",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_006",
+							"identifier": "mobileNumber",
+							"type":       "string",
+							"required":   false,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},

--- a/tests/integration/flow/authentication/authz_test.go
+++ b/tests/integration/flow/authentication/authz_test.go
@@ -70,46 +70,48 @@ var (
 			{
 				"id":   "prompt_credentials",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "PASSWORD_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "authorization_check",
 			},

--- a/tests/integration/flow/authentication/basic_auth_test.go
+++ b/tests/integration/flow/authentication/basic_auth_test.go
@@ -48,46 +48,48 @@ var (
 			{
 				"id":   "prompt_credentials",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "PASSWORD_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},
@@ -119,22 +121,22 @@ var (
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},

--- a/tests/integration/flow/authentication/multi_action_input_binding_test.go
+++ b/tests/integration/flow/authentication/multi_action_input_binding_test.go
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/tests/integration/flow/common"
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+)
+
+const (
+	mockMultiActionGooglePort = 8099
+)
+
+var (
+	multiActionInputBindingFlow = testutils.Flow{
+		Name:     "Multi Action Input Binding Test Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "multi_action_input_binding_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_choice",
+			},
+			{
+				"id":   "prompt_choice",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "string",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_basic",
+							"nextNode": "basic_auth",
+						},
+					},
+					{
+						"action": map[string]interface{}{
+							"ref":      "action_google",
+							"nextNode": "google_auth",
+						},
+					},
+				},
+			},
+			{
+				"id":   "basic_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "BasicAuthExecutor",
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "google_auth",
+				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"idpId": "placeholder-idp-id",
+				},
+				"executor": map[string]interface{}{
+					"name": "GoogleOIDCAuthExecutor",
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	multiActionInputBindingTestApp = testutils.Application{
+		Name:                      "Multi Action Input Binding Test Application",
+		Description:               "Application for testing prompts-based input-action binding",
+		IsRegistrationFlowEnabled: false,
+		ClientID:                  "multi_action_input_binding_test_client",
+		ClientSecret:              "multi_action_input_binding_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"multi_action_input_binding_test_person"},
+	}
+
+	multiActionInputBindingTestOU = testutils.OrganizationUnit{
+		Handle:      "multi-action-input-binding-test-ou",
+		Name:        "Multi Action Input Binding Test Organization Unit",
+		Description: "Organization unit for multi action input binding testing",
+		Parent:      nil,
+	}
+
+	multiActionInputBindingUserSchema = testutils.UserSchema{
+		Name: "multi_action_input_binding_test_person",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"sub": map[string]interface{}{
+				"type": "string",
+			},
+			"givenName": map[string]interface{}{
+				"type": "string",
+			},
+			"familyName": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	testUserMultiActionInputBinding = testutils.User{
+		Type: multiActionInputBindingUserSchema.Name,
+		Attributes: json.RawMessage(`{
+			"username": "multiactionuser",
+			"password": "testpassword",
+			"email": "multiactionuser@example.com",
+			"sub": "google-multi-action-user-123",
+			"givenName": "Multi",
+			"familyName": "Action"
+		}`),
+	}
+)
+
+var (
+	multiActionInputBindingTestAppID    string
+	multiActionInputBindingTestOUID     string
+	multiActionInputBindingUserSchemaID string
+)
+
+type MultiActionInputBindingTestSuite struct {
+	suite.Suite
+	config           *common.TestSuiteConfig
+	mockGoogleServer *testutils.MockGoogleOIDCServer
+}
+
+func TestMultiActionInputBindingTestSuite(t *testing.T) {
+	suite.Run(t, new(MultiActionInputBindingTestSuite))
+}
+
+func (ts *MultiActionInputBindingTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	// Start mock Google server
+	mockServer, err := testutils.NewMockGoogleOIDCServer(mockMultiActionGooglePort,
+		"test_multi_action_google_client", "test_multi_action_google_secret")
+	ts.Require().NoError(err, "Failed to create mock Google server")
+	ts.mockGoogleServer = mockServer
+
+	ts.mockGoogleServer.AddUser(&testutils.GoogleUserInfo{
+		Sub:           "google-multi-action-user-123",
+		Email:         "multiactionuser@example.com",
+		EmailVerified: true,
+		Name:          "Multi Action",
+		GivenName:     "Multi",
+		FamilyName:    "Action",
+		Picture:       "https://example.com/picture.jpg",
+		Locale:        "en",
+	})
+
+	err = ts.mockGoogleServer.Start()
+	ts.Require().NoError(err, "Failed to start mock Google server")
+
+	// Create test organization unit
+	ouID, err := testutils.CreateOrganizationUnit(multiActionInputBindingTestOU)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test organization unit: %v", err)
+	}
+	multiActionInputBindingTestOUID = ouID
+
+	// Create test user schema within the OU
+	multiActionInputBindingUserSchema.OrganizationUnitId = multiActionInputBindingTestOUID
+	schemaID, err := testutils.CreateUserType(multiActionInputBindingUserSchema)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user schema: %v", err)
+	}
+	multiActionInputBindingUserSchemaID = schemaID
+
+	// Create test user with the created OU
+	testUser := testUserMultiActionInputBinding
+	testUser.OrganizationUnit = multiActionInputBindingTestOUID
+	userID, err := testutils.CreateUser(testUser)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test user: %v", err)
+	}
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, userID)
+
+	// Create Google IDP
+	googleIDP := testutils.IDP{
+		Name:        "Multi Action Test Google IDP",
+		Description: "Google IDP for multi action input binding test",
+		Type:        "GOOGLE",
+		Properties: []testutils.IDPProperty{
+			{Name: "client_id", Value: "test_multi_action_google_client", IsSecret: false},
+			{Name: "client_secret", Value: "test_multi_action_google_secret", IsSecret: true},
+			{Name: "redirect_uri", Value: "http://localhost:3000/callback", IsSecret: false},
+			{Name: "scopes", Value: "openid email profile", IsSecret: false},
+			{Name: "authorization_endpoint", Value: ts.mockGoogleServer.GetURL() + "/o/oauth2/v2/auth", IsSecret: false},
+			{Name: "token_endpoint", Value: ts.mockGoogleServer.GetURL() + "/token", IsSecret: false},
+			{Name: "userinfo_endpoint", Value: ts.mockGoogleServer.GetURL() + "/v1/userinfo", IsSecret: false},
+			{Name: "jwks_endpoint", Value: ts.mockGoogleServer.GetURL() + "/oauth2/v3/certs", IsSecret: false},
+		},
+	}
+
+	idpID, err := testutils.CreateIDP(googleIDP)
+	ts.Require().NoError(err, "Failed to create Google IDP")
+	ts.config.CreatedIdpIDs = append(ts.config.CreatedIdpIDs, idpID)
+
+	// Update flow definition with created IDP ID
+	nodes := multiActionInputBindingFlow.Nodes.([]map[string]interface{})
+	nodes[3]["properties"].(map[string]interface{})["idpId"] = idpID
+	multiActionInputBindingFlow.Nodes = nodes
+
+	// Create flow
+	flowID, err := testutils.CreateFlow(multiActionInputBindingFlow)
+	ts.Require().NoError(err, "Failed to create multi action input binding flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+	multiActionInputBindingTestApp.AuthFlowID = flowID
+
+	// Create test application
+	appID, err := testutils.CreateApplication(multiActionInputBindingTestApp)
+	if err != nil {
+		ts.T().Fatalf("Failed to create test application: %v", err)
+	}
+	multiActionInputBindingTestAppID = appID
+}
+
+func (ts *MultiActionInputBindingTestSuite) TearDownSuite() {
+	// Delete test users
+	if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+		ts.T().Logf("Failed to cleanup users: %v", err)
+	}
+
+	// Delete test flows
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete flow %s: %v", flowID, err)
+		}
+	}
+
+	// Delete test IDPs
+	for _, idpID := range ts.config.CreatedIdpIDs {
+		if err := testutils.DeleteIDP(idpID); err != nil {
+			ts.T().Logf("Failed to delete IDP %s: %v", idpID, err)
+		}
+	}
+
+	// Delete test application
+	if multiActionInputBindingTestAppID != "" {
+		if err := testutils.DeleteApplication(multiActionInputBindingTestAppID); err != nil {
+			ts.T().Logf("Failed to delete test application: %v", err)
+		}
+	}
+
+	// Delete test user schema
+	if multiActionInputBindingUserSchemaID != "" {
+		if err := testutils.DeleteUserType(multiActionInputBindingUserSchemaID); err != nil {
+			ts.T().Logf("Failed to delete user schema: %v", err)
+		}
+	}
+
+	// Delete test organization unit
+	if multiActionInputBindingTestOUID != "" {
+		if err := testutils.DeleteOrganizationUnit(multiActionInputBindingTestOUID); err != nil {
+			ts.T().Logf("Failed to delete organization unit: %v", err)
+		}
+	}
+
+	// Stop mock Google server
+	if ts.mockGoogleServer != nil {
+		_ = ts.mockGoogleServer.Stop()
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (ts *MultiActionInputBindingTestSuite) TestInitiateFlow_ShowsAllActions() {
+	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	ts.Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Equal("VIEW", flowStep.Type)
+	ts.Len(flowStep.Data.Actions, 2, "Should have 2 actions available")
+	ts.Len(flowStep.Data.Inputs, 2, "Should have all inputs from prompts available for rendering")
+
+	actionRefs := make([]string, len(flowStep.Data.Actions))
+	for i, action := range flowStep.Data.Actions {
+		actionRefs[i] = action.Ref
+	}
+	ts.Contains(actionRefs, "action_basic")
+	ts.Contains(actionRefs, "action_google")
+
+	inputIdentifiers := make([]string, len(flowStep.Data.Inputs))
+	for i, input := range flowStep.Data.Inputs {
+		inputIdentifiers[i] = input.Identifier
+	}
+	ts.Contains(inputIdentifiers, "username")
+	ts.Contains(inputIdentifiers, "password")
+}
+
+func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithoutInputs_ShouldRedirectToGoogle() {
+	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().NotEmpty(flowStep.FlowID)
+
+	// Select action_google which has no inputs - should redirect to Google
+	flowStep, err = common.CompleteFlow(flowStep.FlowID, nil, "action_google")
+	ts.Require().NoError(err, "Failed to complete flow with action_google")
+
+	// Should redirect to Google OAuth
+	ts.Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Equal("REDIRECTION", flowStep.Type)
+	ts.NotEmpty(flowStep.Data.RedirectURL, "Should have redirect URL for Google auth")
+}
+
+func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputs_ShouldPromptForInputs() {
+	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().NotEmpty(flowStep.FlowID)
+
+	// Select action_basic which requires username and password
+	flowStep, err = common.CompleteFlow(flowStep.FlowID, nil, "action_basic")
+	ts.Require().NoError(err, "Failed to complete flow with action_basic")
+
+	ts.Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Equal("VIEW", flowStep.Type)
+	ts.Len(flowStep.Data.Inputs, 2, "Should prompt for 2 inputs")
+
+	inputIdentifiers := make([]string, len(flowStep.Data.Inputs))
+	for i, input := range flowStep.Data.Inputs {
+		inputIdentifiers[i] = input.Identifier
+	}
+	ts.Contains(inputIdentifiers, "username")
+	ts.Contains(inputIdentifiers, "password")
+}
+
+func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputsProvided_ShouldComplete() {
+	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().NotEmpty(flowStep.FlowID)
+
+	// Select action_basic
+	flowStep, err = common.CompleteFlow(flowStep.FlowID, nil, "action_basic")
+	ts.Require().NoError(err, "Failed to select action_basic")
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	// Provide username and password
+	inputs := map[string]string{
+		"username": "multiactionuser",
+		"password": "testpassword",
+	}
+	flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "")
+	ts.Require().NoError(err, "Failed to complete flow with inputs")
+
+	ts.Equal("COMPLETE", flowStep.FlowStatus, "Flow should complete after providing required inputs")
+	ts.NotEmpty(flowStep.Assertion, "Should have assertion token")
+}
+
+func (ts *MultiActionInputBindingTestSuite) TestGoogleAuthFlowComplete() {
+	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	flowID := flowStep.FlowID
+
+	// Select action_google
+	flowStep, err = common.CompleteFlow(flowID, nil, "action_google")
+	ts.Require().NoError(err, "Failed to select action_google")
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().Equal("REDIRECTION", flowStep.Type)
+
+	redirectURL := flowStep.Data.RedirectURL
+	ts.Require().NotEmpty(redirectURL)
+
+	// Simulate Google OAuth flow
+	authCode, err := testutils.SimulateFederatedOAuthFlow(redirectURL)
+	ts.Require().NoError(err, "Failed to simulate Google authorization")
+	ts.Require().NotEmpty(authCode)
+
+	// Complete flow with authorization code
+	inputs := map[string]string{"code": authCode}
+	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	ts.Require().NoError(err, "Failed to complete flow with auth code")
+
+	ts.Equal("COMPLETE", flowStep.FlowStatus)
+	ts.NotEmpty(flowStep.Assertion, "Should have assertion token")
+}

--- a/tests/integration/flow/authentication/prompt_actions_test.go
+++ b/tests/integration/flow/authentication/prompt_actions_test.go
@@ -46,70 +46,76 @@ var (
 			{
 				"id":   "choose_auth",
 				"type": "PROMPT",
-				"actions": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":      "basic_auth",
-						"nextNode": "basic_auth",
+						"action": map[string]interface{}{
+							"ref":      "basic_auth",
+							"nextNode": "basic_auth",
+						},
 					},
 					{
-						"ref":      "prompt_mobile",
-						"nextNode": "prompt_mobile",
+						"action": map[string]interface{}{
+							"ref":      "prompt_mobile",
+							"nextNode": "prompt_mobile",
+						},
 					},
 				},
 			},
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "attr_collector",
 			},
 			{
 				"id":   "attr_collector",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_003",
-						"identifier": "mobileNumber",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "AttributeCollector",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_003",
+							"identifier": "mobileNumber",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "sms_otp_send",
 			},
 			{
 				"id":   "prompt_mobile",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_004",
-						"identifier": "mobileNumber",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_mobile",
-						"nextNode": "sms_otp_send",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_004",
+								"identifier": "mobileNumber",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_mobile",
+							"nextNode": "sms_otp_send",
+						},
 					},
 				},
 			},
@@ -128,18 +134,20 @@ var (
 			{
 				"id":   "prompt_otp",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_005",
-						"identifier": "otp",
-						"type":       "number",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_otp",
-						"nextNode": "sms_otp_verify",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_005",
+								"identifier": "otp",
+								"type":       "number",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_otp",
+							"nextNode": "sms_otp_verify",
+						},
 					},
 				},
 			},

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -46,18 +46,20 @@ var (
 			{
 				"id":   "prompt_mobile",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "mobileNumber",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "sms_otp_send",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "mobileNumber",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "sms_otp_send",
+						},
 					},
 				},
 			},
@@ -76,18 +78,20 @@ var (
 			{
 				"id":   "prompt_otp",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_002",
-						"identifier": "otp",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_002",
-						"nextNode": "sms_otp_verify",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_002",
+								"identifier": "otp",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_002",
+							"nextNode": "sms_otp_verify",
+						},
 					},
 				},
 			},
@@ -131,18 +135,20 @@ var (
 			{
 				"id":   "mobile_prompt_username",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "sms_otp_send",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "sms_otp_send",
+						},
 					},
 				},
 			},
@@ -161,18 +167,20 @@ var (
 			{
 				"id":   "prompt_otp",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_002",
-						"identifier": "otp",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_002",
-						"nextNode": "sms_otp_verify",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_002",
+								"identifier": "otp",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_002",
+							"nextNode": "sms_otp_verify",
+						},
 					},
 				},
 			},

--- a/tests/integration/flow/authentication/verbose_meta_test.go
+++ b/tests/integration/flow/authentication/verbose_meta_test.go
@@ -76,24 +76,26 @@ var (
 						},
 					},
 				},
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "PASSWORD_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},
@@ -133,22 +135,22 @@ var (
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"type":       "TEXT_INPUT",
-						"identifier": "username",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"type":       "PASSWORD_INPUT",
-						"identifier": "password",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"type":       "TEXT_INPUT",
+							"identifier": "username",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"type":       "PASSWORD_INPUT",
+							"identifier": "password",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},

--- a/tests/integration/flow/registration/http_request_executor_registration_test.go
+++ b/tests/integration/flow/registration/http_request_executor_registration_test.go
@@ -53,40 +53,40 @@ var (
 			{
 				"id":   "provision_user",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_003",
-						"identifier": "email",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_004",
-						"identifier": "firstName",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_005",
-						"identifier": "lastName",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "ProvisioningExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_003",
+							"identifier": "email",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_004",
+							"identifier": "firstName",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_005",
+							"identifier": "lastName",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "create_external_profile",
 			},

--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -70,40 +70,40 @@ var (
 			{
 				"id":   "provisioning",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_003",
-						"identifier": "firstName",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_004",
-						"identifier": "lastName",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_005",
-						"identifier": "email",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "ProvisioningExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_003",
+							"identifier": "firstName",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_004",
+							"identifier": "lastName",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_005",
+							"identifier": "email",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},
@@ -143,18 +143,20 @@ var (
 			{
 				"id":   "prompt_mobile",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "mobileNumber",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "send_sms",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "mobileNumber",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "send_sms",
+						},
 					},
 				},
 			},
@@ -173,18 +175,20 @@ var (
 			{
 				"id":   "prompt_otp",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_002",
-						"identifier": "otp",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_002",
-						"nextNode": "verify_sms",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_002",
+								"identifier": "otp",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_002",
+							"nextNode": "verify_sms",
+						},
 					},
 				},
 			},
@@ -200,62 +204,62 @@ var (
 			{
 				"id":   "ou_creation",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_003",
-						"identifier": "ouName",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_004",
-						"identifier": "ouHandle",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_005",
-						"identifier": "ouDescription",
-						"type":       "TEXT_INPUT",
-						"required":   false,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "OUExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_003",
+							"identifier": "ouName",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_004",
+							"identifier": "ouHandle",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_005",
+							"identifier": "ouDescription",
+							"type":       "TEXT_INPUT",
+							"required":   false,
+						},
+					},
 				},
 				"onSuccess": "provisioning",
 			},
 			{
 				"id":   "provisioning",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_006",
-						"identifier": "mobileNumber",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_007",
-						"identifier": "firstName",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_008",
-						"identifier": "lastName",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_009",
-						"identifier": "email",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "ProvisioningExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_006",
+							"identifier": "mobileNumber",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_007",
+							"identifier": "firstName",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_008",
+							"identifier": "lastName",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_009",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -50,18 +50,20 @@ var (
 			{
 				"id":   "prompt_mobile",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "mobileNumber",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "sms_otp_send",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "mobileNumber",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "sms_otp_send",
+						},
 					},
 				},
 			},
@@ -80,18 +82,20 @@ var (
 			{
 				"id":   "prompt_otp",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_otp",
-						"identifier": "otp",
-						"type":       "string",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_otp",
-						"nextNode": "sms_otp_verify",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_otp",
+								"identifier": "otp",
+								"type":       "string",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_otp",
+							"nextNode": "sms_otp_verify",
+						},
 					},
 				},
 			},
@@ -110,34 +114,34 @@ var (
 			{
 				"id":   "provisioning",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_002",
-						"identifier": "firstName",
-						"type":       "string",
-						"required":   false,
-					},
-					{
-						"ref":        "input_003",
-						"identifier": "lastName",
-						"type":       "string",
-						"required":   false,
-					},
-					{
-						"ref":        "input_004",
-						"identifier": "email",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_005",
-						"identifier": "mobileNumber",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "ProvisioningExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_002",
+							"identifier": "firstName",
+							"type":       "string",
+							"required":   false,
+						},
+						{
+							"ref":        "input_003",
+							"identifier": "lastName",
+							"type":       "string",
+							"required":   false,
+						},
+						{
+							"ref":        "input_004",
+							"identifier": "email",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_005",
+							"identifier": "mobileNumber",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -470,46 +470,48 @@ func (ts *OAuthAuthzScopeTestSuite) createTestAuthenticationFlow() string {
 			{
 				"id":   "prompt_credentials",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "PASSWORD_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "authorization_check",
 			},

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -97,46 +97,48 @@ var (
 			{
 				"id":   "prompt_credentials",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "PASSWORD_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "authorization_check",
 			},

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -178,46 +178,48 @@ func (ts *UserInfoTestSuite) createTestAuthenticationFlow() string {
 			{
 				"id":   "prompt_credentials",
 				"type": "PROMPT",
-				"inputs": []map[string]interface{}{
+				"prompts": []map[string]interface{}{
 					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "TEXT_INPUT",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "PASSWORD_INPUT",
-						"required":   true,
-					},
-				},
-				"actions": []map[string]interface{}{
-					{
-						"ref":      "action_001",
-						"nextNode": "basic_auth",
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
 					},
 				},
 			},
 			{
 				"id":   "basic_auth",
 				"type": "TASK_EXECUTION",
-				"inputs": []map[string]interface{}{
-					{
-						"ref":        "input_001",
-						"identifier": "username",
-						"type":       "string",
-						"required":   true,
-					},
-					{
-						"ref":        "input_002",
-						"identifier": "password",
-						"type":       "string",
-						"required":   true,
-					},
-				},
 				"executor": map[string]interface{}{
 					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "string",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "string",
+							"required":   true,
+						},
+					},
 				},
 				"onSuccess": "auth_assert",
 			},


### PR DESCRIPTION
### Purpose
Currently there's no logical grouping of inputs with actions inside nodes. Some inputs will only be applicable for a particular action and some actions may not have inputs at all. However in current flow engine implementation, it always expects inputs when a node has defined inputs regardless of the selected action. Consider a login scenario where user can either pick Username/Password or Google login. Currently Google login is failing as it expects username and password also to be entered. Ideally inputs should be binded to actions.

This pull request resolves that issue by introducing a `prompts` element to the PROMPT type nodes to allow defining inputs and action sets. Additionally this PR also moves the inputs to inside `executor` block for the TASK_EXECUTION nodes for consistency.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
This PR changes the structure of flow node definitions to logically bind inputs with actions.

- **PROMPT nodes** now use a `prompts` array instead of a standalone `actions` array. Each prompt explicitly defines the related `action` and its applicable `inputs`.
- **TASK_EXECUTION nodes** now require `inputs` to be defined **inside the `executor` block** instead of at the node root level.

#### 💥 Impact
- Existing flow definitions that:
  - Has PROMPT nodes with inputs and/ or actions
  - Has TASK_EXECUTION nodes with explicitly defined inputs
  will no longer be compatible and will fail validation or execution.

#### 🔄 Migration Guide
- **For PROMPT nodes**:
  - Replace the `actions` array with `prompts`.
  - Move each `action` and its relevant `inputs` inside a corresponding prompt entry.

- **For TASK_EXECUTION nodes**:
  - Move `inputs` under the `executor` block.

Flows must be updated to explicitly associate inputs with their relevant actions to align with the new flow definition model. Refer following example to get an idea of the new flow definitions.

**PROMPT node:**

Before:
```json
{
    "id": "prompt_credentials",
    "type": "PROMPT",
    "meta": {...},
    "inputs": [
        {
            "ref": "input_001",
            "identifier": "username",
            "type": "TEXT_INPUT",
            "required": true
        },
        {
            "ref": "input_002",
            "identifier": "password",
            "type": "PASSWORD_INPUT",
            "required": true
        }
    ],
    "actions": [
        {
            "ref": "action_001",
            "nextNode": "basic_auth"
        }
    ]
},
```

After:
```json
{
    "id": "prompt_credentials",
    "type": "PROMPT",
    "meta": {...},
    "prompts": [
        {
            "inputs": [
                {
                    "ref": "input_001",
                    "identifier": "username",
                    "type": "TEXT_INPUT",
                    "required": true
                },
                {
                    "ref": "input_002",
                    "identifier": "password",
                    "type": "PASSWORD_INPUT",
                    "required": true
                }
            ],
            "action": {
                "ref": "action_001",
                "nextNode": "basic_auth"
            }
        }
    ]
},
```

**TASK_EXECUTION node:**

Before:
```json
{
    "id": "provisioning_local_sms",
    "type": "TASK_EXECUTION",
    "inputs": [
        {
            "ref": "input_007",
            "identifier": "firstName",
            "type": "TEXT_INPUT",
            "required": false
        },
        {
            "ref": "input_008",
            "identifier": "lastName",
            "type": "TEXT_INPUT",
            "required": false
        },
        {
            "ref": "input_009",
            "identifier": "mobileNumber",
            "type": "PHONE_INPUT",
            "required": true
        }
    ],
    "executor": {
        "name": "ProvisioningExecutor"
    },
    "onSuccess": "auth_assert"
},
```

After:
```json
{
    "id": "provisioning_local_sms",
    "type": "TASK_EXECUTION",
    "executor": {
        "name": "ProvisioningExecutor",
        "inputs": [
            {
                "ref": "input_007",
                "identifier": "firstName",
                "type": "TEXT_INPUT",
                "required": false
            },
            {
                "ref": "input_008",
                "identifier": "lastName",
                "type": "TEXT_INPUT",
                "required": false
            },
            {
                "ref": "input_009",
                "identifier": "mobileNumber",
                "type": "PHONE_INPUT",
                "required": true
            }
        ]
    },
    "onSuccess": "auth_assert"
},
```

---

### Approach
* Replaced the `actions` array with a `prompts` array in all prompt nodes, embedding the `action` object along with the related inputs directly inside each prompt.
* Refactored task execution nodes to consistently have `inputs` inside the `executor` block.
* Update multiple authentication and registration flow files, including those for basic, Google, GitHub, SMS, and combinations thereof to reflect the above change.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1034

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [x] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
