### PR TITLE
[Flow Builder] Modify prompt nodes to use prompts and improve input handling

### DIFF
--- a/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useGetFlowById.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useGetFlowById.test.tsx
@@ -54,8 +54,7 @@ describe('useGetFlowById', () => {
         meta: {
           components: [],
         },
-        inputs: [],
-        actions: [],
+        prompts: []
       },
       {
         id: 'node-end',
@@ -283,7 +282,7 @@ describe('useGetFlowById', () => {
       ...mockFlowResponse,
       nodes: [
         {id: 'start', type: FlowNodeType.START, onSuccess: 'prompt'},
-        {id: 'prompt', type: FlowNodeType.PROMPT, actions: [{ref: 'btn', nextNode: 'exec'}]},
+        {id: 'prompt', type: FlowNodeType.PROMPT, prompts: [{action: {ref: 'btn', nextNode: 'exec'}}]},
         {id: 'exec', type: FlowNodeType.TASK_EXECUTION, executor: {name: 'TestExecutor'}, onSuccess: 'end'},
         {id: 'end', type: FlowNodeType.END},
       ],

--- a/frontend/apps/thunder-develop/src/features/flows/models/responses.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/responses.ts
@@ -166,6 +166,29 @@ export interface FlowNodeAction {
 }
 
 /**
+ * A {@link FlowPrompt} represents a single logical prompt within a PROMPT node.
+ * Inputs are associated with actions based on their shared container (BLOCK) in the
+ * layout/metadata structure: only the inputs that are placed in the same BLOCK as
+ * a given action (or its ancestors) are considered to belong to that action.
+ *
+ * This scoping rule is important when a PROMPT node contains multiple actions
+ * (for example, several buttons) and different subsets of inputs should be
+ * submitted or validated with each action.
+ */
+export interface FlowPrompt {
+  /**
+   * Input fields associated with this action. These are the inputs that share the
+   * same container (BLOCK) hierarchy as the {@link FlowNodeAction} in the prompt structure.
+   */
+  inputs?: FlowNodeInput[];
+  /**
+   * The action for this prompt. This action is scoped to, and operates on, the
+   * inputs defined in the same container (BLOCK) ancestry as this prompt.
+   */
+  action?: FlowNodeAction;
+}
+
+/**
  * Executor configuration for TASK_EXECUTION nodes.
  */
 export interface FlowExecutor {
@@ -173,6 +196,10 @@ export interface FlowExecutor {
    * Name of the registered executor
    */
   name: string;
+  /**
+   * Input definitions for this executor
+   */
+  inputs?: FlowNodeInput[];
   /**
    * Additional executor properties
    */
@@ -200,13 +227,10 @@ export interface FlowNode {
    */
   meta?: FlowNodeMeta;
   /**
-   * Input definitions
+   * Prompt definitions for PROMPT nodes.
+   * Each prompt groups inputs with an action button.
    */
-  inputs?: FlowNodeInput[];
-  /**
-   * Action definitions for PROMPT nodes
-   */
-  actions?: FlowNodeAction[];
+  prompts?: FlowPrompt[];
   /**
    * Node-level properties for configuration
    */

--- a/frontend/apps/thunder-develop/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
@@ -234,9 +234,9 @@ describe('flowToCanvasTransformer', () => {
           {
             id: 'prompt-node',
             type: 'PROMPT',
-            actions: [
-              {ref: 'button-1', nextNode: 'next-node-1'},
-              {ref: 'button-2', nextNode: 'next-node-2'},
+            prompts: [
+              {action: {ref: 'button-1', nextNode: 'next-node-1'}},
+              {action: {ref: 'button-2', nextNode: 'next-node-2'}},
             ],
             layout: {position: {x: 0, y: 0}, size: {width: 300, height: 200}},
           },
@@ -336,8 +336,8 @@ describe('flowToCanvasTransformer', () => {
                 {id: 'submit-btn', type: 'ACTION', label: 'Submit'},
               ],
             },
-            actions: [
-              {ref: 'submit-btn', nextNode: 'next-node', executor: {name: 'SomeExecutor'}},
+            prompts: [
+              {action: {ref: 'submit-btn', nextNode: 'next-node', executor: {name: 'SomeExecutor'}}},
             ],
             layout: {position: {x: 0, y: 0}, size: {width: 300, height: 200}},
           },
@@ -393,8 +393,8 @@ describe('flowToCanvasTransformer', () => {
                 },
               ],
             },
-            actions: [
-              {ref: 'button-1', nextNode: 'next-node'},
+            prompts: [
+              {action: {ref: 'button-1', nextNode: 'next-node'}},
             ],
             layout: {position: {x: 0, y: 0}, size: {width: 300, height: 200}},
           },


### PR DESCRIPTION
### Purpose

This pull request refactors how form inputs and actions are represented and handled in flow nodes, modified frontend flow builder to use the new `prompts` structure that groups inputs with their associated action buttons. This change;
- Introduces prompts for PROMPT nodes that groups inputs and actions together
- Moves inputs to inside executor block for the TASK_EXECUTION nodes

### Approach

**Model and API changes:**

- Introduced the `FlowPrompt` interface, which groups `inputs` with a corresponding `action`, and updated `FlowNode` to use a `prompts` array instead of separate `inputs` and `actions` arrays. Also, moved input definitions for executors into the `FlowExecutor` interface.

**Transformation logic updates:**

- Updated `flowToCanvasTransformer.ts` to extract actions from the new `prompts` array and to use this structure when restoring components and generating edges. Helper functions like `extractActionsFromPrompts` and `getNodeActions` were added to facilitate this.

**Test updates for new structure:**

- Refactored all relevant tests in `useGetFlowById.test.tsx` and `flowToCanvasTransformer.test.ts` to use the `prompts` structure instead of `inputs` and `actions`. Assertions now check for correct grouping of inputs and actions within prompts.

**React Flow transformer test enhancements:**

- Updated tests for the React Flow transformer to ensure that extracted inputs and actions are correctly grouped in prompts, including handling of nested components, blocks, and executor inputs.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1034

### Related PRs
- https://github.com/asgardeo/thunder/pull/1071

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
