### PR TITLE
Add passkey executor support for flow execution

### DIFF
--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_passkey.json
@@ -1,0 +1,171 @@
+{
+  "name": "Basic + Passkey Authentication and Registration Flow",
+  "handle": "default-basic-passkey-flow",
+  "flowType": "AUTHENTICATION",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "START",
+      "onSuccess": "choose_auth_method"
+    },
+    {
+      "id": "choose_auth_method",
+      "type": "PROMPT",
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "input_username",
+              "identifier": "username",
+              "type": "TEXT_INPUT",
+              "required": true
+            },
+            {
+              "ref": "input_password",
+              "identifier": "password",
+              "type": "PASSWORD_INPUT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_basic",
+            "nextNode": "basic_auth"
+          }
+        },
+        {
+          "action": {
+            "ref": "action_passkey",
+            "nextNode": "prompt_passkey_identifier"
+          }
+        }
+      ]
+    },
+    {
+      "id": "prompt_passkey_identifier",
+      "type": "PROMPT",
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "passkey_username",
+              "identifier": "username",
+              "type": "TEXT_INPUT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_continue",
+            "nextNode": "identity_resolver"
+          }
+        }
+      ]
+    },
+    {
+      "id": "identity_resolver",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "IdentityResolver"
+      },
+      "onSuccess": "passkey_challenge",
+      "onFailure": "prompt_passkey_identifier"
+    },
+    {
+      "id": "passkey_challenge",
+      "type": "TASK_EXECUTION",
+      "properties": {
+        "relyingPartyId": "localhost",
+        "relyingPartyName": "Thunder"
+      },
+      "executor": {
+        "name": "PasskeyAuthExecutor",
+        "mode": "challenge"
+      },
+      "onSuccess": "passkey_verify",
+      "onFailure": "prompt_password_for_registration"
+    },
+    {
+      "id": "passkey_verify",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "PasskeyAuthExecutor",
+        "mode": "verify"
+      },
+      "onSuccess": "auth_assert",
+      "onFailure": "choose_auth_method"
+    },
+    {
+      "id": "prompt_password_for_registration",
+      "type": "PROMPT",
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "reg_password",
+              "identifier": "password",
+              "type": "PASSWORD_INPUT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_verify_password",
+            "nextNode": "basic_auth_for_registration"
+          }
+        }
+      ]
+    },
+    {
+      "id": "basic_auth_for_registration",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "BasicAuthExecutor"
+      },
+      "onSuccess": "passkey_register_start",
+      "onFailure": "prompt_password_for_registration"
+    },
+    {
+      "id": "passkey_register_start",
+      "type": "TASK_EXECUTION",
+      "properties": {
+        "relyingPartyId": "localhost",
+        "relyingPartyName": "Thunder"
+      },
+      "executor": {
+        "name": "PasskeyAuthExecutor",
+        "mode": "register_start"
+      },
+      "onSuccess": "passkey_register_finish",
+      "onFailure": "choose_auth_method"
+    },
+    {
+      "id": "passkey_register_finish",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "PasskeyAuthExecutor",
+        "mode": "register_finish"
+      },
+      "onSuccess": "auth_assert",
+      "onFailure": "choose_auth_method"
+    },
+    {
+      "id": "basic_auth",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "BasicAuthExecutor"
+      },
+      "onSuccess": "auth_assert",
+      "onFailure": "choose_auth_method"
+    },
+    {
+      "id": "auth_assert",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "AuthAssertExecutor"
+      },
+      "onSuccess": "end"
+    },
+    {
+      "id": "end",
+      "type": "END"
+    }
+  ]
+}

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
@@ -1,0 +1,108 @@
+{
+    "name": "Passkey Only Authentication Flow",
+    "handle": "passkey-authentication-flow",
+    "flowType": "AUTHENTICATION",
+    "nodes": [
+        {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "prompt_identifier"
+        },
+        {
+            "id": "prompt_identifier",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "type": "TEXT",
+                        "id": "text_001",
+                        "label": "{{ t(signin:heading) }}",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "BLOCK",
+                        "id": "block_001",
+                        "components": [
+                            {
+                                "id": "input_001",
+                                "ref": "username",
+                                "type": "TEXT_INPUT",
+                                "label": "{{ t(elements:fields.username.label) }}",
+                                "required": true,
+                                "placeholder": "{{ t(elements:fields.username.placeholder) }}"
+                            },
+                            {
+                                "type": "ACTION",
+                                "id": "action_001",
+                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "variant": "PRIMARY",
+                                "eventType": "SUBMIT"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "prompts": [
+                {
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "username",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "identity_resolver"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "identity_resolver",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "IdentityResolver"
+            },
+            "onSuccess": "passkey_challenge",
+            "onFailure": "prompt_identifier"
+        },
+        {
+            "id": "passkey_challenge",
+            "type": "TASK_EXECUTION",
+            "properties": {
+                "relyingPartyId": "localhost",
+                "relyingPartyName": "Thunder"
+            },
+            "executor": {
+                "name": "PasskeyAuthExecutor",
+                "mode": "challenge"
+            },
+            "onSuccess": "passkey_verify",
+            "onFailure": "prompt_identifier"
+        },
+        {
+            "id": "passkey_verify",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "PasskeyAuthExecutor",
+                "mode": "verify"
+            },
+            "onSuccess": "auth_assert",
+            "onFailure": "prompt_identifier"
+        },
+        {
+            "id": "auth_assert",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "AuthAssertExecutor"
+            },
+            "onSuccess": "end"
+        },
+        {
+            "id": "end",
+            "type": "END"
+        }
+    ]
+}

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_passkey.json
@@ -1,0 +1,134 @@
+{
+    "name": "Passkey Registration Flow",
+    "flowType": "REGISTRATION",
+    "handle": "passkey_registration_flow",
+    "nodes": [
+        {
+            "id": "start",
+            "type": "START",
+            "onSuccess": "user_type_resolver"
+        },
+        {
+            "id": "user_type_resolver",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "UserTypeResolver"
+            },
+            "onSuccess": "collect_user_info"
+        },
+        {
+            "id": "collect_user_info",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "type": "TEXT",
+                        "id": "text_001",
+                        "label": "{{ t(signup:heading) }}",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "BLOCK",
+                        "id": "block_001",
+                        "components": [
+                            {
+                                "id": "input_001",
+                                "ref": "username",
+                                "type": "TEXT_INPUT",
+                                "label": "{{ t(elements:fields.username.label) }}",
+                                "required": true,
+                                "placeholder": "{{ t(elements:fields.username.placeholder) }}"
+                            },
+                            {
+                                "id": "input_002",
+                                "ref": "email",
+                                "type": "TEXT_INPUT",
+                                "label": "{{ t(elements:fields.email.label) }}",
+                                "required": true,
+                                "placeholder": "{{ t(elements:fields.email.placeholder) }}"
+                            },
+                            {
+                                "type": "ACTION",
+                                "id": "action_001",
+                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "variant": "PRIMARY",
+                                "eventType": "SUBMIT"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "prompts": [
+                {
+                    "inputs": [
+                        {
+                            "ref": "input_001",
+                            "identifier": "username",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        },
+                        {
+                            "ref": "input_002",
+                            "identifier": "email",
+                            "type": "TEXT_INPUT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_001",
+                        "nextNode": "provisioning"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "provisioning",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "ProvisioningExecutor"
+            },
+            "onSuccess": "passkey_reg_start"
+        },
+        {
+            "id": "passkey_reg_start",
+            "type": "TASK_EXECUTION",
+            "properties": {
+                "relyingPartyId": "localhost",
+                "relyingPartyName": "Thunder",
+                "authenticatorSelection": {
+                  "authenticatorAttachment": "platform",
+                  "requireResidentKey": true,
+                  "residentKey": "required",
+                  "userVerification": "required"
+                },
+                "attestation": "direct"
+            },
+            "executor": {
+                "name": "PasskeyAuthExecutor",
+                "mode": "register_start"
+            },
+            "onSuccess": "passkey_reg_finish"
+        },
+        {
+            "id": "passkey_reg_finish",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "PasskeyAuthExecutor",
+                "mode": "register_finish"
+            },
+            "onSuccess": "auth_assert"
+        },
+        {
+            "id": "auth_assert",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "AuthAssertExecutor"
+            },
+            "onSuccess": "end"
+        },
+        {
+            "id": "end",
+            "type": "END"
+        }
+    ]
+}

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -22,8 +22,10 @@ import "github.com/asgardeo/thunder/internal/flow/common"
 
 // Executor name constants
 const (
-	ExecutorNameBasicAuth           = "BasicAuthExecutor"
-	ExecutorNameSMSAuth             = "SMSOTPAuthExecutor"
+	ExecutorNameBasicAuth = "BasicAuthExecutor"
+	ExecutorNameSMSAuth   = "SMSOTPAuthExecutor"
+	// nolint:gosec // G101: This is an executor name, not a credential
+	ExecutorNamePasskeyAuth         = "PasskeyAuthExecutor"
 	ExecutorNameOAuth               = "OAuthExecutor"
 	ExecutorNameOIDCAuth            = "OIDCAuthExecutor"
 	ExecutorNameGitHubAuth          = "GithubOAuthExecutor"
@@ -39,6 +41,7 @@ const (
 	ExecutorNameUserTypeResolver    = "UserTypeResolver"
 	ExecutorNameInviteExecutor      = "InviteExecutor"
 	ExecutorNameCredentialSetter    = "CredentialSetter"
+	ExecutorNameIdentityResolver    = "IdentityResolver"
 )
 
 // User attribute and input constants
@@ -89,4 +92,5 @@ const runtimeKeyStoredInviteToken = "storedInviteToken"
 const (
 	failureReasonUserNotAuthenticated = "User is not authenticated"
 	failureReasonUserNotFound         = "User not found"
+	failureReasonFailedToIdentifyUser = "Failed to identify user"
 )

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -94,7 +94,7 @@ func (i *identifyingExecutor) IdentifyUser(filters map[string]interface{},
 		} else {
 			logger.Debug("Failed to identify user due to error: " + svcErr.Error)
 			execResp.Status = common.ExecFailure
-			execResp.FailureReason = "Failed to identify user"
+			execResp.FailureReason = failureReasonFailedToIdentifyUser
 			return nil, nil
 		}
 	}

--- a/backend/internal/flow/executor/identity_resolver_executor.go
+++ b/backend/internal/flow/executor/identity_resolver_executor.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/user"
+)
+
+// identityResolverExecutor implements the ExecutorInterface for resolving user identity from username.
+// This is a standalone executor that can be used in flows to resolve username → userID.
+type identityResolverExecutor struct {
+	core.ExecutorInterface
+	identifyingExecutorInterface
+	userService user.UserServiceInterface
+	logger      *log.Logger
+}
+
+var _ core.ExecutorInterface = (*identityResolverExecutor)(nil)
+
+// newIdentityResolverExecutor creates a new instance of IdentityResolverExecutor.
+func newIdentityResolverExecutor(
+	flowFactory core.FlowFactoryInterface,
+	userService user.UserServiceInterface,
+) *identityResolverExecutor {
+	defaultInputs := []common.Input{
+		{
+			Identifier: userAttributeUsername,
+			Type:       "string",
+			Required:   true,
+		},
+	}
+
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdentityResolverExecutor"),
+		log.String(log.LoggerKeyExecutorName, ExecutorNameIdentityResolver))
+
+	identifyExec := newIdentifyingExecutor(ExecutorNameIdentityResolver, defaultInputs, []common.Input{},
+		flowFactory, userService)
+	base := flowFactory.CreateExecutor(ExecutorNameIdentityResolver, common.ExecutorTypeUtility,
+		defaultInputs, []common.Input{})
+
+	return &identityResolverExecutor{
+		ExecutorInterface:            base,
+		identifyingExecutorInterface: identifyExec,
+		userService:                  userService,
+		logger:                       logger,
+	}
+}
+
+// Execute executes the identity resolution logic.
+// It takes a username input and resolves it to a userID, storing it in RuntimeData.
+func (i *identityResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
+	logger := i.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Executing identity resolver executor")
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// Check if required inputs are provided
+	if !i.HasRequiredInputs(ctx, execResp) {
+		logger.Debug("Required inputs for identity resolver is not provided")
+		execResp.Status = common.ExecUserInputRequired
+		return execResp, nil
+	}
+
+	// Get username from inputs
+	username := ctx.UserInputs[userAttributeUsername]
+	if username == "" {
+		username = ctx.RuntimeData[userAttributeUsername]
+	}
+	if username == "" {
+		logger.Debug("Username not provided")
+		execResp.Status = common.ExecUserInputRequired
+		return execResp, nil
+	}
+
+	// Try to identify the user
+	filters := map[string]interface{}{userAttributeUsername: username}
+	userID, err := i.IdentifyUser(filters, execResp)
+	if err != nil {
+		logger.Error("Failed to identify user", log.Error(err))
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = failureReasonFailedToIdentifyUser
+		return execResp, nil
+	}
+
+	if userID == nil || *userID == "" {
+		logger.Debug("User not found for the provided username")
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = failureReasonUserNotFound
+		return execResp, nil
+	}
+
+	// Store the resolved userID in RuntimeData for subsequent executors
+	execResp.RuntimeData[userAttributeUserID] = *userID
+	execResp.Status = common.ExecComplete
+
+	logger.Debug("Identity resolver executor completed successfully",
+		log.String("username", username),
+		log.String("userID", *userID))
+
+	return execResp, nil
+}

--- a/backend/internal/flow/executor/identity_resolver_executor_test.go
+++ b/backend/internal/flow/executor/identity_resolver_executor_test.go
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+)
+
+const (
+	testIdentityResolverFlowID   = "identity-resolver-flow-123"
+	testIdentityResolverUsername = "testuser"
+	testIdentityResolverUserID   = "user-id-456"
+)
+
+type IdentityResolverExecutorTestSuite struct {
+	suite.Suite
+	mockUserService *usermock.UserServiceInterfaceMock
+	mockFlowFactory *coremock.FlowFactoryInterfaceMock
+	executor        *identityResolverExecutor
+}
+
+func TestIdentityResolverExecutorSuite(t *testing.T) {
+	suite.Run(t, new(IdentityResolverExecutorTestSuite))
+}
+
+func (suite *IdentityResolverExecutorTestSuite) SetupTest() {
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+
+	// Create mock identifying executor
+	identifyingMock := coremock.NewExecutorInterfaceMock(suite.T())
+	identifyingMock.On("GetName").Return(ExecutorNameIdentifying).Maybe()
+	identifyingMock.On("GetType").Return(common.ExecutorTypeUtility).Maybe()
+	identifyingMock.On("GetDefaultInputs").Return([]common.Input{}).Maybe()
+	identifyingMock.On("GetPrerequisites").Return([]common.Input{}).Maybe()
+	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameIdentifying, common.ExecutorTypeUtility,
+		mock.Anything, mock.Anything).Return(identifyingMock).Maybe()
+
+	// Create mock base executor for identity resolver
+	mockExec := coremock.NewExecutorInterfaceMock(suite.T())
+	mockExec.On("GetName").Return(ExecutorNameIdentityResolver).Maybe()
+	mockExec.On("GetType").Return(common.ExecutorTypeUtility).Maybe()
+	mockExec.On("GetDefaultInputs").Return([]common.Input{
+		{Identifier: userAttributeUsername, Type: "string", Required: true},
+	}).Maybe()
+	mockExec.On("GetPrerequisites").Return([]common.Input{}).Maybe()
+	mockExec.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{Identifier: userAttributeUsername, Type: "string", Required: true},
+	}).Maybe()
+	mockExec.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(
+		func(ctx *core.NodeContext, execResp *common.ExecutorResponse) bool {
+			if _, exists := ctx.UserInputs[userAttributeUsername]; exists {
+				return true
+			}
+			if _, exists := ctx.RuntimeData[userAttributeUsername]; exists {
+				return true
+			}
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = []common.Input{
+				{Identifier: userAttributeUsername, Type: "string", Required: true},
+			}
+			return false
+		}).Maybe()
+	mockExec.On("ValidatePrerequisites", mock.Anything, mock.Anything).Return(true).Maybe()
+
+	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameIdentityResolver, common.ExecutorTypeUtility,
+		mock.Anything, mock.Anything).Return(mockExec)
+
+	suite.executor = newIdentityResolverExecutor(suite.mockFlowFactory, suite.mockUserService)
+}
+
+// Helper to create a node context for identity resolver
+func createIdentityResolverNodeContext() *core.NodeContext {
+	return &core.NodeContext{
+		FlowID:      testIdentityResolverFlowID,
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs:  make(map[string]string),
+		RuntimeData: make(map[string]string),
+	}
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestNewIdentityResolverExecutor() {
+	assert.NotNil(suite.T(), suite.executor)
+	assert.NotNil(suite.T(), suite.executor.userService)
+	assert.NotNil(suite.T(), suite.executor.identifyingExecutorInterface)
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_Success_UsernameInUserInputs() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.UserInputs[userAttributeUsername] = testIdentityResolverUsername
+
+	userID := testIdentityResolverUserID
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: testIdentityResolverUsername,
+	}).Return(&userID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), testIdentityResolverUserID, resp.RuntimeData[userAttributeUserID])
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_Success_UsernameInRuntimeData() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.RuntimeData[userAttributeUsername] = testIdentityResolverUsername
+
+	userID := testIdentityResolverUserID
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: testIdentityResolverUsername,
+	}).Return(&userID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), testIdentityResolverUserID, resp.RuntimeData[userAttributeUserID])
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_UserInputRequired_NoUsername() {
+	ctx := createIdentityResolverNodeContext()
+	// No username provided in UserInputs or RuntimeData
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_UserInputRequired_EmptyUsername() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.UserInputs[userAttributeUsername] = "" // Empty username
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_Failure_UserNotFound() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.UserInputs[userAttributeUsername] = "nonexistent_user"
+
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: "nonexistent_user",
+	}).Return(nil, &user.ErrorUserNotFound)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, failureReasonUserNotFound)
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_Failure_NilUserID() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.UserInputs[userAttributeUsername] = testIdentityResolverUsername
+
+	// Return nil userID (edge case)
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: testIdentityResolverUsername,
+	}).Return(nil, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, failureReasonUserNotFound)
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_Failure_EmptyUserID() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.UserInputs[userAttributeUsername] = testIdentityResolverUsername
+
+	// Return empty userID
+	emptyUserID := ""
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: testIdentityResolverUsername,
+	}).Return(&emptyUserID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, failureReasonUserNotFound)
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_Failure_ServiceError() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.UserInputs[userAttributeUsername] = testIdentityResolverUsername
+
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: testIdentityResolverUsername,
+	}).Return(nil, &user.ErrorInternalServerError)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_PreservesExistingRuntimeData() {
+	ctx := createIdentityResolverNodeContext()
+	ctx.UserInputs[userAttributeUsername] = testIdentityResolverUsername
+	ctx.RuntimeData["existingKey"] = "existingValue"
+
+	userID := testIdentityResolverUserID
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: testIdentityResolverUsername,
+	}).Return(&userID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	// The resolved userID should be in RuntimeData
+	assert.Equal(suite.T(), testIdentityResolverUserID, resp.RuntimeData[userAttributeUserID])
+}
+
+func (suite *IdentityResolverExecutorTestSuite) TestExecute_UserInputsPrioritizedOverRuntimeData() {
+	ctx := createIdentityResolverNodeContext()
+	// Set username in both places - UserInputs should take priority
+	ctx.UserInputs[userAttributeUsername] = "user_from_inputs"
+	ctx.RuntimeData[userAttributeUsername] = "user_from_runtime"
+
+	userID := testIdentityResolverUserID
+	suite.mockUserService.On("IdentifyUser", map[string]interface{}{
+		userAttributeUsername: "user_from_inputs",
+	}).Return(&userID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -54,6 +54,8 @@ func Initialize(
 		flowFactory, userService, authRegistry.CredentialsAuthnService, observabilitySvc))
 	reg.RegisterExecutor(ExecutorNameSMSAuth, newSMSOTPAuthExecutor(
 		flowFactory, userService, otpService, observabilitySvc))
+	reg.RegisterExecutor(ExecutorNamePasskeyAuth, newPasskeyAuthExecutor(
+		flowFactory, userService, authRegistry.PasskeyService, observabilitySvc))
 
 	reg.RegisterExecutor(ExecutorNameOAuth, newOAuthExecutor(
 		"", []common.Input{}, []common.Input{}, flowFactory, idpService, userSchemaService,
@@ -79,6 +81,7 @@ func Initialize(
 	reg.RegisterExecutor(ExecutorNameInviteExecutor, newInviteExecutor(flowFactory))
 	reg.RegisterExecutor(ExecutorNameCredentialSetter, newCredentialSetter(flowFactory, userService))
 	reg.RegisterExecutor(ExecutorNamePermissionValidator, newPermissionValidator(flowFactory))
+	reg.RegisterExecutor(ExecutorNameIdentityResolver, newIdentityResolverExecutor(flowFactory, userService))
 
 	return reg
 }

--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -1,0 +1,611 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	authncm "github.com/asgardeo/thunder/internal/authn/common"
+	"github.com/asgardeo/thunder/internal/authn/passkey"
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/observability"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/user"
+)
+
+const (
+	passkeyExecutorModeChallenge = "challenge"
+	passkeyExecutorModeVerify    = "verify"
+	passkeyExecutorModeRegStart  = "register_start"
+	passkeyExecutorModeRegFinish = "register_finish"
+	errorInvalidPasskey          = "invalid passkey credentials provided"
+)
+
+// Passkey authentication input identifiers
+const (
+	// nolint:gosec // G101: This is a JSON field identifier, not a credential
+	inputCredentialID      = "credentialId"
+	inputClientDataJSON    = "clientDataJSON"
+	inputAuthenticatorData = "authenticatorData"
+	inputSignature         = "signature"
+	inputUserHandle        = "userHandle"
+)
+
+// Passkey registration input identifiers
+const (
+	inputAttestationObject = "attestationObject"
+	// nolint:gosec // G101: This is a JSON field identifier, not a credential
+	inputCredentialName = "credentialName"
+)
+
+// Runtime data keys
+const (
+	runtimePasskeySessionToken    = "passkeySessionToken"
+	runtimePasskeyChallenge       = "passkeyChallenge"
+	runtimePasskeyCreationOptions = "passkeyCreationOptions"
+	runtimePasskeyCredentialID    = "passkeyCredentialID"
+	runtimePasskeyCredentialName  = "passkeyCredentialName"
+)
+
+// passkeyAuthExecutor implements the ExecutorInterface for passkey authentication.
+type passkeyAuthExecutor struct {
+	core.ExecutorInterface
+	identifyingExecutorInterface
+	passkeyService   passkey.PasskeyServiceInterface
+	userService      user.UserServiceInterface
+	observabilitySvc observability.ObservabilityServiceInterface
+	logger           *log.Logger
+}
+
+var _ core.ExecutorInterface = (*passkeyAuthExecutor)(nil)
+var _ identifyingExecutorInterface = (*passkeyAuthExecutor)(nil)
+
+// newPasskeyAuthExecutor creates a new instance of PasskeyAuthExecutor.
+func newPasskeyAuthExecutor(
+	flowFactory core.FlowFactoryInterface,
+	userService user.UserServiceInterface,
+	passkeyService passkey.PasskeyServiceInterface,
+	observabilitySvc observability.ObservabilityServiceInterface,
+) *passkeyAuthExecutor {
+	defaultInputs := []common.Input{
+		{
+			Identifier: inputCredentialID,
+			Type:       "string",
+			Required:   true,
+		},
+		{
+			Identifier: inputClientDataJSON,
+			Type:       "string",
+			Required:   true,
+		},
+		{
+			Identifier: inputAuthenticatorData,
+			Type:       "string",
+			Required:   true,
+		},
+		{
+			Identifier: inputSignature,
+			Type:       "string",
+			Required:   true,
+		},
+		{
+			Identifier: inputUserHandle,
+			Type:       "string",
+			Required:   false,
+		},
+	}
+
+	prerequisites := []common.Input{
+		{
+			Identifier: userAttributeUserID,
+			Type:       "string",
+			Required:   true,
+		},
+	}
+
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "PasskeyAuthExecutor"),
+		log.String(log.LoggerKeyExecutorName, ExecutorNamePasskeyAuth))
+
+	identifyExec := newIdentifyingExecutor(ExecutorNamePasskeyAuth, defaultInputs, prerequisites,
+		flowFactory, userService)
+	base := flowFactory.CreateExecutor(ExecutorNamePasskeyAuth, common.ExecutorTypeAuthentication,
+		defaultInputs, prerequisites)
+
+	return &passkeyAuthExecutor{
+		ExecutorInterface:            base,
+		identifyingExecutorInterface: identifyExec,
+		passkeyService:               passkeyService,
+		userService:                  userService,
+		observabilitySvc:             observabilitySvc,
+		logger:                       logger,
+	}
+}
+
+// Execute executes the passkey authentication logic.
+func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
+	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Executing passkey authentication executor")
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	if !p.ValidatePrerequisites(ctx, execResp) {
+		logger.Debug("Prerequisites not met for passkey authentication executor")
+		return execResp, nil
+	}
+
+	// Determine the executor mode
+	switch ctx.ExecutorMode {
+	case passkeyExecutorModeChallenge:
+		return p.executeChallenge(ctx, execResp)
+	case passkeyExecutorModeVerify:
+		return p.executeVerify(ctx, execResp)
+	case passkeyExecutorModeRegStart:
+		return p.executeRegisterStart(ctx, execResp)
+	case passkeyExecutorModeRegFinish:
+		return p.executeRegisterFinish(ctx, execResp)
+	default:
+		return execResp, fmt.Errorf("invalid executor mode: %s", ctx.ExecutorMode)
+	}
+}
+
+// executeChallenge generates and returns a passkey authentication challenge.
+func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
+	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
+	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Generating passkey authentication challenge")
+
+	userID := p.GetUserIDFromContext(ctx)
+	if userID == "" {
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "User ID is required for passkey authentication"
+		return execResp, nil
+	}
+
+	// Get relying party ID from node properties or use a default
+	relyingPartyID := p.getRelyingPartyID(ctx)
+	if relyingPartyID == "" {
+		logger.Error("Relying party ID not configured")
+		return execResp, errors.New("relying party ID is not configured in node properties")
+	}
+
+	// Start passkey authentication
+	startReq := &passkey.PasskeyAuthenticationStartRequest{
+		UserID:         userID,
+		RelyingPartyID: relyingPartyID,
+	}
+	startData, svcErr := p.passkeyService.StartAuthentication(startReq)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			logger.Debug("Failed to start passkey authentication",
+				log.String("userID", userID), log.String("error", svcErr.ErrorDescription))
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = svcErr.ErrorDescription
+			return execResp, nil
+		}
+		logger.Error("Failed to start passkey authentication",
+			log.String("userID", userID), log.Error(errors.New(svcErr.ErrorDescription)))
+		return execResp, fmt.Errorf("failed to start passkey authentication: %s", svcErr.ErrorDescription)
+	}
+
+	// Store session token in runtime data for verification phase
+	execResp.RuntimeData[runtimePasskeySessionToken] = startData.SessionToken
+
+	// Marshal the challenge options to JSON
+	challengeJSON, err := json.Marshal(startData.PublicKeyCredentialRequestOptions)
+	if err != nil {
+		logger.Error("Failed to marshal challenge options", log.Error(err))
+		return execResp, fmt.Errorf("failed to marshal challenge options: %w", err)
+	}
+
+	// Return challenge data to client
+	execResp.AdditionalData[runtimePasskeyChallenge] = string(challengeJSON)
+	execResp.Status = common.ExecComplete
+
+	logger.Debug("Passkey challenge generated successfully", log.String("userID", userID))
+	return execResp, nil
+}
+
+// executeVerify verifies the passkey authentication response.
+func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
+	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
+	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Verifying passkey authentication response")
+
+	// Check for required inputs
+	if !p.HasRequiredInputs(ctx, execResp) {
+		logger.Debug("Required inputs for passkey verification are not provided")
+		execResp.Status = common.ExecUserInputRequired
+		return execResp, nil
+	}
+
+	// Validate the passkey
+	err := p.validatePasskey(ctx, execResp, logger)
+	if err != nil {
+		logger.Error("Error validating passkey", log.Error(err))
+		return execResp, fmt.Errorf("error validating passkey: %w", err)
+	}
+	if execResp.Status == common.ExecFailure || execResp.Status == common.ExecUserInputRequired {
+		return execResp, nil
+	}
+
+	// Get authenticated user details
+	authenticatedUser, err := p.getAuthenticatedUser(ctx, execResp)
+	if err != nil {
+		logger.Error("Failed to get authenticated user details", log.Error(err))
+		return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
+	}
+
+	execResp.AuthenticatedUser = *authenticatedUser
+	execResp.Status = common.ExecComplete
+
+	logger.Debug("Passkey verification completed successfully",
+		log.String("status", string(execResp.Status)),
+		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
+
+	return execResp, nil
+}
+
+// validatePasskey validates the passkey authentication response.
+func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *common.ExecutorResponse,
+	logger *log.Logger) error {
+	userID := p.GetUserIDFromContext(ctx)
+
+	// Extract passkey response data from user inputs
+	credentialID := ctx.UserInputs[inputCredentialID]
+	clientDataJSON := ctx.UserInputs[inputClientDataJSON]
+	authenticatorData := ctx.UserInputs[inputAuthenticatorData]
+	signature := ctx.UserInputs[inputSignature]
+	userHandle := ctx.UserInputs[inputUserHandle]
+
+	logger.Debug("Validating passkey", log.String("userID", userID))
+
+	// Get session token from runtime data
+	sessionToken := ctx.RuntimeData[runtimePasskeySessionToken]
+	if sessionToken == "" {
+		logger.Error("No session token found for passkey authentication", log.String("userID", userID))
+		return fmt.Errorf("no session token found for passkey authentication")
+	}
+
+	// Call passkey service to finish authentication
+	finishReq := &passkey.PasskeyAuthenticationFinishRequest{
+		CredentialID:      credentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    clientDataJSON,
+		AuthenticatorData: authenticatorData,
+		Signature:         signature,
+		UserHandle:        userHandle,
+		SessionToken:      sessionToken,
+	}
+	authResp, svcErr := p.passkeyService.FinishAuthentication(finishReq)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			logger.Debug("Passkey verification failed", log.String("userID", userID),
+				log.String("error", svcErr.ErrorDescription))
+			// Return USER_INPUT_REQUIRED to allow retry on invalid passkey
+			execResp.Status = common.ExecUserInputRequired
+			execResp.FailureReason = errorInvalidPasskey
+			return nil
+		}
+		logger.Error("Failed to verify passkey", log.String("userID", userID),
+			log.String("error", svcErr.ErrorDescription))
+		return fmt.Errorf("failed to verify passkey: %s", svcErr.ErrorDescription)
+	}
+
+	// Store authenticated user ID in runtime data
+	if authResp.ID != "" {
+		execResp.RuntimeData[userAttributeUserID] = authResp.ID
+	}
+
+	// Clear session token after successful verification
+	execResp.RuntimeData[runtimePasskeySessionToken] = ""
+
+	logger.Debug("Passkey validated successfully", log.String("userID", userID))
+	return nil
+}
+
+// getAuthenticatedUser returns the authenticated user details.
+func (p *passkeyAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
+	execResp *common.ExecutorResponse) (*authncm.AuthenticatedUser, error) {
+	userID := execResp.RuntimeData[userAttributeUserID]
+	if userID == "" {
+		userID = p.GetUserIDFromContext(ctx)
+	}
+	if userID == "" {
+		return nil, errors.New("user ID is empty after passkey authentication")
+	}
+
+	// Get user details from user service
+	user, svcErr := p.userService.GetUser(userID)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to get user details: %s", svcErr.Error)
+	}
+
+	// Extract user attributes
+	var attrs map[string]interface{}
+	if err := json.Unmarshal(user.Attributes, &attrs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal user attributes: %w", err)
+	}
+
+	authenticatedUser := &authncm.AuthenticatedUser{
+		IsAuthenticated:    true,
+		UserID:             user.ID,
+		OrganizationUnitID: user.OrganizationUnit,
+		UserType:           user.Type,
+		Attributes:         attrs,
+	}
+
+	return authenticatedUser, nil
+}
+
+// executeRegisterStart initiates passkey credential registration.
+func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
+	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
+	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Starting passkey registration")
+
+	userID := p.GetUserIDFromContext(ctx)
+	if userID == "" {
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "User ID is required for passkey registration"
+		return execResp, nil
+	}
+
+	relyingPartyID := p.getRelyingPartyID(ctx)
+	if relyingPartyID == "" {
+		logger.Error("Relying party ID not configured")
+		return execResp, errors.New("relying party ID is not configured in node properties")
+	}
+
+	relyingPartyName := p.getRelyingPartyName(ctx)
+	if relyingPartyName == "" {
+		relyingPartyName = relyingPartyID // Default to ID if name not specified
+	}
+
+	// Build registration request
+	regReq := &passkey.PasskeyRegistrationStartRequest{
+		UserID:           userID,
+		RelyingPartyID:   relyingPartyID,
+		RelyingPartyName: relyingPartyName,
+		// Optional: Get authenticator selection and attestation from node properties
+		AuthenticatorSelection: p.getAuthenticatorSelection(ctx),
+		Attestation:            p.getAttestation(ctx),
+	}
+
+	// Start passkey registration
+	startData, svcErr := p.passkeyService.StartRegistration(regReq)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			logger.Debug("Failed to start passkey registration",
+				log.String("userID", userID), log.String("error", svcErr.ErrorDescription))
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = svcErr.ErrorDescription
+			return execResp, nil
+		}
+		logger.Error("Failed to start passkey registration",
+			log.String("userID", userID), log.Error(errors.New(svcErr.ErrorDescription)))
+		return execResp, fmt.Errorf("failed to start passkey registration: %s", svcErr.ErrorDescription)
+	}
+
+	// Store session token in runtime data for finish phase
+	execResp.RuntimeData[runtimePasskeySessionToken] = startData.SessionToken
+
+	// Marshal the creation options to JSON
+	creationJSON, err := json.Marshal(startData.PublicKeyCredentialCreationOptions)
+	if err != nil {
+		logger.Error("Failed to marshal creation options", log.Error(err))
+		return execResp, fmt.Errorf("failed to marshal creation options: %w", err)
+	}
+
+	// Return creation options to client
+	execResp.AdditionalData[runtimePasskeyCreationOptions] = string(creationJSON)
+	execResp.Status = common.ExecComplete
+
+	logger.Debug("Passkey registration options generated successfully", log.String("userID", userID))
+	return execResp, nil
+}
+
+// executeRegisterFinish completes passkey credential registration.
+func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
+	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
+	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Finishing passkey registration")
+
+	// Check for required inputs
+	allInputs := []common.Input{
+		{Identifier: inputCredentialID, Required: true},
+		{Identifier: inputClientDataJSON, Required: true},
+		{Identifier: inputAttestationObject, Required: true},
+		{Identifier: inputCredentialName, Required: false}, // Optional: user-friendly name for the passkey
+	}
+
+	// Validate inputs - only block on missing REQUIRED inputs
+	missingRequiredInputs := false
+	for _, input := range allInputs {
+		if _, ok := ctx.UserInputs[input.Identifier]; !ok {
+			execResp.Inputs = append(execResp.Inputs, input)
+			if input.Required {
+				missingRequiredInputs = true
+			}
+		}
+	}
+
+	if missingRequiredInputs {
+		logger.Debug("Required inputs for passkey registration are not provided")
+		execResp.Status = common.ExecUserInputRequired
+		return execResp, nil
+	}
+
+	// Extract registration response data from user inputs
+	credentialID := ctx.UserInputs[inputCredentialID]
+	clientDataJSON := ctx.UserInputs[inputClientDataJSON]
+	attestationObject := ctx.UserInputs[inputAttestationObject]
+	credentialName := ctx.UserInputs[inputCredentialName]
+	if credentialName == "" {
+		credentialName = "Passkey" // Default name if not provided
+	}
+
+	// Get session token from runtime data
+	sessionToken := ctx.RuntimeData[runtimePasskeySessionToken]
+	if sessionToken == "" {
+		logger.Error("No session token found for passkey registration")
+		return execResp, fmt.Errorf("no session token found for passkey registration")
+	}
+
+	// Build finish registration request
+	finishReq := &passkey.PasskeyRegistrationFinishRequest{
+		CredentialID:      credentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    clientDataJSON,
+		AttestationObject: attestationObject,
+		SessionToken:      sessionToken,
+		CredentialName:    credentialName,
+	}
+
+	// Call passkey service to finish registration
+	finishData, svcErr := p.passkeyService.FinishRegistration(finishReq)
+	if svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			logger.Debug("Passkey registration failed", log.String("error", svcErr.ErrorDescription))
+			// Return USER_INPUT_REQUIRED to allow retry on invalid registration
+			execResp.Status = common.ExecUserInputRequired
+			execResp.FailureReason = svcErr.ErrorDescription
+			return execResp, nil
+		}
+		logger.Error("Failed to finish passkey registration", log.String("error", svcErr.ErrorDescription))
+		return execResp, fmt.Errorf("failed to finish passkey registration: %s", svcErr.ErrorDescription)
+	}
+
+	// Store credential info in runtime data
+	execResp.RuntimeData[runtimePasskeyCredentialID] = finishData.CredentialID
+	execResp.RuntimeData[runtimePasskeyCredentialName] = finishData.CredentialName
+
+	// Clear session token after successful registration
+	execResp.RuntimeData[runtimePasskeySessionToken] = ""
+
+	// For registration flows, return the credential info in additional data
+	execResp.AdditionalData[runtimePasskeyCredentialID] = finishData.CredentialID
+	execResp.AdditionalData[runtimePasskeyCredentialName] = finishData.CredentialName
+	execResp.AdditionalData["credentialCreatedAt"] = finishData.CreatedAt
+
+	// Handle flow completion based on flow type
+	if ctx.FlowType == common.FlowTypeRegistration {
+		// For registration flows, user may not be fully authenticated yet
+		// Return credential info but don't set authenticated user
+		execResp.Status = common.ExecComplete
+		logger.Debug("Passkey registration completed for registration flow")
+	} else {
+		// For authentication flows (adding passkey to existing account)
+		// Get and return authenticated user details
+		authenticatedUser, err := p.getAuthenticatedUser(ctx, execResp)
+		if err != nil {
+			logger.Error("Failed to get authenticated user details", log.Error(err))
+			return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
+		}
+		execResp.AuthenticatedUser = *authenticatedUser
+		execResp.Status = common.ExecComplete
+		logger.Debug("Passkey registration completed for existing user")
+	}
+
+	logger.Debug("Passkey registration finished successfully",
+		log.String("credentialID", finishData.CredentialID))
+	return execResp, nil
+}
+
+// getRelyingPartyID retrieves the relying party ID from node properties.
+func (p *passkeyAuthExecutor) getRelyingPartyID(ctx *core.NodeContext) string {
+	if len(ctx.NodeProperties) == 0 {
+		return ""
+	}
+
+	if rpID, ok := ctx.NodeProperties["relyingPartyId"]; ok {
+		if rpIDStr, valid := rpID.(string); valid && rpIDStr != "" {
+			return rpIDStr
+		}
+	}
+
+	return ""
+}
+
+// getRelyingPartyName retrieves the relying party name from node properties.
+func (p *passkeyAuthExecutor) getRelyingPartyName(ctx *core.NodeContext) string {
+	if len(ctx.NodeProperties) == 0 {
+		return ""
+	}
+
+	if rpName, ok := ctx.NodeProperties["relyingPartyName"]; ok {
+		if rpNameStr, valid := rpName.(string); valid && rpNameStr != "" {
+			return rpNameStr
+		}
+	}
+
+	return ""
+}
+
+// getAuthenticatorSelection retrieves authenticator selection criteria from node properties.
+func (p *passkeyAuthExecutor) getAuthenticatorSelection(ctx *core.NodeContext) *passkey.AuthenticatorSelection {
+	if len(ctx.NodeProperties) == 0 {
+		return nil
+	}
+
+	// Check if authenticatorSelection is configured
+	if authSel, ok := ctx.NodeProperties["authenticatorSelection"]; ok {
+		if authSelMap, valid := authSel.(map[string]interface{}); valid {
+			selection := &passkey.AuthenticatorSelection{}
+
+			if authAttachment, ok := authSelMap["authenticatorAttachment"].(string); ok {
+				selection.AuthenticatorAttachment = authAttachment
+			}
+			if reqResidentKey, ok := authSelMap["requireResidentKey"].(bool); ok {
+				selection.RequireResidentKey = reqResidentKey
+			}
+			if residentKey, ok := authSelMap["residentKey"].(string); ok {
+				selection.ResidentKey = residentKey
+			}
+			if userVerification, ok := authSelMap["userVerification"].(string); ok {
+				selection.UserVerification = userVerification
+			}
+
+			return selection
+		}
+	}
+
+	return nil
+}
+
+// getAttestation retrieves attestation conveyance preference from node properties.
+func (p *passkeyAuthExecutor) getAttestation(ctx *core.NodeContext) string {
+	if len(ctx.NodeProperties) == 0 {
+		return "none" // Default to "none"
+	}
+
+	if attestation, ok := ctx.NodeProperties["attestation"]; ok {
+		if attestationStr, valid := attestation.(string); valid && attestationStr != "" {
+			return attestationStr
+		}
+	}
+
+	return "none"
+}

--- a/backend/internal/flow/executor/passkey_executor_test.go
+++ b/backend/internal/flow/executor/passkey_executor_test.go
@@ -1,0 +1,1024 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	authncm "github.com/asgardeo/thunder/internal/authn/common"
+	"github.com/asgardeo/thunder/internal/authn/passkey"
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/tests/mocks/authn/passkeymock"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/observabilitymock"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+)
+
+const (
+	testPasskeyUserID    = "test-user-123"
+	testRelyingPartyID   = "example.com"
+	testRelyingPartyName = "Example App"
+	testPasskeyFlowID    = "passkey-flow-123"
+	testSessionToken     = "session-token-abc"
+	// nolint:gosec // G101: This is a test value, not an actual credential
+	testCredentialIDValue = "credential-id-xyz"
+)
+
+type PasskeyAuthExecutorTestSuite struct {
+	suite.Suite
+	mockUserService    *usermock.UserServiceInterfaceMock
+	mockPasskeyService *passkeymock.PasskeyServiceInterfaceMock
+	mockFlowFactory    *coremock.FlowFactoryInterfaceMock
+	mockObservability  *observabilitymock.ObservabilityServiceInterfaceMock
+	executor           *passkeyAuthExecutor
+}
+
+func TestPasskeyAuthExecutorSuite(t *testing.T) {
+	suite.Run(t, new(PasskeyAuthExecutorTestSuite))
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) SetupTest() {
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockPasskeyService = passkeymock.NewPasskeyServiceInterfaceMock(suite.T())
+	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
+	suite.mockObservability = observabilitymock.NewObservabilityServiceInterfaceMock(suite.T())
+
+	// Create mock identifying executor
+	identifyingMock := createMockIdentifyingExecutor(suite.T())
+	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameIdentifying, common.ExecutorTypeUtility,
+		mock.Anything, mock.Anything).Return(identifyingMock).Maybe()
+
+	// Create mock passkey executor base
+	mockExec := createMockPasskeyAuthExecutor(suite.T())
+	suite.mockFlowFactory.On("CreateExecutor", ExecutorNamePasskeyAuth, common.ExecutorTypeAuthentication,
+		mock.Anything, mock.Anything).Return(mockExec)
+
+	suite.executor = newPasskeyAuthExecutor(suite.mockFlowFactory, suite.mockUserService,
+		suite.mockPasskeyService, suite.mockObservability)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) BeforeTest(suiteName, testName string) {
+	suite.mockObservability.ExpectedCalls = nil
+	suite.mockObservability.On("IsEnabled").Return(false).Maybe()
+}
+
+func createMockPasskeyAuthExecutor(t *testing.T) core.ExecutorInterface {
+	mockExec := coremock.NewExecutorInterfaceMock(t)
+	mockExec.On("GetName").Return(ExecutorNamePasskeyAuth).Maybe()
+	mockExec.On("GetType").Return(common.ExecutorTypeAuthentication).Maybe()
+	mockExec.On("GetDefaultInputs").Return([]common.Input{
+		{Identifier: inputCredentialID, Type: "string", Required: true},
+		{Identifier: inputClientDataJSON, Type: "string", Required: true},
+		{Identifier: inputAuthenticatorData, Type: "string", Required: true},
+		{Identifier: inputSignature, Type: "string", Required: true},
+		{Identifier: inputUserHandle, Type: "string", Required: false},
+	}).Maybe()
+	mockExec.On("GetPrerequisites").Return([]common.Input{
+		{Identifier: userAttributeUserID, Type: "string", Required: true},
+	}).Maybe()
+	mockExec.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{Identifier: inputCredentialID, Type: "string", Required: true},
+		{Identifier: inputClientDataJSON, Type: "string", Required: true},
+		{Identifier: inputAuthenticatorData, Type: "string", Required: true},
+		{Identifier: inputSignature, Type: "string", Required: true},
+	}).Maybe()
+	mockExec.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(
+		func(ctx *core.NodeContext, execResp *common.ExecutorResponse) bool {
+			// Check if all required inputs are present
+			requiredInputs := []string{inputCredentialID, inputClientDataJSON, inputAuthenticatorData, inputSignature}
+			for _, input := range requiredInputs {
+				if _, exists := ctx.UserInputs[input]; !exists {
+					execResp.Status = common.ExecUserInputRequired
+					return false
+				}
+			}
+			return true
+		}).Maybe()
+	mockExec.On("ValidatePrerequisites", mock.Anything, mock.Anything).Return(true).Maybe()
+	mockExec.On("GetUserIDFromContext", mock.Anything).Return(
+		func(ctx *core.NodeContext) string {
+			// Check AuthenticatedUser first, then RuntimeData, then UserInputs
+			if ctx.AuthenticatedUser.UserID != "" {
+				return ctx.AuthenticatedUser.UserID
+			}
+			if userID, ok := ctx.RuntimeData[userAttributeUserID]; ok {
+				return userID
+			}
+			if userID, ok := ctx.UserInputs[userAttributeUserID]; ok {
+				return userID
+			}
+			return ""
+		}).Maybe()
+	return mockExec
+}
+
+// Helper to create a node context with common properties
+func createPasskeyNodeContext(mode string, flowType common.FlowType) *core.NodeContext {
+	return &core.NodeContext{
+		FlowID:       testPasskeyFlowID,
+		FlowType:     flowType,
+		ExecutorMode: mode,
+		UserInputs:   make(map[string]string),
+		RuntimeData:  make(map[string]string),
+		NodeProperties: map[string]interface{}{
+			"relyingPartyId":   testRelyingPartyID,
+			"relyingPartyName": testRelyingPartyName,
+		},
+	}
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestNewPasskeyAuthExecutor() {
+	assert.NotNil(suite.T(), suite.executor)
+	assert.NotNil(suite.T(), suite.executor.passkeyService)
+	assert.NotNil(suite.T(), suite.executor.userService)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecute_InvalidMode() {
+	ctx := createPasskeyNodeContext("invalid_mode", common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "invalid executor mode")
+	assert.NotNil(suite.T(), resp)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteChallenge_Success() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	expectedStartData := &passkey.PasskeyAuthenticationStartData{
+		SessionToken: testSessionToken,
+		PublicKeyCredentialRequestOptions: passkey.PublicKeyCredentialRequestOptions{
+			Challenge: "dGVzdC1jaGFsbGVuZ2U=",
+		},
+	}
+
+	suite.mockPasskeyService.On("StartAuthentication", mock.MatchedBy(
+		func(req *passkey.PasskeyAuthenticationStartRequest) bool {
+			return req.UserID == testPasskeyUserID && req.RelyingPartyID == testRelyingPartyID
+		})).Return(expectedStartData, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), testSessionToken, resp.RuntimeData[runtimePasskeySessionToken])
+	assert.NotEmpty(suite.T(), resp.AdditionalData[runtimePasskeyChallenge])
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteChallenge_MissingUserID() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	// Not setting userID in RuntimeData
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, "User ID is required")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteChallenge_MissingRelyingPartyID() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.NodeProperties = map[string]interface{}{} // Empty node properties
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "relying party ID is not configured")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteChallenge_ServiceError_Client() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	suite.mockPasskeyService.On("StartAuthentication", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			ErrorDescription: "User has no registered passkeys",
+		})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, "User has no registered passkeys")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteChallenge_ServiceError_Server() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	suite.mockPasskeyService.On("StartAuthentication", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ServerErrorType,
+			ErrorDescription: "Database connection failed",
+		})
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to start passkey authentication")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_Success() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0",
+		inputAuthenticatorData: "authenticator-data",
+		inputSignature:         "signature-data",
+		inputUserHandle:        "user-handle",
+	}
+
+	authResp := &authncm.AuthenticationResponse{
+		ID: testPasskeyUserID,
+	}
+	suite.mockPasskeyService.On("FinishAuthentication", mock.Anything).Return(authResp, nil)
+
+	attrs := map[string]interface{}{"email": "test@example.com"}
+	attrsJSON, _ := json.Marshal(attrs)
+	testUser := &user.User{
+		ID:               testPasskeyUserID,
+		OrganizationUnit: "ou-123",
+		Type:             "INTERNAL",
+		Attributes:       attrsJSON,
+	}
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(testUser, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.True(suite.T(), resp.AuthenticatedUser.IsAuthenticated)
+	assert.Equal(suite.T(), testPasskeyUserID, resp.AuthenticatedUser.UserID)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_MissingInputs() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	// Empty UserInputs triggers UserInputRequired
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_MissingSessionToken() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	// Not setting session token
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAuthenticatorData: "authenticator-data",
+		inputSignature:         "signature",
+	}
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "no session token found")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_InvalidPasskey_ClientError() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAuthenticatorData: "authenticator-data",
+		inputSignature:         "invalid-signature",
+	}
+
+	suite.mockPasskeyService.On("FinishAuthentication", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			ErrorDescription: "Invalid signature",
+		})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, "invalid passkey credentials")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_ServiceError_Server() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAuthenticatorData: "authenticator-data",
+		inputSignature:         "signature",
+	}
+
+	suite.mockPasskeyService.On("FinishAuthentication", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ServerErrorType,
+			ErrorDescription: "Database error",
+		})
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to verify passkey")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterStart_Success() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	expectedStartData := &passkey.PasskeyRegistrationStartData{
+		SessionToken: testSessionToken,
+		PublicKeyCredentialCreationOptions: passkey.PublicKeyCredentialCreationOptions{
+			Challenge: "cmVnaXN0cmF0aW9uLWNoYWxsZW5nZQ==",
+		},
+	}
+
+	suite.mockPasskeyService.On("StartRegistration", mock.MatchedBy(
+		func(req *passkey.PasskeyRegistrationStartRequest) bool {
+			return req.UserID == testPasskeyUserID &&
+				req.RelyingPartyID == testRelyingPartyID &&
+				req.RelyingPartyName == testRelyingPartyName
+		})).Return(expectedStartData, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), testSessionToken, resp.RuntimeData[runtimePasskeySessionToken])
+	assert.NotEmpty(suite.T(), resp.AdditionalData[runtimePasskeyCreationOptions])
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterStart_MissingUserID() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	// Not setting userID
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, "User ID is required")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterStart_MissingRelyingPartyID() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.NodeProperties = map[string]interface{}{} // Empty
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "relying party ID is not configured")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterStart_ServiceError_Client() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	suite.mockPasskeyService.On("StartRegistration", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			ErrorDescription: "User not found",
+		})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterStart_ServiceError_Server() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	suite.mockPasskeyService.On("StartRegistration", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ServerErrorType,
+			ErrorDescription: "Database error",
+		})
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to start passkey registration")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterStart_DefaultRelyingPartyName() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	// Set only relyingPartyId, not relyingPartyName
+	ctx.NodeProperties = map[string]interface{}{
+		"relyingPartyId": testRelyingPartyID,
+	}
+
+	expectedStartData := &passkey.PasskeyRegistrationStartData{
+		SessionToken:                       testSessionToken,
+		PublicKeyCredentialCreationOptions: passkey.PublicKeyCredentialCreationOptions{},
+	}
+
+	suite.mockPasskeyService.On("StartRegistration", mock.MatchedBy(
+		func(req *passkey.PasskeyRegistrationStartRequest) bool {
+			// relyingPartyName should default to relyingPartyId
+			return req.RelyingPartyName == testRelyingPartyID
+		})).Return(expectedStartData, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_Success_RegistrationFlow() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0",
+		inputAttestationObject: "attestation-object-data",
+		inputCredentialName:    "My Passkey",
+	}
+
+	finishData := &passkey.PasskeyRegistrationFinishData{
+		CredentialID:   testCredentialIDValue,
+		CredentialName: "My Passkey",
+		CreatedAt:      "2025-01-15T00:00:00Z",
+	}
+	suite.mockPasskeyService.On("FinishRegistration", mock.Anything).Return(finishData, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), testCredentialIDValue, resp.RuntimeData[runtimePasskeyCredentialID])
+	assert.Equal(suite.T(), "My Passkey", resp.RuntimeData[runtimePasskeyCredentialName])
+	assert.Equal(suite.T(), "", resp.RuntimeData[runtimePasskeySessionToken]) // Should be cleared
+	// For registration flow, authenticated user should not be set
+	assert.False(suite.T(), resp.AuthenticatedUser.IsAuthenticated)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_Success_AuthenticationFlow() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAttestationObject: "attestation-object",
+	}
+
+	finishData := &passkey.PasskeyRegistrationFinishData{
+		CredentialID:   testCredentialIDValue,
+		CredentialName: "Passkey", // Default name
+		CreatedAt:      "2025-01-15T00:00:00Z",
+	}
+	suite.mockPasskeyService.On("FinishRegistration", mock.Anything).Return(finishData, nil)
+
+	attrs := map[string]interface{}{"email": "test@example.com"}
+	attrsJSON, _ := json.Marshal(attrs)
+	testUser := &user.User{
+		ID:               testPasskeyUserID,
+		OrganizationUnit: "ou-123",
+		Type:             "INTERNAL",
+		Attributes:       attrsJSON,
+	}
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(testUser, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.True(suite.T(), resp.AuthenticatedUser.IsAuthenticated)
+	assert.Equal(suite.T(), testPasskeyUserID, resp.AuthenticatedUser.UserID)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_MissingInputs() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	// Empty UserInputs
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_MissingSessionToken() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	// Not setting session token
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAttestationObject: "attestation-object",
+	}
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "no session token found")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_ServiceError_Client() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAttestationObject: "invalid-attestation",
+	}
+
+	suite.mockPasskeyService.On("FinishRegistration", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			ErrorDescription: "Invalid attestation object",
+		})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Contains(suite.T(), resp.FailureReason, "Invalid attestation object")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_ServiceError_Server() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAttestationObject: "attestation-object",
+	}
+
+	suite.mockPasskeyService.On("FinishRegistration", mock.Anything).Return(
+		nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ServerErrorType,
+			ErrorDescription: "Database error",
+		})
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to finish passkey registration")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyID_FromNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+
+	rpID := suite.executor.getRelyingPartyID(ctx)
+
+	assert.Equal(suite.T(), testRelyingPartyID, rpID)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyID_EmptyNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.NodeProperties = nil
+
+	rpID := suite.executor.getRelyingPartyID(ctx)
+
+	assert.Empty(suite.T(), rpID)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyName_FromNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+
+	rpName := suite.executor.getRelyingPartyName(ctx)
+
+	assert.Equal(suite.T(), testRelyingPartyName, rpName)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyName_EmptyNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.NodeProperties = nil
+
+	rpName := suite.executor.getRelyingPartyName(ctx)
+
+	assert.Empty(suite.T(), rpName)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatorSelection_FromNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.NodeProperties["authenticatorSelection"] = map[string]interface{}{
+		"authenticatorAttachment": "platform",
+		"requireResidentKey":      true,
+		"residentKey":             "required",
+		"userVerification":        "required",
+	}
+
+	authSel := suite.executor.getAuthenticatorSelection(ctx)
+
+	assert.NotNil(suite.T(), authSel)
+	assert.Equal(suite.T(), "platform", authSel.AuthenticatorAttachment)
+	assert.True(suite.T(), authSel.RequireResidentKey)
+	assert.Equal(suite.T(), "required", authSel.ResidentKey)
+	assert.Equal(suite.T(), "required", authSel.UserVerification)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatorSelection_NotConfigured() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	// No authenticatorSelection in node properties
+
+	authSel := suite.executor.getAuthenticatorSelection(ctx)
+
+	assert.Nil(suite.T(), authSel)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAttestation_FromNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.NodeProperties["attestation"] = "direct"
+
+	attestation := suite.executor.getAttestation(ctx)
+
+	assert.Equal(suite.T(), "direct", attestation)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAttestation_DefaultValue() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	// No attestation in node properties
+
+	attestation := suite.executor.getAttestation(ctx)
+
+	assert.Equal(suite.T(), "none", attestation) // Default value
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAttestation_EmptyNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.NodeProperties = nil
+
+	attestation := suite.executor.getAttestation(ctx)
+
+	assert.Equal(suite.T(), "none", attestation)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatedUser_Success() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	execResp := &common.ExecutorResponse{
+		RuntimeData: map[string]string{
+			userAttributeUserID: testPasskeyUserID,
+		},
+	}
+
+	attrs := map[string]interface{}{"email": "test@example.com", "name": "Test User"}
+	attrsJSON, _ := json.Marshal(attrs)
+	testUser := &user.User{
+		ID:               testPasskeyUserID,
+		OrganizationUnit: "ou-123",
+		Type:             "INTERNAL",
+		Attributes:       attrsJSON,
+	}
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(testUser, nil)
+
+	authUser, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), authUser)
+	assert.True(suite.T(), authUser.IsAuthenticated)
+	assert.Equal(suite.T(), testPasskeyUserID, authUser.UserID)
+	assert.Equal(suite.T(), "ou-123", authUser.OrganizationUnitID)
+	assert.Equal(suite.T(), "INTERNAL", authUser.UserType)
+	assert.Equal(suite.T(), "test@example.com", authUser.Attributes["email"])
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatedUser_UserNotFound() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	execResp := &common.ExecutorResponse{
+		RuntimeData: map[string]string{
+			userAttributeUserID: testPasskeyUserID,
+		},
+	}
+
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(
+		nil, &serviceerror.ServiceError{Error: "User not found"})
+
+	authUser, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), authUser)
+	assert.Contains(suite.T(), err.Error(), "failed to get user details")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatedUser_InvalidJSON() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	execResp := &common.ExecutorResponse{
+		RuntimeData: map[string]string{
+			userAttributeUserID: testPasskeyUserID,
+		},
+	}
+
+	testUser := &user.User{
+		ID:               testPasskeyUserID,
+		OrganizationUnit: "ou-123",
+		Type:             "INTERNAL",
+		Attributes:       json.RawMessage(`invalid json`),
+	}
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(testUser, nil)
+
+	authUser, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), authUser)
+	assert.Contains(suite.T(), err.Error(), "failed to unmarshal user attributes")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatedUser_EmptyUserID() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	// Not setting userID in RuntimeData
+
+	execResp := &common.ExecutorResponse{
+		RuntimeData: make(map[string]string),
+	}
+
+	authUser, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), authUser)
+	assert.Contains(suite.T(), err.Error(), "user ID is empty")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyID_InvalidType() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	// Set relyingPartyId as wrong type (int instead of string)
+	ctx.NodeProperties = map[string]interface{}{
+		"relyingPartyId": 12345, // Wrong type
+	}
+
+	rpID := suite.executor.getRelyingPartyID(ctx)
+
+	assert.Empty(suite.T(), rpID)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyID_EmptyStringValue() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.NodeProperties = map[string]interface{}{
+		"relyingPartyId": "", // Empty string
+	}
+
+	rpID := suite.executor.getRelyingPartyID(ctx)
+
+	assert.Empty(suite.T(), rpID)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyName_InvalidType() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.NodeProperties = map[string]interface{}{
+		"relyingPartyName": 12345, // Wrong type
+	}
+
+	rpName := suite.executor.getRelyingPartyName(ctx)
+
+	assert.Empty(suite.T(), rpName)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetRelyingPartyName_EmptyStringValue() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	ctx.NodeProperties = map[string]interface{}{
+		"relyingPartyName": "", // Empty string
+	}
+
+	rpName := suite.executor.getRelyingPartyName(ctx)
+
+	assert.Empty(suite.T(), rpName)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatorSelection_InvalidMapType() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	// Set authenticatorSelection as wrong type (string instead of map)
+	ctx.NodeProperties["authenticatorSelection"] = "invalid"
+
+	authSel := suite.executor.getAuthenticatorSelection(ctx)
+
+	assert.Nil(suite.T(), authSel)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatorSelection_PartialFields() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	// Set only some authenticatorSelection fields
+	ctx.NodeProperties["authenticatorSelection"] = map[string]interface{}{
+		"authenticatorAttachment": "cross-platform",
+		// Missing other fields
+	}
+
+	authSel := suite.executor.getAuthenticatorSelection(ctx)
+
+	assert.NotNil(suite.T(), authSel)
+	assert.Equal(suite.T(), "cross-platform", authSel.AuthenticatorAttachment)
+	assert.False(suite.T(), authSel.RequireResidentKey)
+	assert.Empty(suite.T(), authSel.ResidentKey)
+	assert.Empty(suite.T(), authSel.UserVerification)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatorSelection_EmptyNodeProperties() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.NodeProperties = nil
+
+	authSel := suite.executor.getAuthenticatorSelection(ctx)
+
+	assert.Nil(suite.T(), authSel)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAttestation_InvalidType() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.NodeProperties["attestation"] = 12345 // Wrong type
+
+	attestation := suite.executor.getAttestation(ctx)
+
+	assert.Equal(suite.T(), "none", attestation) // Should return default
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAttestation_EmptyStringValue() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	ctx.NodeProperties["attestation"] = "" // Empty string
+
+	attestation := suite.executor.getAttestation(ctx)
+
+	assert.Equal(suite.T(), "none", attestation) // Should return default
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_GetAuthenticatedUserFails() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0",
+		inputAuthenticatorData: "authenticator-data",
+		inputSignature:         "signature-data",
+		inputUserHandle:        "user-handle",
+	}
+
+	authResp := &authncm.AuthenticationResponse{
+		ID: testPasskeyUserID,
+	}
+	suite.mockPasskeyService.On("FinishAuthentication", mock.Anything).Return(authResp, nil)
+
+	// Simulate user not found when getting authenticated user details
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(
+		nil, &serviceerror.ServiceError{Error: "User not found"})
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to get authenticated user details")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_GetAuthenticatedUserFails_AuthFlow() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	ctx.UserInputs = map[string]string{
+		inputCredentialID:      testCredentialIDValue,
+		inputClientDataJSON:    "client-data",
+		inputAttestationObject: "attestation-object",
+	}
+
+	finishData := &passkey.PasskeyRegistrationFinishData{
+		CredentialID:   testCredentialIDValue,
+		CredentialName: "Passkey",
+		CreatedAt:      "2025-01-15T00:00:00Z",
+	}
+	suite.mockPasskeyService.On("FinishRegistration", mock.Anything).Return(finishData, nil)
+
+	// Simulate user not found when getting authenticated user details
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(
+		nil, &serviceerror.ServiceError{Error: "User not found"})
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to get authenticated user details")
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteChallenge_UserIDFromAuthenticatedUser() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeChallenge, common.FlowTypeAuthentication)
+	// Set userID in AuthenticatedUser instead of RuntimeData
+	ctx.AuthenticatedUser = authncm.AuthenticatedUser{
+		UserID:          testPasskeyUserID,
+		IsAuthenticated: true,
+	}
+
+	expectedStartData := &passkey.PasskeyAuthenticationStartData{
+		SessionToken: testSessionToken,
+		PublicKeyCredentialRequestOptions: passkey.PublicKeyCredentialRequestOptions{
+			Challenge: "dGVzdC1jaGFsbGVuZ2U=",
+		},
+	}
+
+	suite.mockPasskeyService.On("StartAuthentication", mock.MatchedBy(
+		func(req *passkey.PasskeyAuthenticationStartRequest) bool {
+			return req.UserID == testPasskeyUserID && req.RelyingPartyID == testRelyingPartyID
+		})).Return(expectedStartData, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterStart_UserIDFromAuthenticatedUser() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegStart, common.FlowTypeRegistration)
+	// Set userID in AuthenticatedUser
+	ctx.AuthenticatedUser = authncm.AuthenticatedUser{
+		UserID:          testPasskeyUserID,
+		IsAuthenticated: true,
+	}
+
+	expectedStartData := &passkey.PasskeyRegistrationStartData{
+		SessionToken:                       testSessionToken,
+		PublicKeyCredentialCreationOptions: passkey.PublicKeyCredentialCreationOptions{},
+	}
+
+	suite.mockPasskeyService.On("StartRegistration", mock.MatchedBy(
+		func(req *passkey.PasskeyRegistrationStartRequest) bool {
+			return req.UserID == testPasskeyUserID
+		})).Return(expectedStartData, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatedUser_UserIDFromContext() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeVerify, common.FlowTypeAuthentication)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+
+	// Empty runtime data in execResp, should fall back to context
+	execResp := &common.ExecutorResponse{
+		RuntimeData: make(map[string]string),
+	}
+
+	attrs := map[string]interface{}{"email": "test@example.com"}
+	attrsJSON, _ := json.Marshal(attrs)
+	testUser := &user.User{
+		ID:               testPasskeyUserID,
+		OrganizationUnit: "ou-123",
+		Type:             "INTERNAL",
+		Attributes:       attrsJSON,
+	}
+	suite.mockUserService.On("GetUser", testPasskeyUserID).Return(testUser, nil)
+
+	authUser, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), authUser)
+	assert.Equal(suite.T(), testPasskeyUserID, authUser.UserID)
+}

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -114,7 +114,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 	if err != nil {
 		logger.Error("Failed to identify user", log.Error(err))
 		execResp.Status = common.ExecFailure
-		execResp.FailureReason = "Failed to identify user"
+		execResp.FailureReason = failureReasonFailedToIdentifyUser
 		return execResp, nil
 	}
 	if execResp.Status == common.ExecFailure && execResp.FailureReason != failureReasonUserNotFound {

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -1,0 +1,922 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package flowexec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	authncm "github.com/asgardeo/thunder/internal/authn/common"
+	"github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/observabilitymock"
+)
+
+type EngineTestSuite struct {
+	suite.Suite
+}
+
+func TestEngineTestSuite(t *testing.T) {
+	suite.Run(t, new(EngineTestSuite))
+}
+
+func (s *EngineTestSuite) TestGetNodeInputs_ExecutorBackedNode() {
+	t := s.T()
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	expectedInputs := []common.Input{
+		{Identifier: "username", Type: "string", Required: true},
+		{Identifier: "password", Type: "string", Required: true},
+	}
+	mockNode.On("GetInputs").Return(expectedInputs)
+
+	inputs := getNodeInputs(mockNode)
+
+	s.NotNil(inputs)
+	s.Len(inputs, 2)
+	s.Equal("username", inputs[0].Identifier)
+	s.Equal("password", inputs[1].Identifier)
+}
+
+func (s *EngineTestSuite) TestGetNodeInputs_PromptNode() {
+	t := s.T()
+	mockNode := coremock.NewPromptNodeInterfaceMock(t)
+	prompts := []common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "email", Type: "string", Required: true},
+			},
+		},
+		{
+			Inputs: []common.Input{
+				{Identifier: "code", Type: "string", Required: true},
+			},
+		},
+	}
+	mockNode.On("GetPrompts").Return(prompts)
+
+	inputs := getNodeInputs(mockNode)
+
+	s.NotNil(inputs)
+	s.Len(inputs, 2)
+	s.Equal("email", inputs[0].Identifier)
+	s.Equal("code", inputs[1].Identifier)
+}
+
+func (s *EngineTestSuite) TestGetNodeInputs_RegularNode() {
+	mockNode := coremock.NewNodeInterfaceMock(s.T())
+
+	inputs := getNodeInputs(mockNode)
+
+	s.Nil(inputs)
+}
+
+func (s *EngineTestSuite) TestGetNodeInputs_NilNode() {
+	inputs := getNodeInputs(nil)
+
+	s.Nil(inputs)
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_AdditionalData() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		RuntimeData: make(map[string]string),
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		AdditionalData: map[string]string{
+			"passkeyChallenge":       `{"challenge": "abc123"}`,
+			"passkeyCreationOptions": `{"rpId": "example.com"}`,
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.NotNil(ctx.AdditionalData)
+	s.Equal(`{"challenge": "abc123"}`, ctx.AdditionalData["passkeyChallenge"])
+	s.Equal(`{"rpId": "example.com"}`, ctx.AdditionalData["passkeyCreationOptions"])
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_MergesAdditionalData() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		RuntimeData: make(map[string]string),
+		AdditionalData: map[string]string{
+			"existingKey": "existingValue",
+		},
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		AdditionalData: map[string]string{
+			"newKey": "newValue",
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.NotNil(ctx.AdditionalData)
+	s.Equal("existingValue", ctx.AdditionalData["existingKey"])
+	s.Equal("newValue", ctx.AdditionalData["newKey"])
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_ClearsActionOnComplete() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		CurrentAction: "someAction",
+		RuntimeData:   make(map[string]string),
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.Empty(ctx.CurrentAction)
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_ClearsActionOnForward() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		CurrentAction: "someAction",
+		RuntimeData:   make(map[string]string),
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusForward,
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.Empty(ctx.CurrentAction)
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_PreservesActionOnIncomplete() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		CurrentAction: "passkeyChallenge",
+		RuntimeData:   make(map[string]string),
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusIncomplete,
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.Equal("passkeyChallenge", ctx.CurrentAction)
+}
+
+func (s *EngineTestSuite) TestResolveStepForRedirection_WithAdditionalData() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{
+		AdditionalData: map[string]string{
+			"passkeyChallenge": `{"challenge": "xyz789"}`,
+			"sessionToken":     "abc123",
+		},
+	}
+
+	nodeResp := &common.NodeResponse{
+		RedirectURL: "https://example.com/auth",
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{},
+	}
+
+	err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.Equal("https://example.com/auth", flowStep.Data.RedirectURL)
+	s.NotNil(flowStep.Data.AdditionalData)
+	s.Equal(`{"challenge": "xyz789"}`, flowStep.Data.AdditionalData["passkeyChallenge"])
+	s.Equal("abc123", flowStep.Data.AdditionalData["sessionToken"])
+}
+
+func (s *EngineTestSuite) TestResolveStepForRedirection_NoAdditionalData() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		RedirectURL: "https://example.com/auth",
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{},
+	}
+
+	err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.Equal("https://example.com/auth", flowStep.Data.RedirectURL)
+	s.Nil(flowStep.Data.AdditionalData)
+}
+
+func (s *EngineTestSuite) TestResolveStepForRedirection_NilNodeResponse() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{}
+	flowStep := &FlowStep{}
+
+	err := fe.resolveStepForRedirection(ctx, nil, flowStep)
+
+	s.Error(err)
+	s.Contains(err.Error(), "node response is nil")
+}
+
+func (s *EngineTestSuite) TestResolveStepForRedirection_EmptyRedirectURL() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{}
+	nodeResp := &common.NodeResponse{
+		RedirectURL: "",
+	}
+	flowStep := &FlowStep{}
+
+	err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
+
+	s.Error(err)
+	s.Contains(err.Error(), "redirect URL not found")
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_WithAdditionalData() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{
+		AdditionalData: map[string]string{
+			"passkeyCreationOptions": `{"rpId": "example.com"}`,
+		},
+	}
+
+	nodeResp := &common.NodeResponse{
+		Inputs: []common.Input{
+			{Identifier: "username", Type: "string", Required: true},
+		},
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{},
+	}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.NotNil(flowStep.Data.AdditionalData)
+	s.Equal(`{"rpId": "example.com"}`, flowStep.Data.AdditionalData["passkeyCreationOptions"])
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_WithActions() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		Actions: []common.Action{
+			{Ref: "submit-action", NextNode: "next-node"},
+		},
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{},
+	}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.Len(flowStep.Data.Actions, 1)
+	s.Equal("submit-action", flowStep.Data.Actions[0].Ref)
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_NilNodeResponse() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{}
+	flowStep := &FlowStep{}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nil, flowStep)
+
+	s.Error(err)
+	s.Contains(err.Error(), "node response is nil")
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_NoInputsOrActions() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{}
+	nodeResp := &common.NodeResponse{}
+	flowStep := &FlowStep{}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
+
+	s.Error(err)
+	s.Contains(err.Error(), "no required data or actions found")
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_RuntimeData() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		RuntimeData: map[string]string{"existing": "value"},
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		RuntimeData: map[string]string{
+			"newKey": "newValue",
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.Equal("value", ctx.RuntimeData["existing"])
+	s.Equal("newValue", ctx.RuntimeData["newKey"])
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_RuntimeDataNilContext() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{} // No RuntimeData initialized
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		RuntimeData: map[string]string{
+			"userID": "user-123",
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.NotNil(ctx.RuntimeData)
+	s.Equal("user-123", ctx.RuntimeData["userID"])
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_Assertion() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		Status:    common.NodeStatusComplete,
+		Assertion: "test-assertion-token",
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.Equal("test-assertion-token", ctx.Assertion)
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_AuthenticatedUserUpdate() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeAuthentication)
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeAuthentication,
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID:          "user-123",
+			IsAuthenticated: true,
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.True(ctx.AuthenticatedUser.IsAuthenticated)
+	s.Equal("user-123", ctx.AuthenticatedUser.UserID)
+	s.Equal("user-123", ctx.RuntimeData["userID"])
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_MergesUserAttributes() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeAuthentication)
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				"existingAttr": "existingValue",
+			},
+		},
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID:          "user-456",
+			IsAuthenticated: true,
+			Attributes: map[string]interface{}{
+				"newAttr": "newValue",
+			},
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	s.True(ctx.AuthenticatedUser.IsAuthenticated)
+	s.Equal("existingValue", ctx.AuthenticatedUser.Attributes["existingAttr"])
+	s.Equal("newValue", ctx.AuthenticatedUser.Attributes["newAttr"])
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_PreservesExistingUserID() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeAuthentication)
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeAuthentication,
+		RuntimeData: map[string]string{
+			"userID": "existing-user-id",
+		},
+	}
+
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID:          "new-user-id",
+			IsAuthenticated: true,
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	// Existing userID in RuntimeData should be preserved
+	s.Equal("existing-user-id", ctx.RuntimeData["userID"])
+}
+
+func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_PreviousAttrsNilNewAttrs() {
+	t := s.T()
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObservability.On("IsEnabled").Return(false).Maybe()
+
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeAuthentication)
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{
+		observabilitySvc: mockObservability,
+	}
+
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				"prevAttr": "prevValue",
+			},
+		},
+	}
+
+	// Node response has nil Attributes
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusComplete,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID:          "user-789",
+			IsAuthenticated: true,
+			Attributes:      nil,
+		},
+	}
+
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	// Previous attributes should be preserved when new ones are nil
+	s.Equal("prevValue", ctx.AuthenticatedUser.Attributes["prevAttr"])
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_NilNode() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: nil,
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.False(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_NonTaskExecutionNode() {
+	mockNode := coremock.NewNodeInterfaceMock(s.T())
+	mockNode.On("GetType").Return(common.NodeTypePrompt)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.False(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_NonExecutorBackedNode() {
+	mockNode := coremock.NewNodeInterfaceMock(s.T())
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.False(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_NilExecutor() {
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(nil)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.False(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_AuthFlowWithAuthExecutor() {
+	t := s.T()
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeAuthentication)
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeAuthentication,
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.True(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_AuthFlowWithProvisioningExecutor() {
+	t := s.T()
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeRegistration)
+	mockExecutor.On("GetName").Return("ProvisioningExecutor")
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeAuthentication,
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserEligibleForProvisioning: "true",
+		},
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.True(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_AuthFlowWithNonAuthExecutor() {
+	t := s.T()
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeUtility)
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeAuthentication,
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.False(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_RegistrationFlowWithProvisioning() {
+	t := s.T()
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetName").Return("ProvisioningExecutor")
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeRegistration,
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.True(result)
+}
+
+func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_RegistrationFlowSkipProvisioning() {
+	t := s.T()
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetType").Return(common.ExecutorTypeAuthentication)
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		CurrentNode: mockNode,
+		FlowType:    common.FlowTypeRegistration,
+		RuntimeData: map[string]string{
+			common.RuntimeKeySkipProvisioning: "true",
+		},
+	}
+
+	result := fe.shouldUpdateAuthenticatedUser(ctx)
+
+	s.True(result)
+}
+
+func (s *EngineTestSuite) TestResolveStepForRedirection_WithInputs() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		RedirectURL: "https://example.com/auth",
+		Inputs: []common.Input{
+			{Identifier: "code", Type: "string", Required: true},
+		},
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{},
+	}
+
+	err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.Len(flowStep.Data.Inputs, 1)
+	s.Equal("code", flowStep.Data.Inputs[0].Identifier)
+	s.Equal(common.FlowStatusIncomplete, flowStep.Status)
+	s.Equal(common.StepTypeRedirection, flowStep.Type)
+}
+
+func (s *EngineTestSuite) TestResolveStepForRedirection_AppendsInputs() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		RedirectURL: "https://example.com/auth",
+		Inputs: []common.Input{
+			{Identifier: "code", Type: "string", Required: true},
+		},
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{
+			Inputs: []common.Input{
+				{Identifier: "state", Type: "string", Required: true},
+			},
+		},
+	}
+
+	err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.Len(flowStep.Data.Inputs, 2)
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_WithMeta() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		Inputs: []common.Input{
+			{Identifier: "username", Type: "string", Required: true},
+		},
+		Meta: map[string]interface{}{
+			"title":       "Login",
+			"description": "Enter your credentials",
+		},
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{},
+	}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.NotNil(flowStep.Data.Meta)
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_WithFailureReason() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		Inputs: []common.Input{
+			{Identifier: "otp", Type: "string", Required: true},
+		},
+		FailureReason: "Invalid OTP provided",
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{},
+	}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.Equal("Invalid OTP provided", flowStep.FailureReason)
+	s.Equal(common.FlowStatusIncomplete, flowStep.Status)
+	s.Equal(common.StepTypeView, flowStep.Type)
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_AppendsInputs() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		Inputs: []common.Input{
+			{Identifier: "password", Type: "string", Required: true},
+		},
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{
+			Inputs: []common.Input{
+				{Identifier: "username", Type: "string", Required: true},
+			},
+		},
+	}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	s.Len(flowStep.Data.Inputs, 2)
+}
+
+func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_ExistingActions() {
+	fe := &flowEngine{}
+
+	ctx := &EngineContext{}
+
+	nodeResp := &common.NodeResponse{
+		Actions: []common.Action{
+			{Ref: "submit-action"},
+		},
+	}
+
+	flowStep := &FlowStep{
+		Data: FlowData{
+			Actions: []common.Action{
+				{Ref: "existing-action"},
+			},
+		},
+	}
+
+	err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
+
+	s.NoError(err)
+	// Actions are replaced, not appended
+	s.Len(flowStep.Data.Actions, 1)
+	s.Equal("submit-action", flowStep.Data.Actions[0].Ref)
+}
+
+func (s *EngineTestSuite) TestGetNodeInputs_PromptNodeEmptyInputs() {
+	mockNode := coremock.NewPromptNodeInterfaceMock(s.T())
+	prompts := []common.Prompt{
+		{
+			Inputs: []common.Input{},
+		},
+	}
+	mockNode.On("GetPrompts").Return(prompts)
+
+	inputs := getNodeInputs(mockNode)
+
+	s.Nil(inputs)
+}

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -33,13 +33,14 @@ import (
 type EngineContext struct {
 	Context context.Context
 
-	FlowID      string
-	FlowType    common.FlowType
-	AppID       string
-	Verbose     bool
-	UserInputs  map[string]string
-	RuntimeData map[string]string
-	TraceID     string
+	FlowID         string
+	FlowType       common.FlowType
+	AppID          string
+	Verbose        bool
+	UserInputs     map[string]string
+	RuntimeData    map[string]string
+	AdditionalData map[string]string
+	TraceID        string
 
 	CurrentNode         core.NodeInterface
 	CurrentNodeResponse *common.NodeResponse

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -984,8 +984,14 @@ const translations = {
   signin: {
     'errors.signin.failed.message': 'Error',
     'errors.signin.failed.description': 'We are sorry, something has gone wrong here. Please try again.',
+    'errors.passkey.failed': 'Passkey authentication failed. Please try again.',
     'redirect.to.signup': "Don't have an account? <1>Sign up</1>",
     heading: 'Sign In',
+    // Passkey authentication
+    'passkey.button.use': 'Sign in with Passkey',
+    'passkey.signin.heading': 'Sign in with Passkey',
+    'passkey.register.heading': 'Register Passkey',
+    'passkey.register.description': 'Create a passkey to securely sign in to your account without a password.',
   },
 
   // ============================================================================
@@ -996,6 +1002,12 @@ const translations = {
     'errors.signup.failed.description': 'We are sorry, but we were unable to create your account. Please try again.',
     'redirect.to.signin': 'Already have an account? <1>Sign in</1>',
     heading: 'Sign Up',
+    // Passkey registration translations
+    'passkey.setup.heading': 'Set Up Passkey',
+    'passkey.setup.description': 'Create a passkey to securely sign in to your account without a password.',
+    'passkey.button.create': 'Create Passkey',
+    'passkey.registering': 'Creating passkey...',
+    'errors.passkey.failed': 'Failed to create passkey. Please try again.',
   },
 
   // ============================================================================

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.8.0
-      version: 0.8.0
+      specifier: 0.9.0
+      version: 0.9.0
     '@asgardeo/react-router':
       specifier: 1.0.27
       version: 1.0.27
@@ -184,10 +184,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.8.0(@types/react@19.2.7)(react@19.2.3)
+        version: 0.9.0(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 1.0.27(@asgardeo/react@0.8.0(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.0.27(@asgardeo/react@0.9.0(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/abstract':
         specifier: 0.1.21
         version: 0.1.21
@@ -395,7 +395,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.8.0(@types/react@19.2.7)(react@19.2.3)
+        version: 0.9.0(@types/react@19.2.7)(react@19.2.3)
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@19.2.7)(react@19.2.3)
@@ -755,7 +755,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.8.0(@types/react@19.2.7)(react@19.2.3)
+        version: 0.9.0(@types/react@19.2.7)(react@19.2.3)
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@19.2.7)(react@19.2.3)
@@ -902,14 +902,14 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@asgardeo/browser@0.2.1':
-    resolution: {integrity: sha512-gXvQLoF/QGmKIdmlsqZB5a7wjygBd7FDqCoGo4THVyyFtpA8QC34PPAYVoG71OzIGigFkMv5LDKY2nPNBgsxCw==}
+  '@asgardeo/browser@0.2.2':
+    resolution: {integrity: sha512-c3/M8B6KAYwvFW13L4t37MAKoDqneYHA2TE85kXcddOSEcNuFbw76/UvLYstKlCSHzIOcq30AOEkPJ1LY5EHVQ==}
 
-  '@asgardeo/i18n@0.3.9':
-    resolution: {integrity: sha512-IEK3vN1t/5cJCWYhRJ71kE2heiczvqemJfK/pCFFBhMrVTPqy7+SoT7Wvf0oeORFWMDwEVXAALHJP+7blN+nHg==}
+  '@asgardeo/i18n@0.4.0':
+    resolution: {integrity: sha512-bJBY4qkZb9MM2ZGxqlKjSEHkQwreWU1I4MWeGsGLxq2um9q4eXqnHkpgEqMJSsKYo68TURnm1o579LMh2Xa7uw==}
 
-  '@asgardeo/javascript@0.4.0':
-    resolution: {integrity: sha512-0Bek7Y7p6g+HnBKudCViOzZwhjd9PxBXpzXA1Y7iACy0iLVBs4U9PErWTphBzcaN76drfv2y8e64UT5ewDKfxg==}
+  '@asgardeo/javascript@0.5.0':
+    resolution: {integrity: sha512-S/SC8w+Vn04++FeHvKLCLsRsTX116zgXPIOZIhyuhb7ckNvlWEoz9wFT5hFdeJqxNflQ+//ueaa+s1GmnDP4Ow==}
 
   '@asgardeo/react-router@1.0.27':
     resolution: {integrity: sha512-/xb29w82Wj7Gsgx75/SrIx6UYcMfHm4njuss62eQkufXp1BWYvJuG52esRJsggn68Cv5eL7/E5Ke2r3MzaW7hQ==}
@@ -918,8 +918,8 @@ packages:
       react: '>=19.1.4'
       react-router: '>=6.30.1'
 
-  '@asgardeo/react@0.8.0':
-    resolution: {integrity: sha512-Vu8U50ku8e/uKqDfh+LAqLLMJOhVOpviJ/QKMKbVtS3mpTq1p43nHXQ2TfmAOhnEB+INqQeNEkI6H6vF1FQyCg==}
+  '@asgardeo/react@0.9.0':
+    resolution: {integrity: sha512-Be5S1RE4v3JC0MhqfIi57+bs/cXrWcA+Q+Hhs8ACKCTkNQbg39lbJ7cWJR+DA6bIjeYxZ6M/0uv4YoRLJeLEXQ==}
     peerDependencies:
       '@types/react': '>=19.1.5'
       react: '>=19.1.4'
@@ -1475,6 +1475,7 @@ packages:
 
   '@base-ui-components/utils@0.1.2':
     resolution: {integrity: sha512-aEitDGpMsYO2qnSpYOwZNykn9Rzn2ioyEVk2fyDRH7t+TIHVKpp9CeV7SPTq43M9mMSDxQ+7UeZJVkrj2dCVIQ==}
+    deprecated: Package was renamed to @base-ui/utils
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -6160,9 +6161,9 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@asgardeo/browser@0.2.1(esbuild@0.25.9)':
+  '@asgardeo/browser@0.2.2(esbuild@0.25.9)':
     dependencies:
-      '@asgardeo/javascript': 0.4.0
+      '@asgardeo/javascript': 0.5.0
       axios: 0.30.2
       base64url: 3.0.1
       buffer: 6.0.3
@@ -6179,26 +6180,26 @@ snapshots:
       - debug
       - esbuild
 
-  '@asgardeo/i18n@0.3.9':
+  '@asgardeo/i18n@0.4.0':
     dependencies:
       tslib: 2.8.1
 
-  '@asgardeo/javascript@0.4.0':
+  '@asgardeo/javascript@0.5.0':
     dependencies:
-      '@asgardeo/i18n': 0.3.9
+      '@asgardeo/i18n': 0.4.0
       tslib: 2.8.1
 
-  '@asgardeo/react-router@1.0.27(@asgardeo/react@0.8.0(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@asgardeo/react-router@1.0.27(@asgardeo/react@0.9.0(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@asgardeo/react': 0.8.0(@types/react@19.2.7)(react@19.2.3)
+      '@asgardeo/react': 0.9.0(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.8.0(@types/react@19.2.7)(react@19.2.3)':
+  '@asgardeo/react@0.9.0(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
-      '@asgardeo/browser': 0.2.1(esbuild@0.25.9)
-      '@asgardeo/i18n': 0.3.9
+      '@asgardeo/browser': 0.2.2(esbuild@0.25.9)
+      '@asgardeo/i18n': 0.4.0
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.1.4(react@19.2.3))(react@19.2.3)
       '@types/react': 19.2.7

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  '@asgardeo/react': 0.8.0
+  '@asgardeo/react': 0.9.0
   '@asgardeo/react-router': 1.0.27
   '@emotion/react': 11.14.0
   '@emotion/styled': 11.14.1


### PR DESCRIPTION
### Purpose
This pull request introduces the `PasskeyAuthExecutor` along with the new `IdentityResolver` to the flow engine.  
`PasskeyAuthExecutor` provides the capability of integrating passkey based authentication and passkey registration for the flow engine customizations.
`IdentityResolver` provides a dedicated mechanism for resolving a user's identity (userID) from a username. 

This also updates the flow engine (`engine.go`) to propagate `AdditionalData` from node responses throughout the flow context, ensuring data such as passkey options are available for subsequent steps and responses. [[1]](diffhunk://#diff-994db006ec85b11148c244ca8b6586775bdf8920db2a42b9e6df0ac82fc8ec9aR288-R295) [[2]](diffhunk://#diff-994db006ec85b11148c244ca8b6586775bdf8920db2a42b9e6df0ac82fc8ec9aL516-R535) [[3]](diffhunk://#diff-994db006ec85b11148c244ca8b6586775bdf8920db2a42b9e6df0ac82fc8ec9aL550-R555) [[4]](diffhunk://#diff-994db006ec85b11148c244ca8b6586775bdf8920db2a42b9e6df0ac82fc8ec9aR580-R584)

**Model Update:**

* Added an `AdditionalData` field to the `EngineContext` struct, supporting the new data propagation mechanism.


### Related Issues
- https://github.com/asgardeo/thunder/issues/1094
- https://github.com/asgardeo/thunder/issues/610

### Related PRs
- https://github.com/asgardeo/thunder/pull/1096

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
