### PR TITLE
Allow defining meta for TASK_EXECUTION nodes

### DIFF
--- a/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/ExecutorBackedNodeInterface_mock_test.go
@@ -407,6 +407,52 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetInputs_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetMeta provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) GetMeta() interface{} {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMeta")
+	}
+
+	var r0 interface{}
+	if returnFunc, ok := ret.Get(0).(func() interface{}); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interface{})
+		}
+	}
+	return r0
+}
+
+// ExecutorBackedNodeInterfaceMock_GetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMeta'
+type ExecutorBackedNodeInterfaceMock_GetMeta_Call struct {
+	*mock.Call
+}
+
+// GetMeta is a helper method to define mock.On call
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) GetMeta() *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	return &ExecutorBackedNodeInterfaceMock_GetMeta_Call{Call: _e.mock.On("GetMeta")}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetMeta_Call) Run(run func()) *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetMeta_Call) Return(ifaceVal interface{}) *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(ifaceVal)
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetMeta_Call) RunAndReturn(run func() interface{}) *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetMode provides a mock function for the type ExecutorBackedNodeInterfaceMock
 func (_mock *ExecutorBackedNodeInterfaceMock) GetMode() string {
 	ret := _mock.Called()
@@ -1111,6 +1157,46 @@ func (_c *ExecutorBackedNodeInterfaceMock_SetInputs_Call) Return() *ExecutorBack
 }
 
 func (_c *ExecutorBackedNodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *ExecutorBackedNodeInterfaceMock_SetInputs_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetMeta provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) SetMeta(meta interface{}) {
+	_mock.Called(meta)
+	return
+}
+
+// ExecutorBackedNodeInterfaceMock_SetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetMeta'
+type ExecutorBackedNodeInterfaceMock_SetMeta_Call struct {
+	*mock.Call
+}
+
+// SetMeta is a helper method to define mock.On call
+//   - meta interface{}
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) SetMeta(meta interface{}) *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
+	return &ExecutorBackedNodeInterfaceMock_SetMeta_Call{Call: _e.mock.On("SetMeta", meta)}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetMeta_Call) Run(run func(meta interface{})) *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 interface{}
+		if args[0] != nil {
+			arg0 = args[0].(interface{})
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetMeta_Call) Return() *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetMeta_Call) RunAndReturn(run func(meta interface{})) *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/NodeInterface_mock_test.go
+++ b/backend/internal/flow/core/NodeInterface_mock_test.go
@@ -271,6 +271,52 @@ func (_c *NodeInterfaceMock_GetID_Call) RunAndReturn(run func() string) *NodeInt
 	return _c
 }
 
+// GetMeta provides a mock function for the type NodeInterfaceMock
+func (_mock *NodeInterfaceMock) GetMeta() interface{} {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMeta")
+	}
+
+	var r0 interface{}
+	if returnFunc, ok := ret.Get(0).(func() interface{}); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interface{})
+		}
+	}
+	return r0
+}
+
+// NodeInterfaceMock_GetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMeta'
+type NodeInterfaceMock_GetMeta_Call struct {
+	*mock.Call
+}
+
+// GetMeta is a helper method to define mock.On call
+func (_e *NodeInterfaceMock_Expecter) GetMeta() *NodeInterfaceMock_GetMeta_Call {
+	return &NodeInterfaceMock_GetMeta_Call{Call: _e.mock.On("GetMeta")}
+}
+
+func (_c *NodeInterfaceMock_GetMeta_Call) Run(run func()) *NodeInterfaceMock_GetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetMeta_Call) Return(ifaceVal interface{}) *NodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(ifaceVal)
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetMeta_Call) RunAndReturn(run func() interface{}) *NodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNextNodeList provides a mock function for the type NodeInterfaceMock
 func (_mock *NodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -723,6 +769,46 @@ func (_c *NodeInterfaceMock_SetCondition_Call) Return() *NodeInterfaceMock_SetCo
 }
 
 func (_c *NodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *NodeCondition)) *NodeInterfaceMock_SetCondition_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetMeta provides a mock function for the type NodeInterfaceMock
+func (_mock *NodeInterfaceMock) SetMeta(meta interface{}) {
+	_mock.Called(meta)
+	return
+}
+
+// NodeInterfaceMock_SetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetMeta'
+type NodeInterfaceMock_SetMeta_Call struct {
+	*mock.Call
+}
+
+// SetMeta is a helper method to define mock.On call
+//   - meta interface{}
+func (_e *NodeInterfaceMock_Expecter) SetMeta(meta interface{}) *NodeInterfaceMock_SetMeta_Call {
+	return &NodeInterfaceMock_SetMeta_Call{Call: _e.mock.On("SetMeta", meta)}
+}
+
+func (_c *NodeInterfaceMock_SetMeta_Call) Run(run func(meta interface{})) *NodeInterfaceMock_SetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 interface{}
+		if args[0] != nil {
+			arg0 = args[0].(interface{})
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *NodeInterfaceMock_SetMeta_Call) Return() *NodeInterfaceMock_SetMeta_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *NodeInterfaceMock_SetMeta_Call) RunAndReturn(run func(meta interface{})) *NodeInterfaceMock_SetMeta_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/RepresentationNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/RepresentationNodeInterface_mock_test.go
@@ -271,6 +271,52 @@ func (_c *RepresentationNodeInterfaceMock_GetID_Call) RunAndReturn(run func() st
 	return _c
 }
 
+// GetMeta provides a mock function for the type RepresentationNodeInterfaceMock
+func (_mock *RepresentationNodeInterfaceMock) GetMeta() interface{} {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMeta")
+	}
+
+	var r0 interface{}
+	if returnFunc, ok := ret.Get(0).(func() interface{}); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interface{})
+		}
+	}
+	return r0
+}
+
+// RepresentationNodeInterfaceMock_GetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMeta'
+type RepresentationNodeInterfaceMock_GetMeta_Call struct {
+	*mock.Call
+}
+
+// GetMeta is a helper method to define mock.On call
+func (_e *RepresentationNodeInterfaceMock_Expecter) GetMeta() *RepresentationNodeInterfaceMock_GetMeta_Call {
+	return &RepresentationNodeInterfaceMock_GetMeta_Call{Call: _e.mock.On("GetMeta")}
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetMeta_Call) Run(run func()) *RepresentationNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetMeta_Call) Return(ifaceVal interface{}) *RepresentationNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(ifaceVal)
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetMeta_Call) RunAndReturn(run func() interface{}) *RepresentationNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNextNodeList provides a mock function for the type RepresentationNodeInterfaceMock
 func (_mock *RepresentationNodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -767,6 +813,46 @@ func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) Return() *Represent
 }
 
 func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *NodeCondition)) *RepresentationNodeInterfaceMock_SetCondition_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetMeta provides a mock function for the type RepresentationNodeInterfaceMock
+func (_mock *RepresentationNodeInterfaceMock) SetMeta(meta interface{}) {
+	_mock.Called(meta)
+	return
+}
+
+// RepresentationNodeInterfaceMock_SetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetMeta'
+type RepresentationNodeInterfaceMock_SetMeta_Call struct {
+	*mock.Call
+}
+
+// SetMeta is a helper method to define mock.On call
+//   - meta interface{}
+func (_e *RepresentationNodeInterfaceMock_Expecter) SetMeta(meta interface{}) *RepresentationNodeInterfaceMock_SetMeta_Call {
+	return &RepresentationNodeInterfaceMock_SetMeta_Call{Call: _e.mock.On("SetMeta", meta)}
+}
+
+func (_c *RepresentationNodeInterfaceMock_SetMeta_Call) Run(run func(meta interface{})) *RepresentationNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 interface{}
+		if args[0] != nil {
+			arg0 = args[0].(interface{})
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_SetMeta_Call) Return() *RepresentationNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_SetMeta_Call) RunAndReturn(run func(meta interface{})) *RepresentationNodeInterfaceMock_SetMeta_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/factory.go
+++ b/backend/internal/flow/core/factory.go
@@ -130,6 +130,11 @@ func (f *flowFactory) CloneNode(source NodeInterface) (NodeInterface, error) {
 		})
 	}
 
+	// Copy meta if present
+	if sourceMeta := source.GetMeta(); sourceMeta != nil {
+		nodeCopy.SetMeta(sourceMeta)
+	}
+
 	// Copy onSuccess for representation nodes (START/END)
 	if repSource, ok := source.(RepresentationNodeInterface); ok {
 		if repCopy, ok := nodeCopy.(RepresentationNodeInterface); ok {
@@ -149,11 +154,10 @@ func (f *flowFactory) CloneNode(source NodeInterface) (NodeInterface, error) {
 		}
 	}
 
-	// Copy prompts and meta if the node is a prompt node
+	// Copy prompts if the node is a prompt node
 	if promptSource, ok := source.(PromptNodeInterface); ok {
 		if promptCopy, ok := nodeCopy.(PromptNodeInterface); ok {
 			promptCopy.SetPrompts(append([]common.Prompt{}, promptSource.GetPrompts()...))
-			promptCopy.SetMeta(promptSource.GetMeta())
 		} else {
 			return nil, errors.New("mismatch in node types during cloning. copy is not a prompt node")
 		}

--- a/backend/internal/flow/core/factory_test.go
+++ b/backend/internal/flow/core/factory_test.go
@@ -297,6 +297,54 @@ func (s *FlowFactoryTestSuite) TestCloneTaskExecutionNodeWithOnSuccess() {
 	}
 }
 
+func (s *FlowFactoryTestSuite) TestCloneNodeWithMeta() {
+	// Test meta cloning on task execution node
+	taskNode, _ := s.factory.CreateNode("task-1", string(common.NodeTypeTaskExecution),
+		map[string]interface{}{}, false, false)
+	taskMeta := map[string]interface{}{"title": "Task Title", "description": "Task Description"}
+	taskNode.SetMeta(taskMeta)
+
+	clonedTaskNode, err := s.factory.CloneNode(taskNode)
+
+	s.NoError(err)
+	s.NotNil(clonedTaskNode)
+	s.Equal(taskMeta, clonedTaskNode.GetMeta())
+
+	// Test meta cloning on prompt node
+	promptNode, _ := s.factory.CreateNode("prompt-1", string(common.NodeTypePrompt),
+		map[string]interface{}{}, false, false)
+	promptMeta := map[string]interface{}{"components": []string{"input1", "button1"}}
+	promptNode.SetMeta(promptMeta)
+
+	clonedPromptNode, err := s.factory.CloneNode(promptNode)
+
+	s.NoError(err)
+	s.NotNil(clonedPromptNode)
+	s.Equal(promptMeta, clonedPromptNode.GetMeta())
+
+	// Test meta cloning on representation node (START)
+	startNode, _ := s.factory.CreateNode("start-1", string(common.NodeTypeStart),
+		map[string]interface{}{}, true, false)
+	startMeta := "start-meta"
+	startNode.SetMeta(startMeta)
+
+	clonedStartNode, err := s.factory.CloneNode(startNode)
+
+	s.NoError(err)
+	s.NotNil(clonedStartNode)
+	s.Equal(startMeta, clonedStartNode.GetMeta())
+
+	// Verify that nil meta is not copied (stays nil)
+	nodeWithoutMeta, _ := s.factory.CreateNode("task-2", string(common.NodeTypeTaskExecution),
+		map[string]interface{}{}, false, false)
+	s.Nil(nodeWithoutMeta.GetMeta())
+
+	clonedNodeWithoutMeta, err := s.factory.CloneNode(nodeWithoutMeta)
+
+	s.NoError(err)
+	s.Nil(clonedNodeWithoutMeta.GetMeta())
+}
+
 func (s *FlowFactoryTestSuite) TestCloneNodesSuccess() {
 	nodes := make(map[string]NodeInterface)
 	node1, _ := s.factory.CreateNode("node-1", string(common.NodeTypeTaskExecution),
@@ -431,6 +479,12 @@ func (f *fakeExecutorBackedNode) GetMode() string {
 }
 
 func (f *fakeExecutorBackedNode) SetMode(mode string) {}
+
+func (f *fakeExecutorBackedNode) GetMeta() interface{} {
+	return nil
+}
+
+func (f *fakeExecutorBackedNode) SetMeta(meta interface{}) {}
 
 func (s *FlowFactoryTestSuite) TestCloneNodeMismatchExecutorBacked() {
 	// source claims to be executor-backed but GetType returns Prompt which

--- a/backend/internal/flow/core/node.go
+++ b/backend/internal/flow/core/node.go
@@ -44,39 +44,6 @@ type NodeInterface interface {
 	RemovePreviousNode(previousNodeID string)
 	GetCondition() *NodeCondition
 	SetCondition(condition *NodeCondition)
-}
-
-// RepresentationNodeInterface extends NodeInterface for representation nodes (START/END).
-// These nodes use simple onSuccess navigation for linear flow.
-type RepresentationNodeInterface interface {
-	NodeInterface
-	GetOnSuccess() string
-	SetOnSuccess(nodeID string)
-}
-
-// ExecutorBackedNodeInterface extends NodeInterface for nodes backed by executors.
-// Only task execution nodes implement this interface to delegate their execution logic to executors.
-type ExecutorBackedNodeInterface interface {
-	NodeInterface
-	GetExecutorName() string
-	SetExecutorName(name string)
-	GetExecutor() ExecutorInterface
-	SetExecutor(executor ExecutorInterface)
-	GetInputs() []common.Input
-	SetInputs(inputs []common.Input)
-	GetOnSuccess() string
-	SetOnSuccess(nodeID string)
-	GetOnFailure() string
-	SetOnFailure(nodeID string)
-	GetMode() string
-	SetMode(mode string)
-}
-
-// PromptNodeInterface extends NodeInterface for nodes that require user interaction.
-type PromptNodeInterface interface {
-	NodeInterface
-	GetPrompts() []common.Prompt
-	SetPrompts(prompts []common.Prompt)
 	GetMeta() interface{}
 	SetMeta(meta interface{})
 }
@@ -91,6 +58,7 @@ type node struct {
 	nextNodeList     []string
 	previousNodeList []string
 	condition        *NodeCondition
+	meta             interface{}
 }
 
 var _ NodeInterface = (*node)(nil)
@@ -250,4 +218,14 @@ func (n *node) GetCondition() *NodeCondition {
 // SetCondition sets the execution condition for the node
 func (n *node) SetCondition(condition *NodeCondition) {
 	n.condition = condition
+}
+
+// GetMeta returns the meta object for the node
+func (n *node) GetMeta() interface{} {
+	return n.meta
+}
+
+// SetMeta sets the meta object for the node
+func (n *node) SetMeta(meta interface{}) {
+	n.meta = meta
 }

--- a/backend/internal/flow/core/node_test.go
+++ b/backend/internal/flow/core/node_test.go
@@ -124,3 +124,34 @@ func (s *NodeTestSuite) TestInputsAndProperties() {
 	execNode.SetInputs(inputs)
 	s.Equal(inputs, execNode.GetInputs())
 }
+
+func (s *NodeTestSuite) TestMetaGetterSetter() {
+	// Test meta on task execution node (inherits from base node)
+	taskNode := newTaskExecutionNode("task-1", nil, false, false)
+
+	// Initially nil
+	s.Nil(taskNode.GetMeta())
+
+	// Set and get meta
+	metaData := map[string]interface{}{"key": "value", "nested": map[string]string{"a": "b"}}
+	taskNode.SetMeta(metaData)
+	s.Equal(metaData, taskNode.GetMeta())
+
+	// Test meta on prompt node (also inherits from base node)
+	promptNode := newPromptNode("prompt-1", nil, false, false)
+
+	s.Nil(promptNode.GetMeta())
+
+	promptMeta := map[string]interface{}{"components": []string{"input1", "button1"}}
+	promptNode.SetMeta(promptMeta)
+	s.Equal(promptMeta, promptNode.GetMeta())
+
+	// Test meta on representation node (START/END)
+	startNode := newRepresentationNode("start-1", common.NodeTypeStart, nil, true, false)
+
+	s.Nil(startNode.GetMeta())
+
+	// Even representation nodes can have meta set (though typically unused)
+	startNode.SetMeta("unused-meta")
+	s.Equal("unused-meta", startNode.GetMeta())
+}

--- a/backend/internal/flow/core/representation_node.go
+++ b/backend/internal/flow/core/representation_node.go
@@ -23,6 +23,14 @@ import (
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
 
+// RepresentationNodeInterface extends NodeInterface for representation nodes (START/END).
+// These nodes use simple onSuccess navigation for linear flow.
+type RepresentationNodeInterface interface {
+	NodeInterface
+	GetOnSuccess() string
+	SetOnSuccess(nodeID string)
+}
+
 // representationNode implements the RepresentationNodeInterface
 type representationNode struct {
 	*node

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -280,8 +280,10 @@ func (s *TaskExecutionNodeTestSuite) TestBuildNodeResponse() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
+			node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false).(*taskExecutionNode)
 			execResp := &common.ExecutorResponse{Status: tt.execStatus}
-			nodeResp := buildNodeResponse(execResp)
+			ctx := &NodeContext{FlowID: "test-flow"}
+			nodeResp := node.buildNodeResponse(execResp, ctx)
 
 			s.NotNil(nodeResp)
 			s.Equal(tt.nodeStatus, nodeResp.Status)
@@ -466,14 +468,16 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteCompleteWithoutOnSuccess() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestBuildNodeResponseWithNilMaps() {
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false).(*taskExecutionNode)
 	execResp := &common.ExecutorResponse{
 		Status:         common.ExecComplete,
 		AdditionalData: nil,
 		RuntimeData:    nil,
 		Inputs:         nil,
 	}
+	ctx := &NodeContext{FlowID: "test-flow"}
 
-	nodeResp := buildNodeResponse(execResp)
+	nodeResp := node.buildNodeResponse(execResp, ctx)
 
 	s.NotNil(nodeResp)
 	s.NotNil(nodeResp.AdditionalData, "AdditionalData should be initialized")
@@ -487,6 +491,7 @@ func (s *TaskExecutionNodeTestSuite) TestBuildNodeResponseWithNilMaps() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestBuildNodeResponsePreservesExecutorData() {
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false).(*taskExecutionNode)
 	authUser := authncm.AuthenticatedUser{
 		UserID:             "user-123",
 		OrganizationUnitID: "org-456",
@@ -502,8 +507,9 @@ func (s *TaskExecutionNodeTestSuite) TestBuildNodeResponsePreservesExecutorData(
 		AuthenticatedUser: authUser,
 		Assertion:         "assertion-token",
 	}
+	ctx := &NodeContext{FlowID: "test-flow"}
 
-	nodeResp := buildNodeResponse(execResp)
+	nodeResp := node.buildNodeResponse(execResp, ctx)
 
 	s.NotNil(nodeResp)
 	s.Equal("TEST_FAILURE", nodeResp.FailureReason)
@@ -606,4 +612,108 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithEmptyFailureReasonAnd
 	// When FailureReason is empty, onFailure handler should NOT be triggered
 	s.Equal(common.NodeStatusFailure, resp.Status, "Status should remain failure when FailureReason is empty")
 	s.Empty(resp.NextNodeID, "NextNodeID should not be set when FailureReason is empty")
+}
+
+func (s *TaskExecutionNodeTestSuite) TestExecuteVerboseModeWithMeta() {
+	mockExec := NewExecutorInterfaceMock(s.T())
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
+	metaData := map[string]interface{}{"title": "OTP Verification", "description": "Enter the code"}
+	node.SetMeta(metaData)
+
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	mockExec.On("GetName").Return("test-executor").Once()
+	mockExec.On("Execute", mock.Anything).Return(
+		&common.ExecutorResponse{
+			Status: common.ExecUserInputRequired,
+			Inputs: []common.Input{{Identifier: "otp", Required: true}},
+		}, nil,
+	).Once()
+
+	execNode.SetExecutor(mockExec)
+
+	ctx := &NodeContext{FlowID: "test-flow", Verbose: true}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Equal(common.NodeResponseTypeView, resp.Type)
+	s.Equal(metaData, resp.Meta, "Meta should be included when verbose mode is enabled and prompting for user input")
+}
+
+func (s *TaskExecutionNodeTestSuite) TestExecuteVerboseModeWithoutMeta() {
+	mockExec := NewExecutorInterfaceMock(s.T())
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
+	// No meta set
+
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	mockExec.On("GetName").Return("test-executor").Once()
+	mockExec.On("Execute", mock.Anything).Return(
+		&common.ExecutorResponse{
+			Status: common.ExecUserInputRequired,
+			Inputs: []common.Input{{Identifier: "otp", Required: true}},
+		}, nil,
+	).Once()
+
+	execNode.SetExecutor(mockExec)
+
+	ctx := &NodeContext{FlowID: "test-flow", Verbose: true}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Nil(resp.Meta, "Meta should be nil when not set even in verbose mode")
+}
+
+func (s *TaskExecutionNodeTestSuite) TestExecuteNonVerboseModeWithMeta() {
+	mockExec := NewExecutorInterfaceMock(s.T())
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
+	metaData := map[string]interface{}{"title": "OTP Verification", "description": "Enter the code"}
+	node.SetMeta(metaData)
+
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	mockExec.On("GetName").Return("test-executor").Once()
+	mockExec.On("Execute", mock.Anything).Return(
+		&common.ExecutorResponse{
+			Status: common.ExecUserInputRequired,
+			Inputs: []common.Input{{Identifier: "otp", Required: true}},
+		}, nil,
+	).Once()
+
+	execNode.SetExecutor(mockExec)
+
+	ctx := &NodeContext{FlowID: "test-flow", Verbose: false}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Nil(resp.Meta, "Meta should not be included when verbose mode is disabled")
+}
+
+func (s *TaskExecutionNodeTestSuite) TestExecuteVerboseModeMetaNotIncludedForNonViewResponses() {
+	mockExec := NewExecutorInterfaceMock(s.T())
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
+	metaData := map[string]interface{}{"title": "OTP Verification", "description": "Enter the code"}
+	node.SetMeta(metaData)
+
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	// Test complete status - meta should not be included
+	mockExec.On("GetName").Return("test-executor").Once()
+	mockExec.On("Execute", mock.Anything).Return(
+		&common.ExecutorResponse{Status: common.ExecComplete}, nil,
+	).Once()
+
+	execNode.SetExecutor(mockExec)
+
+	ctx := &NodeContext{FlowID: "test-flow", Verbose: true}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusComplete, resp.Status)
+	s.Nil(resp.Meta, "Meta should not be included for complete responses even in verbose mode")
 }

--- a/backend/internal/flow/mgt/graph_builder.go
+++ b/backend/internal/flow/mgt/graph_builder.go
@@ -240,16 +240,12 @@ func (b *graphBuilder) configureNodeInputs(nodeDef *NodeDefinition, node core.No
 	executorNode.SetInputs(inputs)
 }
 
-// configureNodeMeta configures the meta object for a prompt node.
+// configureNodeMeta configures the meta object for a node.
 func (b *graphBuilder) configureNodeMeta(nodeDef *NodeDefinition, node core.NodeInterface) {
 	if nodeDef.Meta == nil {
 		return
 	}
-
-	// Set meta only if the node is a prompt node
-	if promptNode, ok := node.(core.PromptNodeInterface); ok {
-		promptNode.SetMeta(nodeDef.Meta)
-	}
+	node.SetMeta(nodeDef.Meta)
 }
 
 // configureNodeCondition configures the condition for a node.

--- a/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/ExecutorBackedNodeInterface_mock.go
@@ -408,6 +408,52 @@ func (_c *ExecutorBackedNodeInterfaceMock_GetInputs_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetMeta provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) GetMeta() interface{} {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMeta")
+	}
+
+	var r0 interface{}
+	if returnFunc, ok := ret.Get(0).(func() interface{}); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interface{})
+		}
+	}
+	return r0
+}
+
+// ExecutorBackedNodeInterfaceMock_GetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMeta'
+type ExecutorBackedNodeInterfaceMock_GetMeta_Call struct {
+	*mock.Call
+}
+
+// GetMeta is a helper method to define mock.On call
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) GetMeta() *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	return &ExecutorBackedNodeInterfaceMock_GetMeta_Call{Call: _e.mock.On("GetMeta")}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetMeta_Call) Run(run func()) *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetMeta_Call) Return(ifaceVal interface{}) *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(ifaceVal)
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_GetMeta_Call) RunAndReturn(run func() interface{}) *ExecutorBackedNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetMode provides a mock function for the type ExecutorBackedNodeInterfaceMock
 func (_mock *ExecutorBackedNodeInterfaceMock) GetMode() string {
 	ret := _mock.Called()
@@ -1112,6 +1158,46 @@ func (_c *ExecutorBackedNodeInterfaceMock_SetInputs_Call) Return() *ExecutorBack
 }
 
 func (_c *ExecutorBackedNodeInterfaceMock_SetInputs_Call) RunAndReturn(run func(inputs []common.Input)) *ExecutorBackedNodeInterfaceMock_SetInputs_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetMeta provides a mock function for the type ExecutorBackedNodeInterfaceMock
+func (_mock *ExecutorBackedNodeInterfaceMock) SetMeta(meta interface{}) {
+	_mock.Called(meta)
+	return
+}
+
+// ExecutorBackedNodeInterfaceMock_SetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetMeta'
+type ExecutorBackedNodeInterfaceMock_SetMeta_Call struct {
+	*mock.Call
+}
+
+// SetMeta is a helper method to define mock.On call
+//   - meta interface{}
+func (_e *ExecutorBackedNodeInterfaceMock_Expecter) SetMeta(meta interface{}) *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
+	return &ExecutorBackedNodeInterfaceMock_SetMeta_Call{Call: _e.mock.On("SetMeta", meta)}
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetMeta_Call) Run(run func(meta interface{})) *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 interface{}
+		if args[0] != nil {
+			arg0 = args[0].(interface{})
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetMeta_Call) Return() *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ExecutorBackedNodeInterfaceMock_SetMeta_Call) RunAndReturn(run func(meta interface{})) *ExecutorBackedNodeInterfaceMock_SetMeta_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/NodeInterface_mock.go
@@ -272,6 +272,52 @@ func (_c *NodeInterfaceMock_GetID_Call) RunAndReturn(run func() string) *NodeInt
 	return _c
 }
 
+// GetMeta provides a mock function for the type NodeInterfaceMock
+func (_mock *NodeInterfaceMock) GetMeta() interface{} {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMeta")
+	}
+
+	var r0 interface{}
+	if returnFunc, ok := ret.Get(0).(func() interface{}); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interface{})
+		}
+	}
+	return r0
+}
+
+// NodeInterfaceMock_GetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMeta'
+type NodeInterfaceMock_GetMeta_Call struct {
+	*mock.Call
+}
+
+// GetMeta is a helper method to define mock.On call
+func (_e *NodeInterfaceMock_Expecter) GetMeta() *NodeInterfaceMock_GetMeta_Call {
+	return &NodeInterfaceMock_GetMeta_Call{Call: _e.mock.On("GetMeta")}
+}
+
+func (_c *NodeInterfaceMock_GetMeta_Call) Run(run func()) *NodeInterfaceMock_GetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetMeta_Call) Return(ifaceVal interface{}) *NodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(ifaceVal)
+	return _c
+}
+
+func (_c *NodeInterfaceMock_GetMeta_Call) RunAndReturn(run func() interface{}) *NodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNextNodeList provides a mock function for the type NodeInterfaceMock
 func (_mock *NodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -724,6 +770,46 @@ func (_c *NodeInterfaceMock_SetCondition_Call) Return() *NodeInterfaceMock_SetCo
 }
 
 func (_c *NodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *core.NodeCondition)) *NodeInterfaceMock_SetCondition_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetMeta provides a mock function for the type NodeInterfaceMock
+func (_mock *NodeInterfaceMock) SetMeta(meta interface{}) {
+	_mock.Called(meta)
+	return
+}
+
+// NodeInterfaceMock_SetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetMeta'
+type NodeInterfaceMock_SetMeta_Call struct {
+	*mock.Call
+}
+
+// SetMeta is a helper method to define mock.On call
+//   - meta interface{}
+func (_e *NodeInterfaceMock_Expecter) SetMeta(meta interface{}) *NodeInterfaceMock_SetMeta_Call {
+	return &NodeInterfaceMock_SetMeta_Call{Call: _e.mock.On("SetMeta", meta)}
+}
+
+func (_c *NodeInterfaceMock_SetMeta_Call) Run(run func(meta interface{})) *NodeInterfaceMock_SetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 interface{}
+		if args[0] != nil {
+			arg0 = args[0].(interface{})
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *NodeInterfaceMock_SetMeta_Call) Return() *NodeInterfaceMock_SetMeta_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *NodeInterfaceMock_SetMeta_Call) RunAndReturn(run func(meta interface{})) *NodeInterfaceMock_SetMeta_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/coremock/RepresentationNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/RepresentationNodeInterface_mock.go
@@ -272,6 +272,52 @@ func (_c *RepresentationNodeInterfaceMock_GetID_Call) RunAndReturn(run func() st
 	return _c
 }
 
+// GetMeta provides a mock function for the type RepresentationNodeInterfaceMock
+func (_mock *RepresentationNodeInterfaceMock) GetMeta() interface{} {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMeta")
+	}
+
+	var r0 interface{}
+	if returnFunc, ok := ret.Get(0).(func() interface{}); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interface{})
+		}
+	}
+	return r0
+}
+
+// RepresentationNodeInterfaceMock_GetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMeta'
+type RepresentationNodeInterfaceMock_GetMeta_Call struct {
+	*mock.Call
+}
+
+// GetMeta is a helper method to define mock.On call
+func (_e *RepresentationNodeInterfaceMock_Expecter) GetMeta() *RepresentationNodeInterfaceMock_GetMeta_Call {
+	return &RepresentationNodeInterfaceMock_GetMeta_Call{Call: _e.mock.On("GetMeta")}
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetMeta_Call) Run(run func()) *RepresentationNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetMeta_Call) Return(ifaceVal interface{}) *RepresentationNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(ifaceVal)
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_GetMeta_Call) RunAndReturn(run func() interface{}) *RepresentationNodeInterfaceMock_GetMeta_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNextNodeList provides a mock function for the type RepresentationNodeInterfaceMock
 func (_mock *RepresentationNodeInterfaceMock) GetNextNodeList() []string {
 	ret := _mock.Called()
@@ -768,6 +814,46 @@ func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) Return() *Represent
 }
 
 func (_c *RepresentationNodeInterfaceMock_SetCondition_Call) RunAndReturn(run func(condition *core.NodeCondition)) *RepresentationNodeInterfaceMock_SetCondition_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetMeta provides a mock function for the type RepresentationNodeInterfaceMock
+func (_mock *RepresentationNodeInterfaceMock) SetMeta(meta interface{}) {
+	_mock.Called(meta)
+	return
+}
+
+// RepresentationNodeInterfaceMock_SetMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetMeta'
+type RepresentationNodeInterfaceMock_SetMeta_Call struct {
+	*mock.Call
+}
+
+// SetMeta is a helper method to define mock.On call
+//   - meta interface{}
+func (_e *RepresentationNodeInterfaceMock_Expecter) SetMeta(meta interface{}) *RepresentationNodeInterfaceMock_SetMeta_Call {
+	return &RepresentationNodeInterfaceMock_SetMeta_Call{Call: _e.mock.On("SetMeta", meta)}
+}
+
+func (_c *RepresentationNodeInterfaceMock_SetMeta_Call) Run(run func(meta interface{})) *RepresentationNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 interface{}
+		if args[0] != nil {
+			arg0 = args[0].(interface{})
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_SetMeta_Call) Return() *RepresentationNodeInterfaceMock_SetMeta_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *RepresentationNodeInterfaceMock_SetMeta_Call) RunAndReturn(run func(meta interface{})) *RepresentationNodeInterfaceMock_SetMeta_Call {
 	_c.Run(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request adds support for handling node metadata (`meta`) across all node types in the flow core system. The changes introduce `GetMeta` and `SetMeta` methods to the base `NodeInterface`, ensure metadata is properly cloned when duplicating nodes, and update tests and mocks to cover these new behaviors. This makes it possible to attach arbitrary metadata to any node, especially for the TASK_EXECUTION nodes.

### Approach
**Core interface and implementation changes:**

* Added `GetMeta` and `SetMeta` methods to the base `NodeInterface`, allowing all node types (including representation, executor-backed, and prompt nodes) to store and retrieve metadata. The `meta` field and its methods are now implemented in the base node struct (`node`).
* Refactored `PromptNodeInterface` and `RepresentationNodeInterface` definitions to remove redundant `meta` handling from prompt nodes and ensure all node types inherit metadata support from the base interface.

**Node cloning logic:**

* Updated the `CloneNode` method in `flowFactory` to copy metadata from the source node to the cloned node, ensuring that metadata is preserved for all node types during cloning. Redundant metadata copying for prompt nodes was removed as it's now handled generically.

**Prompt node execution logic:**

* Refactored prompt node execution to use the new base node `GetMeta` method when including metadata in the response, removing the separate `meta` field from prompt nodes.

**Testing and mocks:**

* Added comprehensive unit tests to verify metadata getter/setter functionality on all node types, and to ensure metadata is correctly cloned.
* Updated and extended mock implementations for all node interfaces to support the new `GetMeta` and `SetMeta` methods, enabling proper mocking in unit tests.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1085

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
