### PR TITLE
Fix setup.sh to run with bash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,17 @@
 # 3. Stops Thunder server
 # 4. Exits cleanly
 
+# Ensure the script runs with Bash even if invoked via `sh`
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec /usr/bin/env bash "$0" "$@"
+fi
+
+# Guard against Bash POSIX mode (e.g., Bash started with --posix or POSIXLY_CORRECT);
+# use a guard to avoid re-exec loops if POSIX stays enabled.
+if [ -z "${SETUP_SH_POSIX_REEXEC:-}" ] && set -o | grep -q 'posix.*on'; then
+    SETUP_SH_POSIX_REEXEC=1 exec /usr/bin/env bash "$0" "$@"
+fi
+
 set -e
 
 # Default settings


### PR DESCRIPTION
### Purpose
Running the setup.sh using `sh setup.sh` leading to the following error.
```
./bootstrap/01-default-resources.sh: line 422: syntax error near unexpected token `<'
-e [ERROR] ✗ 01-default-resources.sh failed with exit code 2 (0s)
-e [ERROR] ✗ Stopping bootstrap (BOOTSTRAP_FAIL_FAST=true)
```
This PR make setup.sh fixes that, so setup.sh can be run as `sh setup.sh`.

### Approach
This pull request improves the robustness of the `setup.sh` script by ensuring it always runs under Bash, even if invoked with `sh` or in POSIX mode. This helps prevent subtle bugs due to differences between shell interpreters.

Shell compatibility improvements:

* Added checks at the start of `setup.sh` to re-execute the script with Bash if it is not already running under Bash or if Bash is in POSIX mode, ensuring consistent behavior regardless of how the script is invoked.

### Related Issues
- N/A

### Related PRs
- https://github.com/asgardeo/thunder/pull/1014

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
