### PR TITLE
Remove i18n keys from default flows

### DIFF
--- a/backend/cmd/server/bootstrap/flows/apps/develop/auth_flow_develop.json
+++ b/backend/cmd/server/bootstrap/flows/apps/develop/auth_flow_develop.json
@@ -16,7 +16,7 @@
                     {
                         "type": "TEXT",
                         "id": "text_001",
-                        "label": "{{ t(signin:heading) }}",
+                        "label": "Sign In",
                         "variant": "HEADING_1"
                     },
                     {
@@ -27,22 +27,22 @@
                                 "id": "input_001",
                                 "ref": "username",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.username.label) }}",
+                                "label": "Username",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.username.placeholder) }}"
+                                "placeholder": "Enter your username"
                             },
                             {
                                 "id": "input_002",
                                 "ref": "password",
                                 "type": "PASSWORD_INPUT",
-                                "label": "{{ t(elements:fields.password.label) }}",
+                                "label": "Password",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.password.placeholder) }}"
+                                "placeholder": "Enter your password"
                             },
                             {
                                 "type": "ACTION",
                                 "id": "action_001",
-                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "label": "Sign In",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }

--- a/backend/cmd/server/bootstrap/flows/apps/develop/registration_flow_develop.json
+++ b/backend/cmd/server/bootstrap/flows/apps/develop/registration_flow_develop.json
@@ -24,7 +24,7 @@
                     {
                         "type": "TEXT",
                         "id": "text_001",
-                        "label": "{{ t(signup:heading) }}",
+                        "label": "Sign Up",
                         "variant": "HEADING_1"
                     },
                     {
@@ -35,46 +35,46 @@
                                 "id": "input_001",
                                 "ref": "username",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.username.label) }}",
+                                "label": "Username",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.username.placeholder) }}"
+                                "placeholder": "Enter your username"
                             },
                             {
                                 "id": "input_002",
                                 "ref": "password",
                                 "type": "PASSWORD_INPUT",
-                                "label": "{{ t(elements:fields.password.label) }}",
+                                "label": "Password",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.password.placeholder) }}"
+                                "placeholder": "Enter your password"
                             },
                             {
                                 "id": "input_003",
                                 "ref": "firstName",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.first_name.label) }}",
+                                "label": "First Name",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.first_name.placeholder) }}"
+                                "placeholder": "Enter your first name"
                             },
                             {
                                 "id": "input_004",
                                 "ref": "lastName",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.last_name.label) }}",
+                                "label": "Last Name",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.last_name.placeholder) }}"
+                                "placeholder": "Enter your last name"
                             },
                             {
                                 "id": "input_005",
                                 "ref": "email",
                                 "type": "EMAIL_INPUT",
-                                "label": "{{ t(elements:fields.email.label) }}",
+                                "label": "Email Address",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.email.placeholder) }}"
+                                "placeholder": "Enter your email address"
                             },
                             {
                                 "type": "ACTION",
                                 "id": "action_001",
-                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "label": "Sign Up",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic.json
@@ -16,7 +16,7 @@
                     {
                         "type": "TEXT",
                         "id": "text_001",
-                        "label": "{{ t(signin:heading) }}",
+                        "label": "Sign In",
                         "variant": "HEADING_1"
                     },
                     {
@@ -27,22 +27,22 @@
                                 "id": "input_001",
                                 "ref": "username",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.username.label) }}",
+                                "label": "Username",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.username.placeholder) }}"
+                                "placeholder": "Enter your username"
                             },
                             {
                                 "id": "input_002",
                                 "ref": "password",
                                 "type": "PASSWORD_INPUT",
-                                "label": "{{ t(elements:fields.password.label) }}",
+                                "label": "Password",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.password.placeholder) }}"
+                                "placeholder": "Enter your password"
                             },
                             {
                                 "type": "ACTION",
                                 "id": "action_001",
-                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "label": "Sign In",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic.json
@@ -24,7 +24,7 @@
                     {
                         "type": "TEXT",
                         "id": "heading_credentials",
-                        "label": "{{ t(signup:heading) }}",
+                        "label": "Sign Up",
                         "variant": "HEADING_2"
                     },
                     {
@@ -35,22 +35,22 @@
                                 "type": "TEXT_INPUT",
                                 "id": "input_username",
                                 "ref": "username",
-                                "label": "{{ t(elements:fields.username.label) }}",
-                                "placeholder": "{{ t(elements:fields.username.placeholder) }}",
+                                "label": "Username",
+                                "placeholder": "Enter your username",
                                 "required": true
                             },
                             {
                                 "type": "PASSWORD_INPUT",
                                 "id": "input_password",
                                 "ref": "password",
-                                "label": "{{ t(elements:fields.password.label) }}",
-                                "placeholder": "{{ t(elements:fields.password.placeholder) }}",
+                                "label": "Password",
+                                "placeholder": "Enter your password",
                                 "required": true
                             },
                             {
                                 "type": "ACTION",
                                 "id": "action_credentials",
-                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "label": "Continue",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }
@@ -97,7 +97,7 @@
                     {
                         "type": "TEXT",
                         "id": "heading_user_info",
-                        "label": "{{ t(signup:heading) }}",
+                        "label": "Sign Up",
                         "variant": "HEADING_2"
                     },
                     {
@@ -108,30 +108,30 @@
                                 "type": "TEXT_INPUT",
                                 "id": "input_firstName",
                                 "ref": "firstName",
-                                "label": "{{ t(elements:fields.first_name.label) }}",
-                                "placeholder": "{{ t(elements:fields.first_name.placeholder) }}",
+                                "label": "First Name",
+                                "placeholder": "Enter your first name",
                                 "required": true
                             },
                             {
                                 "type": "TEXT_INPUT",
                                 "id": "input_lastName",
                                 "ref": "lastName",
-                                "label": "{{ t(elements:fields.last_name.label) }}",
-                                "placeholder": "{{ t(elements:fields.last_name.placeholder) }}",
+                                "label": "Last Name",
+                                "placeholder": "Enter your last name",
                                 "required": true
                             },
                             {
                                 "type": "EMAIL_INPUT",
                                 "id": "input_email",
                                 "ref": "email",
-                                "label": "{{ t(elements:fields.email.label) }}",
-                                "placeholder": "{{ t(elements:fields.email.placeholder) }}",
+                                "label": "Email Address",
+                                "placeholder": "Enter your email address",
                                 "required": true
                             },
                             {
                                 "type": "ACTION",
                                 "id": "action_user_info",
-                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "label": "Sign Up",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_with_prompt.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_with_prompt.json
@@ -24,7 +24,7 @@
                     {
                         "type": "TEXT",
                         "id": "text_001",
-                        "label": "{{ t(signup:heading) }}",
+                        "label": "Sign Up",
                         "variant": "HEADING_1"
                     },
                     {
@@ -35,46 +35,46 @@
                                 "id": "input_001",
                                 "ref": "username",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.username.label) }}",
+                                "label": "Username",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.username.placeholder) }}"
+                                "placeholder": "Enter your username"
                             },
                             {
                                 "id": "input_002",
                                 "ref": "password",
                                 "type": "PASSWORD_INPUT",
-                                "label": "{{ t(elements:fields.password.label) }}",
+                                "label": "Password",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.password.placeholder) }}"
+                                "placeholder": "Enter your password"
                             },
                             {
                                 "id": "input_003",
                                 "ref": "firstName",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.first_name.label) }}",
+                                "label": "First Name",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.first_name.placeholder) }}"
+                                "placeholder": "Enter your first name"
                             },
                             {
                                 "id": "input_004",
                                 "ref": "lastName",
                                 "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.last_name.label) }}",
+                                "label": "Last Name",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.last_name.placeholder) }}"
+                                "placeholder": "Enter your last name"
                             },
                             {
                                 "id": "input_005",
                                 "ref": "email",
                                 "type": "EMAIL_INPUT",
-                                "label": "{{ t(elements:fields.email.label) }}",
+                                "label": "Email Address",
                                 "required": true,
-                                "placeholder": "{{ t(elements:fields.email.placeholder) }}"
+                                "placeholder": "Enter your email address"
                             },
                             {
                                 "type": "ACTION",
                                 "id": "action_001",
-                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "label": "Sign Up",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }


### PR DESCRIPTION
### Purpose
This pull request updates the authentication and registration flow JSON files to remove all localization template references and replace them with hardcoded English labels and placeholders. This makes the UI text consistent and readable without relying on translation functions.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
