### PR TITLE
Add i18n resolution support for the flow builder UI

### DIFF
--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/TextPropertyField.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/TextPropertyField.tsx
@@ -18,12 +18,12 @@
 
 import {useMemo, useRef, useState, type ChangeEvent, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
-import {Box, FormControl, FormHelperText, FormLabel, TextField} from '@wso2/oxygen-ui';
+import {Box, FormControl, FormHelperText, FormLabel, TextField, Typography} from '@wso2/oxygen-ui';
 import startCase from 'lodash-es/startCase';
 import useValidationStatus from '../../hooks/useValidationStatus';
 import type {Resource} from '../../models/resources';
 import I18nConfigurationCard from './I18nConfigurationCard';
-import {isI18nPattern as checkIsI18nPattern, extractI18nKey} from '../../utils/i18nPatternUtils';
+import {isI18nPattern as checkIsI18nPattern, extractI18nKey, resolveI18nValue} from '../../utils/i18nPatternUtils';
 
 /**
  * Props interface of {@link TextPropertyField}
@@ -78,6 +78,17 @@ function TextPropertyField({
   const isI18nPattern: boolean = useMemo(() => checkIsI18nPattern(propertyValue), [propertyValue]);
 
   /**
+   * Resolve the i18n value if the pattern is detected.
+   */
+  const resolvedI18nValue: string = useMemo(() => {
+    if (isI18nPattern) {
+      return resolveI18nValue(propertyValue, t);
+    }
+
+    return '';
+  }, [propertyValue, isI18nPattern, t]);
+
+  /**
    * Get the error message for the text property field.
    */
   const errorMessage: string = useMemo(() => {
@@ -111,22 +122,31 @@ function TextPropertyField({
         <TextField
           fullWidth
           defaultValue={propertyValue}
-          value={isI18nPattern ? '' : undefined}
           error={!!errorMessage}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(propertyKey, e.target.value, resource)}
-          placeholder={
-            isI18nPattern
-              ? ''
-              : t('flows:core.elements.textPropertyField.placeholder', {propertyName: startCase(propertyKey)})
-          }
+          placeholder={t('flows:core.elements.textPropertyField.placeholder', {propertyName: startCase(propertyKey)})}
           {...rest}
         />
       </FormControl>
       {errorMessage && <FormHelperText error>{errorMessage}</FormHelperText>}
-      {isI18nPattern && (
-        <div className="text-property-field-i18n-placeholder">
-          <div className="text-property-field-i18n-placeholder-key">{propertyValue}</div>
-        </div>
+      {isI18nPattern && resolvedI18nValue && (
+        <Box
+          sx={{
+            mt: 1,
+            p: 1.5,
+            backgroundColor: 'action.hover',
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 0.5}}>
+            {t('flows:core.elements.textPropertyField.resolvedValue')}
+          </Typography>
+          <Typography variant="body2" sx={{wordBreak: 'break-word'}}>
+            {resolvedI18nValue}
+          </Typography>
+        </Box>
       )}
       {isI18nCardOpen && (
         <I18nConfigurationCard

--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/__tests__/TextPropertyField.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/__tests__/TextPropertyField.test.tsx
@@ -199,7 +199,7 @@ describe('TextPropertyField', () => {
   });
 
   describe('I18n Pattern', () => {
-    it('should display i18n placeholder when value matches i18n pattern', () => {
+    it('should display resolved value box when value matches i18n pattern', () => {
       render(
         <TextPropertyField
           resource={mockResource}
@@ -210,10 +210,15 @@ describe('TextPropertyField', () => {
         {wrapper: createWrapper()},
       );
 
-      expect(screen.getByText('{{t(common.submit)}}')).toBeInTheDocument();
+      // The text field should have the i18n key
+      expect(screen.getByRole('textbox')).toHaveValue('{{t(common.submit)}}');
+      // The resolved value label should be displayed
+      expect(screen.getByText('flows:core.elements.textPropertyField.resolvedValue')).toBeInTheDocument();
+      // The resolved value should be displayed (mock returns the key itself)
+      expect(screen.getByText('common.submit')).toBeInTheDocument();
     });
 
-    it('should not display i18n placeholder for regular text', () => {
+    it('should not display resolved value box for regular text', () => {
       render(
         <TextPropertyField
           resource={mockResource}
@@ -224,8 +229,8 @@ describe('TextPropertyField', () => {
         {wrapper: createWrapper()},
       );
 
-      // Should not have the i18n placeholder container
-      expect(screen.queryByText('{{t(common.submit)}}')).not.toBeInTheDocument();
+      // Should not have the resolved value label
+      expect(screen.queryByText('flows:core.elements.textPropertyField.resolvedValue')).not.toBeInTheDocument();
     });
   });
 
@@ -265,7 +270,7 @@ describe('TextPropertyField', () => {
   });
 
   describe('TextField Props', () => {
-    it('should clear text field value when i18n pattern is detected', () => {
+    it('should keep i18n key in text field when i18n pattern is detected', () => {
       render(
         <TextPropertyField
           resource={mockResource}
@@ -277,8 +282,8 @@ describe('TextPropertyField', () => {
       );
 
       const textField = screen.getByRole('textbox');
-      // When i18n pattern is detected, value is set to empty string
-      expect(textField).toHaveValue('');
+      // When i18n pattern is detected, value is kept in the text field
+      expect(textField).toHaveValue('{{t(common.button)}}');
     });
 
     it('should render placeholder when not i18n pattern', () => {
@@ -297,7 +302,7 @@ describe('TextPropertyField', () => {
       expect(textField).toHaveAttribute('placeholder', 'Enter Title');
     });
 
-    it('should not render placeholder when i18n pattern is detected', () => {
+    it('should render placeholder even when i18n pattern is detected', () => {
       render(
         <TextPropertyField
           resource={mockResource}
@@ -309,8 +314,8 @@ describe('TextPropertyField', () => {
       );
 
       const textField = screen.getByRole('textbox');
-      // When i18n pattern is detected, placeholder is empty
-      expect(textField).toHaveAttribute('placeholder', '');
+      // The placeholder should still be shown for i18n patterns
+      expect(textField).toHaveAttribute('placeholder', 'Enter Label');
     });
   });
 
@@ -362,8 +367,10 @@ describe('TextPropertyField', () => {
         {wrapper: createWrapper()},
       );
 
-      // The i18n pattern should be displayed
-      expect(screen.getByText('{{t(login.submit)}}')).toBeInTheDocument();
+      // The i18n key should be kept in the input field
+      expect(screen.getByRole('textbox')).toHaveValue('{{t(login.submit)}}');
+      // The resolved value should be displayed below
+      expect(screen.getByText('login.submit')).toBeInTheDocument();
     });
 
     it('should extract i18n key from pattern with nested key', () => {
@@ -377,7 +384,10 @@ describe('TextPropertyField', () => {
         {wrapper: createWrapper()},
       );
 
-      expect(screen.getByText('{{t(flows.login.welcome.message)}}')).toBeInTheDocument();
+      // The i18n key should be kept in the input field
+      expect(screen.getByRole('textbox')).toHaveValue('{{t(flows.login.welcome.message)}}');
+      // The resolved value should be displayed below
+      expect(screen.getByText('flows.login.welcome.message')).toBeInTheDocument();
     });
   });
 

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/ChoiceAdapter.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/ChoiceAdapter.tsx
@@ -20,6 +20,7 @@ import type {ReactElement} from 'react';
 import type {Element as FlowElement} from '@/features/flows/models/elements';
 import type {FieldOption} from '@/features/flows/models/base';
 import {FormControl, FormControlLabel, FormHelperText, FormLabel, Radio, RadioGroup} from '@wso2/oxygen-ui';
+import PlaceholderComponent from './PlaceholderComponent';
 import {Hint} from '../hint';
 
 /**
@@ -53,10 +54,17 @@ function ChoiceAdapter({resource}: ChoiceAdapterPropsInterface): ReactElement {
 
   return (
     <FormControl sx={{my: 2}}>
-      <FormLabel id={choiceElement?.id}>{choiceElement?.label}</FormLabel>
+      <FormLabel id={choiceElement?.id}>
+        <PlaceholderComponent value={choiceElement?.label ?? ''} />
+      </FormLabel>
       <RadioGroup defaultValue={choiceElement?.defaultValue}>
         {choiceElement?.options?.map((option: FieldOption) => (
-          <FormControlLabel key={option?.key} value={option?.value} control={<Radio />} label={option?.label} />
+          <FormControlLabel
+            key={option?.key}
+            value={option?.value}
+            control={<Radio />}
+            label={<PlaceholderComponent value={option?.label ?? ''} />}
+          />
         ))}
       </RadioGroup>
       {choiceElement?.hint && (

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/DividerAdapter.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/DividerAdapter.tsx
@@ -22,6 +22,7 @@ import {Divider, type DividerProps} from '@wso2/oxygen-ui';
 import type {RequiredFieldInterface} from '@/features/flows/hooks/useRequiredFields';
 import useRequiredFields from '@/features/flows/hooks/useRequiredFields';
 import {DividerVariants, type Element as FlowElement} from '@/features/flows/models/elements';
+import PlaceholderComponent from './PlaceholderComponent';
 
 const DIVIDER_VALIDATION_FIELD_NAMES = {
   variant: 'variant',
@@ -92,7 +93,11 @@ function DividerAdapter({resource}: DividerAdapterPropsInterface): ReactElement 
     return {};
   }, [variantStr]);
 
-  return <Divider {...config}>{dividerElement?.label}</Divider>;
+  return (
+    <Divider {...config}>
+      {dividerElement?.label && <PlaceholderComponent value={dividerElement.label} />}
+    </Divider>
+  );
 }
 
 export default DividerAdapter;

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/PlaceholderComponent.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/PlaceholderComponent.tsx
@@ -17,6 +17,8 @@
  */
 
 import {useMemo, type PropsWithChildren, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import {isI18nPattern as checkIsI18nPattern, resolveI18nValue} from '@/features/flows/utils/i18nPatternUtils';
 import './PlaceholderComponent.scss';
 
 /**
@@ -28,28 +30,37 @@ export interface PlaceholderComponentProps {
 
 /**
  * Placeholder component for displaying a placeholder text.
+ * If the value matches the i18n pattern {{t(key)}}, it resolves and displays the translated value.
+ * Otherwise, it displays the raw text content.
  *
  * @param props - Props injected to the component.
  * @returns The PlaceholderComponent component.
  */
 function PlaceholderComponent({value, children = null}: PropsWithChildren<PlaceholderComponentProps>): ReactElement {
+  const {t} = useTranslation();
+
   /**
-   * Check if the value matches the i18n pattern.
+   * Check if the value matches the i18n pattern and resolve it if so.
+   * Returns an object with isI18nPattern flag and the resolved/original value.
    */
-  const isI18nPattern: boolean = useMemo(() => {
-    if (!value) return false;
+  const {isI18nPattern, displayValue} = useMemo(() => {
+    const isPattern = checkIsI18nPattern(value);
 
-    const i18nPattern = /^\{\{[^}]+\}\}$/;
+    if (isPattern) {
+      return {
+        isI18nPattern: true,
+        displayValue: resolveI18nValue(value, t),
+      };
+    }
 
-    return i18nPattern.test(value.trim());
-  }, [value]);
+    return {
+      isI18nPattern: false,
+      displayValue: value,
+    };
+  }, [value, t]);
 
   if (isI18nPattern) {
-    return (
-      <span className="flow-builder-display-field-i18n-placeholder">
-        <span className="flow-builder-display-field-i18n-placeholder-key">{value}</span>
-      </span>
-    );
+    return <span>{displayValue}</span>;
   }
 
   if (children) {

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/input/DefaultInputAdapter.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/input/DefaultInputAdapter.tsx
@@ -21,6 +21,7 @@ import {Trans, useTranslation} from 'react-i18next';
 import {TextField} from '@wso2/oxygen-ui';
 import type {RequiredFieldInterface} from '@/features/flows/hooks/useRequiredFields';
 import useRequiredFields from '@/features/flows/hooks/useRequiredFields';
+import useResolveI18n from '@/features/flows/hooks/useResolveI18n';
 import type {Element as FlowElement} from '@/features/flows/models/elements';
 import {Hint} from '../../hint';
 import PlaceholderComponent from '../PlaceholderComponent';
@@ -92,6 +93,7 @@ function DefaultInputAdapter({resource}: DefaultInputAdapterPropsInterface): Rea
   useRequiredFields(resource, generalMessage, validationFields);
 
   const inputElement = resource as InputElement;
+  const resolvedPlaceholder = useResolveI18n(inputElement?.placeholder);
 
   return (
     <TextField
@@ -105,7 +107,7 @@ function DefaultInputAdapter({resource}: DefaultInputAdapterPropsInterface): Rea
       }}
       label={<PlaceholderComponent value={inputElement?.label ?? ''} />}
       multiline={inputElement?.multiline}
-      placeholder={inputElement?.placeholder ?? ''}
+      placeholder={resolvedPlaceholder}
       required={inputElement?.required}
       InputLabelProps={{
         required: inputElement?.required,

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/input/OTPInputAdapter.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/input/OTPInputAdapter.tsx
@@ -21,6 +21,7 @@ import type {Element as FlowElement} from '@/features/flows/models/elements';
 import {Trans, useTranslation} from 'react-i18next';
 import type {RequiredFieldInterface} from '@/features/flows/hooks/useRequiredFields';
 import useRequiredFields from '@/features/flows/hooks/useRequiredFields';
+import useResolveI18n from '@/features/flows/hooks/useResolveI18n';
 import {Box, FormHelperText, InputLabel, OutlinedInput} from '@wso2/oxygen-ui';
 import PlaceholderComponent from '../PlaceholderComponent';
 import {Hint} from '../../hint';
@@ -79,6 +80,7 @@ function OTPInputAdapter({resource}: OTPInputAdapterPropsInterface): ReactElemen
   useRequiredFields(resource, generalMessage, fields);
 
   const otpElement = resource as OTPInputElement;
+  const resolvedPlaceholder = useResolveI18n(otpElement?.placeholder);
 
   return (
     <div className={otpElement?.className}>
@@ -93,7 +95,7 @@ function OTPInputAdapter({resource}: OTPInputAdapterPropsInterface): ReactElemen
             id="otp-input-adapter"
             type={otpElement?.inputType}
             style={otpElement?.styles}
-            placeholder={otpElement?.placeholder ?? ''}
+            placeholder={resolvedPlaceholder}
           />
         ))}
       </Box>

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/input/PhoneNumberInputAdapter.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/input/PhoneNumberInputAdapter.tsx
@@ -21,7 +21,9 @@ import type {Element as FlowElement} from '@/features/flows/models/elements';
 import {Trans, useTranslation} from 'react-i18next';
 import type {RequiredFieldInterface} from '@/features/flows/hooks/useRequiredFields';
 import useRequiredFields from '@/features/flows/hooks/useRequiredFields';
+import useResolveI18n from '@/features/flows/hooks/useResolveI18n';
 import {FormHelperText, TextField} from '@wso2/oxygen-ui';
+import PlaceholderComponent from '../PlaceholderComponent';
 import {Hint} from '../../hint';
 
 /**
@@ -80,13 +82,14 @@ function PhoneNumberInputAdapter({resource}: PhoneNumberInputAdapterPropsInterfa
   useRequiredFields(resource, generalMessage, fields);
 
   const phoneElement = resource as PhoneNumberInputElement;
+  const resolvedPlaceholder = useResolveI18n(phoneElement?.placeholder);
 
   return (
     <>
       <TextField
         className={phoneElement?.className}
-        label={phoneElement?.label}
-        placeholder={phoneElement?.placeholder ?? ''}
+        label={<PlaceholderComponent value={phoneElement?.label ?? ''} />}
+        placeholder={resolvedPlaceholder}
         InputLabelProps={{
           required: phoneElement?.required,
         }}

--- a/frontend/apps/thunder-develop/src/features/flows/hooks/useResolveI18n.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/hooks/useResolveI18n.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMemo} from 'react';
+import {useTranslation} from 'react-i18next';
+import {isI18nPattern, resolveI18nValue} from '@/features/flows/utils/i18nPatternUtils';
+
+/**
+ * Hook to resolve i18n pattern values.
+ * If the value matches the i18n pattern {{t(key)}}, it returns the translated value.
+ * Otherwise, it returns the original value.
+ *
+ * @param value - The value to resolve.
+ * @param stripHtml - Whether to strip HTML tags before checking the pattern. Default is false.
+ * @returns The resolved value.
+ */
+function useResolveI18n(value: string | undefined, stripHtml = false): string {
+  const {t} = useTranslation();
+
+  return useMemo(() => {
+    if (!value) return '';
+
+    if (isI18nPattern(value, stripHtml)) {
+      return resolveI18nValue(value, t, stripHtml);
+    }
+
+    return value;
+  }, [value, stripHtml, t]);
+}
+
+export default useResolveI18n;

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
@@ -657,6 +657,295 @@
   {
     "resourceType": "TEMPLATE",
     "category": "STARTER",
+    "type": "BASIC_SMS_OTP_MFA",
+    "display": {
+      "label": "Password + SMS OTP",
+      "description": "Password login with SMS OTP as second factor authentication",
+      "image": "assets/images/icons/mobile-message.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "defaultPropertySelectorId": "{{SMS_SEND_EXECUTOR_ID}}",
+          "replacers": [
+            {
+              "key": "BASIC_AUTH_EXECUTION_STEP_ID",
+              "type": "ID"
+            },
+            {
+              "key": "SMS_SEND_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "SMS_OTP_VERIFICATION_STEP_ID",
+              "type": "ID"
+            },
+            {
+              "key": "SMS_VERIFY_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "AUTH_ASSERT_EXECUTOR_ID",
+              "type": "ID"
+            }
+          ]
+        },
+        "steps": [
+          {
+            "id": "start",
+            "type": "START",
+            "size": {
+              "width": 101,
+              "height": 34
+            },
+            "position": {
+              "x": 62,
+              "y": 330
+            }
+          },
+          {
+            "id": "{{ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 350,
+              "height": 569
+            },
+            "position": {
+              "x": 310,
+              "y": 63
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "HEADING_3",
+                  "label": "Sign In"
+                },
+                {
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "id": "{{ID}}",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "FIELD",
+                      "type": "TEXT_INPUT",
+                      "inputType": "text",
+                      "hint": "",
+                      "label": "Username",
+                      "required": true,
+                      "placeholder": "Enter your username",
+                      "ref": "username"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "FIELD",
+                      "type": "PASSWORD_INPUT",
+                      "inputType": "password",
+                      "ref": "password",
+                      "hint": "",
+                      "label": "Password",
+                      "required": true,
+                      "placeholder": "Enter your password"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Sign In",
+                      "action": {
+                        "type": "NEXT",
+                        "next": "{{BASIC_AUTH_EXECUTION_STEP_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{BASIC_AUTH_EXECUTION_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 217,
+              "height": 113
+            },
+            "position": {
+              "x": 820,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "BasicAuthExecutor"
+                },
+                "next": "{{SMS_SEND_EXECUTOR_ID}}"
+              }
+            }
+          },
+          {
+            "id": "{{SMS_SEND_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1200,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "SMSOTPAuthExecutor",
+                  "mode": "send"
+                },
+                "next": "{{SMS_OTP_VERIFICATION_STEP_ID}}"
+              }
+            }
+          },
+          {
+            "id": "{{SMS_OTP_VERIFICATION_STEP_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 350,
+              "height": 556
+            },
+            "position": {
+              "x": 1550,
+              "y": 69
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "HEADING_3",
+                  "label": "Verify OTP"
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "FIELD",
+                      "type": "OTP_INPUT",
+                      "inputType": "text",
+                      "hint": "",
+                      "ref": "otp",
+                      "label": "Enter the OTP code",
+                      "required": true,
+                      "placeholder": ""
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Verify",
+                      "action": {
+                        "type": "NEXT",
+                        "next": "{{SMS_VERIFY_EXECUTOR_ID}}"
+                      }
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "RESEND",
+                      "eventType": "SUBMIT",
+                      "label": "Resend OTP",
+                      "action": {
+                        "type": "NEXT",
+                        "next": "{{SMS_SEND_EXECUTOR_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{SMS_VERIFY_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 2050,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "SMSOTPAuthExecutor",
+                  "mode": "verify"
+                },
+                "next": "{{AUTH_ASSERT_EXECUTOR_ID}}"
+              }
+            }
+          },
+          {
+            "id": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 244,
+              "height": 113
+            },
+            "position": {
+              "x": 2400,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "AuthAssertExecutor"
+                },
+                "next": "END"
+              }
+            }
+          },
+          {
+            "id": "END",
+            "type": "END",
+            "size": {
+              "width": 85,
+              "height": 34
+            },
+            "position": {
+              "x": 2800,
+              "y": 330
+            },
+            "config": {},
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "LoginCompletionExecutor"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "resourceType": "TEMPLATE",
+    "category": "STARTER",
     "type": "SMS_OTP",
     "display": {
       "label": "SMS OTP",

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -958,6 +958,8 @@ const translations = {
     // Elements - text property field
     'core.elements.textPropertyField.placeholder': 'Enter {{propertyName}}',
     'core.elements.textPropertyField.tooltip.configureTranslation': 'Configure translation',
+    'core.elements.textPropertyField.i18nKey': 'Translation Key',
+    'core.elements.textPropertyField.resolvedValue': 'Resolved Value',
 
     // Elements - i18n card
     'core.elements.textPropertyField.i18nCard.title': 'Translation for {{field}}',


### PR DESCRIPTION
### Purpose
This pull request improves the handling and display of internationalized (i18n) text across several resource property and input components in the flow builder UI. The changes introduce a new reusable hook for resolving i18n patterns, refactor placeholder and label rendering to use this hook and a dedicated component, and enhance the user experience by showing resolved translations where appropriate.

**i18n Pattern Resolution and Display Improvements**

* Introduced a new `useResolveI18n` hook to consistently resolve i18n pattern values (e.g., `{{t(key)}}`) to their translated text, used across multiple input adapters.
* Updated the `PlaceholderComponent` to resolve and display translated values if the input matches the i18n pattern, ensuring labels and placeholders are always shown in the correct language. [[1]](diffhunk://#diff-331bfdd247cdb247b0aca3ba955bb27dd9ceb2630f7109a3ddb7417847c355a0R20-R21) [[2]](diffhunk://#diff-331bfdd247cdb247b0aca3ba955bb27dd9ceb2630f7109a3ddb7417847c355a0R33-R59)

**Component Refactors for i18n Support**

* Refactored input adapters (`DefaultInputAdapter`, `OTPInputAdapter`, `PhoneNumberInputAdapter`) to use the new `useResolveI18n` hook for resolving placeholder text, and to use `PlaceholderComponent` for labels, improving translation support and consistency. [[1]](diffhunk://#diff-b854c05ec77bf4a5bc9fa3f68a8f1d05e724d6f5d90eec2da7a1c1de7b8a3be6R24) [[2]](diffhunk://#diff-b854c05ec77bf4a5bc9fa3f68a8f1d05e724d6f5d90eec2da7a1c1de7b8a3be6R96) [[3]](diffhunk://#diff-b854c05ec77bf4a5bc9fa3f68a8f1d05e724d6f5d90eec2da7a1c1de7b8a3be6L108-R110) [[4]](diffhunk://#diff-83bbf9d2f2063d2ad39ea116e0f3ecd04a13a1aa48a84b57c9c426e3c86dcf59R24) [[5]](diffhunk://#diff-83bbf9d2f2063d2ad39ea116e0f3ecd04a13a1aa48a84b57c9c426e3c86dcf59R83) [[6]](diffhunk://#diff-83bbf9d2f2063d2ad39ea116e0f3ecd04a13a1aa48a84b57c9c426e3c86dcf59L96-R98) [[7]](diffhunk://#diff-736a72e27ec71b16c1ac17a87c625a9f82b055fe4eaf330021118513d6fd1bf5R24-R26) [[8]](diffhunk://#diff-736a72e27ec71b16c1ac17a87c625a9f82b055fe4eaf330021118513d6fd1bf5R85-R92)

**Enhanced Resource Property Panel Experience**

* In the `TextPropertyField` component, added logic to resolve and display the translated value when an i18n pattern is detected, and improved the UI to show this resolved value in a styled box below the input field. [[1]](diffhunk://#diff-e4b34ce064c3eaf32945273e20de8bd7c7266112707755dcb67167fef67cbe61L21-R26) [[2]](diffhunk://#diff-e4b34ce064c3eaf32945273e20de8bd7c7266112707755dcb67167fef67cbe61R80-R90) [[3]](diffhunk://#diff-e4b34ce064c3eaf32945273e20de8bd7c7266112707755dcb67167fef67cbe61L114-R149)

**Consistent i18n Handling in Choice and Divider Adapters**

* Updated `ChoiceAdapter` and `DividerAdapter` to use `PlaceholderComponent` for rendering labels and option text, ensuring all static text supports i18n patterns and translations. [[1]](diffhunk://#diff-cc7f31dd8327a121932128c50b6f243fa0787ce1f5198807f1b912f55a34bbfaR23) [[2]](diffhunk://#diff-cc7f31dd8327a121932128c50b6f243fa0787ce1f5198807f1b912f55a34bbfaL56-R67) [[3]](diffhunk://#diff-8a43e3f0e2dd96a52086fe11497dcace4d98a3ecca1fe8d0880bfb613d27bff1R25) [[4]](diffhunk://#diff-8a43e3f0e2dd96a52086fe11497dcace4d98a3ecca1fe8d0880bfb613d27bff1L95-R100)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
