### PR TITLE
Fix SMS OTP executor to prompt mobile during registration

### DIFF
--- a/backend/internal/flow/executor/sms_auth_executor_test.go
+++ b/backend/internal/flow/executor/sms_auth_executor_test.go
@@ -21,6 +21,7 @@ package executor
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -56,17 +57,14 @@ func (suite *SMSAuthExecutorTestSuite) SetupTest() {
 
 	defaultInputs := []common.Input{
 		{
+			Ref:        "otp_input",
 			Identifier: userInputOTP,
-			Type:       "string",
+			Type:       "OTP_INPUT",
 			Required:   true,
 		},
 	}
 	prerequisites := []common.Input{
-		{
-			Identifier: userAttributeMobileNumber,
-			Type:       "string",
-			Required:   true,
-		},
+		mobileNumberInput,
 	}
 
 	// Mock identifying executor
@@ -100,4 +98,140 @@ func (suite *SMSAuthExecutorTestSuite) SetupTest() {
 		suite.mockOTPService, suite.mockObservability)
 	// Inject the mock base executor
 	suite.executor.ExecutorInterface = mockExec
+}
+
+func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlow_PromptsMobileNumber() {
+	// Create a mock that returns false for ValidatePrerequisites (prerequisites not met)
+	mockExec := coremock.NewExecutorInterfaceMock(suite.T())
+	mockExec.On("ValidatePrerequisites", mock.Anything, mock.Anything).Return(false)
+	suite.executor.ExecutorInterface = mockExec
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  make(map[string]string),
+		RuntimeData: make(map[string]string),
+	}
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	result := suite.executor.ValidatePrerequisites(ctx, execResp)
+
+	// Should return false (prerequisites not met)
+	assert.False(suite.T(), result)
+
+	// Should set status to ExecUserInputRequired
+	assert.Equal(suite.T(), common.ExecUserInputRequired, execResp.Status)
+
+	// Should return mobile number input
+	assert.Len(suite.T(), execResp.Inputs, 1)
+	assert.Equal(suite.T(), userAttributeMobileNumber, execResp.Inputs[0].Identifier)
+	assert.Equal(suite.T(), "PHONE_INPUT", execResp.Inputs[0].Type)
+	assert.Equal(suite.T(), "mobile_number_input", execResp.Inputs[0].Ref)
+	assert.True(suite.T(), execResp.Inputs[0].Required)
+
+	// Should include meta for UI rendering
+	assert.NotNil(suite.T(), execResp.Meta)
+	meta, ok := execResp.Meta.(core.MetaStructure)
+	assert.True(suite.T(), ok, "Meta should be of type core.MetaStructure")
+	assert.NotEmpty(suite.T(), meta.Components, "Meta should contain components")
+}
+
+func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlow_PrerequisitesMet() {
+	// Create a mock that returns true for ValidatePrerequisites (prerequisites met)
+	mockExec := coremock.NewExecutorInterfaceMock(suite.T())
+	mockExec.On("ValidatePrerequisites", mock.Anything, mock.Anything).Return(true)
+	suite.executor.ExecutorInterface = mockExec
+
+	ctx := &core.NodeContext{
+		FlowID:   "test-flow-123",
+		FlowType: common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			userAttributeMobileNumber: "+1234567890",
+		},
+		RuntimeData: make(map[string]string),
+	}
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	result := suite.executor.ValidatePrerequisites(ctx, execResp)
+
+	// Should return true (prerequisites met)
+	assert.True(suite.T(), result)
+
+	// Status should NOT be set to ExecUserInputRequired
+	assert.NotEqual(suite.T(), common.ExecUserInputRequired, execResp.Status)
+}
+
+func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_AuthenticationFlow_DoesNotPromptMobile() {
+	// Create a mock that returns false initially (prerequisites not met)
+	// and also mock additional methods that satisfyPrerequisites might call
+	mockExec := coremock.NewExecutorInterfaceMock(suite.T())
+	mockExec.On("ValidatePrerequisites", mock.Anything, mock.Anything).Return(false)
+	mockExec.On("GetUserIDFromContext", mock.Anything).Return("").Maybe()
+	suite.executor.ExecutorInterface = mockExec
+
+	ctx := &core.NodeContext{
+		FlowID:      "test-flow-123",
+		FlowType:    common.FlowTypeAuthentication, // Authentication flow, NOT registration
+		UserInputs:  make(map[string]string),
+		RuntimeData: make(map[string]string),
+	}
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	result := suite.executor.ValidatePrerequisites(ctx, execResp)
+
+	assert.False(suite.T(), result, "Should return false when prerequisites not met")
+	assert.NotEqual(suite.T(), common.ExecUserInputRequired, execResp.Status,
+		"Authentication flows should not prompt for mobile number directly")
+}
+
+func (suite *SMSAuthExecutorTestSuite) TestGetMobileInputMeta() {
+	meta := suite.executor.getMobileInputMeta()
+
+	// Should return MetaStructure
+	metaStruct, ok := meta.(core.MetaStructure)
+	assert.True(suite.T(), ok, "getMobileInputMeta should return core.MetaStructure")
+	assert.NotEmpty(suite.T(), metaStruct.Components, "Meta should contain components")
+
+	// Verify components structure
+	var hasHeading, hasBlock bool
+	for _, comp := range metaStruct.Components {
+		if comp.Type == "TEXT" && comp.Variant == "HEADING_2" {
+			hasHeading = true
+			assert.Equal(suite.T(), "{{ t(signup:heading) }}", comp.Label)
+		}
+		if comp.Type == "BLOCK" {
+			hasBlock = true
+			// Block should contain input and action
+			assert.GreaterOrEqual(suite.T(), len(comp.Components), 1)
+
+			// Find the input and action within block
+			var hasInput, hasAction bool
+			for _, blockComp := range comp.Components {
+				if blockComp.Type == "PHONE_INPUT" {
+					hasInput = true
+					assert.Equal(suite.T(), userAttributeMobileNumber, blockComp.Ref)
+					assert.Equal(suite.T(), "{{ t(elements:fields.mobile.label) }}", blockComp.Label)
+				}
+				if blockComp.Type == "ACTION" {
+					hasAction = true
+					assert.Equal(suite.T(), "{{ t(elements:buttons.submit.text) }}", blockComp.Label)
+					assert.Equal(suite.T(), "SUBMIT", blockComp.EventType)
+				}
+			}
+			assert.True(suite.T(), hasInput, "Block should contain PHONE_INPUT component")
+			assert.True(suite.T(), hasAction, "Block should contain ACTION component")
+		}
+	}
+
+	assert.True(suite.T(), hasHeading, "Meta should contain heading")
+	assert.True(suite.T(), hasBlock, "Meta should contain block with inputs")
 }

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -797,6 +797,8 @@ const translations = {
     'fields.last_name.placeholder': 'Enter your last name',
     'fields.email.label': 'Email',
     'fields.email.placeholder': 'Enter your email address',
+    'fields.mobile.label': 'Mobile Number',
+    'fields.mobile.placeholder': 'Enter your mobile number',
     'fields.password.label': 'Password',
     'fields.password.placeholder': 'Enter your password',
     'fields.username.label': 'Username',


### PR DESCRIPTION
### Purpose
This pull request improves the SMS OTP executor by introducing a dedicated input definition and UI metadata for mobile number collection during registration flows. If a mobile number is not available during registration, the flow will prompt the user to enter a mobile.

Additionally this fixes the bug of not being able to execute an auto inferred registration flow for a MFA authentication flow with SMS OTP.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
