### PR TITLE
Update JWKS service to retrieve all certificates

### DIFF
--- a/backend/internal/oauth/jwks/constants.go
+++ b/backend/internal/oauth/jwks/constants.go
@@ -20,42 +20,10 @@ package jwks
 
 import "github.com/asgardeo/thunder/internal/system/error/serviceerror"
 
-// ErrorTLSConfigNotFound is returned when the TLS configuration is not set.
-var ErrorTLSConfigNotFound = &serviceerror.ServiceError{
+// ErrorNoCertificateFound is returned when no certificate is found to generate JWKS.
+var ErrorNoCertificateFound = &serviceerror.ServiceError{
 	Code:             "JWKS-5001",
 	Type:             serviceerror.ServerErrorType,
-	Error:            "Error retrieving TLS configuration.",
-	ErrorDescription: "TLS configuration is not set.",
-}
-
-// ErrorWhileParsingCertificate is returned when there is an error parsing the server certificate.
-var ErrorWhileParsingCertificate = &serviceerror.ServiceError{
-	Code:             "JWKS-5002",
-	Type:             serviceerror.ServerErrorType,
-	Error:            "Error while parsing certificate.",
-	ErrorDescription: "An error occurred while parsing the server certificate.",
-}
-
-// ErrorNoCertificateFound is returned when no certificate is found in the TLS configuration.
-var ErrorNoCertificateFound = &serviceerror.ServiceError{
-	Code:             "JWKS-5003",
-	Type:             serviceerror.ServerErrorType,
 	Error:            "No certificate found.",
-	ErrorDescription: "No certificate found in TLS config.",
-}
-
-// ErrorUnsupportedPublicKeyType is returned when the public key type is not supported for JWKS.
-var ErrorUnsupportedPublicKeyType = &serviceerror.ServiceError{
-	Code:             "JWKS-5004",
-	Type:             serviceerror.ServerErrorType,
-	Error:            "Unsupported public key type.",
-	ErrorDescription: "The certificate public key type is not supported for JWKS.",
-}
-
-// ErrorCertificateKidNotFound is returned when the certificate Key ID (kid) is not found.
-var ErrorCertificateKidNotFound = &serviceerror.ServiceError{
-	Code:             "JWKS-5005",
-	Type:             serviceerror.ServerErrorType,
-	Error:            "Error while retrieving certificate Key ID (kid).",
-	ErrorDescription: "Certificate Key ID (kid) not found.",
+	ErrorDescription: "No certificate found to generate JWKS.",
 }

--- a/backend/internal/oauth/jwks/init_test.go
+++ b/backend/internal/oauth/jwks/init_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/system/config"
@@ -66,12 +65,13 @@ func (suite *InitTestSuite) TestInitialize() {
 
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
-	// Prepare PKI mock with minimal expectations for handler invocation
+	// Prepare PKI mock with expectations for handler invocation using new method
 	pkiMock := pkimock.NewPKIServiceInterfaceMock(suite.T())
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
 	cert := &x509.Certificate{Raw: []byte("raw-cert"), PublicKey: &key.PublicKey}
-	pkiMock.EXPECT().GetX509Certificate(mock.Anything).Return(cert, nil)
-	pkiMock.EXPECT().GetCertThumbprint(mock.Anything).Return("test-kid")
+	allCerts := map[string]*x509.Certificate{"test-kid": cert}
+	pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
+	pkiMock.EXPECT().GetCertThumbprint("test-kid").Return("test-kid")
 
 	_ = Initialize(mux, pkiMock)
 

--- a/backend/internal/oauth/jwks/service_test.go
+++ b/backend/internal/oauth/jwks/service_test.go
@@ -46,9 +46,9 @@ func TestJWKSServiceSuite(t *testing.T) {
 }
 
 func (suite *JWKSServiceTestSuite) SetupTest() {
-	// Reset runtime and set preferred key ID
+	// Reset runtime
 	config.ResetThunderRuntime()
-	testConfig := &config.Config{JWT: config.JWTConfig{PreferredKeyID: "kid-1"}}
+	testConfig := &config.Config{}
 	_ = config.InitializeThunderRuntime("", testConfig)
 
 	// Create PKI mock and service under test
@@ -60,7 +60,8 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_Success() {
 	// Prepare RSA cert and mock
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
 	cert := &x509.Certificate{Raw: []byte("rsa-cert-raw"), PublicKey: &key.PublicKey}
-	suite.pkiMock.EXPECT().GetX509Certificate("kid-1").Return(cert, nil)
+	allCerts := map[string]*x509.Certificate{"kid-1": cert}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
 	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
 
 	resp, svcErr := suite.jwksService.GetJWKS()
@@ -81,7 +82,8 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_P256_Success() {
 	// Prepare ECDSA P-256 cert and mock
 	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	cert := &x509.Certificate{Raw: []byte("ec-cert-raw"), PublicKey: &ecdsaKey.PublicKey}
-	suite.pkiMock.EXPECT().GetX509Certificate("kid-1").Return(cert, nil)
+	allCerts := map[string]*x509.Certificate{"kid-1": cert}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
 	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
 
 	resp, svcErr := suite.jwksService.GetJWKS()
@@ -99,10 +101,32 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_P256_Success() {
 	assert.NotEmpty(suite.T(), k.X5tS256)
 }
 
+func (suite *JWKSServiceTestSuite) TestGetJWKS_EdDSA_Success() {
+	// Prepare EdDSA cert and mock
+	_, edPriv, _ := ed25519.GenerateKey(rand.Reader)
+	cert := &x509.Certificate{Raw: []byte("ed-cert-raw"), PublicKey: edPriv.Public()}
+	allCerts := map[string]*x509.Certificate{"kid-1": cert}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
+	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
+
+	resp, svcErr := suite.jwksService.GetJWKS()
+	assert.Nil(suite.T(), svcErr)
+	assert.NotNil(suite.T(), resp)
+	assert.Len(suite.T(), resp.Keys, 1)
+	k := resp.Keys[0]
+	assert.Equal(suite.T(), "OKP", k.Kty)
+	assert.Equal(suite.T(), "EdDSA", k.Alg)
+	assert.Equal(suite.T(), "Ed25519", k.Crv)
+	assert.NotEmpty(suite.T(), k.X)
+	assert.NotEmpty(suite.T(), k.X5c)
+	assert.NotEmpty(suite.T(), k.X5t)
+	assert.NotEmpty(suite.T(), k.X5tS256)
+}
+
 func (suite *JWKSServiceTestSuite) TestGetJWKS_CertParseError() {
 	// Mock parse error
 	parseErr := serviceerror.CustomServiceError(serviceerror.InternalServerError, "parse error")
-	suite.pkiMock.EXPECT().GetX509Certificate("kid-1").Return(nil, parseErr)
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(nil, parseErr)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), resp)
@@ -112,28 +136,148 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_CertParseError() {
 	assert.Equal(suite.T(), parseErr.ErrorDescription, svcErr.ErrorDescription)
 }
 
-func (suite *JWKSServiceTestSuite) TestGetJWKS_KidNotFoundError() {
-	// Mock empty kid to trigger ErrorCertificateKidNotFound
-	key, _ := rsa.GenerateKey(rand.Reader, 2048)
-	cert := &x509.Certificate{Raw: []byte("rsa-cert-raw"), PublicKey: &key.PublicKey}
-	suite.pkiMock.EXPECT().GetX509Certificate("kid-1").Return(cert, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("")
+func (suite *JWKSServiceTestSuite) TestGetJWKS_NoCertificatesFound() {
+	// Mock empty certificates
+	allCerts := map[string]*x509.Certificate{}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
-	assert.Equal(suite.T(), ErrorCertificateKidNotFound.Code, svcErr.Code)
+	assert.Equal(suite.T(), ErrorNoCertificateFound.Code, svcErr.Code)
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_UnsupportedPublicKeyType() {
-	// Provide unsupported ed25519 public key
-	_, edPriv, _ := ed25519.GenerateKey(rand.Reader)
-	cert := &x509.Certificate{Raw: []byte("ed-cert-raw"), PublicKey: edPriv.Public()}
-	suite.pkiMock.EXPECT().GetX509Certificate("kid-1").Return(cert, nil)
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	cert := &x509.Certificate{Raw: []byte("rsa-cert-raw"), PublicKey: &key.PublicKey}
+	// Provide an unsupported public key type (using a string as an invalid example)
+	errCert := &x509.Certificate{Raw: []byte("unsupported-cert-raw"), PublicKey: "unsupported-key-type"}
+	allCerts := map[string]*x509.Certificate{"kid-1": errCert, "kid-2": cert}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
+	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
+	suite.pkiMock.EXPECT().GetCertThumbprint("kid-2").Return("kid-2")
+
+	resp, svcErr := suite.jwksService.GetJWKS()
+	assert.Nil(suite.T(), svcErr)
+	assert.NotNil(suite.T(), resp)
+	// The unsupported key should be skipped, so only one valid key should be present
+	assert.Len(suite.T(), resp.Keys, 1)
+}
+
+func (suite *JWKSServiceTestSuite) TestGetJWKS_MultipleCertificates() {
+	// Prepare multiple certs (RSA and ECDSA)
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	rsaCert := &x509.Certificate{Raw: []byte("rsa-cert-raw"), PublicKey: &rsaKey.PublicKey}
+
+	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	ecCert := &x509.Certificate{Raw: []byte("ec-cert-raw"), PublicKey: &ecdsaKey.PublicKey}
+
+	allCerts := map[string]*x509.Certificate{
+		"rsa-kid": rsaCert,
+		"ec-kid":  ecCert,
+	}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
+	suite.pkiMock.EXPECT().GetCertThumbprint("rsa-kid").Return("rsa-kid")
+	suite.pkiMock.EXPECT().GetCertThumbprint("ec-kid").Return("ec-kid")
+
+	resp, svcErr := suite.jwksService.GetJWKS()
+	assert.Nil(suite.T(), svcErr)
+	assert.NotNil(suite.T(), resp)
+	assert.Len(suite.T(), resp.Keys, 2)
+
+	// Check that both key types are present
+	rsaFound := false
+	ecFound := false
+	for _, k := range resp.Keys {
+		if k.Kty == "RSA" {
+			rsaFound = true
+			assert.Equal(suite.T(), "RS256", k.Alg)
+		}
+		if k.Kty == "EC" {
+			ecFound = true
+			assert.Equal(suite.T(), "ES256", k.Alg)
+		}
+	}
+	assert.True(suite.T(), rsaFound, "RSA key not found in JWKS")
+	assert.True(suite.T(), ecFound, "EC key not found in JWKS")
+}
+
+func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_AdditionalCurves() {
+	tests := []struct {
+		name  string
+		curve elliptic.Curve
+		alg   string
+		crv   string
+	}{
+		{
+			name:  "P-384",
+			curve: elliptic.P384(),
+			alg:   "ES384",
+			crv:   "P-384",
+		},
+		{
+			name:  "P-521",
+			curve: elliptic.P521(),
+			alg:   "ES512",
+			crv:   "P-521",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			ecdsaKey, _ := ecdsa.GenerateKey(tt.curve, rand.Reader)
+			cert := &x509.Certificate{Raw: []byte("ec-cert-raw-" + tt.name), PublicKey: &ecdsaKey.PublicKey}
+			kid := "kid-" + tt.name
+			allCerts := map[string]*x509.Certificate{kid: cert}
+
+			suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil).Once()
+			suite.pkiMock.EXPECT().GetCertThumbprint(kid).Return(kid).Once()
+
+			resp, svcErr := suite.jwksService.GetJWKS()
+			assert.Nil(suite.T(), svcErr)
+			assert.NotNil(suite.T(), resp)
+			assert.Len(suite.T(), resp.Keys, 1)
+			k := resp.Keys[0]
+			assert.Equal(suite.T(), "EC", k.Kty)
+			assert.Equal(suite.T(), tt.alg, k.Alg)
+			assert.Equal(suite.T(), tt.crv, k.Crv)
+			assert.NotEmpty(suite.T(), k.X)
+			assert.NotEmpty(suite.T(), k.Y)
+		})
+	}
+}
+
+func (suite *JWKSServiceTestSuite) TestGetJWKS_OnlyUnsupportedKeys() {
+	// Provide only an unsupported public key type
+	errCert := &x509.Certificate{Raw: []byte("unsupported-cert-raw"), PublicKey: "unsupported-key-type"}
+	allCerts := map[string]*x509.Certificate{"kid-1": errCert}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
 	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
-	assert.Equal(suite.T(), ErrorUnsupportedPublicKeyType.Code, svcErr.Code)
+	assert.Equal(suite.T(), ErrorNoCertificateFound.Code, svcErr.Code)
+}
+
+func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_ZeroExponent() {
+	// Prepare RSA cert with E=0 and mock
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	key.PublicKey.E = 0
+	cert := &x509.Certificate{Raw: []byte("rsa-cert-raw-zero"), PublicKey: &key.PublicKey}
+	allCerts := map[string]*x509.Certificate{"kid-zero": cert}
+	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
+	suite.pkiMock.EXPECT().GetCertThumbprint("kid-zero").Return("kid-zero")
+
+	resp, svcErr := suite.jwksService.GetJWKS()
+	assert.Nil(suite.T(), svcErr)
+	assert.NotNil(suite.T(), resp)
+	assert.Len(suite.T(), resp.Keys, 1)
+	k := resp.Keys[0]
+	assert.Equal(suite.T(), "RSA", k.Kty)
+	// Base64Url(0) -> "AA" (if []byte{0}) or ""?
+	// The code does:
+	// if len(eBytes) == 0 { eBytes = []byte{0} }
+	// encodeBase64URL([]byte{0}) -> "AA" (because base64 of 0 is AA==, trimmed =) -> "AA"
+	assert.Equal(suite.T(), "AA", k.E)
 }

--- a/backend/internal/system/crypto/pki/utils_test.go
+++ b/backend/internal/system/crypto/pki/utils_test.go
@@ -132,6 +132,29 @@ func (suite *PKIUtilsTestSuite) TestLoadTLSConfig_MissingKeyFile() {
 	assert.Contains(suite.T(), err.Error(), "key file not found")
 }
 
+func (suite *PKIUtilsTestSuite) TestLoadTLSConfig_InvalidContent() {
+	// Create invalid cert file
+	invalidCertFile, err := os.CreateTemp("", "invalid_cert_*.pem")
+	assert.NoError(suite.T(), err)
+	defer func() { _ = os.Remove(invalidCertFile.Name()) }()
+	_, err = invalidCertFile.WriteString("invalid-pem-content")
+	assert.NoError(suite.T(), err)
+	_ = invalidCertFile.Close()
+
+	// Create invalid key file
+	invalidKeyFile, err := os.CreateTemp("", "invalid_key_*.pem")
+	assert.NoError(suite.T(), err)
+	defer func() { _ = os.Remove(invalidKeyFile.Name()) }()
+	_, err = invalidKeyFile.WriteString("invalid-pem-content")
+	assert.NoError(suite.T(), err)
+	_ = invalidKeyFile.Close()
+
+	tlsConfig, err := LoadTLSConfig(suite.cfg, invalidCertFile.Name(), invalidKeyFile.Name())
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), tlsConfig)
+	assert.Contains(suite.T(), err.Error(), "failed to find any PEM data")
+}
+
 func createTestSelfSignedCert(privateKey *rsa.PrivateKey) (*x509.Certificate, []byte, error) {
 	template := x509.Certificate{
 		SerialNumber:          big.NewInt(1),

--- a/backend/tests/mocks/crypto/pki/pkimock/PKIServiceInterface_mock.go
+++ b/backend/tests/mocks/crypto/pki/pkimock/PKIServiceInterface_mock.go
@@ -39,6 +39,63 @@ func (_m *PKIServiceInterfaceMock) EXPECT() *PKIServiceInterfaceMock_Expecter {
 	return &PKIServiceInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
+// GetAllX509Certificates provides a mock function for the type PKIServiceInterfaceMock
+func (_mock *PKIServiceInterfaceMock) GetAllX509Certificates() (map[string]*x509.Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllX509Certificates")
+	}
+
+	var r0 map[string]*x509.Certificate
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func() (map[string]*x509.Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() map[string]*x509.Certificate); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*x509.Certificate)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() *serviceerror.ServiceError); ok {
+		r1 = returnFunc()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// PKIServiceInterfaceMock_GetAllX509Certificates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllX509Certificates'
+type PKIServiceInterfaceMock_GetAllX509Certificates_Call struct {
+	*mock.Call
+}
+
+// GetAllX509Certificates is a helper method to define mock.On call
+func (_e *PKIServiceInterfaceMock_Expecter) GetAllX509Certificates() *PKIServiceInterfaceMock_GetAllX509Certificates_Call {
+	return &PKIServiceInterfaceMock_GetAllX509Certificates_Call{Call: _e.mock.On("GetAllX509Certificates")}
+}
+
+func (_c *PKIServiceInterfaceMock_GetAllX509Certificates_Call) Run(run func()) *PKIServiceInterfaceMock_GetAllX509Certificates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PKIServiceInterfaceMock_GetAllX509Certificates_Call) Return(stringToCertificate map[string]*x509.Certificate, serviceError *serviceerror.ServiceError) *PKIServiceInterfaceMock_GetAllX509Certificates_Call {
+	_c.Call.Return(stringToCertificate, serviceError)
+	return _c
+}
+
+func (_c *PKIServiceInterfaceMock_GetAllX509Certificates_Call) RunAndReturn(run func() (map[string]*x509.Certificate, *serviceerror.ServiceError)) *PKIServiceInterfaceMock_GetAllX509Certificates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCertThumbprint provides a mock function for the type PKIServiceInterfaceMock
 func (_mock *PKIServiceInterfaceMock) GetCertThumbprint(id string) string {
 	ret := _mock.Called(id)


### PR DESCRIPTION
### Purpose
This pull request significantly refactors the JWKS (JSON Web Key Set) service to support multiple certificates and key types, improves error handling, and updates the related tests and PKI interface. The main changes include switching from single-certificate to multi-certificate handling, supporting EdDSA/Ed25519 keys, simplifying error codes, and updating tests to reflect the new logic.

**JWKS Service Enhancements:**

* Refactored the JWKS service (`jwksService`) to retrieve and process all certificates using the new `GetAllX509Certificates()` PKI method, allowing support for multiple keys in the JWKS endpoint. Now iterates through all certificates, generating JWKS entries for each supported key type. [[1]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34R46-R74) [[2]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L78-R110)
* Added support for EdDSA/Ed25519 public keys in JWKS output, alongside existing RSA and ECDSA support. [[1]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L78-R110) [[2]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L138-R183)
* Unsupported public key types are now logged and skipped, rather than causing errors.

**Error Handling and Constants:**

* Removed unused or redundant error constants and error codes in `constants.go`, simplifying error handling and aligning codes with updated logic.
* Now returns `ErrorNoCertificateFound` if no valid certificates are found or if all are unsupported, and no longer returns an error for unsupported key types (they are skipped instead). [[1]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34R46-R74) [[2]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L78-R110)

**PKI Service Interface and Implementation:**

* Extended the PKI service interface with a new `GetAllX509Certificates()` method, and implemented it to return all loaded certificates as a map. [[1]](diffhunk://#diff-30882764d6c4610f3955075a5805d7347237c449db39a9158eba5ba435bea5d4R44) [[2]](diffhunk://#diff-30882764d6c4610f3955075a5805d7347237c449db39a9158eba5ba435bea5d4R148-R165)

**Testing Improvements:**

* Updated and expanded tests for the JWKS service to cover multiple certificates, EdDSA/Ed25519 keys, unsupported key types, and new error handling logic. Removed tests for error cases that no longer apply. [[1]](diffhunk://#diff-164d709332aaaba7253d0f2ac1a3bb3f21d007a12d7254e7a4d9ad251e77936cL63-R64) [[2]](diffhunk://#diff-164d709332aaaba7253d0f2ac1a3bb3f21d007a12d7254e7a4d9ad251e77936cL84-R86) [[3]](diffhunk://#diff-164d709332aaaba7253d0f2ac1a3bb3f21d007a12d7254e7a4d9ad251e77936cR104-R129) [[4]](diffhunk://#diff-164d709332aaaba7253d0f2ac1a3bb3f21d007a12d7254e7a4d9ad251e77936cL115-R202)
* Adjusted test setups to use the new PKI interface and multi-certificate logic. [[1]](diffhunk://#diff-9b148c3cf8c810f5d33fab7aa87aecd749fd87403029e2cbe4738edd95250d86L69-R74) [[2]](diffhunk://#diff-164d709332aaaba7253d0f2ac1a3bb3f21d007a12d7254e7a4d9ad251e77936cL49-R51)

**Miscellaneous:**

* Added logger initialization to the JWKS service for improved debugging and error reporting.
* Cleaned up imports and removed unused dependencies in test files. [[1]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34R24-R35) [[2]](diffhunk://#diff-9b148c3cf8c810f5d33fab7aa87aecd749fd87403029e2cbe4738edd95250d86L30) [[3]](diffhunk://#diff-eb2f6b2ceb61b876582631e11d3869ead83f80cdf63006ca4d8930b42d463e8bL45-R50)

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/1136

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
