### PR TITLE
Update invite link for onboarding flow

### DIFF
--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -127,5 +127,5 @@ func (e *inviteExecutor) generateInviteLink(ctx *core.NodeContext, inviteToken s
 		gateConfig.Port,
 		gateConfig.Path)
 
-	return fmt.Sprintf("%s?flowId=%s&inviteToken=%s", gateAppURL, ctx.FlowID, inviteToken)
+	return fmt.Sprintf("%s/invite?flowId=%s&inviteToken=%s", gateAppURL, ctx.FlowID, inviteToken)
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the invite link generation logic, ensuring that all generated invite URLs include the `/invite` path segment for consistency and correctness. 

- Updated the `generateInviteLink` method in `invite_executor.go` to append `/invite` to the base URL when formatting invite links.