### PR TITLE
Fix `token` tab unresponsive issues in Applications edit view

### DIFF
--- a/frontend/apps/thunder-develop/src/features/applications/components/LogoUpdateModal.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/LogoUpdateModal.tsx
@@ -30,8 +30,10 @@ import {
   Typography,
   Grid,
   IconButton,
+  FormControl,
+  FormHelperText,
 } from '@wso2/oxygen-ui';
-import {X, RefreshCcw, AppWindow} from '@wso2/oxygen-ui-icons-react';
+import {X, AppWindow, Shuffle} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
 import generateAppLogoSuggestions from '../utils/generateAppLogoSuggestion';
 
@@ -51,14 +53,14 @@ export default function LogoUpdateModal({open, onClose, currentLogoUrl = '', onL
   useEffect(() => {
     if (open) {
       // Generate new suggestions when modal opens
-      setSuggestions(generateAppLogoSuggestions(8));
+      setSuggestions(generateAppLogoSuggestions(12));
       setSelectedLogo(currentLogoUrl);
       setCustomUrl(currentLogoUrl);
     }
   }, [open, currentLogoUrl]);
 
-  const handleRefreshSuggestions = useCallback(() => {
-    setSuggestions(generateAppLogoSuggestions(8));
+  const handleRotateLogos = useCallback(() => {
+    setSuggestions(generateAppLogoSuggestions(12));
   }, []);
 
   const handleSave = useCallback(() => {
@@ -134,26 +136,34 @@ export default function LogoUpdateModal({open, onClose, currentLogoUrl = '', onL
             <Typography variant="subtitle2" gutterBottom>
               {t('applications:logoModal.customUrl.title')}
             </Typography>
-            <TextField
-              fullWidth
-              placeholder={t('applications:logoModal.customUrl.placeholder')}
-              value={customUrl}
-              onChange={(e) => handleCustomUrlChange(e.target.value)}
-              helperText={t('applications:logoModal.customUrl.hint')}
-            />
+            <FormControl fullWidth>
+              <TextField
+                fullWidth
+                placeholder={t('applications:logoModal.customUrl.placeholder')}
+                value={customUrl}
+                onChange={(e) => handleCustomUrlChange(e.target.value)}
+              />
+              <FormHelperText>{t('applications:logoModal.customUrl.hint')}</FormHelperText>
+            </FormControl>
           </Box>
 
           {/* Suggestions */}
           <Box>
             <Stack direction="row" alignItems="center" justifyContent="space-between" mb={2}>
-              <Typography variant="subtitle2">{t('applications:logoModal.suggestions.title')}</Typography>
-              <Button size="small" startIcon={<RefreshCcw size={14} />} onClick={handleRefreshSuggestions}>
-                {t('applications:logoModal.refresh')}
+              <Typography variant="h6">{t('applications:logoModal.logos.title')}</Typography>
+              <Button
+                size="small"
+                variant="text"
+                startIcon={<Shuffle size={14} />}
+                onClick={handleRotateLogos}
+                sx={{minWidth: 'auto'}}
+              >
+                {t('applications:logoModal.logos.shuffle')}
               </Button>
             </Stack>
             <Grid container spacing={2}>
               {suggestions.map((logoUrl) => (
-                <Grid size={{xs: 3}} key={logoUrl}>
+                <Grid size={{xs: 2}} key={logoUrl}>
                   <Box
                     onClick={() => handleLogoSelect(logoUrl)}
                     sx={{

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -804,8 +804,8 @@ const translations = {
     'logoModal.customUrl.title': 'Custom Logo URL',
     'logoModal.customUrl.placeholder': 'https://example.com/logo.png',
     'logoModal.customUrl.hint': 'Enter a direct URL to your custom logo image',
-    'logoModal.suggestions.title': 'Suggested Logos',
-    'logoModal.refresh': 'Refresh',
+    'logoModal.logos.title': 'Application Logo',
+    'logoModal.logos.shuffle': 'Shuffle',
     'logoModal.cancel': 'Cancel',
     'logoModal.update': 'Update Logo',
     // Edit page


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

`Token` tab in applications edit view becomes unresponsive when using the `frontend/apps/thunder-develop/src/features/user-types/api/useGetUserTypes.ts` hook.

Created an issue to track fixing the hook: https://github.com/asgardeo/thunder/issues/1159

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Temporarily implemented a minimal hook locally inside the component.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1126
- https://github.com/asgardeo/thunder/issues/1159

### Related PRs
- https://github.com/asgardeo/thunder/pull/1150

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
