### PR TITLE
Fix bootstrap scripts to fetch OUs by handle instead of picking first from list

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -76,12 +76,12 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
 }
 elseif ($response.StatusCode -eq 409) {
     Log-Warning "Organization unit already exists, retrieving OU ID..."
-    # Get existing OU ID
-    $response = Invoke-ThunderApi -Method GET -Endpoint "/organization-units"
+    # Get existing OU ID by handle to ensure we get the correct "default" OU
+    $response = Invoke-ThunderApi -Method GET -Endpoint "/organization-units/tree/default"
 
     if ($response.StatusCode -eq 200) {
         $body = $response.Body | ConvertFrom-Json
-        $DEFAULT_OU_ID = $body.organizationUnits[0].id
+        $DEFAULT_OU_ID = $body.id
         if ($DEFAULT_OU_ID) {
             Log-Success "Found OU ID: $DEFAULT_OU_ID"
         }
@@ -91,7 +91,7 @@ elseif ($response.StatusCode -eq 409) {
         }
     }
     else {
-        Log-Error "Failed to fetch organization units (HTTP $($response.StatusCode))"
+        Log-Error "Failed to fetch organization unit by handle 'default' (HTTP $($response.StatusCode))"
         exit 1
     }
 }

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -69,8 +69,8 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "Organization unit already exists, retrieving OU ID..."
-    # Get existing OU ID
-    RESPONSE=$(thunder_api_call GET "/organization-units")
+    # Get existing OU ID by handle to ensure we get the correct "default" OU
+    RESPONSE=$(thunder_api_call GET "/organization-units/tree/default")
     HTTP_CODE="${RESPONSE: -3}"
     BODY="${RESPONSE%???}"
 
@@ -83,7 +83,7 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             exit 1
         fi
     else
-        log_error "Failed to fetch organization units (HTTP $HTTP_CODE)"
+        log_error "Failed to fetch organization unit by handle 'default' (HTTP $HTTP_CODE)"
         exit 1
     fi
 else

--- a/backend/cmd/server/bootstrap/02-sample-resources.ps1
+++ b/backend/cmd/server/bootstrap/02-sample-resources.ps1
@@ -67,16 +67,14 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
 }
 elseif ($response.StatusCode -eq 409) {
     Log-Warning "Customers organization unit already exists, retrieving ID..."
-    $response = Invoke-ThunderApi -Method GET -Endpoint "/organization-units"
+    # Get existing OU ID by handle to ensure we get the correct "customers" OU
+    $response = Invoke-ThunderApi -Method GET -Endpoint "/organization-units/tree/$customerOuHandle"
     if ($response.StatusCode -eq 200) {
         $body = $response.Body | ConvertFrom-Json
-        $customersOu = $body.organizationUnits | Where-Object { $_.handle -eq $customerOuHandle } | Select-Object -First 1
-        if ($customersOu) {
-            $CUSTOMER_OU_ID = $customersOu.id
-        }
+        $CUSTOMER_OU_ID = $body.id
     }
     else {
-        Log-Error "Failed to fetch organization units (HTTP $($response.StatusCode))"
+        Log-Error "Failed to fetch organization unit by handle '$customerOuHandle' (HTTP $($response.StatusCode))"
         Write-Host "Response: $($response.Body)"
         exit 1
     }


### PR DESCRIPTION
## Description

Fixes #1168

Bootstrap scripts were failing on subsequent runs with "Organization unit mismatch" error. The issue occurred because scripts were fetching all OUs and picking the first ID from the list, which could be wrong when multiple OUs exist.

## Changes

Updated all 4 bootstrap scripts (bash and PowerShell) to use the `/organization-units/tree/{handle}` API endpoint instead of `/organization-units` list endpoint:

- **01-default-resources.sh**: Fetch "default" OU by handle
- **02-sample-resources.sh**: Fetch "customers" OU by handle  
- **01-default-resources.ps1**: Same fix for PowerShell
- **02-sample-resources.ps1**: Same fix for PowerShell

## Benefits

✅ Scripts are now idempotent - can be run multiple times safely  
✅ No dependency on OU ordering in API responses  
✅ Precise retrieval of OUs by their unique handle  
✅ Consistent behavior across bash and PowerShell versions

## Testing

- [x] Verified scripts work on first run
- [x] Verified scripts work on subsequent runs with multiple OUs present
- [ ] Tested both bash and PowerShell versions
