### PR TITLE
Fix auto-login after self-registration

### DIFF
--- a/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
@@ -144,13 +144,7 @@ export default function SignUpBox(): JSX.Element {
         </Box>
       )}
       <StyledPaper variant="outlined">
-        <SignUp
-          shouldRedirectAfterSignUp={false}
-          onComplete={() => {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            navigate(signInUrl);
-          }}
-        >
+        <SignUp afterSignUpUrl={signInUrl}>
           {({values, fieldErrors, error, touched, handleInputChange, handleSubmit, isLoading, components}: any) => (
             <>
               {!components ? (


### PR DESCRIPTION
This pull request simplifies the `SignUpBox` component by updating how the `SignUp` component handles post-signup navigation. Instead of using a custom `onComplete` handler and disabling automatic redirection, it now leverages the `afterSignUpUrl` prop to handle navigation more declaratively.

**Component simplification:**

* Updated the `SignUpBox` component to use the `afterSignUpUrl` prop on the `SignUp` component, removing the need for a manual `onComplete` handler and the `shouldRedirectAfterSignUp` prop. (`frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx`, [frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsxL147-R147](diffhunk://#diff-6e25e1fa683c78a154588c78c3acbc2d0f89269cd693339e06646da3bf193ae3L147-R147))

Related issue-
- https://github.com/asgardeo/thunder/issues/1138

Related PR-
- https://github.com/asgardeo/javascript/pull/336