### PR TITLE
Add authentication demo postman collection

### DIFF
--- a/samples/api/postman/authentication/README.md
+++ b/samples/api/postman/authentication/README.md
@@ -1,0 +1,263 @@
+# Authentication Demo - Postman Collection
+
+This Postman collection demonstrates the main authentication/registration capabilities in Thunder. It showcases three different approaches to authenticate users and includes resources setup for running the demos. Additionally, it includes one scenario for user registration.
+
+## Demo Scenarios
+
+### 1. Authenticate with Atomic APIs
+Individual authentication endpoints that can be used independently for specific authentication mechanisms:
+- **Credential Login** - Username/password and email/password authentication
+- **SMS OTP Login** - Send and verify SMS OTP
+- **Google Login** - Social login with Google
+- **GitHub Login** - Social login with GitHub
+- **Asgardeo Login** - OAuth-based login with Asgardeo
+
+### 2. Authenticate with Flow Native APIs
+Orchestrated authentication flows using Thunder's flow execution engine:
+- **Login with Username & Password** - Basic username/password flow
+- **Login with Username & Password (Verbose)** - Detailed flow execution with frontend metadata
+- **Login with SMS OTP** - SMS OTP-based authentication flow
+- **Login with MFA** - Multi-factor authentication (username/password + SMS OTP)
+- **Login with Multi Options** - Multiple authentication options (username/password, Google, etc.)
+
+### 3. Authenticate with OAuth (Standard Based)
+Standard OAuth 2.0 authorization code flow with PKCE:
+- Initiate authorization request
+- Execute flow-based authentication
+- Complete authorization and exchange code for tokens
+
+### 4. Registration with Flow Native APIs
+User self-registration flows:
+- **Registration with Username & Password** - Basic user registration flow
+
+## Collection Structure
+
+```
+├── 01 - Set Token              # Obtain access token for management APIs
+├── 02 - Setup Resources        # Create demo resources (OU, schemas, integrations, users, apps, flows)
+├── 03 - Authenticate with Atomic APIs
+│   ├── 03.01 - Credential Login
+│   ├── 03.02 - SMS OTP Login
+│   ├── 03.03 - Google Login
+│   ├── 03.04 - GitHub Login
+│   └── 03.05 - Asgardeo Login
+├── 04 - Authenticate with Flow Native APIs
+│   ├── 04.01 - Login With Username & Password
+│   ├── 04.02 - Login With Username & Password (Verbose)
+│   ├── 04.03 - Login With SMS OTP
+│   ├── 04.04 - Login With MFA
+│   └── 04.05 - Login With Multi Options
+├── 05 - Registration with Flow Native APIs
+│   └── 05.01 - Registration With Username & Password
+└── 06 - Authenticate with OAuth (Standard Based)
+```
+
+## Prerequisites
+
+1. A running Thunder server
+2. Postman desktop app or web version
+3. External service credentials (for social login demos):
+   - Google OAuth credentials
+   - GitHub OAuth credentials
+   - Asgardeo OAuth credentials (optional)
+   - SMS notification sender webhook URL (for SMS OTP demos)
+
+## Environment Setup
+
+Import the `environment.json` file into Postman and fill in the required values. Alternatively, create a new environment manually with the following variables.
+
+### Server Configuration
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `scheme` | Thunder server scheme | `https` |
+| `host` | Thunder server host | `localhost` |
+| `port` | Thunder server port | `8090` |
+| `baseUrl` | Thunder server base URL | `{{scheme}}://{{host}}:{{port}}` (`https://localhost:8090`) |
+
+### Management Token App (for obtaining access tokens)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MGT_TOKEN_APP_CLIENT_ID` | Client ID of the management app | `DEVELOP` |
+| `MGT_TOKEN_APP_REDIRECT_URI` | Redirect URI for the management app | `https://localhost:8090/develop` |
+| `MGT_TOKEN_SCOPE` | OAuth scopes to request | `system` |
+| `ADMIN_USERNAME` | Admin username for authentication | `admin` |
+| `ADMIN_PASSWORD` | Admin password for authentication | `admin` |
+
+### Identity Provider Credentials
+
+#### Google IDP
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
+
+#### GitHub IDP
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_CLIENT_ID` | GitHub OAuth client ID |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth client secret |
+
+#### Asgardeo IDP (Optional)
+
+| Variable | Description |
+|----------|-------------|
+| `ASGARDEO_CLIENT_ID` | Asgardeo OAuth client ID |
+| `ASGARDEO_CLIENT_SECRET` | Asgardeo OAuth client secret |
+| `ASGARDEO_BASE_URI` | Asgardeo organization base URI (Ex: https://api.asgardeo.io/t/your-org) |
+
+Note: Replace `your-org` with your actual Asgardeo organization name.
+
+#### Federated IDP Configuration (Common for all IDPs)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `FED_IDP_REDIRECT_URI` | Redirect URI for federated IDPs | `https://localhost:8090/callback` |
+
+### Notification Configuration
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MESSAGE_NOTIFICATION_SENDER_URL` | Webhook URL for SMS sending | `https://webhook.site/xxxx` |
+
+### Demo Application Configuration
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `LOGIN_APPLICATION_CLIENT_ID` | Client ID for the demo login app | `DEMO_CLIENT_ID` |
+| `LOGIN_APPLICATION_REDIRECT_URI` | Redirect URI for the demo app | `https://localhost:3000` |
+
+### Demo User Configuration
+
+#### Local User
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `demoLoginUser1Username` | Demo user username | `jane` |
+| `demoLoginUser1Password` | Demo user password | `password123` |
+| `demoLoginUser1Email` | Demo user email | `jane@example.com` |
+| `demoLoginUser1Mobile` | Demo user mobile number | `+1234567890` |
+
+#### Google User
+
+| Variable | Description |
+|----------|-------------|
+| `demoGoogleUserSub` | Google user subject identifier (unique id from Google) |
+| `demoGoogleUserEmail` | Google user email |
+
+#### GitHub User
+
+| Variable | Description |
+|----------|-------------|
+| `demoGithubUserSub` | GitHub user subject identifier (unique id from GitHub) |
+| `demoGithubUserEmail` | GitHub user email |
+
+#### Asgardeo User
+
+| Variable | Description |
+|----------|-------------|
+| `demoAsgardeoUserSub` | Asgardeo user subject identifier (unique id from Asgardeo) |
+| `demoAsgardeoUserEmail` | Asgardeo user email |
+
+### Resource IDs (For the created resources)
+
+These variables will be auto-populated during the resource setup phase:
+
+| Variable | Description |
+|----------|-------------|
+| `demoOuId` | Created demo organization unit ID |
+| `demoOuHandle` | Created demo organization unit handle |
+| `demoSchemaId` | Created demo user schema ID |
+| `demoSchemaName` | Created demo user schema name |
+| `googleIDPId` | Created Google IDP ID |
+| `githubIDPId` | Created GitHub IDP ID |
+| `asgardeoIDPId` | Created Asgardeo IDP ID |
+| `messageNotificationSenderId` | Created SMS notification sender ID |
+| `loginApplicationId` | Created demo application ID |
+| `basicAuthFlowGraphId` | Created basic authentication flow graph ID |
+| `smsAuthFlowGraphId` | Created SMS OTP authentication flow graph ID |
+| `mfaAuthFlowGraphId` | Created MFA authentication flow graph ID |
+| `multiOptionAuthFlowGraphId` | Created multi-option authentication flow graph ID |
+| `basicRegistrationFlowGraphId` | Created basic registration flow graph ID |
+
+### Token Management
+
+These variables are used to manage tokens and authentication state. These will be auto-populated during the demo execution:
+
+| Variable | Description |
+|----------|-------------|
+| `accessToken` | Access token for management API calls |
+| `refreshToken` | Refresh token for token renewal |
+| `expiresAt` | Token expiration timestamp |
+| `codeVerifier` | PKCE code verifier |
+| `codeChallenge` | PKCE code challenge |
+| `authId` | Authentication session ID |
+| `flowId` | Flow execution ID |
+| `assertion` | Authentication assertion |
+| `authCode` | Authorization code |
+
+## Collection Variables (Auto-populated)
+
+These variables are automatically populated during the demo execution:
+
+### Authentication Session (Demo execution)
+
+| Variable | Description |
+|----------|-------------|
+| `sms_otp_session_token` | SMS OTP session token |
+| `first_factor_assertion` | First factor authentication assertion for MFA flows |
+| `google_session_token` | Google authentication session token |
+| `github_session_token` | GitHub authentication session token |
+| `asgardeo_session_token` | Asgardeo authentication session token |
+| `exec_flow_id` | Flow execution ID for flow-native APIs |
+| `auth_std_auth_id` | OAuth standard flow auth ID |
+| `auth_std_flow_id` | OAuth standard flow flow exec ID |
+| `auth_std_assertion` | OAuth standard flow assertion |
+| `auth_std_auth_code` | OAuth standard flow authorization code |
+
+## Usage
+
+### Step 1: Import Collection and Set Up Environment
+
+1. Import the `authentication_demo.json` collection into Postman
+2. Import the `environment.json` file or create a new environment with the required variables listed above
+3. Fill in the environment variable values (server config, credentials, demo user details, etc)
+4. Select the environment before running requests
+
+### Step 2: Obtain Management Token
+
+Run the requests in `01 - Set Token` folder sequentially:
+1. **01 - Initiate Authorization** - Starts the OAuth flow
+2. **02 - Init Flow** - Initializes the authentication flow
+3. **03 - Execute Flow** - Completes authentication with admin credentials
+4. **04 - Complete Authorization** - Completes the authorization
+5. **05 - Exchange Code for Token** - Exchanges code for access token
+
+### Step 3: Setup Demo Resources
+
+Run the requests in `02 - Setup Resources` folder to create:
+- Demo organization unit
+- User schema
+- Notification sender (for SMS OTP)
+- Identity providers (Google, GitHub, Asgardeo)
+- Demo users
+- Demo application
+- Authentication and registration flows
+
+### Step 4: Run Authentication Demos
+
+Choose any of the authentication demo folders:
+- `03 - Authenticate with Atomic APIs` - For individual authentication mechanism demos
+- `04 - Authenticate with Flow Native APIs` - For flow-based authentication demos
+- `05 - Registration with Flow Native APIs` - For user registration demos
+- `06 - Authenticate with OAuth (Standard Based)` - For OAuth 2.0 flow demo
+
+## Notes
+
+- The collection includes a pre-request script that automatically refreshes the access token when it's about to expire.
+- For social login demos (Google, GitHub, Asgardeo), you'll need to complete the OAuth flow in a browser and provide the authorization code manually.
+- SMS OTP demos require a webhook endpoint to receive OTP messages. You can use services like [webhook.site](https://webhook.site/) for testing.
+- Some requests may return `201` (created) or `409` (already exists) depending on whether resources were previously created

--- a/samples/api/postman/authentication/authentication_demo.json
+++ b/samples/api/postman/authentication/authentication_demo.json
@@ -1,0 +1,3863 @@
+{
+  "info": {
+    "_postman_id": "28f739e9-1857-41d7-9605-c2779603228b",
+    "name": "Demo - Authentication",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "15629984",
+    "_collection_link": "https://go.postman.co/collection/15629984-28f739e9-1857-41d7-9605-c2779603228b?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "01 - Set Token",
+      "item": [
+        {
+          "name": "01 - Initiate Authorization",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "// Generate PKCE code verifier (43-128 chars, URL-safe)",
+                  "function base64UrlEncode(buffer) {",
+                  "    return btoa(String.fromCharCode(...new Uint8Array(buffer)))",
+                  "        .replace(/\\+/g, '-')",
+                  "        .replace(/\\//g, '_')",
+                  "        .replace(/=/g, '');",
+                  "}",
+                  "",
+                  "// Generate random code verifier",
+                  "const array = new Uint8Array(32);",
+                  "crypto.getRandomValues(array);",
+                  "const codeVerifier = base64UrlEncode(array);",
+                  "pm.environment.set(\"codeVerifier\", codeVerifier);",
+                  "",
+                  "// Generate code challenge (SHA-256 hash of verifier)",
+                  "crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier))",
+                  "    .then(hash => {",
+                  "        const codeChallenge = base64UrlEncode(hash);",
+                  "        pm.environment.set(\"codeChallenge\", codeChallenge);",
+                  "        console.log(\"PKCE generated - Verifier length:\", codeVerifier.length);",
+                  "    });",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Should redirect to login\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([302, 303, 307]);",
+                  "});",
+                  "const location = pm.response.headers.get(\"Location\");",
+                  "if (location) {",
+                  "    const url = new URL(location);",
+                  "    const authId = url.searchParams.get(\"authId\");",
+                  "    const flowId = url.searchParams.get(\"flowId\");",
+                  "    ",
+                  "    pm.environment.set(\"authId\", authId);",
+                  "    pm.environment.set(\"flowId\", flowId);",
+                  "    ",
+                  "    console.log(\"AuthId:\", authId);",
+                  "    console.log(\"FlowId:\", flowId);",
+                  "}",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/oauth2/authorize?client_id={{MGT_TOKEN_APP_CLIENT_ID}}&redirect_uri={{MGT_TOKEN_APP_REDIRECT_URI}}&response_type=code&scope={{MGT_TOKEN_SCOPE}}&state=test-state&code_challenge={{codeChallenge}}&code_challenge_method=S256",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "oauth2",
+                "authorize"
+              ],
+              "query": [
+                {
+                  "key": "client_id",
+                  "value": "{{MGT_TOKEN_APP_CLIENT_ID}}"
+                },
+                {
+                  "key": "redirect_uri",
+                  "value": "{{MGT_TOKEN_APP_REDIRECT_URI}}"
+                },
+                {
+                  "key": "response_type",
+                  "value": "code"
+                },
+                {
+                  "key": "scope",
+                  "value": "{{MGT_TOKEN_SCOPE}}"
+                },
+                {
+                  "key": "state",
+                  "value": "test-state"
+                },
+                {
+                  "key": "code_challenge",
+                  "value": "{{codeChallenge}}"
+                },
+                {
+                  "key": "code_challenge_method",
+                  "value": "S256"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "02 - Init Flow",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Flow step returned\", function() {",
+                  "    pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const resp = pm.response.json();",
+                  "console.log(\"Flow status:\", resp.flowStatus);",
+                  "console.log(\"Flow type:\", resp.type);",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"flowId\": \"{{flowId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flow/execute",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flow",
+                "execute"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "03 - Execute Flow",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Authentication successful\", function() {",
+                  "    pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const resp = pm.response.json();",
+                  "if (resp.flowStatus === \"COMPLETE\" && resp.assertion) {",
+                  "    pm.environment.set(\"assertion\", resp.assertion);",
+                  "    console.log(\"✓ Authentication complete, assertion obtained\");",
+                  "} else {",
+                  "    console.log(\"✗ Authentication failed:\", resp.failureReason || resp.flowStatus);",
+                  "}",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"flowId\": \"{{flowId}}\",\n    \"inputs\": {\n        \"username\": \"{{ADMIN_USERNAME}}\",\n        \"password\": \"{{ADMIN_PASSWORD}}\"\n    },\n    \"action\": \"action_001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flow/execute",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flow",
+                "execute"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "04 - Complete Authorization",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Authorization completed\", function() {",
+                  "    pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const resp = pm.response.json();",
+                  "if (resp.redirect_uri) {",
+                  "    const url = new URL(resp.redirect_uri);",
+                  "    const code = url.searchParams.get(\"code\");",
+                  "    pm.environment.set(\"authCode\", code);",
+                  "    console.log(\"✓ Authorization code obtained\");",
+                  "}",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "packages": {},
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"authId\": \"{{authId}}\",\n    \"assertion\": \"{{assertion}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/oauth2/authorize",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "oauth2",
+                "authorize"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "05 - Exchange Code for Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Token obtained\", function() {",
+                  "    pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const token = pm.response.json();",
+                  "if (token.access_token) {",
+                  "    pm.environment.set(\"accessToken\", token.access_token);",
+                  "    pm.environment.set(\"expiresAt\", String(Date.now() + (token.expires_in * 1000)));",
+                  "    ",
+                  "    if (token.refresh_token) {",
+                  "        pm.environment.set(\"refreshToken\", token.refresh_token);",
+                  "    }",
+                  "    ",
+                  "    console.log(\"✓ Access token stored\");",
+                  "    console.log(\"✓ Expires in:\", token.expires_in, \"seconds\");",
+                  "}",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "authorization_code",
+                  "type": "text",
+                  "uuid": "77f67144-1112-4773-b322-171030e13d31"
+                },
+                {
+                  "key": "code",
+                  "value": "{{authCode}}",
+                  "type": "text",
+                  "uuid": "d0096182-585d-4066-927f-52b1791b330c"
+                },
+                {
+                  "key": "redirect_uri",
+                  "value": "{{MGT_TOKEN_APP_REDIRECT_URI}}",
+                  "type": "text",
+                  "uuid": "72d50dd8-c9d5-4b1e-88c6-f9522b85a79e"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{MGT_TOKEN_APP_CLIENT_ID}}",
+                  "type": "text",
+                  "uuid": "677ae63e-a94d-482a-aa1c-216b111db30b"
+                },
+                {
+                  "key": "code_verifier",
+                  "value": "{{codeVerifier}}",
+                  "type": "text",
+                  "uuid": "25e13a0f-8751-4d85-9100-14c7dca21bdd"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/oauth2/token",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "oauth2",
+                "token"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "auth": {
+        "type": "noauth"
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "02 - Setup Resources",
+      "item": [
+        {
+          "name": "01 - Create OU",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the OU ID and handle",
+                  "    pm.environment.set(\"demoOuId\", response.id);",
+                  "    pm.environment.set(\"demoOuHandle\", response.handle);",
+                  "    ",
+                  "    console.log(\"✓ Organization Unit created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Handle:\", response.handle);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ OU already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"OU created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "packages": {},
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"handle\": \"demo\",\n  \"name\": \"DemoOU\",\n  \"description\": \"Demo Organization Unit\",\n  \"parent\": null\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/organization-units",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "organization-units"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "02 - Create User Schema",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the schema name and id",
+                  "    pm.environment.set(\"demoSchemaId\", response.id);",
+                  "    pm.environment.set(\"demoSchemaName\", response.name);",
+                  "    ",
+                  "    console.log(\"✓ User Schema created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Name:\", response.name);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ User Schema already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"User Schema created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Demo User\",\n  \"ouId\": \"{{demoOuId}}\",\n  \"allowSelfRegistration\": true,\n  \"schema\": {\n        \"username\": {\n            \"type\": \"string\",\n            \"required\": false,\n            \"unique\": true\n        },\n        \"sub\": {\n            \"type\": \"string\",\n            \"required\": false,\n            \"unique\": true\n        },\n        \"email\": {\n            \"type\": \"string\",\n            \"required\": false,\n            \"unique\": true\n        },\n        \"givenName\": {\n            \"type\": \"string\",\n            \"required\": false\n        },\n        \"familyName\": {\n            \"type\": \"string\",\n            \"required\": false\n        },\n        \"mobileNumber\": {\n            \"type\": \"string\",\n            \"required\": false\n        },\n        \"userSource\": {\n            \"type\": \"string\",\n            \"required\": false\n        },\n        \"password\": {\n            \"type\": \"string\",\n            \"required\": false\n        }\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/user-schemas",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user-schemas"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "03 - Create Message Notification Sender",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the sender id",
+                  "    pm.environment.set(\"messageNotificationSenderId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ Message Notification Sender created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Name:\", response.name);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ Message Notification Sender already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Custom SMS Sender\",\n    \"description\": \"Sender for sending SMS messages using Webhook.io\",\n    \"provider\": \"custom\",\n    \"properties\": [\n        {\n            \"name\": \"content_type\",\n            \"value\": \"JSON\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"http_method\",\n            \"value\": \"POST\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"url\",\n            \"value\": \"{{MESSAGE_NOTIFICATION_SENDER_URL}}\",\n            \"is_secret\": false\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://localhost:8090/notification-senders/message",
+              "protocol": "https",
+              "host": [
+                "localhost"
+              ],
+              "port": "8090",
+              "path": [
+                "notification-senders",
+                "message"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "04 - Create Google IDP",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the IDP id",
+                  "    pm.environment.set(\"googleIDPId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ Google IDP created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Name:\", response.name);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ IDP already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Google\",\n    \"description\": \"Login with Google\",\n    \"type\": \"GOOGLE\",\n    \"properties\": [\n        {\n            \"name\": \"client_id\",\n            \"value\": \"{{GOOGLE_CLIENT_ID}}\",\n            \"is_secret\": true\n        },\n        {\n            \"name\": \"client_secret\",\n            \"value\": \"{{GOOGLE_CLIENT_SECRET}}\",\n            \"is_secret\": true\n        },\n        {\n            \"name\": \"redirect_uri\",\n            \"value\": \"{{FED_IDP_REDIRECT_URI}}\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"prompt\",\n            \"value\": \"select_account\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"scopes\",\n            \"value\": \"openid,email,profile\",\n            \"is_secret\": false\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/identity-providers",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "identity-providers"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "05 - Create GitHub IDP",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the IDP id",
+                  "    pm.environment.set(\"githubIDPId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ GitHub IDP created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Name:\", response.name);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ IDP already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"GitHub\",\n    \"description\": \"Login with GitHub\",\n    \"type\": \"GITHUB\",\n    \"properties\": [\n    {\n      \"name\": \"client_id\",\n      \"value\": \"{{GITHUB_CLIENT_ID}}\",\n      \"is_secret\": true\n    },\n    {\n      \"name\": \"client_secret\",\n      \"value\": \"{{GITHUB_CLIENT_SECRET}}\",\n      \"is_secret\": true\n    },\n    {\n      \"name\": \"redirect_uri\",\n      \"value\": \"{{FED_IDP_REDIRECT_URI}}\",\n      \"is_secret\": false\n    },\n    {\n      \"name\": \"scopes\",\n      \"value\": \"user:email,read:user\",\n      \"is_secret\": false\n    },\n    {\n      \"name\": \"prompt\",\n      \"value\": \"select_account\",\n      \"is_secret\": false\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/identity-providers",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "identity-providers"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "06 - Create Asgardeo OAuth IDP",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the IDP id",
+                  "    pm.environment.set(\"asgardeoIDPId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ Asgardeo IDP created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Name:\", response.name);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ IDP already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Asgardeo Prod\",\n    \"description\": \"Login with Asgardeo\",\n    \"type\": \"OAUTH\",\n    \"properties\": [\n        {\n            \"name\": \"client_id\",\n            \"value\": \"{{ASGARDEO_CLIENT_ID}}\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"client_secret\",\n            \"value\": \"{{ASGARDEO_CLIENT_SECRET}}\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"redirect_uri\",\n            \"value\": \"{{FED_IDP_REDIRECT_URI}}\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"scopes\",\n            \"value\": \"openid,custom,email,groups,profile\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"authorization_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oauth2/authorize\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"token_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oauth2/token\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"userinfo_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oauth2/userinfo\",\n            \"is_secret\": false\n        },\n        {\n            \"name\": \"logout_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oidc/logout\",\n            \"is_secret\": false\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/identity-providers",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "identity-providers"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "07 - Create Local User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"organizationUnit\": \"{{demoOuId}}\",\n    \"type\": \"{{demoSchemaName}}\",\n    \"attributes\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\",\n        \"email\": \"{{demoLoginUser1Email}}\",\n        \"firstName\": \"Jane\",\n        \"lastName\": \"Doe\",\n        \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "users"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "08 - Create Google User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"organizationUnit\": \"{{demoOuId}}\",\n    \"type\": \"{{demoSchemaName}}\",\n    \"attributes\": {\n        \"sub\": \"{{demoGoogleUserSub}}\",\n        \"email\": \"{{demoGoogleUserEmail}}\",\n        \"userSource\": \"Google\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "users"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "09 - Create GitHub User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"organizationUnit\": \"{{demoOuId}}\",\n    \"type\": \"{{demoSchemaName}}\",\n    \"attributes\": {\n        \"sub\": \"{{demoGithubUserSub}}\",\n        \"email\": \"{{demoGithubUserEmail}}\",\n        \"userSource\": \"Github\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "users"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "10 - Create Asgardeo User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"organizationUnit\": \"{{demoOuId}}\",\n    \"type\": \"{{demoSchemaName}}\",\n    \"attributes\": {\n        \"sub\": \"{{demoAsgardeoUserSub}}\",\n        \"email\": \"{{demoAsgardeoUserEmail}}\",\n        \"userSource\": \"Asgardeo\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "users"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "11 - Create Application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the application id",
+                  "    pm.environment.set(\"loginApplicationId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ Application created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Name:\", response.name);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ Application already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"public_client\": true,\n                \"pkce_required\": true,\n                \"token_endpoint_auth_method\": \"none\",\n                \"token\": {\n                    \"access_token\": {\n                        \"issuer\": \"thunder.wso2.com\",\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ],\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/applications",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "12 - Create Basic Authentication Flow",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the flow id",
+                  "    pm.environment.set(\"basicAuthFlowGraphId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ Basic Auth Flow created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Handle:\", response.handle);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ Basic Flow already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Demo Basic Authentication Flow\",\n    \"handle\": \"demo-basic-flow\",\n    \"flowType\": \"AUTHENTICATION\",\n    \"nodes\": [\n        {\n            \"id\": \"start\",\n            \"type\": \"START\",\n            \"onSuccess\": \"prompt_credentials\"\n        },\n        {\n            \"id\": \"prompt_credentials\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_001\",\n                        \"label\": \"Sign In\",\n                        \"variant\": \"HEADING_1\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_001\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_001\",\n                                \"ref\": \"username\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Username\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your username\"\n                            },\n                            {\n                                \"id\": \"input_002\",\n                                \"ref\": \"password\",\n                                \"type\": \"PASSWORD_INPUT\",\n                                \"label\": \"Password\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your password\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_001\",\n                                \"label\": \"Sign In\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_001\",\n                            \"identifier\": \"username\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_002\",\n                            \"identifier\": \"password\",\n                            \"type\": \"PASSWORD_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"basic_auth\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"basic_auth\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"BasicAuthExecutor\"\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"auth_assert\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"AuthAssertExecutor\"\n            },\n            \"onSuccess\": \"end\"\n        },\n        {\n            \"id\": \"end\",\n            \"type\": \"END\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flows",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flows"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "13 - Create SMS Authentication Flow",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the flow id",
+                  "    pm.environment.set(\"smsAuthFlowGraphId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ SMS Auth Flow created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Handle:\", response.handle);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ SMS Flow already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Demo SMS Authentication Flow\",\n    \"handle\": \"demo-sms-flow\",\n    \"flowType\": \"AUTHENTICATION\",\n    \"nodes\": [\n        {\n            \"id\": \"start\",\n            \"type\": \"START\",\n            \"onSuccess\": \"prompt_mobile\"\n        },\n        {\n            \"id\": \"prompt_mobile\",\n            \"type\": \"PROMPT\",\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_001\",\n                            \"identifier\": \"mobileNumber\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"send_sms\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"send_sms\",\n            \"type\": \"TASK_EXECUTION\",\n            \"properties\": {\n                \"senderId\": \"{{messageNotificationSenderId}}\"\n            },\n            \"executor\": {\n                \"name\": \"SMSOTPAuthExecutor\",\n                \"mode\": \"send\"\n            },\n            \"onSuccess\": \"prompt_otp\"\n        },\n        {\n            \"id\": \"prompt_otp\",\n            \"type\": \"PROMPT\",\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_002\",\n                            \"identifier\": \"otp\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"verify_sms\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"verify_sms\",\n            \"type\": \"TASK_EXECUTION\",\n            \"properties\": {\n                \"senderId\": \"{{messageNotificationSenderId}}\"\n            },\n            \"executor\": {\n                \"name\": \"SMSOTPAuthExecutor\",\n                \"mode\": \"verify\"\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"auth_assert\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"AuthAssertExecutor\"\n            },\n            \"onSuccess\": \"end\"\n        },\n        {\n            \"id\": \"end\",\n            \"type\": \"END\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flows",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flows"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "14 - Create MFA Authentication Flow",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the flow id",
+                  "    pm.environment.set(\"mfaAuthFlowGraphId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ MFA Auth Flow created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Handle:\", response.handle);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ Auth Flow already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Demo MFA Authentication Flow\",\n    \"handle\": \"demo-mfa-flow\",\n    \"flowType\": \"AUTHENTICATION\",\n    \"nodes\": [\n        {\n            \"id\": \"start\",\n            \"type\": \"START\",\n            \"onSuccess\": \"prompt_credentials\"\n        },\n        {\n            \"id\": \"prompt_credentials\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_001\",\n                        \"label\": \"{{ t(signin:heading) }}\",\n                        \"variant\": \"HEADING_1\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_001\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_001\",\n                                \"ref\": \"username\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"{{ t(elements:fields.username.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.username.placeholder) }}\"\n                            },\n                            {\n                                \"id\": \"input_002\",\n                                \"ref\": \"password\",\n                                \"type\": \"PASSWORD_INPUT\",\n                                \"label\": \"{{ t(elements:fields.password.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.password.placeholder) }}\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_001\",\n                                \"label\": \"{{ t(elements:buttons.submit.text) }}\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_001\",\n                            \"identifier\": \"username\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_002\",\n                            \"identifier\": \"password\",\n                            \"type\": \"PASSWORD_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"basic_auth\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"basic_auth\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"BasicAuthExecutor\"\n            },\n            \"onSuccess\": \"send_sms\"\n        },\n        {\n            \"id\": \"send_sms\",\n            \"type\": \"TASK_EXECUTION\",\n            \"properties\": {\n                \"senderId\": \"{{messageNotificationSenderId}}\"\n            },\n            \"executor\": {\n                \"name\": \"SMSOTPAuthExecutor\",\n                \"mode\": \"send\"\n            },\n            \"onSuccess\": \"prompt_otp\"\n        },\n        {\n            \"id\": \"prompt_otp\",\n            \"type\": \"PROMPT\",\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_002\",\n                            \"identifier\": \"otp\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"verify_sms\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"verify_sms\",\n            \"type\": \"TASK_EXECUTION\",\n            \"properties\": {\n                \"senderId\": \"{{messageNotificationSenderId}}\"\n            },\n            \"executor\": {\n                \"name\": \"SMSOTPAuthExecutor\",\n                \"mode\": \"verify\"\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"auth_assert\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"AuthAssertExecutor\"\n            },\n            \"onSuccess\": \"end\"\n        },\n        {\n            \"id\": \"end\",\n            \"type\": \"END\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flows",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flows"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "15 - Create Multi Option Authentication Flow",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the flow id",
+                  "    pm.environment.set(\"multiOptionAuthFlowGraphId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ Multi Option Auth Flow created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Handle:\", response.handle);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ Auth Flow already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Demo Multi Option Authentication Flow\",\n    \"handle\": \"demo-multi-option-flow\",\n    \"flowType\": \"AUTHENTICATION\",\n    \"nodes\": [\n        {\n            \"id\": \"start\",\n            \"type\": \"START\",\n            \"onSuccess\": \"prompt_credentials_or_choice\"\n        },\n        {\n            \"id\": \"prompt_credentials_or_choice\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"category\": \"DISPLAY\",\n                        \"id\": \"text_001\",\n                        \"label\": \"Login\",\n                        \"type\": \"TEXT\",\n                        \"variant\": \"HEADING_3\"\n                    },\n                    {\n                        \"components\": [\n                            {\n                                \"category\": \"FIELD\",\n                                \"id\": \"input_001\",\n                                \"label\": \"{{ t(elements:fields.username.label) }}\",\n                                \"placeholder\": \"{{ t(elements:fields.username.placeholder) }}\",\n                                \"ref\": \"username\",\n                                \"required\": true,\n                                \"type\": \"TEXT_INPUT\"\n                            },\n                            {\n                                \"category\": \"FIELD\",\n                                \"id\": \"input_002\",\n                                \"label\": \"{{ t(elements:fields.password.label) }}\",\n                                \"placeholder\": \"{{ t(elements:fields.password.placeholder) }}\",\n                                \"ref\": \"password\",\n                                \"required\": true,\n                                \"type\": \"PASSWORD_INPUT\"\n                            },\n                            {\n                                \"category\": \"ACTION\",\n                                \"eventType\": \"SUBMIT\",\n                                \"id\": \"action_001\",\n                                \"label\": \"{{ t(elements:buttons.submit.text) }}\",\n                                \"type\": \"ACTION\",\n                                \"variant\": \"PRIMARY\"\n                            }\n                        ],\n                        \"id\": \"block_001\",\n                        \"type\": \"BLOCK\"\n                    },\n                    {\n                        \"category\": \"DISPLAY\",\n                        \"id\": \"divider_001\",\n                        \"label\": \"{{ t(signin:or) }}\",\n                        \"type\": \"DIVIDER\"\n                    },\n                    {\n                        \"category\": \"ACTION\",\n                        \"components\": [\n                            {\n                                \"category\": \"ACTION\",\n                                \"eventType\": \"NAVIGATE\",\n                                \"id\": \"action_002\",\n                                \"label\": \"{{ t(signin:use_google) }}\",\n                                \"nextNode\": \"basic_auth\",\n                                \"type\": \"ACTION\",\n                                \"variant\": \"SOCIAL\"\n                            }\n                        ],\n                        \"id\": \"block_002\",\n                        \"type\": \"BLOCK\"\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_001\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"identifier\": \"username\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_002\",\n                            \"type\": \"PASSWORD_INPUT\",\n                            \"identifier\": \"password\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"basic_auth\"\n                    }\n                },\n                {\n                    \"action\": {\n                        \"ref\": \"action_002\",\n                        \"nextNode\": \"google_auth\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"basic_auth\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"BasicAuthExecutor\"\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"google_auth\",\n            \"type\": \"TASK_EXECUTION\",\n            \"properties\": {\n                \"idpId\": \"{{googleIDPId}}\"\n            },\n            \"executor\": {\n                \"name\": \"GoogleOIDCAuthExecutor\",\n                \"inputs\": [\n                    {\n                        \"ref\": \"input_003\",\n                        \"type\": \"TEXT_INPUT\",\n                        \"identifier\": \"code\",\n                        \"required\": true\n                    }\n                ]\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"auth_assert\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"AuthAssertExecutor\"\n            },\n            \"onSuccess\": \"end\"\n        },\n        {\n            \"id\": \"end\",\n            \"type\": \"END\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flows",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flows"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "16 - Create Basic Registration Flow",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Only store if creation was successful (201 Created)",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    ",
+                  "    // Store the flow id",
+                  "    pm.environment.set(\"basicRegistrationFlowGraphId\", response.id);",
+                  "    ",
+                  "    console.log(\"✓ Basic Registration Flow created\");",
+                  "    console.log(\"  ID:\", response.id);",
+                  "    console.log(\"  Handle:\", response.handle);",
+                  "} else if (pm.response.code === 409) {",
+                  "    console.log(\"⚠ Basic Flow already exists - you may need to fetch its ID separately\");",
+                  "}",
+                  "",
+                  "// Test assertion",
+                  "pm.test(\"created or already exists\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Demo Basic Registration Flow\",\n    \"handle\": \"demo-basic-flow\",\n    \"flowType\": \"REGISTRATION\",\n    \"nodes\": [\n        {\n            \"id\": \"start\",\n            \"type\": \"START\",\n            \"onSuccess\": \"user_type_resolver\"\n        },\n        {\n            \"id\": \"user_type_resolver\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"UserTypeResolver\"\n            },\n            \"onSuccess\": \"prompt_basic\"\n        },\n        {\n            \"id\": \"prompt_basic\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_001\",\n                        \"label\": \"{{ t(signup:heading) }}\",\n                        \"variant\": \"HEADING_1\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_001\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_001\",\n                                \"ref\": \"username\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"{{ t(elements:fields.username.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.username.placeholder) }}\"\n                            },\n                            {\n                                \"id\": \"input_002\",\n                                \"ref\": \"password\",\n                                \"type\": \"PASSWORD_INPUT\",\n                                \"label\": \"{{ t(elements:fields.password.label) }}\",\n                                \"required\": true,\n                                \"placeholder\": \"{{ t(elements:fields.password.placeholder) }}\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_001\",\n                                \"label\": \"{{ t(elements:buttons.continue.text) }}\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_001\",\n                            \"identifier\": \"username\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_002\",\n                            \"identifier\": \"password\",\n                            \"type\": \"PASSWORD_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_001\",\n                        \"nextNode\": \"basic_auth\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"basic_auth\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"BasicAuthExecutor\"\n            },\n            \"onSuccess\": \"prompt_additional_info\"\n        },\n        {\n            \"id\": \"prompt_additional_info\",\n            \"type\": \"PROMPT\",\n            \"meta\": {\n                \"components\": [\n                    {\n                        \"type\": \"TEXT\",\n                        \"id\": \"text_002\",\n                        \"label\": \"Additional Information\",\n                        \"variant\": \"HEADING_2\"\n                    },\n                    {\n                        \"type\": \"BLOCK\",\n                        \"id\": \"block_002\",\n                        \"components\": [\n                            {\n                                \"id\": \"input_003\",\n                                \"ref\": \"firstName\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"First Name\",\n                                \"required\": false,\n                                \"placeholder\": \"Enter your first name\"\n                            },\n                            {\n                                \"id\": \"input_004\",\n                                \"ref\": \"lastName\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Last Name\",\n                                \"required\": false,\n                                \"placeholder\": \"Enter your last name\"\n                            },\n                            {\n                                \"id\": \"input_005\",\n                                \"ref\": \"email\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Email Address\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your email address\"\n                            },\n                            {\n                                \"id\": \"input_006\",\n                                \"ref\": \"mobileNumber\",\n                                \"type\": \"TEXT_INPUT\",\n                                \"label\": \"Mobile Number\",\n                                \"required\": true,\n                                \"placeholder\": \"Enter your mobile number\"\n                            },\n                            {\n                                \"type\": \"ACTION\",\n                                \"id\": \"action_002\",\n                                \"label\": \"Complete Registration\",\n                                \"variant\": \"PRIMARY\",\n                                \"eventType\": \"SUBMIT\"\n                            }\n                        ]\n                    }\n                ]\n            },\n            \"prompts\": [\n                {\n                    \"inputs\": [\n                        {\n                            \"ref\": \"input_003\",\n                            \"identifier\": \"firstName\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": false\n                        },\n                        {\n                            \"ref\": \"input_004\",\n                            \"identifier\": \"lastName\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": false\n                        },\n                        {\n                            \"ref\": \"input_005\",\n                            \"identifier\": \"email\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        },\n                        {\n                            \"ref\": \"input_006\",\n                            \"identifier\": \"mobileNumber\",\n                            \"type\": \"TEXT_INPUT\",\n                            \"required\": true\n                        }\n                    ],\n                    \"action\": {\n                        \"ref\": \"action_002\",\n                        \"nextNode\": \"provisioning\"\n                    }\n                }\n            ]\n        },\n        {\n            \"id\": \"provisioning\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"ProvisioningExecutor\"\n            },\n            \"onSuccess\": \"auth_assert\"\n        },\n        {\n            \"id\": \"auth_assert\",\n            \"type\": \"TASK_EXECUTION\",\n            \"executor\": {\n                \"name\": \"AuthAssertExecutor\"\n            },\n            \"onSuccess\": \"end\"\n        },\n        {\n            \"id\": \"end\",\n            \"type\": \"END\"\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flows",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flows"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "03 - Authenticate with Atomic APIs",
+      "item": [
+        {
+          "name": "03.01 - Credential Login",
+          "item": [
+            {
+              "name": "01 - Login with Username & Password",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the assertion from the response",
+                      "const assertion = jsonResponse.assertion;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"first_factor_assertion\", assertion);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"username\": \"{{demoLoginUser1Username}}\",\n  \"password\": \"{{demoLoginUser1Password}}\"\n//   \"skip_assertion\": false\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/credentials/authenticate",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "credentials",
+                    "authenticate"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Login with Email & Password",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"{{demoLoginUser1Email}}\",\n  \"password\": \"{{demoLoginUser1Password}}\",\n  \"skip_assertion\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/credentials/authenticate",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "credentials",
+                    "authenticate"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "03.02 - SMS OTP Login",
+          "item": [
+            {
+              "name": "01 - Send",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the session_token from the response",
+                      "const sessionToken = jsonResponse.session_token;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"sms_otp_session_token\", sessionToken);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"sender_id\": \"{{messageNotificationSenderId}}\",\n  \"recipient\": \"{{demoLoginUser1Mobile}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/otp/sms/send",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "otp",
+                    "sms",
+                    "send"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Verify",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"session_token\": \"{{sms_otp_session_token}}\",\n  \"otp\": \"857723\"\n//   \"skip_assertion\": false\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/otp/sms/verify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "otp",
+                    "sms",
+                    "verify"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03 - Verify with Assertion",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"session_token\": \"{{sms_otp_session_token}}\",\n  \"assertion\": \"{{first_factor_assertion}}\",\n  \"otp\": \"956782\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/otp/sms/verify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "otp",
+                    "sms",
+                    "verify"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "03.03 - Google Login",
+          "item": [
+            {
+              "name": "01 - Start",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the session_token from the response",
+                      "const sessionToken = jsonResponse.session_token;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"google_session_token\", sessionToken);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"idp_id\": \"{{googleIDPId}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/oauth/google/start",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "oauth",
+                    "google",
+                    "start"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Finish",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"session_token\": \"{{google_session_token}}\",\n  \"code\": \"<GOOGLE_AUTHORIZATION_CODE>\"\n//   \"skip_assertion\": false,\n//   \"assertion\": \"\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/oauth/google/finish",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "oauth",
+                    "google",
+                    "finish"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "03.04 - GitHub Login",
+          "item": [
+            {
+              "name": "01 - Start",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the session_token from the response",
+                      "const sessionToken = jsonResponse.session_token;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"github_session_token\", sessionToken);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"idp_id\": \"{{githubIDPId}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/oauth/github/start",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "oauth",
+                    "github",
+                    "start"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Finish",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"session_token\": \"{{github_session_token}}\",\n  \"code\": \"<GITHUB_AUTHORIZATION_CODE>\"\n//   \"skip_assertion\": false,\n//   \"assertion\": \"\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/oauth/github/finish",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "oauth",
+                    "github",
+                    "finish"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "03.05 - Asgardeo Login",
+          "item": [
+            {
+              "name": "01 - Start",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the session_token from the response",
+                      "const sessionToken = jsonResponse.session_token;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"asgardeo_session_token\", sessionToken);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"idp_id\": \"{{asgardeoIDPId}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/oauth/standard/start",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "oauth",
+                    "standard",
+                    "start"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Finish",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"session_token\": \"{{asgardeo_session_token}}\",\n  \"code\": \"<ASGARDEO_AUTHORIZATION_CODE>\"\n//   \"skip_assertion\": false,\n//   \"assertion\": \"\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/auth/oauth/standard/finish",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "auth",
+                    "oauth",
+                    "standard",
+                    "finish"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        }
+      ],
+      "auth": {
+        "type": "noauth"
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "04 - Authenticate with Flow Native APIs",
+      "item": [
+        {
+          "name": "04.01 - Login With Username & Password",
+          "item": [
+            {
+              "name": "01 - Update Application",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{accessToken}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"auth_flow_id\": \"{{basicAuthFlowGraphId}}\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"token_endpoint_auth_method\": \"none\",\n                \"pkce_required\": true,\n                \"public_client\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"access_token\": {\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "applications",
+                    "{{loginApplicationId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Initiate Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the flowId from the response",
+                      "const flowId = jsonResponse.flowId;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"applicationId\": \"{{loginApplicationId}}\",\n    \"flowType\": \"AUTHENTICATION\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03 - Complete Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ],
+          "auth": {
+            "type": "noauth"
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "04.02 - Login With Username & Password (Verbose)",
+          "item": [
+            {
+              "name": "01 - Update Application",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{accessToken}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"auth_flow_id\": \"{{basicAuthFlowGraphId}}\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"token_endpoint_auth_method\": \"none\",\n                \"pkce_required\": true,\n                \"public_client\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"access_token\": {\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "applications",
+                    "{{loginApplicationId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Initiate Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the flowId from the response",
+                      "const flowId = jsonResponse.flowId;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"applicationId\": \"{{loginApplicationId}}\",\n    \"flowType\": \"AUTHENTICATION\",\n    \"verbose\": true\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03 - Complete Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ],
+          "auth": {
+            "type": "noauth"
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "04.03 - Login With SMS OTP",
+          "item": [
+            {
+              "name": "01 - Update Application",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{accessToken}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"auth_flow_id\": \"{{smsAuthFlowGraphId}}\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"token_endpoint_auth_method\": \"none\",\n                \"pkce_required\": true,\n                \"public_client\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"access_token\": {\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "applications",
+                    "{{loginApplicationId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Initiate Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the flowId from the response",
+                      "const flowId = jsonResponse.flowId;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"applicationId\": \"{{loginApplicationId}}\",\n    \"flowType\": \"AUTHENTICATION\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03 - Continue Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "04 - Complete Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"443375\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ],
+          "auth": {
+            "type": "noauth"
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "04.04 - Login With MFA",
+          "item": [
+            {
+              "name": "01 - Update Application",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{accessToken}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"auth_flow_id\": \"{{mfaAuthFlowGraphId}}\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"token_endpoint_auth_method\": \"none\",\n                \"pkce_required\": true,\n                \"public_client\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"access_token\": {\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "applications",
+                    "{{loginApplicationId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Initiate Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the flowId from the response",
+                      "const flowId = jsonResponse.flowId;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"applicationId\": \"{{loginApplicationId}}\",\n    \"flowType\": \"AUTHENTICATION\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03 - Continue Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "04 - Complete Authentication",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"921262\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ],
+          "auth": {
+            "type": "noauth"
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "04.05 - Login With Multi Options",
+          "item": [
+            {
+              "name": "01 - Update Application",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{accessToken}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"auth_flow_id\": \"{{multiOptionAuthFlowGraphId}}\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"token_endpoint_auth_method\": \"none\",\n                \"pkce_required\": true,\n                \"public_client\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"access_token\": {\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "applications",
+                    "{{loginApplicationId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02.01 - Initiate Authentication (Username & Password)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the flowId from the response",
+                      "const flowId = jsonResponse.flowId;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"applicationId\": \"{{loginApplicationId}}\",\n    \"flowType\": \"AUTHENTICATION\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02.02 - Complete Authentication (Username & Password)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n        // \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03.01 - Initiate Authentication (Google)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the flowId from the response",
+                      "const flowId = jsonResponse.flowId;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"applicationId\": \"{{loginApplicationId}}\",\n    \"flowType\": \"AUTHENTICATION\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03.02 - Continue Authentication (Google)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"action\": \"action_002\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03.03 - Complete Authentication (Google)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"code\": \"<GOOGLE_AUTHORIZATION_CODE>\"\n    }\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ],
+          "auth": {
+            "type": "noauth"
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "auth": {
+        "type": "noauth"
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "05 - Registration with Flow Native APIs",
+      "item": [
+        {
+          "name": "05.01 - Registration With Username & Password",
+          "item": [
+            {
+              "name": "01 - Update Application",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{accessToken}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"auth_flow_id\": \"{{basicAuthFlowGraphId}}\",\n    \"registration_flow_id\": \"{{basicRegistrationFlowGraphId}}\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"token_endpoint_auth_method\": \"none\",\n                \"pkce_required\": true,\n                \"public_client\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"access_token\": {\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "applications",
+                    "{{loginApplicationId}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "02 - Initiate Registration",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Parse the JSON response",
+                      "const jsonResponse = pm.response.json();",
+                      "",
+                      "// Extract the flowId from the response",
+                      "const flowId = jsonResponse.flowId;",
+                      "",
+                      "// Store it as a collection variable",
+                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"applicationId\": \"{{loginApplicationId}}\",\n    \"flowType\": \"REGISTRATION\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "03 - Continue Registration",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"kurt\",\n        \"password\": \"kurt@123\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "04 - Complete Registration",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"firstName\": \"Kurt\",\n        \"lastName\": \"Weller\",\n        \"email\": \"kurt@fbi.com\",\n        \"mobileNumber\": \"+94712345688\"\n    },\n    \"action\": \"action_002\"\n}\n",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/flow/execute",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "flow",
+                    "execute"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ],
+          "auth": {
+            "type": "noauth"
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {},
+                "exec": [
+                  ""
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "auth": {
+        "type": "noauth"
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "06 - Authenticate with OAuth (Standard Based)",
+      "item": [
+        {
+          "name": "01 - Update Application",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{accessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Demo App\",\n    \"description\": \"Application to demonstrate app native login\",\n    \"auth_flow_id\": \"{{basicAuthFlowGraphId}}\",\n    \"is_registration_flow_enabled\": true,\n    \"allowed_user_types\": [\n        \"{{demoSchemaName}}\"\n    ],\n    \"token\": {\n        \"issuer\": \"thunder.wso2.com\",\n        \"validity_period\": 3600,\n        \"user_attributes\": [\n            \"email\",\n            \"username\",\n            \"firstName\",\n            \"lastName\",\n            \"groups\"\n        ]\n    },\n    \"certificate\": {\n        \"type\": \"NONE\",\n        \"value\": \"\"\n    },\n    \"inbound_auth_config\": [\n        {\n            \"type\": \"oauth2\",\n            \"config\": {\n                \"client_id\": \"{{LOGIN_APPLICATION_CLIENT_ID}}\",\n                \"redirect_uris\": [\n                    \"{{LOGIN_APPLICATION_REDIRECT_URI}}\"\n                ],\n                \"grant_types\": [\n                    \"authorization_code\",\n                    \"refresh_token\"\n                ],\n                \"response_types\": [\n                    \"code\"\n                ],\n                \"token_endpoint_auth_method\": \"none\",\n                \"pkce_required\": true,\n                \"public_client\": true,\n                \"token\": {\n                    \"issuer\": \"thunder.wso2.com\",\n                    \"access_token\": {\n                        \"validity_period\": 7200,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ]\n                    },\n                    \"id_token\": {\n                        \"validity_period\": 3600,\n                        \"user_attributes\": [\n                            \"email\",\n                            \"username\",\n                            \"firstName\",\n                            \"lastName\",\n                            \"groups\"\n                        ],\n                        \"scope_claims\": {\n                            \"email\": [\n                                \"email\"\n                            ],\n                            \"group\": [\n                                \"group\"\n                            ],\n                            \"profile\": [\n                                \"username\",\n                                \"family_name\",\n                                \"given_name\"\n                            ]\n                        }\n                    }\n                }\n            }\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/applications/{{loginApplicationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "applications",
+                "{{loginApplicationId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "02 - Initiate Authorization",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Should redirect to login\", function() {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([302, 303, 307]);",
+                  "});",
+                  "const location = pm.response.headers.get(\"Location\");",
+                  "if (location) {",
+                  "    const url = new URL(location);",
+                  "    const authId = url.searchParams.get(\"authId\");",
+                  "    const flowId = url.searchParams.get(\"flowId\");",
+                  "    ",
+                  "    pm.collectionVariables.set(\"auth_std_auth_id\", authId);",
+                  "    pm.collectionVariables.set(\"auth_std_flow_id\", flowId);",
+                  "    ",
+                  "    console.log(\"AuthId:\", authId);",
+                  "    console.log(\"FlowId:\", flowId);",
+                  "}",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/oauth2/authorize?client_id={{LOGIN_APPLICATION_CLIENT_ID}}&redirect_uri={{LOGIN_APPLICATION_REDIRECT_URI}}&response_type=code&state=test-state&code_challenge=wxmTR5SueS1wRSqFa5LMXJ7BgjZ-dubItVtJjblSVKg&code_challenge_method=S256",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "oauth2",
+                "authorize"
+              ],
+              "query": [
+                {
+                  "key": "client_id",
+                  "value": "{{LOGIN_APPLICATION_CLIENT_ID}}"
+                },
+                {
+                  "key": "redirect_uri",
+                  "value": "{{LOGIN_APPLICATION_REDIRECT_URI}}"
+                },
+                {
+                  "key": "response_type",
+                  "value": "code"
+                },
+                {
+                  "key": "state",
+                  "value": "test-state"
+                },
+                {
+                  "key": "code_challenge",
+                  "value": "wxmTR5SueS1wRSqFa5LMXJ7BgjZ-dubItVtJjblSVKg"
+                },
+                {
+                  "key": "code_challenge_method",
+                  "value": "S256"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "03 - Initiate Flow Authentication",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "packages": {},
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"flowId\": \"{{auth_std_flow_id}}\"\n}\n",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flow/execute",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flow",
+                "execute"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "04 - Execute Flow Authentication",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Authentication successful\", function() {",
+                  "    pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const resp = pm.response.json();",
+                  "if (resp.flowStatus === \"COMPLETE\" && resp.assertion) {",
+                  "    pm.collectionVariables.set(\"auth_std_assertion\", resp.assertion);",
+                  "    console.log(\"✓ Authentication complete, assertion obtained\");",
+                  "} else {",
+                  "    console.log(\"✗ Authentication failed:\", resp.failureReason || resp.flowStatus);",
+                  "}",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"flowId\": \"{{auth_std_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/flow/execute",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "flow",
+                "execute"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "05 - Complete Authorization",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Authorization completed\", function() {",
+                  "    pm.expect(pm.response.code).to.equal(200);",
+                  "});",
+                  "const resp = pm.response.json();",
+                  "if (resp.redirect_uri) {",
+                  "    const url = new URL(resp.redirect_uri);",
+                  "    const code = url.searchParams.get(\"code\");",
+                  "    pm.collectionVariables.set(\"auth_std_auth_code\", code);",
+                  "    console.log(\"✓ Authorization code obtained\");",
+                  "}",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"authId\": \"{{auth_std_auth_id}}\",\n    \"assertion\": \"{{auth_std_assertion}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/oauth2/authorize",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "oauth2",
+                "authorize"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "06 - Exchange Code for Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "packages": {},
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "authorization_code",
+                  "type": "text",
+                  "uuid": "77f67144-1112-4773-b322-171030e13d31"
+                },
+                {
+                  "key": "code",
+                  "value": "{{auth_std_auth_code}}",
+                  "type": "text",
+                  "uuid": "d0096182-585d-4066-927f-52b1791b330c"
+                },
+                {
+                  "key": "redirect_uri",
+                  "value": "{{LOGIN_APPLICATION_REDIRECT_URI}}",
+                  "type": "text",
+                  "uuid": "72d50dd8-c9d5-4b1e-88c6-f9522b85a79e"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{LOGIN_APPLICATION_CLIENT_ID}}",
+                  "type": "text",
+                  "uuid": "677ae63e-a94d-482a-aa1c-216b111db30b"
+                },
+                {
+                  "key": "code_verifier",
+                  "value": "FkWZduGU2HVVMuyOh5banOevZOYgLIH-zoeAj5CJLG4",
+                  "type": "text",
+                  "uuid": "25e13a0f-8751-4d85-9100-14c7dca21bdd"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/oauth2/token",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "oauth2",
+                "token"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "auth": {
+        "type": "noauth"
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{accessToken}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          "// Skip token check for auth-related endpoints",
+          "const skipPaths = [\"/oauth2/authorize\", \"/oauth2/token\", \"/flow/execute\"];",
+          "const requestPath = pm.request.url.getPath();",
+          "if (skipPaths.some(path => requestPath.includes(path))) {",
+          "    return;",
+          "}",
+          "// Check if we have a valid token",
+          "const accessToken = pm.environment.get(\"accessToken\");",
+          "const expiresAt = parseInt(pm.environment.get(\"expiresAt\") || \"0\");",
+          "const currentTime = Date.now();",
+          "const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes",
+          "if (accessToken && expiresAt && (currentTime < expiresAt - REFRESH_BUFFER_MS)) {",
+          "    console.log(\"✓ Token still valid\");",
+          "    return;",
+          "}",
+          "// Try to refresh token if we have one",
+          "const refreshToken = pm.environment.get(\"refreshToken\");",
+          "if (refreshToken) {",
+          "    console.log(\"⟳ Attempting token refresh...\");",
+          "    ",
+          "    pm.sendRequest({",
+          "        url: pm.environment.get(\"baseUrl\") + \"/oauth2/token\",",
+          "        method: 'POST',",
+          "        header: { 'Content-Type': 'application/x-www-form-urlencoded' },",
+          "        body: {",
+          "            mode: 'urlencoded',",
+          "            urlencoded: [",
+          "                { key: 'grant_type', value: 'refresh_token' },",
+          "                { key: 'refresh_token', value: refreshToken },",
+          "                { key: 'client_id', value: pm.environment.get(\"MGT_TOKEN_APP_CLIENT_ID\") }",
+          "            ]",
+          "        }",
+          "    }, (err, res) => {",
+          "        if (!err && res.code === 200) {",
+          "            const token = res.json();",
+          "            pm.environment.set(\"accessToken\", token.access_token);",
+          "            pm.environment.set(\"expiresAt\", String(Date.now() + (token.expires_in * 1000)));",
+          "            if (token.refresh_token) {",
+          "                pm.environment.set(\"refreshToken\", token.refresh_token);",
+          "            }",
+          "            console.log(\"✓ Token refreshed successfully\");",
+          "        } else {",
+          "            console.log(\"✗ Token refresh failed - run auth flow manually\");",
+          "            pm.environment.set(\"accessToken\", \"\");",
+          "        }",
+          "    });",
+          "} else {",
+          "    console.log(\"⚠ No token available - run the Auth folder requests first\");",
+          "}",
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "sms_otp_session_token",
+      "value": ""
+    },
+    {
+      "key": "first_factor_assertion",
+      "value": ""
+    },
+    {
+      "key": "google_session_token",
+      "value": ""
+    },
+    {
+      "key": "github_session_token",
+      "value": ""
+    },
+    {
+      "key": "asgardeo_session_token",
+      "value": ""
+    },
+    {
+      "key": "exec_flow_id",
+      "value": ""
+    },
+    {
+      "key": "auth_std_auth_id",
+      "value": ""
+    },
+    {
+      "key": "auth_std_flow_id",
+      "value": ""
+    },
+    {
+      "key": "auth_std_assertion",
+      "value": ""
+    },
+    {
+      "key": "auth_std_auth_code",
+      "value": "",
+      "type": "string"
+    }
+  ]
+}

--- a/samples/api/postman/authentication/environment.json
+++ b/samples/api/postman/authentication/environment.json
@@ -1,0 +1,328 @@
+{
+	"id": "ec72ce9d-77b9-403c-9737-c85fc831741c",
+	"name": "Thunder",
+	"values": [
+		{
+			"key": "scheme",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "host",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "port",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "baseUrl",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "accessToken",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "refreshToken",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "expiresAt",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "codeVerifier",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "codeChallenge",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "authId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "flowId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "assertion",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "authCode",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "MGT_TOKEN_APP_CLIENT_ID",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "MGT_TOKEN_APP_REDIRECT_URI",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "MGT_TOKEN_SCOPE",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ADMIN_USERNAME",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ADMIN_PASSWORD",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "demoOuId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoOuHandle",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoSchemaId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoSchemaName",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoLoginUser1Username",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoLoginUser1Password",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "demoLoginUser1Email",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoLoginUser1Mobile",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "MESSAGE_NOTIFICATION_SENDER_URL",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "messageNotificationSenderId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "GOOGLE_CLIENT_ID",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "GOOGLE_CLIENT_SECRET",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "FED_IDP_REDIRECT_URI",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "googleIDPId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "GITHUB_CLIENT_ID",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "GITHUB_CLIENT_SECRET",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "githubIDPId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ASGARDEO_CLIENT_ID",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "ASGARDEO_CLIENT_SECRET",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "ASGARDEO_BASE_URI",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "asgardeoIDPId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoGoogleUserSub",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "demoGoogleUserEmail",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoGithubUserSub",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "demoGithubUserEmail",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "demoAsgardeoUserSub",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "demoAsgardeoUserEmail",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "LOGIN_APPLICATION_CLIENT_ID",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "LOGIN_APPLICATION_REDIRECT_URI",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "loginApplicationId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "basicAuthFlowGraphId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "smsAuthFlowGraphId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "mfaAuthFlowGraphId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "multiOptionAuthFlowGraphId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "basicRegistrationFlowGraphId",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"color": 62,
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2026-01-26T05:39:44.821Z",
+	"_postman_exported_using": "Postman/11.81.4"
+}


### PR DESCRIPTION
### Purpose
This pull request introduces a comprehensive Postman demo for Thunder's authentication and registration APIs. It adds detailed documentation and a ready-to-use environment configuration template, making it much easier for users to try out and understand various authentication flows, including social logins, MFA, and OAuth-based scenarios.

<img width="1047" height="423" alt="Screenshot 2026-01-26 at 11 16 48 AM" src="https://github.com/user-attachments/assets/00886088-bda4-41e8-99af-d9eb4950b016" />

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
