### PR TITLE
Add passkey template and components to the login flow builder

### DIFF
--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/__tests__/CommonWidgetPropertyFactory.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/__tests__/CommonWidgetPropertyFactory.test.tsx
@@ -121,10 +121,10 @@ describe('CommonWidgetPropertyFactory', () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it('should return null for PasskeyEnrollment widget', () => {
+    it('should return null for PasskeyAuthentication widget', () => {
       const resource: Resource = {
         id: 'widget-9',
-        type: WidgetTypes.PasskeyEnrollment,
+        type: WidgetTypes.PasskeyAuthentication,
         config: {},
       } as Resource;
 

--- a/frontend/apps/thunder-develop/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/constants/VisualFlowConstants.ts
@@ -55,7 +55,7 @@ class VisualFlowConstants {
     TemplateTypes.Basic,
     TemplateTypes.BasicFederated,
     TemplateTypes.Blank,
-    TemplateTypes.BasicPasskey,
+    TemplateTypes.PasskeyLogin,
     BlockTypes.Form, // Form is allowed for drop detection, but handled specially to show dialog
     // Input types are allowed for drop detection, but handled specially to show dialog
     ElementTypes.TextInput,
@@ -76,7 +76,7 @@ class VisualFlowConstants {
     WidgetTypes.FacebookFederation,
     WidgetTypes.MicrosoftFederation,
     WidgetTypes.GithubFederation,
-    WidgetTypes.PasskeyEnrollment,
+    WidgetTypes.PasskeyAuthentication,
     WidgetTypes.MagicLink,
   ];
 
@@ -106,7 +106,7 @@ class VisualFlowConstants {
     WidgetTypes.FacebookFederation,
     WidgetTypes.MicrosoftFederation,
     WidgetTypes.GithubFederation,
-    WidgetTypes.PasskeyEnrollment,
+    WidgetTypes.PasskeyAuthentication,
     WidgetTypes.MagicLink,
   ];
 

--- a/frontend/apps/thunder-develop/src/features/flows/data/steps.json
+++ b/frontend/apps/thunder-develop/src/features/flows/data/steps.json
@@ -175,6 +175,57 @@
   {
     "resourceType": "STEP",
     "category": "INTERFACE",
+    "type": "VIEW",
+    "display": {
+      "label": "Passkey View",
+      "image": "assets/images/icons/passkey.svg",
+      "showOnResourcePanel": true
+    },
+    "data": {
+      "components": [
+        {
+          "id": "{{ID}}",
+          "category": "DISPLAY",
+          "type": "TEXT",
+          "variant": "HEADING_3",
+          "label": "Sign In"
+        },
+        {
+          "id": "{{ID}}",
+          "category": "BLOCK",
+          "type": "BLOCK",
+          "components": [
+            {
+              "id": "{{ID}}",
+              "category": "FIELD",
+              "type": "TEXT_INPUT",
+              "ref": "username",
+              "inputType": "text",
+              "hint": "",
+              "label": "Username",
+              "required": true,
+              "placeholder": "Enter your username"
+            },
+            {
+              "id": "{{ID}}",
+              "category": "ACTION",
+              "type": "ACTION",
+              "variant": "PRIMARY",
+              "eventType": "SUBMIT",
+              "label": "Sign In with Passkey",
+              "action": {
+                "type": "NEXT",
+                "next": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "INTERFACE",
     "type": "END",
     "version": "0.1.0",
     "deprecated": false,

--- a/frontend/apps/thunder-develop/src/features/flows/models/__tests__/steps.test.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/__tests__/steps.test.ts
@@ -106,10 +106,6 @@ describe('steps models', () => {
       expect(ExecutionTypes.GithubFederation).toBe('GithubOAuthExecutor');
     });
 
-    it('should have PasskeyEnrollment type', () => {
-      expect(ExecutionTypes.PasskeyEnrollment).toBe('FIDO2Executor');
-    });
-
     it('should have ConfirmationCode type', () => {
       expect(ExecutionTypes.ConfirmationCode).toBe('ConfirmationCodeValidationExecutor');
     });

--- a/frontend/apps/thunder-develop/src/features/flows/models/steps.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/steps.ts
@@ -87,7 +87,7 @@ export const ExecutionTypes = {
   FacebookFederation: 'FacebookExecutor',
   MicrosoftFederation: 'Office365Executor',
   GithubFederation: 'GithubOAuthExecutor',
-  PasskeyEnrollment: 'FIDO2Executor',
+  PasskeyAuth: 'PasskeyAuthExecutor',
   ConfirmationCode: 'ConfirmationCodeValidationExecutor',
   MagicLinkExecutor: 'MagicLinkExecutor',
   SendEmailOTP: 'SendEmailOTPExecutor',

--- a/frontend/apps/thunder-develop/src/features/flows/models/templates.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/templates.ts
@@ -76,7 +76,7 @@ export const TemplateTypes = {
   Basic: 'BASIC',
   BasicFederated: 'BASIC_FEDERATED',
   GeneratedWithAI: 'GENERATE_WITH_AI',
-  BasicPasskey: 'BASIC_PASSKEY',
+  PasskeyLogin: 'PASSKEY_LOGIN',
   Default: 'DEFAULT',
 } as const;
 

--- a/frontend/apps/thunder-develop/src/features/flows/models/widget.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/widget.ts
@@ -48,7 +48,7 @@ export const WidgetTypes = {
   FacebookFederation: 'FACEBOOK_FEDERATION',
   MicrosoftFederation: 'MICROSOFT_FEDERATION',
   GithubFederation: 'GITHUB_FEDERATION',
-  PasskeyEnrollment: 'PASSKEY_ENROLLMENT',
+  PasskeyAuthentication: 'PASSKEY_AUTHENTICATION',
   MagicLink: 'MAGIC_LINK',
 } as const;
 

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/executors.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/executors.json
@@ -158,6 +158,52 @@
     "category": "EXECUTOR",
     "type": "TASK_EXECUTION",
     "display": {
+      "header": "Passkey Executor",
+      "label": "Passkey Challenge",
+      "image": "assets/images/icons/fingerprint.svg",
+      "showOnResourcePanel": true
+    },
+    "data": {
+      "action": {
+        "type": "EXECUTOR",
+        "executor": {
+          "name": "PasskeyAuthExecutor",
+          "mode": "challenge"
+        },
+        "next": ""
+      },
+      "properties": {
+        "relyingPartyId": "localhost",
+        "relyingPartyName": "Thunder"
+      }
+    }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "EXECUTOR",
+    "type": "TASK_EXECUTION",
+    "display": {
+      "header": "Passkey Executor",
+      "label": "Passkey Verify",
+      "image": "assets/images/icons/fingerprint.svg",
+      "showOnResourcePanel": true
+    },
+    "data": {
+      "action": {
+        "type": "EXECUTOR",
+        "executor": {
+          "name": "PasskeyAuthExecutor",
+          "mode": "verify"
+        },
+        "next": ""
+      }
+    }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "EXECUTOR",
+    "type": "TASK_EXECUTION",
+    "display": {
       "header": "Identifying Executor",
       "label": "Identifying",
       "image": "assets/images/icons/magnifying-glass.svg",
@@ -387,26 +433,6 @@
     "category": "EXECUTOR",
     "type": "TASK_EXECUTION",
     "display": {
-      "header": "Passkey Executor",
-      "label": "Passkey",
-      "image": "assets/images/icons/fingerprint.svg",
-      "showOnResourcePanel": false
-    },
-    "data": {
-      "action": {
-        "type": "EXECUTOR",
-        "executor": {
-          "name": "FIDO2Executor"
-        },
-        "next": ""
-      }
-    }
-  },
-  {
-    "resourceType": "STEP",
-    "category": "EXECUTOR",
-    "type": "TASK_EXECUTION",
-    "display": {
       "header": "Magic Link Executor",
       "label": "Magic Link",
       "image": "assets/images/icons/link.svg",
@@ -477,6 +503,26 @@
         "type": "EXECUTOR",
         "executor": {
           "name": "VerifyEmailOTPExecutor"
+        },
+        "next": ""
+      }
+    }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "EXECUTOR",
+    "type": "TASK_EXECUTION",
+    "display": {
+      "header": "Identity Resolver",
+      "label": "Identity Resolver",
+      "image": "assets/images/icons/magnifying-glass.svg",
+      "showOnResourcePanel": true
+    },
+    "data": {
+      "action": {
+        "type": "EXECUTOR",
+        "executor": {
+          "name": "IdentityResolver"
         },
         "next": ""
       }

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
@@ -522,141 +522,6 @@
   {
     "resourceType": "TEMPLATE",
     "category": "STARTER",
-    "type": "BASIC_PASSKEY",
-    "display": {
-      "label": "Basic + Passkey",
-      "description": "Basic login experience with passkey authentication",
-      "image": "assets/images/icons/fingerprint.svg",
-      "showOnResourcePanel": false
-    },
-    "config": {
-      "data": {
-        "__generationMeta__": {
-          "defaultPropertySelectorId": "{{PASSKEY_ENROLLMENT_STEP_ID}}",
-          "replacers": [
-            {
-              "key": "PASSKEY_ENROLLMENT_STEP_ID",
-              "type": "ID"
-            },
-            {
-              "key": "AUTH_ASSERT_EXECUTOR_ID",
-              "type": "ID"
-            }
-          ]
-        },
-        "steps": [
-          {
-            "id": "{{ID}}",
-            "type": "VIEW",
-            "size": {
-              "width": 350,
-              "height": 291
-            },
-            "position": {
-              "x": 0,
-              "y": 330
-            },
-            "data": {
-              "components": [
-                {
-                  "id": "{{ID}}",
-                  "category": "DISPLAY",
-                  "type": "TEXT",
-                  "variant": "HEADING_3",
-                  "label": "Login"
-                },
-                {
-                  "id": "{{ID}}",
-                  "category": "ACTION",
-                  "type": "BLOCK",
-                  "components": [
-                    {
-                      "id": "{{ID}}",
-                      "category": "ACTION",
-                      "type": "ACTION",
-                      "variant": "PRIMARY",
-                      "eventType": "TRIGGER",
-                      "label": "Login with Passkey",
-                      "action": {
-                        "type": "NEXT",
-                        "next": "{{PASSKEY_ENROLLMENT_STEP_ID}}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "id": "{{PASSKEY_ENROLLMENT_STEP_ID}}",
-            "type": "TASK_EXECUTION",
-            "size": {
-              "width": 350,
-              "height": 291
-            },
-            "position": {
-              "x": 500,
-              "y": 330
-            },
-            "data": {
-              "action": {
-                "type": "EXECUTOR",
-                "executor": {
-                  "name": "FIDO2Executor"
-                },
-                "next": "{{AUTH_ASSERT_EXECUTOR_ID}}"
-              }
-            }
-          },
-          {
-            "id": "{{AUTH_ASSERT_EXECUTOR_ID}}",
-            "type": "TASK_EXECUTION",
-            "size": {
-              "width": 200,
-              "height": 113
-            },
-            "position": {
-              "x": 890,
-              "y": 400
-            },
-            "data": {
-              "action": {
-                "type": "EXECUTOR",
-                "executor": {
-                  "name": "AuthAssertExecutor"
-                },
-                "next": "END"
-              }
-            }
-          },
-          {
-            "id": "END",
-            "type": "END",
-            "size": {
-              "width": 85,
-              "height": 34
-            },
-            "position": {
-              "x": 1280,
-              "y": 330
-            },
-            "config": {},
-            "data": {
-              "action": {
-                "type": "EXECUTOR",
-                "executor": {
-                  "name": "LoginCompletionExecutor"
-                }
-              }
-            }
-          }
-        ]
-      }
-    }
-  },
-  {
-    "resourceType": "TEMPLATE",
-    "category": "STARTER",
     "type": "BASIC_SMS_OTP_MFA",
     "display": {
       "label": "Password + SMS OTP",
@@ -1187,6 +1052,226 @@
             "position": {
               "x": 1812,
               "y": 466
+            },
+            "config": {},
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "LoginCompletionExecutor"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "resourceType": "TEMPLATE",
+    "category": "STARTER",
+    "type": "PASSKEY_LOGIN",
+    "display": {
+      "label": "Passkey Login",
+      "description": "Passwordless login experience using passkeys",
+      "image": "assets/images/icons/fingerprint.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "defaultPropertySelectorId": "{{PASSKEY_CHALLENGE_EXECUTOR_ID}}",
+          "replacers": [
+            {
+              "key": "IDENTITY_RESOLVER_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PASSKEY_CHALLENGE_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PASSKEY_VERIFY_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "AUTH_ASSERT_EXECUTOR_ID",
+              "type": "ID"
+            }
+          ]
+        },
+        "steps": [
+          {
+            "id": "start",
+            "type": "START",
+            "size": {
+              "width": 101,
+              "height": 34
+            },
+            "position": {
+              "x": 62,
+              "y": 330
+            }
+          },
+          {
+            "id": "{{ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 350,
+              "height": 500
+            },
+            "position": {
+              "x": 310,
+              "y": 97
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "HEADING_3",
+                  "label": "Sign In"
+                },
+                {
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "id": "{{ID}}",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "FIELD",
+                      "type": "TEXT_INPUT",
+                      "inputType": "text",
+                      "hint": "",
+                      "label": "Username",
+                      "required": true,
+                      "placeholder": "Enter your username",
+                      "ref": "username"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Sign In with Passkey",
+                      "action": {
+                        "type": "NEXT",
+                        "next": "{{IDENTITY_RESOLVER_EXECUTOR_ID}}"
+                      }
+                    },
+                    {
+                      "category": "DISPLAY",
+                      "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{application.selfRegisterUrl}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
+                      "id": "{{ID}}",
+                      "type": "RICH_TEXT"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{IDENTITY_RESOLVER_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 820,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "IdentityResolver"
+                },
+                "next": "{{PASSKEY_CHALLENGE_EXECUTOR_ID}}"
+              }
+            }
+          },
+          {
+            "id": "{{PASSKEY_CHALLENGE_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1200,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "PasskeyAuthExecutor",
+                  "mode": "challenge"
+                },
+                "next": "{{PASSKEY_VERIFY_EXECUTOR_ID}}"
+              },
+              "properties": {
+                "relyingPartyId": "localhost",
+                "relyingPartyName": "Thunder"
+              }
+            }
+          },
+          {
+            "id": "{{PASSKEY_VERIFY_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1580,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "PasskeyAuthExecutor",
+                  "mode": "verify"
+                },
+                "next": "{{AUTH_ASSERT_EXECUTOR_ID}}"
+              }
+            }
+          },
+          {
+            "id": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 244,
+              "height": 113
+            },
+            "position": {
+              "x": 1960,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "AuthAssertExecutor"
+                },
+                "next": "END"
+              }
+            }
+          },
+          {
+            "id": "END",
+            "type": "END",
+            "size": {
+              "width": 85,
+              "height": 34
+            },
+            "position": {
+              "x": 2380,
+              "y": 330
             },
             "config": {},
             "data": {

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/widgets.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/widgets.json
@@ -486,6 +486,10 @@
         "__generationMeta__": {
           "replacers": [
             {
+              "key": "MOBILE_NUMBER_VIEW_ID",
+              "type": "ID"
+            },
+            {
               "key": "SMS_SEND_EXECUTOR_ID",
               "type": "ID"
             },
@@ -524,8 +528,61 @@
                       "eventType": "TRIGGER",
                       "label": "Continue with SMS OTP",
                       "action": {
-                        "next": "{{SMS_SEND_EXECUTOR_ID}}",
+                        "next": "{{MOBILE_NUMBER_VIEW_ID}}",
                         "type": "NEXT"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{MOBILE_NUMBER_VIEW_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 350,
+              "height": 300
+            },
+            "position": {
+              "x": 690,
+              "y": 50
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "HEADING_3",
+                  "label": "Enter Mobile Number"
+                },
+                {
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "config": {},
+                  "id": "{{ID}}",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "FIELD",
+                      "type": "PHONE_INPUT",
+                      "hint": "",
+                      "label": "Mobile Number",
+                      "required": true,
+                      "placeholder": "Enter your mobile number",
+                      "ref": "mobile"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Send OTP",
+                      "action": {
+                        "type": "NEXT",
+                        "next": "{{SMS_SEND_EXECUTOR_ID}}"
                       }
                     }
                   ]
@@ -542,7 +599,7 @@
             },
             "position": {
               "x": 690,
-              "y": 200
+              "y": 400
             },
             "data": {
               "action": {
@@ -670,18 +727,30 @@
     "category": "FLOW",
     "type": "PASSKEY_AUTHENTICATION",
     "display": {
-      "label": "Continue with Passkey",
-      "description": "Login experience with Passkeys",
+      "label": "Sign In with Passkey",
+      "description": "Passwordless login experience with Passkeys",
       "image": "assets/images/icons/fingerprint.svg",
-      "showOnResourcePanel": false
+      "showOnResourcePanel": true
     },
     "config": {
       "data": {
         "__generationMeta__": {
-          "defaultPropertySelectorId": "{{PASSKEY_EXECUTION_STEP_ID}}",
+          "defaultPropertySelectorId": "{{PASSKEY_CHALLENGE_EXECUTOR_ID}}",
           "replacers": [
             {
-              "key": "PASSKEY_EXECUTION_STEP_ID",
+              "key": "USERNAME_VIEW_ID",
+              "type": "ID"
+            },
+            {
+              "key": "IDENTITY_RESOLVER_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PASSKEY_CHALLENGE_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PASSKEY_VERIFY_EXECUTOR_ID",
               "type": "ID"
             },
             {
@@ -709,11 +778,11 @@
                       "type": "ACTION",
                       "variant": "SOCIAL",
                       "eventType": "TRIGGER",
-                      "label": "Continue with Passkey",
+                      "label": "Sign In with Passkey",
                       "image": "assets/images/icons/fingerprint.svg",
                       "action": {
                         "type": "NEXT",
-                        "next": "{{PASSKEY_EXECUTION_STEP_ID}}"
+                        "next": "{{USERNAME_VIEW_ID}}"
                       }
                     }
                   ]
@@ -722,11 +791,86 @@
             }
           },
           {
-            "id": "{{PASSKEY_EXECUTION_STEP_ID}}",
-            "type": "TASK_EXECUTION",
+            "id": "{{USERNAME_VIEW_ID}}",
+            "type": "VIEW",
             "size": {
               "width": 350,
-              "height": 291
+              "height": 300
+            },
+            "position": {
+              "x": 690,
+              "y": 200
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "HEADING_3",
+                  "label": "Sign In with Passkey"
+                },
+                {
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "config": {},
+                  "id": "{{ID}}",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "FIELD",
+                      "type": "TEXT_INPUT",
+                      "inputType": "text",
+                      "hint": "",
+                      "label": "Username",
+                      "required": true,
+                      "placeholder": "Enter your username",
+                      "ref": "username"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Continue",
+                      "action": {
+                        "type": "NEXT",
+                        "next": "{{IDENTITY_RESOLVER_EXECUTOR_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{IDENTITY_RESOLVER_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 690,
+              "y": 350
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "IdentityResolver"
+                },
+                "next": "{{PASSKEY_CHALLENGE_EXECUTOR_ID}}"
+              }
+            }
+          },
+          {
+            "id": "{{PASSKEY_CHALLENGE_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
             },
             "position": {
               "x": 690,
@@ -736,7 +880,34 @@
               "action": {
                 "type": "EXECUTOR",
                 "executor": {
-                  "name": "FIDO2Executor"
+                  "name": "PasskeyAuthExecutor",
+                  "mode": "challenge"
+                },
+                "next": "{{PASSKEY_VERIFY_EXECUTOR_ID}}"
+              },
+              "properties": {
+                "relyingPartyId": "localhost",
+                "relyingPartyName": "Thunder"
+              }
+            }
+          },
+          {
+            "id": "{{PASSKEY_VERIFY_EXECUTOR_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 690,
+              "y": 650
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "PasskeyAuthExecutor",
+                  "mode": "verify"
                 },
                 "next": "{{AUTH_ASSERT_EXECUTOR_ID}}"
               }
@@ -750,8 +921,8 @@
               "height": 113
             },
             "position": {
-              "x": 1080,
-              "y": 570
+              "x": 690,
+              "y": 800
             },
             "data": {
               "action": {

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -1127,7 +1127,7 @@ const translations = {
     'core.executions.names.github': 'GitHub',
     'core.executions.names.facebook': 'Facebook',
     'core.executions.names.microsoft': 'Microsoft',
-    'core.executions.names.passkeyEnrollment': 'Passkey Enrollment',
+    'core.executions.names.PasskeyAuthentication': 'Passkey Authentication',
     'core.executions.names.confirmationCode': 'Confirmation Code',
     'core.executions.names.magicLink': 'Magic Link',
     'core.executions.names.sendEmailOTP': 'Send Email OTP',
@@ -1149,6 +1149,13 @@ const translations = {
     'core.executions.smsOtp.sender.required': 'Notification sender is required and must be selected.',
     'core.executions.smsOtp.sender.noSenders':
       'No notification senders available. Please create a notification sender first.',
+
+    // Passkey executor modes
+    'core.executions.passkey.mode.challenge': 'Challenge',
+    'core.executions.passkey.mode.verify': 'Verify',
+    'core.executions.passkey.mode.label': 'Mode',
+    'core.executions.passkey.mode.placeholder': 'Select a mode',
+    'core.executions.passkey.description': 'Configure the Passkey executor settings.',
 
     // Execution steps - tooltips and messages
     'core.executions.tooltip.configurationHint': 'Click to configure this step',


### PR DESCRIPTION
### Purpose
This pull request introduces significant updates to the Passkey authentication flow in the Thunder Develop frontend, including new executor and view steps, improved configuration options for Passkey executors, and the removal of legacy Passkey template support. The changes also update naming conventions and add UI support for Passkey mode selection.

**Passkey Authentication Flow Enhancements**

* Added new Passkey authentication executor steps (`PasskeyAuthExecutor`) for both "challenge" and "verify" modes, with corresponding configuration and display settings in `executors.json`.
* Introduced a new "Passkey View" interface step in `steps.json` for Passkey login, including username input and a "Sign In with Passkey" action.
* Added UI logic and constants to support Passkey executor mode selection (challenge/verify) in the resource property panel, including a new `PASSKEY_MODES` array and handler in `ExecutionExtendedProperties.tsx`. [[1]](diffhunk://#diff-4cb26c658f4d4a908a0d95b3a8a0bf5db39d204c0c04a18ef784f8ffb2bd7874R54-R61) [[2]](diffhunk://#diff-4cb26c658f4d4a908a0d95b3a8a0bf5db39d204c0c04a18ef784f8ffb2bd7874R192-R216) [[3]](diffhunk://#diff-4cb26c658f4d4a908a0d95b3a8a0bf5db39d204c0c04a18ef784f8ffb2bd7874R283-R313)

**Naming and Template Updates**

* Renamed template and type identifiers: replaced `BasicPasskey`/`BASIC_PASSKEY` with `PasskeyLogin`/`PASSKEY_LOGIN` in constants and models for clarity and consistency. [[1]](diffhunk://#diff-0481757480180804d7c438472cf9d7efefa4e4fcb22ef43fc199f36e2d4e8a2bL58-R58) [[2]](diffhunk://#diff-4bf5626428f2b1c3997d33470a0e819d48cd84db509a3c286814b12a739bc8ccL79-R79)
* Removed the legacy "Basic + Passkey" template from `templates.json`, reflecting the new Passkey flow structure.

**Executor and Widget Model Adjustments**

* Updated the executor types: replaced `PasskeyEnrollment`/`FIDO2Executor` with `PasskeyAuth`/`PasskeyAuthExecutor` in step models, and added `PasskeyAuthentication` to widget types. [[1]](diffhunk://#diff-90b2577493fa26e2c4d5bfde1aadd8728a2a789294ad0563c23765303dbfaf71L90-R90) [[2]](diffhunk://#diff-28456d031b9038451555b1fe386af70dbaec9b1dc41b5a2a3640252006da8eeaR52)
* Cleaned up related tests to remove references to the old `PasskeyEnrollment` type.

**Executor Step Improvements**

* Updated and clarified display and executor names for Magic Link, Confirmation Code, Email OTP, and Identity Resolver steps in `executors.json` for better accuracy and consistency. [[1]](diffhunk://#diff-aae065b38af260747834102f0fa627ddee66efa0a92c6acc5e9c9d964fd00baaL390-R445) [[2]](diffhunk://#diff-aae065b38af260747834102f0fa627ddee66efa0a92c6acc5e9c9d964fd00baaL410-R465) [[3]](diffhunk://#diff-aae065b38af260747834102f0fa627ddee66efa0a92c6acc5e9c9d964fd00baaL430-R485) [[4]](diffhunk://#diff-aae065b38af260747834102f0fa627ddee66efa0a92c6acc5e9c9d964fd00baaL451-R505) [[5]](diffhunk://#diff-aae065b38af260747834102f0fa627ddee66efa0a92c6acc5e9c9d964fd00baaL470-R525)

### Related Issues
- https://github.com/asgardeo/thunder/issues/1174

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
