### PR TITLE
Update Helm image tag to 0.19.0

### DIFF
--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -41,7 +41,7 @@ deployment:
     # -- Container image digest
     digest: ""
     # -- Container image tag. Either "tag" or "digest" should be defined
-    tag: "0.16.0"
+    tag: "0.19.0"
     pullPolicy: "Always"
   startupProbe:
     initialDelaySeconds: 1


### PR DESCRIPTION
## Description
Updates the Helm values.yaml image tag from 0.16.0 to 0.19.0.

## Changes
- Updated `install/helm/values.yaml` line 44: `tag: "0.16.0"` → `tag: "0.19.0"`

Fixes #1177