### PR TITLE
Add MCP authorization 

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -162,7 +162,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	oauth.Initialize(mux, applicationService, userService, jwtService, flowExecService, observabilitySvc, pkiService)
 
 	// Initialize MCP server.
-	mcp.Initialize(mux, applicationService, flowMgtService)
+	mcp.Initialize(mux, applicationService, flowMgtService, jwtService)
 
 	// TODO: Legacy way of initializing services. These need to be refactored in the future aligning to the
 	// dependency injection pattern used above.

--- a/backend/internal/mcp/auth/token_verifier.go
+++ b/backend/internal/mcp/auth/token_verifier.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package auth provides authentication utilities for the MCP server.
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+
+	"github.com/asgardeo/thunder/internal/system/jwt"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+// NewTokenVerifier creates a TokenVerifier function that verifies tokens
+// issued by Thunder's OAuth server. This implements the auth.TokenVerifier
+// function type from the MCP SDK.
+func NewTokenVerifier(
+	jwtService jwt.JWTServiceInterface,
+	issuer string,
+	mcpURL string,
+) auth.TokenVerifier {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "MCPTokenVerifier"))
+
+	return func(ctx context.Context, token string, req *http.Request) (*auth.TokenInfo, error) {
+		// Verify JWT signature and claims (iss, aud, exp, nbf)
+		if err := jwtService.VerifyJWT(token, mcpURL, issuer); err != nil {
+			logger.Error("JWT verification failed", log.String("error", err.Error))
+			return nil, auth.ErrInvalidToken
+		}
+
+		// Decode payload to extract claims for TokenInfo
+		payload, err := jwt.DecodeJWTPayload(token)
+		if err != nil {
+			logger.Error("Failed to decode JWT payload", log.Error(err))
+			return nil, auth.ErrInvalidToken
+		}
+
+		// Extract expiration time for SDK middleware
+		var expiration time.Time
+		if exp, ok := payload["exp"].(float64); ok {
+			expiration = time.Unix(int64(exp), 0)
+		}
+
+		// Extract scopes from token
+		var scopes []string
+		if scopeStr, ok := payload["scope"].(string); ok && scopeStr != "" {
+			scopes = strings.Fields(scopeStr)
+			logger.Debug("Token scopes extracted",
+				log.String("scopes", strings.Join(scopes, ",")),
+				log.String("path", req.URL.Path))
+		} else {
+			logger.Warn("Token missing 'scope' claim", log.String("path", req.URL.Path))
+		}
+
+		// Extract user ID from 'sub' claim
+		userID := ""
+		if sub, ok := payload["sub"].(string); ok && sub != "" {
+			userID = sub
+		}
+
+		// Build TokenInfo with user ID, scopes, and expiration
+		tokenInfo := &auth.TokenInfo{
+			UserID:     userID,
+			Scopes:     scopes,
+			Expiration: expiration,
+		}
+
+		return tokenInfo, nil
+	}
+}

--- a/backend/internal/mcp/auth/token_verifier_test.go
+++ b/backend/internal/mcp/auth/token_verifier_test.go
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mcpauth "github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/tests/mocks/jwtmock"
+)
+
+const (
+	testIssuer = "https://localhost:8090"
+	testMCPURL = "https://localhost:8090/mcp"
+)
+
+type TokenVerifierTestSuite struct {
+	suite.Suite
+	mockJWTService *jwtmock.JWTServiceInterfaceMock
+}
+
+func TestTokenVerifierTestSuite(t *testing.T) {
+	suite.Run(t, new(TokenVerifierTestSuite))
+}
+
+func (suite *TokenVerifierTestSuite) SetupTest() {
+	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
+}
+
+// createTestJWT creates a test JWT token with the given payload.
+func createTestJWT(payload map[string]interface{}) string {
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	headerJSON, _ := json.Marshal(header)
+	payloadJSON, _ := json.Marshal(payload)
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	// Signature doesn't matter for these tests as we mock VerifyJWT
+	return headerB64 + "." + payloadB64 + ".signature"
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_Success() {
+	// Create a valid token payload
+	futureExp := time.Now().Add(1 * time.Hour).Unix()
+	payload := map[string]interface{}{
+		"sub":   "user123",
+		"iss":   testIssuer,
+		"aud":   testMCPURL,
+		"exp":   float64(futureExp),
+		"scope": "system openid",
+	}
+	token := createTestJWT(payload)
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(token, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), token, req)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), tokenInfo)
+	assert.Equal(suite.T(), "user123", tokenInfo.UserID)
+	assert.Equal(suite.T(), []string{"system", "openid"}, tokenInfo.Scopes)
+	assert.Equal(suite.T(), time.Unix(futureExp, 0), tokenInfo.Expiration)
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_JWTVerificationFails() {
+	token := createTestJWT(map[string]interface{}{
+		"sub": "user123",
+	})
+
+	// Setup mock to return an error
+	suite.mockJWTService.EXPECT().
+		VerifyJWT(token, testMCPURL, testIssuer).
+		Return(&serviceerror.ServiceError{Error: "invalid token"})
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), token, req)
+
+	assert.ErrorIs(suite.T(), err, mcpauth.ErrInvalidToken)
+	assert.Nil(suite.T(), tokenInfo)
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_InvalidTokenFormat() {
+	// Invalid JWT format (not 3 parts)
+	invalidToken := "invalid.token"
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(invalidToken, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), invalidToken, req)
+
+	// DecodeJWTPayload will fail
+	assert.ErrorIs(suite.T(), err, mcpauth.ErrInvalidToken)
+	assert.Nil(suite.T(), tokenInfo)
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_InvalidPayloadBase64() {
+	// Valid structure but invalid base64 payload
+	malformedJWT := "eyJhbGciOiJSUzI1NiJ9.!!!invalid-base64!!!.signature"
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(malformedJWT, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), malformedJWT, req)
+
+	assert.ErrorIs(suite.T(), err, mcpauth.ErrInvalidToken)
+	assert.Nil(suite.T(), tokenInfo)
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_MissingScopes() {
+	// Token without scope claim
+	futureExp := time.Now().Add(1 * time.Hour).Unix()
+	payload := map[string]interface{}{
+		"sub": "user123",
+		"iss": testIssuer,
+		"aud": testMCPURL,
+		"exp": float64(futureExp),
+	}
+	token := createTestJWT(payload)
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(token, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), token, req)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), tokenInfo)
+	assert.Equal(suite.T(), "user123", tokenInfo.UserID)
+	assert.Empty(suite.T(), tokenInfo.Scopes)
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_EmptyScopes() {
+	// Token with empty scope string
+	futureExp := time.Now().Add(1 * time.Hour).Unix()
+	payload := map[string]interface{}{
+		"sub":   "user123",
+		"iss":   testIssuer,
+		"aud":   testMCPURL,
+		"exp":   float64(futureExp),
+		"scope": "",
+	}
+	token := createTestJWT(payload)
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(token, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), token, req)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), tokenInfo)
+	assert.Empty(suite.T(), tokenInfo.Scopes)
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_MissingSubClaim() {
+	// Token without sub claim
+	futureExp := time.Now().Add(1 * time.Hour).Unix()
+	payload := map[string]interface{}{
+		"iss":   testIssuer,
+		"aud":   testMCPURL,
+		"exp":   float64(futureExp),
+		"scope": "system",
+	}
+	token := createTestJWT(payload)
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(token, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), token, req)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), tokenInfo)
+	assert.Empty(suite.T(), tokenInfo.UserID)
+	assert.Equal(suite.T(), []string{"system"}, tokenInfo.Scopes)
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_MissingExpClaim() {
+	// Token without exp claim
+	payload := map[string]interface{}{
+		"sub":   "user123",
+		"iss":   testIssuer,
+		"aud":   testMCPURL,
+		"scope": "system",
+	}
+	token := createTestJWT(payload)
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(token, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), token, req)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), tokenInfo)
+	assert.Equal(suite.T(), "user123", tokenInfo.UserID)
+	// Expiration should be zero value when not present
+	assert.True(suite.T(), tokenInfo.Expiration.IsZero())
+}
+
+func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_MultipleScopes() {
+	// Token with multiple scopes
+	futureExp := time.Now().Add(1 * time.Hour).Unix()
+	payload := map[string]interface{}{
+		"sub":   "user123",
+		"iss":   testIssuer,
+		"aud":   testMCPURL,
+		"exp":   float64(futureExp),
+		"scope": "system openid profile email",
+	}
+	token := createTestJWT(payload)
+
+	// Setup mock
+	suite.mockJWTService.EXPECT().VerifyJWT(token, testMCPURL, testIssuer).Return(nil)
+
+	// Create verifier and test
+	verifier := NewTokenVerifier(suite.mockJWTService, testIssuer, testMCPURL)
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	tokenInfo, err := verifier(context.Background(), token, req)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), tokenInfo)
+	assert.Equal(suite.T(), []string{"system", "openid", "profile", "email"}, tokenInfo.Scopes)
+}

--- a/backend/internal/mcp/constants.go
+++ b/backend/internal/mcp/constants.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package mcp
+
+const (
+	// MCPEndpointPath is the base path for the MCP server endpoint.
+	MCPEndpointPath = "/mcp"
+
+	// OAuthProtectedResourceMetadataPath is the path for the OAuth protected resource metadata endpoint.
+	OAuthProtectedResourceMetadataPath = "/.well-known/oauth-protected-resource"
+)

--- a/backend/internal/system/security/constants.go
+++ b/backend/internal/system/security/constants.go
@@ -34,6 +34,7 @@ var publicPaths = []string{
 	"/oauth2/**",
 	"/.well-known/openid-configuration/**",
 	"/.well-known/oauth-authorization-server/**",
+	"/.well-known/oauth-protected-resource",
 	"/gate/**",
 	"/develop/**",
 	"/error/**",
@@ -41,6 +42,5 @@ var publicPaths = []string{
 	"/i18n/languages",
 	"/i18n/languages/*/translations/resolve",
 	"/i18n/languages/*/translations/ns/*/keys/*/resolve",
-	"/mcp",
-	"/mcp/**",
+	"/mcp/**", // MCP authorization is handled at MCP server handler.
 }


### PR DESCRIPTION
This pull request introduces a secure, standards-based authentication layer for the MCP server by implementing bearer token verification using Thunder's OAuth JWTs. It adds a dedicated token verifier, integrates it into the MCP server initialization, and exposes the protected resource metadata endpoint. Comprehensive unit tests are included to ensure robust token verification under various scenarios.

**MCP Server Authentication & Security Improvements:**

* Added a new `NewTokenVerifier` function in `backend/internal/mcp/auth/token_verifier.go` to validate JWT tokens for MCP requests, extracting user info, scopes, and expiration, and returning errors for invalid tokens.
* Updated `backend/internal/mcp/init.go` to secure MCP endpoints with bearer token authentication using the new token verifier and to register the OAuth protected resource metadata endpoint, following OAuth best practices.
* Added `backend/internal/mcp/constants.go` to define constants for MCP endpoint paths and OAuth metadata paths, improving maintainability and clarity.
* Adjusted `backend/cmd/server/servicemanager.go` to pass the `jwtService` dependency to MCP initialization, enabling JWT verification for MCP requests.
* Modified `backend/internal/system/security/constants.go` to remove `/mcp` from the list of globally public paths, ensuring MCP authorization is handled exclusively by the new handler.

**Testing Enhancements:**

* Added comprehensive unit tests in `backend/internal/mcp/auth/token_verifier_test.go` to verify correct behavior of the token verifier, covering success, JWT verification failures, invalid formats, missing claims, and multiple scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP endpoints are now protected by JWT bearer-token authentication.
  * Added an OAuth protected-resource metadata endpoint that advertises the MCP resource URL, issuer, and required scopes.
  * Public routing updated so MCP traffic is handled via the authenticated MCP handler.

* **Tests**
  * Added a comprehensive token verifier test suite covering successful verification, error cases, and varied token payload scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->