### PR TITLE
Add leeway for time claims in token validation

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -72,7 +72,8 @@
   "jwt": {
     "validity_period": 3600,
     "audience": "application",
-    "preferred_key_id": "default-key"
+    "preferred_key_id": "default-key",
+    "leeway": 30
   },
   "oauth": {
     "refresh_token": {

--- a/backend/internal/authn/google/service_test.go
+++ b/backend/internal/authn/google/service_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/authn/oidc"
+	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/user"
@@ -60,6 +61,14 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) SetupTest() {
 		jwtService: suite.mockJWTService,
 		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "GoogleOIDCAuthnService")),
 	}
+
+	// Initialize config with leeway for tests
+	testConfig := &config.Config{
+		JWT: config.JWTConfig{
+			Leeway: 30, // 30 seconds leeway for clock skew
+		},
+	}
+	_ = config.InitializeThunderRuntime("test", testConfig)
 }
 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
@@ -790,4 +799,215 @@ func generateTestJWT(claims map[string]interface{}) string {
 	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
 
 	return encodedHeader + "." + encodedClaims + "." + signature
+}
+
+// ============================================================================
+// Leeway Tests - Time-based claim validation with clock skew tolerance
+// ============================================================================
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_ExpiredWithinLeeway_ShouldPass() {
+	now := time.Now()
+	// Token expired 10 seconds ago, but leeway is 30 seconds - should pass
+	claims := map[string]interface{}{
+		"iss": Issuer1,
+		"aud": testClientID,
+		"sub": "user123",
+		"exp": float64(now.Add(-10 * time.Second).Unix()), // Expired 10 seconds ago
+		"iat": float64(now.Add(-1 * time.Hour).Unix()),
+	}
+	idToken := generateTestJWT(claims)
+
+	oAuthConfig := &oauth.OAuthClientConfig{
+		ClientID:       testClientID,
+		ClientSecret:   "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{},
+	}
+
+	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+
+	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	suite.Nil(err)
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_ExpiredBeyondLeeway_ShouldFail() {
+	now := time.Now()
+	// Token expired 60 seconds ago, leeway is 30 seconds - should fail
+	claims := map[string]interface{}{
+		"iss": Issuer1,
+		"aud": testClientID,
+		"sub": "user123",
+		"exp": float64(now.Add(-60 * time.Second).Unix()), // Expired 60 seconds ago
+		"iat": float64(now.Add(-2 * time.Hour).Unix()),
+	}
+	idToken := generateTestJWT(claims)
+
+	oAuthConfig := &oauth.OAuthClientConfig{
+		ClientID:       testClientID,
+		ClientSecret:   "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{},
+	}
+
+	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+
+	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	suite.NotNil(err)
+	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
+	suite.Contains(err.ErrorDescription, "expired")
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IssuedInFutureWithinLeeway_ShouldPass() {
+	now := time.Now()
+	// Token iat is 10 seconds in future, but leeway is 30 seconds - should pass
+	claims := map[string]interface{}{
+		"iss": Issuer1,
+		"aud": testClientID,
+		"sub": "user123",
+		"exp": float64(now.Add(1 * time.Hour).Unix()),
+		"iat": float64(now.Add(10 * time.Second).Unix()), // Issued 10 seconds in future
+	}
+	idToken := generateTestJWT(claims)
+
+	oAuthConfig := &oauth.OAuthClientConfig{
+		ClientID:       testClientID,
+		ClientSecret:   "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{},
+	}
+
+	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+
+	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	suite.Nil(err)
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IssuedInFutureBeyondLeeway_ShouldFail() {
+	now := time.Now()
+	// Token iat is 60 seconds in future, leeway is 30 seconds - should fail
+	claims := map[string]interface{}{
+		"iss": Issuer1,
+		"aud": testClientID,
+		"sub": "user123",
+		"exp": float64(now.Add(2 * time.Hour).Unix()),
+		"iat": float64(now.Add(60 * time.Second).Unix()), // Issued 60 seconds in future
+	}
+	idToken := generateTestJWT(claims)
+
+	oAuthConfig := &oauth.OAuthClientConfig{
+		ClientID:       testClientID,
+		ClientSecret:   "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{},
+	}
+
+	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+
+	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	suite.NotNil(err)
+	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
+	suite.Contains(err.ErrorDescription, "future")
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_ZeroLeeway_ExpiredShouldFail() {
+	// Reset and reinitialize with zero leeway
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		JWT: config.JWTConfig{
+			Leeway: 0, // No leeway
+		},
+	}
+	_ = config.InitializeThunderRuntime("test", testConfig)
+
+	now := time.Now()
+	// Token expired 1 second ago - should fail with zero leeway
+	claims := map[string]interface{}{
+		"iss": Issuer1,
+		"aud": testClientID,
+		"sub": "user123",
+		"exp": float64(now.Add(-1 * time.Second).Unix()), // Expired 1 second ago
+		"iat": float64(now.Add(-1 * time.Hour).Unix()),
+	}
+	idToken := generateTestJWT(claims)
+
+	oAuthConfig := &oauth.OAuthClientConfig{
+		ClientID:       testClientID,
+		ClientSecret:   "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{},
+	}
+
+	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+
+	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	suite.NotNil(err)
+	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
+	suite.Contains(err.ErrorDescription, "expired")
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IatExactlyAtBoundary_ShouldPass() {
+	// Reset and reinitialize with 30 second leeway
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		JWT: config.JWTConfig{
+			Leeway: 30, // 30 seconds leeway
+		},
+	}
+	_ = config.InitializeThunderRuntime("test", testConfig)
+
+	now := time.Now()
+	// Token iat is exactly at leeway boundary (now + 30 seconds)
+	// Condition: time.Now().Unix() < int64(iat) - leeway
+	// = now < (now + 30) - 30 = now < now = FALSE (should pass)
+	claims := map[string]interface{}{
+		"iss": Issuer1,
+		"aud": testClientID,
+		"sub": "user123",
+		"exp": float64(now.Add(1 * time.Hour).Unix()),
+		"iat": float64(now.Add(30 * time.Second).Unix()), // Exactly at boundary
+	}
+	idToken := generateTestJWT(claims)
+
+	oAuthConfig := &oauth.OAuthClientConfig{
+		ClientID:       testClientID,
+		ClientSecret:   "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{},
+	}
+
+	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+
+	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	suite.Nil(err)
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IatJustBeyondBoundary_ShouldFail() {
+	// Reset and reinitialize with 30 second leeway
+	config.ResetThunderRuntime()
+	testConfig := &config.Config{
+		JWT: config.JWTConfig{
+			Leeway: 30, // 30 seconds leeway
+		},
+	}
+	_ = config.InitializeThunderRuntime("test", testConfig)
+
+	now := time.Now()
+	// Token iat is just beyond leeway boundary (now + 31 seconds)
+	// Condition: time.Now().Unix() < int64(iat) - leeway
+	// = now < (now + 31) - 30 = now < now + 1 = TRUE (should fail)
+	claims := map[string]interface{}{
+		"iss": Issuer1,
+		"aud": testClientID,
+		"sub": "user123",
+		"exp": float64(now.Add(2 * time.Hour).Unix()),
+		"iat": float64(now.Add(31 * time.Second).Unix()), // Just beyond boundary
+	}
+	idToken := generateTestJWT(claims)
+
+	oAuthConfig := &oauth.OAuthClientConfig{
+		ClientID:       testClientID,
+		ClientSecret:   "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{},
+	}
+
+	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+
+	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	suite.NotNil(err)
+	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
+	suite.Contains(err.ErrorDescription, "future")
 }

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -109,6 +109,7 @@ type JWTConfig struct {
 	ValidityPeriod int64  `yaml:"validity_period" json:"validity_period"`
 	Audience       string `yaml:"audience" json:"audience"`
 	PreferredKeyID string `yaml:"preferred_key_id" json:"preferred_key_id"`
+	Leeway         int64  `yaml:"leeway" json:"leeway"`
 }
 
 // RefreshTokenConfig holds the refresh token configuration details.


### PR DESCRIPTION
This pull request introduces configurable leeway (in seconds) for time-based JWT validations across the authentication and OAuth subsystems, allowing the system to tolerate small clock skews between servers. The leeway value is now configurable via the main config and is respected in all relevant JWT claim checks (`exp`, `nbf`, and `iat`). Comprehensive unit tests have been added to ensure correct behavior for tokens near expiration, not-yet-valid, or issued in the future, both within and beyond the leeway window.

**Leeway configuration and usage:**

* Added a new `leeway` parameter to the JWT configuration (`JWTConfig`) and the default config file (`default.json`), enabling system-wide clock skew tolerance for JWT validation. [[1]](diffhunk://#diff-beec713bb8f44ef8633de8d745de6dcd555593b5cd0758d7788470fee3b2d974L75-R76) [[2]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR112)
* Updated JWT claim validation logic in the Google OIDC authentication service, OAuth token validator, and core JWT service to use the configured leeway when checking `exp`, `nbf`, and `iat` claims. [[1]](diffhunk://#diff-a5b044241b22c362b38508dd09ad0b565ec9b55d5e87e3871a4283fb03b37dc0R162-R184) [[2]](diffhunk://#diff-ef8e3cff68ea3a4ac66f0ee805abcd05c771536d7c66506883aff62d976e76cfR195-R209) [[3]](diffhunk://#diff-a6adf3395a1977c374db36e94ae9a881988468a4e6610edf2e947a982751dd2dR446-R453) [[4]](diffhunk://#diff-a6adf3395a1977c374db36e94ae9a881988468a4e6610edf2e947a982751dd2dL460-R463)

**Testing and reliability:**

* Added and updated test setup to initialize the leeway configuration for all relevant test suites. [[1]](diffhunk://#diff-07fa6b7d966fbed03882ff4fe8f143b9e4781250a0eb242c52d6bb9e1ae122dfR64-R71) [[2]](diffhunk://#diff-e54fae60295c6be9e1651f6e17000855cee2420b4f41279f560721325cb22d1aR61) [[3]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1R139)
* Implemented extensive new unit tests for the Google OIDC service, OAuth token validator, and JWT service to verify correct leeway handling for tokens expiring, not yet valid, or issued in the future, including edge cases for zero and non-zero leeway. [[1]](diffhunk://#diff-07fa6b7d966fbed03882ff4fe8f143b9e4781250a0eb242c52d6bb9e1ae122dfR803-R941) [[2]](diffhunk://#diff-e54fae60295c6be9e1651f6e17000855cee2420b4f41279f560721325cb22d1aR1374-R1500) [[3]](diffhunk://#diff-17d57f04a8044070e7b47bdfca7200f357eacd8797bc7a5d357b67c5688537a1R2314-R2454)

**Codebase consistency:**

* Ensured all relevant imports and initializations are updated to support the new leeway configuration. [[1]](diffhunk://#diff-a5b044241b22c362b38508dd09ad0b565ec9b55d5e87e3871a4283fb03b37dc0R30) [[2]](diffhunk://#diff-07fa6b7d966fbed03882ff4fe8f143b9e4781250a0eb242c52d6bb9e1ae122dfR31)

These changes make JWT validation more robust in distributed environments by preventing unnecessary authentication failures due to minor time discrepancies between systems.


Related issue:
- https://github.com/asgardeo/thunder/issues/1183