### PR TITLE
Optimize user store calls in BasicAuth and SMSAuth executors

### DIFF
--- a/tests/integration/flow/authentication/attribute_collect_test.go
+++ b/tests/integration/flow/authentication/attribute_collect_test.go
@@ -429,7 +429,7 @@ func (ts *AttributeCollectFlowTestSuite) TestInvalidCredentials() {
 	errorResp, err := common.CompleteFlow(flowStep.FlowID, invalidCredentials, "")
 	ts.Require().NoError(err, "Expected error response for invalid credentials")
 	ts.Require().NotEmpty(errorResp.FailureReason, "Expected failure reason for invalid credentials")
-	ts.Require().Equal("User not found", errorResp.FailureReason,
+	ts.Require().Contains(errorResp.FailureReason, "No user found",
 		"Expected failure reason to indicate user not found")
 }
 


### PR DESCRIPTION
This pull request refactors the authentication and registration logic in the `basicAuthExecutor` and improves the handling of user mobile numbers in the `smsOTPAuthExecutor`. The main changes optimize the user identification and authentication flow, reduce redundant service calls, and enhance test coverage to verify these optimizations. Additionally, the SMS OTP executor now more robustly retrieves the user's mobile number from various sources and avoids unnecessary user store lookups.

**Authentication and Registration Flow Improvements:**

- Refactored `getAuthenticatedUser` in `basicAuthExecutor` to:
  - Only call `IdentifyUser` for registration flows to check if the user exists, and fail registration if the user is already present. For authentication flows, directly call `Authenticate` without a redundant `IdentifyUser` call.
  - Simplified the return of the `AuthenticatedUser` struct by returning it directly instead of assigning to a variable first.

**Test Suite Updates and Additions:**

- Updated tests in `basic_auth_executor_test.go` to:
  - Remove unnecessary mocks and assertions for `IdentifyUser` in authentication scenarios, reflecting the new code path. [[1]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L164-L168) [[2]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L188) [[3]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L214-L218) [[4]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L238) [[5]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L291-L296) [[6]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L317) [[7]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L348-L352) [[8]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L367) [[9]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L382-R371) [[10]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L430-R424) [[11]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L453-L457) [[12]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L470) [[13]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L491-L495) [[14]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L517) [[15]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L535-L539) [[16]](diffhunk://#diff-3f26e1b6d9669d01de1d6b1f4df9bcfe45de2d8408a4b78a683992e4bd269a80L553-R597)
  - Add new tests to verify that `IdentifyUser` is only called for registration flows and not for authentication flows, ensuring the optimization is enforced.

**SMS OTP Executor Enhancements:**

- Improved `getUserMobileFromContext` to:
  - Attempt to retrieve the user's mobile number from multiple sources in the context, including authenticated user attributes, before returning an error.
- Optimized `getUserMobileNumber` to:
  - First check for the mobile number in the context and only query the user store if not found, reducing unnecessary service calls. [[1]](diffhunk://#diff-25cd5c935d890c8eb0b68019b40386c222a7234f9e160d224b848b00048a571cL436-R454) [[2]](diffhunk://#diff-25cd5c935d890c8eb0b68019b40386c222a7234f9e160d224b848b00048a571cL448-L472)
- Enhanced `getAuthenticatedUser` to:
  - Return the authenticated user from context if already present, updating their attributes with the mobile number, and only fetch from the user store if needed. [[1]](diffhunk://#diff-25cd5c935d890c8eb0b68019b40386c222a7234f9e160d224b848b00048a571cR614-R615) [[2]](diffhunk://#diff-25cd5c935d890c8eb0b68019b40386c222a7234f9e160d224b848b00048a571cR633-R648)
  
 Related Issue-
- https://github.com/asgardeo/thunder/issues/1200