### PR TITLE
Fix sample artifacts failure

### DIFF
--- a/scripts/verify-sample-artifacts.sh
+++ b/scripts/verify-sample-artifacts.sh
@@ -46,14 +46,18 @@ SAMPLE_APPS=("react-vanilla" "react-sdk" "react-api-based")
 MISSING_COUNT=0
 
 for app in "${SAMPLE_APPS[@]}"; do
-  EXPECTED_FILE="target/dist/sample-app-${app}-*-$OS-$ARCH.zip"
+  EXPECTED_PATTERN="target/dist/sample-app-${app}-*-$OS-$ARCH.zip"
 
-  if ! ls "$EXPECTED_FILE" 1> /dev/null 2>&1; then
-    echo "❌ Sample artifact not found: $EXPECTED_FILE"
+  # Expand glob once into an array (nullglob ensures empty array if no match)
+  shopt -s nullglob
+  MATCHED_FILES=($EXPECTED_PATTERN)
+  shopt -u nullglob
+
+  if [ ${#MATCHED_FILES[@]} -eq 0 ]; then
+    echo "❌ Sample artifact not found: $EXPECTED_PATTERN"
     MISSING_COUNT=$((MISSING_COUNT + 1))
   else
-    FOUND_FILE=$(ls "$EXPECTED_FILE")
-    echo "✅ Found sample artifact: $(basename $FOUND_FILE)"
+    echo "✅ Found sample artifact: $(basename "${MATCHED_FILES[0]}")"
   fi
 done
 


### PR DESCRIPTION
### Purpose
This pull request makes a minor update to the `scripts/verify-sample-artifacts.sh` script, changing how shell variable expansion is handled in the `ls` commands. The script now omits quotes around the `$EXPECTED_FILE` variable.

- Shell scripting update:
  * Removed quotes from `$EXPECTED_FILE` in `ls` commands to change how file patterns are expanded and matched in the artifact verification script.

### Related Issues
- Resolves https://github.com/asgardeo/thunder/issues/1222

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
