### PR TITLE
Improve tests in the flow-builder UI

### DIFF
--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/steps/execution/ExecutionMinimal.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/steps/execution/ExecutionMinimal.tsx
@@ -148,7 +148,7 @@ function ExecutionMinimal({resource}: ExecutionMinimalPropsInterface): ReactElem
           id={`${resource.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`}
         />
       )}
-      {/* Failure handle - shown at the bottom when onFailure path exists */}
+      {/* Failure handle - shown at the bottom when the action supports branching (has onFailure property) */}
       {hasBranchingSupport && (
         <Tooltip title={t('flows:core.executions.handles.failure')} placement="bottom">
           <Box className="handle-wrapper failure-wrapper">

--- a/frontend/apps/thunder-develop/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
@@ -414,7 +414,7 @@ describe('useDeleteExecutionResource', () => {
         category: 'ACTION',
         action: {
           type: 'NEXT',
-          next: 'execution-1',
+          onSuccess: 'execution-1',
         },
       };
 

--- a/frontend/apps/thunder-develop/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -1332,7 +1332,7 @@ describe('reactFlowTransformer', () => {
           type: ElementTypes.Action,
           category: ElementCategories.Action,
           action: {
-            next: 'exec-1',
+            onSuccess: 'exec-1',
             executor: {name: 'TestExecutor'},
           },
         } as unknown as Element,

--- a/frontend/apps/thunder-develop/src/features/login-flow/components/__tests__/LoginFlowBuilder.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/login-flow/components/__tests__/LoginFlowBuilder.test.tsx
@@ -1822,7 +1822,7 @@ describe('generateUnconnectedEdges Function', () => {
           components: [
             {
               id: 'button-1',
-              action: {next: 'step-2'},
+              action: {onSuccess: 'step-2'},
             },
           ],
         },
@@ -1851,7 +1851,7 @@ describe('generateUnconnectedEdges Function', () => {
           components: [
             {
               id: 'button-1',
-              action: {next: 'non-existent-step'},
+              action: {onSuccess: 'non-existent-step'},
             },
           ],
         },
@@ -1878,7 +1878,7 @@ describe('generateUnconnectedEdges Function', () => {
               components: [
                 {
                   id: 'button-1',
-                  action: {next: 'step-2'},
+                  action: {onSuccess: 'step-2'},
                 },
               ],
             },
@@ -1906,7 +1906,7 @@ describe('generateUnconnectedEdges Function', () => {
         type: 'EXECUTION',
         position: {x: 0, y: 0},
         data: {
-          action: {next: 'step-2'},
+          action: {onSuccess: 'step-2'},
         },
       },
       {
@@ -1919,7 +1919,7 @@ describe('generateUnconnectedEdges Function', () => {
 
     // Verify node-level action
     expect(currentNodes[0].data.action).toBeDefined();
-    expect((currentNodes[0].data.action as {next: string}).next).toBe('step-2');
+    expect((currentNodes[0].data.action as {onSuccess: string}).onSuccess).toBe('step-2');
   });
 });
 
@@ -3492,7 +3492,7 @@ describe('generateUnconnectedEdges - Node Data Processing', () => {
             {
               id: 'form-1',
               type: BlockTypes.Form,
-              components: [{id: 'button-1', action: {next: 'step-2'}}],
+              components: [{id: 'button-1', action: {onSuccess: 'step-2'}}],
             },
           ],
         },
@@ -3513,7 +3513,7 @@ describe('generateUnconnectedEdges - Node Data Processing', () => {
         type: 'EXECUTION',
         position: {x: 0, y: 0},
         data: {
-          action: {next: 'view-step'},
+          action: {onSuccess: 'view-step'},
         },
       },
       {id: 'view-step', type: 'VIEW', position: {x: 100, y: 0}, data: {}},
@@ -3521,7 +3521,7 @@ describe('generateUnconnectedEdges - Node Data Processing', () => {
 
     // Verify node-level action is accessible
     expect(nodes[0].data.action).toBeDefined();
-    expect((nodes[0].data.action as {next: string}).next).toBe('view-step');
+    expect((nodes[0].data.action as {onSuccess: string}).onSuccess).toBe('view-step');
   });
 });
 
@@ -4795,7 +4795,7 @@ describe('generateUnconnectedEdges - Edge Generation', () => {
         type: 'VIEW',
         position: {x: 0, y: 0},
         data: {
-          components: [{id: 'btn-1', action: {next: 'step-2'}}],
+          components: [{id: 'btn-1', action: {onSuccess: 'step-2'}}],
         },
       },
       {id: 'step-2', type: 'VIEW', position: {x: 100, y: 0}, data: {}},
@@ -4823,7 +4823,7 @@ describe('generateUnconnectedEdges - Edge Generation', () => {
         type: 'VIEW',
         position: {x: 0, y: 0},
         data: {
-          components: [{id: 'btn-1', action: {next: 'non-existent'}}],
+          components: [{id: 'btn-1', action: {onSuccess: 'non-existent'}}],
         },
       },
     ];
@@ -4843,7 +4843,7 @@ describe('generateUnconnectedEdges - Edge Generation', () => {
             {
               id: 'form-1',
               type: BlockTypes.Form,
-              components: [{id: 'nested-btn', action: {next: 'step-2'}}],
+              components: [{id: 'nested-btn', action: {onSuccess: 'step-2'}}],
             },
           ],
         },
@@ -4864,13 +4864,13 @@ describe('generateUnconnectedEdges - Edge Generation', () => {
         type: 'EXECUTION',
         position: {x: 0, y: 0},
         data: {
-          action: {next: 'view-1'},
+          action: {onSuccess: 'view-1'},
         },
       },
     ];
 
     expect(nodes[0].data.action).toBeDefined();
-    expect((nodes[0].data.action as {next: string}).next).toBe('view-1');
+    expect((nodes[0].data.action as {onSuccess: string}).onSuccess).toBe('view-1');
   });
 });
 


### PR DESCRIPTION
### Purpose
This pull request updates the way action transitions are represented in flow-related components and tests. Specifically, it replaces the use of the `next` property with `onSuccess` for defining the next step in an action, aligning the codebase with a more explicit branching model. The changes also clarify when failure handles are shown in the UI.

Action transition property updates:

* Replaced `next` with `onSuccess` in all action definitions within test cases for flow and login flow components, ensuring consistency with the new branching model. [[1]](diffhunk://#diff-ff1abb2137b70dd0279c077843705dad7bb1051e0cef4bb20eac9a6536372434L417-R417) [[2]](diffhunk://#diff-8fe5d6a1603cb67b22e079226cc63493a40b39a5eb7820a3c6392f9c294f3dbeL1335-R1335) [[3]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L1825-R1825) [[4]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L1854-R1854) [[5]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L1881-R1881) [[6]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L1909-R1909) [[7]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L1922-R1922) [[8]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L3495-R3495) [[9]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L3516-R3524) [[10]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L4798-R4798) [[11]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L4826-R4826) [[12]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L4846-R4846) [[13]](diffhunk://#diff-2d9bd4becbaedc7ed1fa6709b054ff146e173db1787716f0ec6ef5af523ca115L4867-R4873)

UI and documentation improvements:

* Updated the comment in `ExecutionMinimal.tsx` to clarify that the failure handle is shown when the action supports branching (i.e., has an `onFailure` property), improving code readability.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
