### PR TITLE
Support k8s secrets for db passwords

### DIFF
--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -47,7 +47,7 @@ database:
     port: {{ .Values.configuration.database.identity.port }}
     name: {{ .Values.configuration.database.identity.name | quote }}
     username: {{ .Values.configuration.database.identity.username | quote }}
-    password: {{ .Values.configuration.database.identity.password | quote }}
+    password: {{ "{{.DB_IDENTITY_PASSWORD}}" | quote }}
     sslmode: {{ .Values.configuration.database.identity.sslmode | quote }}
     {{- end }}
   runtime:
@@ -60,7 +60,7 @@ database:
     port: {{ .Values.configuration.database.runtime.port }}
     name: {{ .Values.configuration.database.runtime.name | quote }}
     username: {{ .Values.configuration.database.runtime.username | quote }}
-    password: {{ .Values.configuration.database.runtime.password | quote }}
+    password: {{ "{{.DB_RUNTIME_PASSWORD}}" | quote }}
     sslmode: {{ .Values.configuration.database.runtime.sslmode | quote }}
     {{- end }}
   user:
@@ -73,7 +73,7 @@ database:
     port: {{ .Values.configuration.database.user.port }}
     name: {{ .Values.configuration.database.user.name | quote }}
     username: {{ .Values.configuration.database.user.username | quote }}
-    password: {{ .Values.configuration.database.user.password | quote }}
+    password: {{ "{{.DB_USER_PASSWORD}}" | quote }}
     sslmode: {{ .Values.configuration.database.user.sslmode | quote }}
     {{- end }}    
 

--- a/install/helm/templates/_helpers.tpl
+++ b/install/helm/templates/_helpers.tpl
@@ -79,3 +79,54 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Check if auto-generated database credentials Secret should be included in checksum annotation.
+Returns true if any database password is set without a passwordRef.key.
+This is used to trigger pod restarts when auto-generated Secrets change.
+*/}}
+{{- define "thunder.shouldIncludeSecretChecksum" -}}
+{{- $configuration := default dict .Values.configuration -}}
+{{- $database := default dict $configuration.database -}}
+{{- $identity := default dict $database.identity -}}
+{{- $runtime := default dict $database.runtime -}}
+{{- $user := default dict $database.user -}}
+{{- if or (and $identity.password (not (default dict $identity.passwordRef).key)) (and $runtime.password (not (default dict $runtime.passwordRef).key)) (and $user.password (not (default dict $user.passwordRef).key)) }}true{{- end }}
+{{- end }}
+
+{{/*
+Generate database password environment variable definitions for both deployment and setup job.
+Injects DB_IDENTITY_PASSWORD, DB_RUNTIME_PASSWORD, and DB_USER_PASSWORD from either auto-generated or external Secrets.
+*/}}
+{{- define "thunder.databasePasswordEnvVars" -}}
+{{- $defaultDbSecretName := printf "%s-db-credentials" (include "thunder.fullname" .) -}}
+{{- $configuration := default dict .Values.configuration -}}
+{{- $database := default dict $configuration.database -}}
+{{- $identity := default dict $database.identity -}}
+{{- $runtime := default dict $database.runtime -}}
+{{- $user := default dict $database.user -}}
+{{- $identityPasswordRef := default dict $identity.passwordRef -}}
+{{- $runtimePasswordRef := default dict $runtime.passwordRef -}}
+{{- $userPasswordRef := default dict $user.passwordRef -}}
+{{- if or $identity.password $identityPasswordRef.key }}
+- name: DB_IDENTITY_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ if $identityPasswordRef.key }}{{ $identityPasswordRef.name | default $defaultDbSecretName }}{{ else }}{{ $defaultDbSecretName }}{{ end }}
+      key: {{ $identityPasswordRef.key | default "identity-db-password" }}
+{{- end }}
+{{- if or $runtime.password $runtimePasswordRef.key }}
+- name: DB_RUNTIME_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ if $runtimePasswordRef.key }}{{ $runtimePasswordRef.name | default $defaultDbSecretName }}{{ else }}{{ $defaultDbSecretName }}{{ end }}
+      key: {{ $runtimePasswordRef.key | default "runtime-db-password" }}
+{{- end }}
+{{- if or $user.password $userPasswordRef.key }}
+- name: DB_USER_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ if $userPasswordRef.key }}{{ $userPasswordRef.name | default $defaultDbSecretName }}{{ else }}{{ $defaultDbSecretName }}{{ end }}
+      key: {{ $userPasswordRef.key | default "user-db-password" }}
+{{- end }}
+{{- end }}

--- a/install/helm/templates/secret.yaml
+++ b/install/helm/templates/secret.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- $configuration := default dict .Values.configuration -}}
+{{- $database := default dict $configuration.database -}}
+{{- $identity := default dict $database.identity -}}
+{{- $runtime := default dict $database.runtime -}}
+{{- $user := default dict $database.user -}}
+
+{{- $identityPassword := "" }}
+{{- $runtimePassword := "" }}
+{{- $userPassword := "" }}
+
+{{- if and $identity.password (not (default dict $identity.passwordRef).key) }}
+  {{- $identityPassword = $identity.password }}
+{{- end }}
+{{- if and $runtime.password (not (default dict $runtime.passwordRef).key) }}
+  {{- $runtimePassword = $runtime.password }}
+{{- end }}
+{{- if and $user.password (not (default dict $user.passwordRef).key) }}
+  {{- $userPassword = $user.password }}
+{{- end }}
+
+{{- $createSecret := or $identityPassword $runtimePassword $userPassword }}
+
+{{- if $createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-db-credentials" (include "thunder.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database-credentials
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    # Use a lower weight than other pre-install/pre-upgrade hooks (e.g., -5 or default 0)
+    # so this secret is created before dependent resources that consume these credentials.
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": before-hook-creation
+type: Opaque
+data:
+  {{- if $identityPassword }}
+  identity-db-password: {{ $identityPassword | b64enc | quote }}
+  {{- end }}
+  {{- if $runtimePassword }}
+  runtime-db-password: {{ $runtimePassword | b64enc | quote }}
+  {{- end }}
+  {{- if $userPassword }}
+  user-db-password: {{ $userPassword | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -44,6 +44,9 @@ spec:
         app.kubernetes.io/component: setup
       annotations:
         checksum.deployment.yaml: {{ include (print $.Template.BasePath "/setup-config-map.yaml") . | sha256sum }}
+        {{- if include "thunder.shouldIncludeSecretChecksum" . }}
+        checksum.secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thunder.serviceAccountName" . }}
       restartPolicy: OnFailure
@@ -117,6 +120,7 @@ spec:
             - name: DEBUG
               value: "true"
             {{- end }}
+            {{- include "thunder.databasePasswordEnvVars" . | nindent 12 }}
             {{- if .Values.setup.env }}
             {{- toYaml .Values.setup.env | nindent 12 }}
             {{- end }}

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         {{- include "thunder.selectorLabels" . | nindent 8 }}
       annotations:
         checksum.deployment.yaml: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
+        {{- if include "thunder.shouldIncludeSecretChecksum" . }}
+        checksum.secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "thunder.serviceAccountName" . }}
       securityContext:
@@ -86,6 +89,7 @@ spec:
           env:
             - name: THUNDER_SKIP_SECURITY
               value: {{ .Values.deployment.skipSecurity | quote }}
+            {{- include "thunder.databasePasswordEnvVars" . | nindent 12 }}
           startupProbe:
             exec:
               command:


### PR DESCRIPTION
### Purpose
Add helm chart support to use external k8s secrets 


### Approach
This pull request introduces a robust and flexible password management system for database connections in the Thunder Helm chart. The changes enable automatic and secure handling of database passwords using Kubernetes Secrets, with support for both development (auto-generated Secrets) and production (external Secrets) patterns. The documentation is expanded to explain these patterns, and the Helm templates are updated to inject passwords as environment variables from Secrets, ensuring best practices for security and maintainability.

**Key changes include:**

### Password Management and Security

- Added a comprehensive section in `README.md` detailing new password management options, including security warnings, usage patterns for auto-generated and external Secrets, and configuration examples. This guides users to avoid plaintext passwords and adopt secure methods.
- Updated the configuration table in `README.md` to document new `passwordRef` fields and clarify the behavior of password handling for each database type.

### Helm Template Enhancements

- Introduced a new `secret.yaml` Helm template that auto-creates a Kubernetes Secret with database passwords as a pre-install/pre-upgrade hook, only when plaintext passwords are provided and no external Secret is referenced.
- Modified `deployment.yaml` to use environment variable placeholders (`{{.DB_IDENTITY_PASSWORD}}`, etc.) for database passwords, enabling runtime injection from Secrets rather than storing plaintext values. [[1]](diffhunk://#diff-f2cb3073a4637c871c6a543d4e76655f861053c8b63ebfc66ed958980466eb34L50-R50) [[2]](diffhunk://#diff-f2cb3073a4637c871c6a543d4e76655f861053c8b63ebfc66ed958980466eb34L63-R63) [[3]](diffhunk://#diff-f2cb3073a4637c871c6a543d4e76655f861053c8b63ebfc66ed958980466eb34L76-R76)

### Secret Injection and Pod Updates

- Enhanced `setup-job.yaml` and `thunder-deployment.yaml` to inject database passwords as environment variables from the appropriate Secret, supporting both auto-generated and external Secret patterns. Also added checksum annotations to trigger pod updates when Secrets change. [[1]](diffhunk://#diff-347defecc78c600bb09918a1ffee9bb8844c401332830dfb0b49d594e6d79b4bR47-R54) [[2]](diffhunk://#diff-347defecc78c600bb09918a1ffee9bb8844c401332830dfb0b49d594e6d79b4bR128-R157) [[3]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R41-R48) [[4]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R97-R126)

These changes together provide a secure, flexible, and production-ready approach to managing database passwords in Thunder deployments.

### Related Issues
-  https://github.com/asgardeo/thunder/issues/1233


### Checklist
- [ ] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
