### PR TITLE
Improve prompt nodes to auto select single actions

### DIFF
--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -658,71 +658,63 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
 	ts.Require().NotEmpty(completeFlowStep.FailureReason, "Failure reason should be provided for invalid OTP")
 }
 
-// TODO: With improvements to the PROMPT node, currently server doesn't allow sending
-// action along with inputs in the initial request. Hence, this test is disabled for now.
-// Should re-enable after addressing the limitation.
-// func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {
-// 	// Update app to use SMS flow
-// 	err := common.UpdateAppConfig(smsAuthTestAppID, "auth_flow_sms")
-// 	if err != nil {
-// 		ts.T().Fatalf("Failed to update app config for SMS flow: %v", err)
-// 	}
+func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {
+	// Clear any previous messages
+	ts.mockServer.ClearMessages()
 
-// 	// Clear any previous messages
-// 	ts.mockServer.ClearMessages()
+	// Get user attributes
+	var userAttrs map[string]interface{}
+	err := json.Unmarshal(testUserWithMobile.Attributes, &userAttrs)
+	ts.Require().NoError(err, "Failed to unmarshal user attributes")
 
-// 	// Get user attributes
-// 	var userAttrs map[string]interface{}
-// 	err = json.Unmarshal(testUserWithMobile.Attributes, &userAttrs)
-// 	ts.Require().NoError(err, "Failed to unmarshal user attributes")
+	// Step 1: Initialize the flow with mobile number - single action should auto-select
+	inputs := map[string]string{
+		"mobileNumber": userAttrs["mobileNumber"].(string),
+	}
 
-// 	// Step 1: Initialize the flow with mobile number
-// 	inputs := map[string]string{
-// 		"mobileNumber": userAttrs["mobileNumber"].(string),
-// 	}
+	flowStep, err := common.InitiateAuthenticationFlow(smsAuthTestAppID, false, inputs, "")
+	if err != nil {
+		ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
+	}
 
-// 	flowStep, err := common.InitiateAuthenticationFlow(smsAuthTestAppID, inputs, "action_001")
-// 	if err != nil {
-// 		ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
-// 	}
+	// Should require OTP input now (single action was auto-selected)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
+	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
+	ts.Require().True(common.HasInput(flowStep.Data.Inputs, "otp"), "OTP input should be required")
 
-// 	// Should require OTP input now
-// 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
-// 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
+	// Wait for SMS to be sent
+	time.Sleep(500 * time.Millisecond)
 
-// 	// Wait for SMS to be sent
-// 	time.Sleep(500 * time.Millisecond)
+	// Get the OTP from mock server
+	lastMessage := ts.mockServer.GetLastMessage()
+	ts.Require().NotNil(lastMessage, "SMS should have been sent")
+	ts.Require().NotEmpty(lastMessage.OTP, "OTP should be available")
 
-// 	// Get the OTP from mock server
-// 	lastMessage := ts.mockServer.GetLastMessage()
-// 	ts.Require().NotNil(lastMessage, "SMS should have been sent")
-// 	ts.Require().NotEmpty(lastMessage.OTP, "OTP should be available")
+	// Step 2: Complete with OTP - single action should auto-select
+	otpInputs := map[string]string{
+		"otp": lastMessage.OTP,
+	}
 
-// 	// Step 2: Complete with OTP
-// 	otpInputs := map[string]string{
-// 		"otp": lastMessage.OTP,
-// 	}
+	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "")
+	if err != nil {
+		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
+	}
 
-// 	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, "", otpInputs)
-// 	if err != nil {
-// 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
-// 	}
+	// Verify successful authentication
+	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be COMPLETE")
+	ts.Require().NotEmpty(completeFlowStep.Assertion,
+		"JWT assertion should be returned after successful authentication")
+	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
 
-// 	// Verify successful authentication
-// 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be COMPLETE")
-// 	ts.Require().NotEmpty(completeFlowStep.Assertion,
-// 		"JWT assertion should be returned after successful authentication")
-// 	ts.Require().Empty(completeFlowStep.FailureReason, "Failure reason should be empty for successful authentication")
-
-// 	// Validate JWT assertion fields using common utility
-// 	jwtClaims, err := testutils.ValidateJWTAssertionFields(
-// 		completeFlowStep.Assertion,
-// 		smsAuthTestAppID,
-// 		smsAuthUserSchema.Name,
-// 		smsAuthTestOU.ID,
-// 		smsAuthTestOU.Name,
-// 		smsAuthTestOU.Handle,
-// 	)
-// 	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
-// 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
-// }
+	// Validate JWT assertion fields using common utility
+	jwtClaims, err := testutils.ValidateJWTAssertionFields(
+		completeFlowStep.Assertion,
+		smsAuthTestAppID,
+		smsAuthUserSchema.Name,
+		smsAuthTestOU.ID,
+		smsAuthTestOU.Name,
+		smsAuthTestOU.Handle,
+	)
+	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+}

--- a/tests/integration/flow/registration/basic_registration_test.go
+++ b/tests/integration/flow/registration/basic_registration_test.go
@@ -350,53 +350,50 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 	}
 }
 
-// TODO: With improvements to the PROMPT node, currently server doesn't allow sending
-// action along with inputs in the initial request. Hence, this test is disabled for now.
-// Should re-enable after addressing the limitation.
-// func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSingleRequest() {
-// 	// Generate unique username for this test
-// 	username := common.GenerateUniqueUsername("singlereguser")
+func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSingleRequest() {
+	// Generate unique username for this test
+	username := common.GenerateUniqueUsername("singlereguser")
 
-// 	// Step 1: Initialize the registration flow with credentials in one request
-// 	inputs := map[string]string{
-// 		"username":  username,
-// 		"password":  "testpassword123",
-// 		"email":     username + "@example.com",
-// 		"firstName": "Single",
-// 		"lastName":  "Request",
-// 	}
+	// Step 1: Initialize the registration flow with credentials in one request
+	inputs := map[string]string{
+		"username":  username,
+		"password":  "testpassword123",
+		"email":     username + "@example.com",
+		"firstName": "Single",
+		"lastName":  "Request",
+	}
 
-// 	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, false, inputs, "")
-// 	if err != nil {
-// 		ts.T().Fatalf("Failed to initiate registration flow with inputs: %v", err)
-// 	}
+	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, false, inputs, "")
+	if err != nil {
+		ts.T().Fatalf("Failed to initiate registration flow with inputs: %v", err)
+	}
 
-// 	// Step 2: Verify successful registration in a single request
-// 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Expected flow status to be COMPLETE")
-// 	ts.Require().NotEmpty(flowStep.Assertion,
-// 		"JWT assertion should be returned after successful registration")
-// 	ts.Require().Empty(flowStep.FailureReason, "Failure reason should be empty for successful registration")
+	// Step 2: Verify successful registration in a single request
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Expected flow status to be COMPLETE")
+	ts.Require().NotEmpty(flowStep.Assertion,
+		"JWT assertion should be returned after successful registration")
+	ts.Require().Empty(flowStep.FailureReason, "Failure reason should be empty for successful registration")
 
-// 	// Decode and validate JWT claims
-// 	jwtClaims, err := testutils.DecodeJWT(flowStep.Assertion)
-// 	ts.Require().NoError(err, "Failed to decode JWT assertion")
-// 	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
+	// Decode and validate JWT claims
+	jwtClaims, err := testutils.DecodeJWT(flowStep.Assertion)
+	ts.Require().NoError(err, "Failed to decode JWT assertion")
+	ts.Require().NotNil(jwtClaims, "JWT claims should not be nil")
 
-// 	// Validate JWT contains expected user type and OU ID
-// 	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
-// 	ts.Require().Equal(ts.testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
-// 	ts.Require().Equal(ts.testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
-// 	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
+	// Validate JWT contains expected user type and OU ID
+	ts.Require().Equal(testUserSchema.Name, jwtClaims.UserType, "Expected userType to match created schema")
+	ts.Require().Equal(ts.testOUID, jwtClaims.OuID, "Expected ouId to match the created organization unit")
+	ts.Require().Equal(ts.testAppID, jwtClaims.Aud, "Expected aud to match the application ID")
+	ts.Require().NotEmpty(jwtClaims.Sub, "JWT subject should not be empty")
 
-// 	// Step 3: Verify the user was created by searching via the user API
-// 	user, err := testutils.FindUserByAttribute("username", username)
-// 	if err != nil {
-// 		ts.T().Fatalf("Failed to retrieve user by username: %v", err)
-// 	}
-// 	ts.Require().NotNil(user, "User should be found in user list after registration")
+	// Step 3: Verify the user was created by searching via the user API
+	user, err := testutils.FindUserByAttribute("username", username)
+	if err != nil {
+		ts.T().Fatalf("Failed to retrieve user by username: %v", err)
+	}
+	ts.Require().NotNil(user, "User should be found in user list after registration")
 
-// 	// Store the created user for cleanup
-// 	if user != nil {
-// 		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
-// 	}
-// }
+	// Store the created user for cleanup
+	if user != nil {
+		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+	}
+}


### PR DESCRIPTION
### Purpose
This pull request introduces an enhancement to the prompt node logic, allowing automatic selection of a single available action when all required inputs are provided and no action has been selected. This change streamlines flows such as registration and authentication, enabling single-request flows and simplifying user interaction.

### Approach
* Added `tryAutoSelectSingleAction` method to `promptNode`, which auto-selects an action if there is exactly one available and all required inputs are present. This ensures the node can automatically proceed without explicit user action selection. 
* Updated the `Execute` method in `promptNode` to invoke auto-selection logic, clearing actions from the response if auto-selection occurs, and ensuring the node completes as expected.
* Re-enabled the commented out integration tests for SMS authentication flow and basic registration flow confirming that a single action with provided inputs now allows the flow to proceed automatically in a single request.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1035

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
