### PR TITLE
Improve default attributes handling in flows and oauth

### DIFF
--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -41,10 +41,7 @@ const (
 	jsonDataKeyCodeChallenge       = "code_challenge"
 	jsonDataKeyCodeChallengeMethod = "code_challenge_method"
 	jsonDataKeyResource            = "resource"
-	jsonDataKeyAuthorizedUserType  = "authorized_user_type"
-	jsonDataKeyUserOUID            = "user_ou_id"
-	jsonDataKeyUserOUName          = "user_ou_name"
-	jsonDataKeyUserOUHandle        = "user_ou_handle"
+	jsonDataKeyUserAttributes      = "user_attributes"
 )
 
 // AuthorizationCodeStoreInterface defines the interface for managing authorization codes.
@@ -147,10 +144,11 @@ func (acs *authorizationCodeStore) getJSONDataBytes(authzCode AuthorizationCode)
 		jsonDataKeyCodeChallenge:       authzCode.CodeChallenge,
 		jsonDataKeyCodeChallengeMethod: authzCode.CodeChallengeMethod,
 		jsonDataKeyResource:            authzCode.Resource,
-		jsonDataKeyAuthorizedUserType:  authzCode.AuthorizedUserType,
-		jsonDataKeyUserOUID:            authzCode.UserOUID,
-		jsonDataKeyUserOUName:          authzCode.UserOUName,
-		jsonDataKeyUserOUHandle:        authzCode.UserOUHandle,
+	}
+
+	// Include user attributes if present
+	if len(authzCode.UserAttributes) > 0 {
+		jsonData[jsonDataKeyUserAttributes] = authzCode.UserAttributes
 	}
 
 	jsonDataBytes, err := json.Marshal(jsonData)
@@ -253,17 +251,8 @@ func appendAuthzDataJSON(row map[string]interface{}, authzCode *AuthorizationCod
 		authzCode.Resource = resource
 	}
 
-	if authorizedUserType, ok := authzData[jsonDataKeyAuthorizedUserType].(string); ok {
-		authzCode.AuthorizedUserType = authorizedUserType
-	}
-	if userOUID, ok := authzData[jsonDataKeyUserOUID].(string); ok {
-		authzCode.UserOUID = userOUID
-	}
-	if userOUName, ok := authzData[jsonDataKeyUserOUName].(string); ok {
-		authzCode.UserOUName = userOUName
-	}
-	if userOUHandle, ok := authzData[jsonDataKeyUserOUHandle].(string); ok {
-		authzCode.UserOUHandle = userOUHandle
+	if userAttrs, ok := authzData[jsonDataKeyUserAttributes].(map[string]interface{}); ok && userAttrs != nil {
+		authzCode.UserAttributes = userAttrs
 	}
 
 	return authzCode, nil

--- a/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
@@ -144,10 +144,12 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_Success()
 		"code_challenge":        "abc123",
 		"code_challenge_method": "s256",
 		"resource":              "",
-		"authorized_user_type":  "person",
-		"user_ou_id":            "550e8400-e29b-41d4-a716-446655440000",
-		"user_ou_name":          "Default OU",
-		"user_ou_handle":        "default",
+		"user_attributes": map[string]interface{}{
+			"userType": "person",
+			"ouId":     "550e8400-e29b-41d4-a716-446655440000",
+			"ouName":   "Default OU",
+			"ouHandle": "default",
+		},
 	}
 	authzDataJSON, _ := json.Marshal(authzData)
 
@@ -173,10 +175,11 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_Success()
 	assert.Equal(suite.T(), "test-user-id", result.AuthorizedUserID)
 	assert.Equal(suite.T(), "abc123", result.CodeChallenge)
 	assert.Equal(suite.T(), "s256", result.CodeChallengeMethod)
-	assert.Equal(suite.T(), "person", result.AuthorizedUserType)
-	assert.Equal(suite.T(), "550e8400-e29b-41d4-a716-446655440000", result.UserOUID)
-	assert.Equal(suite.T(), "Default OU", result.UserOUName)
-	assert.Equal(suite.T(), "default", result.UserOUHandle)
+	assert.NotNil(suite.T(), result.UserAttributes)
+	assert.Equal(suite.T(), "person", result.UserAttributes["userType"])
+	assert.Equal(suite.T(), "550e8400-e29b-41d4-a716-446655440000", result.UserAttributes["ouId"])
+	assert.Equal(suite.T(), "Default OU", result.UserAttributes["ouName"])
+	assert.Equal(suite.T(), "default", result.UserAttributes["ouHandle"])
 	assert.NotZero(suite.T(), result.TimeCreated)
 	assert.NotZero(suite.T(), result.ExpiryTime)
 	assert.Equal(suite.T(), "read write", result.Scopes)

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -37,10 +37,7 @@ type AuthorizationCode struct {
 	ClientID            string
 	RedirectURI         string
 	AuthorizedUserID    string
-	AuthorizedUserType  string
-	UserOUID            string
-	UserOUName          string
-	UserOUHandle        string
+	UserAttributes      map[string]interface{}
 	TimeCreated         time.Time
 	ExpiryTime          time.Time
 	Scopes              string
@@ -63,10 +60,7 @@ type AuthZPostResponse struct {
 
 // assertionClaims represents the claims extracted from the flow assertion JWT.
 type assertionClaims struct {
-	userID         string
-	userType       string
-	ouID           string
-	ouName         string
-	ouHandle       string
-	userAttributes map[string]string
+	userID                string
+	authorizedPermissions string
+	userAttributes        map[string]interface{}
 }

--- a/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
+++ b/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
@@ -39,6 +39,5 @@ type RefreshTokenGrantHandlerInterface interface {
 		oauthApp *appmodel.OAuthAppConfigProcessedDTO,
 		subject, audience, grantType string,
 		scopes []string,
-		userType, ouID, ouName, ouHandle string,
 	) *model.ErrorResponse
 }

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -105,10 +105,6 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 		UserAttributes: refreshTokenClaims.UserAttributes,
 		GrantType:      refreshTokenClaims.GrantType,
 		OAuthApp:       oauthApp,
-		UserType:       refreshTokenClaims.UserType,
-		OuID:           refreshTokenClaims.OuID,
-		OuName:         refreshTokenClaims.OuName,
-		OuHandle:       refreshTokenClaims.OuHandle,
 	})
 	if err != nil {
 		logger.Error("Failed to generate access token", log.Error(err))
@@ -131,9 +127,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 	if renewRefreshToken {
 		logger.Debug("Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
 		errResp := h.IssueRefreshToken(tokenResponse, oauthApp, refreshTokenClaims.Sub, refreshTokenClaims.Aud,
-			refreshTokenClaims.GrantType, newTokenScopes,
-			refreshTokenClaims.UserType, refreshTokenClaims.OuID,
-			refreshTokenClaims.OuName, refreshTokenClaims.OuHandle)
+			refreshTokenClaims.GrantType, newTokenScopes)
 		if errResp != nil && errResp.Error != "" {
 			errResp.ErrorDescription = "Error while issuing refresh token: " + errResp.ErrorDescription
 			logger.Error("Failed to issue refresh token", log.String("error", errResp.Error))
@@ -158,7 +152,6 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	oauthApp *appmodel.OAuthAppConfigProcessedDTO,
 	subject, audience, grantType string,
 	scopes []string,
-	userType, ouID, ouName, ouHandle string,
 ) *model.ErrorResponse {
 	tokenCtx := &tokenservice.RefreshTokenBuildContext{
 		ClientID:             oauthApp.ClientID,
@@ -168,20 +161,6 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 		AccessTokenAudience:  audience,
 		AccessTokenUserAttrs: tokenResponse.AccessToken.UserAttributes,
 		OAuthApp:             oauthApp,
-	}
-
-	// Set user type and organizational unit details if provided
-	if userType != "" {
-		tokenCtx.UserType = userType
-	}
-	if ouID != "" {
-		tokenCtx.OuID = ouID
-	}
-	if ouName != "" {
-		tokenCtx.OuName = ouName
-	}
-	if ouHandle != "" {
-		tokenCtx.OuHandle = ouHandle
 	}
 
 	// Build refresh token using token builder

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -212,7 +212,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() 
 
 	err := suite.handler.IssueRefreshToken(tokenResponse, suite.oauthApp,
 		testRefreshTokenUserID, testRefreshTokenAudience,
-		"authorization_code", []string{"read", "write"}, "", "", "", "")
+		"authorization_code", []string{"read", "write"})
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), tokenResponse.RefreshToken)
@@ -232,7 +232,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_JWTGenerat
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(tokenResponse, suite.oauthApp, "", "",
-		"authorization_code", []string{"read"}, "", "", "", "")
+		"authorization_code", []string{"read"})
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
@@ -252,7 +252,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyT
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(tokenResponse, suite.oauthApp, "", "",
-		"authorization_code", []string{"read"}, "", "", "", "")
+		"authorization_code", []string{"read"})
 
 	assert.Nil(suite.T(), err)
 }

--- a/backend/internal/oauth/oauth2/model/token.go
+++ b/backend/internal/oauth/oauth2/model/token.go
@@ -62,10 +62,6 @@ type TokenDTO struct {
 	UserAttributes map[string]interface{}
 	Subject        string
 	Audience       string
-	UserType       string
-	OuID           string
-	OuName         string
-	OuHandle       string
 }
 
 // TokenResponseDTO represents the data transfer object for token responses.

--- a/backend/internal/oauth/oauth2/token/token_handler.go
+++ b/backend/internal/oauth/oauth2/token/token_handler.go
@@ -231,9 +231,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 
 		refreshTokenError := refreshGrantHandlerTyped.IssueRefreshToken(tokenRespDTO, oauthApp,
 			tokenRespDTO.AccessToken.Subject, tokenRespDTO.AccessToken.Audience,
-			grantTypeStr, tokenRespDTO.AccessToken.Scopes,
-			tokenRespDTO.AccessToken.UserType, tokenRespDTO.AccessToken.OuID,
-			tokenRespDTO.AccessToken.OuName, tokenRespDTO.AccessToken.OuHandle)
+			grantTypeStr, tokenRespDTO.AccessToken.Scopes)
 		if refreshTokenError != nil && refreshTokenError.Error != "" {
 			th.publishTokenIssuanceFailedEvent(r.Context(), clientID, grantTypeStr, scopeStr,
 				http.StatusInternalServerError, refreshTokenError.ErrorDescription, startTime)

--- a/backend/internal/oauth/oauth2/token/token_handler_test.go
+++ b/backend/internal/oauth/oauth2/token/token_handler_test.go
@@ -585,7 +585,9 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_WithRefreshToken() {
 		Return(tokenResponse, nil)
 
 	mockRefreshHandler.On("IssueRefreshToken", tokenResponse, mockApp, "user123", "test-audience",
-		"authorization_code", []string{"openid"}, "", "", "", "").
+		"authorization_code", mock.MatchedBy(func(scopes []string) bool {
+			return len(scopes) == 1 && scopes[0] == "openid"
+		})).
 		Return(nil)
 
 	rr := httptest.NewRecorder()
@@ -664,7 +666,9 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_RefreshTokenIssuanceE
 		ErrorDescription: "Failed to issue refresh token",
 	}
 	mockRefreshHandler.On("IssueRefreshToken", tokenResponse, mockApp, "user123", "test-audience",
-		"authorization_code", []string{"openid"}, "", "", "", "").
+		"authorization_code", mock.MatchedBy(func(scopes []string) bool {
+			return len(scopes) == 1 && scopes[0] == "openid"
+		})).
 		Return(refreshError)
 
 	rr := httptest.NewRecorder()

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -73,6 +73,7 @@ func (suite *TokenBuilderTestSuite) SetupTest() {
 			Issuer: "https://thunder.io",
 			AccessToken: &appmodel.AccessTokenConfig{
 				ValidityPeriod: 3600,
+				UserAttributes: []string{"name"}, // Configure user attributes for tests
 			},
 		},
 	}

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -48,14 +48,9 @@ type AccessTokenBuildContext struct {
 	ClientID       string
 	Scopes         []string
 	UserAttributes map[string]interface{}
-	UserGroups     []string
 	GrantType      string
 	OAuthApp       *appmodel.OAuthAppConfigProcessedDTO
 	ActorClaims    *SubjectTokenClaims
-	UserType       string
-	OuID           string
-	OuName         string
-	OuHandle       string
 }
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
@@ -67,10 +62,6 @@ type RefreshTokenBuildContext struct {
 	AccessTokenAudience  string
 	AccessTokenUserAttrs map[string]interface{}
 	OAuthApp             *appmodel.OAuthAppConfigProcessedDTO
-	UserType             string
-	OuID                 string
-	OuName               string
-	OuHandle             string
 }
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
@@ -79,13 +70,8 @@ type IDTokenBuildContext struct {
 	Audience       string
 	Scopes         []string
 	UserAttributes map[string]interface{}
-	UserGroups     []string
 	AuthTime       int64
 	OAuthApp       *appmodel.OAuthAppConfigProcessedDTO
-	UserType       string
-	OuID           string
-	OuName         string
-	OuHandle       string
 }
 
 // RefreshTokenClaims represents the validated claims from a refresh token.
@@ -96,10 +82,6 @@ type RefreshTokenClaims struct {
 	Scopes         []string
 	UserAttributes map[string]interface{}
 	Iat            int64
-	UserType       string
-	OuID           string
-	OuName         string
-	OuHandle       string
 }
 
 // SubjectTokenClaims represents the validated claims from a subject token (for token exchange).

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
-	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 )
@@ -75,11 +74,6 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 	}
 
 	// Extract user type and organizational unit details if present
-	userType, _ := extractStringClaim(claims, constants.ClaimUserType)
-	ouID, _ := extractStringClaim(claims, constants.ClaimOUID)
-	ouName, _ := extractStringClaim(claims, constants.ClaimOUName)
-	ouHandle, _ := extractStringClaim(claims, constants.ClaimOUHandle)
-
 	return &RefreshTokenClaims{
 		Sub:            sub,
 		Aud:            aud,
@@ -87,10 +81,6 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 		Scopes:         scopes,
 		UserAttributes: userAttributes,
 		Iat:            iat,
-		UserType:       userType,
-		OuID:           ouID,
-		OuName:         ouName,
-		OuHandle:       ouHandle,
 	}, nil
 }
 

--- a/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
@@ -108,16 +108,16 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_HandleGrant_Call) RunAndReturn(r
 }
 
 // IssueRefreshToken provides a mock function for the type RefreshTokenGrantHandlerInterfaceMock
-func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, userType string, ouID string, ouName string, ouHandle string) *model.ErrorResponse {
-	ret := _mock.Called(tokenResponse, oauthApp, subject, audience, grantType, scopes, userType, ouID, ouName, ouHandle)
+func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string) *model.ErrorResponse {
+	ret := _mock.Called(tokenResponse, oauthApp, subject, audience, grantType, scopes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IssueRefreshToken")
 	}
 
 	var r0 *model.ErrorResponse
-	if returnFunc, ok := ret.Get(0).(func(*model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string, string, string, string, string) *model.ErrorResponse); ok {
-		r0 = returnFunc(tokenResponse, oauthApp, subject, audience, grantType, scopes, userType, ouID, ouName, ouHandle)
+	if returnFunc, ok := ret.Get(0).(func(*model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string) *model.ErrorResponse); ok {
+		r0 = returnFunc(tokenResponse, oauthApp, subject, audience, grantType, scopes)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ErrorResponse)
@@ -138,15 +138,11 @@ type RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call struct {
 //   - audience string
 //   - grantType string
 //   - scopes []string
-//   - userType string
-//   - ouID string
-//   - ouName string
-//   - ouHandle string
-func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}, userType interface{}, ouID interface{}, ouName interface{}, ouHandle interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
-	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", tokenResponse, oauthApp, subject, audience, grantType, scopes, userType, ouID, ouName, ouHandle)}
+func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", tokenResponse, oauthApp, subject, audience, grantType, scopes)}
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, userType string, ouID string, ouName string, ouHandle string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *model.TokenResponseDTO
 		if args[0] != nil {
@@ -172,22 +168,6 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 		if args[5] != nil {
 			arg5 = args[5].([]string)
 		}
-		var arg6 string
-		if args[6] != nil {
-			arg6 = args[6].(string)
-		}
-		var arg7 string
-		if args[7] != nil {
-			arg7 = args[7].(string)
-		}
-		var arg8 string
-		if args[8] != nil {
-			arg8 = args[8].(string)
-		}
-		var arg9 string
-		if args[9] != nil {
-			arg9 = args[9].(string)
-		}
 		run(
 			arg0,
 			arg1,
@@ -195,10 +175,6 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 			arg3,
 			arg4,
 			arg5,
-			arg6,
-			arg7,
-			arg8,
-			arg9,
 		)
 	})
 	return _c
@@ -209,7 +185,7 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Return(e
 	return _c
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, userType string, ouID string, ouName string, ouHandle string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/flow/authentication/assurance_test.go
+++ b/tests/integration/flow/authentication/assurance_test.go
@@ -303,6 +303,9 @@ var (
 		ClientSecret:              "assurance_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"assurance_test_user"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	assuranceUserSchema = testutils.UserSchema{

--- a/tests/integration/flow/authentication/attribute_collect_test.go
+++ b/tests/integration/flow/authentication/attribute_collect_test.go
@@ -103,6 +103,9 @@ var (
 		ClientSecret:              "attr_collect_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"attr_collect_flow_user"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	attrCollectTestOU = testutils.OrganizationUnit{

--- a/tests/integration/flow/authentication/authz_test.go
+++ b/tests/integration/flow/authentication/authz_test.go
@@ -146,6 +146,9 @@ var (
 		ClientSecret:              "authz_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"authz-test-person"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	userWithRole = testutils.User{

--- a/tests/integration/flow/authentication/conditional_exec_auth_test.go
+++ b/tests/integration/flow/authentication/conditional_exec_auth_test.go
@@ -110,6 +110,9 @@ var (
 		ClientSecret:              "conditional_exec_auth_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"conditional_exec_flow_user"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	conditionalExecTestOU = testutils.OrganizationUnit{

--- a/tests/integration/flow/authentication/github_auth_test.go
+++ b/tests/integration/flow/authentication/github_auth_test.go
@@ -75,6 +75,9 @@ var (
 		ClientSecret:              "github_auth_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"github_auth_user"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 )
 

--- a/tests/integration/flow/authentication/google_auth_test.go
+++ b/tests/integration/flow/authentication/google_auth_test.go
@@ -75,6 +75,9 @@ var (
 		ClientSecret:              "google_auth_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"google_auth_user"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 )
 

--- a/tests/integration/flow/authentication/http_request_executor_test.go
+++ b/tests/integration/flow/authentication/http_request_executor_test.go
@@ -191,6 +191,9 @@ var (
 		ClientSecret:              "http_request_executor_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"http_request_test_person"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	httpRequestTestOU = testutils.OrganizationUnit{

--- a/tests/integration/flow/authentication/multi_action_input_binding_test.go
+++ b/tests/integration/flow/authentication/multi_action_input_binding_test.go
@@ -118,6 +118,9 @@ var (
 		ClientSecret:              "multi_action_input_binding_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"multi_action_input_binding_test_person"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	multiActionInputBindingTestOU = testutils.OrganizationUnit{

--- a/tests/integration/flow/authentication/prompt_actions_test.go
+++ b/tests/integration/flow/authentication/prompt_actions_test.go
@@ -186,6 +186,9 @@ var (
 		ClientSecret:              "prompt_actions_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"prompt_actions_test_person"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	promptActionsTestOU = testutils.OrganizationUnit{

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -221,6 +221,9 @@ var (
 		ClientSecret:              "sms_auth_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{"sms_auth_user"},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	smsAuthUserSchema = testutils.UserSchema{

--- a/tests/integration/flow/authentication/verbose_meta_test.go
+++ b/tests/integration/flow/authentication/verbose_meta_test.go
@@ -201,6 +201,9 @@ var (
 		ClientSecret:              "verbose_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{verboseTestUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	verboseTestUser = testutils.User{

--- a/tests/integration/flow/registration/github_registration_test.go
+++ b/tests/integration/flow/registration/github_registration_test.go
@@ -122,6 +122,9 @@ var (
 		ClientSecret:              "github_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{githubRegUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 )
 

--- a/tests/integration/flow/registration/google_registration_test.go
+++ b/tests/integration/flow/registration/google_registration_test.go
@@ -175,6 +175,9 @@ var (
 		ClientSecret:              "google_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{googleRegUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 )
 

--- a/tests/integration/flow/registration/google_registration_with_role_group_test.go
+++ b/tests/integration/flow/registration/google_registration_with_role_group_test.go
@@ -120,6 +120,9 @@ var (
 		ClientSecret:              "google_reg_group_role_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{googleRegGroupRoleUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 )
 

--- a/tests/integration/flow/registration/http_request_executor_registration_test.go
+++ b/tests/integration/flow/registration/http_request_executor_registration_test.go
@@ -166,6 +166,9 @@ var (
 		Description:               "Application for testing HTTP request executor in registration flows",
 		IsRegistrationFlowEnabled: true,
 		AllowedUserTypes:          []string{httpRequestRegTestUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 )
 

--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -286,6 +286,9 @@ var (
 		ClientSecret:              "ou_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{dynamicUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	smsApp = testutils.Application{
@@ -296,6 +299,9 @@ var (
 		ClientSecret:              "ou_sms_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{dynamicUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	ouRegTestOU = testutils.OrganizationUnit{

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -200,6 +200,9 @@ var (
 		ClientSecret:              "sms_reg_flow_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{smsRegTestUserSchema.Name},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 )
 

--- a/tests/integration/flow/registration/user_type_resolver_test.go
+++ b/tests/integration/flow/registration/user_type_resolver_test.go
@@ -100,6 +100,9 @@ func (ts *UserTypeResolverRuntimeTestSuite) SetupSuite() {
 		ClientSecret:              "runtime_meta_test_secret",
 		RedirectURIs:              []string{"http://localhost:3000/callback"},
 		AllowedUserTypes:          []string{ts.testUserTypeName1, ts.testUserTypeName2},
+		TokenConfig: map[string]interface{}{
+			"user_attributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
 	}
 
 	appID, err := testutils.CreateApplication(testApp)

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -236,6 +236,11 @@ func CreateApplication(app Application) (string, error) {
 		appData["allowed_user_types"] = app.AllowedUserTypes
 	}
 
+	// Add token if provided
+	if app.TokenConfig != nil {
+		appData["token"] = app.TokenConfig
+	}
+
 	appJSON, err := json.Marshal(appData)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal application: %w", err)

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -54,6 +54,7 @@ type Application struct {
 	AllowedUserTypes          []string                 `json:"allowed_user_types,omitempty"`
 	Certificate               map[string]interface{}   `json:"certificate,omitempty"`
 	InboundAuthConfig         []map[string]interface{} `json:"inbound_auth_config,omitempty"`
+	TokenConfig               map[string]interface{}   `json:"token_config,omitempty"`
 }
 
 // OrganizationUnit represents an organization unit in the system


### PR DESCRIPTION
This pull request refactors how user-related claims are added to JWT assertions in the authentication flow, making the process more configurable and aligned with OAuth2 standards. Instead of always including certain user and organization unit (OU) attributes, these claims are now conditionally included based on the application's token configuration. The changes also add support for including user groups and ensure that only requested attributes are added to the JWT. Tests have been updated to reflect and verify the new behavior.

## ⚠️ Breaking Changes

This PR introduces breaking change on retrieving user attributes via access token/ID token application configurations.

### 🔧 Summary of Breaking Changes

- `user_atttributes` configured in application's token config for both access and ID tokens may not be available in the respective tokens

### 🔄 Migration Guide

- Include the `user_attributes` required via access token/ID tokens in the root token's `user_attributes` too


Key changes:

**JWT Claims Generation & User Attribute Handling**
- Refactored `generateAuthAssertion` and related methods to only include user, group, and OU claims in the JWT if they are explicitly listed in the application's `Token.UserAttributes` configuration. This includes user type, OU ID, OU name, and OU handle. [[1]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL158-R191) [[2]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL230-R267) [[3]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL246-R281) [[4]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL263-R302) [[5]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL286-R322) [[6]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL296-R367)
- Added a new `appendGroupsToClaims` method to include user groups in the JWT if requested.

**Context Propagation**
- Updated internal calls to `getUserAttributes` and related methods to accept a `context.Context` parameter, ensuring proper context propagation throughout user and group retrieval operations. [[1]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL246-R281) [[2]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL263-R302)

**OAuth2 Authorization Code Store Updates**
- Simplified the storage of user-related attributes in the OAuth2 authorization code store: instead of storing individual user/OU fields, all user attributes are now stored in a single `user_attributes` map. [[1]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL44-R44) [[2]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL150-R151) [[3]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL256-R255)
- Updated deserialization logic to handle the new `user_attributes` structure.

**Test Suite Enhancements**
- Updated and expanded test cases to verify that only the configured user attributes are included in JWTs, including new tests for merged OAuth and root attributes, group claims, and OU claims. [[1]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L124-R130) [[2]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L398-R404) [[3]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L412-R418) [[4]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L428-R434) [[5]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L448-R463) [[6]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L506-R520) [[7]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L517-R533) [[8]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L610-R628) [[9]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L668-R690) [[10]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R706-R752)

**Test Data & Imports**
- Adjusted imports and test data to support the refactored logic and new configuration-driven behavior. [[1]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR25-R32) [[2]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R22) [[3]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R35) [[4]](diffhunk://#diff-4505abf3272b6504ef692bf20b049aeb554ecbdb84a5b966bb587577e5d69772L147-R152)

Related issue:
- https://github.com/asgardeo/thunder/issues/1221