### PR TITLE
Migrate thunder-gate tests to Vitest Browser Mode and Vitest v4

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -195,6 +195,11 @@ jobs:
           cd frontend/apps/thunder-develop
           pnpm test:coverage
 
+      - name: 🎭 Install Playwright System Dependencies for Thunder-Gate Tests
+        run: |
+          cd frontend
+          pnpm exec playwright install-deps chromium
+
       - name: 🧪 Run Thunder-Gate Tests with Coverage
         run: |
           cd frontend/apps/thunder-gate

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ samples/apps/*/server/app
 backend/coverage_unit.out
 backend/coverage_unit.html
 
+# Vitest browser mode screenshots
+**/__screenshots__/
+
 # IDE settings
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md

--- a/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useCreateApplication.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useCreateApplication.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {waitFor, act, renderHook} from '@thunder/test-utils';
 import {useAsgardeo} from '@asgardeo/react';
 import {useConfig} from '@thunder/shared-contexts';
@@ -136,7 +136,7 @@ describe('useCreateApplication', () => {
     user_attributes: ['email', 'username'],
   };
 
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
 
   beforeEach(() => {
     // Mock HTTP request function

--- a/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useDeleteApplication.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useDeleteApplication.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {waitFor, renderHook} from '@thunder/test-utils';
 import useDeleteApplication from '../useDeleteApplication';
 import type {ApplicationListResponse} from '../../models/responses';
@@ -39,8 +39,8 @@ const {useAsgardeo} = await import('@asgardeo/react');
 const {useConfig} = await import('@thunder/shared-contexts');
 
 describe('useDeleteApplication', () => {
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
-  let mockGetServerUrl: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
+  let mockGetServerUrl: Mock;
 
   beforeEach(() => {
     mockHttpRequest = vi.fn();

--- a/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useGetApplication.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useGetApplication.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {waitFor, renderHook} from '@thunder/test-utils';
 import useGetApplication from '../useGetApplication';
 import type {Application} from '../../models/application';
@@ -39,8 +39,8 @@ const {useAsgardeo} = await import('@asgardeo/react');
 const {useConfig} = await import('@thunder/shared-contexts');
 
 describe('useGetApplication', () => {
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
-  let mockGetServerUrl: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
+  let mockGetServerUrl: Mock;
 
   const mockApplication: Application = {
     id: '550e8400-e29b-41d4-a716-446655440000',

--- a/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useGetApplications.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useGetApplications.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {waitFor, renderHook} from '@thunder/test-utils';
 import useGetApplications from '../useGetApplications';
 import type {ApplicationListResponse} from '../../models/responses';
@@ -39,8 +39,8 @@ const {useAsgardeo} = await import('@asgardeo/react');
 const {useConfig} = await import('@thunder/shared-contexts');
 
 describe('useGetApplications', () => {
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
-  let mockGetServerUrl: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
+  let mockGetServerUrl: Mock;
 
   const mockApplicationListResponse: ApplicationListResponse = {
     totalResults: 2,

--- a/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useUpdateApplication.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/api/__tests__/useUpdateApplication.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {waitFor, renderHook} from '@thunder/test-utils';
 import useUpdateApplication from '../useUpdateApplication';
 import type {Application} from '../../models/application';
@@ -40,8 +40,8 @@ const {useAsgardeo} = await import('@asgardeo/react');
 const {useConfig} = await import('@thunder/shared-contexts');
 
 describe('useUpdateApplication', () => {
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
-  let mockGetServerUrl: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
+  let mockGetServerUrl: Mock;
 
   const mockApplication: Application = {
     id: '550e8400-e29b-41d4-a716-446655440000',

--- a/frontend/apps/thunder-develop/src/features/applications/components/__tests__/ApplicationsList.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/__tests__/ApplicationsList.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, vi, type Mock} from 'vitest';
 import {render, screen, waitFor} from '@thunder/test-utils';
 import userEvent from '@testing-library/user-event';
 import type {ApplicationListResponse} from '../../models/responses';
@@ -111,7 +111,7 @@ const {useNavigate} = await import('react-router');
 const {default: useDataGridLocaleText} = await import('../../../../hooks/useDataGridLocaleText');
 
 describe('ApplicationsList', () => {
-  let mockNavigate: ReturnType<typeof vi.fn>;
+  let mockNavigate: Mock;
 
   const mockApplicationsData: ApplicationListResponse = {
     totalResults: 2,

--- a/frontend/apps/thunder-develop/src/features/applications/components/create-application/__tests__/IntegrationGuide.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/create-application/__tests__/IntegrationGuide.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach, type Mock} from 'vitest';
 import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {BrowserRouter} from 'react-router';
@@ -56,7 +56,7 @@ describe('IntegrationGuide', () => {
   const renderWithRouter = (ui: React.ReactElement) => render(<BrowserRouter>{ui}</BrowserRouter>);
 
   // Store mock at module level so tests can access it
-  let clipboardWriteTextMock: ReturnType<typeof vi.fn>;
+  let clipboardWriteTextMock: Mock;
   // Store original document.execCommand to restore after tests
   let originalExecCommand: typeof document.execCommand;
 

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
@@ -128,7 +128,7 @@ export default function EditTokenSettings({
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
 
-  const applyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const applyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['user', 'default']));
   const [userSchemas, setUserSchemas] = useState<ApiUserSchema[]>([]);
 

--- a/frontend/apps/thunder-develop/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
@@ -18,7 +18,7 @@
 
 import {render, screen, waitFor} from '@thunder/test-utils';
 import userEvent from '@testing-library/user-event';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, type Mock} from 'vitest';
 import type {UseQueryResult, UseMutationResult} from '@tanstack/react-query';
 import type {Application} from '../../models/application';
 import ApplicationEditPage from '../ApplicationEditPage';
@@ -119,10 +119,10 @@ vi.mock('../../components/LogoUpdateModal', () => ({
   ),
 }));
 
-const mockUseGetApplication = useGetApplication as ReturnType<typeof vi.fn>;
-const mockUseUpdateApplication = useUpdateApplication as ReturnType<typeof vi.fn>;
-const mockGetTemplateMetadata = getTemplateMetadata as ReturnType<typeof vi.fn>;
-const mockGetIntegrationGuidesForTemplate = getIntegrationGuidesForTemplate as ReturnType<typeof vi.fn>;
+const mockUseGetApplication = useGetApplication as Mock;
+const mockUseUpdateApplication = useUpdateApplication as Mock;
+const mockGetTemplateMetadata = getTemplateMetadata as Mock;
+const mockGetIntegrationGuidesForTemplate = getIntegrationGuidesForTemplate as Mock;
 
 describe('ApplicationEditPage', () => {
   const mockApplication: Application = {
@@ -875,7 +875,7 @@ describe('ApplicationEditPage', () => {
     it('should not save when application or applicationId is missing', async () => {
       // Mock useParams to return undefined applicationId
       const {useParams} = await import('react-router');
-      (useParams as ReturnType<typeof vi.fn>).mockReturnValue({applicationId: undefined});
+      (useParams as Mock).mockReturnValue({applicationId: undefined});
 
       const mockMutateAsync = vi.fn().mockResolvedValue(mockApplication);
       mockUseUpdateApplication.mockReturnValue({
@@ -892,7 +892,7 @@ describe('ApplicationEditPage', () => {
       expect(mockMutateAsync).not.toHaveBeenCalled();
 
       // Restore original mock
-      (useParams as ReturnType<typeof vi.fn>).mockReturnValue({applicationId: 'test-app-id'});
+      (useParams as Mock).mockReturnValue({applicationId: 'test-app-id'});
     });
   });
 

--- a/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useCreateFlow.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useCreateFlow.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {renderHook, waitFor, act} from '@thunder/test-utils';
 import {useAsgardeo} from '@asgardeo/react';
 import {useConfig} from '@thunder/shared-contexts';
@@ -62,7 +62,7 @@ describe('useCreateFlow', () => {
     ],
   };
 
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
 
   beforeEach(() => {
     mockHttpRequest = vi.fn();

--- a/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useDeleteFlow.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useDeleteFlow.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {renderHook, waitFor, act} from '@thunder/test-utils';
 import {useAsgardeo} from '@asgardeo/react';
 import {useConfig} from '@thunder/shared-contexts';
@@ -36,7 +36,7 @@ vi.mock('@thunder/shared-contexts', async (importOriginal) => {
 });
 
 describe('useDeleteFlow', () => {
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
 
   beforeEach(() => {
     mockHttpRequest = vi.fn();

--- a/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useGetFlowById.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useGetFlowById.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {renderHook, waitFor} from '@thunder/test-utils';
 import {useAsgardeo} from '@asgardeo/react';
 import {useConfig} from '@thunder/shared-contexts';
@@ -67,7 +67,7 @@ describe('useGetFlowById', () => {
     updatedAt: '2025-01-01T00:00:00Z',
   };
 
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
 
   beforeEach(() => {
     mockHttpRequest = vi.fn();

--- a/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useGetFlows.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useGetFlows.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {renderHook, waitFor} from '@thunder/test-utils';
 import {useAsgardeo} from '@asgardeo/react';
 import {useConfig} from '@thunder/shared-contexts';
@@ -68,7 +68,7 @@ describe('useGetFlows', () => {
     ],
   };
 
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
 
   beforeEach(() => {
     mockHttpRequest = vi.fn();

--- a/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useUpdateFlow.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/api/__tests__/useUpdateFlow.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {renderHook, waitFor, act} from '@thunder/test-utils';
 import {useAsgardeo} from '@asgardeo/react';
 import {useConfig} from '@thunder/shared-contexts';
@@ -64,7 +64,7 @@ describe('useUpdateFlow', () => {
     ],
   };
 
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
 
   beforeEach(() => {
     mockHttpRequest = vi.fn();

--- a/frontend/apps/thunder-develop/src/features/flows/components/dnd/__tests__/Sortable.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/dnd/__tests__/Sortable.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, type Mock} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import Sortable from '../Sortable';
 
@@ -436,7 +436,7 @@ describe('Sortable', () => {
     // Create a fresh manager for each test in this block to avoid WeakMap caching
     let freshManager: {
       monitor: {
-        addEventListener: ReturnType<typeof vi.fn>;
+        addEventListener: Mock;
       };
     };
 

--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/ToolbarPlugin.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/ToolbarPlugin.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, type Mock} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import ToolbarPlugin from '../ToolbarPlugin';
 
@@ -610,8 +610,8 @@ describe('ToolbarPlugin', () => {
     it('should update toolbar state on selection change', async () => {
       // Mock $isRangeSelection to return true and provide selection
       const lexical = await vi.importMock<typeof import('lexical')>('lexical');
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({
@@ -632,8 +632,8 @@ describe('ToolbarPlugin', () => {
 
     it('should update bold state when selection has bold format', async () => {
       const lexical = await vi.importMock<typeof import('lexical')>('lexical');
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: (format: string) => format === 'bold',
         anchor: {
           getNode: () => ({
@@ -654,8 +654,8 @@ describe('ToolbarPlugin', () => {
 
     it('should update italic state when selection has italic format', async () => {
       const lexical = await vi.importMock<typeof import('lexical')>('lexical');
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: (format: string) => format === 'italic',
         anchor: {
           getNode: () => ({
@@ -676,8 +676,8 @@ describe('ToolbarPlugin', () => {
 
     it('should update underline state when selection has underline format', async () => {
       const lexical = await vi.importMock<typeof import('lexical')>('lexical');
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: (format: string) => format === 'underline',
         anchor: {
           getNode: () => ({
@@ -732,7 +732,7 @@ describe('ToolbarPlugin', () => {
   describe('Block Type Detection', () => {
     it('should detect heading block type', async () => {
       const {$isHeadingNode} = await vi.importMock<typeof import('@lexical/rich-text')>('@lexical/rich-text');
-      ($isHeadingNode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      ($isHeadingNode as Mock).mockReturnValue(true);
 
       render(<ToolbarPlugin typography />);
 
@@ -757,7 +757,7 @@ describe('ToolbarPlugin', () => {
   describe('Link State Detection', () => {
     it('should detect when parent node is a link', async () => {
       const {$isLinkNode} = await vi.importMock<typeof import('@lexical/link')>('@lexical/link');
-      ($isLinkNode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      ($isLinkNode as Mock).mockReturnValue(true);
 
       render(<ToolbarPlugin link />);
 
@@ -766,7 +766,7 @@ describe('ToolbarPlugin', () => {
 
     it('should detect when current node is a link', async () => {
       const {$isLinkNode} = await vi.importMock<typeof import('@lexical/link')>('@lexical/link');
-      ($isLinkNode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      ($isLinkNode as Mock).mockReturnValue(true);
 
       render(<ToolbarPlugin link />);
 
@@ -784,8 +784,8 @@ describe('ToolbarPlugin', () => {
 
     it('should apply active class to bold button when bold is active and not disabled', async () => {
       const lexical = await vi.importMock<typeof import('lexical')>('lexical');
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: (format: string) => format === 'bold',
         anchor: {
           getNode: () => ({
@@ -994,8 +994,8 @@ describe('ToolbarPlugin', () => {
       const lexicalSelection = await vi.importMock<typeof import('@lexical/selection')>('@lexical/selection');
 
       // Mock $isRangeSelection to return true
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({
@@ -1034,8 +1034,8 @@ describe('ToolbarPlugin', () => {
       const lexicalLink = await vi.importMock<typeof import('@lexical/link')>('@lexical/link');
 
       // Setup mock to make isLink true
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({
@@ -1050,7 +1050,7 @@ describe('ToolbarPlugin', () => {
       });
 
       // Make $isLinkNode return true to set isLink state
-      (lexicalLink.$isLinkNode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (lexicalLink.$isLinkNode as Mock).mockReturnValue(true);
 
       // Capture the update listener to trigger $updateToolbar
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1173,14 +1173,14 @@ describe('ToolbarPlugin', () => {
       const richText = await vi.importMock<typeof import('@lexical/rich-text')>('@lexical/rich-text');
 
       // Make $isRangeSelection return true
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
 
       // Make blockType be 'h1' initially (not paragraph)
-      (richText.$isHeadingNode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (richText.$isHeadingNode as Mock).mockReturnValue(true);
 
       // Mock getSelectedNode to set up proper node structure
       const getSelectedNode = await vi.importMock<typeof import('../../utils/getSelectedNode')>('../../utils/getSelectedNode');
-      (getSelectedNode.default as ReturnType<typeof vi.fn>).mockReturnValue({
+      (getSelectedNode.default as Mock).mockReturnValue({
         getParent: () => null,
         getKey: () => 'test-key',
         getTopLevelElementOrThrow: () => ({
@@ -1192,7 +1192,7 @@ describe('ToolbarPlugin', () => {
       });
 
       // Mock selection
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({
@@ -1235,10 +1235,10 @@ describe('ToolbarPlugin', () => {
       const getSelectedNode = await vi.importMock<typeof import('../../utils/getSelectedNode')>('../../utils/getSelectedNode');
 
       // Setup for isLink to become true
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexicalLink.$isLinkNode as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (richText.$isHeadingNode as ReturnType<typeof vi.fn>).mockReturnValue(false);
-      (getSelectedNode.default as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexicalLink.$isLinkNode as Mock).mockReturnValue(true);
+      (richText.$isHeadingNode as Mock).mockReturnValue(false);
+      (getSelectedNode.default as Mock).mockReturnValue({
         getParent: () => ({type: 'link'}),
         getKey: () => 'test-key',
         getTopLevelElementOrThrow: () => ({
@@ -1248,7 +1248,7 @@ describe('ToolbarPlugin', () => {
           getTag: () => 'p',
         }),
       });
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({
@@ -1295,10 +1295,10 @@ describe('ToolbarPlugin', () => {
       const getSelectedNode = await vi.importMock<typeof import('../../utils/getSelectedNode')>('../../utils/getSelectedNode');
 
       // Setup for isLink to be false
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (lexicalLink.$isLinkNode as ReturnType<typeof vi.fn>).mockReturnValue(false);
-      (richText.$isHeadingNode as ReturnType<typeof vi.fn>).mockReturnValue(false);
-      (getSelectedNode.default as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (lexicalLink.$isLinkNode as Mock).mockReturnValue(false);
+      (richText.$isHeadingNode as Mock).mockReturnValue(false);
+      (getSelectedNode.default as Mock).mockReturnValue({
         getParent: () => ({type: 'paragraph'}),
         getKey: () => 'test-key',
         getTopLevelElementOrThrow: () => ({
@@ -1308,7 +1308,7 @@ describe('ToolbarPlugin', () => {
           getTag: () => 'p',
         }),
       });
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({
@@ -1356,9 +1356,9 @@ describe('ToolbarPlugin', () => {
       const richText = await vi.importMock<typeof import('@lexical/rich-text')>('@lexical/rich-text');
       const getSelectedNode = await vi.importMock<typeof import('../../utils/getSelectedNode')>('../../utils/getSelectedNode');
 
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (richText.$isHeadingNode as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (getSelectedNode.default as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (richText.$isHeadingNode as Mock).mockReturnValue(true);
+      (getSelectedNode.default as Mock).mockReturnValue({
         getParent: () => null,
         getKey: () => 'test-key',
         getTopLevelElementOrThrow: () => ({
@@ -1368,7 +1368,7 @@ describe('ToolbarPlugin', () => {
           getTag: () => 'h2',
         }),
       });
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({
@@ -1410,9 +1410,9 @@ describe('ToolbarPlugin', () => {
       const richText = await vi.importMock<typeof import('@lexical/rich-text')>('@lexical/rich-text');
       const getSelectedNode = await vi.importMock<typeof import('../../utils/getSelectedNode')>('../../utils/getSelectedNode');
 
-      (lexical.$isRangeSelection as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (richText.$isHeadingNode as ReturnType<typeof vi.fn>).mockReturnValue(false);
-      (getSelectedNode.default as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$isRangeSelection as Mock).mockReturnValue(true);
+      (richText.$isHeadingNode as Mock).mockReturnValue(false);
+      (getSelectedNode.default as Mock).mockReturnValue({
         getParent: () => null,
         getKey: () => 'test-key',
         getTopLevelElementOrThrow: () => ({
@@ -1421,7 +1421,7 @@ describe('ToolbarPlugin', () => {
           getType: () => 'unknown-type', // Not in blockTypeToBlockName
         }),
       });
-      (lexical.$getSelection as ReturnType<typeof vi.fn>).mockReturnValue({
+      (lexical.$getSelection as Mock).mockReturnValue({
         hasFormat: vi.fn().mockReturnValue(false),
         anchor: {
           getNode: () => ({

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/steps/execution/__tests__/Execution.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/steps/execution/__tests__/Execution.test.tsx
@@ -16,13 +16,13 @@
  * under the License.
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, type Mock} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import Execution from '../Execution';
 import type {CommonStepFactoryPropsInterface} from '../../CommonStepFactory';
 
 // Mock @xyflow/react
-const mockUseNodeId = vi.fn(() => 'execution-node-id') as ReturnType<typeof vi.fn> & {
+const mockUseNodeId = vi.fn(() => 'execution-node-id') as Mock & {
   mockReturnValue: (value: string | null) => void;
 };
 

--- a/frontend/apps/thunder-develop/src/features/integrations/api/__tests__/useIdentityProviders.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/integrations/api/__tests__/useIdentityProviders.test.tsx
@@ -18,7 +18,7 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi, type Mock} from 'vitest';
 import {waitFor, act, renderHook} from '@thunder/test-utils';
 import {QueryClient} from '@tanstack/react-query';
 import {useAsgardeo} from '@asgardeo/react';
@@ -63,7 +63,7 @@ describe('useIdentityProviders', () => {
     },
   ];
 
-  let mockHttpRequest: ReturnType<typeof vi.fn>;
+  let mockHttpRequest: Mock;
 
   beforeEach(() => {
     mockHttpRequest = vi.fn().mockResolvedValue({data: mockIdentityProviders});

--- a/frontend/apps/thunder-develop/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, type Mock} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ExecutionTypes} from '@/features/flows/models/steps';
@@ -629,10 +629,10 @@ describe('ExecutionExtendedProperties', () => {
     });
 
     it('should show validation error for sender field', () => {
-      (mockSelectedNotification.hasResourceFieldNotification as unknown as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
+      (mockSelectedNotification.hasResourceFieldNotification as unknown as Mock).mockImplementation((key: string) =>
         key === 'sms-otp-executor-1_data.properties.senderId'
       );
-      (mockSelectedNotification.getResourceFieldNotification as unknown as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
+      (mockSelectedNotification.getResourceFieldNotification as unknown as Mock).mockImplementation((key: string) =>
         key === 'sms-otp-executor-1_data.properties.senderId' ? 'Sender ID is invalid' : ''
       );
       mockNotificationSenders.mockReturnValue({

--- a/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useElementAddition.test.ts
+++ b/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useElementAddition.test.ts
@@ -17,7 +17,7 @@
  */
 
 import type React from 'react';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, type Mock} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import type {Node} from '@xyflow/react';
 import {BlockTypes, ElementCategories, ElementTypes, type Element} from '@/features/flows/models/elements';
@@ -83,8 +83,8 @@ const createMockViewNode = (overrides: Partial<Node> = {}): Node => ({
 type SetNodesFn = React.Dispatch<React.SetStateAction<Node[]>>;
 
 describe('useElementAddition', () => {
-  let mockSetNodes: ReturnType<typeof vi.fn> & SetNodesFn;
-  let mockUpdateNodeInternals: ReturnType<typeof vi.fn>;
+  let mockSetNodes: Mock & SetNodesFn;
+  let mockUpdateNodeInternals: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,7 +93,7 @@ describe('useElementAddition', () => {
         return updater([]);
       }
       return updater;
-    }) as ReturnType<typeof vi.fn> & SetNodesFn;
+    }) as Mock & SetNodesFn;
     mockUpdateNodeInternals = vi.fn();
   });
 
@@ -180,7 +180,7 @@ describe('useElementAddition', () => {
           return updater(nodes);
         }
         return updater;
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -210,7 +210,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: []}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -245,7 +245,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: [existingForm]}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -277,7 +277,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: []}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -308,7 +308,7 @@ describe('useElementAddition', () => {
           return updater(nodes);
         }
         return undefined;
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -338,7 +338,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -400,7 +400,7 @@ describe('useElementAddition', () => {
           return updater(nodes);
         }
         return updater;
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -438,7 +438,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: [existingForm]}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -482,7 +482,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: [existingForm]}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -519,7 +519,7 @@ describe('useElementAddition', () => {
           return updater(nodes);
         }
         return undefined;
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -562,7 +562,7 @@ describe('useElementAddition', () => {
           ];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -605,7 +605,7 @@ describe('useElementAddition', () => {
           ];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -642,7 +642,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: [existingForm]}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -672,7 +672,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: []}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -703,7 +703,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: []}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -730,7 +730,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: []}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -760,7 +760,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: []}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({
@@ -789,7 +789,7 @@ describe('useElementAddition', () => {
           const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: []}})];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderHook(() =>
         useElementAddition({

--- a/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useFlowInitialization.test.ts
+++ b/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useFlowInitialization.test.ts
@@ -17,7 +17,7 @@
  */
 
 import type React from 'react';
-import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach, type Mock} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import type {Edge, Node} from '@xyflow/react';
 import {StaticStepTypes, StepTypes} from '@/features/flows/models/steps';
@@ -153,12 +153,12 @@ const createMockExistingFlowData = (): FlowDefinitionResponse =>
   }) as FlowDefinitionResponse;
 
 describe('useFlowInitialization', () => {
-  let mockSetNodes: ReturnType<typeof vi.fn>;
-  let mockSetEdges: ReturnType<typeof vi.fn>;
-  let mockUpdateNodeInternals: ReturnType<typeof vi.fn>;
-  let mockGenerateEdges: ReturnType<typeof vi.fn>;
-  let mockValidateEdges: ReturnType<typeof vi.fn>;
-  let mockOnNeedsAutoLayout: ReturnType<typeof vi.fn>;
+  let mockSetNodes: Mock;
+  let mockSetEdges: Mock;
+  let mockUpdateNodeInternals: Mock;
+  let mockGenerateEdges: Mock;
+  let mockValidateEdges: Mock;
+  let mockOnNeedsAutoLayout: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useFlowSave.test.ts
+++ b/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useFlowSave.test.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach, type Mock} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import type {CanvasData} from '../useFlowSave';
 import useFlowSave from '../useFlowSave';
@@ -74,9 +74,9 @@ const createMockCanvasData = (): CanvasData => ({
 });
 
 describe('useFlowSave', () => {
-  let mockShowError: ReturnType<typeof vi.fn>;
-  let mockShowSuccess: ReturnType<typeof vi.fn>;
-  let mockSetOpenValidationPanel: ReturnType<typeof vi.fn>;
+  let mockShowError: Mock;
+  let mockShowSuccess: Mock;
+  let mockSetOpenValidationPanel: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -148,7 +148,7 @@ describe('useFlowSave', () => {
 
     it('should show error when flow graph validation fails', async () => {
       const {validateFlowGraph} = await import('@/features/flows/utils/reactFlowTransformer');
-      (validateFlowGraph as ReturnType<typeof vi.fn>).mockReturnValueOnce(['Disconnected node found']);
+      (validateFlowGraph as Mock).mockReturnValueOnce(['Disconnected node found']);
 
       const {result} = renderUseFlowSave({isFlowValid: true});
 

--- a/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useNodeTypes.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useNodeTypes.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, type Mock, beforeEach} from 'vitest';
 import {renderHook, render, fireEvent} from '@testing-library/react';
 import type {NodeProps} from '@xyflow/react';
 import {StaticStepTypes, StepTypes, type Step} from '@/features/flows/models/steps';
@@ -91,8 +91,8 @@ const createMockResources = (): Resources =>
   }) as unknown as Resources;
 
 describe('useNodeTypes', () => {
-  let mockOnAddElementToView: ReturnType<typeof vi.fn>;
-  let mockOnAddElementToForm: ReturnType<typeof vi.fn>;
+  let mockOnAddElementToView: Mock;
+  let mockOnAddElementToForm: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useTemplateAndWidgetLoading.test.ts
+++ b/frontend/apps/thunder-develop/src/features/login-flow/hooks/__tests__/useTemplateAndWidgetLoading.test.ts
@@ -17,7 +17,7 @@
  */
 
 import type React from 'react';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, type Mock, beforeEach} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import type {Edge, Node} from '@xyflow/react';
 import {BlockTypes, ElementCategories, ElementTypes, type Element} from '@/features/flows/models/elements';
@@ -167,12 +167,12 @@ const createMockEdge = (overrides: Partial<Edge> = {}): Edge => ({
 type SetNodesFn = React.Dispatch<React.SetStateAction<Node[]>>;
 
 describe('useTemplateAndWidgetLoading', () => {
-  let mockSetNodes: ReturnType<typeof vi.fn> & SetNodesFn;
-  let mockUpdateNodeInternals: ReturnType<typeof vi.fn>;
-  let mockGenerateSteps: ReturnType<typeof vi.fn>;
-  let mockGenerateEdges: ReturnType<typeof vi.fn>;
-  let mockValidateEdges: ReturnType<typeof vi.fn>;
-  let mockGetBlankTemplateComponents: ReturnType<typeof vi.fn>;
+  let mockSetNodes: Mock & SetNodesFn;
+  let mockUpdateNodeInternals: Mock;
+  let mockGenerateSteps: Mock;
+  let mockGenerateEdges: Mock;
+  let mockValidateEdges: Mock;
+  let mockGetBlankTemplateComponents: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -181,7 +181,7 @@ describe('useTemplateAndWidgetLoading', () => {
         return updater([]);
       }
       return updater;
-    }) as ReturnType<typeof vi.fn> & SetNodesFn;
+    }) as Mock & SetNodesFn;
     mockUpdateNodeInternals = vi.fn();
     mockGenerateSteps = vi.fn((steps: Node[]) => steps);
     mockGenerateEdges = vi.fn().mockReturnValue([]);
@@ -830,7 +830,7 @@ describe('useTemplateAndWidgetLoading', () => {
           const nodes = [createMockNode({id: 'view-1', type: StepTypes.View, data: {components: []}})];
           updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderUseTemplateAndWidgetLoading({setNodes: mockSetNodes});
 
@@ -867,7 +867,7 @@ describe('useTemplateAndWidgetLoading', () => {
           ];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       mockGenerateStepElement.mockReturnValue(createMockElement({
         id: 'generated-new-form',
@@ -905,7 +905,7 @@ describe('useTemplateAndWidgetLoading', () => {
           const nodes = [createMockNode({id: 'end-1', type: StepTypes.End})]; // No View
           resultNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderUseTemplateAndWidgetLoading({setNodes: mockSetNodes});
 
@@ -937,7 +937,7 @@ describe('useTemplateAndWidgetLoading', () => {
           return updater(nodes);
         }
         return undefined;
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderUseTemplateAndWidgetLoading({setNodes: mockSetNodes});
 
@@ -970,7 +970,7 @@ describe('useTemplateAndWidgetLoading', () => {
           ];
           capturedNodes = updater(nodes);
         }
-      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+      }) as Mock & SetNodesFn;
 
       const {result} = renderUseTemplateAndWidgetLoading({setNodes: mockSetNodes});
 

--- a/frontend/apps/thunder-develop/src/hooks/useDataGridLocaleText.ts
+++ b/frontend/apps/thunder-develop/src/hooks/useDataGridLocaleText.ts
@@ -54,12 +54,6 @@ function getTranslationFunction<T>(commonBundle: Record<string, unknown>, key: s
     return value as T;
   }
 
-  // Log a warning in development if the key exists but is not a function
-  if (process.env.NODE_ENV === 'development' && value !== undefined) {
-    // eslint-disable-next-line no-console
-    console.warn(`Translation key '${key}' exists but is not a function. Expected a function, got ${typeof value}.`);
-  }
-
   return undefined;
 }
 
@@ -174,10 +168,7 @@ export default function useDataGridLocaleText(): Partial<DataGrid.GridLocaleText
       columnHeaderSortIconLabel: t('common:dataTable.columnHeaderSortIconLabel'),
 
       // Rows selected footer text
-      footerRowSelected: getTranslationFunction<(count: number) => string>(
-        commonBundle,
-        'dataTable.footerRowSelected',
-      ),
+      footerRowSelected: getTranslationFunction<(count: number) => string>(commonBundle, 'dataTable.footerRowSelected'),
 
       // Total row amount footer text
       footerTotalRows: t('common:dataTable.footerTotalRows'),

--- a/frontend/apps/thunder-gate/package.json
+++ b/frontend/apps/thunder-gate/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
+    "postinstall": "playwright install chromium",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -54,9 +55,6 @@
     "react-router": "catalog:"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "catalog:",
-    "@testing-library/react": "catalog:",
-    "@testing-library/user-event": "catalog:",
     "@thunder/eslint-plugin-thunder": "workspace:^",
     "@thunder/prettier-config": "workspace:^",
     "@thunder/test-utils": "workspace:^",
@@ -65,12 +63,14 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-basic-ssl": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
     "@vitest/coverage-istanbul": "catalog:",
+    "playwright": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "eslint": "catalog:",
-    "jsdom": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-browser-react": "catalog:"
   }
 }

--- a/frontend/apps/thunder-gate/src/__tests__/components/SignIn/SignIn.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/components/SignIn/SignIn.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@thunder/test-utils';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import SignIn from '../../../components/SignIn/SignIn';
 
 // Mock child components
@@ -49,40 +50,35 @@ describe('SignIn', () => {
     });
   });
 
-  it('renders without crashing', () => {
-    const {container} = render(<SignIn />);
-    expect(container).toBeInTheDocument();
+  it('renders SignInBox component', async () => {
+    await render(<SignIn />);
+    await expect.element(page.getByTestId('signin-box')).toBeInTheDocument();
   });
 
-  it('renders SignInBox component', () => {
-    render(<SignIn />);
-    expect(screen.getByTestId('signin-box')).toBeInTheDocument();
-  });
-
-  it('shows SignInSlogan when branding is not enabled', () => {
+  it('shows SignInSlogan when branding is not enabled', async () => {
     mockUseBranding.mockReturnValue({
       isBrandingEnabled: false,
       layout: null,
     });
-    render(<SignIn />);
-    expect(screen.getByTestId('signin-slogan')).toBeInTheDocument();
+    await render(<SignIn />);
+    await expect.element(page.getByTestId('signin-slogan')).toBeInTheDocument();
   });
 
-  it('shows SignInSlogan when branding is enabled with LEFT_ALIGNED layout', () => {
+  it('shows SignInSlogan when branding is enabled with LEFT_ALIGNED layout', async () => {
     mockUseBranding.mockReturnValue({
       isBrandingEnabled: true,
       layout: {type: 'LEFT_ALIGNED'},
     });
-    render(<SignIn />);
-    expect(screen.getByTestId('signin-slogan')).toBeInTheDocument();
+    await render(<SignIn />);
+    await expect.element(page.getByTestId('signin-slogan')).toBeInTheDocument();
   });
 
-  it('hides SignInSlogan when branding is enabled with non-LEFT_ALIGNED layout', () => {
+  it('hides SignInSlogan when branding is enabled with non-LEFT_ALIGNED layout', async () => {
     mockUseBranding.mockReturnValue({
       isBrandingEnabled: true,
       layout: {type: 'CENTERED'},
     });
-    render(<SignIn />);
-    expect(screen.queryByTestId('signin-slogan')).not.toBeInTheDocument();
+    await render(<SignIn />);
+    await expect.element(page.getByTestId('signin-slogan')).not.toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/components/SignIn/SignInSlogan.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/components/SignIn/SignInSlogan.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@thunder/test-utils';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import SignInSlogan from '../../../components/SignIn/SignInSlogan';
 
 // Mock useBranding
@@ -35,36 +36,31 @@ describe('SignInSlogan', () => {
     });
   });
 
-  it('renders without crashing', () => {
-    const {container} = render(<SignInSlogan />);
-    expect(container).toBeInTheDocument();
+  it('renders all slogan items', async () => {
+    await render(<SignInSlogan />);
+    await expect.element(page.getByText('Flexible Identity Platform')).toBeInTheDocument();
+    await expect.element(page.getByText('Zero-trust Security')).toBeInTheDocument();
+    await expect.element(page.getByText('Developer-first Experience')).toBeInTheDocument();
+    await expect.element(page.getByText('Extensible & Enterprise-ready')).toBeInTheDocument();
   });
 
-  it('renders all slogan items', () => {
-    render(<SignInSlogan />);
-    expect(screen.getByText('Flexible Identity Platform')).toBeInTheDocument();
-    expect(screen.getByText('Zero-trust Security')).toBeInTheDocument();
-    expect(screen.getByText('Developer-first Experience')).toBeInTheDocument();
-    expect(screen.getByText('Extensible & Enterprise-ready')).toBeInTheDocument();
-  });
-
-  it('renders item descriptions', () => {
-    render(<SignInSlogan />);
-    expect(
-      screen.getByText(/Centralizes identity management/),
+  it('renders item descriptions', async () => {
+    await render(<SignInSlogan />);
+    await expect.element(
+      page.getByText(/Centralizes identity management/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Leverage adaptive authentication/),
+    await expect.element(
+      page.getByText(/Leverage adaptive authentication/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Configure auth flows and manage organizations/),
+    await expect.element(
+      page.getByText(/Configure auth flows and manage organizations/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Built for scale/),
+    await expect.element(
+      page.getByText(/Built for scale/),
     ).toBeInTheDocument();
   });
 
-  it('uses branded logo when available', () => {
+  it('uses branded logo when available', async () => {
     mockUseBranding.mockReturnValue({
       images: {
         logo: {
@@ -74,39 +70,39 @@ describe('SignInSlogan', () => {
         },
       },
     });
-    render(<SignInSlogan />);
+    await render(<SignInSlogan />);
     // Component should render with branded logo
-    expect(screen.getByText('Flexible Identity Platform')).toBeInTheDocument();
+    await expect.element(page.getByText('Flexible Identity Platform')).toBeInTheDocument();
   });
 
-  it('uses default logo when no branded logo', () => {
+  it('uses default logo when no branded logo', async () => {
     mockUseBranding.mockReturnValue({
       images: null,
     });
-    render(<SignInSlogan />);
+    await render(<SignInSlogan />);
     // Component should render with default logo
-    expect(screen.getByText('Flexible Identity Platform')).toBeInTheDocument();
+    await expect.element(page.getByText('Flexible Identity Platform')).toBeInTheDocument();
   });
 
-  it('uses default logo when images object exists but no logo', () => {
+  it('uses default logo when images object exists but no logo', async () => {
     mockUseBranding.mockReturnValue({
       images: {},
     });
-    render(<SignInSlogan />);
-    expect(screen.getByText('Flexible Identity Platform')).toBeInTheDocument();
+    await render(<SignInSlogan />);
+    await expect.element(page.getByText('Flexible Identity Platform')).toBeInTheDocument();
   });
 
-  it('uses default logo when logo object exists but no primary', () => {
+  it('uses default logo when logo object exists but no primary', async () => {
     mockUseBranding.mockReturnValue({
       images: {
         logo: {},
       },
     });
-    render(<SignInSlogan />);
-    expect(screen.getByText('Flexible Identity Platform')).toBeInTheDocument();
+    await render(<SignInSlogan />);
+    await expect.element(page.getByText('Flexible Identity Platform')).toBeInTheDocument();
   });
 
-  it('uses default logo when primary object exists but no url', () => {
+  it('uses default logo when primary object exists but no url', async () => {
     mockUseBranding.mockReturnValue({
       images: {
         logo: {
@@ -114,7 +110,7 @@ describe('SignInSlogan', () => {
         },
       },
     });
-    render(<SignInSlogan />);
-    expect(screen.getByText('Flexible Identity Platform')).toBeInTheDocument();
+    await render(<SignInSlogan />);
+    await expect.element(page.getByText('Flexible Identity Platform')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/components/SignUp/SignUp.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/components/SignUp/SignUp.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@thunder/test-utils';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import SignUp from '../../../components/SignUp/SignUp';
 
 // Mock child component
@@ -26,19 +27,13 @@ vi.mock('../../../components/SignUp/SignUpBox', () => ({
 }));
 
 describe('SignUp', () => {
-  it('renders without crashing', () => {
-    const {container} = render(<SignUp />);
-    expect(container).toBeInTheDocument();
+  it('renders SignUpBox component', async () => {
+    await render(<SignUp />);
+    await expect.element(page.getByTestId('signup-box')).toBeInTheDocument();
   });
 
-  it('renders SignUpBox component', () => {
-    render(<SignUp />);
-    expect(screen.getByTestId('signup-box')).toBeInTheDocument();
-  });
-
-  it('renders main element', () => {
-    render(<SignUp />);
-    const main = screen.getByRole('main');
-    expect(main).toBeInTheDocument();
+  it('renders main element', async () => {
+    await render(<SignUp />);
+    await expect.element(page.getByRole('main')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/config/appRoutes.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/config/appRoutes.test.tsx
@@ -16,8 +16,67 @@
  * under the License.
  */
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
+
+// Mock @asgardeo/react to avoid import errors from components that use it
+vi.mock('@asgardeo/react', () => ({
+  SignIn: ({children}: {children: () => React.ReactNode}) => children(),
+  SignUp: ({children}: {children: () => React.ReactNode}) => children(),
+  AcceptInvite: ({children}: {children: () => React.ReactNode}) => children(),
+  EmbeddedFlowComponentType: {
+    Text: 'TEXT',
+    Block: 'BLOCK',
+    TextInput: 'TEXT_INPUT',
+    PasswordInput: 'PASSWORD_INPUT',
+    Action: 'ACTION',
+  },
+  EmbeddedFlowEventType: {
+    Submit: 'SUBMIT',
+    Trigger: 'TRIGGER',
+  },
+  EmbeddedFlowTextVariant: {
+    H1: 'H1',
+    H2: 'H2',
+    Body1: 'Body1',
+    Body2: 'Body2',
+  },
+}));
+
+// Mock other dependencies
+vi.mock('@thunder/shared-branding', () => ({
+  useBranding: () => ({images: null, theme: null, isBrandingEnabled: false, layout: null}),
+  mapEmbeddedFlowTextVariant: (variant: string) => variant?.toLowerCase() ?? 'body1',
+  BrandingProvider: ({children}: {children: React.ReactNode}) => children,
+  LayoutType: {
+    CENTERED: 'CENTERED',
+    LEFT_ALIGNED: 'LEFT_ALIGNED',
+    RIGHT_ALIGNED: 'RIGHT_ALIGNED',
+  },
+}));
+
+vi.mock('@thunder/shared-hooks', () => ({
+  useTemplateLiteralResolver: () => ({resolve: (key: string) => key}),
+}));
+
+vi.mock('@thunder/shared-contexts', () => ({
+  useConfig: () => ({getServerUrl: () => 'https://api.example.com'}),
+}));
+
+vi.mock('react-router', () => ({
+  Navigate: () => null,
+  Outlet: () => null,
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+  Trans: ({children}: {children: React.ReactNode}) => children,
+}));
+
+// eslint-disable-next-line import/first
 import appRoutes, {type AppRoute} from '../../config/appRoutes';
+// eslint-disable-next-line import/first
 import ROUTES from '../../constants/routes';
 
 describe('appRoutes', () => {

--- a/frontend/apps/thunder-gate/src/__tests__/layouts/DefaultLayout.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/layouts/DefaultLayout.test.tsx
@@ -17,48 +17,33 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {render, screen} from '@testing-library/react';
-import {MemoryRouter, Routes, Route} from 'react-router';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
+import {Routes, Route} from 'react-router';
 import DefaultLayout from '../../layouts/DefaultLayout';
 
 describe('DefaultLayout', () => {
-  it('renders without crashing', () => {
-    const {container} = render(
-      <MemoryRouter>
-        <Routes>
-          <Route element={<DefaultLayout />}>
-            <Route path="*" element={<div>Child Content</div>} />
-          </Route>
-        </Routes>
-      </MemoryRouter>,
+  it('renders child routes through Outlet', async () => {
+    await render(
+      <Routes>
+        <Route element={<DefaultLayout />}>
+          <Route path="/" element={<div data-testid="child-content">Child Content</div>} />
+        </Route>
+      </Routes>,
+      {initialEntries: ['/']},
     );
-    expect(container).toBeInTheDocument();
+    await expect.element(page.getByTestId('child-content')).toBeInTheDocument();
   });
 
-  it('renders child routes through Outlet', () => {
-    render(
-      <MemoryRouter initialEntries={['/']}>
-        <Routes>
-          <Route element={<DefaultLayout />}>
-            <Route path="/" element={<div data-testid="child-content">Child Content</div>} />
-          </Route>
-        </Routes>
-      </MemoryRouter>,
-    );
-    expect(screen.getByTestId('child-content')).toBeInTheDocument();
-  });
-
-  it('renders Box with correct height styling', () => {
-    render(
-      <MemoryRouter>
-        <Routes>
-          <Route element={<DefaultLayout />}>
-            <Route path="*" element={<div>Child</div>} />
-          </Route>
-        </Routes>
-      </MemoryRouter>,
+  it('renders Box with correct height styling', async () => {
+    await render(
+      <Routes>
+        <Route element={<DefaultLayout />}>
+          <Route path="*" element={<div>Child</div>} />
+        </Route>
+      </Routes>,
     );
     // The layout should contain the child content
-    expect(screen.getByText('Child')).toBeInTheDocument();
+    await expect.element(page.getByText('Child')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/pages/AcceptInvitePage.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/pages/AcceptInvitePage.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@thunder/test-utils';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import AcceptInvitePage from '../../pages/AcceptInvitePage';
 
 // Mock the AcceptInviteBox component
@@ -26,19 +27,13 @@ vi.mock('../../components/AcceptInvite/AcceptInviteBox', () => ({
 }));
 
 describe('AcceptInvitePage', () => {
-  it('renders without crashing', () => {
-    const {container} = render(<AcceptInvitePage />);
-    expect(container).toBeInTheDocument();
+  it('renders AcceptInviteBox component', async () => {
+    await render(<AcceptInvitePage />);
+    await expect.element(page.getByTestId('accept-invite-box')).toBeInTheDocument();
   });
 
-  it('renders AcceptInviteBox component', () => {
-    render(<AcceptInvitePage />);
-    expect(screen.getByTestId('accept-invite-box')).toBeInTheDocument();
-  });
-
-  it('renders main element', () => {
-    render(<AcceptInvitePage />);
-    const main = screen.getByRole('main');
-    expect(main).toBeInTheDocument();
+  it('renders main element', async () => {
+    await render(<AcceptInvitePage />);
+    await expect.element(page.getByRole('main')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/pages/InviteAcceptancePage.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/pages/InviteAcceptancePage.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@thunder/test-utils';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import InviteAcceptancePage from '../../pages/InviteAcceptancePage';
 
 // Mock the AcceptInviteBox component
@@ -26,19 +27,13 @@ vi.mock('../../components/AcceptInvite/AcceptInviteBox', () => ({
 }));
 
 describe('InviteAcceptancePage', () => {
-  it('renders without crashing', () => {
-    const {container} = render(<InviteAcceptancePage />);
-    expect(container).toBeInTheDocument();
+  it('renders AcceptInviteBox component', async () => {
+    await render(<InviteAcceptancePage />);
+    await expect.element(page.getByTestId('accept-invite-box')).toBeInTheDocument();
   });
 
-  it('renders AcceptInviteBox component', () => {
-    render(<InviteAcceptancePage />);
-    expect(screen.getByTestId('accept-invite-box')).toBeInTheDocument();
-  });
-
-  it('renders main element', () => {
-    render(<InviteAcceptancePage />);
-    const main = screen.getByRole('main');
-    expect(main).toBeInTheDocument();
+  it('renders main element', async () => {
+    await render(<InviteAcceptancePage />);
+    await expect.element(page.getByRole('main')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/pages/SignInPage.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/pages/SignInPage.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@thunder/test-utils';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import SignInPage from '../../pages/SignInPage';
 
 // Mock the SignIn component
@@ -26,13 +27,8 @@ vi.mock('../../components/SignIn/SignIn', () => ({
 }));
 
 describe('SignInPage', () => {
-  it('renders without crashing', () => {
-    const {container} = render(<SignInPage />);
-    expect(container).toBeInTheDocument();
-  });
-
-  it('renders SignIn component', () => {
-    render(<SignInPage />);
-    expect(screen.getByTestId('signin-component')).toBeInTheDocument();
+  it('renders SignIn component', async () => {
+    await render(<SignInPage />);
+    await expect.element(page.getByTestId('signin-component')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/pages/SignUpPage.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/pages/SignUpPage.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@thunder/test-utils';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import SignUpPage from '../../pages/SignUpPage';
 
 // Mock the SignUp component
@@ -26,13 +27,8 @@ vi.mock('../../components/SignUp/SignUp', () => ({
 }));
 
 describe('SignUpPage', () => {
-  it('renders without crashing', () => {
-    const {container} = render(<SignUpPage />);
-    expect(container).toBeInTheDocument();
-  });
-
-  it('renders SignUp component', () => {
-    render(<SignUpPage />);
-    expect(screen.getByTestId('signup-component')).toBeInTheDocument();
+  it('renders SignUp component', async () => {
+    await render(<SignUpPage />);
+    await expect.element(page.getByTestId('signup-component')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/__tests__/utils/getIntegrationIcon.test.tsx
+++ b/frontend/apps/thunder-gate/src/__tests__/utils/getIntegrationIcon.test.tsx
@@ -17,7 +17,8 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render} from '@thunder/test-utils/browser';
+import {page} from 'vitest/browser';
 import getIntegrationIcon from '../../utils/getIntegrationIcon';
 
 // Mock the icons
@@ -27,36 +28,36 @@ vi.mock('@wso2/oxygen-ui-icons-react', () => ({
 }));
 
 describe('getIntegrationIcon', () => {
-  it('returns Google icon when label contains google', () => {
+  it('returns Google icon when label contains google', async () => {
     const icon = getIntegrationIcon('Continue with google', '');
     expect(icon).not.toBeNull();
 
-    render(<div>{icon}</div>);
-    expect(screen.getByTestId('google-icon')).toBeInTheDocument();
+    await render(<div>{icon}</div>);
+    await expect.element(page.getByTestId('google-icon')).toBeInTheDocument();
   });
 
-  it('returns Google icon when image contains google', () => {
+  it('returns Google icon when image contains google', async () => {
     const icon = getIntegrationIcon('', 'assets/images/google.svg');
     expect(icon).not.toBeNull();
 
-    render(<div>{icon}</div>);
-    expect(screen.getByTestId('google-icon')).toBeInTheDocument();
+    await render(<div>{icon}</div>);
+    await expect.element(page.getByTestId('google-icon')).toBeInTheDocument();
   });
 
-  it('returns GitHub icon when label contains github', () => {
+  it('returns GitHub icon when label contains github', async () => {
     const icon = getIntegrationIcon('Sign in with github', '');
     expect(icon).not.toBeNull();
 
-    render(<div>{icon}</div>);
-    expect(screen.getByTestId('github-icon')).toBeInTheDocument();
+    await render(<div>{icon}</div>);
+    await expect.element(page.getByTestId('github-icon')).toBeInTheDocument();
   });
 
-  it('returns GitHub icon when image contains github', () => {
+  it('returns GitHub icon when image contains github', async () => {
     const icon = getIntegrationIcon('', 'icons/github-icon.png');
     expect(icon).not.toBeNull();
 
-    render(<div>{icon}</div>);
-    expect(screen.getByTestId('github-icon')).toBeInTheDocument();
+    await render(<div>{icon}</div>);
+    await expect.element(page.getByTestId('github-icon')).toBeInTheDocument();
   });
 
   it('returns null for unknown provider', () => {
@@ -76,32 +77,32 @@ describe('getIntegrationIcon', () => {
     expect(icon).toBeNull();
   });
 
-  it('returns Google icon when label matches google even if image contains github', () => {
+  it('returns Google icon when label matches google even if image contains github', async () => {
     // Due to short-circuit evaluation in OR logic (label.includes() || image.includes()),
     // when label contains 'google', the image is never checked
     const icon = getIntegrationIcon('google login', 'github.svg');
     expect(icon).not.toBeNull();
 
-    render(<div>{icon}</div>);
-    expect(screen.getByTestId('google-icon')).toBeInTheDocument();
+    await render(<div>{icon}</div>);
+    await expect.element(page.getByTestId('google-icon')).toBeInTheDocument();
   });
 
-  it('checks Google before GitHub regardless of source', () => {
+  it('checks Google before GitHub regardless of source', async () => {
     // The function checks for 'google' first (in both label and image)
     // before checking for 'github', so image containing 'google' wins
     const icon = getIntegrationIcon('github login', 'google.svg');
     expect(icon).not.toBeNull();
 
-    render(<div>{icon}</div>);
+    await render(<div>{icon}</div>);
     // Google check happens first, and image contains 'google'
-    expect(screen.getByTestId('google-icon')).toBeInTheDocument();
+    await expect.element(page.getByTestId('google-icon')).toBeInTheDocument();
   });
 
-  it('falls back to image when label does not match', () => {
+  it('falls back to image when label does not match', async () => {
     const icon = getIntegrationIcon('Sign in', 'github-logo.png');
     expect(icon).not.toBeNull();
 
-    render(<div>{icon}</div>);
-    expect(screen.getByTestId('github-icon')).toBeInTheDocument();
+    await render(<div>{icon}</div>);
+    await expect.element(page.getByTestId('github-icon')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/test/setup.ts
+++ b/frontend/apps/thunder-gate/src/test/setup.ts
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-// Import shared test setup from @thunder/test-utils
-import '@thunder/test-utils/setup';
-import {configureTestUtils} from '@thunder/test-utils';
+// Import shared test setup for Vitest Browser Mode from @thunder/test-utils
+import '@thunder/test-utils/setup-browser';
+import {configureTestUtils} from '@thunder/test-utils/browser';
 
 configureTestUtils({
   base: '/gate',

--- a/frontend/apps/thunder-gate/vite.config.ts
+++ b/frontend/apps/thunder-gate/vite.config.ts
@@ -19,6 +19,7 @@
 import {defineConfig} from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import basicSsl from '@vitejs/plugin-basic-ssl';
+import {playwright} from '@vitest/browser-playwright';
 import {resolve, dirname} from 'path';
 import {fileURLToPath} from 'url';
 
@@ -54,7 +55,14 @@ export default defineConfig({
   ],
   test: {
     globals: true,
-    environment: 'jsdom',
+    browser: {
+      provider: playwright(),
+      enabled: true,
+      instances: [
+        {browser: 'chromium'},
+      ],
+      headless: true,
+    },
     setupFiles: resolve(currentDir, 'src', 'test', 'setup.ts'),
     css: {
       modules: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@thunder/prettier-config": "workspace:^",
     "eslint": "catalog:",
     "nx": "21.6.4",
+    "playwright": "catalog:",
     "prettier": "catalog:",
     "rimraf": "catalog:",
     "tslib": "catalog:",

--- a/frontend/packages/thunder-test-utils/package.json
+++ b/frontend/packages/thunder-test-utils/package.json
@@ -25,10 +25,18 @@
       "import": "./dist/index.js",
       "require": "./dist/cjs/index.cjs"
     },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js"
+    },
     "./setup": {
       "types": "./dist/setup.d.ts",
       "import": "./dist/setup.js",
       "require": "./dist/cjs/setup.cjs"
+    },
+    "./setup-browser": {
+      "types": "./dist/setup-browser.d.ts",
+      "import": "./dist/setup-browser.js"
     },
     "./mocks": {
       "types": "./dist/mocks/index.d.ts",
@@ -63,7 +71,8 @@
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@testing-library/user-event": "catalog:",
-    "tslib": "catalog:"
+    "tslib": "catalog:",
+    "vitest-browser-react": "catalog:"
   },
   "devDependencies": {
     "@tanstack/react-query": "catalog:",
@@ -101,6 +110,7 @@
     "react-router": "catalog:",
     "vitest": "catalog:"
   },
+  "peerDependenciesMeta": {},
   "publishConfig": {
     "access": "public"
   }

--- a/frontend/packages/thunder-test-utils/rolldown.config.js
+++ b/frontend/packages/thunder-test-utils/rolldown.config.js
@@ -32,41 +32,63 @@ const external = [
   /^@wso2\//,
   /^@tanstack\//,
   /^@testing-library\//,
-  'vitest',
+  /^@vitest\//,
+  /^vitest/,
   'i18next',
   'react-i18next',
   'react-router',
 ];
 
+// Common input files for jsdom mode (existing)
+const jsdomInput = {
+  index: join('src', 'index.ts'),
+  setup: join('src', 'setup.ts'),
+  'mocks/index': join('src', 'mocks', 'index.ts'),
+};
+
+// Browser mode input files (new)
+const browserInput = {
+  browser: join('src', 'browser.ts'),
+  'setup-browser': join('src', 'setup-browser.ts'),
+};
+
 const commonOptions = {
-  input: {
-    index: join('src', 'index.ts'),
-    setup: join('src', 'setup.ts'),
-    'mocks/index': join('src', 'mocks', 'index.ts'),
-  },
   external,
   target: 'es2020',
   sourcemap: true,
 };
 
 export default defineConfig([
-  // ESM build (for browsers/bundlers)
+  // ESM build for jsdom mode (existing)
   {
     ...commonOptions,
+    input: jsdomInput,
     platform: 'browser',
     output: {
       dir: 'dist',
       format: 'esm',
     },
   },
-  // CommonJS build (for Node/SSR/testing)
+  // CommonJS build for jsdom mode (existing)
   {
     ...commonOptions,
+    input: jsdomInput,
     platform: 'node',
     output: {
       dir: join('dist', 'cjs'),
       entryFileNames: '[name].cjs',
       format: 'cjs',
+    },
+  },
+  // ESM build for browser mode - Vitest Browser Mode runs tests in real browsers
+  // which natively support ES modules, so CJS is not needed for this build target
+  {
+    ...commonOptions,
+    input: browserInput,
+    platform: 'browser',
+    output: {
+      dir: 'dist',
+      format: 'esm',
     },
   },
 ]);

--- a/frontend/packages/thunder-test-utils/src/browser-test-utils.tsx
+++ b/frontend/packages/thunder-test-utils/src/browser-test-utils.tsx
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable react-refresh/only-export-components */
+import {useMemo, type ReactElement, type ReactNode} from 'react';
+import {render as browserRender, renderHook as browserRenderHook} from 'vitest-browser-react';
+import {MemoryRouter} from 'react-router';
+import {OxygenUIThemeProvider} from '@wso2/oxygen-ui';
+import {ConfigProvider} from '@thunder/shared-contexts';
+import {LoggerProvider, LogLevel} from '@thunder/logger';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+
+/**
+ * Configuration options for Thunder test utilities
+ */
+export interface ThunderTestConfig {
+  /**
+   * Base path for the application (e.g., '/develop', '/gate')
+   */
+  base: string;
+  /**
+   * Client ID for the application
+   */
+  clientId: string;
+  /**
+   * Server hostname
+   * @default 'localhost'
+   */
+  hostname?: string;
+  /**
+   * Server port
+   * @default 8090
+   */
+  port?: number;
+  /**
+   * Whether to use HTTP only
+   * @default false
+   */
+  httpOnly?: boolean;
+}
+
+interface ProvidersProps {
+  children: ReactNode;
+  queryClient?: QueryClient;
+  config?: ThunderTestConfig;
+  initialEntries?: string[];
+}
+
+// Default configuration for thunder-develop (backwards compatibility)
+const defaultConfig: ThunderTestConfig = {
+  base: '/develop',
+  clientId: 'DEVELOP',
+};
+
+// Store the current config
+let currentConfig: ThunderTestConfig = defaultConfig;
+
+// Create a new QueryClient for each test to avoid shared state
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+// Wrapper component with common providers
+function Providers({children, queryClient = undefined, config = undefined, initialEntries = undefined}: ProvidersProps) {
+  const testConfig = config ?? currentConfig;
+
+  // Setup window.__THUNDER_RUNTIME_CONFIG__ for tests
+  // Always set fresh config to avoid test pollution from previous tests
+  if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-underscore-dangle
+    window.__THUNDER_RUNTIME_CONFIG__ = {
+      client: {
+        base: testConfig.base,
+        client_id: testConfig.clientId,
+      },
+      server: {
+        hostname: testConfig.hostname ?? 'localhost',
+        port: testConfig.port ?? 8090,
+        http_only: testConfig.httpOnly ?? false,
+      },
+    };
+  }
+
+  // Use useMemo to ensure the default QueryClient is only created once per mount,
+  // preventing cache reset on re-renders when queryClient prop is not provided
+  const client = useMemo(() => queryClient ?? createTestQueryClient(), [queryClient]);
+
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <QueryClientProvider client={client}>
+        <ConfigProvider>
+          <LoggerProvider
+            logger={{
+              level: LogLevel.ERROR,
+              transports: [],
+            }}
+          >
+            <OxygenUIThemeProvider>{children}</OxygenUIThemeProvider>
+          </LoggerProvider>
+        </ConfigProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+/**
+ * Configure the test utilities with app-specific settings
+ * Call this in your test setup file before running tests
+ *
+ * Note: Configuration is set at the module level. Each app should call this
+ * once in their test setup file. Tests within the same app share the same config.
+ */
+export function configureTestUtils(config: ThunderTestConfig): void {
+  currentConfig = config;
+}
+
+/**
+ * Reset test utilities to default configuration
+ * Useful for cleanup in afterAll hooks or when switching between app configurations
+ */
+export function resetTestUtils(): void {
+  currentConfig = defaultConfig;
+}
+
+// Custom render options that extend vitest-browser-react options
+export interface ThunderRenderOptions {
+  /**
+   * Initial route entries for MemoryRouter
+   */
+  initialEntries?: string[];
+  /**
+   * Additional wrapper component (applied inside default providers)
+   */
+  wrapper?: React.ComponentType<{children: ReactNode}>;
+}
+
+/**
+ * Custom render function for Vitest Browser Mode
+ * Wraps components with all necessary providers and returns the native page object
+ *
+ * @example
+ * ```typescript
+ * import {render} from '@thunder/test-utils/browser';
+ * import {page} from 'vitest/browser';
+ *
+ * await render(<MyComponent />);
+ *
+ * // Use page object for queries (native Vitest Browser Mode API)
+ * const button = page.getByRole('button', {name: 'Submit'});
+ * await button.click();
+ *
+ * const input = page.getByLabelText('Email');
+ * await input.fill('test@example.com');
+ *
+ * // For multiple elements
+ * const textboxes = page.getByRole('textbox').all();
+ * expect(textboxes).toHaveLength(3);
+ * ```
+ */
+export function render(ui: ReactElement, options?: ThunderRenderOptions) {
+  const {wrapper: CustomWrapper, initialEntries} = options ?? {};
+
+  const wrapper = ({children}: {children: ReactNode}) => {
+    const content = CustomWrapper ? <CustomWrapper>{children}</CustomWrapper> : children;
+    return (
+      <Providers config={currentConfig} initialEntries={initialEntries}>
+        {content}
+      </Providers>
+    );
+  };
+
+  // Render the component with providers
+  return browserRender(ui, {wrapper});
+}
+
+/**
+ * Alternative render function with providers
+ * Alias for render to support different naming conventions
+ */
+export function renderWithProviders(ui: ReactElement, options?: ThunderRenderOptions) {
+  return render(ui, options);
+}
+
+export interface ThunderRenderHookOptions<Props> {
+  /**
+   * Optional QueryClient instance for tests that need to manipulate cache
+   */
+  queryClient?: QueryClient;
+  /**
+   * Initial props for the hook
+   */
+  initialProps?: Props;
+}
+
+/**
+ * Custom renderHook function for Vitest Browser Mode
+ * Wraps hooks with necessary context providers for testing
+ * Optionally accepts a queryClient for tests that need direct access to manipulate cache or spy on methods
+ * Returns the hook result along with the queryClient instance for convenience
+ */
+export async function renderHook<Result, Props>(
+  hook: (props?: Props) => Result,
+  options?: ThunderRenderHookOptions<Props>,
+) {
+  const {queryClient: providedQueryClient, initialProps} = options ?? {};
+  const queryClient = providedQueryClient ?? createTestQueryClient();
+
+  const wrapper = ({children}: {children: ReactNode}) => <Providers queryClient={queryClient}>{children}</Providers>;
+
+  const hookResult = await browserRenderHook(hook, {wrapper, initialProps});
+
+  return {
+    ...hookResult,
+    queryClient,
+  };
+}
+
+/**
+ * Helper to get element by translation key
+ * Useful when using mocked translations that return keys
+ */
+export function getByTranslationKey(container: HTMLElement, key: string) {
+  return (
+    container.querySelector(`[data-testid="${key}"]`) ??
+    Array.from(container.querySelectorAll('*')).find((el) => el.textContent === key)
+  );
+}

--- a/frontend/packages/thunder-test-utils/src/browser.ts
+++ b/frontend/packages/thunder-test-utils/src/browser.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Browser mode test utilities for Vitest Browser Mode
+ * Import from '@thunder/test-utils/browser' instead of '@thunder/test-utils'
+ * when using Vitest Browser Mode with Playwright
+ *
+ * @example
+ * ```typescript
+ * import {render} from '@thunder/test-utils/browser';
+ * import {page, userEvent} from 'vitest/browser';
+ *
+ * await render(<MyComponent />);
+ *
+ * // Use native Vitest Browser Mode page object for queries
+ * const button = page.getByRole('button', {name: 'Submit'});
+ * await userEvent.click(button);
+ *
+ * const input = page.getByLabelText('Email');
+ * await userEvent.fill(input, 'test@example.com');
+ * ```
+ */
+
+export {render, renderWithProviders, renderHook, getByTranslationKey, configureTestUtils, resetTestUtils} from './browser-test-utils';
+export type {ThunderTestConfig, ThunderRenderOptions, ThunderRenderHookOptions} from './browser-test-utils';

--- a/frontend/packages/thunder-test-utils/src/mocks/i18n.ts
+++ b/frontend/packages/thunder-test-utils/src/mocks/i18n.ts
@@ -16,12 +16,12 @@
  * under the License.
  */
 
-import {vi} from 'vitest';
+import {type Mock, vi} from 'vitest';
 
 /**
  * Mock implementation of useTranslation hook for testing
  */
-export const mockUseTranslation = () => ({
+export const mockUseTranslation = (): {t: (key: string) => string; i18n: {changeLanguage: Mock; language: string}} => ({
   t: (key: string) => key,
   i18n: {
     changeLanguage: vi.fn(),
@@ -32,7 +32,7 @@ export const mockUseTranslation = () => ({
 /**
  * Mock implementation of useLanguage hook for testing
  */
-export const mockUseLanguage = () => ({
+export const mockUseLanguage = (): {currentLanguage: string; setLanguage: Mock; availableLanguages: string[]} => ({
   currentLanguage: 'en',
   setLanguage: vi.fn(),
   availableLanguages: ['en', 'si'],

--- a/frontend/packages/thunder-test-utils/src/setup-browser.ts
+++ b/frontend/packages/thunder-test-utils/src/setup-browser.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Browser mode test setup for Vitest Browser Mode
+ * This file is used instead of setup.ts when running tests in real browsers
+ * via Vitest Browser Mode with Playwright.
+ *
+ * Unlike the jsdom setup, this does not need:
+ * - @testing-library/jest-dom (browser mode has built-in matchers)
+ * - cleanup() calls (vitest-browser-react handles this automatically)
+ * - jsdom workarounds (IntersectionObserver, ResizeObserver, etc.)
+ */
+
+import {beforeAll, vi} from 'vitest';
+import i18n from 'i18next';
+import {initReactI18next} from 'react-i18next';
+import enUS from '@thunder/i18n/locales/en-US';
+
+// Initialize i18n for tests
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({
+    resources: {
+      'en-US': {
+        common: enUS.common,
+        navigation: enUS.navigation,
+        users: enUS.users,
+        userTypes: enUS.userTypes,
+        integrations: enUS.integrations,
+        applications: enUS.applications,
+        dashboard: enUS.dashboard,
+        auth: enUS.auth,
+        mfa: enUS.mfa,
+        social: enUS.social,
+        consent: enUS.consent,
+        errors: enUS.errors,
+      },
+    },
+    lng: 'en-US',
+    fallbackLng: 'en-US',
+    defaultNS: 'common',
+    interpolation: {
+      escapeValue: false,
+    },
+    // Disable Suspense in tests for faster execution
+    react: {
+      useSuspense: false,
+    },
+  });
+});
+
+// Mock global for Node.js built-ins used by @asgardeo packages
+if (typeof window !== 'undefined') {
+  (window as unknown as {global: Window}).global = window;
+}
+
+// Mock @asgardeo/react to avoid buffer import issues in tests
+vi.mock('@asgardeo/react', () => ({
+  useAsgardeo: vi.fn(() => ({
+    http: {
+      request: vi.fn(),
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    getAccessToken: vi.fn(),
+    getIDToken: vi.fn(),
+    getDecodedIDToken: vi.fn(),
+    isAuthenticated: false,
+    isLoading: false,
+  })),
+  AsgardeoProvider: ({children}: {children: React.ReactNode}) => children,
+}));

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -57,9 +57,12 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: 5.0.4
       version: 5.0.4
+    '@vitest/browser-playwright':
+      specifier: 4.0.18
+      version: 4.0.18
     '@vitest/coverage-istanbul':
-      specifier: 3.2.4
-      version: 3.2.4
+      specifier: 4.0.18
+      version: 4.0.18
     '@wso2/oxygen-ui':
       specifier: 0.0.1-alpha.10
       version: 0.0.1-alpha.10
@@ -93,6 +96,9 @@ catalogs:
     lucide-react:
       specifier: 0.545.0
       version: 0.545.0
+    playwright:
+      specifier: 1.55.1
+      version: 1.55.1
     prettier:
       specifier: 3.6.2
       version: 3.6.2
@@ -127,11 +133,14 @@ catalogs:
       specifier: 5.9.3
       version: 5.9.3
     vitest:
-      specifier: 3.2.4
-      version: 3.2.4
+      specifier: 4.0.18
+      version: 4.0.18
+    vitest-browser-react:
+      specifier: 2.0.5
+      version: 2.0.5
     zod:
-      specifier: 4.2.0
-      version: 4.2.0
+      specifier: 4.3.6
+      version: 4.3.6
 
 overrides:
   vite: npm:rolldown-vite@7.1.14
@@ -167,6 +176,9 @@ importers:
       nx:
         specifier: 21.6.4
         version: 21.6.4(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
+      playwright:
+        specifier: 'catalog:'
+        version: 1.55.1
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -386,7 +398,7 @@ importers:
         version: 16.1.0(react@19.2.3)
       zod:
         specifier: 'catalog:'
-        version: 4.2.0
+        version: 4.3.6
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 'catalog:'
@@ -432,7 +444,7 @@ importers:
         version: 5.0.4(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18)
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 19.1.0-rc.3
@@ -456,7 +468,7 @@ importers:
         version: rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   apps/thunder-gate:
     dependencies:
@@ -515,15 +527,6 @@ importers:
         specifier: 'catalog:'
         version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
-      '@testing-library/jest-dom':
-        specifier: 'catalog:'
-        version: 6.9.1
-      '@testing-library/react':
-        specifier: 'catalog:'
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@testing-library/user-event':
-        specifier: 'catalog:'
-        version: 14.6.1(@testing-library/dom@10.4.1)
       '@thunder/eslint-plugin-thunder':
         specifier: workspace:^
         version: link:../../packages/thunder-eslint-plugin
@@ -548,18 +551,21 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 5.0.4(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.0.18(playwright@1.55.1)(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18)
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 19.1.0-rc.3
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
-      jsdom:
+      playwright:
         specifier: 'catalog:'
-        version: 27.0.1(postcss@8.5.6)
+        version: 1.55.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -568,7 +574,10 @@ importers:
         version: rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+      vitest-browser-react:
+        specifier: 'catalog:'
+        version: 2.0.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18)
 
   packages/thunder-create:
     dependencies:
@@ -620,7 +629,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-eslint-plugin:
     dependencies:
@@ -714,7 +723,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-i18n:
     dependencies:
@@ -763,7 +772,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-logger:
     dependencies:
@@ -803,7 +812,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-prettier-config:
     dependencies:
@@ -834,7 +843,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-shared-branding:
     dependencies:
@@ -916,7 +925,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-shared-contexts:
     dependencies:
@@ -971,7 +980,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-shared-hooks:
     dependencies:
@@ -1026,7 +1035,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
   packages/thunder-test-utils:
     dependencies:
@@ -1042,6 +1051,9 @@ importers:
       tslib:
         specifier: 'catalog:'
         version: 2.8.1
+      vitest-browser-react:
+        specifier: 'catalog:'
+        version: 2.0.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18)
     devDependencies:
       '@tanstack/react-query':
         specifier: 'catalog:'
@@ -1105,7 +1117,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
 packages:
 
@@ -2795,10 +2807,6 @@ packages:
     resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -3349,25 +3357,21 @@ packages:
     resolution: {integrity: sha512-Ohlh3YdzbmWnXjlDZd6yw20mNMWvZ1CGW/iQ5suerfyJZGjO+ToPjw3Mp8HgBoesHaWPGi81GhjAEyiZmEAHug==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@21.6.4':
     resolution: {integrity: sha512-OLvEpJYo7n8nHGaBSl7Fb+Oz68wmPfRP+i6voQbM8qV/g5No9vE/QtAdSTlyFXOCGwSekCGpc2Ef2KOvpmYUTg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@21.6.4':
     resolution: {integrity: sha512-TYC5a5VnXhEGGVAtPVwdG5qLzf9p7SZyOrOdQMZlAZCchFpL37gmV1OMH1Eb5eM32o+mGF/DDIgbyNXAErTN5g==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@21.6.4':
     resolution: {integrity: sha512-2ZG3DUadDpP79oW5DIYMZPKFMCGSRbqLKeHlW8miYORbPJ6VinUp6wTVDx6cAoL2IhP9biD6dItc9Dcfn5Hj2g==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@21.6.4':
     resolution: {integrity: sha512-o64p5hVavJhD+ISxCfwCKhKccgXalEnvfXfqXBV6yZiud6kDnYphPp2SPzyf9NgZyuFJdeFRvJ1XtuEzW3VcXg==}
@@ -3425,42 +3429,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -3520,10 +3518,6 @@ packages:
 
   '@phosphor-icons/core@2.1.1':
     resolution: {integrity: sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3618,56 +3612,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.45':
     resolution: {integrity: sha512-LE1gjAwQRrbCOorJJ7LFr10s5vqYf5a00V5Ea9wXcT2+56n5YosJkcp8eQ12FxRBv2YX8dsdQJb+ZTtYJwb6XQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.45':
     resolution: {integrity: sha512-tdy8ThO/fPp40B81v0YK3QC+KODOmzJzSUOO37DinQxzlTJ026gqUSOM8tzlVixRbQJltgVDCTYF8HNPRErQTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
     resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
     resolution: {integrity: sha512-lS082ROBWdmOyVY/0YB3JmsiClaWoxvC+dA8/rbhyB9VLkvVEaihLEOr4CYmrMse151C4+S6hCw6oa1iewox7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.45':
     resolution: {integrity: sha512-Hi73aYY0cBkr1/SvNQqH8Cd+rSV6S9RB5izCv0ySBcRnd/Wfn5plguUoGYwBnhHgFbh6cPw9m2dUVBR6BG1gxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
     resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
@@ -3770,67 +3756,56 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -4130,28 +4105,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.5.7':
     resolution: {integrity: sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.5.7':
     resolution: {integrity: sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.5.7':
     resolution: {integrity: sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.5.7':
     resolution: {integrity: sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==}
@@ -4634,49 +4605,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4714,39 +4677,50 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/coverage-istanbul@3.2.4':
-    resolution: {integrity: sha512-IDlpuFJiWU9rhcKLkpzj8mFu/lpe64gVgnV15ZOrYx1iFzxxrxCzbExiUEKtwwXRvEiEMUS6iZeYgnMxgbqbxQ==}
+  '@vitest/browser-playwright@4.0.18':
+    resolution: {integrity: sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==}
     peerDependencies:
-      vitest: 3.2.4
+      playwright: '*'
+      vitest: 4.0.18
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/browser@4.0.18':
+    resolution: {integrity: sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==}
+    peerDependencies:
+      vitest: 4.0.18
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/coverage-istanbul@4.0.18':
+    resolution: {integrity: sha512-0OhjP30owEDihYTZGWuq20rNtV1RjjJs1Mv4MaZIKcFBmiLUXX7HJLX4fU7wE+Mrc3lQxI2HKq6WrSXi5FGuCQ==}
+    peerDependencies:
+      vitest: 4.0.18
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   '@vue/compiler-core@3.5.27':
     resolution: {integrity: sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==}
@@ -5368,10 +5342,6 @@ packages:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
     engines: {node: '>=6.0.0'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
     engines: {node: '>=14.16'}
@@ -5416,8 +5386,8 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
@@ -5443,10 +5413,6 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
-
-  check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -5991,10 +5957,6 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -6666,10 +6628,6 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
@@ -6705,6 +6663,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -6789,10 +6752,6 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    hasBin: true
 
   glob@13.0.1:
     resolution: {integrity: sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==}
@@ -7497,10 +7456,6 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
@@ -7508,9 +7463,6 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -7548,9 +7500,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -7698,28 +7647,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -7793,9 +7738,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -7831,8 +7773,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
   make-asynchronous@1.0.1:
     resolution: {integrity: sha512-T9BPOmEOhp6SmV25SwLVcHK4E6JyG/coH3C6F1NjNXSziv/fd4GmsqMk8YR6qpPOswfaOCApSNkZv6fxoaYFcQ==}
@@ -8301,6 +8243,9 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -8461,10 +8406,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
@@ -8484,10 +8425,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
@@ -8512,6 +8449,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pixelmatch@7.1.0:
+    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
+    hasBin: true
+
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
@@ -8519,6 +8460,20 @@ packages:
   pkijs@3.3.3:
     resolution: {integrity: sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==}
     engines: {node: '>=16.0.0'}
+
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -9519,56 +9474,48 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-arm@1.93.3:
     resolution: {integrity: sha512-yeiv2y+dp8B4wNpd3+JsHYD0mvpXSfov7IGyQ1tMIR40qv+ROkRqYiqQvAOXf76Qwh4Y9OaYZtLpnsPjfeq6mA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.93.3:
     resolution: {integrity: sha512-PS829l+eUng+9W4PFclXGb4uA2+965NHV3/Sa5U7qTywjeeUUYTZg70dJHSqvhrBEfCc2XJABeW3adLJbyQYkw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-arm@1.93.3:
     resolution: {integrity: sha512-fU0fwAwbp7sBE3h5DVU5UPzvaLg7a4yONfFWkkcCp6ZrOiPuGRHXXYriWQ0TUnWy4wE+svsVuWhwWgvlb/tkKg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.93.3:
     resolution: {integrity: sha512-cK1oBY+FWQquaIGEeQ5H74KTO8cWsSWwXb/WaildOO9U6wmUypTgUYKQ0o5o/29nZbWWlM1PHuwVYTSnT23Jjg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-x64@1.93.3:
     resolution: {integrity: sha512-A7wkrsHu2/I4Zpa0NMuPGkWDVV7QGGytxGyUq3opSXgAexHo/vBPlGoDXoRlSdex0cV+aTMRPjoGIfdmNlHwyg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-riscv64@1.93.3:
     resolution: {integrity: sha512-vWkW1+HTF5qcaHa6hO80gx/QfB6GGjJUP0xLbnAoY4pwEnw5ulGv6RM8qYr8IDhWfVt/KH+lhJ2ZFxnJareisQ==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-x64@1.93.3:
     resolution: {integrity: sha512-k6uFxs+e5jSuk1Y0niCwuq42F9ZC5UEP7P+RIOurIm8w/5QFa0+YqeW+BPWEW5M1FqVOsNZH3qGn4ahqvAEjPA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-unknown-all@1.93.3:
     resolution: {integrity: sha512-o5wj2rLpXH0C+GJKt/VpWp6AnMsCCbfFmnMAttcrsa+U3yrs/guhZ3x55KAqqUsE8F47e3frbsDL+1OuQM5DAA==}
@@ -9727,13 +9674,13 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -9909,9 +9856,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -10015,10 +9959,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  test-exclude@7.0.1:
-    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
-    engines: {node: '>=18'}
-
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -10044,8 +9984,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -10055,12 +9996,8 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.19:
@@ -10355,31 +10292,46 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
+  vitest-browser-react@2.0.5:
+    resolution: {integrity: sha512-YODQX8mHTJCyKNVYTWJrLEYrUtw+QfLl78owgvuE7C5ydgmGBq6v5s4jK2w6wdPhIZsN9PpV1rQbmAevWJjO9g==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      vitest: ^4.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -10666,9 +10618,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
-
-  zod@4.2.0:
-    resolution: {integrity: sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -13273,15 +13222,6 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.2
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@istanbuljs/schema@0.1.3': {}
 
   '@jest/diff-sequences@30.0.1': {}
@@ -14224,9 +14164,6 @@ snapshots:
 
   '@phosphor-icons/core@2.1.1': {}
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
-
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -14680,7 +14617,7 @@ snapshots:
 
   '@scalar/openapi-types@0.5.3':
     dependencies:
-      zod: 4.2.0
+      zod: 4.3.6
 
   '@scalar/openapi-upgrader@0.1.8':
     dependencies:
@@ -14754,7 +14691,7 @@ snapshots:
       cva: 1.0.0-beta.2(typescript@5.6.3)
       tailwind-merge: 2.6.0
       vue: 3.5.27(typescript@5.6.3)
-      zod: 4.2.0
+      zod: 4.3.6
     transitivePeerDependencies:
       - typescript
 
@@ -15562,63 +15499,90 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/browser-playwright@4.0.18(playwright@1.55.1)(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/browser': 4.0.18(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
+      playwright: 1.55.1
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.0.18(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/mocker': 4.0.18(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
+      '@vitest/utils': 4.0.18
+      magic-string: 0.30.21
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/coverage-istanbul@4.0.18(vitest@4.0.18)':
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      debug: 4.4.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magicast: 0.3.5
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+      magicast: 0.5.1
+      obug: 2.1.1
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.0.18':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.0.3
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.0.18':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.0.18
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.0.18
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.0.18': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   '@vue/compiler-core@3.5.27':
     dependencies:
@@ -16398,8 +16362,6 @@ snapshots:
 
   bytestreamjs@2.0.1: {}
 
-  cac@6.7.14: {}
-
   cacheable-lookup@7.0.0: {}
 
   cacheable-request@10.2.14:
@@ -16451,13 +16413,7 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -16475,8 +16431,6 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
-
-  check-error@2.1.1: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -17051,8 +17005,6 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deep-eql@5.0.2: {}
-
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -17580,8 +17532,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 8.57.1
       hermes-parser: 0.25.1
-      zod: 4.2.0
-      zod-validation-error: 4.0.2(zod@4.2.0)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -17924,11 +17876,6 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   form-data-encoder@2.1.4: {}
 
   form-data@4.0.5:
@@ -17960,6 +17907,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -18038,15 +17988,6 @@ snapshots:
       tslib: 2.8.1
 
   glob-to-regexp@0.4.1: {}
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@13.0.1:
     dependencies:
@@ -18864,14 +18805,6 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
@@ -18885,12 +18818,6 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jake@10.9.4:
     dependencies:
@@ -18942,8 +18869,6 @@ snapshots:
   js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -19153,8 +19078,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@3.2.1: {}
-
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -19190,7 +19113,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.1:
     dependencies:
       '@babel/parser': 7.28.6
       '@babel/types': 7.28.6
@@ -19984,6 +19907,8 @@ snapshots:
 
   obuf@1.1.2: {}
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -20165,11 +20090,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-
   path-scurry@2.0.1:
     dependencies:
       lru-cache: 11.2.4
@@ -20186,8 +20106,6 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   pbkdf2@3.1.5:
     dependencies:
@@ -20208,6 +20126,10 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pixelmatch@7.1.0:
+    dependencies:
+      pngjs: 7.0.0
+
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
@@ -20220,6 +20142,16 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  playwright-core@1.55.1: {}
+
+  playwright@1.55.1:
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -21632,9 +21564,13 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
-  signal-exit@4.1.0: {}
-
   sirv@2.0.4:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
+  sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
@@ -21845,10 +21781,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
@@ -21945,12 +21877,6 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  test-exclude@7.0.1:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.5.0
-      minimatch: 9.0.5
-
   text-table@0.2.0: {}
 
   thingies@2.5.0(tslib@2.8.1):
@@ -21969,7 +21895,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -21978,9 +21904,7 @@ snapshots:
 
   tinypool@1.1.1: {}
 
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.0.3: {}
 
   tldts-core@7.0.19: {}
 
@@ -22305,55 +22229,41 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2):
+  vitest-browser-react@2.0.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.0.18)(esbuild@0.25.9)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.0.3
       vite: rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.12
+      '@opentelemetry/api': 1.9.0
       '@types/node': 24.7.2
+      '@vitest/browser-playwright': 4.0.18(playwright@1.55.1)(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.18)
       jsdom: 27.0.1(postcss@8.5.6)
     transitivePeerDependencies:
       - esbuild
@@ -22364,7 +22274,6 @@ snapshots:
       - sass-embedded
       - stylus
       - sugarss
-      - supports-color
       - terser
       - tsx
       - yaml
@@ -22695,11 +22604,9 @@ snapshots:
 
   zhead@2.2.4: {}
 
-  zod-validation-error@4.0.2(zod@4.2.0):
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
-      zod: 4.2.0
-
-  zod@4.2.0: {}
+      zod: 4.3.6
 
   zod@4.3.6: {}
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -25,7 +25,9 @@ catalog:
   '@types/react-dom': 19.2.3
   '@vitejs/plugin-basic-ssl': 2.1.0
   '@vitejs/plugin-react': 5.0.4
-  '@vitest/coverage-istanbul': 3.2.4
+  '@vitest/browser-playwright': 4.0.18
+  playwright: 1.55.1
+  '@vitest/coverage-istanbul': 4.0.18
   '@wso2/oxygen-ui': 0.0.1-alpha.10
   '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.10
   babel-plugin-react-compiler: 19.1.0-rc.3
@@ -54,5 +56,6 @@ catalog:
   typescript: 5.9.3
   typescript-eslint: 8.45.0
   vite: npm:rolldown-vite@7.1.14
-  vitest: 3.2.4
-  zod: 4.2.0
+  vitest: 4.0.18
+  vitest-browser-react: 2.0.5
+  zod: 4.3.6


### PR DESCRIPTION
### Purpose
This pull request refactors test and component code throughout the `thunder-develop` frontend to improve type safety and clarity when working with mock functions. The main change is replacing the use of `ReturnType<typeof vi.fn>` with the explicit `Mock` type imported from `vitest`. This makes mock variable types more accurate and consistent, especially in test files. Additionally, one minor improvement updates a `useRef` type for better compatibility.

The most important changes are:

**Test type improvements:**

* Replaced all instances of `ReturnType<typeof vi.fn>` with the explicit `Mock` type for mock variables in test files across applications and flows features, including API and component tests.

**Component type improvement:**

* Updated the type of `applyTimeoutRef` in `EditTokenSettings.tsx` from `NodeJS.Timeout | null` to `ReturnType<typeof setTimeout> | null` for better compatibility across environments.

These changes enhance code maintainability and reduce the risk of type errors when working with mocks in tests.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1261

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
