### PR TITLE
Username-less passkey authentication

### DIFF
--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
@@ -1,40 +1,38 @@
 {
-    "name": "Passkey Only Authentication Flow",
+    "name": "Passkey Authentication Flow",
     "handle": "default-passkey-flow",
     "flowType": "AUTHENTICATION",
     "nodes": [
         {
             "id": "start",
             "type": "START",
-            "onSuccess": "prompt_identifier"
+            "onSuccess": "prompt_passkey"
         },
         {
-            "id": "prompt_identifier",
+            "id": "prompt_passkey",
             "type": "PROMPT",
             "meta": {
                 "components": [
                     {
                         "type": "TEXT",
                         "id": "text_001",
-                        "label": "{{ t(signin:heading) }}",
+                        "label": "Sign in with Passkey",
                         "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "TEXT",
+                        "id": "text_002",
+                        "label": "Use your passkey to securely sign in to your account without a password.",
+                        "variant": "BODY"
                     },
                     {
                         "type": "BLOCK",
                         "id": "block_001",
                         "components": [
                             {
-                                "id": "input_001",
-                                "ref": "username",
-                                "type": "TEXT_INPUT",
-                                "label": "{{ t(elements:fields.username.label) }}",
-                                "required": true,
-                                "placeholder": "{{ t(elements:fields.username.placeholder) }}"
-                            },
-                            {
                                 "type": "ACTION",
                                 "id": "action_001",
-                                "label": "{{ t(elements:buttons.submit.text) }}",
+                                "label": "Sign in with Passkey",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }
@@ -44,28 +42,12 @@
             },
             "prompts": [
                 {
-                    "inputs": [
-                        {
-                            "ref": "input_001",
-                            "identifier": "username",
-                            "type": "TEXT_INPUT",
-                            "required": true
-                        }
-                    ],
                     "action": {
                         "ref": "action_001",
-                        "nextNode": "identity_resolver"
+                        "nextNode": "passkey_challenge"
                     }
                 }
             ]
-        },
-        {
-            "id": "identity_resolver",
-            "type": "TASK_EXECUTION",
-            "executor": {
-                "name": "IdentifyingExecutor"
-            },
-            "onSuccess": "passkey_challenge"
         },
         {
             "id": "passkey_challenge",

--- a/backend/internal/authn/passkey/sessionStoreInterface_mock_test.go
+++ b/backend/internal/authn/passkey/sessionStoreInterface_mock_test.go
@@ -7,6 +7,7 @@ package passkey
 import (
 	"time"
 
+	"github.com/go-webauthn/webauthn/webauthn"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -133,25 +134,25 @@ func (_c *sessionStoreInterfaceMock_deleteSession_Call) RunAndReturn(run func(se
 }
 
 // retrieveSession provides a mock function for the type sessionStoreInterfaceMock
-func (_mock *sessionStoreInterfaceMock) retrieveSession(sessionKey string) (*sessionData, string, string, error) {
+func (_mock *sessionStoreInterfaceMock) retrieveSession(sessionKey string) (*webauthn.SessionData, string, string, error) {
 	ret := _mock.Called(sessionKey)
 
 	if len(ret) == 0 {
 		panic("no return value specified for retrieveSession")
 	}
 
-	var r0 *sessionData
+	var r0 *webauthn.SessionData
 	var r1 string
 	var r2 string
 	var r3 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*sessionData, string, string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) (*webauthn.SessionData, string, string, error)); ok {
 		return returnFunc(sessionKey)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *sessionData); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) *webauthn.SessionData); ok {
 		r0 = returnFunc(sessionKey)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*sessionData)
+			r0 = ret.Get(0).(*webauthn.SessionData)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string) string); ok {
@@ -196,27 +197,27 @@ func (_c *sessionStoreInterfaceMock_retrieveSession_Call) Run(run func(sessionKe
 	return _c
 }
 
-func (_c *sessionStoreInterfaceMock_retrieveSession_Call) Return(v *sessionData, s string, s1 string, err error) *sessionStoreInterfaceMock_retrieveSession_Call {
+func (_c *sessionStoreInterfaceMock_retrieveSession_Call) Return(v *webauthn.SessionData, s string, s1 string, err error) *sessionStoreInterfaceMock_retrieveSession_Call {
 	_c.Call.Return(v, s, s1, err)
 	return _c
 }
 
-func (_c *sessionStoreInterfaceMock_retrieveSession_Call) RunAndReturn(run func(sessionKey string) (*sessionData, string, string, error)) *sessionStoreInterfaceMock_retrieveSession_Call {
+func (_c *sessionStoreInterfaceMock_retrieveSession_Call) RunAndReturn(run func(sessionKey string) (*webauthn.SessionData, string, string, error)) *sessionStoreInterfaceMock_retrieveSession_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // storeSession provides a mock function for the type sessionStoreInterfaceMock
-func (_mock *sessionStoreInterfaceMock) storeSession(sessionKey string, userID string, relyingPartyID string, sessData *sessionData, expiryTime time.Time) error {
-	ret := _mock.Called(sessionKey, userID, relyingPartyID, sessData, expiryTime)
+func (_mock *sessionStoreInterfaceMock) storeSession(sessionKey string, userID string, relyingPartyID string, sessionData *webauthn.SessionData, expiryTime time.Time) error {
+	ret := _mock.Called(sessionKey, userID, relyingPartyID, sessionData, expiryTime)
 
 	if len(ret) == 0 {
 		panic("no return value specified for storeSession")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, *sessionData, time.Time) error); ok {
-		r0 = returnFunc(sessionKey, userID, relyingPartyID, sessData, expiryTime)
+	if returnFunc, ok := ret.Get(0).(func(string, string, string, *webauthn.SessionData, time.Time) error); ok {
+		r0 = returnFunc(sessionKey, userID, relyingPartyID, sessionData, expiryTime)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -232,13 +233,13 @@ type sessionStoreInterfaceMock_storeSession_Call struct {
 //   - sessionKey string
 //   - userID string
 //   - relyingPartyID string
-//   - sessionData *sessionData
+//   - sessionData *webauthn.SessionData
 //   - expiryTime time.Time
 func (_e *sessionStoreInterfaceMock_Expecter) storeSession(sessionKey interface{}, userID interface{}, relyingPartyID interface{}, sessionData interface{}, expiryTime interface{}) *sessionStoreInterfaceMock_storeSession_Call {
 	return &sessionStoreInterfaceMock_storeSession_Call{Call: _e.mock.On("storeSession", sessionKey, userID, relyingPartyID, sessionData, expiryTime)}
 }
 
-func (_c *sessionStoreInterfaceMock_storeSession_Call) Run(run func(sessionKey string, userID string, relyingPartyID string, sessionData *sessionData, expiryTime time.Time)) *sessionStoreInterfaceMock_storeSession_Call {
+func (_c *sessionStoreInterfaceMock_storeSession_Call) Run(run func(sessionKey string, userID string, relyingPartyID string, sessionData *webauthn.SessionData, expiryTime time.Time)) *sessionStoreInterfaceMock_storeSession_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -252,9 +253,9 @@ func (_c *sessionStoreInterfaceMock_storeSession_Call) Run(run func(sessionKey s
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 *sessionData
+		var arg3 *webauthn.SessionData
 		if args[3] != nil {
-			arg3 = args[3].(*sessionData)
+			arg3 = args[3].(*webauthn.SessionData)
 		}
 		var arg4 time.Time
 		if args[4] != nil {
@@ -276,7 +277,7 @@ func (_c *sessionStoreInterfaceMock_storeSession_Call) Return(err error) *sessio
 	return _c
 }
 
-func (_c *sessionStoreInterfaceMock_storeSession_Call) RunAndReturn(run func(sessionKey string, userID string, relyingPartyID string, sessionData *sessionData, expiryTime time.Time) error) *sessionStoreInterfaceMock_storeSession_Call {
+func (_c *sessionStoreInterfaceMock_storeSession_Call) RunAndReturn(run func(sessionKey string, userID string, relyingPartyID string, sessionData *webauthn.SessionData, expiryTime time.Time) error) *sessionStoreInterfaceMock_storeSession_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/authn/passkey/utils.go
+++ b/backend/internal/authn/passkey/utils.go
@@ -186,9 +186,6 @@ func validateAuthenticationStartRequest(req *PasskeyAuthenticationStartRequest) 
 	if req == nil {
 		return &ErrorInvalidFinishData
 	}
-	if strings.TrimSpace(req.UserID) == "" {
-		return &ErrorEmptyUserIdentifier
-	}
 	if strings.TrimSpace(req.RelyingPartyID) == "" {
 		return &ErrorEmptyRelyingPartyID
 	}

--- a/backend/internal/authn/passkey/utils_test.go
+++ b/backend/internal/authn/passkey/utils_test.go
@@ -196,6 +196,13 @@ func (suite *UtilsTestSuite) TestValidateRegistrationStartRequest_EmptyRelyingPa
 	suite.Equal(ErrorEmptyRelyingPartyID.Code, err.Code)
 }
 
+func (suite *UtilsTestSuite) TestValidateAuthenticationStartRequest_NilRequest() {
+	err := validateAuthenticationStartRequest(nil)
+
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidFinishData.Code, err.Code)
+}
+
 func (suite *UtilsTestSuite) TestHandleUserRetrievalError_ClientError() {
 	svcErr := &serviceerror.ServiceError{
 		Type: serviceerror.ClientErrorType,

--- a/backend/internal/authn/passkey/webAuthnService_mock_test.go
+++ b/backend/internal/authn/passkey/webAuthnService_mock_test.go
@@ -35,6 +35,69 @@ func (_m *webAuthnServiceMock) EXPECT() *webAuthnServiceMock_Expecter {
 	return &webAuthnServiceMock_Expecter{mock: &_m.Mock}
 }
 
+// BeginDiscoverableLogin provides a mock function for the type webAuthnServiceMock
+func (_mock *webAuthnServiceMock) BeginDiscoverableLogin() (*credentialAssertion, *sessionData, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for BeginDiscoverableLogin")
+	}
+
+	var r0 *credentialAssertion
+	var r1 *sessionData
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func() (*credentialAssertion, *sessionData, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *credentialAssertion); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*credentialAssertion)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() *sessionData); ok {
+		r1 = returnFunc()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*sessionData)
+		}
+	}
+	if returnFunc, ok := ret.Get(2).(func() error); ok {
+		r2 = returnFunc()
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// webAuthnServiceMock_BeginDiscoverableLogin_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BeginDiscoverableLogin'
+type webAuthnServiceMock_BeginDiscoverableLogin_Call struct {
+	*mock.Call
+}
+
+// BeginDiscoverableLogin is a helper method to define mock.On call
+func (_e *webAuthnServiceMock_Expecter) BeginDiscoverableLogin() *webAuthnServiceMock_BeginDiscoverableLogin_Call {
+	return &webAuthnServiceMock_BeginDiscoverableLogin_Call{Call: _e.mock.On("BeginDiscoverableLogin")}
+}
+
+func (_c *webAuthnServiceMock_BeginDiscoverableLogin_Call) Run(run func()) *webAuthnServiceMock_BeginDiscoverableLogin_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *webAuthnServiceMock_BeginDiscoverableLogin_Call) Return(v *credentialAssertion, v1 *sessionData, err error) *webAuthnServiceMock_BeginDiscoverableLogin_Call {
+	_c.Call.Return(v, v1, err)
+	return _c
+}
+
+func (_c *webAuthnServiceMock_BeginDiscoverableLogin_Call) RunAndReturn(run func() (*credentialAssertion, *sessionData, error)) *webAuthnServiceMock_BeginDiscoverableLogin_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BeginLogin provides a mock function for the type webAuthnServiceMock
 func (_mock *webAuthnServiceMock) BeginLogin(user webauthnUserInterface) (*credentialAssertion, *sessionData, error) {
 	ret := _mock.Called(user)
@@ -325,6 +388,88 @@ func (_c *webAuthnServiceMock_ValidateLogin_Call) Return(v *webauthnCredential, 
 }
 
 func (_c *webAuthnServiceMock_ValidateLogin_Call) RunAndReturn(run func(user webauthnUserInterface, session sessionData, response *parsedCredentialAssertionData) (*webauthnCredential, error)) *webAuthnServiceMock_ValidateLogin_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ValidatePasskeyLogin provides a mock function for the type webAuthnServiceMock
+func (_mock *webAuthnServiceMock) ValidatePasskeyLogin(userHandler func(rawID []byte, userHandle []byte) (webauthnUserInterface, error), session sessionData, response *parsedCredentialAssertionData) (webauthnUserInterface, *webauthnCredential, error) {
+	ret := _mock.Called(userHandler, session, response)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidatePasskeyLogin")
+	}
+
+	var r0 webauthnUserInterface
+	var r1 *webauthnCredential
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(func(rawID []byte, userHandle []byte) (webauthnUserInterface, error), sessionData, *parsedCredentialAssertionData) (webauthnUserInterface, *webauthnCredential, error)); ok {
+		return returnFunc(userHandler, session, response)
+	}
+	if returnFunc, ok := ret.Get(0).(func(func(rawID []byte, userHandle []byte) (webauthnUserInterface, error), sessionData, *parsedCredentialAssertionData) webauthnUserInterface); ok {
+		r0 = returnFunc(userHandler, session, response)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(webauthnUserInterface)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(func(rawID []byte, userHandle []byte) (webauthnUserInterface, error), sessionData, *parsedCredentialAssertionData) *webauthnCredential); ok {
+		r1 = returnFunc(userHandler, session, response)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*webauthnCredential)
+		}
+	}
+	if returnFunc, ok := ret.Get(2).(func(func(rawID []byte, userHandle []byte) (webauthnUserInterface, error), sessionData, *parsedCredentialAssertionData) error); ok {
+		r2 = returnFunc(userHandler, session, response)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// webAuthnServiceMock_ValidatePasskeyLogin_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidatePasskeyLogin'
+type webAuthnServiceMock_ValidatePasskeyLogin_Call struct {
+	*mock.Call
+}
+
+// ValidatePasskeyLogin is a helper method to define mock.On call
+//   - userHandler func(rawID []byte, userHandle []byte) (webauthnUserInterface, error)
+//   - session sessionData
+//   - response *parsedCredentialAssertionData
+func (_e *webAuthnServiceMock_Expecter) ValidatePasskeyLogin(userHandler interface{}, session interface{}, response interface{}) *webAuthnServiceMock_ValidatePasskeyLogin_Call {
+	return &webAuthnServiceMock_ValidatePasskeyLogin_Call{Call: _e.mock.On("ValidatePasskeyLogin", userHandler, session, response)}
+}
+
+func (_c *webAuthnServiceMock_ValidatePasskeyLogin_Call) Run(run func(userHandler func(rawID []byte, userHandle []byte) (webauthnUserInterface, error), session sessionData, response *parsedCredentialAssertionData)) *webAuthnServiceMock_ValidatePasskeyLogin_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 func(rawID []byte, userHandle []byte) (webauthnUserInterface, error)
+		if args[0] != nil {
+			arg0 = args[0].(func(rawID []byte, userHandle []byte) (webauthnUserInterface, error))
+		}
+		var arg1 sessionData
+		if args[1] != nil {
+			arg1 = args[1].(sessionData)
+		}
+		var arg2 *parsedCredentialAssertionData
+		if args[2] != nil {
+			arg2 = args[2].(*parsedCredentialAssertionData)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *webAuthnServiceMock_ValidatePasskeyLogin_Call) Return(webauthnUserInterfaceMoqParam webauthnUserInterface, v *webauthnCredential, err error) *webAuthnServiceMock_ValidatePasskeyLogin_Call {
+	_c.Call.Return(webauthnUserInterfaceMoqParam, v, err)
+	return _c
+}
+
+func (_c *webAuthnServiceMock_ValidatePasskeyLogin_Call) RunAndReturn(run func(userHandler func(rawID []byte, userHandle []byte) (webauthnUserInterface, error), session sessionData, response *parsedCredentialAssertionData) (webauthnUserInterface, *webauthnCredential, error)) *webAuthnServiceMock_ValidatePasskeyLogin_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/authn/passkey/webauthn_service_test.go
+++ b/backend/internal/authn/passkey/webauthn_service_test.go
@@ -1,0 +1,478 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package passkey
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testWebAuthnUserID         = "user123"
+	testWebAuthnRelyingPartyID = "example.com"
+	testWebAuthnOrigin         = "https://example.com"
+)
+
+type WebAuthnLibServiceTestSuite struct {
+	suite.Suite
+	service *defaultWebAuthnService
+}
+
+func TestWebAuthnLibServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(WebAuthnLibServiceTestSuite))
+}
+
+func (suite *WebAuthnLibServiceTestSuite) SetupTest() {
+	// Create a real webauthn service for testing
+	service, err := newDefaultWebAuthnService(
+		testWebAuthnRelyingPartyID,
+		"Test RP",
+		[]string{testWebAuthnOrigin},
+	)
+	suite.Require().NoError(err, "Failed to create webauthn service")
+	suite.service = service.(*defaultWebAuthnService)
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidatePasskeyLogin_UserHandlerError() {
+	// Test that errors from the user handler are properly propagated
+
+	session := sessionData{
+		Challenge:        "test-challenge",
+		UserVerification: protocol.VerificationPreferred,
+	}
+
+	// Create a user handler that returns an error
+	expectedError := errors.New("user not found")
+	userHandler := func(rawID, userHandle []byte) (webauthnUserInterface, error) {
+		return nil, expectedError
+	}
+
+	parsedResponse := &parsedCredentialAssertionData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			RawID: []byte("test-raw-id"),
+			ParsedCredential: protocol.ParsedCredential{
+				ID:   "test-credential-id",
+				Type: "public-key",
+			},
+		},
+		Response: protocol.ParsedAssertionResponse{
+			CollectedClientData: protocol.CollectedClientData{
+				Type:      "webauthn.get",
+				Challenge: "test-challenge",
+				Origin:    testWebAuthnOrigin,
+			},
+			UserHandle: []byte(testWebAuthnUserID),
+		},
+	}
+
+	user, credential, err := suite.service.ValidatePasskeyLogin(userHandler, session, parsedResponse)
+
+	suite.Error(err, "Expected error from user handler")
+	suite.Nil(user, "User should be nil on handler error")
+	suite.Nil(credential, "Credential should be nil on handler error")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidatePasskeyLogin_EmptySession() {
+	// Test with empty session data
+
+	mockUser := newWebauthnUserInterfaceMock(suite.T())
+	// Setup default expectations (optional)
+	mockUser.On("WebAuthnID").Return([]byte(testWebAuthnUserID)).Maybe()
+	mockUser.On("WebAuthnName").Return("test@example.com").Maybe()
+	mockUser.On("WebAuthnDisplayName").Return("Test User").Maybe()
+	mockUser.On("WebAuthnCredentials").Return([]webauthnCredential{}).Maybe()
+
+	emptySession := sessionData{}
+
+	userHandler := func(_, _ []byte) (webauthnUserInterface, error) {
+		return mockUser, nil
+	}
+
+	parsedResponse := &parsedCredentialAssertionData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			RawID: []byte("test-raw-id"),
+		},
+	}
+
+	user, credential, err := suite.service.ValidatePasskeyLogin(userHandler, emptySession, parsedResponse)
+
+	suite.Error(err, "Expected error with empty session")
+	suite.Nil(user, "User should be nil on validation failure")
+	suite.Nil(credential, "Credential should be nil on validation failure")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidatePasskeyLogin_NilResponse() {
+	// Test with nil parsed response - this should panic or error
+
+	mockUser := newWebauthnUserInterfaceMock(suite.T())
+	// Setup default expectations
+	mockUser.On("WebAuthnID").Return([]byte(testWebAuthnUserID)).Maybe()
+	mockUser.On("WebAuthnName").Return("test@example.com").Maybe()
+	mockUser.On("WebAuthnDisplayName").Return("Test User").Maybe()
+	mockUser.On("WebAuthnCredentials").Return([]webauthnCredential{}).Maybe()
+	mockUser.On("WebAuthnIcon").Return("").Maybe()
+
+	session := sessionData{
+		Challenge:        "test-challenge",
+		UserVerification: protocol.VerificationPreferred,
+	}
+
+	userHandler := func(_, _ []byte) (webauthnUserInterface, error) { //nolint:unparam
+		return mockUser, nil
+	}
+
+	// The webauthn library will panic with nil response, so we test for that
+	suite.Panics(func() {
+		_, _, _ = suite.service.ValidatePasskeyLogin(userHandler, session, nil)
+	}, "Expected panic with nil response")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidatePasskeyLogin_EmptyUserHandle() {
+	// Test with empty user handle in response
+
+	mockUser := newWebauthnUserInterfaceMock(suite.T())
+	// Setup default expectations (optional)
+	mockUser.On("WebAuthnID").Return([]byte(testWebAuthnUserID)).Maybe()
+	mockUser.On("WebAuthnName").Return("test@example.com").Maybe()
+	mockUser.On("WebAuthnDisplayName").Return("Test User").Maybe()
+	mockUser.On("WebAuthnCredentials").Return([]webauthnCredential{}).Maybe()
+	mockUser.On("WebAuthnIcon").Return("").Maybe()
+
+	session := sessionData{
+		Challenge:        "test-challenge",
+		UserVerification: protocol.VerificationPreferred,
+	}
+
+	userHandler := func(_, _ []byte) (webauthnUserInterface, error) {
+		// The handler might be called depending on how the library handles empty user handles
+		return mockUser, nil
+	}
+
+	parsedResponse := &parsedCredentialAssertionData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			RawID: []byte("test-raw-id"),
+		},
+		Response: protocol.ParsedAssertionResponse{
+			CollectedClientData: protocol.CollectedClientData{
+				Type:      "webauthn.get",
+				Challenge: "test-challenge",
+				Origin:    testWebAuthnOrigin,
+			},
+			UserHandle: nil, // Empty user handle
+		},
+	}
+
+	user, credential, err := suite.service.ValidatePasskeyLogin(userHandler, session, parsedResponse)
+
+	// Expected behavior: should fail validation due to missing cryptographic data or user handle
+	suite.Error(err, "Expected validation error")
+	suite.Nil(user, "User should be nil on validation failure")
+	suite.Nil(credential, "Credential should be nil on validation failure")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidatePasskeyLogin_UserHandlerReturnsValidUser() {
+	// Test that user handler is called and user is returned properly
+
+	mockUser := newWebauthnUserInterfaceMock(suite.T())
+	// Setup default expectations (optional)
+	mockUser.On("WebAuthnID").Return([]byte(testWebAuthnUserID)).Maybe()
+	mockUser.On("WebAuthnName").Return("test@example.com").Maybe()
+	mockUser.On("WebAuthnDisplayName").Return("Test User").Maybe()
+	mockUser.On("WebAuthnCredentials").Return([]webauthnCredential{}).Maybe()
+	mockUser.On("WebAuthnIcon").Return("").Maybe()
+
+	session := sessionData{
+		Challenge:        "test-challenge",
+		UserVerification: protocol.VerificationPreferred,
+	}
+
+	userHandlerCalled := false
+	var capturedRawID, capturedUserHandle []byte
+
+	userHandler := func(rawID, userHandle []byte) (webauthnUserInterface, error) {
+		userHandlerCalled = true
+		capturedRawID = rawID
+		capturedUserHandle = userHandle
+		return mockUser, nil
+	}
+
+	parsedResponse := &parsedCredentialAssertionData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			RawID: []byte("test-raw-id"),
+		},
+		Response: protocol.ParsedAssertionResponse{
+			CollectedClientData: protocol.CollectedClientData{
+				Type:      "webauthn.get",
+				Challenge: "test-challenge",
+				Origin:    testWebAuthnOrigin,
+			},
+			UserHandle: []byte(testWebAuthnUserID),
+		},
+	}
+
+	// This will fail actual validation due to missing cryptographic data,
+	// but we're testing the user handler invocation
+	_, _, err := suite.service.ValidatePasskeyLogin(userHandler, session, parsedResponse)
+
+	suite.Error(err, "Expected validation error with mock data")
+	suite.True(userHandlerCalled, "User handler should be called")
+	suite.Equal([]byte("test-raw-id"), capturedRawID, "RawID should be passed to handler")
+	suite.Equal([]byte(testWebAuthnUserID), capturedUserHandle, "UserHandle should be passed to handler")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidatePasskeyLogin_TypeAssertionError() {
+	// Test the type assertion failure path when userHandler returns an error
+	// The actual type assertion code path (lines 232-234) is difficult to trigger
+	// because the library creates the user internally, so we test the error handling
+
+	session := sessionData{
+		Challenge:        "test-challenge",
+		UserVerification: protocol.VerificationPreferred,
+	}
+
+	// Create a user handler that returns an error to simulate failure
+	userHandler := func(rawID, userHandle []byte) (webauthnUserInterface, error) {
+		return nil, errors.New("user lookup failed")
+	}
+
+	parsedResponse := &parsedCredentialAssertionData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			RawID: []byte("test-raw-id"),
+		},
+		Response: protocol.ParsedAssertionResponse{
+			CollectedClientData: protocol.CollectedClientData{
+				Type:      "webauthn.get",
+				Challenge: "test-challenge",
+				Origin:    testWebAuthnOrigin,
+			},
+			UserHandle: []byte(testWebAuthnUserID),
+		},
+	}
+
+	user, credential, err := suite.service.ValidatePasskeyLogin(userHandler, session, parsedResponse)
+
+	// Should get an error from the user handler
+	suite.Error(err, "Expected error from user handler")
+	suite.Nil(user, "User should be nil on error")
+	suite.Nil(credential, "Credential should be nil on error")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidateLogin_Success() {
+	// Test successful login validation with proper credentials
+
+	mockUser := newWebauthnUserInterfaceMock(suite.T())
+	mockUser.On("WebAuthnID").Return([]byte(testWebAuthnUserID)).Maybe()
+	mockUser.On("WebAuthnName").Return("test@example.com").Maybe()
+	mockUser.On("WebAuthnDisplayName").Return("Test User").Maybe()
+	mockUser.On("WebAuthnCredentials").Return([]webauthnCredential{}).Maybe()
+
+	session := sessionData{
+		Challenge:        "test-challenge",
+		UserVerification: protocol.VerificationPreferred,
+	}
+
+	parsedResponse := &parsedCredentialAssertionData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			RawID: []byte("test-raw-id"),
+			ParsedCredential: protocol.ParsedCredential{
+				ID:   "test-credential-id",
+				Type: "public-key",
+			},
+		},
+		Response: protocol.ParsedAssertionResponse{
+			CollectedClientData: protocol.CollectedClientData{
+				Type:      "webauthn.get",
+				Challenge: "test-challenge",
+				Origin:    testWebAuthnOrigin,
+			},
+		},
+	}
+
+	credential, err := suite.service.ValidateLogin(mockUser, session, parsedResponse)
+
+	// Will fail due to missing cryptographic data, but we're testing the function is called
+	suite.Error(err, "Expected validation error with mock data")
+	suite.Nil(credential, "Credential should be nil on validation failure")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestValidateLogin_EmptySession() {
+	// Test login validation with empty session data
+
+	mockUser := newWebauthnUserInterfaceMock(suite.T())
+	mockUser.On("WebAuthnID").Return([]byte(testWebAuthnUserID)).Maybe()
+	mockUser.On("WebAuthnName").Return("test@example.com").Maybe()
+	mockUser.On("WebAuthnDisplayName").Return("Test User").Maybe()
+	mockUser.On("WebAuthnCredentials").Return([]webauthnCredential{}).Maybe()
+
+	emptySession := sessionData{}
+
+	parsedResponse := &parsedCredentialAssertionData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			RawID: []byte("test-raw-id"),
+		},
+	}
+
+	credential, err := suite.service.ValidateLogin(mockUser, emptySession, parsedResponse)
+
+	suite.Error(err, "Expected error with empty session")
+	suite.Nil(credential, "Credential should be nil on validation failure")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestBeginDiscoverableLogin_Success() {
+	// Test that BeginDiscoverableLogin creates proper options for usernameless authentication
+
+	options, session, err := suite.service.BeginDiscoverableLogin()
+
+	suite.NoError(err, "BeginDiscoverableLogin should not return error")
+	suite.NotNil(options, "Options should not be nil")
+	suite.NotNil(session, "Session should not be nil")
+
+	// Verify that the challenge is generated
+	suite.NotEmpty(session.Challenge, "Challenge should be generated")
+
+	// Verify user verification is set to preferred
+	suite.Equal(protocol.VerificationPreferred, session.UserVerification,
+		"User verification should be preferred for discoverable login")
+
+	// Verify that AllowedCredentials is empty for usernameless flow
+	suite.Empty(session.AllowedCredentialIDs, "Allowed credentials should be empty for discoverable login")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestParseAssertionResponse_Success() {
+	// Test successful parsing of assertion response
+
+	credentialID := base64.RawURLEncoding.EncodeToString([]byte("test-credential-id"))
+	clientJSON := `{"type":"webauthn.get","challenge":"test-challenge","origin":"https://example.com"}`
+	clientData := base64.RawURLEncoding.EncodeToString([]byte(clientJSON))
+	authData := base64.RawURLEncoding.EncodeToString(createMinimalAuthData())
+	signature := base64.RawURLEncoding.EncodeToString([]byte("test-signature"))
+	userHandle := base64.RawURLEncoding.EncodeToString([]byte("test-user-id"))
+
+	parsed, err := parseAssertionResponse(
+		credentialID,
+		"public-key",
+		clientData,
+		authData,
+		signature,
+		userHandle,
+	)
+
+	suite.NoError(err, "Parsing should succeed")
+	suite.NotNil(parsed, "Parsed response should not be nil")
+	suite.Equal("test-credential-id", string(parsed.RawID))
+	suite.Equal("public-key", parsed.Type)
+	suite.NotNil(parsed.Response.UserHandle, "User handle should be parsed")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestParseAssertionResponse_InvalidBase64() {
+	// Test parsing with invalid base64 encoding
+
+	credentialID := "invalid!!!base64"
+	clientData := base64.RawURLEncoding.EncodeToString([]byte(`{"type":"webauthn.get"}`))
+	authData := base64.RawURLEncoding.EncodeToString(createMinimalAuthData())
+	signature := base64.RawURLEncoding.EncodeToString([]byte("test-signature"))
+
+	parsed, err := parseAssertionResponse(
+		credentialID,
+		"public-key",
+		clientData,
+		authData,
+		signature,
+		"",
+	)
+
+	suite.Error(err, "Should return error for invalid base64")
+	suite.Nil(parsed, "Parsed response should be nil on error")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestParseAssertionResponse_EmptyUserHandle() {
+	// Test parsing with empty user handle (valid for usernameless flow after discovery)
+
+	credentialID := base64.RawURLEncoding.EncodeToString([]byte("test-credential-id"))
+	clientJSON := `{"type":"webauthn.get","challenge":"test","origin":"https://example.com"}`
+	clientData := base64.RawURLEncoding.EncodeToString([]byte(clientJSON))
+	authData := base64.RawURLEncoding.EncodeToString(createMinimalAuthData())
+	signature := base64.RawURLEncoding.EncodeToString([]byte("test-signature"))
+
+	parsed, err := parseAssertionResponse(
+		credentialID,
+		"public-key",
+		clientData,
+		authData,
+		signature,
+		"", // Empty user handle
+	)
+
+	suite.NoError(err, "Parsing should succeed with empty user handle")
+	suite.NotNil(parsed, "Parsed response should not be nil")
+	suite.Nil(parsed.Response.UserHandle, "User handle should be nil")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestParseAssertionResponse_InvalidJSON() {
+	// Test parsing with invalid client data JSON
+
+	credentialID := base64.RawURLEncoding.EncodeToString([]byte("test-credential-id"))
+	clientData := base64.RawURLEncoding.EncodeToString([]byte(`{invalid json}`))
+	authData := base64.RawURLEncoding.EncodeToString(createMinimalAuthData())
+	signature := base64.RawURLEncoding.EncodeToString([]byte("test-signature"))
+
+	parsed, err := parseAssertionResponse(
+		credentialID,
+		"public-key",
+		clientData,
+		authData,
+		signature,
+		"",
+	)
+
+	suite.Error(err, "Should return error for invalid JSON")
+	suite.Nil(parsed, "Parsed response should be nil on error")
+}
+
+func (suite *WebAuthnLibServiceTestSuite) TestParseAttestationResponse_InvalidBase64() {
+	// Test parsing with invalid base64
+
+	credentialID := base64.RawURLEncoding.EncodeToString([]byte("test-credential-id"))
+	clientData := "invalid!!!base64"
+	attestation := base64.RawURLEncoding.EncodeToString([]byte("test-attestation"))
+
+	parsed, err := parseAttestationResponse(
+		credentialID,
+		"public-key",
+		clientData,
+		attestation,
+	)
+
+	suite.Error(err, "Should return error for invalid base64")
+	suite.Nil(parsed, "Parsed response should be nil on error")
+}
+
+// Helper function to create a minimal valid authenticator data for testing
+func createMinimalAuthData() []byte {
+	// Authenticator data must be at least 37 bytes:
+	// 32 bytes RP ID hash + 1 byte flags + 4 bytes sign count
+	authData := make([]byte, 37)
+	// Set UP (User Present) flag
+	authData[32] = 0x01
+	return authData
+}

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -128,6 +128,11 @@ func (e *executor) ValidatePrerequisites(ctx *NodeContext, execResp *common.Exec
 	}
 
 	for _, prerequisite := range prerequisites {
+		// Skip optional prerequisites
+		if !prerequisite.Required {
+			continue
+		}
+
 		if prerequisite.Identifier == userAttributeUserID {
 			userID := ctx.AuthenticatedUser.UserID
 			if userID != "" {

--- a/backend/internal/flow/core/executor_test.go
+++ b/backend/internal/flow/core/executor_test.go
@@ -238,6 +238,16 @@ func (s *ExecutorTestSuite) TestValidatePrerequisites() {
 			common.ExecFailure,
 			"Prerequisite not met: apiKey",
 		},
+		{
+			"Optional prerequisite not met",
+			[]common.Input{{Identifier: "optionalKey", Required: false}},
+			authncm.AuthenticatedUser{},
+			map[string]string{},
+			map[string]string{},
+			true,
+			"",
+			"",
+		},
 	}
 
 	for _, tt := range tests {

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -1043,6 +1043,7 @@ const translations = {
     // Passkey authentication
     'passkey.button.use': 'Sign in with Passkey',
     'passkey.signin.heading': 'Sign in with Passkey',
+    'passkey.signin.description': 'Use your passkey to securely sign in to your account without a password.',
     'passkey.register.heading': 'Register Passkey',
     'passkey.register.description': 'Create a passkey to securely sign in to your account without a password.',
   },


### PR DESCRIPTION
### Purpose
This pull request introduces support for usernameless (discoverable credential) passkey authentication, allowing users to authenticate without providing a username or user ID. 

**Usernameless Passkey Authentication Support**

* Added a new authentication flow definition for usernameless passkey authentication (`authentication/auth_flow_usernameless_passkey.json`).
* Updated the `passkeyService` logic to detect when the user ID is empty and initiate usernameless authentication using discoverable credentials, including handling both the challenge and verification steps. [[1]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caR291-R328) [[2]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL325-R361) [[3]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL376-R436) [[4]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL428-R502)
* Extended the WebAuthn service interface and implementation to support usernameless authentication, adding `BeginDiscoverableLogin` and `ValidatePasskeyLogin` methods. [[1]](diffhunk://#diff-7dd94fca0962df0fea1a1f03886e2869cdbd7f658e4990e6412a2ab85bdd532cR123-R139) [[2]](diffhunk://#diff-7dd94fca0962df0fea1a1f03886e2869cdbd7f658e4990e6412a2ab85bdd532cR192-R196) [[3]](diffhunk://#diff-7dd94fca0962df0fea1a1f03886e2869cdbd7f658e4990e6412a2ab85bdd532cR206-R236)

* Prevents unintended auto-selection in prompt nodes by skipping auto-select when the prompt is confirmation-only (no inputs defined). This ensures confirmation prompts wait for explicit user action instead of automatically selecting the single available action. Improves flow behavior consistency and avoids accidental confirmations.

**Validation and Flow Improvements**

* Relaxed input validation to allow empty user IDs for usernameless authentication, removing the requirement for a user ID in `validateAuthenticationStartRequest`.
* Updated flow executor logic to skip optional prerequisites, supporting flows that do not require a user to be pre-authenticated.



### Related Issues
- https://github.com/asgardeo/thunder/issues/610
- https://github.com/asgardeo/thunder/issues/1314

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added usernameless passkey authentication — sign in with a passkey without entering a username.

* **UI/UX Changes**
  * Renamed flow to "Passkey Authentication Flow".
  * Updated sign-in heading, button text, and added descriptive copy explaining passkey sign-in benefits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->