### PR TITLE
Unify passkey authentication and registration flow graph handles

### DIFF
--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
@@ -1,6 +1,6 @@
 {
     "name": "Passkey Only Authentication Flow",
-    "handle": "passkey-authentication-flow",
+    "handle": "default-passkey-flow",
     "flowType": "AUTHENTICATION",
     "nodes": [
         {
@@ -65,8 +65,7 @@
             "executor": {
                 "name": "IdentifyingExecutor"
             },
-            "onSuccess": "passkey_challenge",
-            "onFailure": "prompt_identifier"
+            "onSuccess": "passkey_challenge"
         },
         {
             "id": "passkey_challenge",
@@ -79,8 +78,7 @@
                 "name": "PasskeyAuthExecutor",
                 "mode": "challenge"
             },
-            "onSuccess": "passkey_verify",
-            "onFailure": "prompt_identifier"
+            "onSuccess": "passkey_verify"
         },
         {
             "id": "passkey_verify",
@@ -89,8 +87,7 @@
                 "name": "PasskeyAuthExecutor",
                 "mode": "verify"
             },
-            "onSuccess": "auth_assert",
-            "onFailure": "prompt_identifier"
+            "onSuccess": "auth_assert"
         },
         {
             "id": "auth_assert",

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_passkey.json
@@ -1,7 +1,7 @@
 {
     "name": "Passkey Registration Flow",
     "flowType": "REGISTRATION",
-    "handle": "passkey_registration_flow",
+    "handle": "default-passkey-flow",
     "nodes": [
         {
             "id": "start",


### PR DESCRIPTION
### Purpose
This pull request updates the handles for both the passkey authentication and registration flows to use a unified name, and simplifies the passkey authentication flow by removing redundant failure transitions. These changes improve consistency and streamline the flow definitions.

**Flow handle updates:**
* Changed the `handle` field in both `auth_flow_passkey.json` and `registration_flow_passkey.json` to `default-passkey-flow` for consistency between authentication and registration flows. [[1]](diffhunk://#diff-2b27d3e248553c2765d96fb6a0781827f27ade3929017cf4538361836af309eeL3-R3) [[2]](diffhunk://#diff-01b09c84280b5c41a22b84bc06afc18a40a5b45e68e84dd3ff59268179d06752L4-R4)

**Authentication flow simplification:**
* Removed the `"onFailure": "prompt_identifier"` transitions from the `IdentifyingExecutor`, `PasskeyAuthExecutor` (challenge), and `PasskeyAuthExecutor` (verify) nodes in `auth_flow_passkey.json`, leaving only the success transitions. [[1]](diffhunk://#diff-2b27d3e248553c2765d96fb6a0781827f27ade3929017cf4538361836af309eeL68-R68) [[2]](diffhunk://#diff-2b27d3e248553c2765d96fb6a0781827f27ade3929017cf4538361836af309eeL82-R81) [[3]](diffhunk://#diff-2b27d3e248553c2765d96fb6a0781827f27ade3929017cf4538361836af309eeL92-R90)

### Related Issues
- https://github.com/asgardeo/thunder/issues/610


### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
