### PR TITLE
Wait for the `config.js` to load before initializing the SDK

### DIFF
--- a/frontend/apps/thunder-develop/src/AppWithConfig.tsx
+++ b/frontend/apps/thunder-develop/src/AppWithConfig.tsx
@@ -27,8 +27,12 @@ import App from './App';
 
 const queryClient: QueryClient = new QueryClient();
 
-export default function AppWithConfig(): JSX.Element {
-  const {getClientId, getServerUrl, getClientUrl, getScopes} = useConfig();
+export default function AppWithConfig(): JSX.Element | null {
+  const {getClientId, getServerUrl, getClientUrl, getScopes, isLoading} = useConfig();
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <AsgardeoProvider

--- a/frontend/apps/thunder-gate/src/AppWithConfig.tsx
+++ b/frontend/apps/thunder-gate/src/AppWithConfig.tsx
@@ -22,8 +22,12 @@ import {useConfig} from '@thunder/shared-contexts';
 import {BrandingProvider} from '@thunder/shared-branding';
 import AppWithTheme from './AppWithTheme';
 
-export default function AppWithConfig(): JSX.Element {
-  const {getServerUrl} = useConfig();
+export default function AppWithConfig(): JSX.Element | null {
+  const {getServerUrl, isLoading} = useConfig();
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <AsgardeoProvider

--- a/frontend/packages/thunder-shared-contexts/src/Config/ConfigContext.tsx
+++ b/frontend/packages/thunder-shared-contexts/src/Config/ConfigContext.tsx
@@ -79,6 +79,12 @@ export interface ConfigContextType {
    * @returns The client UUID string or undefined if not available
    */
   getClientUuid: () => string | undefined;
+
+  /**
+   * Indicates whether the configuration is still being loaded
+   * @returns True if configuration is loading, false if ready
+   */
+  isLoading: boolean;
 }
 
 /**

--- a/frontend/packages/thunder-shared-contexts/src/Config/ConfigProvider.tsx
+++ b/frontend/packages/thunder-shared-contexts/src/Config/ConfigProvider.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, {useMemo, PropsWithChildren} from 'react';
+import {useMemo, useState, useEffect, PropsWithChildren} from 'react';
 import {ThunderConfig} from './types';
 import ConfigContext, {ConfigContextType} from './ConfigContext';
 
@@ -81,11 +81,19 @@ function loadConfig(): ThunderConfig {
  * @public
  */
 export default function ConfigProvider({children}: ConfigProviderProps) {
+  const [isLoading, setIsLoading] = useState(true);
   const config = useMemo(() => loadConfig(), []);
+
+  useEffect(() => {
+    if (config && typeof config === 'object' && config.server && config.client) {
+      setIsLoading(false);
+    }
+  }, [config]);
 
   const contextValue: ConfigContextType = useMemo(
     () => ({
       config,
+      isLoading,
       getServerUrl: () => {
         // If public_url is provided, use it directly
         if (config.server.public_url) {
@@ -133,7 +141,7 @@ export default function ConfigProvider({children}: ConfigProviderProps) {
         return undefined;
       },
     }),
-    [config],
+    [config, isLoading],
   );
 
   return <ConfigContext.Provider value={contextValue}>{children}</ConfigContext.Provider>;


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request introduces a loading state to the shared configuration context and updates consuming applications to handle asynchronous configuration loading. The main goal is to ensure that apps do not render before configuration is ready, preventing potential errors or undefined behavior.

**Config Context Enhancements:**

* Added an `isLoading` boolean to the `ConfigContextType` interface to indicate whether configuration is still being loaded.
* Updated `ConfigProvider` to manage and expose the `isLoading` state, utilizing `useState` and `useEffect` to track when configuration has finished loading. The context value now includes `isLoading` and updates when it changes. [[1]](diffhunk://#diff-f459193f5e130cbfd122a4ad75df06c043d47f2134dd2a1b25900829d9226881L19-R19) [[2]](diffhunk://#diff-f459193f5e130cbfd122a4ad75df06c043d47f2134dd2a1b25900829d9226881R84-R96) [[3]](diffhunk://#diff-f459193f5e130cbfd122a4ad75df06c043d47f2134dd2a1b25900829d9226881L136-R144)

**Consumer Application Updates:**

* Modified `AppWithConfig` in both `thunder-develop` and `thunder-gate` apps to check `isLoading` from the config context and return `null` (render nothing) while loading, preventing premature rendering. [[1]](diffhunk://#diff-652e4e243fe5308932ec4c7cefc71cb0dfb9859870610139321854fe0d2fc626L30-R35) [[2]](diffhunk://#diff-250166b18a8647a78c5fb2e7cc0bdcd3c51f0d24d7188fed75fc85b5b698db0cL25-R30)
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Wait for `config.js` to load before initializing the SDK

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application initialization by deferring component rendering until configuration loading completes, preventing premature UI display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->