### PR TITLE
Improve Reliability Intermittent Test Failures

### DIFF
--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -752,7 +752,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
 			// Wait for OTP to be sent
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 
 			lastMessage := ts.mockServer.GetLastMessage()
 			ts.Require().NotNil(lastMessage)
@@ -875,7 +875,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 				"mobileNumber": mobileNumber,
 			}
 			// Wait for OTP to be sent
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 
 			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
 			ts.Require().NoError(err)

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -443,7 +443,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 	ts.Require().True(common.HasInput(otpFlowStep.Data.Inputs, "otp"), "OTP input should be required")
 
 	// Wait for SMS to be sent
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	// Verify SMS was sent
 	lastMessage := ts.mockServer.GetLastMessage()
@@ -554,7 +554,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 
 	// Wait for SMS to be sent
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	// Step 2: Try with invalid OTP
 	invalidOTPInputs := map[string]string{
@@ -612,7 +612,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 	ts.Require().Equal("VIEW", otpStep.Type, "Expected flow type to be VIEW")
 
 	// Wait for SMS to be sent
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	// Get the OTP from mock server
 	lastMessage := ts.mockServer.GetLastMessage()

--- a/tests/integration/testutils/mock_notification_server.go
+++ b/tests/integration/testutils/mock_notification_server.go
@@ -171,8 +171,8 @@ func (m *MockNotificationServer) handleClearMessages(w http.ResponseWriter, r *h
 
 // GetLastMessage returns the last received message
 func (m *MockNotificationServer) GetLastMessage() *SMSMessage {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
 	if len(m.messages) == 0 {
 		return nil


### PR DESCRIPTION
### Purpose
This pull request updates the integration test suites for SMS and organizational unit (OU) registration flows to improve test reliability. The main change is increasing the wait time after triggering SMS/OTP sends, ensuring that asynchronous messages have enough time to be processed before assertions are made. Additionally, there is a thread-safety improvement for accessing the mock notification server's messages.

Test reliability improvements:

* Increased the `time.Sleep` duration from 500ms or 1000ms to 1 second after triggering SMS/OTP sends in several test cases (`TestSMSRegistrationFlow`, `TestSMSRegistrationFlowInvalidOTP`, `TestSMSRegistrationFlowSingleRequestWith`, `TestSMSRegistrationFlowWithOUCreation`, and `TestSMSRegistrationFlowWithOUCreationDupl`) to reduce flakiness due to race conditions. [[1]](diffhunk://#diff-8560a0298148d9a9ef98df4f52361180c9c0d436895c988bf3f809496051cbb8L446-R446) [[2]](diffhunk://#diff-8560a0298148d9a9ef98df4f52361180c9c0d436895c988bf3f809496051cbb8L557-R557) [[3]](diffhunk://#diff-8560a0298148d9a9ef98df4f52361180c9c0d436895c988bf3f809496051cbb8L615-R615) [[4]](diffhunk://#diff-5558903bdb1abab2ae86a30b692470dfb042e2e3fbd2de4cf9ed3312bcb6d2faL755-R755) [[5]](diffhunk://#diff-5558903bdb1abab2ae86a30b692470dfb042e2e3fbd2de4cf9ed3312bcb6d2faL878-R878)

Thread-safety fix:

* Changed the `GetLastMessage` method in `MockNotificationServer` to use a write lock (`Lock`) instead of a read lock (`RLock`) for safe concurrent access to the messages slice.

### Related Issues
- https://github.com/asgardeo/thunder/issues/869

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

