### PR TITLE
Add offset limit support to composite store

### DIFF
--- a/backend/internal/ou/config.go
+++ b/backend/internal/ou/config.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/asgardeo/thunder/internal/system/config"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 )
 
@@ -36,37 +37,37 @@ import (
 //     - If disabled: return "mutable"
 //
 // Returns normalized store mode: "mutable", "declarative", or "composite"
-func getOrganizationUnitStoreMode() string {
+func getOrganizationUnitStoreMode() serverconst.StoreMode {
 	cfg := config.GetThunderRuntime().Config
 	// Check if service-level configuration is explicitly set
 	if cfg.OrganizationUnit.Store != "" {
-		mode := strings.ToLower(strings.TrimSpace(cfg.OrganizationUnit.Store))
+		mode := serverconst.StoreMode(strings.ToLower(strings.TrimSpace(cfg.OrganizationUnit.Store)))
 		// Validate and normalize
 		switch mode {
-		case config.StoreModeMutable, config.StoreModeDeclarative, config.StoreModeComposite:
+		case serverconst.StoreModeMutable, serverconst.StoreModeDeclarative, serverconst.StoreModeComposite:
 			return mode
 		}
 	}
 
 	// Fall back to global declarative resources setting
 	if declarativeresource.IsDeclarativeModeEnabled() {
-		return config.StoreModeDeclarative
+		return serverconst.StoreModeDeclarative
 	}
 
-	return config.StoreModeMutable
+	return serverconst.StoreModeMutable
 }
 
 // isCompositeModeEnabled checks if composite store mode is enabled for organization units.
 func isCompositeModeEnabled() bool {
-	return getOrganizationUnitStoreMode() == config.StoreModeComposite
+	return getOrganizationUnitStoreMode() == serverconst.StoreModeComposite
 }
 
 // isMutableModeEnabled checks if mutable-only store mode is enabled for organization units.
 func isMutableModeEnabled() bool {
-	return getOrganizationUnitStoreMode() == config.StoreModeMutable
+	return getOrganizationUnitStoreMode() == serverconst.StoreModeMutable
 }
 
 // isDeclarativeModeEnabled checks if immutable-only store mode is enabled for organization units.
 func isDeclarativeModeEnabled() bool {
-	return getOrganizationUnitStoreMode() == config.StoreModeDeclarative
+	return getOrganizationUnitStoreMode() == serverconst.StoreModeDeclarative
 }

--- a/backend/internal/ou/config_test.go
+++ b/backend/internal/ou/config_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/asgardeo/thunder/internal/system/config"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -38,61 +39,61 @@ func TestGetOrganizationUnitStoreMode(t *testing.T) {
 		name                      string
 		ouStoreConfig             string
 		immutableResourcesEnabled bool
-		expectedMode              string
+		expectedMode              serverconst.StoreMode
 	}{
 		{
 			name:                      "explicit mutable mode",
 			ouStoreConfig:             "mutable",
 			immutableResourcesEnabled: true, // Should be ignored
-			expectedMode:              config.StoreModeMutable,
+			expectedMode:              serverconst.StoreModeMutable,
 		},
 		{
 			name:                      "explicit declarative mode",
 			ouStoreConfig:             "declarative",
 			immutableResourcesEnabled: false, // Should be ignored
-			expectedMode:              config.StoreModeDeclarative,
+			expectedMode:              serverconst.StoreModeDeclarative,
 		},
 		{
 			name:                      "explicit composite mode",
 			ouStoreConfig:             "composite",
 			immutableResourcesEnabled: false, // Should be ignored
-			expectedMode:              config.StoreModeComposite,
+			expectedMode:              serverconst.StoreModeComposite,
 		},
 		{
 			name:                      "uppercase explicit mode",
 			ouStoreConfig:             "COMPOSITE",
 			immutableResourcesEnabled: false,
-			expectedMode:              config.StoreModeComposite,
+			expectedMode:              serverconst.StoreModeComposite,
 		},
 		{
 			name:                      "whitespace in explicit mode",
 			ouStoreConfig:             "  mutable  ",
 			immutableResourcesEnabled: true,
-			expectedMode:              config.StoreModeMutable,
+			expectedMode:              serverconst.StoreModeMutable,
 		},
 		{
 			name:                      "invalid mode falls back to global config - immutable",
 			ouStoreConfig:             "invalid",
 			immutableResourcesEnabled: true,
-			expectedMode:              config.StoreModeDeclarative,
+			expectedMode:              serverconst.StoreModeDeclarative,
 		},
 		{
 			name:                      "invalid mode falls back to global config - mutable",
 			ouStoreConfig:             "invalid",
 			immutableResourcesEnabled: false,
-			expectedMode:              config.StoreModeMutable,
+			expectedMode:              serverconst.StoreModeMutable,
 		},
 		{
 			name:                      "empty config falls back to global - immutable",
 			ouStoreConfig:             "",
 			immutableResourcesEnabled: true,
-			expectedMode:              config.StoreModeDeclarative,
+			expectedMode:              serverconst.StoreModeDeclarative,
 		},
 		{
 			name:                      "empty config falls back to global - mutable",
 			ouStoreConfig:             "",
 			immutableResourcesEnabled: false,
-			expectedMode:              config.StoreModeMutable,
+			expectedMode:              serverconst.StoreModeMutable,
 		},
 	}
 

--- a/backend/internal/ou/error_constants.go
+++ b/backend/internal/ou/error_constants.go
@@ -21,6 +21,7 @@ package ou
 import (
 	"errors"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
 
@@ -110,6 +111,13 @@ var (
 		Error:            "Cannot modify declarative resource",
 		ErrorDescription: "The organization unit is declarative and cannot be modified or deleted",
 	}
+	// ErrorResultLimitExceeded is the error returned when the result limit is exceeded in composite mode.
+	ErrorResultLimitExceeded = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "OU-1013",
+		Error:            "Result limit exceeded",
+		ErrorDescription: serverconst.CompositeStoreLimitWarning,
+	}
 )
 
 // Server errors for organization unit management operations.
@@ -131,4 +139,6 @@ var (
 	ErrCannotUpdateDeclarativeOU = errors.New("cannot update declarative organization unit")
 	// ErrCannotDeleteDeclarativeOU is returned when attempting to delete a declarative organization unit.
 	ErrCannotDeleteDeclarativeOU = errors.New("cannot delete declarative organization unit")
+	// ErrResultLimitExceededInCompositeMode is returned when the result limit is exceeded in composite mode.
+	ErrResultLimitExceededInCompositeMode = errors.New("result limit exceeded in composite mode")
 )

--- a/backend/internal/ou/init.go
+++ b/backend/internal/ou/init.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/asgardeo/thunder/internal/system/config"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
@@ -77,7 +77,7 @@ func initializeStore() (organizationUnitStoreInterface, error) {
 	storeMode := getOrganizationUnitStoreMode()
 
 	switch storeMode {
-	case config.StoreModeComposite:
+	case serverconst.StoreModeComposite:
 		fileStore := newFileBasedStore()
 		dbStore := newOrganizationUnitStore()
 		ouStore = newCompositeOUStore(fileStore, dbStore)
@@ -85,7 +85,7 @@ func initializeStore() (organizationUnitStoreInterface, error) {
 			return nil, err
 		}
 
-	case config.StoreModeDeclarative:
+	case serverconst.StoreModeDeclarative:
 		fileStore := newFileBasedStore()
 		ouStore = fileStore
 

--- a/backend/internal/ou/model.go
+++ b/backend/internal/ou/model.go
@@ -24,6 +24,7 @@ type OrganizationUnitBasic struct {
 	Handle      string `json:"handle"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly,omitempty"`
 }
 
 // OrganizationUnit represents an organization unit.

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -443,16 +443,3 @@ func isZeroValue(v reflect.Value) bool {
 		return false
 	}
 }
-
-// Store modes for Declarative configurations.
-const (
-	// StoreModeMutable uses only the database store. All OUs are mutable and support full CRUD.
-	StoreModeMutable = "mutable"
-
-	// StoreModeDeclarative uses only the file-based store. All OUs are declarative (read-only from YAML).
-	StoreModeDeclarative = "declarative"
-
-	// StoreModeComposite (hybrid) uses both file-based (declarative) and database (mutable) stores.
-	// Reads merge both stores, writes only go to database store.
-	StoreModeComposite = "composite"
-)

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -79,3 +79,24 @@ const DefaultPageSize = 30
 
 // MaxPageSize is the maximum allowed limit for pagination.
 const MaxPageSize = 100
+
+// MaxCompositeStoreRecords is the maximum number of records that can be fetched in composite/hybrid store mode.
+// This limit prevents memory exhaustion when merging results from multiple data sources (database + file-based).
+// For larger datasets, use search functionality instead of list operations.
+const MaxCompositeStoreRecords = 1000
+
+// CompositeStoreLimitWarning is the message displayed when the composite store result limit is exceeded.
+const CompositeStoreLimitWarning = "Result limit exceeded in hybrid mode. Use search for larger datasets."
+
+// StoreMode represents the storage mode for resources.
+type StoreMode string
+
+// Store mode constants define how resources are persisted and retrieved.
+const (
+	// StoreModeMutable indicates resources are stored only in the database and can be modified via API.
+	StoreModeMutable StoreMode = "mutable"
+	// StoreModeDeclarative indicates resources are loaded only from declarative files (read-only).
+	StoreModeDeclarative StoreMode = "declarative"
+	// StoreModeComposite indicates resources are merged from both database and declarative files (hybrid mode).
+	StoreModeComposite StoreMode = "composite"
+)


### PR DESCRIPTION
### Purpose
Add the pagination support when there is two data sources

### Approach
https://github.com/asgardeo/thunder/discussions/1286

### Related Issues
- https://github.com/asgardeo/thunder/issues/963

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Organization unit list and hierarchy queries in hybrid/composite mode are capped at 1,000 records and surface a specific limit error/warning when exceeded.
  * Merged results annotate items with mutability: file-backed items shown read-only; DB-backed items shown writable.
* **API**
  * Public isReadOnly flag added to organization unit items.
* **Utilities**
  * New helpers to detect composite mode and apply the composite result cap.
* **Tests**
  * Expanded tests for merging, de-duplication, limit enforcement, pagination, and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->