### PR TITLE
Add support for configuring separate attributes for OIDC userinfo

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -137,9 +137,11 @@ paths:
                       id_token:
                         validity_period: 3600
                         user_attributes: ["email", "name", "given_name", "family_name"]
-                        scope_claims:
-                          profile: ["name", "family_name", "given_name", "picture"]
-                          employee: ["emp_id", "department"]
+                    user_info:
+                      user_attributes: ["email", "name", "given_name", "family_name", "picture"]
+                    scope_claims:
+                      profile: ["name", "family_name", "given_name", "picture"]
+                      employee: ["emp_id", "department"]
       responses:
         "201":
           description: Application created
@@ -195,9 +197,11 @@ paths:
                         id_token:
                           validity_period: 1800
                           user_attributes: ["email", "email_verified", "name", "given_name", "family_name"]
-                          scope_claims:
-                            profile: ["name", "given_name", "family_name"]
-                            email: ["email", "email_verified"]
+                      user_info:
+                        user_attributes: ["email", "name", "given_name", "family_name", "picture"]
+                      scope_claims:
+                        profile: ["name", "family_name", "given_name", "picture"]
+                        employee: ["emp_id", "department"]
         "400":
           description: Bad request
           content:
@@ -303,9 +307,11 @@ paths:
                         id_token:
                           validity_period: 1800
                           user_attributes: ["email", "email_verified", "name", "given_name", "family_name"]
-                          scope_claims:
-                            profile: ["name", "given_name", "family_name"]
-                            email: ["email", "email_verified"]
+                      user_info:
+                        user_attributes: ["email", "name", "given_name", "family_name", "picture"]
+                      scope_claims:
+                        profile: ["name", "family_name", "given_name", "picture"]
+                        employee: ["emp_id", "department"]
         "400":
           description: Bad request
           content:
@@ -398,17 +404,18 @@ paths:
                       - "profile"
                       - "email"
                     token:
+                      issuer: "thunder-oauth"
                       access_token:
-                        issuer: "thunder"
                         validity_period: 3600
                         user_attributes: ["email", "username"]
                       id_token:
-                        issuer: "thunder-oidc"
                         validity_period: 1800
                         user_attributes: ["email", "email_verified", "name", "given_name", "family_name"]
-                        scope_claims:
-                          profile: ["name", "given_name", "family_name"]
-                          email: ["email", "email_verified"]
+                    user_info:
+                      user_attributes: ["email", "name", "given_name", "family_name", "picture"]
+                    scope_claims:
+                      profile: ["name", "family_name", "given_name", "picture"]
+                      employee: ["emp_id", "department"]
       responses:
         "200":
           description: Application updated
@@ -466,9 +473,11 @@ paths:
                         id_token:
                           validity_period: 1800
                           user_attributes: ["email", "email_verified", "name", "given_name", "family_name"]
-                          scope_claims:
-                            profile: ["name", "given_name", "family_name"]
-                            email: ["email", "email_verified"]
+                      user_info:
+                        user_attributes: ["email", "name", "given_name", "family_name", "picture"]
+                      scope_claims:
+                        profile: ["name", "family_name", "given_name", "picture"]
+                        employee: ["emp_id", "department"]
         "400":
           description: Bad request
           content:
@@ -942,16 +951,19 @@ components:
             type: string
           description: The user attributes to include in the ID token. Only claims requested by scopes AND listed here will be included.
           example: ["email", "name", "given_name", "family_name"]
-        scope_claims:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-          description: Custom scope-to-claims mapping. Overrides default OIDC scope claims or defines custom scopes.
-          example:
-            profile: ["name", "family_name", "given_name", "picture"]
-            employee: ["emp_id", "department"]
+
+    UserInfoConfig:
+      type: object
+      description: UserInfo endpoint configuration for the OAuth application
+      properties:
+        user_attributes:
+          type: array
+          items:
+            type: string
+          description: |
+            The user attributes to include in the userinfo response. 
+            If not specified, falls back to ID token user attributes.
+          example: ["email", "name", "given_name", "family_name", "picture"]
 
     Certificate:
       type: object
@@ -1054,6 +1066,18 @@ components:
               $ref: '#/components/schemas/AccessTokenConfig'
             id_token:
               $ref: '#/components/schemas/IDTokenConfig'
+        user_info:
+          $ref: '#/components/schemas/UserInfoConfig'
+        scope_claims:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          description: Custom scope-to-claims mapping. Overrides default OIDC scope claims or defines custom scopes. Applies to both ID token and userinfo responses.
+          example:
+            profile: ["name", "family_name", "given_name", "picture"]
+            employee: ["emp_id", "department"]
 
     OAuthAppConfigComplete:
       type: object
@@ -1120,6 +1144,18 @@ components:
               $ref: '#/components/schemas/AccessTokenConfig'
             id_token:
               $ref: '#/components/schemas/IDTokenConfig'
+        user_info:
+          $ref: '#/components/schemas/UserInfoConfig'
+        scope_claims:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          description: Custom scope-to-claims mapping. Overrides default OIDC scope claims or defines custom scopes. Applies to both ID token and userinfo responses.
+          example:
+            profile: ["name", "family_name", "given_name", "picture"]
+            employee: ["emp_id", "department"]
 
     Error:
       type: object

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -159,7 +159,8 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	flowExecService := flowexec.Initialize(mux, flowMgtService, applicationService, execRegistry, observabilitySvc)
 
 	// Initialize OAuth services.
-	oauth.Initialize(mux, applicationService, userService, jwtService, flowExecService, observabilitySvc, pkiService)
+	oauth.Initialize(mux, applicationService, userService, jwtService, flowExecService, observabilitySvc,
+		pkiService, ouService)
 
 	// Initialize MCP server.
 	mcp.Initialize(mux, applicationService, flowMgtService, jwtService)

--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -222,6 +222,8 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 				PublicClient:            config.OAuthAppConfig.PublicClient,
 				Token:                   config.OAuthAppConfig.Token,
 				Scopes:                  config.OAuthAppConfig.Scopes,
+				UserInfo:                config.OAuthAppConfig.UserInfo,
+				ScopeClaims:             config.OAuthAppConfig.ScopeClaims,
 			}
 			returnInboundAuthConfigs = append(returnInboundAuthConfigs, model.InboundAuthConfig{
 				Type:           config.Type,
@@ -390,6 +392,8 @@ func (ah *applicationHandler) processInboundAuthConfig(logger *log.Logger, appDT
 				PublicClient:            config.OAuthAppConfig.PublicClient,
 				Token:                   config.OAuthAppConfig.Token,
 				Scopes:                  config.OAuthAppConfig.Scopes,
+				UserInfo:                config.OAuthAppConfig.UserInfo,
+				ScopeClaims:             config.OAuthAppConfig.ScopeClaims,
 			}
 			returnInboundAuthConfigs = append(returnInboundAuthConfigs, model.InboundAuthConfigComplete{
 				Type:           config.Type,
@@ -450,6 +454,8 @@ func (ah *applicationHandler) processInboundAuthConfigFromRequest(
 				PublicClient:            config.OAuthAppConfig.PublicClient,
 				Token:                   config.OAuthAppConfig.Token,
 				Scopes:                  config.OAuthAppConfig.Scopes,
+				UserInfo:                config.OAuthAppConfig.UserInfo,
+				ScopeClaims:             config.OAuthAppConfig.ScopeClaims,
 			},
 		}
 		inboundAuthConfigDTOs = append(inboundAuthConfigDTOs, inboundAuthConfigDTO)

--- a/backend/internal/application/model/application.go
+++ b/backend/internal/application/model/application.go
@@ -32,27 +32,6 @@ type AssertionConfig struct {
 	UserAttributes []string `json:"user_attributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in the assertion. List of user claim names to embed in the assertion (e.g., email, username, roles)."`
 }
 
-// AccessTokenConfig represents the access token configuration structure.
-type AccessTokenConfig struct {
-	ValidityPeriod int64    `json:"validity_period,omitempty" yaml:"validity_period,omitempty" jsonschema:"Access token validity period in seconds."`
-	UserAttributes []string `json:"user_attributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in access token. Claims embedded in the access token for authorization decisions."`
-}
-
-// IDTokenConfig represents the ID token configuration structure.
-type IDTokenConfig struct {
-	ValidityPeriod int64               `json:"validity_period,omitempty" yaml:"validity_period,omitempty" jsonschema:"ID token validity period in seconds."`
-	UserAttributes []string            `json:"user_attributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in ID token. Standard OIDC claims: sub, name, email, picture, etc."`
-	ScopeClaims    map[string][]string `json:"scope_claims,omitempty" yaml:"scope_claims,omitempty" jsonschema:"Scope-to-claims mapping. Maps OAuth scopes to user claims. Example: {profile: [name, picture], email: [email, email_verified]}."`
-}
-
-// OAuthTokenConfig represents the OAuth token configuration structure with access_token and id_token wrappers.
-// The Issuer field at this level is used by both access and ID tokens.
-type OAuthTokenConfig struct {
-	Issuer      string             `json:"issuer,omitempty" yaml:"issuer,omitempty" jsonschema:"Token issuer URL. The authorization server URL that issues tokens. Used by both access and ID tokens."`
-	AccessToken *AccessTokenConfig `json:"access_token,omitempty" yaml:"access_token,omitempty" jsonschema:"Access token configuration. Configure validity period and user attributes for access tokens used in API authorization."`
-	IDToken     *IDTokenConfig     `json:"id_token,omitempty" yaml:"id_token,omitempty" jsonschema:"ID token configuration. Configure validity period, user attributes, and scope-to-claims mapping for OIDC ID tokens."`
-}
-
 // ApplicationDTO represents the data transfer object for application service operations.
 type ApplicationDTO struct {
 	ID                        string `json:"id,omitempty" jsonschema:"Application ID. Auto-generated unique identifier."`

--- a/backend/internal/application/model/oauth_app.go
+++ b/backend/internal/application/model/oauth_app.go
@@ -33,6 +33,31 @@ import (
 	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
+// AccessTokenConfig represents the access token configuration structure.
+type AccessTokenConfig struct {
+	ValidityPeriod int64    `json:"validity_period,omitempty" yaml:"validity_period,omitempty" jsonschema:"Access token validity period in seconds."`
+	UserAttributes []string `json:"user_attributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in access token. Claims embedded in the access token for authorization decisions."`
+}
+
+// IDTokenConfig represents the ID token configuration structure.
+type IDTokenConfig struct {
+	ValidityPeriod int64    `json:"validity_period,omitempty" yaml:"validity_period,omitempty" jsonschema:"ID token validity period in seconds."`
+	UserAttributes []string `json:"user_attributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in ID token. Standard OIDC claims: sub, name, email, picture, etc."`
+}
+
+// UserInfoConfig represents the user info endpoint configuration structure.
+type UserInfoConfig struct {
+	UserAttributes []string `json:"user_attributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in userinfo response."`
+}
+
+// OAuthTokenConfig represents the OAuth token configuration structure with access_token and id_token wrappers.
+// The Issuer field at this level is used by both access and ID tokens.
+type OAuthTokenConfig struct {
+	Issuer      string             `json:"issuer,omitempty" yaml:"issuer,omitempty" jsonschema:"Token issuer URL. The authorization server URL that issues tokens. Used by both access and ID tokens."`
+	AccessToken *AccessTokenConfig `json:"access_token,omitempty" yaml:"access_token,omitempty" jsonschema:"Access token configuration. Configure validity period and user attributes for access tokens used in API authorization."`
+	IDToken     *IDTokenConfig     `json:"id_token,omitempty" yaml:"id_token,omitempty" jsonschema:"ID token configuration. Configure validity period and user attributes for OIDC ID tokens."`
+}
+
 // OAuthAppConfig represents the structure for OAuth application configuration.
 type OAuthAppConfig struct {
 	ClientID                string                              `json:"client_id"`
@@ -44,6 +69,8 @@ type OAuthAppConfig struct {
 	PublicClient            bool                                `json:"public_client"`
 	Token                   *OAuthTokenConfig                   `json:"token,omitempty"`
 	Scopes                  []string                            `json:"scopes,omitempty"`
+	UserInfo                *UserInfoConfig                     `json:"user_info,omitempty"`
+	ScopeClaims             map[string][]string                 `json:"scope_claims,omitempty"`
 }
 
 // OAuthAppConfigComplete represents the complete structure for OAuth application configuration.
@@ -60,6 +87,8 @@ type OAuthAppConfigComplete struct {
 	PublicClient            bool                                `json:"public_client" yaml:"public_client"`
 	Token                   *OAuthTokenConfig                   `json:"token,omitempty" yaml:"token,omitempty"`
 	Scopes                  []string                            `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	UserInfo                *UserInfoConfig                     `json:"user_info,omitempty" yaml:"user_info,omitempty"`
+	ScopeClaims             map[string][]string                 `json:"scope_claims,omitempty" yaml:"scope_claims,omitempty"`
 }
 
 // OAuthAppConfigDTO represents the data transfer object for OAuth application configuration.
@@ -75,6 +104,8 @@ type OAuthAppConfigDTO struct {
 	PublicClient            bool                                `json:"public_client,omitempty" jsonschema:"Identify if client is public (cannot store secrets). Set true for SPA/Mobile."`
 	Token                   *OAuthTokenConfig                   `json:"token,omitempty" jsonschema:"Token configuration for access tokens and ID tokens"`
 	Scopes                  []string                            `json:"scopes,omitempty" jsonschema:"Allowed OAuth scopes. Add custom scopes as needed for your application."`
+	UserInfo                *UserInfoConfig                     `json:"user_info,omitempty" jsonschema:"UserInfo endpoint configuration. Configure user attributes returned from the OIDC userinfo endpoint."`
+	ScopeClaims             map[string][]string                 `json:"scope_claims,omitempty" jsonschema:"Scope-to-claims mapping. Maps OAuth scopes to user claims for both ID token and userinfo."`
 }
 
 // IsAllowedGrantType checks if the provided grant type is allowed.
@@ -110,6 +141,8 @@ type OAuthAppConfigProcessedDTO struct {
 	PublicClient            bool                                `yaml:"public_client,omitempty"`
 	Token                   *OAuthTokenConfig                   `yaml:"token,omitempty"`
 	Scopes                  []string                            `yaml:"scopes,omitempty"`
+	UserInfo                *UserInfoConfig                     `yaml:"user_info,omitempty"`
+	ScopeClaims             map[string][]string                 `yaml:"scope_claims,omitempty"`
 }
 
 // IsAllowedGrantType checks if the provided grant type is allowed.
@@ -123,7 +156,8 @@ func (o *OAuthAppConfigProcessedDTO) IsAllowedResponseType(responseType string) 
 }
 
 // IsAllowedTokenEndpointAuthMethod checks if the provided token endpoint authentication method is allowed.
-func (o *OAuthAppConfigProcessedDTO) IsAllowedTokenEndpointAuthMethod(method oauth2const.TokenEndpointAuthMethod) bool {
+func (o *OAuthAppConfigProcessedDTO) IsAllowedTokenEndpointAuthMethod(
+	method oauth2const.TokenEndpointAuthMethod) bool {
 	return o.TokenEndpointAuthMethod == method
 }
 

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -33,6 +33,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/userinfo"
 	"github.com/asgardeo/thunder/internal/oauth/scope"
 	"github.com/asgardeo/thunder/internal/observability"
+	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/user"
@@ -47,6 +48,7 @@ func Initialize(
 	flowExecService flowexec.FlowExecServiceInterface,
 	observabilitySvc observability.ObservabilityServiceInterface,
 	pkiService pki.PKIServiceInterface,
+	ouService ou.OrganizationUnitServiceInterface,
 ) {
 	jwks.Initialize(mux, pkiService)
 	grantHandlerProvider := granthandlers.Initialize(
@@ -54,7 +56,7 @@ func Initialize(
 	scopeValidator := scope.Initialize()
 	token.Initialize(mux, applicationService, grantHandlerProvider, scopeValidator, observabilitySvc)
 	introspect.Initialize(mux, jwtService)
-	userinfo.Initialize(mux, jwtService, applicationService, userService)
+	userinfo.Initialize(mux, jwtService, applicationService, userService, ouService)
 	discovery.Initialize(mux)
 	dcr.Initialize(mux, applicationService)
 }

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -171,10 +171,10 @@ func (ah *authorizeHandler) handleInitialAuthorizationRequest(msg *OAuthMessage,
 			}
 			http.Redirect(w, r, redirectURI, http.StatusFound)
 			return
-		} else {
-			ah.redirectToErrorPage(w, r, errorCode, errorMessage)
-			return
 		}
+
+		ah.redirectToErrorPage(w, r, errorCode, errorMessage)
+		return
 	}
 
 	oidcScopes, nonOidcScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(scope)
@@ -356,6 +356,7 @@ func (ah *authorizeHandler) handleAuthorizationResponseFromEngine(msg *OAuthMess
 	ah.writeAuthZResponse(w, redirectURI)
 }
 
+// loadAuthRequestContext loads the authorization request context from the store using the auth ID.
 func (ah *authorizeHandler) loadAuthRequestContext(authID string) (*authRequestContext, error) {
 	ok, authRequestCtx := ah.authReqStore.GetRequest(authID)
 	if !ok {
@@ -576,12 +577,12 @@ func createAuthorizationCode(
 
 	codeID, err := utils.GenerateUUIDv7()
 	if err != nil {
-		return AuthorizationCode{}, errors.New("Failed to generate UUID")
+		return AuthorizationCode{}, errors.New("failed to generate UUID")
 	}
 
 	code, err := utils.GenerateUUIDv7()
 	if err != nil {
-		return AuthorizationCode{}, errors.New("Failed to generate UUID")
+		return AuthorizationCode{}, errors.New("failed to generate UUID")
 	}
 
 	return AuthorizationCode{
@@ -696,9 +697,8 @@ func getRequiredAttributes(oidcScopes []string, app *appmodel.OAuthAppConfigProc
 	if hasOpenIDScope {
 		// Build allowed attributes set and scope claims mapping from ID token config
 		var idTokenAllowedSet map[string]bool
-		var scopeClaimsMapping map[string][]string
+		scopeClaimsMapping := app.ScopeClaims
 		if app.Token.IDToken != nil {
-			scopeClaimsMapping = app.Token.IDToken.ScopeClaims
 			if len(app.Token.IDToken.UserAttributes) > 0 {
 				idTokenAllowedSet = make(map[string]bool, len(app.Token.IDToken.UserAttributes))
 				for _, attr := range app.Token.IDToken.UserAttributes {

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -1340,10 +1340,10 @@ func (suite *AuthorizeHandlerTestSuite) TestGetRequiredAttributes() {
 				Token: &appmodel.OAuthTokenConfig{
 					IDToken: &appmodel.IDTokenConfig{
 						UserAttributes: []string{},
-						ScopeClaims:    nil,
 					},
 					AccessToken: nil,
 				},
+				ScopeClaims: nil,
 			},
 			expectedResult: "",
 			description:    "Should return empty when IDToken.UserAttributes is empty",
@@ -1355,10 +1355,10 @@ func (suite *AuthorizeHandlerTestSuite) TestGetRequiredAttributes() {
 				Token: &appmodel.OAuthTokenConfig{
 					IDToken: &appmodel.IDTokenConfig{
 						UserAttributes: []string{"sub", "name", "email"}, // email_verified not allowed
-						ScopeClaims:    nil,
 					},
 					AccessToken: nil,
 				},
+				ScopeClaims: nil,
 			},
 			expectedResult: "sub name email",
 			description:    "Should filter scope claims by IDToken.UserAttributes",
@@ -1370,11 +1370,11 @@ func (suite *AuthorizeHandlerTestSuite) TestGetRequiredAttributes() {
 				Token: &appmodel.OAuthTokenConfig{
 					IDToken: &appmodel.IDTokenConfig{
 						UserAttributes: []string{"sub", "name", "custom_claim"},
-						ScopeClaims: map[string][]string{
-							"profile": {"name", "custom_claim"},
-						},
 					},
 					AccessToken: nil,
+				},
+				ScopeClaims: map[string][]string{
+					"profile": {"name", "custom_claim"},
 				},
 			},
 			expectedResult: "sub name custom_claim",
@@ -1448,12 +1448,12 @@ func (suite *AuthorizeHandlerTestSuite) TestGetRequiredAttributes() {
 				Token: &appmodel.OAuthTokenConfig{
 					IDToken: &appmodel.IDTokenConfig{
 						UserAttributes: []string{"sub", "name"},
-						ScopeClaims: map[string][]string{
-							"openid": {"sub"}, // Custom mapping for openid
-							// profile falls back to standard
-						},
 					},
 					AccessToken: nil,
+				},
+				ScopeClaims: map[string][]string{
+					"openid": {"sub"}, // Custom mapping for openid
+					// profile falls back to standard
 				},
 			},
 			expectedResult: "sub name",

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -503,14 +503,15 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 				accessTokenAttrs = append(accessTokenAttrs, constants.UserAttributeGroups)
 			}
 			var idTokenConfig *appmodel.IDTokenConfig
+			var scopeClaims map[string][]string
 			if tc.includeInIDToken {
 				if tc.scopeClaimsForGroups {
 					// Include groups in ID token config with scope claims mapping
 					idTokenConfig = &appmodel.IDTokenConfig{
 						UserAttributes: []string{"email", "username", constants.UserAttributeGroups},
-						ScopeClaims: map[string][]string{
-							"openid": {"email", "username", constants.UserAttributeGroups},
-						},
+					}
+					scopeClaims = map[string][]string{
+						"openid": {"email", "username", constants.UserAttributeGroups},
 					}
 				} else {
 					idTokenConfig = &appmodel.IDTokenConfig{
@@ -532,6 +533,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 					},
 					IDToken: idTokenConfig,
 				},
+				ScopeClaims: scopeClaims,
 			}
 
 			authzCode := suite.testAuthzCode
@@ -693,13 +695,14 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 				accessTokenAttrs = append(accessTokenAttrs, constants.UserAttributeGroups)
 			}
 			var idTokenConfig *appmodel.IDTokenConfig
+			var scopeClaims map[string][]string
 			if tc.includeInIDToken {
 				if tc.scopeClaimsForGroups {
 					idTokenConfig = &appmodel.IDTokenConfig{
 						UserAttributes: []string{"email", "username", constants.UserAttributeGroups},
-						ScopeClaims: map[string][]string{
-							"openid": {"email", "username", constants.UserAttributeGroups},
-						},
+					}
+					scopeClaims = map[string][]string{
+						"openid": {"email", "username", constants.UserAttributeGroups},
 					}
 				} else {
 					idTokenConfig = &appmodel.IDTokenConfig{
@@ -721,6 +724,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 					},
 					IDToken: idTokenConfig,
 				},
+				ScopeClaims: scopeClaims,
 			}
 
 			authzCode := suite.testAuthzCode

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -305,8 +305,17 @@ func (tb *tokenBuilder) buildIDTokenClaims(ctx *IDTokenBuildContext) map[string]
 		userAttributes = make(map[string]interface{})
 	}
 
+	// Get scope claims mapping and allowed user attributes from app config
+	var scopeClaimsMapping map[string][]string
+	var allowedUserAttributes []string
+	if ctx.OAuthApp != nil {
+		scopeClaimsMapping = ctx.OAuthApp.ScopeClaims
+		if ctx.OAuthApp.Token != nil && ctx.OAuthApp.Token.IDToken != nil {
+			allowedUserAttributes = ctx.OAuthApp.Token.IDToken.UserAttributes
+		}
+	}
+
 	// Build claims from scopes and explicit claims parameter
-	// Pass only IDToken claims for ID token generation
 	var idTokenClaims map[string]*oauth2model.IndividualClaimRequest
 	if ctx.ClaimsRequest != nil {
 		idTokenClaims = ctx.ClaimsRequest.IDToken
@@ -315,7 +324,8 @@ func (tb *tokenBuilder) buildIDTokenClaims(ctx *IDTokenBuildContext) map[string]
 		ctx.Scopes,
 		idTokenClaims,
 		userAttributes,
-		ctx.OAuthApp,
+		scopeClaimsMapping,
+		allowedUserAttributes,
 	)
 
 	for key, value := range claimData {

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -735,10 +735,10 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithScopeClaims() {
 			IDToken: &appmodel.IDTokenConfig{
 				ValidityPeriod: 3600,
 				UserAttributes: []string{"name", "email"},
-				ScopeClaims: map[string][]string{
-					"profile": {"name", "email"},
-				},
 			},
+		},
+		ScopeClaims: map[string][]string{
+			"profile": {"name", "email"},
 		},
 	}
 

--- a/backend/internal/oauth/oauth2/userinfo/init.go
+++ b/backend/internal/oauth/oauth2/userinfo/init.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/jwt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/user"
@@ -34,8 +35,9 @@ func Initialize(
 	jwtService jwt.JWTServiceInterface,
 	applicationService application.ApplicationServiceInterface,
 	userService user.UserServiceInterface,
+	ouService ou.OrganizationUnitServiceInterface,
 ) userInfoServiceInterface {
-	userInfoService := newUserInfoService(jwtService, applicationService, userService)
+	userInfoService := newUserInfoService(jwtService, applicationService, userService, ouService)
 	userInfoHandler := newUserInfoHandler(userInfoService)
 	registerRoutes(mux, userInfoHandler)
 	return userInfoService

--- a/backend/internal/oauth/oauth2/userinfo/init_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/init_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
 	"github.com/asgardeo/thunder/tests/mocks/jwtmock"
+	"github.com/asgardeo/thunder/tests/mocks/oumock"
 	usersvcmock "github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
@@ -36,6 +37,7 @@ type InitTestSuite struct {
 	mockJWTService  *jwtmock.JWTServiceInterfaceMock
 	mockAppService  *applicationmock.ApplicationServiceInterfaceMock
 	mockUserService *usersvcmock.UserServiceInterfaceMock
+	mockOUService   *oumock.OrganizationUnitServiceInterfaceMock
 }
 
 func TestInitTestSuite(t *testing.T) {
@@ -46,12 +48,14 @@ func (suite *InitTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
 	suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
 }
 
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
 
-	service := Initialize(mux, suite.mockJWTService, suite.mockAppService, suite.mockUserService)
+	service := Initialize(mux, suite.mockJWTService, suite.mockAppService,
+		suite.mockUserService, suite.mockOUService)
 
 	assert.NotNil(suite.T(), service)
 }
@@ -59,7 +63,8 @@ func (suite *InitTestSuite) TestInitialize() {
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
 
-	_ = Initialize(mux, suite.mockJWTService, suite.mockAppService, suite.mockUserService)
+	_ = Initialize(mux, suite.mockJWTService, suite.mockAppService,
+		suite.mockUserService, suite.mockOUService)
 
 	// Verify that the routes are registered by attempting to get a handler for them.
 	// The pattern includes the method because of CORS middleware wrapping.

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -221,10 +221,10 @@ func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplicatio
 			IDToken: &appmodel.IDTokenConfig{
 				ValidityPeriod: 1800,
 				UserAttributes: []string{"email"},
-				ScopeClaims: map[string][]string{
-					"profile": {"name", "picture"},
-				},
 			},
+		},
+		ScopeClaims: map[string][]string{
+			"profile": {"name", "picture"},
 		},
 	}
 

--- a/tests/integration/application/application_api_test.go
+++ b/tests/integration/application/application_api_test.go
@@ -1359,11 +1359,11 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithTokenConfiguration() {
 						IDToken: &IDTokenConfig{
 							ValidityPeriod: 3600,
 							UserAttributes: []string{"sub", "email"},
-							ScopeClaims: map[string][]string{
-								"profile": {"name", "given_name", "family_name"},
-								"email":   {"email", "email_verified"},
-							},
 						},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {"name", "given_name", "family_name"},
+						"email":   {"email", "email_verified"},
 					},
 				},
 			},
@@ -1404,13 +1404,13 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithIDTokenScopeClaims() {
 						IDToken: &IDTokenConfig{
 							ValidityPeriod: 7200,
 							UserAttributes: []string{"sub", "email", "name"},
-							ScopeClaims: map[string][]string{
-								"profile": {"name", "given_name", "family_name", "middle_name", "nickname", "preferred_username"},
-								"email":   {"email", "email_verified"},
-								"address": {"address"},
-								"phone":   {"phone_number", "phone_number_verified"},
-							},
 						},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {"name", "given_name", "family_name", "middle_name", "nickname", "preferred_username"},
+						"email":   {"email", "email_verified"},
+						"address": {"address"},
+						"phone":   {"phone_number", "phone_number_verified"},
 					},
 				},
 			},
@@ -1424,9 +1424,9 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithIDTokenScopeClaims() {
 	// Retrieve and verify scope claims
 	retrievedApp, err := getApplicationByID(appID)
 	ts.Require().NoError(err)
-	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims)
-	ts.Assert().Contains(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims, "profile")
-	ts.Assert().Contains(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims["email"], "email")
+	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims)
+	ts.Assert().Contains(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims, "profile")
+	ts.Assert().Contains(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims["email"], "email")
 }
 
 // TestApplicationUpdateWithTokenConfigChanges tests updating token configuration.
@@ -1470,10 +1470,10 @@ func (ts *ApplicationAPITestSuite) TestApplicationUpdateWithTokenConfigChanges()
 		IDToken: &IDTokenConfig{
 			ValidityPeriod: 3600,
 			UserAttributes: []string{"sub", "email", "name"},
-			ScopeClaims: map[string][]string{
-				"profile": {"name", "picture"},
-			},
 		},
+	}
+	app.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims = map[string][]string{
+		"profile": {"name", "picture"},
 	}
 
 	appJSON, _ := json.Marshal(app)
@@ -1733,11 +1733,11 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithOnlyIDToken() {
 						IDToken: &IDTokenConfig{
 							ValidityPeriod: 3600,
 							UserAttributes: []string{"sub", "email", "name", "picture"},
-							ScopeClaims: map[string][]string{
-								"profile": {"name", "given_name", "family_name", "middle_name"},
-								"email":   {"email", "email_verified"},
-							},
 						},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {"name", "given_name", "family_name", "middle_name"},
+						"email":   {"email", "email_verified"},
 					},
 				},
 			},
@@ -1754,7 +1754,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithOnlyIDToken() {
 	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token)
 	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken)
 	ts.Assert().Equal(int64(3600), retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ValidityPeriod)
-	ts.Assert().Len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims, 2)
+	ts.Assert().Len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims, 2)
 }
 
 // TestApplicationWithBothTokenTypes tests creating application with both AccessToken and IDToken.
@@ -1782,11 +1782,11 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithBothTokenTypes() {
 						IDToken: &IDTokenConfig{
 							ValidityPeriod: 3600,
 							UserAttributes: []string{"sub", "email"},
-							ScopeClaims: map[string][]string{
-								"profile": {"name"},
-								"email":   {"email"},
-							},
 						},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {"name"},
+						"email":   {"email"},
 					},
 				},
 			},
@@ -1988,23 +1988,23 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithComplexScopeClaims() {
 						IDToken: &IDTokenConfig{
 							ValidityPeriod: 3600,
 							UserAttributes: []string{"sub", "email", "name"},
-							ScopeClaims: map[string][]string{
-								"profile": {
-									"name", "given_name", "family_name", "middle_name",
-									"nickname", "preferred_username", "profile", "picture",
-									"website", "gender", "birthdate", "zoneinfo", "locale",
-									"updated_at",
-								},
-								"email": {"email", "email_verified"},
-								"address": {
-									"address.formatted", "address.street_address",
-									"address.locality", "address.region",
-									"address.postal_code", "address.country",
-								},
-								"phone":  {"phone_number", "phone_number_verified"},
-								"custom": {"organization", "department", "employee_id"},
-							},
 						},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {
+							"name", "given_name", "family_name", "middle_name",
+							"nickname", "preferred_username", "profile", "picture",
+							"website", "gender", "birthdate", "zoneinfo", "locale",
+							"updated_at",
+						},
+						"email": {"email", "email_verified"},
+						"address": {
+							"address.formatted", "address.street_address",
+							"address.locality", "address.region",
+							"address.postal_code", "address.country",
+						},
+						"phone":  {"phone_number", "phone_number_verified"},
+						"custom": {"organization", "department", "employee_id"},
 					},
 				},
 			},
@@ -2019,9 +2019,9 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithComplexScopeClaims() {
 	retrievedApp, err := getApplicationByID(appID)
 	ts.Require().NoError(err)
 	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken)
-	ts.Assert().Len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims, 5)
-	ts.Assert().Contains(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims, "profile")
-	ts.Assert().GreaterOrEqual(len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims["profile"]), 10)
+	ts.Assert().Len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims, 5)
+	ts.Assert().Contains(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims, "profile")
+	ts.Assert().GreaterOrEqual(len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims["profile"]), 10)
 }
 
 // TestApplicationCertificateRollbackOnOAuthFail tests certificate rollback when OAuth creation fails.
@@ -2301,11 +2301,11 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithCompleteMetadata() {
 						IDToken: &IDTokenConfig{
 							ValidityPeriod: 3600,
 							UserAttributes: []string{"sub", "email", "name"},
-							ScopeClaims: map[string][]string{
-								"profile": {"name", "given_name", "family_name"},
-								"email":   {"email", "email_verified"},
-							},
 						},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {"name", "given_name", "family_name"},
+						"email":   {"email", "email_verified"},
 					},
 				},
 			},
@@ -2358,8 +2358,8 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithCompleteMetadata() {
 	ts.Require().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken)
 	ts.Assert().Equal(int64(3600), retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ValidityPeriod)
 	ts.Assert().Equal([]string{"sub", "email", "name"}, retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.UserAttributes)
-	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims)
-	ts.Assert().Equal([]string{"name", "given_name", "family_name"}, retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims["profile"])
+	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims)
+	ts.Assert().Equal([]string{"name", "given_name", "family_name"}, retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims["profile"])
 }
 
 // TestApplicationWithOnlyRootToken tests app with only root token config.
@@ -2649,11 +2649,11 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithIDTokenScopeClaimsOnly() {
 					Token: &OAuthTokenConfig{
 						IDToken: &IDTokenConfig{
 							ValidityPeriod: 3600,
-							ScopeClaims: map[string][]string{
-								"profile": {"name", "picture"},
-								"email":   {"email"},
-							},
 						},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {"name", "picture"},
+						"email":   {"email"},
 					},
 				},
 			},
@@ -2668,8 +2668,8 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithIDTokenScopeClaimsOnly() {
 	ts.Require().NoError(err)
 	ts.Require().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token)
 	ts.Require().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken)
-	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims)
-	ts.Assert().Equal([]string{"name", "picture"}, retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ScopeClaims["profile"])
+	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims)
+	ts.Assert().Equal([]string{"name", "picture"}, retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims["profile"])
 }
 
 // TestApplicationWithOAuthTokenIssuerOnly tests app with only OAuth token issuer.
@@ -4356,4 +4356,122 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithPartialInvalidAllowedUserT
 	err = json.NewDecoder(resp.Body).Decode(&errorResp)
 	ts.Require().NoError(err)
 	ts.Assert().Equal("APP-1025", errorResp.Code, "Error code should be APP-1025")
+}
+
+func (ts *ApplicationAPITestSuite) TestApplicationWithUserInfoConfig() {
+	app := Application{
+		Name:                      "App With UserInfo Config",
+		Description:               "Testing UserInfo and ScopeClaims persistence",
+		IsRegistrationFlowEnabled: false,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                "userinfo_config_app_test_client",
+					ClientSecret:            "userinfo_config_app_test_secret",
+					RedirectURIs:            []string{"http://localhost/callback"},
+					GrantTypes:              []string{"authorization_code"},
+					ResponseTypes:           []string{"code"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					PKCERequired:            false,
+					PublicClient:            false,
+					Scopes:                  []string{"openid", "profile", "email"},
+					Token: &OAuthTokenConfig{
+						IDToken: &IDTokenConfig{
+							UserAttributes: []string{"sub"},
+						},
+					},
+					UserInfo: &UserInfoConfig{
+						UserAttributes: []string{"email", "firstName", "lastName"},
+					},
+					ScopeClaims: map[string][]string{
+						"profile": {"firstName", "lastName"},
+						"email":   {"email"},
+					},
+				},
+			},
+		},
+	}
+
+	// Set flow IDs (using defaults from suite)
+	app.AuthFlowID = defaultAuthFlowID
+	app.RegistrationFlowID = defaultRegistrationFlowID
+
+	// Create
+	appID, err := createApplication(app)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	// Get
+	retrievedApp, err := getApplicationByID(appID)
+	ts.Require().NoError(err)
+
+	// Validate
+	ts.Require().NotEmpty(retrievedApp.InboundAuthConfig)
+	oauthConfig := retrievedApp.InboundAuthConfig[0].OAuthAppConfig
+	ts.Require().NotNil(oauthConfig)
+
+	// Check UserInfo
+	ts.Require().NotNil(oauthConfig.UserInfo)
+	ts.Assert().ElementsMatch([]string{"email", "firstName", "lastName"}, oauthConfig.UserInfo.UserAttributes)
+
+	// Check ScopeClaims
+	ts.Require().NotNil(oauthConfig.ScopeClaims)
+	ts.Assert().ElementsMatch([]string{"firstName", "lastName"}, oauthConfig.ScopeClaims["profile"])
+
+	// Check IDToken is separate
+	ts.Require().NotNil(oauthConfig.Token.IDToken)
+	ts.Assert().ElementsMatch([]string{"sub"}, oauthConfig.Token.IDToken.UserAttributes)
+}
+
+func (ts *ApplicationAPITestSuite) TestApplicationUserInfoWithFallback() {
+	app := Application{
+		Name:                      "App UserInfo Fallback",
+		Description:               "Testing UserInfo fallback logic",
+		IsRegistrationFlowEnabled: false,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                "userinfo_fallback_test_client",
+					ClientSecret:            "userinfo_fallback_test_secret",
+					RedirectURIs:            []string{"http://localhost/callback"},
+					GrantTypes:              []string{"authorization_code"},
+					ResponseTypes:           []string{"code"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					PKCERequired:            false,
+					PublicClient:            false,
+					Scopes:                  []string{"openid", "email"},
+					Token: &OAuthTokenConfig{
+						IDToken: &IDTokenConfig{
+							UserAttributes: []string{"email", "sub"},
+						},
+					},
+					// UserInfo not specified
+				},
+			},
+		},
+	}
+
+	// Set flow IDs (using defaults from suite)
+	app.AuthFlowID = defaultAuthFlowID
+	app.RegistrationFlowID = defaultRegistrationFlowID
+
+	// Create
+	appID, err := createApplication(app)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	// Get
+	retrievedApp, err := getApplicationByID(appID)
+	ts.Require().NoError(err)
+
+	// Validate
+	ts.Require().NotEmpty(retrievedApp.InboundAuthConfig)
+	oauthConfig := retrievedApp.InboundAuthConfig[0].OAuthAppConfig
+	ts.Require().NotNil(oauthConfig)
+
+	// Check UserInfo inherited from IDToken
+	ts.Require().NotNil(oauthConfig.UserInfo)
+	ts.Assert().ElementsMatch([]string{"email", "sub"}, oauthConfig.UserInfo.UserAttributes)
 }

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -570,13 +570,13 @@ func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithRequiredAttributes() 
 					"token": map[string]interface{}{
 						"id_token": map[string]interface{}{
 							"user_attributes": []string{"sub", "name", "email"}, // Only allow these in ID token
-							"scope_claims": map[string]interface{}{
-								"profile": []string{"name"}, // Custom mapping
-							},
 						},
 						"access_token": map[string]interface{}{
 							"user_attributes": []string{"groups", "roles"}, // Access token attributes
 						},
+					},
+					"scope_claims": map[string]interface{}{
+						"profile": []string{"name"}, // Custom mapping
 					},
 				},
 			},

--- a/tests/integration/oauth/claims/claims_parameter_test.go
+++ b/tests/integration/oauth/claims/claims_parameter_test.go
@@ -280,12 +280,12 @@ func (ts *ClaimsParameterTestSuite) createTestApplication(authFlowID string) str
 							"user_attributes": []string{
 								"email", "firstName", "lastName", "phone_number", "locale",
 							},
-							"scope_claims": map[string][]string{
-								"profile": {"firstName", "lastName", "locale"},
-								"email":   {"email"},
-								"phone":   {"phone_number"},
-							},
 						},
+					},
+					"scope_claims": map[string][]string{
+						"profile": {"firstName", "lastName", "locale"},
+						"email":   {"email"},
+						"phone":   {"phone_number"},
 					},
 				},
 			},


### PR DESCRIPTION
### Purpose
This pull request adds support for configuring user attributes returned by the OIDC UserInfo endpoint separately. If not defined, the UserInfo endpoint will use the attributes configured for the ID token.
This PR also moves the scope_claims object to the top level, allowing custom mapping of OAuth scopes to user claims for both ID tokens and UserInfo responses commonly.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
This pull request introduces a breaking change that requires updates to application payloads where custom scope-to-claim mappings are configured.

#### 💥 Impact
_What will break? Who is affected?_
Applications with custom scope-to-user-claim mappings will no longer accept the previous payload structure.

#### 🔄 Migration Guide
Application creation and update payloads must be updated as shown below.

Before:
```json
...
"inbound_auth_config": [
        {
            "type": "oauth2",
            "config": {
                ...
                "token": {
                    "access_token": {
                        "issuer": "thunder.wso2.com",
                        "validity_period": 7200,
                        "user_attributes": [
                            "email",
                            "username",
                        ]
                    },
                    "id_token": {
                        "validity_period": 3600,
                        "user_attributes": [
                            "email",
                            "firstName",
                            "lastName"
                        ],
                        "scope_claims": {
                            "profile": [
                                "username",
                                "family_name",
                                "given_name"
                            ],
                            "email": [
                                "email"
                            ]
                        }
                    }
                }
            }
        }
    ]
...
```

After:
```json
...
"inbound_auth_config": [
        {
            "type": "oauth2",
            "config": {
                ...
                "token": {
                    "access_token": {
                        "issuer": "thunder.wso2.com",
                        "validity_period": 7200,
                        "user_attributes": [
                            "email",
                            "username",
                        ]
                    },
                    "id_token": {
                        "validity_period": 3600,
                        "user_attributes": [
                            "email",
                            "firstName",
                            "lastName"
                        ],
                    }
                },
                "user_info": {
                    "user_attributes": [
                        "email",
                        "firstName",
                        "lastName"
                    ],
                }
                "scope_claims": {
                    "profile": [
                        "username",
                        "family_name",
                        "given_name"
                    ],
                    "email": [
                        "email"
                    ]
                }
            }
        }
    ]
...
```

---

### Approach
* Added `user_info` configuration to the OAuth application schema, allowing clients to specify which user attributes are returned from the UserInfo endpoint.
* Moved `scope_claims` object to top level enabling custom mapping of OAuth scopes to user claims for both ID tokens and UserInfo responses.

* Refactored and extended the Go models:
  - Moved token configuration structs (`AccessTokenConfig`, `IDTokenConfig`, `OAuthTokenConfig`) to `model/oauth_app.go`, and added a new `UserInfoConfig` struct.
  - Extended `OAuthAppConfig`, `OAuthAppConfigComplete`, `OAuthAppConfigDTO`, and `OAuthAppConfigProcessedDTO` structs to include `UserInfo` and `ScopeClaims` fields.
* Updated service and handler logic to process, validate, and return the new `user_info` and `scope_claims` fields as part of application configuration responses.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1217
- https://github.com/asgardeo/thunder/issues/1283

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can define a UserInfo configuration to control which user attributes the UserInfo endpoint returns.
  * Apps can declare custom scope-to-claims mappings at the app/token level, applied to both ID token and UserInfo responses.

* **Changes**
  * Scope-claims moved from ID token to a top-level token scope_claims for consistent mapping across ID token and userinfo.
  * UserInfo now falls back to ID token attributes when no explicit UserInfo config is provided.

* **Tests**
  * Updated and added tests to cover UserInfo behavior and top-level scope_claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->