### PR TITLE
Stop browsers from caching `index.html` files

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/cache"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
@@ -303,8 +304,24 @@ func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) 
 	fileServer := http.FileServer(http.Dir(directory))
 
 	return http.StripPrefix(routePrefix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle root path "/" by explicitly serving index.html
+		if r.URL.Path == "/" || r.URL.Path == "" {
+			indexPath := path.Join(directory, "index.html")
+			if fileExists(indexPath) {
+				// Set no-cache headers for index.html
+				w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
+				w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
+				w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
+				http.ServeFile(w, r, indexPath)
+				return
+			}
+		}
+
 		// Get the file path
 		filePath := path.Join(directory, r.URL.Path)
+
+		// Check if the requested file is index.html
+		isIndexHTML := r.URL.Path == "/index.html" || path.Base(filePath) == "index.html"
 
 		// Check if file exists
 		if _, err := os.Stat(filePath); os.IsNotExist(err) {
@@ -314,6 +331,23 @@ func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) 
 				logger.Debug("Serving index.html for SPA routing",
 					log.String("requested_path", r.URL.Path),
 					log.String("route_prefix", routePrefix))
+				// Set no-cache headers for index.html
+				w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
+				w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
+				w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
+				http.ServeFile(w, r, indexPath)
+				return
+			}
+		}
+
+		// Serve index.html directly with no-cache headers when requested
+		if isIndexHTML {
+			indexPath := path.Join(directory, "index.html")
+			if fileExists(indexPath) {
+				// Set no-cache headers for index.html
+				w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
+				w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
+				w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
 				http.ServeFile(w, r, indexPath)
 				return
 			}

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 )
@@ -382,6 +383,216 @@ func TestCreateStaticFileHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Equal(t, string(indexContent), rr.Body.String())
+	})
+}
+
+func TestCreateStaticFileHandler_CacheHeaders(t *testing.T) {
+	logger := log.GetLogger()
+	tmpDir := t.TempDir()
+
+	indexContent := []byte("<!DOCTYPE html><html><body>index</body></html>")
+	jsContent := []byte("console.log('hello');")
+	cssContent := []byte("body { margin: 0; }")
+	imageContent := []byte{0xFF, 0xD8, 0xFF} // Mock image bytes
+
+	requireWriteFile(t, filepath.Join(tmpDir, "index.html"), indexContent)
+	requireWriteFile(t, filepath.Join(tmpDir, "app.js"), jsContent)
+	requireWriteFile(t, filepath.Join(tmpDir, "styles.css"), cssContent)
+	requireWriteFile(t, filepath.Join(tmpDir, "logo.png"), imageContent)
+
+	handler := createStaticFileHandler("/app/", tmpDir, logger)
+
+	t.Run("sets cache headers when serving index.html at root", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/app/", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, constants.CacheControlNoCacheComposite, rr.Header().Get(constants.CacheControlHeaderName),
+			"Cache-Control header should prevent caching for index.html at root")
+		assert.Equal(t, constants.PragmaNoCache, rr.Header().Get(constants.PragmaHeaderName),
+			"Pragma header should be set for index.html at root")
+		assert.Equal(t, constants.ExpiresZero, rr.Header().Get(constants.ExpiresHeaderName),
+			"Expires header should be set for index.html at root")
+		assert.Contains(t, rr.Body.String(), "index")
+	})
+
+	t.Run("sets cache headers when serving index.html directly", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/app/index.html", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, constants.CacheControlNoCacheComposite, rr.Header().Get(constants.CacheControlHeaderName),
+			"Cache-Control header should prevent caching for direct index.html request")
+		assert.Equal(t, constants.PragmaNoCache, rr.Header().Get(constants.PragmaHeaderName),
+			"Pragma header should be set for direct index.html request")
+		assert.Equal(t, constants.ExpiresZero, rr.Header().Get(constants.ExpiresHeaderName),
+			"Expires header should be set for direct index.html request")
+		assert.Contains(t, rr.Body.String(), "index")
+	})
+
+	t.Run("sets cache headers when serving index.html as SPA fallback", func(t *testing.T) {
+		testCases := []struct {
+			path        string
+			description string
+		}{
+			{"/app/dashboard", "single level path"},
+			{"/app/users/profile", "multi level path"},
+			{"/app/settings/advanced/security", "deeply nested path"},
+			{"/app/nonexistent.html", "non-existent HTML file"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+				rr := httptest.NewRecorder()
+
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusOK, rr.Code)
+				assert.Equal(t, constants.CacheControlNoCacheComposite,
+					rr.Header().Get(constants.CacheControlHeaderName),
+					"Cache-Control header should prevent caching for SPA fallback at %s", tc.path)
+				assert.Equal(t, constants.PragmaNoCache, rr.Header().Get(constants.PragmaHeaderName),
+					"Pragma header should be set for SPA fallback at %s", tc.path)
+				assert.Equal(t, constants.ExpiresZero, rr.Header().Get(constants.ExpiresHeaderName),
+					"Expires header should be set for SPA fallback at %s", tc.path)
+				assert.Contains(t, rr.Body.String(), "index",
+					"Should serve index.html content for SPA fallback at %s", tc.path)
+			})
+		}
+	})
+
+	t.Run("does not set cache headers for static assets", func(t *testing.T) {
+		testCases := []struct {
+			path        string
+			description string
+			content     []byte
+		}{
+			{"/app/app.js", "JavaScript file", jsContent},
+			{"/app/styles.css", "CSS file", cssContent},
+			{"/app/logo.png", "image file", imageContent},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+				rr := httptest.NewRecorder()
+
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusOK, rr.Code)
+				assert.Empty(t, rr.Header().Get(constants.CacheControlHeaderName),
+					"Cache-Control header should not be set for %s", tc.description)
+				assert.Empty(t, rr.Header().Get(constants.PragmaHeaderName),
+					"Pragma header should not be set for %s", tc.description)
+				assert.Empty(t, rr.Header().Get(constants.ExpiresHeaderName),
+					"Expires header should not be set for %s", tc.description)
+				assert.Equal(t, string(tc.content), rr.Body.String(),
+					"Should serve correct content for %s", tc.description)
+			})
+		}
+	})
+
+	t.Run("does not match files ending with index.html incorrectly", func(t *testing.T) {
+		customIndexFile := []byte("custom index content")
+		requireWriteFile(t, filepath.Join(tmpDir, "my-custom-index.html"), customIndexFile)
+
+		req := httptest.NewRequest(http.MethodGet, "/app/my-custom-index.html", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Empty(t, rr.Header().Get(constants.CacheControlHeaderName),
+			"Cache-Control should not be set for files that contain 'index.html' but are not exactly 'index.html'")
+		assert.Empty(t, rr.Header().Get(constants.PragmaHeaderName),
+			"Pragma should not be set for files that contain 'index.html' but are not exactly 'index.html'")
+		assert.Empty(t, rr.Header().Get(constants.ExpiresHeaderName),
+			"Expires should not be set for files that contain 'index.html' but are not exactly 'index.html'")
+		assert.Equal(t, string(customIndexFile), rr.Body.String())
+	})
+}
+
+func TestDirectoryExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("returns true for existing directory", func(t *testing.T) {
+		assert.True(t, directoryExists(tmpDir))
+	})
+
+	t.Run("returns false for non-existent directory", func(t *testing.T) {
+		assert.False(t, directoryExists(filepath.Join(tmpDir, "nonexistent")))
+	})
+
+	t.Run("returns false for file, not directory", func(t *testing.T) {
+		filePath := filepath.Join(tmpDir, "file.txt")
+		requireWriteFile(t, filePath, []byte("content"))
+		assert.False(t, directoryExists(filePath))
+	})
+}
+
+func TestFileExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "file.txt")
+	requireWriteFile(t, filePath, []byte("content"))
+
+	t.Run("returns true for existing file", func(t *testing.T) {
+		assert.True(t, fileExists(filePath))
+	})
+
+	t.Run("returns false for non-existent file", func(t *testing.T) {
+		assert.False(t, fileExists(filepath.Join(tmpDir, "nonexistent.txt")))
+	})
+
+	t.Run("returns false for directory, not file", func(t *testing.T) {
+		assert.False(t, fileExists(tmpDir))
+	})
+}
+
+func TestRegisterStaticFileHandlers(t *testing.T) {
+	logger := log.GetLogger()
+	tmpDir := t.TempDir()
+
+	// Create gate and develop directories
+	gateDir := filepath.Join(tmpDir, "apps", "gate")
+	developDir := filepath.Join(tmpDir, "apps", "develop")
+	err := os.MkdirAll(gateDir, 0o750)
+	assert.NoError(t, err)
+	err = os.MkdirAll(developDir, 0o750)
+	assert.NoError(t, err)
+
+	// Create index.html files
+	requireWriteFile(t, filepath.Join(gateDir, "index.html"), []byte("gate app"))
+	requireWriteFile(t, filepath.Join(developDir, "index.html"), []byte("develop app"))
+
+	t.Run("registers handlers for existing directories", func(t *testing.T) {
+		mux := http.NewServeMux()
+		registerStaticFileHandlers(logger, mux, tmpDir)
+
+		// Test gate handler
+		req := httptest.NewRequest(http.MethodGet, "/gate/", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "gate app")
+
+		// Test develop handler
+		req = httptest.NewRequest(http.MethodGet, "/develop/", nil)
+		rr = httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "develop app")
+	})
+
+	t.Run("handles missing directories gracefully", func(t *testing.T) {
+		emptyTmpDir := t.TempDir()
+		mux := http.NewServeMux()
+		// Should not panic
+		registerStaticFileHandlers(logger, mux, emptyTmpDir)
 	})
 }
 

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -50,14 +50,29 @@ const ContentTypeFormURLEncoded = "application/x-www-form-urlencoded"
 // CacheControlHeaderName is the name of the cache-control header used in HTTP responses.
 const CacheControlHeaderName = "Cache-Control"
 
-// CacheControlNoStore is the cache-control value to prevent caching.
+// CacheControlNoCache is the cache-control directive to force revalidation.
+const CacheControlNoCache = "no-cache"
+
+// CacheControlNoStore is the cache-control directive to prevent caching.
 const CacheControlNoStore = "no-store"
+
+// CacheControlMustRevalidate is the cache-control directive to require revalidation of stale cache entries.
+const CacheControlMustRevalidate = "must-revalidate"
 
 // PragmaHeaderName is the name of the pragma header used in HTTP responses.
 const PragmaHeaderName = "Pragma"
 
 // PragmaNoCache is the pragma value to prevent caching.
 const PragmaNoCache = "no-cache"
+
+// ExpiresHeaderName is the name of the expires header used in HTTP responses.
+const ExpiresHeaderName = "Expires"
+
+// CacheControlNoCacheComposite is the combined cache-control directive to prevent caching and require revalidation.
+const CacheControlNoCacheComposite = "no-cache, no-store, must-revalidate"
+
+// ExpiresZero is the expires value to indicate immediate expiration.
+const ExpiresZero = "0"
 
 // DefaultPageSize is the default limit for pagination when not specified.
 const DefaultPageSize = 30

--- a/frontend/apps/thunder-develop/index.html
+++ b/frontend/apps/thunder-develop/index.html
@@ -5,6 +5,11 @@
     <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Prevent browser caching -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+
     <!-- Start of loading application configurations -->
     <script type="text/javascript" src="/config.js"></script>
     <!-- End of loading application configurations -->

--- a/frontend/apps/thunder-gate/index.html
+++ b/frontend/apps/thunder-gate/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Prevent browser caching -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+
     <title>Gate</title>
 
     <!-- Start of loading application configurations -->


### PR DESCRIPTION
### Purpose
Fix browser caching issues that prevented users from seeing updated frontend code after deployments. The SPA entry point (`index.html`) was being cached by browsers, causing stale content to be served even after new deployments.

### Approach
**Backend Changes:**
- Modified `createStaticFileHandler` in `main.go` to detect `index.html` requests (both direct and SPA fallback routing)
- Set cache prevention headers for `index.html`:
  - `Cache-Control: no-cache, no-store, must-revalidate`
  - `Pragma: no-cache` (HTTP/1.0 compatibility)
  - `Expires: 0` (immediate expiration)
- Other static assets (JS, CSS, images) continue normal caching for performance

**Frontend Changes:**
- Added HTML meta tags to both `thunder-develop/index.html` and `thunder-gate/index.html` with the same cache control directives
- Provides defense-in-depth approach combining HTTP headers and HTML meta tags for maximum browser compatibility

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/1321

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Entry page (index.html) is now served with no-cache headers for root, direct index requests, and SPA fallback so users receive the latest app shell.
  * Added meta tags to entry HTML to prevent browser caching in the apps.

* **Tests**
  * Added tests validating no-cache headers for entry pages and normal caching behavior for static assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->