### PR TITLE
Add claims support to OIDC discovery

### DIFF
--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -121,6 +121,9 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery() {
 	assert.Contains(suite.T(), metadata.ClaimsSupported, constants.ClaimSub)
 	assert.Contains(suite.T(), metadata.ClaimsSupported, constants.ClaimIss)
 	assert.Contains(suite.T(), metadata.ClaimsSupported, constants.ClaimAud)
+
+	// Verify claims parameter support
+	assert.True(suite.T(), metadata.ClaimsParameterSupported, "claims_parameter_supported should be true")
 }
 
 // TestGrantTypeIsValid tests the GrantType.IsValid() method

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -41,5 +41,6 @@ type OIDCProviderMetadata struct {
 	SubjectTypesSupported            []string `json:"subject_types_supported"`
 	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 	ClaimsSupported                  []string `json:"claims_supported"`
+	ClaimsParameterSupported         bool     `json:"claims_parameter_supported"`
 	EndSessionEndpoint               string   `json:"end_session_endpoint,omitempty"`
 }

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -69,6 +69,7 @@ func (ds *discoveryService) GetOIDCMetadata() *OIDCProviderMetadata {
 		SubjectTypesSupported:             ds.getSupportedSubjectTypes(),
 		IDTokenSigningAlgValuesSupported:  ds.getSupportedIDTokenSigningAlgorithms(),
 		ClaimsSupported:                   ds.getSupportedClaims(),
+		ClaimsParameterSupported:          true,
 	}
 }
 


### PR DESCRIPTION
This pull request adds support for the `claims_parameter_supported` field in the OIDC provider metadata, ensuring the service advertises support for the `claims` parameter as specified by the OpenID Connect standard. The changes include updating the metadata model, setting the field to `true` in the service, and adding a corresponding test.

**OIDC Discovery Metadata Improvements:**

* Added the `ClaimsParameterSupported` boolean field to the `OIDCProviderMetadata` struct in `model.go` to represent support for the `claims` parameter.
* Set `ClaimsParameterSupported` to `true` in the `GetOIDCMetadata` method in `service.go`, ensuring the service advertises this capability.
* Added a test assertion in `discovery_test.go` to verify that `claims_parameter_supported` is set to `true` in the returned metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The OpenID Connect discovery endpoint now advertises support for the "claims" parameter, so clients can detect and request specific user claims during authentication.

* **Tests**
  * Added a test to verify the discovery metadata exposes claims_parameter_supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related issue-

- https://github.com/asgardeo/thunder/issues/1202