### PR TITLE
Add claims locales parameter support in authorize request

### DIFF
--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -80,7 +80,7 @@ var nonSearchableInputs = []string{"password", "code", "nonce", "otp"}
 // nonUserAttributes contains the list of user attributes that do not belong to user entity.
 var nonUserAttributes = []string{"userID", "code", "nonce", "state", "flowID",
 	"otp", "attemptCount", "expiryTimeInMillis", "otpSessionToken", "value",
-	"authorized_permissions", "requested_permissions", "required_attributes",
+	"authorized_permissions", "requested_permissions", "required_attributes", "required_locales",
 	userTypeKey, ouIDKey, defaultOUIDKey, userInputOuName, userInputOuHandle, userInputOuDesc, userInputInviteToken,
 	common.RuntimeKeyUserEligibleForProvisioning, common.RuntimeKeySkipProvisioning,
 	common.RuntimeKeyUserAutoProvisioned, runtimeKeyStoredInviteToken}

--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -45,6 +45,7 @@ const (
 	jsonDataKeyResource            = "resource"
 	jsonDataKeyUserAttributes      = "user_attributes"
 	jsonDataKeyClaimsRequest       = "claims_request"
+	jsonDataKeyClaimsLocales       = "claims_locales"
 )
 
 // AuthorizationCodeStoreInterface defines the interface for managing authorization codes.
@@ -147,6 +148,7 @@ func (acs *authorizationCodeStore) getJSONDataBytes(authzCode AuthorizationCode)
 		jsonDataKeyCodeChallenge:       authzCode.CodeChallenge,
 		jsonDataKeyCodeChallengeMethod: authzCode.CodeChallengeMethod,
 		jsonDataKeyResource:            authzCode.Resource,
+		jsonDataKeyClaimsLocales:       authzCode.ClaimsLocales,
 	}
 
 	// Include user attributes if present
@@ -257,6 +259,9 @@ func appendAuthzDataJSON(row map[string]interface{}, authzCode *AuthorizationCod
 	}
 	if resource, ok := authzData[jsonDataKeyResource].(string); ok {
 		authzCode.Resource = resource
+	}
+	if claimsLocales, ok := authzData[jsonDataKeyClaimsLocales].(string); ok {
+		authzCode.ClaimsLocales = claimsLocales
 	}
 
 	if userAttrs, ok := authzData[jsonDataKeyUserAttributes].(map[string]interface{}); ok && userAttrs != nil {

--- a/backend/internal/oauth/oauth2/authz/auth_req_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_req_store.go
@@ -157,6 +157,7 @@ func (authzRS *authorizationRequestStore) getJSONDataBytes(authRequestCtx authRe
 		jsonKeyCodeChallenge:       authRequestCtx.OAuthParameters.CodeChallenge,
 		jsonKeyCodeChallengeMethod: authRequestCtx.OAuthParameters.CodeChallengeMethod,
 		jsonKeyResource:            authRequestCtx.OAuthParameters.Resource,
+		jsonKeyClaimsLocales:       authRequestCtx.OAuthParameters.ClaimsLocales,
 	}
 
 	// Add claims_request if present
@@ -230,6 +231,9 @@ func (authzRS *authorizationRequestStore) buildAuthRequestContextFromResultRow(
 	}
 	if resource, ok := requestDataMap[jsonKeyResource].(string); ok {
 		oauthParams.Resource = resource
+	}
+	if claimsLocales, ok := requestDataMap[jsonKeyClaimsLocales].(string); ok {
+		oauthParams.ClaimsLocales = claimsLocales
 	}
 
 	// Parse claims_request if present

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -127,6 +127,9 @@ func (ah *authorizeHandler) handleInitialAuthorizationRequest(msg *OAuthMessage,
 	// Extract claims parameter
 	claimsParam := msg.RequestQueryParams[oauth2const.RequestParamClaims]
 
+	// Extract claims_locales parameter
+	claimsLocales := msg.RequestQueryParams[oauth2const.RequestParamClaimsLocales]
+
 	if clientID == "" {
 		ah.redirectToErrorPage(w, r, oauth2const.ErrorInvalidRequest, "Missing client_id parameter")
 		return
@@ -191,6 +194,7 @@ func (ah *authorizeHandler) handleInitialAuthorizationRequest(msg *OAuthMessage,
 		CodeChallengeMethod: codeChallengeMethod,
 		Resource:            resource,
 		ClaimsRequest:       claimsRequest,
+		ClaimsLocales:       claimsLocales,
 	}
 
 	// Set the redirect URI if not provided in the request. Invalid cases are already handled at this point.
@@ -206,6 +210,7 @@ func (ah *authorizeHandler) handleInitialAuthorizationRequest(msg *OAuthMessage,
 	runtimeData := map[string]string{
 		"requested_permissions": utils.StringifyStringArray(nonOidcScopes, " "),
 		"required_attributes":   requiredAttributes,
+		"required_locales":      claimsLocales,
 	}
 	flowInitCtx := &flowexec.FlowInitContext{
 		ApplicationID: app.AppID,
@@ -600,6 +605,7 @@ func createAuthorizationCode(
 		CodeChallengeMethod: authRequestCtx.OAuthParameters.CodeChallengeMethod,
 		Resource:            resource,
 		ClaimsRequest:       authRequestCtx.OAuthParameters.ClaimsRequest,
+		ClaimsLocales:       authRequestCtx.OAuthParameters.ClaimsLocales,
 	}, nil
 }
 

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -48,6 +48,7 @@ type AuthorizationCode struct {
 	CodeChallengeMethod string
 	Resource            string
 	ClaimsRequest       *oauth2model.ClaimsRequest
+	ClaimsLocales       string
 }
 
 // AuthZPostRequest represents the request body for the authorization POST request.

--- a/backend/internal/oauth/oauth2/authz/store_constants.go
+++ b/backend/internal/oauth/oauth2/authz/store_constants.go
@@ -32,6 +32,7 @@ const (
 	jsonKeyCodeChallengeMethod = "code_challenge_method"
 	jsonKeyResource            = "resource"
 	jsonKeyClaimsRequest       = "claims_request"
+	jsonKeyClaimsLocales       = "claims_locales"
 )
 
 // Database column names for authorization request storage.

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -53,6 +53,7 @@ const (
 	RequestParamRequestedTokenType  string = "requested_token_type"
 	RequestParamAudience            string = "audience"
 	RequestParamClaims              string = "claims"
+	RequestParamClaimsLocales       string = "claims_locales"
 )
 
 // Server OAuth constants.
@@ -275,6 +276,7 @@ const (
 	ClaimOUName        string = "ouName"
 	ClaimOUHandle      string = "ouHandle"
 	ClaimClaimsRequest string = "claims_req"
+	ClaimClaimsLocales string = "claims_locales"
 )
 
 // JWT signing algorithms.

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -144,6 +144,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(tokenRequest *model.TokenReq
 		GrantType:      string(constants.GrantTypeAuthorizationCode),
 		OAuthApp:       oauthApp,
 		ClaimsRequest:  authCode.ClaimsRequest,
+		ClaimsLocales:  authCode.ClaimsLocales,
 	})
 	if err != nil {
 		return nil, &model.ErrorResponse{

--- a/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
+++ b/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
@@ -40,5 +40,6 @@ type RefreshTokenGrantHandlerInterface interface {
 		subject, audience, grantType string,
 		scopes []string,
 		claimsRequest *model.ClaimsRequest,
+		claimsLocales string,
 	) *model.ErrorResponse
 }

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -106,6 +106,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 		GrantType:      refreshTokenClaims.GrantType,
 		OAuthApp:       oauthApp,
 		ClaimsRequest:  refreshTokenClaims.ClaimsRequest,
+		ClaimsLocales:  refreshTokenClaims.ClaimsLocales,
 	})
 	if err != nil {
 		logger.Error("Failed to generate access token", log.Error(err))
@@ -128,7 +129,8 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 	if renewRefreshToken {
 		logger.Debug("Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
 		errResp := h.IssueRefreshToken(tokenResponse, oauthApp, refreshTokenClaims.Sub, refreshTokenClaims.Aud,
-			refreshTokenClaims.GrantType, newTokenScopes, refreshTokenClaims.ClaimsRequest)
+			refreshTokenClaims.GrantType, newTokenScopes, refreshTokenClaims.ClaimsRequest,
+			refreshTokenClaims.ClaimsLocales)
 		if errResp != nil && errResp.Error != "" {
 			errResp.ErrorDescription = "Error while issuing refresh token: " + errResp.ErrorDescription
 			logger.Error("Failed to issue refresh token", log.String("error", errResp.Error))
@@ -154,6 +156,7 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	subject, audience, grantType string,
 	scopes []string,
 	claimsRequest *model.ClaimsRequest,
+	claimsLocales string,
 ) *model.ErrorResponse {
 	tokenCtx := &tokenservice.RefreshTokenBuildContext{
 		ClientID:             oauthApp.ClientID,
@@ -164,6 +167,7 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 		AccessTokenUserAttrs: tokenResponse.AccessToken.UserAttributes,
 		OAuthApp:             oauthApp,
 		ClaimsRequest:        claimsRequest,
+		ClaimsLocales:        claimsLocales,
 	}
 
 	// Build refresh token using token builder

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -32,6 +32,7 @@ type OAuthParameters struct {
 	CodeChallengeMethod string
 	Resource            string
 	ClaimsRequest       *ClaimsRequest
+	ClaimsLocales       string
 }
 
 // ClaimsRequest represents the OIDC claims request parameter structure.

--- a/backend/internal/oauth/oauth2/model/token.go
+++ b/backend/internal/oauth/oauth2/model/token.go
@@ -63,6 +63,7 @@ type TokenDTO struct {
 	Subject        string
 	Audience       string
 	ClaimsRequest  *ClaimsRequest
+	ClaimsLocales  string
 }
 
 // TokenResponseDTO represents the data transfer object for token responses.

--- a/backend/internal/oauth/oauth2/token/token_handler.go
+++ b/backend/internal/oauth/oauth2/token/token_handler.go
@@ -231,7 +231,8 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 
 		refreshTokenError := refreshGrantHandlerTyped.IssueRefreshToken(tokenRespDTO, oauthApp,
 			tokenRespDTO.AccessToken.Subject, tokenRespDTO.AccessToken.Audience,
-			grantTypeStr, tokenRespDTO.AccessToken.Scopes, tokenRespDTO.AccessToken.ClaimsRequest)
+			grantTypeStr, tokenRespDTO.AccessToken.Scopes, tokenRespDTO.AccessToken.ClaimsRequest,
+			tokenRespDTO.AccessToken.ClaimsLocales)
 		if refreshTokenError != nil && refreshTokenError.Error != "" {
 			th.publishTokenIssuanceFailedEvent(r.Context(), clientID, grantTypeStr, scopeStr,
 				http.StatusInternalServerError, refreshTokenError.ErrorDescription, startTime)

--- a/backend/internal/oauth/oauth2/token/token_handler_test.go
+++ b/backend/internal/oauth/oauth2/token/token_handler_test.go
@@ -585,7 +585,7 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_WithRefreshToken() {
 		Return(tokenResponse, nil)
 
 	mockRefreshHandler.On("IssueRefreshToken", tokenResponse, mockApp, "user123", "test-audience",
-		"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil)).
+		"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "").
 		Return(nil)
 
 	rr := httptest.NewRecorder()
@@ -664,7 +664,7 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_RefreshTokenIssuanceE
 		ErrorDescription: "Failed to issue refresh token",
 	}
 	mockRefreshHandler.On("IssueRefreshToken", tokenResponse, mockApp, "user123", "test-audience",
-		"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil)).
+		"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "").
 		Return(refreshError)
 
 	rr := httptest.NewRecorder()

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -70,6 +70,7 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 		Subject:        ctx.Subject,
 		Audience:       ctx.Audience,
 		ClaimsRequest:  ctx.ClaimsRequest,
+		ClaimsLocales:  ctx.ClaimsLocales,
 	}
 
 	token, iat, err := tb.jwtService.GenerateJWT(
@@ -131,6 +132,11 @@ func (tb *tokenBuilder) buildAccessTokenClaims(
 		if serialized != "" {
 			claims[constants.ClaimClaimsRequest] = serialized
 		}
+	}
+
+	// Include claims_locales if present
+	if ctx.ClaimsLocales != "" {
+		claims[constants.ClaimClaimsLocales] = ctx.ClaimsLocales
 	}
 
 	return claims, nil
@@ -197,11 +203,12 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth
 	}
 
 	tokenDTO := &oauth2model.TokenDTO{
-		ExpiresIn: tokenConfig.ValidityPeriod,
-		Scopes:    ctx.Scopes,
-		ClientID:  ctx.ClientID,
-		Subject:   ctx.AccessTokenSubject,
-		Audience:  tokenConfig.Issuer,
+		ExpiresIn:     tokenConfig.ValidityPeriod,
+		Scopes:        ctx.Scopes,
+		ClientID:      ctx.ClientID,
+		Subject:       ctx.AccessTokenSubject,
+		Audience:      tokenConfig.Issuer,
+		ClaimsLocales: ctx.ClaimsLocales,
 	}
 
 	token, iat, err := tb.jwtService.GenerateJWT(
@@ -251,6 +258,11 @@ func (tb *tokenBuilder) buildRefreshTokenClaims(ctx *RefreshTokenBuildContext) (
 		if serialized != "" {
 			claims["access_token_claims_request"] = serialized
 		}
+	}
+
+	// Include claims_locales if present
+	if ctx.ClaimsLocales != "" {
+		claims["access_token_claims_locales"] = ctx.ClaimsLocales
 	}
 
 	return claims, nil

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -53,6 +53,7 @@ type AccessTokenBuildContext struct {
 	OAuthApp       *appmodel.OAuthAppConfigProcessedDTO
 	ActorClaims    *SubjectTokenClaims
 	ClaimsRequest  *oauth2model.ClaimsRequest
+	ClaimsLocales  string
 }
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
@@ -65,6 +66,7 @@ type RefreshTokenBuildContext struct {
 	AccessTokenUserAttrs map[string]interface{}
 	OAuthApp             *appmodel.OAuthAppConfigProcessedDTO
 	ClaimsRequest        *oauth2model.ClaimsRequest
+	ClaimsLocales        string
 }
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
@@ -87,6 +89,7 @@ type RefreshTokenClaims struct {
 	UserAttributes map[string]interface{}
 	Iat            int64
 	ClaimsRequest  *oauth2model.ClaimsRequest
+	ClaimsLocales  string
 }
 
 // SubjectTokenClaims represents the validated claims from a subject token (for token exchange).

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -86,6 +86,9 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 		claimsRequest = parsed
 	}
 
+	// Extract claims_locales if present
+	claimsLocales, _ := extractStringClaim(claims, "access_token_claims_locales")
+
 	// Extract user type and organizational unit details if present
 	return &RefreshTokenClaims{
 		Sub:            sub,
@@ -95,6 +98,7 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 		UserAttributes: userAttributes,
 		Iat:            iat,
 		ClaimsRequest:  claimsRequest,
+		ClaimsLocales:  claimsLocales,
 	}, nil
 }
 

--- a/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
@@ -108,16 +108,16 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_HandleGrant_Call) RunAndReturn(r
 }
 
 // IssueRefreshToken provides a mock function for the type RefreshTokenGrantHandlerInterfaceMock
-func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest) *model.ErrorResponse {
-	ret := _mock.Called(tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest)
+func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string) *model.ErrorResponse {
+	ret := _mock.Called(tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IssueRefreshToken")
 	}
 
 	var r0 *model.ErrorResponse
-	if returnFunc, ok := ret.Get(0).(func(*model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string, *model.ClaimsRequest) *model.ErrorResponse); ok {
-		r0 = returnFunc(tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest)
+	if returnFunc, ok := ret.Get(0).(func(*model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string, *model.ClaimsRequest, string) *model.ErrorResponse); ok {
+		r0 = returnFunc(tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ErrorResponse)
@@ -139,11 +139,12 @@ type RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call struct {
 //   - grantType string
 //   - scopes []string
 //   - claimsRequest *model.ClaimsRequest
-func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}, claimsRequest interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
-	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest)}
+//   - claimsLocales string
+func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}, claimsRequest interface{}, claimsLocales interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales)}
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *model.TokenResponseDTO
 		if args[0] != nil {
@@ -173,6 +174,10 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 		if args[6] != nil {
 			arg6 = args[6].(*model.ClaimsRequest)
 		}
+		var arg7 string
+		if args[7] != nil {
+			arg7 = args[7].(string)
+		}
 		run(
 			arg0,
 			arg1,
@@ -181,6 +186,7 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 			arg4,
 			arg5,
 			arg6,
+			arg7,
 		)
 	})
 	return _c
@@ -191,7 +197,7 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Return(e
 	return _c
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -34,20 +34,20 @@ import (
 
 // InitiateAuthorizationFlow starts the OAuth2 authorization flow
 func InitiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state string) (*http.Response, error) {
-	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, "", "", "", "")
+	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, "", "", "", "", "")
 }
 
 // InitiateAuthorizationFlowWithResource starts the OAuth2 authorization flow with resource parameter
 func InitiateAuthorizationFlowWithResource(clientID, redirectURI, responseType, scope, state,
 	resource string) (*http.Response, error) {
-	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource, "", "", "")
+	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource, "", "", "", "")
 }
 
 // InitiateAuthorizationFlowWithPKCE starts the OAuth2 authorization flow with PKCE parameters
 func InitiateAuthorizationFlowWithPKCE(clientID, redirectURI, responseType, scope, state, resource,
 	codeChallenge, codeChallengeMethod string) (*http.Response, error) {
 	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource,
-		codeChallenge, codeChallengeMethod, "")
+		codeChallenge, codeChallengeMethod, "", "")
 }
 
 // InitiateAuthorizationFlowWithClaims starts the OAuth2 authorization flow with claims parameter
@@ -55,15 +55,24 @@ func InitiateAuthorizationFlowWithClaims(
 	clientID, redirectURI, responseType, scope, state, claimsParam string,
 ) (*http.Response, error) {
 	return initiateAuthorizationFlow(
-		clientID, redirectURI, responseType, scope, state, "", "", "", claimsParam,
+		clientID, redirectURI, responseType, scope, state, "", "", "", claimsParam, "",
+	)
+}
+
+// InitiateAuthorizationFlowWithClaimsLocales starts the OAuth2 authorization flow with claims_locales parameter
+func InitiateAuthorizationFlowWithClaimsLocales(
+	clientID, redirectURI, responseType, scope, state, claimsLocales string,
+) (*http.Response, error) {
+	return initiateAuthorizationFlow(
+		clientID, redirectURI, responseType, scope, state, "", "", "", "", claimsLocales,
 	)
 }
 
 // initiateAuthorizationFlow starts the OAuth2 authorization flow with all optional parameters.
 // clientID, redirectURI, responseType, scope, and state are required parameters.
-// resource, codeChallenge, codeChallengeMethod, and claimsParam are optional parameters.
+// resource, codeChallenge, codeChallengeMethod, claimsParam, and claimsLocales are optional parameters.
 func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource,
-	codeChallenge, codeChallengeMethod, claimsParam string) (*http.Response, error) {
+	codeChallenge, codeChallengeMethod, claimsParam, claimsLocales string) (*http.Response, error) {
 	authURL := TestServerURL + "/oauth2/authorize"
 	params := url.Values{}
 	params.Set("client_id", clientID)
@@ -80,6 +89,9 @@ func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state
 	}
 	if claimsParam != "" {
 		params.Set("claims", claimsParam)
+	}
+	if claimsLocales != "" {
+		params.Set("claims_locales", claimsLocales)
 	}
 
 	req, err := http.NewRequest("GET", authURL+"?"+params.Encode(), nil)


### PR DESCRIPTION
This pull request adds support for the `claims_locales` parameter throughout the OAuth 2.0 authorization and token handling flow. The changes ensure that the `claims_locales` value provided by the client is extracted, stored, and propagated through authorization requests, authorization codes, and token generation, including refresh tokens. Comprehensive test coverage is added to verify correct handling of the new parameter.

**Core OAuth 2.0 Flow Enhancements:**

* Added extraction and handling of the `claims_locales` parameter in the authorization request handler, storing it in `OAuthParameters` and `AuthorizationCode` structs, and passing it through to runtime data and authorization codes. [[1]](diffhunk://#diff-de2c7e2e7e59fcb851b78ff55b0ed14c774e955787d303aa28ff80d2ddfccf23R130-R132) [[2]](diffhunk://#diff-de2c7e2e7e59fcb851b78ff55b0ed14c774e955787d303aa28ff80d2ddfccf23R197) [[3]](diffhunk://#diff-de2c7e2e7e59fcb851b78ff55b0ed14c774e955787d303aa28ff80d2ddfccf23R213) [[4]](diffhunk://#diff-bf9f63eff78affd59ca6a5c5131797e45001fb0fc37c73745d68a04cb8df0ebdR51) [[5]](diffhunk://#diff-a583b9e72c489fa5adc8c3596866529201d456a00286f4a983718f4c8e084b9bR35)
* Updated constants and storage keys to include `claims_locales` for both authorization requests and codes, ensuring consistent serialization and deserialization. [[1]](diffhunk://#diff-68fc6075f5e8a7ea5d0a73f85fecdccdcba3269b653f5a7a9f032d6a70b3915eR56) [[2]](diffhunk://#diff-68fc6075f5e8a7ea5d0a73f85fecdccdcba3269b653f5a7a9f032d6a70b3915eR279) [[3]](diffhunk://#diff-cc25caf069cc38c47aeb6c2159ff237f9f80d567bcf06c9eb9c8a36ac404cf35R35) [[4]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aR48) [[5]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aR151) [[6]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aR263-R265) [[7]](diffhunk://#diff-a5ab79126bea86bd09fc0efe55e92b8949d09ef3cfb19b15ddc10ff8ea8ecfccR160) [[8]](diffhunk://#diff-a5ab79126bea86bd09fc0efe55e92b8949d09ef3cfb19b15ddc10ff8ea8ecfccR235-R237)

**Token and Refresh Token Handling:**

* Modified token and refresh token grant handlers to accept and propagate `claims_locales` when generating tokens and issuing new refresh tokens. [[1]](diffhunk://#diff-353c0ae473a7f38190e1aacc728880e021da05be2fb9ceedfd844e378bee7c9eR147) [[2]](diffhunk://#diff-19ce85dd7746918fa4de5ae1d38f3b703437b0310170c484c773917ab57a67adR109) [[3]](diffhunk://#diff-19ce85dd7746918fa4de5ae1d38f3b703437b0310170c484c773917ab57a67adL131-R133) [[4]](diffhunk://#diff-19ce85dd7746918fa4de5ae1d38f3b703437b0310170c484c773917ab57a67adR159) [[5]](diffhunk://#diff-19ce85dd7746918fa4de5ae1d38f3b703437b0310170c484c773917ab57a67adR170) [[6]](diffhunk://#diff-8786bac9b527eb260e6fdc83592efdb46b63767bbc71ce53a046c3c0d52c1277R43) [[7]](diffhunk://#diff-81242b42b0efb0e4e76622bf7874d577c46cc2923c4172bf223993e29f45ee11R66)
* Updated related tests to cover the new `claims_locales` parameter in token and refresh token flows. [[1]](diffhunk://#diff-812a100cf1b8eb0223abb7259e65851b4f63b994a87839757bc951b00e4bcb09L215-R215) [[2]](diffhunk://#diff-812a100cf1b8eb0223abb7259e65851b4f63b994a87839757bc951b00e4bcb09L235-R235) [[3]](diffhunk://#diff-812a100cf1b8eb0223abb7259e65851b4f63b994a87839757bc951b00e4bcb09L255-R255)

**Test Coverage:**

* Added and updated unit tests to verify correct extraction, storage, and propagation of `claims_locales` in authorization requests, runtime data, and token generation. [[1]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cR386) [[2]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cR424) [[3]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cR462) [[4]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cR508) [[5]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cR866) [[6]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cR902) [[7]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cR1597-R1673)

These changes collectively ensure that the `claims_locales` parameter is fully supported and handled correctly across the OAuth 2.0 authorization and token issuance lifecycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a claims_locales parameter across OAuth2 flows: extracted from requests, stored with authorization codes, included in runtime data, and propagated into access and refresh tokens and token payloads.

* **Tests**
  * Added and updated unit, integration, and helper tests to validate extraction, propagation, storage, token generation, refresh handling, and validation of claims_locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->