### PR TITLE
Add user info config view to application edit

### DIFF
--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/SettingsCard.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/SettingsCard.tsx
@@ -40,6 +40,10 @@ interface SettingsCardProps {
    * Optional toggle change handler
    */
   onToggle?: (enabled: boolean) => void;
+  /**
+   * Optional custom action element to render in the header
+   */
+  headerAction?: ReactNode;
 }
 
 /**
@@ -74,6 +78,7 @@ export default function SettingsCard({
   children,
   enabled = undefined,
   onToggle = undefined,
+  headerAction = undefined,
 }: SettingsCardProps) {
   const hasToggle = enabled !== undefined && onToggle !== undefined;
 
@@ -82,13 +87,16 @@ export default function SettingsCard({
       <Box sx={{p: 3}}>
         <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
           <Typography variant="h5">{title}</Typography>
-          {hasToggle && (
-            <Switch
-              checked={enabled}
-              onChange={(e) => onToggle(e.target.checked)}
-              inputProps={{'aria-label': `Toggle ${title}`}}
-            />
-          )}
+          <Stack direction="row" alignItems="center" spacing={2}>
+            {headerAction}
+            {hasToggle && (
+              <Switch
+                checked={enabled}
+                onChange={(e) => onToggle(e.target.checked)}
+                inputProps={{'aria-label': `Toggle ${title}`}}
+              />
+            )}
+          </Stack>
         </Stack>
         {description && (
           <Typography variant="body2" sx={{mt: 0.5, color: 'text.disabled'}}>
@@ -96,10 +104,11 @@ export default function SettingsCard({
           </Typography>
         )}
       </Box>
-      <Paper sx={{p: 3}}>
-        {/* Only show content if toggle is enabled or if there's no toggle */}
-        {(!hasToggle || enabled) && children}
-      </Paper>
+      {(!hasToggle || enabled) && children && (
+        <Paper sx={{p: 3}}>
+          {children}
+        </Paper>
+      )}
     </Paper>
   );
 }

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/__tests__/SettingsCard.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/__tests__/SettingsCard.test.tsx
@@ -217,4 +217,39 @@ describe('SettingsCard', () => {
       expect(screen.getByRole('button', {name: 'Submit'})).toBeInTheDocument();
     });
   });
+  
+  it('should render headerAction if provided', () => {
+    render(
+      <SettingsCard title="Test Settings" headerAction={<button type="button">Action</button>}>
+        <div>Content</div>
+      </SettingsCard>,
+    );
+
+    expect(screen.getByText('Action')).toBeInTheDocument();
+  });
+
+  it('should not render content wrapper if valid children are not present', () => {
+    const { container } = render(
+      <SettingsCard title="Test Settings">
+        {false && <div>Content</div>}
+      </SettingsCard>,
+    );
+
+    // Should only have the outer paper, title box, but NO inner content paper
+    // The outer paper renders the title box div + potential content div
+    // We expect only the title box div to be present inside the outer Paper
+    const papers = container.querySelectorAll('.MuiPaper-root');
+    expect(papers.length).toBe(1); // Only the outer card, no inner content card
+  });
+
+  it('should render content wrapper if valid children are present', () => {
+    const {container} = render(
+      <SettingsCard title="Test Settings">
+        <div>Content</div>
+      </SettingsCard>,
+    );
+
+    const papers = container.querySelectorAll('.MuiPaper-root');
+    expect(papers.length).toBe(2); // Outer card + Inner content card
+  });
 });

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/token-settings/__tests__/TokenUserAttributesSection.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/token-settings/__tests__/TokenUserAttributesSection.test.tsx
@@ -25,9 +25,20 @@ import type {OAuth2Config} from '../../../../models/oauth';
 
 // Mock the SettingsCard component
 vi.mock('../../SettingsCard', () => ({
-  default: ({title, description, children}: {title: string; description: string; children: React.ReactNode}) => (
+  default: ({
+    title,
+    description,
+    children,
+    headerAction,
+  }: {
+    title: string;
+    description: string;
+    children: React.ReactNode;
+    headerAction?: React.ReactNode;
+  }) => (
     <div data-testid="settings-card">
       <div data-testid="card-title">{title}</div>
+      <div data-testid="card-header-action">{headerAction}</div>
       <div data-testid="card-description">{description}</div>
       {children}
     </div>
@@ -38,6 +49,8 @@ vi.mock('../../SettingsCard', () => ({
 vi.mock('../../../../constants/token-constants', () => ({
   default: {
     DEFAULT_TOKEN_ATTRIBUTES: ['aud', 'exp', 'iat', 'iss', 'sub'],
+    USER_INFO_DEFAULT_ATTRIBUTES: ['sub'],
+    ADDITIONAL_USER_ATTRIBUTES: ['ouHandle', 'ouId', 'ouName', 'userType'],
   },
 }));
 
@@ -50,7 +63,7 @@ function TestWrapper({
   oauth2Config = undefined,
   children = undefined,
 }: {
-  tokenType?: 'shared' | 'access' | 'id';
+  tokenType?: 'shared' | 'access' | 'id' | 'userinfo';
   currentAttributes?: string[];
   userAttributes?: string[];
   isLoadingUserAttributes?: boolean;
@@ -61,7 +74,7 @@ function TestWrapper({
     pendingAdditions: Set<string>;
     pendingRemovals: Set<string>;
     highlightedAttributes: Set<string>;
-    onAttributeClick: (attr: string, tokenType: 'shared' | 'access' | 'id') => void;
+    onAttributeClick: (attr: string, tokenType: 'shared' | 'access' | 'id' | 'userinfo') => void;
   }) => React.ReactNode;
 }) {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set([`user-${tokenType}`]));
@@ -356,6 +369,441 @@ describe('TokenUserAttributesSection', () => {
       // Check that user attributes are rendered as clickable chips
       const emailChip = screen.getByText('email');
       expect(emailChip).toBeInTheDocument();
+    });
+  });
+
+  describe('Pending Additions and Removals', () => {
+    it('should include pending additions in JWT preview for shared token type', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={[]}
+          userAttributes={['email', 'username']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-shared', 'default-shared'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set(['email'])}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      // The pending addition 'email' should appear in the JWT preview
+      const jsonText = container.textContent || '';
+      expect(jsonText).toContain('"email"');
+      expect(jsonText).toContain('<email>');
+    });
+
+    it('should include pending additions in JWT preview for access token when activeTokenType matches', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="access"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-access', 'default-access'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set(['email'])}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      const jsonText = container.textContent || '';
+      expect(jsonText).toContain('"email"');
+      expect(jsonText).toContain('<email>');
+    });
+
+    it('should include pending additions in JWT preview for id token when activeTokenType matches', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="id"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-id', 'default-id'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set(['email'])}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="id"
+        />,
+      );
+
+      const jsonText = container.textContent || '';
+      expect(jsonText).toContain('"email"');
+      expect(jsonText).toContain('<email>');
+    });
+
+    it('should include pending additions in JWT preview for userinfo token when activeTokenType matches', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="userinfo"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-userinfo', 'default-userinfo'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set(['email'])}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="userinfo"
+        />,
+      );
+
+      const jsonText = container.textContent || '';
+      expect(jsonText).toContain('"email"');
+      expect(jsonText).toContain('<email>');
+    });
+
+    it('should not include pending additions in JWT preview when activeTokenType does not match', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="access"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-access', 'default-access'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set(['email'])}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="id"
+        />,
+      );
+
+      // 'email' should NOT appear as a value in the preview since activeTokenType doesn't match
+      const jsonText = container.textContent || '';
+      expect(jsonText).not.toContain('<email>');
+    });
+
+    it('should exclude pending removals from JWT preview for shared token type', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={['email', 'username']}
+          userAttributes={['email', 'username']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-shared', 'default-shared'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set(['email'])}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      const jsonText = container.textContent || '';
+      // email should be removed from preview since it's a pending removal
+      expect(jsonText).not.toContain('<email>');
+      // username should still be in preview
+      expect(jsonText).toContain('<username>');
+    });
+
+    it('should exclude pending removals from JWT preview when activeTokenType matches', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="access"
+          currentAttributes={['email', 'username']}
+          userAttributes={['email', 'username']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-access', 'default-access'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set(['email'])}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      const jsonText = container.textContent || '';
+      expect(jsonText).not.toContain('<email>');
+      expect(jsonText).toContain('<username>');
+    });
+
+    it('should not exclude pending removals from JWT preview when activeTokenType does not match', () => {
+      const {container} = render(
+        <TokenUserAttributesSection
+          tokenType="access"
+          currentAttributes={['email', 'username']}
+          userAttributes={['email', 'username']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-access', 'default-access'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set(['email'])}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="id"
+        />,
+      );
+
+      const jsonText = container.textContent || '';
+      // email should still be in preview since activeTokenType doesn't match tokenType
+      expect(jsonText).toContain('<email>');
+      expect(jsonText).toContain('<username>');
+    });
+
+    it('should show pending addition chip as active for shared token type', () => {
+      render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={[]}
+          userAttributes={['email', 'username']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-shared', 'default-shared'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set(['email'])}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      const emailChip = screen.getByText('email').closest('.MuiChip-root');
+      expect(emailChip).toBeInTheDocument();
+      // The chip for a pending addition should be filled/primary
+      expect(emailChip).toHaveClass('MuiChip-filled');
+    });
+
+    it('should show pending removal chip as inactive for shared token type', () => {
+      render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={['email']}
+          userAttributes={['email', 'username']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-shared', 'default-shared'])}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set(['email'])}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      const emailChip = screen.getByText('email').closest('.MuiChip-root');
+      expect(emailChip).toBeInTheDocument();
+      // The chip for a pending removal should be outlined/inactive
+      expect(emailChip).toHaveClass('MuiChip-outlined');
+    });
+  });
+
+  describe('Accordion Toggle Behavior', () => {
+    it('should collapse and re-expand user attributes accordion', async () => {
+      const user = userEvent.setup();
+      const mockSetExpandedSections = vi.fn();
+
+      render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-shared', 'default-shared'])}
+          setExpandedSections={mockSetExpandedSections}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      // Find the User Attributes accordion summary button
+      const accordionHeaders = screen.getAllByText('User Attributes');
+      const userAttributesButton = accordionHeaders.find((el) => el.closest('button') !== null);
+      expect(userAttributesButton).toBeDefined();
+
+      // Click to collapse
+      await user.click(userAttributesButton!);
+
+      // Verify setExpandedSections was called
+      expect(mockSetExpandedSections).toHaveBeenCalled();
+
+      // Get the updater function and test collapse behavior
+      const collapseUpdater = mockSetExpandedSections.mock.calls[mockSetExpandedSections.mock.calls.length - 1][0] as (
+        prev: Set<string>,
+      ) => Set<string>;
+      const collapseResult: Set<string> = collapseUpdater(new Set(['user-shared', 'default-shared']));
+      expect(collapseResult.has('user-shared')).toBe(false);
+      expect(collapseResult.has('default-shared')).toBe(true);
+
+      // Now simulate re-expand: render with collapsed state, then click to expand
+      mockSetExpandedSections.mockClear();
+
+      const {unmount} = render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['default-shared'])}
+          setExpandedSections={mockSetExpandedSections}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      const accordionHeaders2 = screen.getAllByText('User Attributes');
+      const userAttributesButton2 = accordionHeaders2.find((el) => el.closest('button') !== null);
+
+      await user.click(userAttributesButton2!);
+
+      // Find the call from the onChange handler (not the useEffect auto-expand)
+      const allCalls = mockSetExpandedSections.mock.calls as [(prev: Set<string>) => Set<string>][];
+      // Test the updater that adds user-shared back
+      const expandCall = allCalls.find((call) => {
+        if (typeof call[0] === 'function') {
+          const result: Set<string> = call[0](new Set(['default-shared']));
+          return result.has('user-shared');
+        }
+        return false;
+      });
+      expect(expandCall).toBeDefined();
+      const expandResult: Set<string> = expandCall![0](new Set(['default-shared']));
+      expect(expandResult.has('user-shared')).toBe(true);
+
+      unmount();
+    });
+
+    it('should collapse and re-expand default attributes accordion', async () => {
+      const user = userEvent.setup();
+      const mockSetExpandedSections = vi.fn();
+
+      render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-shared', 'default-shared'])}
+          setExpandedSections={mockSetExpandedSections}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      // Find the Default Attributes accordion summary button
+      const defaultAttributesButton = screen.getByText('Default Attributes').closest('button');
+      expect(defaultAttributesButton).toBeDefined();
+
+      // Click to collapse
+      await user.click(defaultAttributesButton!);
+
+      // Verify setExpandedSections was called
+      expect(mockSetExpandedSections).toHaveBeenCalled();
+
+      // Get the updater function and test collapse behavior (isExpanded=false -> delete)
+      const collapseUpdater = mockSetExpandedSections.mock.calls[mockSetExpandedSections.mock.calls.length - 1][0] as (
+        prev: Set<string>,
+      ) => Set<string>;
+      const collapseResult: Set<string> = collapseUpdater(new Set(['user-shared', 'default-shared']));
+      expect(collapseResult.has('default-shared')).toBe(false);
+      expect(collapseResult.has('user-shared')).toBe(true);
+
+      // Now simulate re-expand: render with collapsed default, click to expand
+      mockSetExpandedSections.mockClear();
+
+      const {unmount} = render(
+        <TokenUserAttributesSection
+          tokenType="shared"
+          currentAttributes={[]}
+          userAttributes={['email']}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set(['user-shared'])}
+          setExpandedSections={mockSetExpandedSections}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="access"
+        />,
+      );
+
+      const defaultAttributesButton2 = screen
+        .getAllByText('Default Attributes')
+        .find((el) => el.closest('button') !== null);
+
+      await user.click(defaultAttributesButton2!);
+
+      // Find the call from the onChange handler that adds default-shared back
+      const allCalls = mockSetExpandedSections.mock.calls as [(prev: Set<string>) => Set<string>][];
+      const expandCall = allCalls.find((call) => {
+        if (typeof call[0] === 'function') {
+          const result: Set<string> = call[0](new Set(['user-shared']));
+          return result.has('default-shared');
+        }
+        return false;
+      });
+      expect(expandCall).toBeDefined();
+      const expandResult: Set<string> = expandCall![0](new Set(['user-shared']));
+      expect(expandResult.has('default-shared')).toBe(true);
+
+      unmount();
+    });
+  });
+
+  describe('Refinements', () => {
+    it('should hide content when readOnly is true', () => {
+      render(
+        <TokenUserAttributesSection
+          tokenType="userinfo"
+          currentAttributes={[]}
+          userAttributes={[]}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set()}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="userinfo"
+          readOnly
+        />,
+      );
+
+      // Content should be hidden
+      expect(screen.queryByText('User Attributes')).not.toBeInTheDocument();
+      expect(screen.queryByText('Default Attributes')).not.toBeInTheDocument();
+    });
+
+    it('should render headerAction', () => {
+      render(
+        <TokenUserAttributesSection
+          tokenType="userinfo"
+          currentAttributes={[]}
+          userAttributes={[]}
+          isLoadingUserAttributes={false}
+          expandedSections={new Set()}
+          setExpandedSections={vi.fn()}
+          pendingAdditions={new Set()}
+          pendingRemovals={new Set()}
+          highlightedAttributes={new Set()}
+          onAttributeClick={vi.fn()}
+          activeTokenType="userinfo"
+          headerAction={<button type="button">Test Action</button>}
+        />,
+      );
+
+      expect(screen.getByText('Test Action')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/apps/thunder-develop/src/features/applications/constants/__tests__/token-constants.test.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/constants/__tests__/token-constants.test.ts
@@ -45,20 +45,8 @@ describe('TokenConstants', () => {
       });
     });
 
-    it('should contain organization unit claims', () => {
-      const ouClaims = ['ouHandle', 'ouId', 'ouName'];
-
-      ouClaims.forEach((claim) => {
-        expect(TokenConstants.DEFAULT_TOKEN_ATTRIBUTES).toContain(claim);
-      });
-    });
-
-    it('should contain userType claim', () => {
-      expect(TokenConstants.DEFAULT_TOKEN_ATTRIBUTES).toContain('userType');
-    });
-
     it('should have the expected number of attributes', () => {
-      expect(TokenConstants.DEFAULT_TOKEN_ATTRIBUTES).toHaveLength(14);
+      expect(TokenConstants.DEFAULT_TOKEN_ATTRIBUTES).toHaveLength(10);
     });
 
     it('should not contain duplicate values', () => {
@@ -76,15 +64,46 @@ describe('TokenConstants', () => {
         'iss',
         'jti',
         'nbf',
-        'ouHandle',
-        'ouId',
-        'ouName',
         'scope',
         'sub',
-        'userType',
       ];
 
       expect(TokenConstants.DEFAULT_TOKEN_ATTRIBUTES).toEqual(expectedAttributes);
+    });
+  });
+
+  describe('USER_INFO_DEFAULT_ATTRIBUTES', () => {
+    it('should be defined', () => {
+      expect(TokenConstants.USER_INFO_DEFAULT_ATTRIBUTES).toBeDefined();
+    });
+
+    it('should be an array', () => {
+      expect(Array.isArray(TokenConstants.USER_INFO_DEFAULT_ATTRIBUTES)).toBe(true);
+    });
+
+    it('should contain sub attribute', () => {
+      expect(TokenConstants.USER_INFO_DEFAULT_ATTRIBUTES).toContain('sub');
+    });
+
+    it('should match expected defaults', () => {
+      expect(TokenConstants.USER_INFO_DEFAULT_ATTRIBUTES).toEqual(['sub']);
+    });
+  });
+
+  describe('ADDITIONAL_USER_ATTRIBUTES', () => {
+    it('should be defined', () => {
+      expect(TokenConstants.ADDITIONAL_USER_ATTRIBUTES).toBeDefined();
+    });
+
+    it('should be an array', () => {
+      expect(Array.isArray(TokenConstants.ADDITIONAL_USER_ATTRIBUTES)).toBe(true);
+    });
+
+    it('should contain expected attributes', () => {
+      expect(TokenConstants.ADDITIONAL_USER_ATTRIBUTES).toContain('ouHandle');
+      expect(TokenConstants.ADDITIONAL_USER_ATTRIBUTES).toContain('ouId');
+      expect(TokenConstants.ADDITIONAL_USER_ATTRIBUTES).toContain('ouName');
+      expect(TokenConstants.ADDITIONAL_USER_ATTRIBUTES).toContain('userType');
     });
   });
 });

--- a/frontend/apps/thunder-develop/src/features/applications/constants/token-constants.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/constants/token-constants.ts
@@ -32,13 +32,19 @@ const TokenConstants = {
     'iss',
     'jti',
     'nbf',
-    'ouHandle',
-    'ouId',
-    'ouName',
     'scope',
     'sub',
-    'userType',
   ],
+
+  /**
+   * Default attributes for User Info response
+   */
+  USER_INFO_DEFAULT_ATTRIBUTES: ['sub'],
+
+  /**
+   * Additional system attributes that can be configured as user attributes
+   */
+  ADDITIONAL_USER_ATTRIBUTES: ['ouHandle', 'ouId', 'ouName', 'userType'],
 } as const;
 
 export default TokenConstants;

--- a/frontend/apps/thunder-develop/src/features/applications/models/__tests__/oauth.test.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/models/__tests__/oauth.test.ts
@@ -17,7 +17,7 @@
  */
 
 import {describe, expect, it} from 'vitest';
-import {OAuth2GrantTypes, OAuth2ResponseTypes} from '../oauth';
+import {OAuth2GrantTypes, OAuth2ResponseTypes, getDefaultOAuthConfig} from '../oauth';
 import type {OAuth2GrantType, OAuth2ResponseType, TokenEndpointAuthMethod} from '../oauth';
 
 describe('OAuth Models', () => {
@@ -123,6 +123,31 @@ describe('OAuth Models', () => {
       validAuthMethods.forEach((method) => {
         expect(typeof method).toBe('string');
       });
+    });
+  });
+
+  describe('getDefaultOAuthConfig', () => {
+    it('should return a valid default configuration', () => {
+      const config = getDefaultOAuthConfig();
+
+      expect(config).toBeDefined();
+      expect(config.token).toBeDefined();
+      expect(config.grant_types).toContain(OAuth2GrantTypes.CLIENT_CREDENTIALS);
+      expect(config.pkce_required).toBe(false);
+    });
+
+    it('should not include user_info configuration by default (implying inheritance)', () => {
+      const config = getDefaultOAuthConfig();
+
+      expect(config.user_info).toBeUndefined();
+    });
+
+    it('should include default ID token scope claims', () => {
+      const config = getDefaultOAuthConfig();
+
+      expect(config.token?.id_token?.scope_claims).toBeDefined();
+      expect(config.token?.id_token?.scope_claims.email).toBeDefined();
+      expect(config.token?.id_token?.scope_claims.profile).toBeDefined();
     });
   });
 });

--- a/frontend/apps/thunder-develop/src/features/applications/models/oauth.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/models/oauth.ts
@@ -398,6 +398,27 @@ export interface OAuth2Config {
    * Defines how access tokens and ID tokens are generated
    */
   token?: OAuth2Token & Partial<TokenConfig>;
+
+  /**
+   * User Info configuration
+   * Defines which attributes are returned in the user info response
+   */
+  user_info?: UserInfoConfig;
+}
+
+/**
+ * User Info Configuration
+ *
+ * Configuration specific to the User Info endpoint response.
+ * Allows defining which user attributes should be returned in the user info response.
+ *
+ * @public
+ */
+export interface UserInfoConfig {
+  /**
+   * List of user attributes to include in the user info response
+   */
+  user_attributes: string[];
 }
 
 /**


### PR DESCRIPTION
### Purpose
This pull request introduces enhancements to the token settings view in the application edit UI to allow customizing user attributes returned in the User Info endpoint, including a toggle to inherit attributes from the ID token, and the generalization of token attribute handling to include this new "userinfo" type.

<img width="1176" height="385" alt="Screenshot 2026-02-09 at 7 47 24 PM" src="https://github.com/user-attachments/assets/22f6723e-244e-489e-98dd-4a84c2a80dd3" />

<img width="1222" height="619" alt="Screenshot 2026-02-09 at 7 46 38 PM" src="https://github.com/user-attachments/assets/ba35c0cc-13d2-4596-a819-f059e7d98b73" />

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/1217

### Related PRs
- https://github.com/asgardeo/thunder/pull/1309

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User Info attributes added to OAuth/OIDC token settings with an "Inherit from ID Token" toggle and a dedicated UserInfo section; UI respects read-only state.
  * Settings cards and attribute sections support custom header actions and read-only gating.
  * Default token attributes adjusted: organization-unit fields moved to an additional attributes list; new default for UserInfo attributes added.

* **Public API**
  * Added a UserInfo configuration model and a default OAuth config helper.

* **Tests**
  * Added/updated unit tests for User Info behavior, header actions, and attribute lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->