### PR TITLE
Group service context propagation and transection usage

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -103,7 +103,10 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	if err != nil {
 		logger.Fatal("Failed to initialize UserService", log.Error(err))
 	}
-	groupService := group.Initialize(mux, ouService, userService)
+	groupService, err := group.Initialize(mux, ouService, userService)
+	if err != nil {
+		logger.Fatal("Failed to initialize GroupService", log.Error(err))
+	}
 
 	resourceService, err := resource.Initialize(mux, ouService)
 	if err != nil {

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -397,7 +397,7 @@ func (p *provisioningExecutor) assignGroupsAndRoles(
 	var groupErr, roleErr error
 	// Assign to group
 	if groupID != "" {
-		if err := p.assignToGroup(userID, groupID, logger); err != nil {
+		if err := p.assignToGroup(context.TODO(), userID, groupID, logger); err != nil {
 			groupErr = fmt.Errorf("failed to assign user to group %s: %w", groupID, err)
 		}
 	}
@@ -460,13 +460,18 @@ func (p *provisioningExecutor) getRoleToAssign(ctx *core.NodeContext) string {
 }
 
 // assignToGroup adds the user to the specified group.
-func (p *provisioningExecutor) assignToGroup(userID string, groupID string, logger *log.Logger) error {
+func (p *provisioningExecutor) assignToGroup(
+	ctx context.Context,
+	userID string,
+	groupID string,
+	logger *log.Logger,
+) error {
 	logger.Debug("Adding user to group",
 		log.String("userID", userID),
 		log.String("groupID", groupID))
 
 	// Get existing group to retrieve current members
-	existingGroup, svcErr := p.groupService.GetGroup(groupID)
+	existingGroup, svcErr := p.groupService.GetGroup(ctx, groupID)
 	if svcErr != nil {
 		logger.Error("Failed to retrieve group for assignment",
 			log.String("groupID", groupID),
@@ -490,7 +495,7 @@ func (p *provisioningExecutor) assignToGroup(userID string, groupID string, logg
 		Members:            updatedMembers,
 	}
 
-	_, svcErr = p.groupService.UpdateGroup(groupID, updateRequest)
+	_, svcErr = p.groupService.UpdateGroup(ctx, groupID, updateRequest)
 	if svcErr != nil {
 		logger.Error("Failed to update group with new member",
 			log.String("groupID", groupID),

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -172,8 +172,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 		OrganizationUnitID: testOUID,
 		Members:            []group.Member{},
 	}
-	suite.mockGroupService.On("GetGroup", "test-group-id").Return(existingGroup, nil)
-	suite.mockGroupService.On("UpdateGroup", "test-group-id",
+	suite.mockGroupService.On("GetGroup", mock.Anything, "test-group-id").Return(existingGroup, nil)
+	suite.mockGroupService.On("UpdateGroup", mock.Anything, "test-group-id",
 		mock.MatchedBy(func(req group.UpdateGroupRequest) bool {
 			return len(req.Members) == 1 &&
 				req.Members[0].ID == testNewUserID &&
@@ -996,7 +996,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_GroupAssignmentF
 	suite.mockUserService.On("CreateUser", mock.Anything, mock.Anything).Return(createdUser, nil)
 
 	// Mock group retrieval fails (e.g., group doesn't exist)
-	suite.mockGroupService.On("GetGroup", "test-group-id").
+	suite.mockGroupService.On("GetGroup", mock.Anything, "test-group-id").
 		Return(nil, &serviceerror.ServiceError{Error: "Group not found"})
 
 	// Role assignment should still be attempted
@@ -1050,7 +1050,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_BothGroupAndRole
 	suite.mockUserService.On("CreateUser", mock.Anything, mock.Anything).Return(createdUser, nil)
 
 	// Mock group retrieval fails
-	suite.mockGroupService.On("GetGroup", "test-group-id").
+	suite.mockGroupService.On("GetGroup", mock.Anything, "test-group-id").
 		Return(nil, &serviceerror.ServiceError{Error: "Group not found"})
 
 	// Mock role assignment also fails
@@ -1111,8 +1111,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_RoleAssignmentFa
 		OrganizationUnitID: testOUID,
 		Members:            []group.Member{},
 	}
-	suite.mockGroupService.On("GetGroup", "test-group-id").Return(existingGroup, nil)
-	suite.mockGroupService.On("UpdateGroup", "test-group-id", mock.Anything).
+	suite.mockGroupService.On("GetGroup", mock.Anything, "test-group-id").Return(existingGroup, nil)
+	suite.mockGroupService.On("UpdateGroup", mock.Anything, "test-group-id", mock.Anything).
 		Return(existingGroup, nil)
 
 	// Role assignment fails (e.g., role doesn't exist)
@@ -1177,10 +1177,10 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_GroupWithExistingMembers
 			{ID: "existing-user-2", Type: group.MemberTypeUser},
 		},
 	}
-	suite.mockGroupService.On("GetGroup", "test-group-id").Return(existingGroup, nil)
+	suite.mockGroupService.On("GetGroup", mock.Anything, "test-group-id").Return(existingGroup, nil)
 
 	// Verify UpdateGroup is called with all 3 members (2 existing + 1 new)
-	suite.mockGroupService.On("UpdateGroup", "test-group-id",
+	suite.mockGroupService.On("UpdateGroup", mock.Anything, "test-group-id",
 		mock.MatchedBy(func(req group.UpdateGroupRequest) bool {
 			if len(req.Members) != 3 {
 				return false
@@ -1255,8 +1255,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_AuthFlow_AutoProvisionin
 		OrganizationUnitID: testOUID,
 		Members:            []group.Member{},
 	}
-	suite.mockGroupService.On("GetGroup", "test-group-id").Return(existingGroup, nil)
-	suite.mockGroupService.On("UpdateGroup", "test-group-id", mock.Anything).
+	suite.mockGroupService.On("GetGroup", mock.Anything, "test-group-id").Return(existingGroup, nil)
+	suite.mockGroupService.On("UpdateGroup", mock.Anything, "test-group-id", mock.Anything).
 		Return(existingGroup, nil)
 	suite.mockRoleService.On("AddAssignments", mock.Anything, "test-role-id", mock.Anything).Return(nil)
 
@@ -1321,10 +1321,10 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success_WithGroupAndRole
 		OrganizationUnitID: testOUID,
 		Members:            []group.Member{},
 	}
-	suite.mockGroupService.On("GetGroup", "test-group-id").Return(existingGroup, nil)
+	suite.mockGroupService.On("GetGroup", mock.Anything, "test-group-id").Return(existingGroup, nil)
 
 	// Mock UpdateGroup - should be called with user added to members
-	suite.mockGroupService.On("UpdateGroup", "test-group-id",
+	suite.mockGroupService.On("UpdateGroup", mock.Anything, "test-group-id",
 		mock.MatchedBy(func(req group.UpdateGroupRequest) bool {
 			return len(req.Members) == 1 &&
 				req.Members[0].ID == testNewUserID &&

--- a/backend/internal/group/GroupServiceInterface_mock_test.go
+++ b/backend/internal/group/GroupServiceInterface_mock_test.go
@@ -5,6 +5,8 @@
 package group
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,8 +39,8 @@ func (_m *GroupServiceInterfaceMock) EXPECT() *GroupServiceInterfaceMock_Expecte
 }
 
 // CreateGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) CreateGroup(request CreateGroupRequest) (*Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *GroupServiceInterfaceMock) CreateGroup(ctx context.Context, request CreateGroupRequest) (*Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGroup")
@@ -46,18 +48,18 @@ func (_mock *GroupServiceInterfaceMock) CreateGroup(request CreateGroupRequest) 
 
 	var r0 *Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(CreateGroupRequest) (*Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateGroupRequest) (*Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(CreateGroupRequest) *Group); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateGroupRequest) *Group); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(CreateGroupRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, CreateGroupRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type GroupServiceInterfaceMock_CreateGroup_Call struct {
 }
 
 // CreateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request CreateGroupRequest
-func (_e *GroupServiceInterfaceMock_Expecter) CreateGroup(request interface{}) *GroupServiceInterfaceMock_CreateGroup_Call {
-	return &GroupServiceInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", request)}
+func (_e *GroupServiceInterfaceMock_Expecter) CreateGroup(ctx interface{}, request interface{}) *GroupServiceInterfaceMock_CreateGroup_Call {
+	return &GroupServiceInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", ctx, request)}
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroup_Call) Run(run func(request CreateGroupRequest)) *GroupServiceInterfaceMock_CreateGroup_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroup_Call) Run(run func(ctx context.Context, request CreateGroupRequest)) *GroupServiceInterfaceMock_CreateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 CreateGroupRequest
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(CreateGroupRequest)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 CreateGroupRequest
+		if args[1] != nil {
+			arg1 = args[1].(CreateGroupRequest)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,14 +103,14 @@ func (_c *GroupServiceInterfaceMock_CreateGroup_Call) Return(group *Group, servi
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroup_Call) RunAndReturn(run func(request CreateGroupRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroup_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroup_Call) RunAndReturn(run func(ctx context.Context, request CreateGroupRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateGroupByPath provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) CreateGroupByPath(handlePath string, request CreateGroupByPathRequest) (*Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(handlePath, request)
+func (_mock *GroupServiceInterfaceMock) CreateGroupByPath(ctx context.Context, handlePath string, request CreateGroupByPathRequest) (*Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGroupByPath")
@@ -110,18 +118,18 @@ func (_mock *GroupServiceInterfaceMock) CreateGroupByPath(handlePath string, req
 
 	var r0 *Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, CreateGroupByPathRequest) (*Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(handlePath, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, CreateGroupByPathRequest) (*Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, CreateGroupByPathRequest) *Group); ok {
-		r0 = returnFunc(handlePath, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, CreateGroupByPathRequest) *Group); ok {
+		r0 = returnFunc(ctx, handlePath, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, CreateGroupByPathRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(handlePath, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, CreateGroupByPathRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -136,25 +144,31 @@ type GroupServiceInterfaceMock_CreateGroupByPath_Call struct {
 }
 
 // CreateGroupByPath is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handlePath string
 //   - request CreateGroupByPathRequest
-func (_e *GroupServiceInterfaceMock_Expecter) CreateGroupByPath(handlePath interface{}, request interface{}) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
-	return &GroupServiceInterfaceMock_CreateGroupByPath_Call{Call: _e.mock.On("CreateGroupByPath", handlePath, request)}
+func (_e *GroupServiceInterfaceMock_Expecter) CreateGroupByPath(ctx interface{}, handlePath interface{}, request interface{}) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
+	return &GroupServiceInterfaceMock_CreateGroupByPath_Call{Call: _e.mock.On("CreateGroupByPath", ctx, handlePath, request)}
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) Run(run func(handlePath string, request CreateGroupByPathRequest)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) Run(run func(ctx context.Context, handlePath string, request CreateGroupByPathRequest)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 CreateGroupByPathRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(CreateGroupByPathRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 CreateGroupByPathRequest
+		if args[2] != nil {
+			arg2 = args[2].(CreateGroupByPathRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -165,22 +179,22 @@ func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) Return(group *Group,
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) RunAndReturn(run func(handlePath string, request CreateGroupByPathRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, request CreateGroupByPathRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) DeleteGroup(groupID string) *serviceerror.ServiceError {
-	ret := _mock.Called(groupID)
+func (_mock *GroupServiceInterfaceMock) DeleteGroup(ctx context.Context, groupID string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, groupID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteGroup")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, groupID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -195,19 +209,25 @@ type GroupServiceInterfaceMock_DeleteGroup_Call struct {
 }
 
 // DeleteGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
-func (_e *GroupServiceInterfaceMock_Expecter) DeleteGroup(groupID interface{}) *GroupServiceInterfaceMock_DeleteGroup_Call {
-	return &GroupServiceInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", groupID)}
+func (_e *GroupServiceInterfaceMock_Expecter) DeleteGroup(ctx interface{}, groupID interface{}) *GroupServiceInterfaceMock_DeleteGroup_Call {
+	return &GroupServiceInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", ctx, groupID)}
 }
 
-func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) Run(run func(groupID string)) *GroupServiceInterfaceMock_DeleteGroup_Call {
+func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) Run(run func(ctx context.Context, groupID string)) *GroupServiceInterfaceMock_DeleteGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -218,14 +238,14 @@ func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) Return(serviceError *servi
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(groupID string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_DeleteGroup_Call {
+func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_DeleteGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroup(groupID string) (*Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(groupID)
+func (_mock *GroupServiceInterfaceMock) GetGroup(ctx context.Context, groupID string) (*Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroup")
@@ -233,18 +253,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroup(groupID string) (*Group, *servi
 
 	var r0 *Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *Group); ok {
-		r0 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *Group); ok {
+		r0 = returnFunc(ctx, groupID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -259,19 +279,25 @@ type GroupServiceInterfaceMock_GetGroup_Call struct {
 }
 
 // GetGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroup(groupID interface{}) *GroupServiceInterfaceMock_GetGroup_Call {
-	return &GroupServiceInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", groupID)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroup(ctx interface{}, groupID interface{}) *GroupServiceInterfaceMock_GetGroup_Call {
+	return &GroupServiceInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", ctx, groupID)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroup_Call) Run(run func(groupID string)) *GroupServiceInterfaceMock_GetGroup_Call {
+func (_c *GroupServiceInterfaceMock_GetGroup_Call) Run(run func(ctx context.Context, groupID string)) *GroupServiceInterfaceMock_GetGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -282,14 +308,14 @@ func (_c *GroupServiceInterfaceMock_GetGroup_Call) Return(group *Group, serviceE
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroup_Call) RunAndReturn(run func(groupID string) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroup_Call {
+func (_c *GroupServiceInterfaceMock_GetGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupList provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroupList(limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(limit, offset)
+func (_mock *GroupServiceInterfaceMock) GetGroupList(ctx context.Context, limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupList")
@@ -297,18 +323,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroupList(limit int, offset int) (*Gr
 
 	var r0 *GroupListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(int, int) (*GroupListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*GroupListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) *GroupListResponse); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *GroupListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*GroupListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -323,25 +349,31 @@ type GroupServiceInterfaceMock_GetGroupList_Call struct {
 }
 
 // GetGroupList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroupList(limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupList_Call {
-	return &GroupServiceInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", limit, offset)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupList(ctx interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupList_Call {
+	return &GroupServiceInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", ctx, limit, offset)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupList_Call) Run(run func(limit int, offset int)) *GroupServiceInterfaceMock_GetGroupList_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupList_Call) Run(run func(ctx context.Context, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -352,14 +384,14 @@ func (_c *GroupServiceInterfaceMock_GetGroupList_Call) Return(groupListResponse 
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupList_Call) RunAndReturn(run func(limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupList_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupMembers provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroupMembers(groupID string, limit int, offset int) (*MemberListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(groupID, limit, offset)
+func (_mock *GroupServiceInterfaceMock) GetGroupMembers(ctx context.Context, groupID string, limit int, offset int) (*MemberListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupMembers")
@@ -367,18 +399,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroupMembers(groupID string, limit in
 
 	var r0 *MemberListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) (*MemberListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*MemberListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) *MemberListResponse); ok {
-		r0 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *MemberListResponse); ok {
+		r0 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*MemberListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -393,31 +425,37 @@ type GroupServiceInterfaceMock_GetGroupMembers_Call struct {
 }
 
 // GetGroupMembers is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
 //   - limit int
 //   - offset int
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroupMembers(groupID interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupMembers_Call {
-	return &GroupServiceInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", groupID, limit, offset)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupMembers(ctx interface{}, groupID interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupMembers_Call {
+	return &GroupServiceInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", ctx, groupID, limit, offset)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) Run(run func(groupID string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) Run(run func(ctx context.Context, groupID string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -428,14 +466,14 @@ func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) Return(memberListRespo
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(groupID string, limit int, offset int) (*MemberListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, limit int, offset int) (*MemberListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupsByPath provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(handlePath string, limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(handlePath, limit, offset)
+func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(ctx context.Context, handlePath string, limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupsByPath")
@@ -443,18 +481,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(handlePath string, limit
 
 	var r0 *GroupListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) (*GroupListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*GroupListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) *GroupListResponse); ok {
-		r0 = returnFunc(handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *GroupListResponse); ok {
+		r0 = returnFunc(ctx, handlePath, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*GroupListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -469,31 +507,37 @@ type GroupServiceInterfaceMock_GetGroupsByPath_Call struct {
 }
 
 // GetGroupsByPath is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handlePath string
 //   - limit int
 //   - offset int
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroupsByPath(handlePath interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
-	return &GroupServiceInterfaceMock_GetGroupsByPath_Call{Call: _e.mock.On("GetGroupsByPath", handlePath, limit, offset)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupsByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+	return &GroupServiceInterfaceMock_GetGroupsByPath_Call{Call: _e.mock.On("GetGroupsByPath", ctx, handlePath, limit, offset)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Run(run func(handlePath string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -504,14 +548,14 @@ func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Return(groupListRespon
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(handlePath string, limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) UpdateGroup(groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(groupID, request)
+func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateGroup")
@@ -519,18 +563,18 @@ func (_mock *GroupServiceInterfaceMock) UpdateGroup(groupID string, request Upda
 
 	var r0 *Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, UpdateGroupRequest) (*Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(groupID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateGroupRequest) (*Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, UpdateGroupRequest) *Group); ok {
-		r0 = returnFunc(groupID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateGroupRequest) *Group); ok {
+		r0 = returnFunc(ctx, groupID, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, UpdateGroupRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(groupID, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, UpdateGroupRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -545,25 +589,31 @@ type GroupServiceInterfaceMock_UpdateGroup_Call struct {
 }
 
 // UpdateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
 //   - request UpdateGroupRequest
-func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", groupID, request)}
+func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(ctx interface{}, groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, groupID, request)}
 }
 
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(groupID string, request UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, groupID string, request UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 UpdateGroupRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(UpdateGroupRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 UpdateGroupRequest
+		if args[2] != nil {
+			arg2 = args[2].(UpdateGroupRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -574,22 +624,22 @@ func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Return(group *Group, servi
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateGroupIDs provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) ValidateGroupIDs(groupIDs []string) *serviceerror.ServiceError {
-	ret := _mock.Called(groupIDs)
+func (_mock *GroupServiceInterfaceMock) ValidateGroupIDs(ctx context.Context, groupIDs []string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, groupIDs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateGroupIDs")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func([]string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, groupIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -604,19 +654,25 @@ type GroupServiceInterfaceMock_ValidateGroupIDs_Call struct {
 }
 
 // ValidateGroupIDs is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupIDs []string
-func (_e *GroupServiceInterfaceMock_Expecter) ValidateGroupIDs(groupIDs interface{}) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
-	return &GroupServiceInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", groupIDs)}
+func (_e *GroupServiceInterfaceMock_Expecter) ValidateGroupIDs(ctx interface{}, groupIDs interface{}) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
+	return &GroupServiceInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", ctx, groupIDs)}
 }
 
-func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) Run(run func(groupIDs []string)) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
+func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -627,7 +683,7 @@ func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) Return(serviceError *
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(groupIDs []string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
+func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/group/groupStoreInterface_mock_test.go
+++ b/backend/internal/group/groupStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package group
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *groupStoreInterfaceMock) EXPECT() *groupStoreInterfaceMock_Expecter {
 }
 
 // CheckGroupNameConflictForCreate provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForCreate(name string, organizationUnitID string) error {
-	ret := _mock.Called(name, organizationUnitID)
+func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForCreate(ctx context.Context, name string, organizationUnitID string) error {
+	ret := _mock.Called(ctx, name, organizationUnitID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckGroupNameConflictForCreate")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(name, organizationUnitID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, name, organizationUnitID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,75 +60,18 @@ type groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call struct {
 }
 
 // CheckGroupNameConflictForCreate is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
 //   - organizationUnitID string
-func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForCreate(name interface{}, organizationUnitID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
-	return &groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call{Call: _e.mock.On("CheckGroupNameConflictForCreate", name, organizationUnitID)}
+func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForCreate(ctx interface{}, name interface{}, organizationUnitID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+	return &groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call{Call: _e.mock.On("CheckGroupNameConflictForCreate", ctx, name, organizationUnitID)}
 }
 
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Run(run func(name string, organizationUnitID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Run(run func(ctx context.Context, name string, organizationUnitID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Return(err error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) RunAndReturn(run func(name string, organizationUnitID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CheckGroupNameConflictForUpdate provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForUpdate(name string, organizationUnitID string, groupID string) error {
-	ret := _mock.Called(name, organizationUnitID, groupID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CheckGroupNameConflictForUpdate")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = returnFunc(name, organizationUnitID, groupID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckGroupNameConflictForUpdate'
-type groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call struct {
-	*mock.Call
-}
-
-// CheckGroupNameConflictForUpdate is a helper method to define mock.On call
-//   - name string
-//   - organizationUnitID string
-//   - groupID string
-func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForUpdate(name interface{}, organizationUnitID interface{}, groupID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
-	return &groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call{Call: _e.mock.On("CheckGroupNameConflictForUpdate", name, organizationUnitID, groupID)}
-}
-
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Run(run func(name string, organizationUnitID string, groupID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -145,27 +90,96 @@ func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Run(run 
 	return _c
 }
 
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Return(err error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) RunAndReturn(run func(ctx context.Context, name string, organizationUnitID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CheckGroupNameConflictForUpdate provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForUpdate(ctx context.Context, name string, organizationUnitID string, groupID string) error {
+	ret := _mock.Called(ctx, name, organizationUnitID, groupID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CheckGroupNameConflictForUpdate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, name, organizationUnitID, groupID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckGroupNameConflictForUpdate'
+type groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call struct {
+	*mock.Call
+}
+
+// CheckGroupNameConflictForUpdate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+//   - organizationUnitID string
+//   - groupID string
+func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForUpdate(ctx interface{}, name interface{}, organizationUnitID interface{}, groupID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
+	return &groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call{Call: _e.mock.On("CheckGroupNameConflictForUpdate", ctx, name, organizationUnitID, groupID)}
+}
+
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Run(run func(ctx context.Context, name string, organizationUnitID string, groupID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
 func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Return(err error) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) RunAndReturn(run func(name string, organizationUnitID string, groupID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) RunAndReturn(run func(ctx context.Context, name string, organizationUnitID string, groupID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) CreateGroup(group GroupDAO) error {
-	ret := _mock.Called(group)
+func (_mock *groupStoreInterfaceMock) CreateGroup(ctx context.Context, group GroupDAO) error {
+	ret := _mock.Called(ctx, group)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGroup")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(GroupDAO) error); ok {
-		r0 = returnFunc(group)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, GroupDAO) error); ok {
+		r0 = returnFunc(ctx, group)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -178,19 +192,25 @@ type groupStoreInterfaceMock_CreateGroup_Call struct {
 }
 
 // CreateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - group GroupDAO
-func (_e *groupStoreInterfaceMock_Expecter) CreateGroup(group interface{}) *groupStoreInterfaceMock_CreateGroup_Call {
-	return &groupStoreInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", group)}
+func (_e *groupStoreInterfaceMock_Expecter) CreateGroup(ctx interface{}, group interface{}) *groupStoreInterfaceMock_CreateGroup_Call {
+	return &groupStoreInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", ctx, group)}
 }
 
-func (_c *groupStoreInterfaceMock_CreateGroup_Call) Run(run func(group GroupDAO)) *groupStoreInterfaceMock_CreateGroup_Call {
+func (_c *groupStoreInterfaceMock_CreateGroup_Call) Run(run func(ctx context.Context, group GroupDAO)) *groupStoreInterfaceMock_CreateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 GroupDAO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(GroupDAO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 GroupDAO
+		if args[1] != nil {
+			arg1 = args[1].(GroupDAO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -201,22 +221,22 @@ func (_c *groupStoreInterfaceMock_CreateGroup_Call) Return(err error) *groupStor
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_CreateGroup_Call) RunAndReturn(run func(group GroupDAO) error) *groupStoreInterfaceMock_CreateGroup_Call {
+func (_c *groupStoreInterfaceMock_CreateGroup_Call) RunAndReturn(run func(ctx context.Context, group GroupDAO) error) *groupStoreInterfaceMock_CreateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) DeleteGroup(id string) error {
-	ret := _mock.Called(id)
+func (_mock *groupStoreInterfaceMock) DeleteGroup(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteGroup")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -229,19 +249,25 @@ type groupStoreInterfaceMock_DeleteGroup_Call struct {
 }
 
 // DeleteGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *groupStoreInterfaceMock_Expecter) DeleteGroup(id interface{}) *groupStoreInterfaceMock_DeleteGroup_Call {
-	return &groupStoreInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", id)}
+func (_e *groupStoreInterfaceMock_Expecter) DeleteGroup(ctx interface{}, id interface{}) *groupStoreInterfaceMock_DeleteGroup_Call {
+	return &groupStoreInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", ctx, id)}
 }
 
-func (_c *groupStoreInterfaceMock_DeleteGroup_Call) Run(run func(id string)) *groupStoreInterfaceMock_DeleteGroup_Call {
+func (_c *groupStoreInterfaceMock_DeleteGroup_Call) Run(run func(ctx context.Context, id string)) *groupStoreInterfaceMock_DeleteGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -252,14 +278,14 @@ func (_c *groupStoreInterfaceMock_DeleteGroup_Call) Return(err error) *groupStor
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(id string) error) *groupStoreInterfaceMock_DeleteGroup_Call {
+func (_c *groupStoreInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(ctx context.Context, id string) error) *groupStoreInterfaceMock_DeleteGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroup(id string) (GroupDAO, error) {
-	ret := _mock.Called(id)
+func (_mock *groupStoreInterfaceMock) GetGroup(ctx context.Context, id string) (GroupDAO, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroup")
@@ -267,16 +293,16 @@ func (_mock *groupStoreInterfaceMock) GetGroup(id string) (GroupDAO, error) {
 
 	var r0 GroupDAO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (GroupDAO, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (GroupDAO, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) GroupDAO); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) GroupDAO); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(GroupDAO)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -289,19 +315,25 @@ type groupStoreInterfaceMock_GetGroup_Call struct {
 }
 
 // GetGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *groupStoreInterfaceMock_Expecter) GetGroup(id interface{}) *groupStoreInterfaceMock_GetGroup_Call {
-	return &groupStoreInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", id)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroup(ctx interface{}, id interface{}) *groupStoreInterfaceMock_GetGroup_Call {
+	return &groupStoreInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", ctx, id)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroup_Call) Run(run func(id string)) *groupStoreInterfaceMock_GetGroup_Call {
+func (_c *groupStoreInterfaceMock_GetGroup_Call) Run(run func(ctx context.Context, id string)) *groupStoreInterfaceMock_GetGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -312,14 +344,14 @@ func (_c *groupStoreInterfaceMock_GetGroup_Call) Return(groupDAO GroupDAO, err e
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroup_Call) RunAndReturn(run func(id string) (GroupDAO, error)) *groupStoreInterfaceMock_GetGroup_Call {
+func (_c *groupStoreInterfaceMock_GetGroup_Call) RunAndReturn(run func(ctx context.Context, id string) (GroupDAO, error)) *groupStoreInterfaceMock_GetGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupList provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupList(limit int, offset int) ([]GroupBasicDAO, error) {
-	ret := _mock.Called(limit, offset)
+func (_mock *groupStoreInterfaceMock) GetGroupList(ctx context.Context, limit int, offset int) ([]GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupList")
@@ -327,18 +359,18 @@ func (_mock *groupStoreInterfaceMock) GetGroupList(limit int, offset int) ([]Gro
 
 	var r0 []GroupBasicDAO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]GroupBasicDAO, error)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []GroupBasicDAO); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]GroupBasicDAO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -351,25 +383,31 @@ type groupStoreInterfaceMock_GetGroupList_Call struct {
 }
 
 // GetGroupList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupList(limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupList_Call {
-	return &groupStoreInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", limit, offset)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupList(ctx interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupList_Call {
+	return &groupStoreInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", ctx, limit, offset)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupList_Call) Run(run func(limit int, offset int)) *groupStoreInterfaceMock_GetGroupList_Call {
+func (_c *groupStoreInterfaceMock_GetGroupList_Call) Run(run func(ctx context.Context, limit int, offset int)) *groupStoreInterfaceMock_GetGroupList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -380,14 +418,14 @@ func (_c *groupStoreInterfaceMock_GetGroupList_Call) Return(groupBasicDAOs []Gro
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupList_Call) RunAndReturn(run func(limit int, offset int) ([]GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupList_Call {
+func (_c *groupStoreInterfaceMock_GetGroupList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupListCount provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupListCount() (int, error) {
-	ret := _mock.Called()
+func (_mock *groupStoreInterfaceMock) GetGroupListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupListCount")
@@ -395,16 +433,16 @@ func (_mock *groupStoreInterfaceMock) GetGroupListCount() (int, error) {
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -417,13 +455,20 @@ type groupStoreInterfaceMock_GetGroupListCount_Call struct {
 }
 
 // GetGroupListCount is a helper method to define mock.On call
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupListCount() *groupStoreInterfaceMock_GetGroupListCount_Call {
-	return &groupStoreInterfaceMock_GetGroupListCount_Call{Call: _e.mock.On("GetGroupListCount")}
+//   - ctx context.Context
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupListCount(ctx interface{}) *groupStoreInterfaceMock_GetGroupListCount_Call {
+	return &groupStoreInterfaceMock_GetGroupListCount_Call{Call: _e.mock.On("GetGroupListCount", ctx)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Run(run func()) *groupStoreInterfaceMock_GetGroupListCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Run(run func(ctx context.Context)) *groupStoreInterfaceMock_GetGroupListCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -433,14 +478,14 @@ func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Return(n int, err erro
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) RunAndReturn(run func() (int, error)) *groupStoreInterfaceMock_GetGroupListCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *groupStoreInterfaceMock_GetGroupListCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupMemberCount provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupMemberCount(groupID string) (int, error) {
-	ret := _mock.Called(groupID)
+func (_mock *groupStoreInterfaceMock) GetGroupMemberCount(ctx context.Context, groupID string) (int, error) {
+	ret := _mock.Called(ctx, groupID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupMemberCount")
@@ -448,16 +493,16 @@ func (_mock *groupStoreInterfaceMock) GetGroupMemberCount(groupID string) (int, 
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, groupID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, groupID)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, groupID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -470,19 +515,25 @@ type groupStoreInterfaceMock_GetGroupMemberCount_Call struct {
 }
 
 // GetGroupMemberCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupMemberCount(groupID interface{}) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
-	return &groupStoreInterfaceMock_GetGroupMemberCount_Call{Call: _e.mock.On("GetGroupMemberCount", groupID)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupMemberCount(ctx interface{}, groupID interface{}) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
+	return &groupStoreInterfaceMock_GetGroupMemberCount_Call{Call: _e.mock.On("GetGroupMemberCount", ctx, groupID)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) Run(run func(groupID string)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) Run(run func(ctx context.Context, groupID string)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -493,14 +544,14 @@ func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) Return(n int, err er
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) RunAndReturn(run func(groupID string) (int, error)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) RunAndReturn(run func(ctx context.Context, groupID string) (int, error)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupMembers provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupMembers(groupID string, limit int, offset int) ([]Member, error) {
-	ret := _mock.Called(groupID, limit, offset)
+func (_mock *groupStoreInterfaceMock) GetGroupMembers(ctx context.Context, groupID string, limit int, offset int) ([]Member, error) {
+	ret := _mock.Called(ctx, groupID, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupMembers")
@@ -508,18 +559,18 @@ func (_mock *groupStoreInterfaceMock) GetGroupMembers(groupID string, limit int,
 
 	var r0 []Member
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]Member, error)); ok {
-		return returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]Member, error)); ok {
+		return returnFunc(ctx, groupID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []Member); ok {
-		r0 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []Member); ok {
+		r0 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]Member)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -532,31 +583,37 @@ type groupStoreInterfaceMock_GetGroupMembers_Call struct {
 }
 
 // GetGroupMembers is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
 //   - limit int
 //   - offset int
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupMembers(groupID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupMembers_Call {
-	return &groupStoreInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", groupID, limit, offset)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupMembers(ctx interface{}, groupID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupMembers_Call {
+	return &groupStoreInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", ctx, groupID, limit, offset)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) Run(run func(groupID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupMembers_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) Run(run func(ctx context.Context, groupID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -567,14 +624,14 @@ func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) Return(members []Member,
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(groupID string, limit int, offset int) ([]Member, error)) *groupStoreInterfaceMock_GetGroupMembers_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, limit int, offset int) ([]Member, error)) *groupStoreInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupsByOrganizationUnit provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(organizationUnitID string, limit int, offset int) ([]GroupBasicDAO, error) {
-	ret := _mock.Called(organizationUnitID, limit, offset)
+func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(ctx context.Context, organizationUnitID string, limit int, offset int) ([]GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, organizationUnitID, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupsByOrganizationUnit")
@@ -582,18 +639,18 @@ func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(organizationUn
 
 	var r0 []GroupBasicDAO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]GroupBasicDAO, error)); ok {
-		return returnFunc(organizationUnitID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, organizationUnitID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []GroupBasicDAO); ok {
-		r0 = returnFunc(organizationUnitID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, organizationUnitID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]GroupBasicDAO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(organizationUnitID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, organizationUnitID, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -606,31 +663,37 @@ type groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call struct {
 }
 
 // GetGroupsByOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - organizationUnitID string
 //   - limit int
 //   - offset int
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnit(organizationUnitID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
-	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call{Call: _e.mock.On("GetGroupsByOrganizationUnit", organizationUnitID, limit, offset)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnit(ctx interface{}, organizationUnitID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
+	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call{Call: _e.mock.On("GetGroupsByOrganizationUnit", ctx, organizationUnitID, limit, offset)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) Run(run func(organizationUnitID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) Run(run func(ctx context.Context, organizationUnitID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -641,14 +704,14 @@ func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) Return(group
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) RunAndReturn(run func(organizationUnitID string, limit int, offset int) ([]GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, organizationUnitID string, limit int, offset int) ([]GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupsByOrganizationUnitCount provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnitCount(organizationUnitID string) (int, error) {
-	ret := _mock.Called(organizationUnitID)
+func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnitCount(ctx context.Context, organizationUnitID string) (int, error) {
+	ret := _mock.Called(ctx, organizationUnitID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupsByOrganizationUnitCount")
@@ -656,16 +719,16 @@ func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnitCount(organizat
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(organizationUnitID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, organizationUnitID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(organizationUnitID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, organizationUnitID)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(organizationUnitID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, organizationUnitID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -678,19 +741,25 @@ type groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call struct {
 }
 
 // GetGroupsByOrganizationUnitCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - organizationUnitID string
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnitCount(organizationUnitID interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
-	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call{Call: _e.mock.On("GetGroupsByOrganizationUnitCount", organizationUnitID)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnitCount(ctx interface{}, organizationUnitID interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
+	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call{Call: _e.mock.On("GetGroupsByOrganizationUnitCount", ctx, organizationUnitID)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) Run(run func(organizationUnitID string)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) Run(run func(ctx context.Context, organizationUnitID string)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -701,22 +770,22 @@ func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) Return(
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) RunAndReturn(run func(organizationUnitID string) (int, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) RunAndReturn(run func(ctx context.Context, organizationUnitID string) (int, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) UpdateGroup(group GroupDAO) error {
-	ret := _mock.Called(group)
+func (_mock *groupStoreInterfaceMock) UpdateGroup(ctx context.Context, group GroupDAO) error {
+	ret := _mock.Called(ctx, group)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateGroup")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(GroupDAO) error); ok {
-		r0 = returnFunc(group)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, GroupDAO) error); ok {
+		r0 = returnFunc(ctx, group)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -729,19 +798,25 @@ type groupStoreInterfaceMock_UpdateGroup_Call struct {
 }
 
 // UpdateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - group GroupDAO
-func (_e *groupStoreInterfaceMock_Expecter) UpdateGroup(group interface{}) *groupStoreInterfaceMock_UpdateGroup_Call {
-	return &groupStoreInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", group)}
+func (_e *groupStoreInterfaceMock_Expecter) UpdateGroup(ctx interface{}, group interface{}) *groupStoreInterfaceMock_UpdateGroup_Call {
+	return &groupStoreInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, group)}
 }
 
-func (_c *groupStoreInterfaceMock_UpdateGroup_Call) Run(run func(group GroupDAO)) *groupStoreInterfaceMock_UpdateGroup_Call {
+func (_c *groupStoreInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, group GroupDAO)) *groupStoreInterfaceMock_UpdateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 GroupDAO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(GroupDAO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 GroupDAO
+		if args[1] != nil {
+			arg1 = args[1].(GroupDAO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -752,14 +827,14 @@ func (_c *groupStoreInterfaceMock_UpdateGroup_Call) Return(err error) *groupStor
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(group GroupDAO) error) *groupStoreInterfaceMock_UpdateGroup_Call {
+func (_c *groupStoreInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, group GroupDAO) error) *groupStoreInterfaceMock_UpdateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateGroupIDs provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) ValidateGroupIDs(groupIDs []string) ([]string, error) {
-	ret := _mock.Called(groupIDs)
+func (_mock *groupStoreInterfaceMock) ValidateGroupIDs(ctx context.Context, groupIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, groupIDs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateGroupIDs")
@@ -767,18 +842,18 @@ func (_mock *groupStoreInterfaceMock) ValidateGroupIDs(groupIDs []string) ([]str
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]string, error)); ok {
-		return returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]string, error)); ok {
+		return returnFunc(ctx, groupIDs)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []string); ok {
-		r0 = returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []string); ok {
+		r0 = returnFunc(ctx, groupIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, groupIDs)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -791,19 +866,25 @@ type groupStoreInterfaceMock_ValidateGroupIDs_Call struct {
 }
 
 // ValidateGroupIDs is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupIDs []string
-func (_e *groupStoreInterfaceMock_Expecter) ValidateGroupIDs(groupIDs interface{}) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
-	return &groupStoreInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", groupIDs)}
+func (_e *groupStoreInterfaceMock_Expecter) ValidateGroupIDs(ctx interface{}, groupIDs interface{}) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
+	return &groupStoreInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", ctx, groupIDs)}
 }
 
-func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) Run(run func(groupIDs []string)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
+func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -814,7 +895,7 @@ func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) Return(strings []string
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(groupIDs []string) ([]string, error)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
+func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) ([]string, error)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/group/handler.go
+++ b/backend/internal/group/handler.go
@@ -46,6 +46,8 @@ func newGroupHandler(groupService GroupServiceInterface) *groupHandler {
 
 // HandleGroupListRequest handles the list groups request.
 func (gh *groupHandler) HandleGroupListRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
@@ -54,7 +56,7 @@ func (gh *groupHandler) HandleGroupListRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	groupListResponse, svcErr := gh.groupService.GetGroupList(limit, offset)
+	groupListResponse, svcErr := gh.groupService.GetGroupList(ctx, limit, offset)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return
@@ -70,6 +72,8 @@ func (gh *groupHandler) HandleGroupListRequest(w http.ResponseWriter, r *http.Re
 
 // HandleGroupListByPathRequest handles the list groups by OU path request.
 func (gh *groupHandler) HandleGroupListByPathRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	path, pathValidationFailed := extractAndValidatePath(w, r)
@@ -83,7 +87,7 @@ func (gh *groupHandler) HandleGroupListByPathRequest(w http.ResponseWriter, r *h
 		return
 	}
 
-	groupListResponse, svcErr := gh.groupService.GetGroupsByPath(path, limit, offset)
+	groupListResponse, svcErr := gh.groupService.GetGroupsByPath(ctx, path, limit, offset)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return
@@ -99,6 +103,8 @@ func (gh *groupHandler) HandleGroupListByPathRequest(w http.ResponseWriter, r *h
 
 // HandleGroupPostRequest handles the create group request.
 func (gh *groupHandler) HandleGroupPostRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	createRequest, err := sysutils.DecodeJSONBody[CreateGroupRequest](r)
@@ -113,7 +119,7 @@ func (gh *groupHandler) HandleGroupPostRequest(w http.ResponseWriter, r *http.Re
 	}
 
 	sanitizedRequest := gh.sanitizeCreateGroupRequest(createRequest)
-	createdGroup, svcErr := gh.groupService.CreateGroup(sanitizedRequest)
+	createdGroup, svcErr := gh.groupService.CreateGroup(ctx, sanitizedRequest)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return
@@ -126,6 +132,8 @@ func (gh *groupHandler) HandleGroupPostRequest(w http.ResponseWriter, r *http.Re
 
 // HandleGroupPostByPathRequest handles the create group by OU path request.
 func (gh *groupHandler) HandleGroupPostByPathRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	path, pathValidationFailed := extractAndValidatePath(w, r)
@@ -144,7 +152,7 @@ func (gh *groupHandler) HandleGroupPostByPathRequest(w http.ResponseWriter, r *h
 		return
 	}
 
-	group, svcErr := gh.groupService.CreateGroupByPath(path, *createRequest)
+	group, svcErr := gh.groupService.CreateGroupByPath(ctx, path, *createRequest)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return
@@ -157,6 +165,8 @@ func (gh *groupHandler) HandleGroupPostByPathRequest(w http.ResponseWriter, r *h
 
 // HandleGroupGetRequest handles the get group by id request.
 func (gh *groupHandler) HandleGroupGetRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	id := r.PathValue("id")
@@ -170,7 +180,7 @@ func (gh *groupHandler) HandleGroupGetRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	group, svcErr := gh.groupService.GetGroup(id)
+	group, svcErr := gh.groupService.GetGroup(ctx, id)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return
@@ -183,6 +193,8 @@ func (gh *groupHandler) HandleGroupGetRequest(w http.ResponseWriter, r *http.Req
 
 // HandleGroupPutRequest handles the update group request.
 func (gh *groupHandler) HandleGroupPutRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	id := r.PathValue("id")
@@ -208,7 +220,7 @@ func (gh *groupHandler) HandleGroupPutRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	sanitizedRequest := gh.sanitizeUpdateGroupRequest(updateRequest)
-	group, svcErr := gh.groupService.UpdateGroup(id, sanitizedRequest)
+	group, svcErr := gh.groupService.UpdateGroup(ctx, id, sanitizedRequest)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return
@@ -221,6 +233,8 @@ func (gh *groupHandler) HandleGroupPutRequest(w http.ResponseWriter, r *http.Req
 
 // HandleGroupDeleteRequest handles the delete group request.
 func (gh *groupHandler) HandleGroupDeleteRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	id := r.PathValue("id")
@@ -234,7 +248,7 @@ func (gh *groupHandler) HandleGroupDeleteRequest(w http.ResponseWriter, r *http.
 		return
 	}
 
-	svcErr := gh.groupService.DeleteGroup(id)
+	svcErr := gh.groupService.DeleteGroup(ctx, id)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return
@@ -246,6 +260,8 @@ func (gh *groupHandler) HandleGroupDeleteRequest(w http.ResponseWriter, r *http.
 
 // HandleGroupMembersGetRequest handles the get group members request.
 func (gh *groupHandler) HandleGroupMembersGetRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	id := r.PathValue("id")
@@ -265,7 +281,7 @@ func (gh *groupHandler) HandleGroupMembersGetRequest(w http.ResponseWriter, r *h
 		return
 	}
 
-	memberListResponse, svcErr := gh.groupService.GetGroupMembers(id, limit, offset)
+	memberListResponse, svcErr := gh.groupService.GetGroupMembers(ctx, id, limit, offset)
 	if svcErr != nil {
 		gh.handleError(w, logger, svcErr)
 		return

--- a/backend/internal/group/handler_test.go
+++ b/backend/internal/group/handler_test.go
@@ -191,7 +191,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_RegisterRoutesGroupIDDispat
 	registerRoutes(mux, handler)
 
 	serviceMock.
-		On("GetGroup", "grp-001").
+		On("GetGroup", mock.Anything, "grp-001").
 		Return(&Group{ID: "grp-001"}, nil).
 		Once()
 
@@ -211,7 +211,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_RegisterRoutesGroupMembersD
 	registerRoutes(mux, handler)
 
 	serviceMock.
-		On("GetGroupMembers", "grp-001", serverconst.DefaultPageSize, 0).
+		On("GetGroupMembers", mock.Anything, "grp-001", serverconst.DefaultPageSize, 0).
 		Return(&MemberListResponse{}, nil).
 		Once()
 
@@ -279,7 +279,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			requestPath: "/groups?limit=3&offset=2",
 			setup: func(svc *GroupServiceInterfaceMock) {
 				svc.
-					On("GetGroupList", 3, 2).
+					On("GetGroupList", mock.Anything, 3, 2).
 					Return(&GroupListResponse{
 						TotalResults: 5,
 						StartIndex:   3,
@@ -318,7 +318,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 				suite.Require().Equal(ErrorInvalidLimit.Error, body.Message)
 			},
 			assertSvc: func(svc *GroupServiceInterfaceMock) {
-				svc.AssertNotCalled(suite.T(), "GetGroupList", mock.Anything, mock.Anything)
+				svc.AssertNotCalled(suite.T(), "GetGroupList", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -327,7 +327,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			useFlaky:    true,
 			setup: func(svc *GroupServiceInterfaceMock) {
 				svc.
-					On("GetGroupList", serverconst.DefaultPageSize, 0).
+					On("GetGroupList", mock.Anything, serverconst.DefaultPageSize, 0).
 					Return(&GroupListResponse{}, nil).
 					Once()
 			},
@@ -345,7 +345,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 				suite.Require().Equal("", recorder.Body.String()) // Write fails, body remains empty
 			},
 			assertSvc: func(svc *GroupServiceInterfaceMock) {
-				svc.AssertNotCalled(suite.T(), "GetGroupList", mock.Anything, mock.Anything)
+				svc.AssertNotCalled(suite.T(), "GetGroupList", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -353,7 +353,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListRequest() {
 			requestPath: "/groups",
 			setup: func(svc *GroupServiceInterfaceMock) {
 				svc.
-					On("GetGroupList", serverconst.DefaultPageSize, 0).
+					On("GetGroupList", mock.Anything, serverconst.DefaultPageSize, 0).
 					Return((*GroupListResponse)(nil), &ErrorInternalServerError).
 					Once()
 			},
@@ -412,7 +412,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 			pathParamValue: "root",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroupsByPath", "root", serverconst.DefaultPageSize, 0).
+					On("GetGroupsByPath", mock.Anything, "root", serverconst.DefaultPageSize, 0).
 					Return(&GroupListResponse{
 						TotalResults: 1,
 						StartIndex:   1,
@@ -440,7 +440,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 				require.Equal(suite.T(), ErrorInvalidRequestFormat.Code, body.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetGroupsByPath", mock.Anything, mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetGroupsByPath",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -451,7 +452,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 			pathParamValue: "root",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroupsByPath", "root", serverconst.DefaultPageSize, 0).
+					On("GetGroupsByPath", mock.Anything, "root", serverconst.DefaultPageSize, 0).
 					Return((*GroupListResponse)(nil), &ErrorInternalServerError).
 					Once()
 			},
@@ -473,7 +474,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 				require.Equal(suite.T(), ErrorInvalidLimit.Code, body.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetGroupsByPath", mock.Anything, mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetGroupsByPath",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -485,7 +487,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupListByPathReques
 			useFlaky:       true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroupsByPath", "root", serverconst.DefaultPageSize, 0).
+					On("GetGroupsByPath", mock.Anything, "root", serverconst.DefaultPageSize, 0).
 					Return(&GroupListResponse{}, nil).
 					Once()
 			},
@@ -523,7 +525,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 				require.Contains(suite.T(), body.Description, "Failed to parse request body")
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "CreateGroup", mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "CreateGroup", mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -538,7 +540,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			}`,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroup", mock.MatchedBy(func(request CreateGroupRequest) bool {
+					On("CreateGroup", mock.Anything, mock.MatchedBy(func(request CreateGroupRequest) bool {
 						return request.Name == "Team &lt;script&gt;" &&
 							request.Description == "desc" &&
 							request.OrganizationUnitID == testOrganizationUnitID &&
@@ -565,7 +567,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			body: `{"name":"group","organizationUnitId":"ou"}`,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroup", mock.AnythingOfType("group.CreateGroupRequest")).
+					On("CreateGroup", mock.Anything, mock.AnythingOfType("group.CreateGroupRequest")).
 					Return((*Group)(nil), &ErrorGroupNameConflict).
 					Once()
 			},
@@ -581,7 +583,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			body: `{"name":"group","organizationUnitId":"ou"}`,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroup", mock.AnythingOfType("group.CreateGroupRequest")).
+					On("CreateGroup", mock.Anything, mock.AnythingOfType("group.CreateGroupRequest")).
 					Return((*Group)(nil), &ErrorInternalServerError).
 					Once()
 			},
@@ -596,7 +598,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			useFlaky: true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroup", mock.MatchedBy(func(request CreateGroupRequest) bool {
+					On("CreateGroup", mock.Anything, mock.MatchedBy(func(request CreateGroupRequest) bool {
 						return request.Name == "team" && request.OrganizationUnitID == "ou"
 					})).
 					Return(&Group{ID: "grp-001", Name: "team"}, nil).
@@ -616,7 +618,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "CreateGroup", mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "CreateGroup", mock.Anything, mock.Anything)
 			},
 		},
 	}
@@ -672,7 +674,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			setJSONHeader:  true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroupByPath", "root", CreateGroupByPathRequest{Name: "name"}).
+					On("CreateGroupByPath", mock.Anything, "root", CreateGroupByPathRequest{Name: "name"}).
 					Return(&Group{ID: "grp-001", Name: "name"}, nil).
 					Once()
 			},
@@ -698,7 +700,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 				require.Equal(suite.T(), ErrorInvalidRequestFormat.Code, body.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "CreateGroupByPath", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "CreateGroupByPath", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -724,7 +726,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			setJSONHeader:  true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroupByPath", "root", CreateGroupByPathRequest{Name: "n"}).
+					On("CreateGroupByPath", mock.Anything, "root", CreateGroupByPathRequest{Name: "n"}).
 					Return((*Group)(nil), &ErrorGroupNotFound).
 					Once()
 			},
@@ -743,7 +745,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			setJSONHeader:  true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroupByPath", "root", CreateGroupByPathRequest{Name: "team"}).
+					On("CreateGroupByPath", mock.Anything, "root", CreateGroupByPathRequest{Name: "team"}).
 					Return(&Group{ID: "grp-001", Name: "team"}, nil).
 					Once()
 			},
@@ -779,7 +781,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostByPathReques
 			setJSONHeader:  true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("CreateGroupByPath", "root", CreateGroupByPathRequest{Name: "n"}).
+					On("CreateGroupByPath", mock.Anything, "root", CreateGroupByPathRequest{Name: "n"}).
 					Return((*Group)(nil), &ErrorInternalServerError).
 					Once()
 			},
@@ -805,7 +807,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 			pathParamValue: "grp-404",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroup", "grp-404").
+					On("GetGroup", mock.Anything, "grp-404").
 					Return(nil, &ErrorGroupNotFound).
 					Once()
 			},
@@ -825,7 +827,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 			pathParamValue: "grp-001",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroup", "grp-001").
+					On("GetGroup", mock.Anything, "grp-001").
 					Return((*Group)(nil), &ErrorInternalServerError).
 					Once()
 			},
@@ -843,7 +845,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 			useFlaky:       true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroup", "grp-001").
+					On("GetGroup", mock.Anything, "grp-001").
 					Return(&Group{ID: "grp-001"}, nil).
 					Once()
 			},
@@ -862,7 +864,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetGroup", mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetGroup", mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -876,7 +878,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupGetRequest() {
 				require.Equal(suite.T(), ErrorMissingGroupID.Code, body.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetGroup", mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetGroup", mock.Anything, mock.Anything)
 			},
 		},
 	}
@@ -905,7 +907,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader: true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("UpdateGroup", "grp-001", mock.MatchedBy(func(request UpdateGroupRequest) bool {
+					On("UpdateGroup", mock.Anything, "grp-001", mock.MatchedBy(func(request UpdateGroupRequest) bool {
 						return request.Name == "team &lt;script&gt;" &&
 							request.Description == "desc" &&
 							request.OrganizationUnitID == testOrganizationUnitID &&
@@ -933,7 +935,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader:  true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("UpdateGroup", "grp-001", mock.AnythingOfType("group.UpdateGroupRequest")).
+					On("UpdateGroup", mock.Anything, "grp-001", mock.AnythingOfType("group.UpdateGroupRequest")).
 					Return(nil, &ErrorGroupNotFound).
 					Once()
 			},
@@ -951,7 +953,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader:  true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("UpdateGroup", "grp-001", mock.AnythingOfType("group.UpdateGroupRequest")).
+					On("UpdateGroup", mock.Anything, "grp-001", mock.AnythingOfType("group.UpdateGroupRequest")).
 					Return(nil, &ErrorInternalServerError).
 					Once()
 			},
@@ -971,7 +973,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setJSONHeader:  true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("UpdateGroup", "grp-001", mock.AnythingOfType("group.UpdateGroupRequest")).
+					On("UpdateGroup", mock.Anything, "grp-001", mock.AnythingOfType("group.UpdateGroupRequest")).
 					Return(&Group{ID: "grp-001"}, nil).
 					Once()
 			},
@@ -996,7 +998,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 				require.Equal(suite.T(), ErrorInvalidRequestFormat.Code, body.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -1013,7 +1015,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -1030,7 +1032,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 				require.Equal(suite.T(), ErrorMissingGroupID.Code, body.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -1045,7 +1047,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "UpdateGroup", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}
@@ -1068,7 +1070,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 				require.Equal(suite.T(), ErrorMissingGroupID.Code, body.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "DeleteGroup", mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "DeleteGroup", mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -1081,7 +1083,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "DeleteGroup", mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "DeleteGroup", mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -1092,7 +1094,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 			pathParamValue: "grp-001",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("DeleteGroup", "grp-001").
+					On("DeleteGroup", mock.Anything, "grp-001").
 					Return(&ErrorCannotDeleteGroup).
 					Once()
 			},
@@ -1111,7 +1113,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 			pathParamValue: "grp-001",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("DeleteGroup", "grp-001").
+					On("DeleteGroup", mock.Anything, "grp-001").
 					Return(&ErrorInternalServerError).
 					Once()
 			},
@@ -1128,7 +1130,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 			pathParamValue: "grp-001",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("DeleteGroup", "grp-001").
+					On("DeleteGroup", mock.Anything, "grp-001").
 					Return(nil).
 					Once()
 			},
@@ -1154,7 +1156,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			pathParamValue: "grp-001",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroupMembers", "grp-001", 2, 1).
+					On("GetGroupMembers", mock.Anything, "grp-001", 2, 1).
 					Return(&MemberListResponse{
 						TotalResults: 3,
 						StartIndex:   2,
@@ -1187,7 +1189,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers", mock.Anything, mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -1198,7 +1201,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			pathParamValue: "grp-001",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroupMembers", "grp-001", serverconst.DefaultPageSize, 0).
+					On("GetGroupMembers", mock.Anything, "grp-001", serverconst.DefaultPageSize, 0).
 					Return((*MemberListResponse)(nil), &ErrorGroupNotFound).
 					Once()
 			},
@@ -1215,7 +1218,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			useFlaky:       true,
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroupMembers", "grp-001", serverconst.DefaultPageSize, 0).
+					On("GetGroupMembers", mock.Anything, "grp-001", serverconst.DefaultPageSize, 0).
 					Return(&MemberListResponse{}, nil).
 					Once()
 			},
@@ -1234,7 +1237,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 				require.Equal(suite.T(), "", rr.Body.String()) // Write fails, body remains empty
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers", mock.Anything, mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -1245,7 +1249,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 			pathParamValue: "grp-001",
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
-					On("GetGroupMembers", "grp-001", serverconst.DefaultPageSize, 0).
+					On("GetGroupMembers", mock.Anything, "grp-001", serverconst.DefaultPageSize, 0).
 					Return((*MemberListResponse)(nil), &ErrorInternalServerError).
 					Once()
 			},
@@ -1262,7 +1266,8 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupMembersGetReques
 				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
 			},
 			assertService: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers", mock.Anything, mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetGroupMembers",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}

--- a/backend/internal/group/init.go
+++ b/backend/internal/group/init.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	oupkg "github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/user"
 )
@@ -32,11 +33,17 @@ func Initialize(
 	mux *http.ServeMux,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	userService user.UserServiceInterface,
-) GroupServiceInterface {
-	groupService := newGroupService(ouService, userService)
+) (GroupServiceInterface, error) {
+	// Get transactioner from DB provider
+	transactioner, err := provider.GetDBProvider().GetUserDBTransactioner()
+	if err != nil {
+		return nil, err
+	}
+
+	groupService := newGroupService(ouService, userService, transactioner)
 	groupHandler := newGroupHandler(groupService)
 	registerRoutes(mux, groupHandler)
-	return groupService
+	return groupService, nil
 }
 
 // registerRoutes registers the routes for group management operations.

--- a/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
+++ b/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
@@ -854,6 +854,57 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitUsersByPath_Ca
 	return _c
 }
 
+// IsOrganizationUnitDeclarative provides a mock function for the type OrganizationUnitServiceInterfaceMock
+func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsOrganizationUnitDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
+type OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - id string
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsOrganizationUnitExists provides a mock function for the type OrganizationUnitServiceInterfaceMock
 func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitExists(id string) (bool, *serviceerror.ServiceError) {
 	ret := _mock.Called(id)
@@ -912,57 +963,6 @@ func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call) Re
 }
 
 func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(id string) (bool, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsOrganizationUnitDeclarative provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsOrganizationUnitDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
-type OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsOrganizationUnitDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
-}
-
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
+++ b/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
@@ -972,6 +972,57 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) 
 	return _c
 }
 
+// IsOrganizationUnitDeclarative provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsOrganizationUnitDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
+type organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - id string
+func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsOrganizationUnitExists provides a mock function for the type organizationUnitStoreInterfaceMock
 func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(id string) (bool, error) {
 	ret := _mock.Called(id)
@@ -1028,57 +1079,6 @@ func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Retu
 }
 
 func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(id string) (bool, error)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsOrganizationUnitDeclarative provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsOrganizationUnitDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
-type organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsOrganizationUnitDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -607,7 +607,7 @@ func (rs *roleService) validateAssignmentIDs(
 
 	// Validate group IDs using group service
 	if len(groupIDs) > 0 {
-		if err := rs.groupService.ValidateGroupIDs(groupIDs); err != nil {
+		if err := rs.groupService.ValidateGroupIDs(ctx, groupIDs); err != nil {
 			if err.Code == group.ErrorInvalidGroupMemberID.Code {
 				logger.Debug("Invalid group member IDs found")
 				return &ErrorInvalidAssignmentID
@@ -682,7 +682,7 @@ func (rs *roleService) getDisplayNameForAssignment(ctx context.Context, assignme
 		return userResp.ID, nil
 
 	case AssigneeTypeGroup:
-		groupResp, svcErr := rs.groupService.GetGroup(assignment.ID)
+		groupResp, svcErr := rs.groupService.GetGroup(ctx, assignment.ID)
 		if svcErr != nil {
 			return "", fmt.Errorf("failed to get group: %w", errors.New(svcErr.Error))
 		}

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -418,7 +418,8 @@ func (suite *RoleServiceTestSuite) TestCreateRole_InvalidGroupID() {
 
 	// Assignment validation now happens before OU and name checks
 	suite.mockResourceService.On("ValidatePermissions", "rs1", []string{"perm1"}).Return([]string{}, nil)
-	suite.mockGroupService.On("ValidateGroupIDs", []string{"invalid_group"}).Return(&group.ErrorInvalidGroupMemberID)
+	suite.mockGroupService.On("ValidateGroupIDs", mock.Anything, []string{"invalid_group"}).
+		Return(&group.ErrorInvalidGroupMemberID)
 
 	result, err := suite.service.CreateRole(context.Background(), request)
 
@@ -1029,7 +1030,7 @@ func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_Success() 
 	suite.mockStore.On("GetRoleAssignmentsCount", mock.Anything, "role1").Return(2, nil)
 	suite.mockStore.On("GetRoleAssignments", mock.Anything, "role1", 10, 0).Return(expectedAssignments, nil)
 	suite.mockUserService.On("GetUser", mock.Anything, testUserID1).Return(&user.User{ID: testUserID1}, nil).Once()
-	suite.mockGroupService.On("GetGroup", "group1").Return(&group.Group{Name: "Test Group"}, nil).Once()
+	suite.mockGroupService.On("GetGroup", mock.Anything, "group1").Return(&group.Group{Name: "Test Group"}, nil).Once()
 
 	result, err := suite.service.GetRoleAssignments(context.Background(), "role1", 10, 0, true)
 
@@ -1061,7 +1062,7 @@ func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_FetchError
 			name:       "Group fetch error",
 			assignment: RoleAssignment{ID: "group1", Type: AssigneeTypeGroup},
 			setupMock: func() {
-				suite.mockGroupService.On("GetGroup", "group1").
+				suite.mockGroupService.On("GetGroup", mock.Anything, "group1").
 					Return(nil, &serviceerror.ServiceError{Code: "GROUP_NOT_FOUND"}).Once()
 			},
 			expectedDisplay: "",
@@ -1300,7 +1301,7 @@ func (suite *RoleServiceTestSuite) TestValidateAssignmentIDs_GroupServiceError()
 
 	// Assignment validation now happens before OU and name checks
 	suite.mockResourceService.On("ValidatePermissions", "rs1", []string{"perm1"}).Return([]string{}, nil)
-	suite.mockGroupService.On("ValidateGroupIDs", []string{"group1"}).
+	suite.mockGroupService.On("ValidateGroupIDs", mock.Anything, []string{"group1"}).
 		Return(&serviceerror.ServiceError{Code: "INTERNAL_ERROR"})
 
 	result, err := suite.service.CreateRole(context.Background(), request)

--- a/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
+++ b/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package groupmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/group"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *GroupServiceInterfaceMock) EXPECT() *GroupServiceInterfaceMock_Expecte
 }
 
 // CreateGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) CreateGroup(request group.CreateGroupRequest) (*group.Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *GroupServiceInterfaceMock) CreateGroup(ctx context.Context, request group.CreateGroupRequest) (*group.Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGroup")
@@ -47,18 +49,18 @@ func (_mock *GroupServiceInterfaceMock) CreateGroup(request group.CreateGroupReq
 
 	var r0 *group.Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(group.CreateGroupRequest) (*group.Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, group.CreateGroupRequest) (*group.Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(group.CreateGroupRequest) *group.Group); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, group.CreateGroupRequest) *group.Group); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*group.Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(group.CreateGroupRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, group.CreateGroupRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,19 +75,25 @@ type GroupServiceInterfaceMock_CreateGroup_Call struct {
 }
 
 // CreateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request group.CreateGroupRequest
-func (_e *GroupServiceInterfaceMock_Expecter) CreateGroup(request interface{}) *GroupServiceInterfaceMock_CreateGroup_Call {
-	return &GroupServiceInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", request)}
+func (_e *GroupServiceInterfaceMock_Expecter) CreateGroup(ctx interface{}, request interface{}) *GroupServiceInterfaceMock_CreateGroup_Call {
+	return &GroupServiceInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", ctx, request)}
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroup_Call) Run(run func(request group.CreateGroupRequest)) *GroupServiceInterfaceMock_CreateGroup_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroup_Call) Run(run func(ctx context.Context, request group.CreateGroupRequest)) *GroupServiceInterfaceMock_CreateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 group.CreateGroupRequest
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(group.CreateGroupRequest)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 group.CreateGroupRequest
+		if args[1] != nil {
+			arg1 = args[1].(group.CreateGroupRequest)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -96,14 +104,14 @@ func (_c *GroupServiceInterfaceMock_CreateGroup_Call) Return(group1 *group.Group
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroup_Call) RunAndReturn(run func(request group.CreateGroupRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroup_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroup_Call) RunAndReturn(run func(ctx context.Context, request group.CreateGroupRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateGroupByPath provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) CreateGroupByPath(handlePath string, request group.CreateGroupByPathRequest) (*group.Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(handlePath, request)
+func (_mock *GroupServiceInterfaceMock) CreateGroupByPath(ctx context.Context, handlePath string, request group.CreateGroupByPathRequest) (*group.Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGroupByPath")
@@ -111,18 +119,18 @@ func (_mock *GroupServiceInterfaceMock) CreateGroupByPath(handlePath string, req
 
 	var r0 *group.Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, group.CreateGroupByPathRequest) (*group.Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(handlePath, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.CreateGroupByPathRequest) (*group.Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, group.CreateGroupByPathRequest) *group.Group); ok {
-		r0 = returnFunc(handlePath, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.CreateGroupByPathRequest) *group.Group); ok {
+		r0 = returnFunc(ctx, handlePath, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*group.Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, group.CreateGroupByPathRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(handlePath, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, group.CreateGroupByPathRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -137,25 +145,31 @@ type GroupServiceInterfaceMock_CreateGroupByPath_Call struct {
 }
 
 // CreateGroupByPath is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handlePath string
 //   - request group.CreateGroupByPathRequest
-func (_e *GroupServiceInterfaceMock_Expecter) CreateGroupByPath(handlePath interface{}, request interface{}) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
-	return &GroupServiceInterfaceMock_CreateGroupByPath_Call{Call: _e.mock.On("CreateGroupByPath", handlePath, request)}
+func (_e *GroupServiceInterfaceMock_Expecter) CreateGroupByPath(ctx interface{}, handlePath interface{}, request interface{}) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
+	return &GroupServiceInterfaceMock_CreateGroupByPath_Call{Call: _e.mock.On("CreateGroupByPath", ctx, handlePath, request)}
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) Run(run func(handlePath string, request group.CreateGroupByPathRequest)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) Run(run func(ctx context.Context, handlePath string, request group.CreateGroupByPathRequest)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 group.CreateGroupByPathRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(group.CreateGroupByPathRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 group.CreateGroupByPathRequest
+		if args[2] != nil {
+			arg2 = args[2].(group.CreateGroupByPathRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -166,22 +180,22 @@ func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) Return(group1 *group
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) RunAndReturn(run func(handlePath string, request group.CreateGroupByPathRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
+func (_c *GroupServiceInterfaceMock_CreateGroupByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, request group.CreateGroupByPathRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_CreateGroupByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) DeleteGroup(groupID string) *serviceerror.ServiceError {
-	ret := _mock.Called(groupID)
+func (_mock *GroupServiceInterfaceMock) DeleteGroup(ctx context.Context, groupID string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, groupID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteGroup")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, groupID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -196,19 +210,25 @@ type GroupServiceInterfaceMock_DeleteGroup_Call struct {
 }
 
 // DeleteGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
-func (_e *GroupServiceInterfaceMock_Expecter) DeleteGroup(groupID interface{}) *GroupServiceInterfaceMock_DeleteGroup_Call {
-	return &GroupServiceInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", groupID)}
+func (_e *GroupServiceInterfaceMock_Expecter) DeleteGroup(ctx interface{}, groupID interface{}) *GroupServiceInterfaceMock_DeleteGroup_Call {
+	return &GroupServiceInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", ctx, groupID)}
 }
 
-func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) Run(run func(groupID string)) *GroupServiceInterfaceMock_DeleteGroup_Call {
+func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) Run(run func(ctx context.Context, groupID string)) *GroupServiceInterfaceMock_DeleteGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -219,14 +239,14 @@ func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) Return(serviceError *servi
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(groupID string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_DeleteGroup_Call {
+func (_c *GroupServiceInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_DeleteGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroup(groupID string) (*group.Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(groupID)
+func (_mock *GroupServiceInterfaceMock) GetGroup(ctx context.Context, groupID string) (*group.Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroup")
@@ -234,18 +254,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroup(groupID string) (*group.Group, 
 
 	var r0 *group.Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*group.Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*group.Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *group.Group); ok {
-		r0 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *group.Group); ok {
+		r0 = returnFunc(ctx, groupID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*group.Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -260,19 +280,25 @@ type GroupServiceInterfaceMock_GetGroup_Call struct {
 }
 
 // GetGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroup(groupID interface{}) *GroupServiceInterfaceMock_GetGroup_Call {
-	return &GroupServiceInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", groupID)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroup(ctx interface{}, groupID interface{}) *GroupServiceInterfaceMock_GetGroup_Call {
+	return &GroupServiceInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", ctx, groupID)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroup_Call) Run(run func(groupID string)) *GroupServiceInterfaceMock_GetGroup_Call {
+func (_c *GroupServiceInterfaceMock_GetGroup_Call) Run(run func(ctx context.Context, groupID string)) *GroupServiceInterfaceMock_GetGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -283,14 +309,14 @@ func (_c *GroupServiceInterfaceMock_GetGroup_Call) Return(group1 *group.Group, s
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroup_Call) RunAndReturn(run func(groupID string) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroup_Call {
+func (_c *GroupServiceInterfaceMock_GetGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupList provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroupList(limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(limit, offset)
+func (_mock *GroupServiceInterfaceMock) GetGroupList(ctx context.Context, limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupList")
@@ -298,18 +324,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroupList(limit int, offset int) (*gr
 
 	var r0 *group.GroupListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(int, int) (*group.GroupListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*group.GroupListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) *group.GroupListResponse); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *group.GroupListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*group.GroupListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -324,25 +350,31 @@ type GroupServiceInterfaceMock_GetGroupList_Call struct {
 }
 
 // GetGroupList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroupList(limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupList_Call {
-	return &GroupServiceInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", limit, offset)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupList(ctx interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupList_Call {
+	return &GroupServiceInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", ctx, limit, offset)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupList_Call) Run(run func(limit int, offset int)) *GroupServiceInterfaceMock_GetGroupList_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupList_Call) Run(run func(ctx context.Context, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -353,14 +385,14 @@ func (_c *GroupServiceInterfaceMock_GetGroupList_Call) Return(groupListResponse 
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupList_Call) RunAndReturn(run func(limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupList_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupMembers provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroupMembers(groupID string, limit int, offset int) (*group.MemberListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(groupID, limit, offset)
+func (_mock *GroupServiceInterfaceMock) GetGroupMembers(ctx context.Context, groupID string, limit int, offset int) (*group.MemberListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupMembers")
@@ -368,18 +400,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroupMembers(groupID string, limit in
 
 	var r0 *group.MemberListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) (*group.MemberListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*group.MemberListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) *group.MemberListResponse); ok {
-		r0 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *group.MemberListResponse); ok {
+		r0 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*group.MemberListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -394,31 +426,37 @@ type GroupServiceInterfaceMock_GetGroupMembers_Call struct {
 }
 
 // GetGroupMembers is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
 //   - limit int
 //   - offset int
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroupMembers(groupID interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupMembers_Call {
-	return &GroupServiceInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", groupID, limit, offset)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupMembers(ctx interface{}, groupID interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupMembers_Call {
+	return &GroupServiceInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", ctx, groupID, limit, offset)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) Run(run func(groupID string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) Run(run func(ctx context.Context, groupID string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -429,14 +467,14 @@ func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) Return(memberListRespo
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(groupID string, limit int, offset int) (*group.MemberListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, limit int, offset int) (*group.MemberListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupsByPath provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(handlePath string, limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(handlePath, limit, offset)
+func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(ctx context.Context, handlePath string, limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupsByPath")
@@ -444,18 +482,18 @@ func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(handlePath string, limit
 
 	var r0 *group.GroupListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) (*group.GroupListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*group.GroupListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) *group.GroupListResponse); ok {
-		r0 = returnFunc(handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *group.GroupListResponse); ok {
+		r0 = returnFunc(ctx, handlePath, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*group.GroupListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -470,31 +508,37 @@ type GroupServiceInterfaceMock_GetGroupsByPath_Call struct {
 }
 
 // GetGroupsByPath is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handlePath string
 //   - limit int
 //   - offset int
-func (_e *GroupServiceInterfaceMock_Expecter) GetGroupsByPath(handlePath interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
-	return &GroupServiceInterfaceMock_GetGroupsByPath_Call{Call: _e.mock.On("GetGroupsByPath", handlePath, limit, offset)}
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupsByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+	return &GroupServiceInterfaceMock_GetGroupsByPath_Call{Call: _e.mock.On("GetGroupsByPath", ctx, handlePath, limit, offset)}
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Run(run func(handlePath string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -505,14 +549,14 @@ func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Return(groupListRespon
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(handlePath string, limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) UpdateGroup(groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(groupID, request)
+func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateGroup")
@@ -520,18 +564,18 @@ func (_mock *GroupServiceInterfaceMock) UpdateGroup(groupID string, request grou
 
 	var r0 *group.Group
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(groupID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, group.UpdateGroupRequest) *group.Group); ok {
-		r0 = returnFunc(groupID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.UpdateGroupRequest) *group.Group); ok {
+		r0 = returnFunc(ctx, groupID, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*group.Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, group.UpdateGroupRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(groupID, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, group.UpdateGroupRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -546,25 +590,31 @@ type GroupServiceInterfaceMock_UpdateGroup_Call struct {
 }
 
 // UpdateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
 //   - request group.UpdateGroupRequest
-func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", groupID, request)}
+func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(ctx interface{}, groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, groupID, request)}
 }
 
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(groupID string, request group.UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, groupID string, request group.UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 group.UpdateGroupRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(group.UpdateGroupRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 group.UpdateGroupRequest
+		if args[2] != nil {
+			arg2 = args[2].(group.UpdateGroupRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -575,22 +625,22 @@ func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Return(group1 *group.Group
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateGroupIDs provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) ValidateGroupIDs(groupIDs []string) *serviceerror.ServiceError {
-	ret := _mock.Called(groupIDs)
+func (_mock *GroupServiceInterfaceMock) ValidateGroupIDs(ctx context.Context, groupIDs []string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, groupIDs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateGroupIDs")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func([]string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, groupIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -605,19 +655,25 @@ type GroupServiceInterfaceMock_ValidateGroupIDs_Call struct {
 }
 
 // ValidateGroupIDs is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupIDs []string
-func (_e *GroupServiceInterfaceMock_Expecter) ValidateGroupIDs(groupIDs interface{}) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
-	return &GroupServiceInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", groupIDs)}
+func (_e *GroupServiceInterfaceMock_Expecter) ValidateGroupIDs(ctx interface{}, groupIDs interface{}) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
+	return &GroupServiceInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", ctx, groupIDs)}
 }
 
-func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) Run(run func(groupIDs []string)) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
+func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -628,7 +684,7 @@ func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) Return(serviceError *
 	return _c
 }
 
-func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(groupIDs []string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
+func (_c *GroupServiceInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) *serviceerror.ServiceError) *GroupServiceInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
+++ b/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package groupmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/group"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,16 +39,16 @@ func (_m *groupStoreInterfaceMock) EXPECT() *groupStoreInterfaceMock_Expecter {
 }
 
 // CheckGroupNameConflictForCreate provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForCreate(name string, organizationUnitID string) error {
-	ret := _mock.Called(name, organizationUnitID)
+func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForCreate(ctx context.Context, name string, organizationUnitID string) error {
+	ret := _mock.Called(ctx, name, organizationUnitID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckGroupNameConflictForCreate")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(name, organizationUnitID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, name, organizationUnitID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,75 +61,18 @@ type groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call struct {
 }
 
 // CheckGroupNameConflictForCreate is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
 //   - organizationUnitID string
-func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForCreate(name interface{}, organizationUnitID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
-	return &groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call{Call: _e.mock.On("CheckGroupNameConflictForCreate", name, organizationUnitID)}
+func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForCreate(ctx interface{}, name interface{}, organizationUnitID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+	return &groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call{Call: _e.mock.On("CheckGroupNameConflictForCreate", ctx, name, organizationUnitID)}
 }
 
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Run(run func(name string, organizationUnitID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Run(run func(ctx context.Context, name string, organizationUnitID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Return(err error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) RunAndReturn(run func(name string, organizationUnitID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CheckGroupNameConflictForUpdate provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForUpdate(name string, organizationUnitID string, groupID string) error {
-	ret := _mock.Called(name, organizationUnitID, groupID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CheckGroupNameConflictForUpdate")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = returnFunc(name, organizationUnitID, groupID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckGroupNameConflictForUpdate'
-type groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call struct {
-	*mock.Call
-}
-
-// CheckGroupNameConflictForUpdate is a helper method to define mock.On call
-//   - name string
-//   - organizationUnitID string
-//   - groupID string
-func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForUpdate(name interface{}, organizationUnitID interface{}, groupID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
-	return &groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call{Call: _e.mock.On("CheckGroupNameConflictForUpdate", name, organizationUnitID, groupID)}
-}
-
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Run(run func(name string, organizationUnitID string, groupID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -146,27 +91,96 @@ func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Run(run 
 	return _c
 }
 
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) Return(err error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call) RunAndReturn(run func(ctx context.Context, name string, organizationUnitID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForCreate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CheckGroupNameConflictForUpdate provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForUpdate(ctx context.Context, name string, organizationUnitID string, groupID string) error {
+	ret := _mock.Called(ctx, name, organizationUnitID, groupID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CheckGroupNameConflictForUpdate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, name, organizationUnitID, groupID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckGroupNameConflictForUpdate'
+type groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call struct {
+	*mock.Call
+}
+
+// CheckGroupNameConflictForUpdate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+//   - organizationUnitID string
+//   - groupID string
+func (_e *groupStoreInterfaceMock_Expecter) CheckGroupNameConflictForUpdate(ctx interface{}, name interface{}, organizationUnitID interface{}, groupID interface{}) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
+	return &groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call{Call: _e.mock.On("CheckGroupNameConflictForUpdate", ctx, name, organizationUnitID, groupID)}
+}
+
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Run(run func(ctx context.Context, name string, organizationUnitID string, groupID string)) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
 func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) Return(err error) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) RunAndReturn(run func(name string, organizationUnitID string, groupID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
+func (_c *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call) RunAndReturn(run func(ctx context.Context, name string, organizationUnitID string, groupID string) error) *groupStoreInterfaceMock_CheckGroupNameConflictForUpdate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) CreateGroup(group1 group.GroupDAO) error {
-	ret := _mock.Called(group1)
+func (_mock *groupStoreInterfaceMock) CreateGroup(ctx context.Context, group1 group.GroupDAO) error {
+	ret := _mock.Called(ctx, group1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGroup")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(group.GroupDAO) error); ok {
-		r0 = returnFunc(group1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, group.GroupDAO) error); ok {
+		r0 = returnFunc(ctx, group1)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -179,19 +193,25 @@ type groupStoreInterfaceMock_CreateGroup_Call struct {
 }
 
 // CreateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - group1 group.GroupDAO
-func (_e *groupStoreInterfaceMock_Expecter) CreateGroup(group1 interface{}) *groupStoreInterfaceMock_CreateGroup_Call {
-	return &groupStoreInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", group1)}
+func (_e *groupStoreInterfaceMock_Expecter) CreateGroup(ctx interface{}, group1 interface{}) *groupStoreInterfaceMock_CreateGroup_Call {
+	return &groupStoreInterfaceMock_CreateGroup_Call{Call: _e.mock.On("CreateGroup", ctx, group1)}
 }
 
-func (_c *groupStoreInterfaceMock_CreateGroup_Call) Run(run func(group1 group.GroupDAO)) *groupStoreInterfaceMock_CreateGroup_Call {
+func (_c *groupStoreInterfaceMock_CreateGroup_Call) Run(run func(ctx context.Context, group1 group.GroupDAO)) *groupStoreInterfaceMock_CreateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 group.GroupDAO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(group.GroupDAO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 group.GroupDAO
+		if args[1] != nil {
+			arg1 = args[1].(group.GroupDAO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -202,22 +222,22 @@ func (_c *groupStoreInterfaceMock_CreateGroup_Call) Return(err error) *groupStor
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_CreateGroup_Call) RunAndReturn(run func(group1 group.GroupDAO) error) *groupStoreInterfaceMock_CreateGroup_Call {
+func (_c *groupStoreInterfaceMock_CreateGroup_Call) RunAndReturn(run func(ctx context.Context, group1 group.GroupDAO) error) *groupStoreInterfaceMock_CreateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) DeleteGroup(id string) error {
-	ret := _mock.Called(id)
+func (_mock *groupStoreInterfaceMock) DeleteGroup(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteGroup")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -230,19 +250,25 @@ type groupStoreInterfaceMock_DeleteGroup_Call struct {
 }
 
 // DeleteGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *groupStoreInterfaceMock_Expecter) DeleteGroup(id interface{}) *groupStoreInterfaceMock_DeleteGroup_Call {
-	return &groupStoreInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", id)}
+func (_e *groupStoreInterfaceMock_Expecter) DeleteGroup(ctx interface{}, id interface{}) *groupStoreInterfaceMock_DeleteGroup_Call {
+	return &groupStoreInterfaceMock_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", ctx, id)}
 }
 
-func (_c *groupStoreInterfaceMock_DeleteGroup_Call) Run(run func(id string)) *groupStoreInterfaceMock_DeleteGroup_Call {
+func (_c *groupStoreInterfaceMock_DeleteGroup_Call) Run(run func(ctx context.Context, id string)) *groupStoreInterfaceMock_DeleteGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -253,14 +279,14 @@ func (_c *groupStoreInterfaceMock_DeleteGroup_Call) Return(err error) *groupStor
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(id string) error) *groupStoreInterfaceMock_DeleteGroup_Call {
+func (_c *groupStoreInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(ctx context.Context, id string) error) *groupStoreInterfaceMock_DeleteGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroup(id string) (group.GroupDAO, error) {
-	ret := _mock.Called(id)
+func (_mock *groupStoreInterfaceMock) GetGroup(ctx context.Context, id string) (group.GroupDAO, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroup")
@@ -268,16 +294,16 @@ func (_mock *groupStoreInterfaceMock) GetGroup(id string) (group.GroupDAO, error
 
 	var r0 group.GroupDAO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (group.GroupDAO, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (group.GroupDAO, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) group.GroupDAO); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) group.GroupDAO); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(group.GroupDAO)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -290,19 +316,25 @@ type groupStoreInterfaceMock_GetGroup_Call struct {
 }
 
 // GetGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *groupStoreInterfaceMock_Expecter) GetGroup(id interface{}) *groupStoreInterfaceMock_GetGroup_Call {
-	return &groupStoreInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", id)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroup(ctx interface{}, id interface{}) *groupStoreInterfaceMock_GetGroup_Call {
+	return &groupStoreInterfaceMock_GetGroup_Call{Call: _e.mock.On("GetGroup", ctx, id)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroup_Call) Run(run func(id string)) *groupStoreInterfaceMock_GetGroup_Call {
+func (_c *groupStoreInterfaceMock_GetGroup_Call) Run(run func(ctx context.Context, id string)) *groupStoreInterfaceMock_GetGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -313,14 +345,14 @@ func (_c *groupStoreInterfaceMock_GetGroup_Call) Return(groupDAO group.GroupDAO,
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroup_Call) RunAndReturn(run func(id string) (group.GroupDAO, error)) *groupStoreInterfaceMock_GetGroup_Call {
+func (_c *groupStoreInterfaceMock_GetGroup_Call) RunAndReturn(run func(ctx context.Context, id string) (group.GroupDAO, error)) *groupStoreInterfaceMock_GetGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupList provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupList(limit int, offset int) ([]group.GroupBasicDAO, error) {
-	ret := _mock.Called(limit, offset)
+func (_mock *groupStoreInterfaceMock) GetGroupList(ctx context.Context, limit int, offset int) ([]group.GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupList")
@@ -328,18 +360,18 @@ func (_mock *groupStoreInterfaceMock) GetGroupList(limit int, offset int) ([]gro
 
 	var r0 []group.GroupBasicDAO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]group.GroupBasicDAO, error)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]group.GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []group.GroupBasicDAO); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []group.GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]group.GroupBasicDAO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -352,25 +384,31 @@ type groupStoreInterfaceMock_GetGroupList_Call struct {
 }
 
 // GetGroupList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupList(limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupList_Call {
-	return &groupStoreInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", limit, offset)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupList(ctx interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupList_Call {
+	return &groupStoreInterfaceMock_GetGroupList_Call{Call: _e.mock.On("GetGroupList", ctx, limit, offset)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupList_Call) Run(run func(limit int, offset int)) *groupStoreInterfaceMock_GetGroupList_Call {
+func (_c *groupStoreInterfaceMock_GetGroupList_Call) Run(run func(ctx context.Context, limit int, offset int)) *groupStoreInterfaceMock_GetGroupList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -381,14 +419,14 @@ func (_c *groupStoreInterfaceMock_GetGroupList_Call) Return(groupBasicDAOs []gro
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupList_Call) RunAndReturn(run func(limit int, offset int) ([]group.GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupList_Call {
+func (_c *groupStoreInterfaceMock_GetGroupList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]group.GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupListCount provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupListCount() (int, error) {
-	ret := _mock.Called()
+func (_mock *groupStoreInterfaceMock) GetGroupListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupListCount")
@@ -396,16 +434,16 @@ func (_mock *groupStoreInterfaceMock) GetGroupListCount() (int, error) {
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -418,13 +456,20 @@ type groupStoreInterfaceMock_GetGroupListCount_Call struct {
 }
 
 // GetGroupListCount is a helper method to define mock.On call
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupListCount() *groupStoreInterfaceMock_GetGroupListCount_Call {
-	return &groupStoreInterfaceMock_GetGroupListCount_Call{Call: _e.mock.On("GetGroupListCount")}
+//   - ctx context.Context
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupListCount(ctx interface{}) *groupStoreInterfaceMock_GetGroupListCount_Call {
+	return &groupStoreInterfaceMock_GetGroupListCount_Call{Call: _e.mock.On("GetGroupListCount", ctx)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Run(run func()) *groupStoreInterfaceMock_GetGroupListCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Run(run func(ctx context.Context)) *groupStoreInterfaceMock_GetGroupListCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -434,14 +479,14 @@ func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Return(n int, err erro
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) RunAndReturn(run func() (int, error)) *groupStoreInterfaceMock_GetGroupListCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *groupStoreInterfaceMock_GetGroupListCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupMemberCount provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupMemberCount(groupID string) (int, error) {
-	ret := _mock.Called(groupID)
+func (_mock *groupStoreInterfaceMock) GetGroupMemberCount(ctx context.Context, groupID string) (int, error) {
+	ret := _mock.Called(ctx, groupID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupMemberCount")
@@ -449,16 +494,16 @@ func (_mock *groupStoreInterfaceMock) GetGroupMemberCount(groupID string) (int, 
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, groupID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, groupID)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(groupID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, groupID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -471,19 +516,25 @@ type groupStoreInterfaceMock_GetGroupMemberCount_Call struct {
 }
 
 // GetGroupMemberCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupMemberCount(groupID interface{}) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
-	return &groupStoreInterfaceMock_GetGroupMemberCount_Call{Call: _e.mock.On("GetGroupMemberCount", groupID)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupMemberCount(ctx interface{}, groupID interface{}) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
+	return &groupStoreInterfaceMock_GetGroupMemberCount_Call{Call: _e.mock.On("GetGroupMemberCount", ctx, groupID)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) Run(run func(groupID string)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) Run(run func(ctx context.Context, groupID string)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -494,14 +545,14 @@ func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) Return(n int, err er
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) RunAndReturn(run func(groupID string) (int, error)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMemberCount_Call) RunAndReturn(run func(ctx context.Context, groupID string) (int, error)) *groupStoreInterfaceMock_GetGroupMemberCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupMembers provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupMembers(groupID string, limit int, offset int) ([]group.Member, error) {
-	ret := _mock.Called(groupID, limit, offset)
+func (_mock *groupStoreInterfaceMock) GetGroupMembers(ctx context.Context, groupID string, limit int, offset int) ([]group.Member, error) {
+	ret := _mock.Called(ctx, groupID, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupMembers")
@@ -509,18 +560,18 @@ func (_mock *groupStoreInterfaceMock) GetGroupMembers(groupID string, limit int,
 
 	var r0 []group.Member
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]group.Member, error)); ok {
-		return returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]group.Member, error)); ok {
+		return returnFunc(ctx, groupID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []group.Member); ok {
-		r0 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []group.Member); ok {
+		r0 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]group.Member)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(groupID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, groupID, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -533,31 +584,37 @@ type groupStoreInterfaceMock_GetGroupMembers_Call struct {
 }
 
 // GetGroupMembers is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupID string
 //   - limit int
 //   - offset int
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupMembers(groupID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupMembers_Call {
-	return &groupStoreInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", groupID, limit, offset)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupMembers(ctx interface{}, groupID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupMembers_Call {
+	return &groupStoreInterfaceMock_GetGroupMembers_Call{Call: _e.mock.On("GetGroupMembers", ctx, groupID, limit, offset)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) Run(run func(groupID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupMembers_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) Run(run func(ctx context.Context, groupID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -568,14 +625,14 @@ func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) Return(members []group.M
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(groupID string, limit int, offset int) ([]group.Member, error)) *groupStoreInterfaceMock_GetGroupMembers_Call {
+func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, limit int, offset int) ([]group.Member, error)) *groupStoreInterfaceMock_GetGroupMembers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupsByOrganizationUnit provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(organizationUnitID string, limit int, offset int) ([]group.GroupBasicDAO, error) {
-	ret := _mock.Called(organizationUnitID, limit, offset)
+func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(ctx context.Context, organizationUnitID string, limit int, offset int) ([]group.GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, organizationUnitID, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupsByOrganizationUnit")
@@ -583,18 +640,18 @@ func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(organizationUn
 
 	var r0 []group.GroupBasicDAO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]group.GroupBasicDAO, error)); ok {
-		return returnFunc(organizationUnitID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]group.GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, organizationUnitID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []group.GroupBasicDAO); ok {
-		r0 = returnFunc(organizationUnitID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []group.GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, organizationUnitID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]group.GroupBasicDAO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(organizationUnitID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, organizationUnitID, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -607,31 +664,37 @@ type groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call struct {
 }
 
 // GetGroupsByOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - organizationUnitID string
 //   - limit int
 //   - offset int
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnit(organizationUnitID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
-	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call{Call: _e.mock.On("GetGroupsByOrganizationUnit", organizationUnitID, limit, offset)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnit(ctx interface{}, organizationUnitID interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
+	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call{Call: _e.mock.On("GetGroupsByOrganizationUnit", ctx, organizationUnitID, limit, offset)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) Run(run func(organizationUnitID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) Run(run func(ctx context.Context, organizationUnitID string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -642,14 +705,14 @@ func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) Return(group
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) RunAndReturn(run func(organizationUnitID string, limit int, offset int) ([]group.GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, organizationUnitID string, limit int, offset int) ([]group.GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetGroupsByOrganizationUnitCount provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnitCount(organizationUnitID string) (int, error) {
-	ret := _mock.Called(organizationUnitID)
+func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnitCount(ctx context.Context, organizationUnitID string) (int, error) {
+	ret := _mock.Called(ctx, organizationUnitID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetGroupsByOrganizationUnitCount")
@@ -657,16 +720,16 @@ func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnitCount(organizat
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(organizationUnitID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, organizationUnitID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(organizationUnitID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, organizationUnitID)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(organizationUnitID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, organizationUnitID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -679,19 +742,25 @@ type groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call struct {
 }
 
 // GetGroupsByOrganizationUnitCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - organizationUnitID string
-func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnitCount(organizationUnitID interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
-	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call{Call: _e.mock.On("GetGroupsByOrganizationUnitCount", organizationUnitID)}
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByOrganizationUnitCount(ctx interface{}, organizationUnitID interface{}) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
+	return &groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call{Call: _e.mock.On("GetGroupsByOrganizationUnitCount", ctx, organizationUnitID)}
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) Run(run func(organizationUnitID string)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) Run(run func(ctx context.Context, organizationUnitID string)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -702,22 +771,22 @@ func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) Return(
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) RunAndReturn(run func(organizationUnitID string) (int, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
+func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) RunAndReturn(run func(ctx context.Context, organizationUnitID string) (int, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateGroup provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) UpdateGroup(group1 group.GroupDAO) error {
-	ret := _mock.Called(group1)
+func (_mock *groupStoreInterfaceMock) UpdateGroup(ctx context.Context, group1 group.GroupDAO) error {
+	ret := _mock.Called(ctx, group1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateGroup")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(group.GroupDAO) error); ok {
-		r0 = returnFunc(group1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, group.GroupDAO) error); ok {
+		r0 = returnFunc(ctx, group1)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -730,19 +799,25 @@ type groupStoreInterfaceMock_UpdateGroup_Call struct {
 }
 
 // UpdateGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - group1 group.GroupDAO
-func (_e *groupStoreInterfaceMock_Expecter) UpdateGroup(group1 interface{}) *groupStoreInterfaceMock_UpdateGroup_Call {
-	return &groupStoreInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", group1)}
+func (_e *groupStoreInterfaceMock_Expecter) UpdateGroup(ctx interface{}, group1 interface{}) *groupStoreInterfaceMock_UpdateGroup_Call {
+	return &groupStoreInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, group1)}
 }
 
-func (_c *groupStoreInterfaceMock_UpdateGroup_Call) Run(run func(group1 group.GroupDAO)) *groupStoreInterfaceMock_UpdateGroup_Call {
+func (_c *groupStoreInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, group1 group.GroupDAO)) *groupStoreInterfaceMock_UpdateGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 group.GroupDAO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(group.GroupDAO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 group.GroupDAO
+		if args[1] != nil {
+			arg1 = args[1].(group.GroupDAO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -753,14 +828,14 @@ func (_c *groupStoreInterfaceMock_UpdateGroup_Call) Return(err error) *groupStor
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(group1 group.GroupDAO) error) *groupStoreInterfaceMock_UpdateGroup_Call {
+func (_c *groupStoreInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, group1 group.GroupDAO) error) *groupStoreInterfaceMock_UpdateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateGroupIDs provides a mock function for the type groupStoreInterfaceMock
-func (_mock *groupStoreInterfaceMock) ValidateGroupIDs(groupIDs []string) ([]string, error) {
-	ret := _mock.Called(groupIDs)
+func (_mock *groupStoreInterfaceMock) ValidateGroupIDs(ctx context.Context, groupIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, groupIDs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateGroupIDs")
@@ -768,18 +843,18 @@ func (_mock *groupStoreInterfaceMock) ValidateGroupIDs(groupIDs []string) ([]str
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]string, error)); ok {
-		return returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]string, error)); ok {
+		return returnFunc(ctx, groupIDs)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []string); ok {
-		r0 = returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []string); ok {
+		r0 = returnFunc(ctx, groupIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(groupIDs)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, groupIDs)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -792,19 +867,25 @@ type groupStoreInterfaceMock_ValidateGroupIDs_Call struct {
 }
 
 // ValidateGroupIDs is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupIDs []string
-func (_e *groupStoreInterfaceMock_Expecter) ValidateGroupIDs(groupIDs interface{}) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
-	return &groupStoreInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", groupIDs)}
+func (_e *groupStoreInterfaceMock_Expecter) ValidateGroupIDs(ctx interface{}, groupIDs interface{}) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
+	return &groupStoreInterfaceMock_ValidateGroupIDs_Call{Call: _e.mock.On("ValidateGroupIDs", ctx, groupIDs)}
 }
 
-func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) Run(run func(groupIDs []string)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
+func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -815,7 +896,7 @@ func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) Return(strings []string
 	return _c
 }
 
-func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(groupIDs []string) ([]string, error)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
+func (_c *groupStoreInterfaceMock_ValidateGroupIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) ([]string, error)) *groupStoreInterfaceMock_ValidateGroupIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
+++ b/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
@@ -855,6 +855,57 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitUsersByPath_Ca
 	return _c
 }
 
+// IsOrganizationUnitDeclarative provides a mock function for the type OrganizationUnitServiceInterfaceMock
+func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsOrganizationUnitDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
+type OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - id string
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsOrganizationUnitExists provides a mock function for the type OrganizationUnitServiceInterfaceMock
 func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitExists(id string) (bool, *serviceerror.ServiceError) {
 	ret := _mock.Called(id)
@@ -913,57 +964,6 @@ func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call) Re
 }
 
 func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(id string) (bool, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitExists_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsOrganizationUnitDeclarative provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsOrganizationUnitDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
-type OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsOrganizationUnitDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
-}
-
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
+++ b/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
@@ -973,6 +973,57 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) 
 	return _c
 }
 
+// IsOrganizationUnitDeclarative provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsOrganizationUnitDeclarative")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
+type organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
+	*mock.Call
+}
+
+// IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - id string
+func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsOrganizationUnitExists provides a mock function for the type organizationUnitStoreInterfaceMock
 func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(id string) (bool, error) {
 	ret := _mock.Called(id)
@@ -1029,57 +1080,6 @@ func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Retu
 }
 
 func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(id string) (bool, error)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsOrganizationUnitDeclarative provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsOrganizationUnitDeclarative")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsOrganizationUnitDeclarative'
-type organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call struct {
-	*mock.Call
-}
-
-// IsOrganizationUnitDeclarative is a helper method to define mock.On call
-//   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Return(b bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
As we have introduced the transection architecture, we are adapting our services to use transections. In this PR we have updated the group service to use transactions.


Sub Issue : https://github.com/asgardeo/thunder/issues/1343
Parent issue : https://github.com/asgardeo/thunder/issues/282




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Request context is now propagated across group-related backend flows.
  * Group operations run inside transactional boundaries for stronger data integrity.
  * Service initialization can now surface failures explicitly (initialization may return an error).

* **Code Quality**
  * Tests and mocks updated to align with context-aware and transactional interfaces.
  * Mock surfaces refined (including declarative organization-unit variants) to match updated APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->