### PR TITLE
Cert service context propagation and transection usage

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -141,7 +141,10 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 		logger.Fatal("Failed to initialize FlowMgtService", log.Error(err))
 	}
 	exporters = append(exporters, flowMgtExporter)
-	certservice := cert.Initialize()
+	certservice, err := cert.Initialize()
+	if err != nil {
+		logger.Fatal("Failed to initialize CertificateService", log.Error(err))
+	}
 
 	// Initialize theme and layout services
 	themeMgtService := thememgt.Initialize(mux)

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -19,6 +19,7 @@
 package application
 
 import (
+	"context"
 	"errors"
 	"slices"
 
@@ -1016,7 +1017,7 @@ func (as *applicationService) createApplicationCertificate(certificate *cert.Cer
 
 	var returnCert *model.ApplicationCertificate
 	if certificate != nil {
-		_, svcErr := as.certService.CreateCertificate(certificate)
+		_, svcErr := as.certService.CreateCertificate(context.TODO(), certificate)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ClientErrorType {
 				errorDescription := "Failed to create application certificate: " +
@@ -1045,7 +1046,8 @@ func (as *applicationService) createApplicationCertificate(certificate *cert.Cer
 // rollbackAppCertificateCreation rolls back the application certificate creation in case of an error during
 // application creation.
 func (as *applicationService) rollbackAppCertificateCreation(appID string) *serviceerror.ServiceError {
-	deleteErr := as.certService.DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, appID)
+	deleteErr := as.certService.DeleteCertificateByReference(context.TODO(),
+		cert.CertificateReferenceTypeApplication, appID)
 	if deleteErr != nil {
 		if deleteErr.Type == serviceerror.ClientErrorType {
 			errorDescription := "Failed to rollback application certificate creation: " +
@@ -1063,7 +1065,7 @@ func (as *applicationService) deleteApplicationCertificate(appID string) *servic
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationService"))
 
 	if certErr := as.certService.DeleteCertificateByReference(
-		cert.CertificateReferenceTypeApplication, appID); certErr != nil {
+		context.TODO(), cert.CertificateReferenceTypeApplication, appID); certErr != nil {
 		if certErr.Type == serviceerror.ClientErrorType {
 			errorDescription := "Failed to delete application certificate: " +
 				certErr.ErrorDescription
@@ -1083,7 +1085,7 @@ func (as *applicationService) getApplicationCertificate(appID string) (*model.Ap
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationService"))
 
 	certificate, certErr := as.certService.GetCertificateByReference(
-		cert.CertificateReferenceTypeApplication, appID)
+		context.TODO(), cert.CertificateReferenceTypeApplication, appID)
 
 	if certErr != nil {
 		if certErr.Code == cert.ErrorCertificateNotFound.Code {
@@ -1125,7 +1127,7 @@ func (as *applicationService) updateApplicationCertificate(app *model.Applicatio
 	appID := app.ID
 
 	existingCert, certErr := as.certService.GetCertificateByReference(
-		cert.CertificateReferenceTypeApplication, appID)
+		context.TODO(), cert.CertificateReferenceTypeApplication, appID)
 	if certErr != nil && certErr.Code != cert.ErrorCertificateNotFound.Code {
 		if certErr.Type == serviceerror.ClientErrorType {
 			errorDescription := "Failed to retrieve application certificate: " +
@@ -1153,7 +1155,7 @@ func (as *applicationService) updateApplicationCertificate(app *model.Applicatio
 	var returnCert *model.ApplicationCertificate
 	if updatedCert != nil {
 		if existingCert != nil {
-			_, svcErr := as.certService.UpdateCertificateByID(existingCert.ID, updatedCert)
+			_, svcErr := as.certService.UpdateCertificateByID(context.TODO(), existingCert.ID, updatedCert)
 			if svcErr != nil {
 				if svcErr.Type == serviceerror.ClientErrorType {
 					errorDescription := "Failed to update application certificate: " +
@@ -1166,7 +1168,7 @@ func (as *applicationService) updateApplicationCertificate(app *model.Applicatio
 				return nil, nil, nil, &ErrorCertificateServerError
 			}
 		} else {
-			_, svcErr := as.certService.CreateCertificate(updatedCert)
+			_, svcErr := as.certService.CreateCertificate(context.TODO(), updatedCert)
 			if svcErr != nil {
 				if svcErr.Type == serviceerror.ClientErrorType {
 					errorDescription := "Failed to create application certificate: " +
@@ -1186,7 +1188,7 @@ func (as *applicationService) updateApplicationCertificate(app *model.Applicatio
 		if existingCert != nil {
 			// If no new certificate is provided, delete the existing certificate.
 			deleteErr := as.certService.DeleteCertificateByReference(
-				cert.CertificateReferenceTypeApplication, appID)
+				context.TODO(), cert.CertificateReferenceTypeApplication, appID)
 			if deleteErr != nil {
 				if deleteErr.Type == serviceerror.ClientErrorType {
 					errorDescription := "Failed to delete application certificate: " + deleteErr.ErrorDescription
@@ -1216,7 +1218,7 @@ func (as *applicationService) rollbackApplicationCertificateUpdate(appID string,
 	if updatedCert != nil {
 		if existingCert != nil {
 			// Update to the previously existed certificate.
-			_, svcErr := as.certService.UpdateCertificateByID(existingCert.ID, existingCert)
+			_, svcErr := as.certService.UpdateCertificateByID(context.TODO(), existingCert.ID, existingCert)
 			if svcErr != nil {
 				if svcErr.Type == serviceerror.ClientErrorType {
 					errorDescription := "Failed to revert application certificate update: " +
@@ -1229,7 +1231,7 @@ func (as *applicationService) rollbackApplicationCertificateUpdate(appID string,
 			}
 		} else { // Delete the newly created certificate.
 			deleteErr := as.certService.DeleteCertificateByReference(
-				cert.CertificateReferenceTypeApplication, appID)
+				context.TODO(), cert.CertificateReferenceTypeApplication, appID)
 			if deleteErr != nil {
 				if deleteErr.Type == serviceerror.ClientErrorType {
 					errorDescription := "Failed to delete application certificate " +
@@ -1243,7 +1245,7 @@ func (as *applicationService) rollbackApplicationCertificateUpdate(appID string,
 		}
 	} else {
 		if existingCert != nil { // Create the previously existed certificate.
-			_, svcErr := as.certService.CreateCertificate(existingCert)
+			_, svcErr := as.certService.CreateCertificate(context.TODO(), existingCert)
 			if svcErr != nil {
 				if svcErr.Type == serviceerror.ClientErrorType {
 					errorDescription := "Failed to revert application certificate creation: " +

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -1060,7 +1060,7 @@ func (suite *ServiceTestSuite) TestGetApplication_Success() {
 	}
 
 	mockStore.On("GetApplicationByID", "app123").Return(app, nil)
-	mockCertService.EXPECT().GetCertificateByReference(
+	mockCertService.EXPECT().GetCertificateByReference(mock.Anything,
 		cert.CertificateReferenceTypeApplication, "app123").Return(nil, &cert.ErrorCertificateNotFound)
 
 	result, svcErr := service.GetApplication("app123")
@@ -1237,7 +1237,7 @@ func (suite *ServiceTestSuite) TestDeleteApplication_Success() {
 	service, mockStore, mockCertService, _ := suite.setupTestService()
 
 	mockStore.On("DeleteApplication", "app123").Return(nil)
-	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication,
+	mockCertService.EXPECT().DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication,
 		"app123").Return(nil)
 
 	svcErr := service.DeleteApplication("app123")
@@ -1260,7 +1260,7 @@ func (suite *ServiceTestSuite) TestDeleteApplication_CertError() {
 
 	mockStore.On("DeleteApplication", "app123").Return(nil)
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(&serviceerror.ServiceError{Type: serviceerror.ClientErrorType})
 
 	svcErr := service.DeleteApplication("app123")
@@ -1274,7 +1274,7 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_NotFound() {
 	svcErr := &cert.ErrorCertificateNotFound
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(nil, svcErr)
 
 	result, err := service.getApplicationCertificate("app123")
@@ -1287,7 +1287,7 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_NotFound() {
 func (suite *ServiceTestSuite) TestGetApplicationCertificate_NilCertificate() {
 	service, _, mockCertService, _ := suite.setupTestService()
 
-	mockCertService.EXPECT().GetCertificateByReference(cert.CertificateReferenceTypeApplication,
+	mockCertService.EXPECT().GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication,
 		"app123").Return(nil, nil)
 
 	result, err := service.getApplicationCertificate("app123")
@@ -1306,7 +1306,7 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_Success() {
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(certificate, nil)
 
 	result, err := service.getApplicationCertificate("app123")
@@ -1324,7 +1324,7 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_Success() {
 		Value: `{"keys":[]}`,
 	}
 
-	mockCertService.EXPECT().CreateCertificate(certificate).Return(certificate, nil)
+	mockCertService.EXPECT().CreateCertificate(mock.Anything, certificate).Return(certificate, nil)
 
 	result, svcErr := service.createApplicationCertificate(certificate)
 
@@ -1356,7 +1356,7 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_ClientError() {
 		ErrorDescription: "Invalid certificate",
 	}
 
-	mockCertService.EXPECT().CreateCertificate(certificate).Return(nil, svcErr)
+	mockCertService.EXPECT().CreateCertificate(mock.Anything, certificate).Return(nil, svcErr)
 
 	result, err := service.createApplicationCertificate(certificate)
 
@@ -1367,7 +1367,7 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_ClientError() {
 func (suite *ServiceTestSuite) TestRollbackAppCertificateCreation_Success() {
 	service, _, mockCertService, _ := suite.setupTestService()
 
-	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication,
+	mockCertService.EXPECT().DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication,
 		"app123").Return(nil)
 
 	svcErr := service.rollbackAppCertificateCreation("app123")
@@ -1384,7 +1384,7 @@ func (suite *ServiceTestSuite) TestRollbackAppCertificateCreation_ClientError() 
 	}
 
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(svcErr)
 
 	err := service.rollbackAppCertificateCreation("app123")
@@ -1581,7 +1581,7 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_ClientError() {
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(nil, svcErr)
 
 	result, err := service.getApplicationCertificate("app123")
@@ -1598,7 +1598,7 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_ServerError() {
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(nil, svcErr)
 
 	result, err := service.getApplicationCertificate("app123")
@@ -1615,7 +1615,7 @@ func (suite *ServiceTestSuite) TestRollbackAppCertificateCreation_ServerError() 
 	}
 
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(svcErr)
 
 	err := service.rollbackAppCertificateCreation("app123")
@@ -1635,7 +1635,7 @@ func (suite *ServiceTestSuite) TestCreateApplicationCertificate_ServerError() {
 		Type: serviceerror.ServerErrorType,
 	}
 
-	mockCertService.EXPECT().CreateCertificate(certificate).Return(nil, svcErr)
+	mockCertService.EXPECT().CreateCertificate(mock.Anything, certificate).Return(nil, svcErr)
 
 	result, err := service.createApplicationCertificate(certificate)
 
@@ -1693,7 +1693,7 @@ func (suite *ServiceTestSuite) TestGetValidatedCertificateForCreate_JWKSURI_Inva
 func (suite *ServiceTestSuite) TestDeleteApplicationCertificate_Success() {
 	service, _, mockCertService, _ := suite.setupTestService()
 
-	mockCertService.EXPECT().DeleteCertificateByReference(cert.CertificateReferenceTypeApplication,
+	mockCertService.EXPECT().DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication,
 		"app123").Return(nil)
 
 	svcErr := service.deleteApplicationCertificate("app123")
@@ -1710,7 +1710,7 @@ func (suite *ServiceTestSuite) TestDeleteApplicationCertificate_ClientError() {
 	}
 
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(svcErr)
 
 	err := service.deleteApplicationCertificate("app123")
@@ -1726,7 +1726,7 @@ func (suite *ServiceTestSuite) TestDeleteApplicationCertificate_ServerError() {
 	}
 
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(svcErr)
 
 	err := service.deleteApplicationCertificate("app123")
@@ -1744,7 +1744,7 @@ func (suite *ServiceTestSuite) TestGetApplicationCertificate_ClientError_NonNotF
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(nil, svcErr)
 
 	result, err := service.getApplicationCertificate("app123")
@@ -1939,7 +1939,7 @@ func (suite *ServiceTestSuite) TestEnrichApplicationWithCertificate_Error() {
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(nil, svcErr)
 
 	result, err := service.enrichApplicationWithCertificate(app)
@@ -1962,7 +1962,7 @@ func (suite *ServiceTestSuite) TestEnrichApplicationWithCertificate_Success() {
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(certificate, nil)
 
 	result, err := service.enrichApplicationWithCertificate(app)
@@ -2523,10 +2523,11 @@ func (suite *ServiceTestSuite) TestCreateApplication_StoreErrorWithRollback() {
 	mockStore.On("GetApplicationByName", "Test App").Return(nil, model.ApplicationNotFoundError)
 	mockFlowMgtService.EXPECT().IsValidFlow("edc013d0-e893-4dc0-990c-3e1d203e005b").Return(true)
 	mockFlowMgtService.EXPECT().IsValidFlow("80024fb3-29ed-4c33-aa48-8aee5e96d522").Return(true)
-	mockCertService.EXPECT().CreateCertificate(mock.Anything).Return(&cert.Certificate{Type: "JWKS"}, nil)
+	mockCertService.EXPECT().CreateCertificate(mock.Anything, mock.Anything).
+		Return(&cert.Certificate{Type: "JWKS"}, nil)
 	mockStore.On("CreateApplication", mock.Anything).Return(errors.New("store error"))
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, mock.Anything).
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, mock.Anything).
 		Return(nil)
 
 	result, svcErr := service.CreateApplication(app)
@@ -2565,14 +2566,15 @@ func (suite *ServiceTestSuite) TestCreateApplication_StoreErrorWithRollbackFailu
 	mockStore.On("GetApplicationByName", "Test App").Return(nil, model.ApplicationNotFoundError)
 	mockFlowMgtService.EXPECT().IsValidFlow("edc013d0-e893-4dc0-990c-3e1d203e005b").Return(true)
 	mockFlowMgtService.EXPECT().IsValidFlow("80024fb3-29ed-4c33-aa48-8aee5e96d522").Return(true)
-	mockCertService.EXPECT().CreateCertificate(mock.Anything).Return(&cert.Certificate{Type: "JWKS"}, nil)
+	mockCertService.EXPECT().CreateCertificate(mock.Anything, mock.Anything).
+		Return(&cert.Certificate{Type: "JWKS"}, nil)
 	mockStore.On("CreateApplication", mock.Anything).Return(errors.New("store error"))
 	rollbackErr := &serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
 		ErrorDescription: "Failed to rollback",
 	}
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, mock.Anything).
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, mock.Anything).
 		Return(rollbackErr)
 
 	result, svcErr := service.CreateApplication(app)
@@ -2735,12 +2737,13 @@ func (suite *ServiceTestSuite) TestUpdateApplication_StoreErrorWithRollback() {
 	mockFlowMgtService.EXPECT().IsValidFlow("edc013d0-e893-4dc0-990c-3e1d203e005b").Return(true)
 	mockFlowMgtService.EXPECT().IsValidFlow("80024fb3-29ed-4c33-aa48-8aee5e96d522").Return(true)
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(nil, &cert.ErrorCertificateNotFound)
-	mockCertService.EXPECT().CreateCertificate(mock.Anything).Return(&cert.Certificate{Type: "JWKS"}, nil)
+	mockCertService.EXPECT().CreateCertificate(mock.Anything, mock.Anything).
+		Return(&cert.Certificate{Type: "JWKS"}, nil)
 	mockStore.On("UpdateApplication", mock.Anything, mock.Anything).Return(errors.New("store error"))
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, "app123").
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, "app123").
 		Return(nil)
 
 	result, svcErr := service.UpdateApplication("app123", app)
@@ -2775,7 +2778,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_UpdateCe
 	}
 
 	mockCertService.EXPECT().
-		UpdateCertificateByID(existingCert.ID, existingCert).
+		UpdateCertificateByID(mock.Anything, existingCert.ID, existingCert).
 		Return(nil, clientError).
 		Once()
 
@@ -2813,7 +2816,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_UpdateCe
 	}
 
 	mockCertService.EXPECT().
-		UpdateCertificateByID(existingCert.ID, existingCert).
+		UpdateCertificateByID(mock.Anything, existingCert.ID, existingCert).
 		Return(nil, serverError).
 		Once()
 
@@ -2843,7 +2846,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_DeleteCe
 	}
 
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, appID).
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, appID).
 		Return(clientError).
 		Once()
 
@@ -2877,7 +2880,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_DeleteCe
 	}
 
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, appID).
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, appID).
 		Return(serverError).
 		Once()
 
@@ -2907,7 +2910,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_CreateCe
 	}
 
 	mockCertService.EXPECT().
-		CreateCertificate(existingCert).
+		CreateCertificate(mock.Anything, existingCert).
 		Return(nil, clientError).
 		Once()
 
@@ -2940,7 +2943,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_CreateCe
 	}
 
 	mockCertService.EXPECT().
-		CreateCertificate(existingCert).
+		CreateCertificate(mock.Anything, existingCert).
 		Return(nil, serverError).
 		Once()
 
@@ -2968,7 +2971,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_Success_
 	}
 
 	mockCertService.EXPECT().
-		UpdateCertificateByID(existingCert.ID, existingCert).
+		UpdateCertificateByID(mock.Anything, existingCert.ID, existingCert).
 		Return(&cert.Certificate{ID: existingCert.ID}, nil).
 		Once()
 
@@ -2990,7 +2993,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_Success_
 	}
 
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, appID).
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, appID).
 		Return(nil).
 		Once()
 
@@ -3012,7 +3015,7 @@ func (suite *ServiceTestSuite) TestRollbackApplicationCertificateUpdate_Success_
 	}
 
 	mockCertService.EXPECT().
-		CreateCertificate(existingCert).
+		CreateCertificate(mock.Anything, existingCert).
 		Return(&cert.Certificate{ID: existingCert.ID}, nil).
 		Once()
 
@@ -3051,7 +3054,7 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_GetCertificateCl
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(nil, clientError).
 		Once()
 
@@ -3085,7 +3088,7 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_GetCertificateSe
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(nil, serverError).
 		Once()
 
@@ -3126,11 +3129,11 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_UpdateCertificat
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(existingCert, nil).
 		Once()
 	mockCertService.EXPECT().
-		UpdateCertificateByID(existingCert.ID, mock.Anything).
+		UpdateCertificateByID(mock.Anything, existingCert.ID, mock.Anything).
 		Return(nil, clientError).
 		Once()
 
@@ -3174,11 +3177,11 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_UpdateCertificat
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(existingCert, nil).
 		Once()
 	mockCertService.EXPECT().
-		UpdateCertificateByID(existingCert.ID, mock.Anything).
+		UpdateCertificateByID(mock.Anything, existingCert.ID, mock.Anything).
 		Return(nil, serverError).
 		Once()
 
@@ -3213,11 +3216,11 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_CreateCertificat
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(nil, &cert.ErrorCertificateNotFound).
 		Once()
 	mockCertService.EXPECT().
-		CreateCertificate(mock.Anything).
+		CreateCertificate(mock.Anything, mock.Anything).
 		Return(nil, clientError).
 		Once()
 
@@ -3255,11 +3258,11 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_CreateCertificat
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(nil, &cert.ErrorCertificateNotFound).
 		Once()
 	mockCertService.EXPECT().
-		CreateCertificate(mock.Anything).
+		CreateCertificate(mock.Anything, mock.Anything).
 		Return(nil, serverError).
 		Once()
 
@@ -3297,11 +3300,11 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_DeleteCertificat
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(existingCert, nil).
 		Once()
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(clientError).
 		Once()
 
@@ -3342,11 +3345,11 @@ func (suite *ServiceTestSuite) TestUpdateApplicationCertificate_DeleteCertificat
 	}
 
 	mockCertService.EXPECT().
-		GetCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		GetCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(existingCert, nil).
 		Once()
 	mockCertService.EXPECT().
-		DeleteCertificateByReference(cert.CertificateReferenceTypeApplication, testAppIDForRollback).
+		DeleteCertificateByReference(mock.Anything, cert.CertificateReferenceTypeApplication, testAppIDForRollback).
 		Return(serverError).
 		Once()
 
@@ -3687,7 +3690,7 @@ func (suite *ServiceTestSuite) TestCreateApplication_CertificateCreationError() 
 	mockFlowMgtService.EXPECT().IsValidFlow("reg-flow-id").Return(true)
 
 	svcErrExpected := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType}
-	mockCertService.EXPECT().CreateCertificate(mock.Anything).Return(nil, svcErrExpected)
+	mockCertService.EXPECT().CreateCertificate(mock.Anything, mock.Anything).Return(nil, svcErrExpected)
 
 	result, svcErr := service.CreateApplication(app)
 

--- a/backend/internal/cert/CertificateServiceInterface_mock_test.go
+++ b/backend/internal/cert/CertificateServiceInterface_mock_test.go
@@ -5,6 +5,8 @@
 package cert
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,8 +39,8 @@ func (_m *CertificateServiceInterfaceMock) EXPECT() *CertificateServiceInterface
 }
 
 // CreateCertificate provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) CreateCertificate(cert *Certificate) (*Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(cert)
+func (_mock *CertificateServiceInterfaceMock) CreateCertificate(ctx context.Context, cert *Certificate) (*Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, cert)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateCertificate")
@@ -46,18 +48,18 @@ func (_mock *CertificateServiceInterfaceMock) CreateCertificate(cert *Certificat
 
 	var r0 *Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(*Certificate) (*Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(cert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Certificate) (*Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, cert)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*Certificate) *Certificate); ok {
-		r0 = returnFunc(cert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Certificate) *Certificate); ok {
+		r0 = returnFunc(ctx, cert)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*Certificate) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(cert)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *Certificate) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, cert)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type CertificateServiceInterfaceMock_CreateCertificate_Call struct {
 }
 
 // CreateCertificate is a helper method to define mock.On call
+//   - ctx context.Context
 //   - cert *Certificate
-func (_e *CertificateServiceInterfaceMock_Expecter) CreateCertificate(cert interface{}) *CertificateServiceInterfaceMock_CreateCertificate_Call {
-	return &CertificateServiceInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", cert)}
+func (_e *CertificateServiceInterfaceMock_Expecter) CreateCertificate(ctx interface{}, cert interface{}) *CertificateServiceInterfaceMock_CreateCertificate_Call {
+	return &CertificateServiceInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", ctx, cert)}
 }
 
-func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) Run(run func(cert *Certificate)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
+func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) Run(run func(ctx context.Context, cert *Certificate)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*Certificate)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *Certificate
+		if args[1] != nil {
+			arg1 = args[1].(*Certificate)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,22 +103,22 @@ func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) Return(certifi
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(cert *Certificate) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
+func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(ctx context.Context, cert *Certificate) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByID provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByID(id string) *serviceerror.ServiceError {
-	ret := _mock.Called(id)
+func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByID(ctx context.Context, id string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByID")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -125,19 +133,25 @@ type CertificateServiceInterfaceMock_DeleteCertificateByID_Call struct {
 }
 
 // DeleteCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByID(id interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
-	return &CertificateServiceInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", id)}
+func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByID(ctx interface{}, id interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
+	return &CertificateServiceInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", ctx, id)}
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) Run(run func(id string)) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) Run(run func(ctx context.Context, id string)) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -148,22 +162,22 @@ func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) Return(ser
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(id string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByReference(refType CertificateReferenceType, refID string) *serviceerror.ServiceError {
-	ret := _mock.Called(refType, refID)
+func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByReference(ctx context.Context, refType CertificateReferenceType, refID string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, refType, refID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByReference")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, refType, refID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -178,25 +192,31 @@ type CertificateServiceInterfaceMock_DeleteCertificateByReference_Call struct {
 }
 
 // DeleteCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - refType CertificateReferenceType
 //   - refID string
-func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByReference(refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
-	return &CertificateServiceInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", refType, refID)}
+func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
+	return &CertificateServiceInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", ctx, refType, refID)}
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) Run(run func(refType CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) Run(run func(ctx context.Context, refType CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 CertificateReferenceType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 CertificateReferenceType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -207,14 +227,14 @@ func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) Ret
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(refType CertificateReferenceType, refID string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType CertificateReferenceType, refID string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCertificateByID provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) GetCertificateByID(id string) (*Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(id)
+func (_mock *CertificateServiceInterfaceMock) GetCertificateByID(ctx context.Context, id string) (*Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByID")
@@ -222,18 +242,18 @@ func (_mock *CertificateServiceInterfaceMock) GetCertificateByID(id string) (*Ce
 
 	var r0 *Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *Certificate); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *Certificate); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -248,19 +268,25 @@ type CertificateServiceInterfaceMock_GetCertificateByID_Call struct {
 }
 
 // GetCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByID(id interface{}) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
-	return &CertificateServiceInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", id)}
+func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByID(ctx interface{}, id interface{}) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
+	return &CertificateServiceInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", ctx, id)}
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) Run(run func(id string)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) Run(run func(ctx context.Context, id string)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -271,14 +297,14 @@ func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) Return(certif
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(id string) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) GetCertificateByReference(refType CertificateReferenceType, refID string) (*Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(refType, refID)
+func (_mock *CertificateServiceInterfaceMock) GetCertificateByReference(ctx context.Context, refType CertificateReferenceType, refID string) (*Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, refType, refID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByReference")
@@ -286,18 +312,18 @@ func (_mock *CertificateServiceInterfaceMock) GetCertificateByReference(refType 
 
 	var r0 *Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string) (*Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string) (*Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, refType, refID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string) *Certificate); ok {
-		r0 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string) *Certificate); ok {
+		r0 = returnFunc(ctx, refType, refID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(CertificateReferenceType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, CertificateReferenceType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, refType, refID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -312,25 +338,31 @@ type CertificateServiceInterfaceMock_GetCertificateByReference_Call struct {
 }
 
 // GetCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - refType CertificateReferenceType
 //   - refID string
-func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByReference(refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
-	return &CertificateServiceInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", refType, refID)}
+func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
+	return &CertificateServiceInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", ctx, refType, refID)}
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) Run(run func(refType CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) Run(run func(ctx context.Context, refType CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 CertificateReferenceType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 CertificateReferenceType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -341,14 +373,14 @@ func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) Return
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(refType CertificateReferenceType, refID string) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType CertificateReferenceType, refID string) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateCertificateByID provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByID(id string, cert *Certificate) (*Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(id, cert)
+func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByID(ctx context.Context, id string, cert *Certificate) (*Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, cert)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateCertificateByID")
@@ -356,18 +388,18 @@ func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByID(id string, c
 
 	var r0 *Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, *Certificate) (*Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(id, cert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *Certificate) (*Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, cert)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *Certificate) *Certificate); ok {
-		r0 = returnFunc(id, cert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *Certificate) *Certificate); ok {
+		r0 = returnFunc(ctx, id, cert)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *Certificate) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id, cert)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *Certificate) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, cert)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -382,88 +414,18 @@ type CertificateServiceInterfaceMock_UpdateCertificateByID_Call struct {
 }
 
 // UpdateCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - cert *Certificate
-func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByID(id interface{}, cert interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
-	return &CertificateServiceInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", id, cert)}
+func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByID(ctx interface{}, id interface{}, cert interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+	return &CertificateServiceInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", ctx, id, cert)}
 }
 
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Run(run func(id string, cert *Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Run(run func(ctx context.Context, id string, cert *Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 *Certificate
-		if args[1] != nil {
-			arg1 = args[1].(*Certificate)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Return(certificate *Certificate, serviceError *serviceerror.ServiceError) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
-	_c.Call.Return(certificate, serviceError)
-	return _c
-}
-
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(id string, cert *Certificate) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByReference(refType CertificateReferenceType, refID string, cert *Certificate) (*Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(refType, refID, cert)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateCertificateByReference")
-	}
-
-	var r0 *Certificate
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string, *Certificate) (*Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(refType, refID, cert)
-	}
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string, *Certificate) *Certificate); ok {
-		r0 = returnFunc(refType, refID, cert)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*Certificate)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(CertificateReferenceType, string, *Certificate) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(refType, refID, cert)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// CertificateServiceInterfaceMock_UpdateCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCertificateByReference'
-type CertificateServiceInterfaceMock_UpdateCertificateByReference_Call struct {
-	*mock.Call
-}
-
-// UpdateCertificateByReference is a helper method to define mock.On call
-//   - refType CertificateReferenceType
-//   - refID string
-//   - cert *Certificate
-func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByReference(refType interface{}, refID interface{}, cert interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
-	return &CertificateServiceInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", refType, refID, cert)}
-}
-
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Run(run func(refType CertificateReferenceType, refID string, cert *Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 CertificateReferenceType
-		if args[0] != nil {
-			arg0 = args[0].(CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -482,12 +444,94 @@ func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Run
 	return _c
 }
 
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Return(certificate *Certificate, serviceError *serviceerror.ServiceError) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+	_c.Call.Return(certificate, serviceError)
+	return _c
+}
+
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string, cert *Certificate) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
+func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByReference(ctx context.Context, refType CertificateReferenceType, refID string, cert *Certificate) (*Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, refType, refID, cert)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateCertificateByReference")
+	}
+
+	var r0 *Certificate
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string, *Certificate) (*Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, refType, refID, cert)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string, *Certificate) *Certificate); ok {
+		r0 = returnFunc(ctx, refType, refID, cert)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Certificate)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, CertificateReferenceType, string, *Certificate) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, refType, refID, cert)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// CertificateServiceInterfaceMock_UpdateCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCertificateByReference'
+type CertificateServiceInterfaceMock_UpdateCertificateByReference_Call struct {
+	*mock.Call
+}
+
+// UpdateCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
+//   - refType CertificateReferenceType
+//   - refID string
+//   - cert *Certificate
+func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByReference(ctx interface{}, refType interface{}, refID interface{}, cert interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
+	return &CertificateServiceInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", ctx, refType, refID, cert)}
+}
+
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Run(run func(ctx context.Context, refType CertificateReferenceType, refID string, cert *Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 CertificateReferenceType
+		if args[1] != nil {
+			arg1 = args[1].(CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 *Certificate
+		if args[3] != nil {
+			arg3 = args[3].(*Certificate)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
 func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Return(certificate *Certificate, serviceError *serviceerror.ServiceError) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Return(certificate, serviceError)
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(refType CertificateReferenceType, refID string, cert *Certificate) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType CertificateReferenceType, refID string, cert *Certificate) (*Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/cert/certificateStoreInterface_mock_test.go
+++ b/backend/internal/cert/certificateStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package cert
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *certificateStoreInterfaceMock) EXPECT() *certificateStoreInterfaceMock
 }
 
 // CreateCertificate provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) CreateCertificate(cert *Certificate) error {
-	ret := _mock.Called(cert)
+func (_mock *certificateStoreInterfaceMock) CreateCertificate(ctx context.Context, cert *Certificate) error {
+	ret := _mock.Called(ctx, cert)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateCertificate")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*Certificate) error); ok {
-		r0 = returnFunc(cert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Certificate) error); ok {
+		r0 = returnFunc(ctx, cert)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,19 +60,25 @@ type certificateStoreInterfaceMock_CreateCertificate_Call struct {
 }
 
 // CreateCertificate is a helper method to define mock.On call
+//   - ctx context.Context
 //   - cert *Certificate
-func (_e *certificateStoreInterfaceMock_Expecter) CreateCertificate(cert interface{}) *certificateStoreInterfaceMock_CreateCertificate_Call {
-	return &certificateStoreInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", cert)}
+func (_e *certificateStoreInterfaceMock_Expecter) CreateCertificate(ctx interface{}, cert interface{}) *certificateStoreInterfaceMock_CreateCertificate_Call {
+	return &certificateStoreInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", ctx, cert)}
 }
 
-func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) Run(run func(cert *Certificate)) *certificateStoreInterfaceMock_CreateCertificate_Call {
+func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) Run(run func(ctx context.Context, cert *Certificate)) *certificateStoreInterfaceMock_CreateCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*Certificate)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *Certificate
+		if args[1] != nil {
+			arg1 = args[1].(*Certificate)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -81,22 +89,22 @@ func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) Return(err error
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(cert *Certificate) error) *certificateStoreInterfaceMock_CreateCertificate_Call {
+func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(ctx context.Context, cert *Certificate) error) *certificateStoreInterfaceMock_CreateCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByID provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) DeleteCertificateByID(id string) error {
-	ret := _mock.Called(id)
+func (_mock *certificateStoreInterfaceMock) DeleteCertificateByID(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByID")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -109,19 +117,25 @@ type certificateStoreInterfaceMock_DeleteCertificateByID_Call struct {
 }
 
 // DeleteCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByID(id interface{}) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
-	return &certificateStoreInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", id)}
+func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByID(ctx interface{}, id interface{}) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
+	return &certificateStoreInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", ctx, id)}
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) Run(run func(id string)) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) Run(run func(ctx context.Context, id string)) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -132,22 +146,22 @@ func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) Return(err e
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(id string) error) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) error) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) DeleteCertificateByReference(refType CertificateReferenceType, refID string) error {
-	ret := _mock.Called(refType, refID)
+func (_mock *certificateStoreInterfaceMock) DeleteCertificateByReference(ctx context.Context, refType CertificateReferenceType, refID string) error {
+	ret := _mock.Called(ctx, refType, refID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByReference")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string) error); ok {
-		r0 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string) error); ok {
+		r0 = returnFunc(ctx, refType, refID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -160,25 +174,31 @@ type certificateStoreInterfaceMock_DeleteCertificateByReference_Call struct {
 }
 
 // DeleteCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - refType CertificateReferenceType
 //   - refID string
-func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByReference(refType interface{}, refID interface{}) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
-	return &certificateStoreInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", refType, refID)}
+func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
+	return &certificateStoreInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", ctx, refType, refID)}
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) Run(run func(refType CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) Run(run func(ctx context.Context, refType CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 CertificateReferenceType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 CertificateReferenceType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -189,14 +209,14 @@ func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) Retur
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(refType CertificateReferenceType, refID string) error) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType CertificateReferenceType, refID string) error) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCertificateByID provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) GetCertificateByID(id string) (*Certificate, error) {
-	ret := _mock.Called(id)
+func (_mock *certificateStoreInterfaceMock) GetCertificateByID(ctx context.Context, id string) (*Certificate, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByID")
@@ -204,18 +224,18 @@ func (_mock *certificateStoreInterfaceMock) GetCertificateByID(id string) (*Cert
 
 	var r0 *Certificate
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*Certificate, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*Certificate, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *Certificate); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *Certificate); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -228,79 +248,17 @@ type certificateStoreInterfaceMock_GetCertificateByID_Call struct {
 }
 
 // GetCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByID(id interface{}) *certificateStoreInterfaceMock_GetCertificateByID_Call {
-	return &certificateStoreInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", id)}
+func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByID(ctx interface{}, id interface{}) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+	return &certificateStoreInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", ctx, id)}
 }
 
-func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Run(run func(id string)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Run(run func(ctx context.Context, id string)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Return(certificate *Certificate, err error) *certificateStoreInterfaceMock_GetCertificateByID_Call {
-	_c.Call.Return(certificate, err)
-	return _c
-}
-
-func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(id string) (*Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) GetCertificateByReference(refType CertificateReferenceType, refID string) (*Certificate, error) {
-	ret := _mock.Called(refType, refID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetCertificateByReference")
-	}
-
-	var r0 *Certificate
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string) (*Certificate, error)); ok {
-		return returnFunc(refType, refID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(CertificateReferenceType, string) *Certificate); ok {
-		r0 = returnFunc(refType, refID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*Certificate)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(CertificateReferenceType, string) error); ok {
-		r1 = returnFunc(refType, refID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// certificateStoreInterfaceMock_GetCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateByReference'
-type certificateStoreInterfaceMock_GetCertificateByReference_Call struct {
-	*mock.Call
-}
-
-// GetCertificateByReference is a helper method to define mock.On call
-//   - refType CertificateReferenceType
-//   - refID string
-func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByReference(refType interface{}, refID interface{}) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
-	return &certificateStoreInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", refType, refID)}
-}
-
-func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Run(run func(refType CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 CertificateReferenceType
-		if args[0] != nil {
-			arg0 = args[0].(CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -314,27 +272,101 @@ func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Run(run 
 	return _c
 }
 
+func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Return(certificate *Certificate, err error) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+	_c.Call.Return(certificate, err)
+	return _c
+}
+
+func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
+func (_mock *certificateStoreInterfaceMock) GetCertificateByReference(ctx context.Context, refType CertificateReferenceType, refID string) (*Certificate, error) {
+	ret := _mock.Called(ctx, refType, refID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCertificateByReference")
+	}
+
+	var r0 *Certificate
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string) (*Certificate, error)); ok {
+		return returnFunc(ctx, refType, refID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CertificateReferenceType, string) *Certificate); ok {
+		r0 = returnFunc(ctx, refType, refID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Certificate)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, CertificateReferenceType, string) error); ok {
+		r1 = returnFunc(ctx, refType, refID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// certificateStoreInterfaceMock_GetCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateByReference'
+type certificateStoreInterfaceMock_GetCertificateByReference_Call struct {
+	*mock.Call
+}
+
+// GetCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
+//   - refType CertificateReferenceType
+//   - refID string
+func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
+	return &certificateStoreInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", ctx, refType, refID)}
+}
+
+func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Run(run func(ctx context.Context, refType CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 CertificateReferenceType
+		if args[1] != nil {
+			arg1 = args[1].(CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Return(certificate *Certificate, err error) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Return(certificate, err)
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(refType CertificateReferenceType, refID string) (*Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType CertificateReferenceType, refID string) (*Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateCertificateByID provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) UpdateCertificateByID(existingCert *Certificate, updatedCert *Certificate) error {
-	ret := _mock.Called(existingCert, updatedCert)
+func (_mock *certificateStoreInterfaceMock) UpdateCertificateByID(ctx context.Context, existingCert *Certificate, updatedCert *Certificate) error {
+	ret := _mock.Called(ctx, existingCert, updatedCert)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateCertificateByID")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*Certificate, *Certificate) error); ok {
-		r0 = returnFunc(existingCert, updatedCert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Certificate, *Certificate) error); ok {
+		r0 = returnFunc(ctx, existingCert, updatedCert)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -347,25 +379,31 @@ type certificateStoreInterfaceMock_UpdateCertificateByID_Call struct {
 }
 
 // UpdateCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - existingCert *Certificate
 //   - updatedCert *Certificate
-func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByID(existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
-	return &certificateStoreInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", existingCert, updatedCert)}
+func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByID(ctx interface{}, existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
+	return &certificateStoreInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", ctx, existingCert, updatedCert)}
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) Run(run func(existingCert *Certificate, updatedCert *Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) Run(run func(ctx context.Context, existingCert *Certificate, updatedCert *Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*Certificate)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 *Certificate
 		if args[1] != nil {
 			arg1 = args[1].(*Certificate)
 		}
+		var arg2 *Certificate
+		if args[2] != nil {
+			arg2 = args[2].(*Certificate)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -376,22 +414,22 @@ func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) Return(err e
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(existingCert *Certificate, updatedCert *Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(ctx context.Context, existingCert *Certificate, updatedCert *Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) UpdateCertificateByReference(existingCert *Certificate, updatedCert *Certificate) error {
-	ret := _mock.Called(existingCert, updatedCert)
+func (_mock *certificateStoreInterfaceMock) UpdateCertificateByReference(ctx context.Context, existingCert *Certificate, updatedCert *Certificate) error {
+	ret := _mock.Called(ctx, existingCert, updatedCert)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateCertificateByReference")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*Certificate, *Certificate) error); ok {
-		r0 = returnFunc(existingCert, updatedCert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Certificate, *Certificate) error); ok {
+		r0 = returnFunc(ctx, existingCert, updatedCert)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -404,25 +442,31 @@ type certificateStoreInterfaceMock_UpdateCertificateByReference_Call struct {
 }
 
 // UpdateCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - existingCert *Certificate
 //   - updatedCert *Certificate
-func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByReference(existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
-	return &certificateStoreInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", existingCert, updatedCert)}
+func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByReference(ctx interface{}, existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
+	return &certificateStoreInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", ctx, existingCert, updatedCert)}
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) Run(run func(existingCert *Certificate, updatedCert *Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) Run(run func(ctx context.Context, existingCert *Certificate, updatedCert *Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*Certificate)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 *Certificate
 		if args[1] != nil {
 			arg1 = args[1].(*Certificate)
 		}
+		var arg2 *Certificate
+		if args[2] != nil {
+			arg2 = args[2].(*Certificate)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -433,7 +477,7 @@ func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) Retur
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(existingCert *Certificate, updatedCert *Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, existingCert *Certificate, updatedCert *Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/cert/init.go
+++ b/backend/internal/cert/init.go
@@ -18,9 +18,18 @@
 
 package cert
 
+import (
+	"github.com/asgardeo/thunder/internal/system/database/provider"
+)
+
 // Initialize initializes and returns the certificate service.
-func Initialize() CertificateServiceInterface {
+func Initialize() (CertificateServiceInterface, error) {
+	dbProvider := provider.GetDBProvider()
+	txn, err := dbProvider.GetConfigDBTransactioner()
+	if err != nil {
+		return nil, err
+	}
 	certStore := newCachedBackedCertificateStore()
-	certService := newCertificateService(certStore)
-	return certService
+	certService := newCertificateService(certStore, txn)
+	return certService, nil
 }

--- a/backend/internal/cert/store_test.go
+++ b/backend/internal/cert/store_test.go
@@ -19,6 +19,7 @@
 package cert
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -69,10 +70,10 @@ func (suite *StoreTestSuite) TestGetCertificateByID_Success() {
 	results := []map[string]interface{}{row}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetCertificateByID, "test-cert-id", mock.Anything).
+	suite.mockDBClient.On("QueryContext", mock.Anything, queryGetCertificateByID, "test-cert-id", mock.Anything).
 		Return(results, nil)
 
-	result, err := suite.store.GetCertificateByID("test-cert-id")
+	result, err := suite.store.GetCertificateByID(context.Background(), "test-cert-id")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -86,7 +87,7 @@ func (suite *StoreTestSuite) TestGetCertificateByID_DBProviderError() {
 	suite.mockDBProvider.On("GetConfigDBClient").
 		Return(nil, errors.New("db provider error"))
 
-	result, err := suite.store.GetCertificateByID("test-id")
+	result, err := suite.store.GetCertificateByID(context.Background(), "test-id")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -96,10 +97,10 @@ func (suite *StoreTestSuite) TestGetCertificateByID_DBProviderError() {
 
 func (suite *StoreTestSuite) TestGetCertificateByID_QueryError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetCertificateByID, "test-id", mock.Anything).
+	suite.mockDBClient.On("QueryContext", mock.Anything, queryGetCertificateByID, "test-id", mock.Anything).
 		Return(nil, errors.New("query error"))
 
-	result, err := suite.store.GetCertificateByID("test-id")
+	result, err := suite.store.GetCertificateByID(context.Background(), "test-id")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -112,10 +113,10 @@ func (suite *StoreTestSuite) TestGetCertificateByID_NotFound() {
 	results := []map[string]interface{}{}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetCertificateByID, "non-existent", mock.Anything).
+	suite.mockDBClient.On("QueryContext", mock.Anything, queryGetCertificateByID, "non-existent", mock.Anything).
 		Return(results, nil)
 
-	result, err := suite.store.GetCertificateByID("non-existent")
+	result, err := suite.store.GetCertificateByID(context.Background(), "non-existent")
 
 	assert.Nil(suite.T(), result)
 	assert.ErrorIs(suite.T(), err, ErrCertificateNotFound)
@@ -130,10 +131,10 @@ func (suite *StoreTestSuite) TestGetCertificateByID_MultipleResults() {
 	results := []map[string]interface{}{row1, row2}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetCertificateByID, "test-id", mock.Anything).
+	suite.mockDBClient.On("QueryContext", mock.Anything, queryGetCertificateByID, "test-id", mock.Anything).
 		Return(results, nil)
 
-	result, err := suite.store.GetCertificateByID("test-id")
+	result, err := suite.store.GetCertificateByID(context.Background(), "test-id")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -151,11 +152,11 @@ func (suite *StoreTestSuite) TestGetCertificateByReference_Success() {
 	results := []map[string]interface{}{row}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetCertificateByReference,
+	suite.mockDBClient.On("QueryContext", mock.Anything, queryGetCertificateByReference,
 		CertificateReferenceTypeApplication, "test-app-id", mock.Anything).
 		Return(results, nil)
 
-	result, err := suite.store.GetCertificateByReference(
+	result, err := suite.store.GetCertificateByReference(context.Background(),
 		CertificateReferenceTypeApplication, "test-app-id")
 
 	assert.Nil(suite.T(), err)
@@ -169,11 +170,11 @@ func (suite *StoreTestSuite) TestGetCertificateByReference_NotFound() {
 	results := []map[string]interface{}{}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Query", queryGetCertificateByReference,
+	suite.mockDBClient.On("QueryContext", mock.Anything, queryGetCertificateByReference,
 		CertificateReferenceTypeIDP, "non-existent", mock.Anything).
 		Return(results, nil)
 
-	result, err := suite.store.GetCertificateByReference(
+	result, err := suite.store.GetCertificateByReference(context.Background(),
 		CertificateReferenceTypeIDP, "non-existent")
 
 	assert.Nil(suite.T(), result)
@@ -269,11 +270,11 @@ func (suite *StoreTestSuite) TestCreateCertificate_Success() {
 	}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryInsertCertificate,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryInsertCertificate,
 		cert.ID, cert.RefType, cert.RefID, cert.Type, cert.Value, mock.Anything).
 		Return(int64(1), nil)
 
-	err := suite.store.CreateCertificate(cert)
+	err := suite.store.CreateCertificate(context.Background(), cert)
 
 	assert.Nil(suite.T(), err)
 	suite.mockDBProvider.AssertExpectations(suite.T())
@@ -292,7 +293,7 @@ func (suite *StoreTestSuite) TestCreateCertificate_DBProviderError() {
 	suite.mockDBProvider.On("GetConfigDBClient").
 		Return(nil, errors.New("db provider error"))
 
-	err := suite.store.CreateCertificate(cert)
+	err := suite.store.CreateCertificate(context.Background(), cert)
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to get database client")
@@ -309,11 +310,11 @@ func (suite *StoreTestSuite) TestCreateCertificate_ExecuteError() {
 	}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryInsertCertificate, mock.Anything, mock.Anything,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryInsertCertificate, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(int64(0), errors.New("execute error"))
 
-	err := suite.store.CreateCertificate(cert)
+	err := suite.store.CreateCertificate(context.Background(), cert)
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to insert certificate")
@@ -331,11 +332,11 @@ func (suite *StoreTestSuite) TestCreateCertificate_NoRowsAffected() {
 	}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryInsertCertificate,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryInsertCertificate,
 		cert.ID, cert.RefType, cert.RefID, cert.Type, cert.Value, mock.Anything).
 		Return(int64(0), nil)
 
-	err := suite.store.CreateCertificate(cert)
+	err := suite.store.CreateCertificate(context.Background(), cert)
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no rows affected")
@@ -364,11 +365,11 @@ func (suite *StoreTestSuite) TestUpdateCertificateByID_Success() {
 	}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateCertificateByID,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryUpdateCertificateByID,
 		existingCert.ID, updatedCert.Type, updatedCert.Value, mock.Anything).
 		Return(int64(1), nil)
 
-	err := suite.store.UpdateCertificateByID(existingCert, updatedCert)
+	err := suite.store.UpdateCertificateByID(context.Background(), existingCert, updatedCert)
 
 	assert.Nil(suite.T(), err)
 	suite.mockDBProvider.AssertExpectations(suite.T())
@@ -382,7 +383,7 @@ func (suite *StoreTestSuite) TestUpdateCertificateByID_DBProviderError() {
 	suite.mockDBProvider.On("GetConfigDBClient").
 		Return(nil, errors.New("db provider error"))
 
-	err := suite.store.UpdateCertificateByID(existingCert, updatedCert)
+	err := suite.store.UpdateCertificateByID(context.Background(), existingCert, updatedCert)
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to get database client")
@@ -394,11 +395,11 @@ func (suite *StoreTestSuite) TestUpdateCertificateByID_ExecuteError() {
 	updatedCert := &Certificate{Type: CertificateTypeJWKS, Value: "new-value"}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateCertificateByID, mock.Anything,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryUpdateCertificateByID, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).
 		Return(int64(0), errors.New("execute error"))
 
-	err := suite.store.UpdateCertificateByID(existingCert, updatedCert)
+	err := suite.store.UpdateCertificateByID(context.Background(), existingCert, updatedCert)
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to update certificate")
@@ -411,11 +412,11 @@ func (suite *StoreTestSuite) TestUpdateCertificateByID_NoRowsAffected() {
 	updatedCert := &Certificate{Type: CertificateTypeJWKS, Value: "new-value"}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateCertificateByID,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryUpdateCertificateByID,
 		existingCert.ID, updatedCert.Type, updatedCert.Value, mock.Anything).
 		Return(int64(0), nil)
 
-	err := suite.store.UpdateCertificateByID(existingCert, updatedCert)
+	err := suite.store.UpdateCertificateByID(context.Background(), existingCert, updatedCert)
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no rows affected")
@@ -443,11 +444,11 @@ func (suite *StoreTestSuite) TestUpdateCertificateByReference_Success() {
 	}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateCertificateByReference,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryUpdateCertificateByReference,
 		existingCert.RefType, existingCert.RefID, updatedCert.Type, updatedCert.Value, mock.Anything).
 		Return(int64(1), nil)
 
-	err := suite.store.UpdateCertificateByReference(existingCert, updatedCert)
+	err := suite.store.UpdateCertificateByReference(context.Background(), existingCert, updatedCert)
 
 	assert.Nil(suite.T(), err)
 	suite.mockDBProvider.AssertExpectations(suite.T())
@@ -465,11 +466,11 @@ func (suite *StoreTestSuite) TestUpdateCertificateByReference_NoRowsAffected() {
 	}
 
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateCertificateByReference,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryUpdateCertificateByReference,
 		existingCert.RefType, existingCert.RefID, updatedCert.Type, updatedCert.Value, mock.Anything).
 		Return(int64(0), nil)
 
-	err := suite.store.UpdateCertificateByReference(existingCert, updatedCert)
+	err := suite.store.UpdateCertificateByReference(context.Background(), existingCert, updatedCert)
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no rows affected")
@@ -483,10 +484,10 @@ func (suite *StoreTestSuite) TestUpdateCertificateByReference_NoRowsAffected() {
 
 func (suite *StoreTestSuite) TestDeleteCertificateByID_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryDeleteCertificateByID, "test-cert-id", mock.Anything).
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteCertificateByID, "test-cert-id", mock.Anything).
 		Return(int64(1), nil)
 
-	err := suite.store.DeleteCertificateByID("test-cert-id")
+	err := suite.store.DeleteCertificateByID(context.Background(), "test-cert-id")
 
 	assert.Nil(suite.T(), err)
 	suite.mockDBProvider.AssertExpectations(suite.T())
@@ -497,7 +498,7 @@ func (suite *StoreTestSuite) TestDeleteCertificateByID_DBProviderError() {
 	suite.mockDBProvider.On("GetConfigDBClient").
 		Return(nil, errors.New("db provider error"))
 
-	err := suite.store.DeleteCertificateByID("test-id")
+	err := suite.store.DeleteCertificateByID(context.Background(), "test-id")
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to get database client")
@@ -506,10 +507,10 @@ func (suite *StoreTestSuite) TestDeleteCertificateByID_DBProviderError() {
 
 func (suite *StoreTestSuite) TestDeleteCertificateByID_ExecuteError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryDeleteCertificateByID, "test-id", mock.Anything).
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteCertificateByID, "test-id", mock.Anything).
 		Return(int64(0), errors.New("execute error"))
 
-	err := suite.store.DeleteCertificateByID("test-id")
+	err := suite.store.DeleteCertificateByID(context.Background(), "test-id")
 
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to execute delete query")
@@ -520,10 +521,10 @@ func (suite *StoreTestSuite) TestDeleteCertificateByID_ExecuteError() {
 func (suite *StoreTestSuite) TestDeleteCertificateByID_NoRowsAffected() {
 	// Delete operations should not fail even if no rows are affected
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryDeleteCertificateByID, "non-existent", mock.Anything).
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteCertificateByID, "non-existent", mock.Anything).
 		Return(int64(0), nil)
 
-	err := suite.store.DeleteCertificateByID("non-existent")
+	err := suite.store.DeleteCertificateByID(context.Background(), "non-existent")
 
 	assert.Nil(suite.T(), err)
 	suite.mockDBProvider.AssertExpectations(suite.T())
@@ -536,11 +537,11 @@ func (suite *StoreTestSuite) TestDeleteCertificateByID_NoRowsAffected() {
 
 func (suite *StoreTestSuite) TestDeleteCertificateByReference_Success() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryDeleteCertificateByReference,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteCertificateByReference,
 		CertificateReferenceTypeApplication, "test-app-id", mock.Anything).
 		Return(int64(1), nil)
 
-	err := suite.store.DeleteCertificateByReference(
+	err := suite.store.DeleteCertificateByReference(context.Background(),
 		CertificateReferenceTypeApplication, "test-app-id")
 
 	assert.Nil(suite.T(), err)
@@ -550,11 +551,11 @@ func (suite *StoreTestSuite) TestDeleteCertificateByReference_Success() {
 
 func (suite *StoreTestSuite) TestDeleteCertificateByReference_ExecuteError() {
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryDeleteCertificateByReference,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteCertificateByReference,
 		CertificateReferenceTypeIDP, "test-id", mock.Anything).
 		Return(int64(0), errors.New("execute error"))
 
-	err := suite.store.DeleteCertificateByReference(
+	err := suite.store.DeleteCertificateByReference(context.Background(),
 		CertificateReferenceTypeIDP, "test-id")
 
 	assert.NotNil(suite.T(), err)
@@ -566,11 +567,11 @@ func (suite *StoreTestSuite) TestDeleteCertificateByReference_ExecuteError() {
 func (suite *StoreTestSuite) TestDeleteCertificateByReference_NoRowsAffected() {
 	// Delete operations should not fail even if no rows are affected
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryDeleteCertificateByReference,
+	suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteCertificateByReference,
 		CertificateReferenceTypeApplication, "non-existent", mock.Anything).
 		Return(int64(0), nil)
 
-	err := suite.store.DeleteCertificateByReference(
+	err := suite.store.DeleteCertificateByReference(context.Background(),
 		CertificateReferenceTypeApplication, "non-existent")
 
 	assert.Nil(suite.T(), err)

--- a/backend/tests/mocks/certmock/CertificateServiceInterface_mock.go
+++ b/backend/tests/mocks/certmock/CertificateServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package certmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/cert"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *CertificateServiceInterfaceMock) EXPECT() *CertificateServiceInterface
 }
 
 // CreateCertificate provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) CreateCertificate(cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(cert1)
+func (_mock *CertificateServiceInterfaceMock) CreateCertificate(ctx context.Context, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, cert1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateCertificate")
@@ -47,18 +49,18 @@ func (_mock *CertificateServiceInterfaceMock) CreateCertificate(cert1 *cert.Cert
 
 	var r0 *cert.Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(*cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(cert1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, cert1)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*cert.Certificate) *cert.Certificate); ok {
-		r0 = returnFunc(cert1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *cert.Certificate) *cert.Certificate); ok {
+		r0 = returnFunc(ctx, cert1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*cert.Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*cert.Certificate) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(cert1)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *cert.Certificate) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, cert1)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,19 +75,25 @@ type CertificateServiceInterfaceMock_CreateCertificate_Call struct {
 }
 
 // CreateCertificate is a helper method to define mock.On call
+//   - ctx context.Context
 //   - cert1 *cert.Certificate
-func (_e *CertificateServiceInterfaceMock_Expecter) CreateCertificate(cert1 interface{}) *CertificateServiceInterfaceMock_CreateCertificate_Call {
-	return &CertificateServiceInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", cert1)}
+func (_e *CertificateServiceInterfaceMock_Expecter) CreateCertificate(ctx interface{}, cert1 interface{}) *CertificateServiceInterfaceMock_CreateCertificate_Call {
+	return &CertificateServiceInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", ctx, cert1)}
 }
 
-func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) Run(run func(cert1 *cert.Certificate)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
+func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) Run(run func(ctx context.Context, cert1 *cert.Certificate)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *cert.Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*cert.Certificate)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cert.Certificate
+		if args[1] != nil {
+			arg1 = args[1].(*cert.Certificate)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -96,22 +104,22 @@ func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) Return(certifi
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
+func (_c *CertificateServiceInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(ctx context.Context, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_CreateCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByID provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByID(id string) *serviceerror.ServiceError {
-	ret := _mock.Called(id)
+func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByID(ctx context.Context, id string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByID")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -126,19 +134,25 @@ type CertificateServiceInterfaceMock_DeleteCertificateByID_Call struct {
 }
 
 // DeleteCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByID(id interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
-	return &CertificateServiceInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", id)}
+func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByID(ctx interface{}, id interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
+	return &CertificateServiceInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", ctx, id)}
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) Run(run func(id string)) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) Run(run func(ctx context.Context, id string)) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -149,22 +163,22 @@ func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) Return(ser
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(id string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByReference(refType cert.CertificateReferenceType, refID string) *serviceerror.ServiceError {
-	ret := _mock.Called(refType, refID)
+func (_mock *CertificateServiceInterfaceMock) DeleteCertificateByReference(ctx context.Context, refType cert.CertificateReferenceType, refID string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, refType, refID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByReference")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, refType, refID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -179,25 +193,31 @@ type CertificateServiceInterfaceMock_DeleteCertificateByReference_Call struct {
 }
 
 // DeleteCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - refType cert.CertificateReferenceType
 //   - refID string
-func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByReference(refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
-	return &CertificateServiceInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", refType, refID)}
+func (_e *CertificateServiceInterfaceMock_Expecter) DeleteCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
+	return &CertificateServiceInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", ctx, refType, refID)}
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) Run(run func(refType cert.CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) Run(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 cert.CertificateReferenceType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(cert.CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 cert.CertificateReferenceType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(cert.CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -208,14 +228,14 @@ func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) Ret
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(refType cert.CertificateReferenceType, refID string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string) *serviceerror.ServiceError) *CertificateServiceInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCertificateByID provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) GetCertificateByID(id string) (*cert.Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(id)
+func (_mock *CertificateServiceInterfaceMock) GetCertificateByID(ctx context.Context, id string) (*cert.Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByID")
@@ -223,18 +243,18 @@ func (_mock *CertificateServiceInterfaceMock) GetCertificateByID(id string) (*ce
 
 	var r0 *cert.Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*cert.Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*cert.Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *cert.Certificate); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *cert.Certificate); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*cert.Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -249,19 +269,25 @@ type CertificateServiceInterfaceMock_GetCertificateByID_Call struct {
 }
 
 // GetCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByID(id interface{}) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
-	return &CertificateServiceInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", id)}
+func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByID(ctx interface{}, id interface{}) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
+	return &CertificateServiceInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", ctx, id)}
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) Run(run func(id string)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) Run(run func(ctx context.Context, id string)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -272,14 +298,14 @@ func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) Return(certif
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(id string) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) GetCertificateByReference(refType cert.CertificateReferenceType, refID string) (*cert.Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(refType, refID)
+func (_mock *CertificateServiceInterfaceMock) GetCertificateByReference(ctx context.Context, refType cert.CertificateReferenceType, refID string) (*cert.Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, refType, refID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByReference")
@@ -287,18 +313,18 @@ func (_mock *CertificateServiceInterfaceMock) GetCertificateByReference(refType 
 
 	var r0 *cert.Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string) (*cert.Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string) (*cert.Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, refType, refID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string) *cert.Certificate); ok {
-		r0 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string) *cert.Certificate); ok {
+		r0 = returnFunc(ctx, refType, refID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*cert.Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(cert.CertificateReferenceType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, cert.CertificateReferenceType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, refType, refID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -313,25 +339,31 @@ type CertificateServiceInterfaceMock_GetCertificateByReference_Call struct {
 }
 
 // GetCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - refType cert.CertificateReferenceType
 //   - refID string
-func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByReference(refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
-	return &CertificateServiceInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", refType, refID)}
+func (_e *CertificateServiceInterfaceMock_Expecter) GetCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
+	return &CertificateServiceInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", ctx, refType, refID)}
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) Run(run func(refType cert.CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) Run(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 cert.CertificateReferenceType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(cert.CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 cert.CertificateReferenceType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(cert.CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -342,14 +374,14 @@ func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) Return
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(refType cert.CertificateReferenceType, refID string) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateCertificateByID provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByID(id string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(id, cert1)
+func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByID(ctx context.Context, id string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, cert1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateCertificateByID")
@@ -357,18 +389,18 @@ func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByID(id string, c
 
 	var r0 *cert.Certificate
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(id, cert1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, cert1)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *cert.Certificate) *cert.Certificate); ok {
-		r0 = returnFunc(id, cert1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *cert.Certificate) *cert.Certificate); ok {
+		r0 = returnFunc(ctx, id, cert1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*cert.Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *cert.Certificate) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id, cert1)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *cert.Certificate) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, cert1)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -383,88 +415,18 @@ type CertificateServiceInterfaceMock_UpdateCertificateByID_Call struct {
 }
 
 // UpdateCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - cert1 *cert.Certificate
-func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByID(id interface{}, cert1 interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
-	return &CertificateServiceInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", id, cert1)}
+func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByID(ctx interface{}, id interface{}, cert1 interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+	return &CertificateServiceInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", ctx, id, cert1)}
 }
 
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Run(run func(id string, cert1 *cert.Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Run(run func(ctx context.Context, id string, cert1 *cert.Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 *cert.Certificate
-		if args[1] != nil {
-			arg1 = args[1].(*cert.Certificate)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Return(certificate *cert.Certificate, serviceError *serviceerror.ServiceError) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
-	_c.Call.Return(certificate, serviceError)
-	return _c
-}
-
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(id string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
-func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByReference(refType cert.CertificateReferenceType, refID string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError) {
-	ret := _mock.Called(refType, refID, cert1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateCertificateByReference")
-	}
-
-	var r0 *cert.Certificate
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string, *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)); ok {
-		return returnFunc(refType, refID, cert1)
-	}
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string, *cert.Certificate) *cert.Certificate); ok {
-		r0 = returnFunc(refType, refID, cert1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*cert.Certificate)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(cert.CertificateReferenceType, string, *cert.Certificate) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(refType, refID, cert1)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// CertificateServiceInterfaceMock_UpdateCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCertificateByReference'
-type CertificateServiceInterfaceMock_UpdateCertificateByReference_Call struct {
-	*mock.Call
-}
-
-// UpdateCertificateByReference is a helper method to define mock.On call
-//   - refType cert.CertificateReferenceType
-//   - refID string
-//   - cert1 *cert.Certificate
-func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByReference(refType interface{}, refID interface{}, cert1 interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
-	return &CertificateServiceInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", refType, refID, cert1)}
-}
-
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Run(run func(refType cert.CertificateReferenceType, refID string, cert1 *cert.Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 cert.CertificateReferenceType
-		if args[0] != nil {
-			arg0 = args[0].(cert.CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -483,12 +445,94 @@ func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Run
 	return _c
 }
 
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) Return(certificate *cert.Certificate, serviceError *serviceerror.ServiceError) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+	_c.Call.Return(certificate, serviceError)
+	return _c
+}
+
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateCertificateByReference provides a mock function for the type CertificateServiceInterfaceMock
+func (_mock *CertificateServiceInterfaceMock) UpdateCertificateByReference(ctx context.Context, refType cert.CertificateReferenceType, refID string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, refType, refID, cert1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateCertificateByReference")
+	}
+
+	var r0 *cert.Certificate
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string, *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, refType, refID, cert1)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string, *cert.Certificate) *cert.Certificate); ok {
+		r0 = returnFunc(ctx, refType, refID, cert1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*cert.Certificate)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, cert.CertificateReferenceType, string, *cert.Certificate) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, refType, refID, cert1)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// CertificateServiceInterfaceMock_UpdateCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCertificateByReference'
+type CertificateServiceInterfaceMock_UpdateCertificateByReference_Call struct {
+	*mock.Call
+}
+
+// UpdateCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
+//   - refType cert.CertificateReferenceType
+//   - refID string
+//   - cert1 *cert.Certificate
+func (_e *CertificateServiceInterfaceMock_Expecter) UpdateCertificateByReference(ctx interface{}, refType interface{}, refID interface{}, cert1 interface{}) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
+	return &CertificateServiceInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", ctx, refType, refID, cert1)}
+}
+
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Run(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string, cert1 *cert.Certificate)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cert.CertificateReferenceType
+		if args[1] != nil {
+			arg1 = args[1].(cert.CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 *cert.Certificate
+		if args[3] != nil {
+			arg3 = args[3].(*cert.Certificate)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
 func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) Return(certificate *cert.Certificate, serviceError *serviceerror.ServiceError) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Return(certificate, serviceError)
 	return _c
 }
 
-func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(refType cert.CertificateReferenceType, refID string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
+func (_c *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string, cert1 *cert.Certificate) (*cert.Certificate, *serviceerror.ServiceError)) *CertificateServiceInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/certmock/certificateStoreInterface_mock.go
+++ b/backend/tests/mocks/certmock/certificateStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package certmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/cert"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,16 +39,16 @@ func (_m *certificateStoreInterfaceMock) EXPECT() *certificateStoreInterfaceMock
 }
 
 // CreateCertificate provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) CreateCertificate(cert1 *cert.Certificate) error {
-	ret := _mock.Called(cert1)
+func (_mock *certificateStoreInterfaceMock) CreateCertificate(ctx context.Context, cert1 *cert.Certificate) error {
+	ret := _mock.Called(ctx, cert1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateCertificate")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*cert.Certificate) error); ok {
-		r0 = returnFunc(cert1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *cert.Certificate) error); ok {
+		r0 = returnFunc(ctx, cert1)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,19 +61,25 @@ type certificateStoreInterfaceMock_CreateCertificate_Call struct {
 }
 
 // CreateCertificate is a helper method to define mock.On call
+//   - ctx context.Context
 //   - cert1 *cert.Certificate
-func (_e *certificateStoreInterfaceMock_Expecter) CreateCertificate(cert1 interface{}) *certificateStoreInterfaceMock_CreateCertificate_Call {
-	return &certificateStoreInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", cert1)}
+func (_e *certificateStoreInterfaceMock_Expecter) CreateCertificate(ctx interface{}, cert1 interface{}) *certificateStoreInterfaceMock_CreateCertificate_Call {
+	return &certificateStoreInterfaceMock_CreateCertificate_Call{Call: _e.mock.On("CreateCertificate", ctx, cert1)}
 }
 
-func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) Run(run func(cert1 *cert.Certificate)) *certificateStoreInterfaceMock_CreateCertificate_Call {
+func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) Run(run func(ctx context.Context, cert1 *cert.Certificate)) *certificateStoreInterfaceMock_CreateCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *cert.Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*cert.Certificate)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *cert.Certificate
+		if args[1] != nil {
+			arg1 = args[1].(*cert.Certificate)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -82,22 +90,22 @@ func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) Return(err error
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(cert1 *cert.Certificate) error) *certificateStoreInterfaceMock_CreateCertificate_Call {
+func (_c *certificateStoreInterfaceMock_CreateCertificate_Call) RunAndReturn(run func(ctx context.Context, cert1 *cert.Certificate) error) *certificateStoreInterfaceMock_CreateCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByID provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) DeleteCertificateByID(id string) error {
-	ret := _mock.Called(id)
+func (_mock *certificateStoreInterfaceMock) DeleteCertificateByID(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByID")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -110,19 +118,25 @@ type certificateStoreInterfaceMock_DeleteCertificateByID_Call struct {
 }
 
 // DeleteCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByID(id interface{}) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
-	return &certificateStoreInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", id)}
+func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByID(ctx interface{}, id interface{}) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
+	return &certificateStoreInterfaceMock_DeleteCertificateByID_Call{Call: _e.mock.On("DeleteCertificateByID", ctx, id)}
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) Run(run func(id string)) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) Run(run func(ctx context.Context, id string)) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -133,22 +147,22 @@ func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) Return(err e
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(id string) error) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) error) *certificateStoreInterfaceMock_DeleteCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) DeleteCertificateByReference(refType cert.CertificateReferenceType, refID string) error {
-	ret := _mock.Called(refType, refID)
+func (_mock *certificateStoreInterfaceMock) DeleteCertificateByReference(ctx context.Context, refType cert.CertificateReferenceType, refID string) error {
+	ret := _mock.Called(ctx, refType, refID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCertificateByReference")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string) error); ok {
-		r0 = returnFunc(refType, refID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string) error); ok {
+		r0 = returnFunc(ctx, refType, refID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -161,25 +175,31 @@ type certificateStoreInterfaceMock_DeleteCertificateByReference_Call struct {
 }
 
 // DeleteCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - refType cert.CertificateReferenceType
 //   - refID string
-func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByReference(refType interface{}, refID interface{}) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
-	return &certificateStoreInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", refType, refID)}
+func (_e *certificateStoreInterfaceMock_Expecter) DeleteCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
+	return &certificateStoreInterfaceMock_DeleteCertificateByReference_Call{Call: _e.mock.On("DeleteCertificateByReference", ctx, refType, refID)}
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) Run(run func(refType cert.CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) Run(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 cert.CertificateReferenceType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(cert.CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 cert.CertificateReferenceType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(cert.CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -190,14 +210,14 @@ func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) Retur
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(refType cert.CertificateReferenceType, refID string) error) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_DeleteCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string) error) *certificateStoreInterfaceMock_DeleteCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCertificateByID provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) GetCertificateByID(id string) (*cert.Certificate, error) {
-	ret := _mock.Called(id)
+func (_mock *certificateStoreInterfaceMock) GetCertificateByID(ctx context.Context, id string) (*cert.Certificate, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCertificateByID")
@@ -205,18 +225,18 @@ func (_mock *certificateStoreInterfaceMock) GetCertificateByID(id string) (*cert
 
 	var r0 *cert.Certificate
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*cert.Certificate, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*cert.Certificate, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *cert.Certificate); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *cert.Certificate); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*cert.Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -229,79 +249,17 @@ type certificateStoreInterfaceMock_GetCertificateByID_Call struct {
 }
 
 // GetCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByID(id interface{}) *certificateStoreInterfaceMock_GetCertificateByID_Call {
-	return &certificateStoreInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", id)}
+func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByID(ctx interface{}, id interface{}) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+	return &certificateStoreInterfaceMock_GetCertificateByID_Call{Call: _e.mock.On("GetCertificateByID", ctx, id)}
 }
 
-func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Run(run func(id string)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Run(run func(ctx context.Context, id string)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Return(certificate *cert.Certificate, err error) *certificateStoreInterfaceMock_GetCertificateByID_Call {
-	_c.Call.Return(certificate, err)
-	return _c
-}
-
-func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(id string) (*cert.Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) GetCertificateByReference(refType cert.CertificateReferenceType, refID string) (*cert.Certificate, error) {
-	ret := _mock.Called(refType, refID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetCertificateByReference")
-	}
-
-	var r0 *cert.Certificate
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string) (*cert.Certificate, error)); ok {
-		return returnFunc(refType, refID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(cert.CertificateReferenceType, string) *cert.Certificate); ok {
-		r0 = returnFunc(refType, refID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*cert.Certificate)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(cert.CertificateReferenceType, string) error); ok {
-		r1 = returnFunc(refType, refID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// certificateStoreInterfaceMock_GetCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateByReference'
-type certificateStoreInterfaceMock_GetCertificateByReference_Call struct {
-	*mock.Call
-}
-
-// GetCertificateByReference is a helper method to define mock.On call
-//   - refType cert.CertificateReferenceType
-//   - refID string
-func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByReference(refType interface{}, refID interface{}) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
-	return &certificateStoreInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", refType, refID)}
-}
-
-func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Run(run func(refType cert.CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 cert.CertificateReferenceType
-		if args[0] != nil {
-			arg0 = args[0].(cert.CertificateReferenceType)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -315,27 +273,101 @@ func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Run(run 
 	return _c
 }
 
+func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) Return(certificate *cert.Certificate, err error) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+	_c.Call.Return(certificate, err)
+	return _c
+}
+
+func (_c *certificateStoreInterfaceMock_GetCertificateByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*cert.Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
+func (_mock *certificateStoreInterfaceMock) GetCertificateByReference(ctx context.Context, refType cert.CertificateReferenceType, refID string) (*cert.Certificate, error) {
+	ret := _mock.Called(ctx, refType, refID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCertificateByReference")
+	}
+
+	var r0 *cert.Certificate
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string) (*cert.Certificate, error)); ok {
+		return returnFunc(ctx, refType, refID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cert.CertificateReferenceType, string) *cert.Certificate); ok {
+		r0 = returnFunc(ctx, refType, refID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*cert.Certificate)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, cert.CertificateReferenceType, string) error); ok {
+		r1 = returnFunc(ctx, refType, refID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// certificateStoreInterfaceMock_GetCertificateByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCertificateByReference'
+type certificateStoreInterfaceMock_GetCertificateByReference_Call struct {
+	*mock.Call
+}
+
+// GetCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
+//   - refType cert.CertificateReferenceType
+//   - refID string
+func (_e *certificateStoreInterfaceMock_Expecter) GetCertificateByReference(ctx interface{}, refType interface{}, refID interface{}) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
+	return &certificateStoreInterfaceMock_GetCertificateByReference_Call{Call: _e.mock.On("GetCertificateByReference", ctx, refType, refID)}
+}
+
+func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Run(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cert.CertificateReferenceType
+		if args[1] != nil {
+			arg1 = args[1].(cert.CertificateReferenceType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) Return(certificate *cert.Certificate, err error) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Return(certificate, err)
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(refType cert.CertificateReferenceType, refID string) (*cert.Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_GetCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, refType cert.CertificateReferenceType, refID string) (*cert.Certificate, error)) *certificateStoreInterfaceMock_GetCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateCertificateByID provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) UpdateCertificateByID(existingCert *cert.Certificate, updatedCert *cert.Certificate) error {
-	ret := _mock.Called(existingCert, updatedCert)
+func (_mock *certificateStoreInterfaceMock) UpdateCertificateByID(ctx context.Context, existingCert *cert.Certificate, updatedCert *cert.Certificate) error {
+	ret := _mock.Called(ctx, existingCert, updatedCert)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateCertificateByID")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*cert.Certificate, *cert.Certificate) error); ok {
-		r0 = returnFunc(existingCert, updatedCert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *cert.Certificate, *cert.Certificate) error); ok {
+		r0 = returnFunc(ctx, existingCert, updatedCert)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -348,25 +380,31 @@ type certificateStoreInterfaceMock_UpdateCertificateByID_Call struct {
 }
 
 // UpdateCertificateByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - existingCert *cert.Certificate
 //   - updatedCert *cert.Certificate
-func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByID(existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
-	return &certificateStoreInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", existingCert, updatedCert)}
+func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByID(ctx interface{}, existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
+	return &certificateStoreInterfaceMock_UpdateCertificateByID_Call{Call: _e.mock.On("UpdateCertificateByID", ctx, existingCert, updatedCert)}
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) Run(run func(existingCert *cert.Certificate, updatedCert *cert.Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) Run(run func(ctx context.Context, existingCert *cert.Certificate, updatedCert *cert.Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *cert.Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*cert.Certificate)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 *cert.Certificate
 		if args[1] != nil {
 			arg1 = args[1].(*cert.Certificate)
 		}
+		var arg2 *cert.Certificate
+		if args[2] != nil {
+			arg2 = args[2].(*cert.Certificate)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -377,22 +415,22 @@ func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) Return(err e
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(existingCert *cert.Certificate, updatedCert *cert.Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByID_Call) RunAndReturn(run func(ctx context.Context, existingCert *cert.Certificate, updatedCert *cert.Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateCertificateByReference provides a mock function for the type certificateStoreInterfaceMock
-func (_mock *certificateStoreInterfaceMock) UpdateCertificateByReference(existingCert *cert.Certificate, updatedCert *cert.Certificate) error {
-	ret := _mock.Called(existingCert, updatedCert)
+func (_mock *certificateStoreInterfaceMock) UpdateCertificateByReference(ctx context.Context, existingCert *cert.Certificate, updatedCert *cert.Certificate) error {
+	ret := _mock.Called(ctx, existingCert, updatedCert)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateCertificateByReference")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*cert.Certificate, *cert.Certificate) error); ok {
-		r0 = returnFunc(existingCert, updatedCert)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *cert.Certificate, *cert.Certificate) error); ok {
+		r0 = returnFunc(ctx, existingCert, updatedCert)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -405,25 +443,31 @@ type certificateStoreInterfaceMock_UpdateCertificateByReference_Call struct {
 }
 
 // UpdateCertificateByReference is a helper method to define mock.On call
+//   - ctx context.Context
 //   - existingCert *cert.Certificate
 //   - updatedCert *cert.Certificate
-func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByReference(existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
-	return &certificateStoreInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", existingCert, updatedCert)}
+func (_e *certificateStoreInterfaceMock_Expecter) UpdateCertificateByReference(ctx interface{}, existingCert interface{}, updatedCert interface{}) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
+	return &certificateStoreInterfaceMock_UpdateCertificateByReference_Call{Call: _e.mock.On("UpdateCertificateByReference", ctx, existingCert, updatedCert)}
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) Run(run func(existingCert *cert.Certificate, updatedCert *cert.Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) Run(run func(ctx context.Context, existingCert *cert.Certificate, updatedCert *cert.Certificate)) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *cert.Certificate
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*cert.Certificate)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 *cert.Certificate
 		if args[1] != nil {
 			arg1 = args[1].(*cert.Certificate)
 		}
+		var arg2 *cert.Certificate
+		if args[2] != nil {
+			arg2 = args[2].(*cert.Certificate)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -434,7 +478,7 @@ func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) Retur
 	return _c
 }
 
-func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(existingCert *cert.Certificate, updatedCert *cert.Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
+func (_c *certificateStoreInterfaceMock_UpdateCertificateByReference_Call) RunAndReturn(run func(ctx context.Context, existingCert *cert.Certificate, updatedCert *cert.Certificate) error) *certificateStoreInterfaceMock_UpdateCertificateByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
As we have introduced the transection architecture, we are adapting our services to use transections. In this PR we have updated the cert service to use transactions.


Sub Issue : https://github.com/asgardeo/thunder/issues/1359
Parent issue : https://github.com/asgardeo/thunder/issues/282




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now fails fast and logs an error if certificate initialization fails, preventing partial startup.

* **Refactor**
  * Certificate operations made context-aware and run inside transactions; cache refresh/invalidation updated to improve consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->