### PR TITLE
Add openid scope validation for userinfo endpoint

### DIFF
--- a/backend/internal/oauth/oauth2/userinfo/error_constants.go
+++ b/backend/internal/oauth/oauth2/userinfo/error_constants.go
@@ -45,4 +45,12 @@ var (
 		Error:            "Invalid access token",
 		ErrorDescription: "UserInfo endpoint is not applicable for client_credentials grant type",
 	}
+
+	// errorInsufficientScope is returned when the access token lacks the required 'openid' scope
+	errorInsufficientScope = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "insufficient_scope",
+		Error:            "Insufficient scope",
+		ErrorDescription: "The 'openid' scope is required for this request",
+	}
 )

--- a/backend/internal/oauth/oauth2/userinfo/handler.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler.go
@@ -75,7 +75,11 @@ func (h *userInfoHandler) writeServiceErrorResponse(w http.ResponseWriter, svcEr
 
 	switch svcErr.Type {
 	case serviceerror.ClientErrorType:
-		statusCode = http.StatusUnauthorized
+		if svcErr == &errorInsufficientScope {
+			statusCode = http.StatusForbidden
+		} else {
+			statusCode = http.StatusUnauthorized
+		}
 	case serviceerror.ServerErrorType:
 		statusCode = http.StatusInternalServerError
 	default:


### PR DESCRIPTION
This pull request updates the `UserInfo` endpoint to enforce the requirement for the `openid` scope in access tokens. If the scope is missing or incorrectly specified, the endpoint now returns a clear error response. The changes also update related tests to reflect this new behavior.

**UserInfo endpoint scope validation:**

* Added a new error constant `errorInsufficientScope` to signal when the required `openid` scope is missing from the access token.
* Introduced a `validateOpenIDScope` method in `userInfoService` to check for the presence of the `openid` scope and return the new error if not found.
* Updated the `GetUserInfo` method to call `validateOpenIDScope` and fail early if the scope is missing, instead of returning only the `sub` claim.

**Error handling improvements:**

* Modified error response logic to return HTTP 403 Forbidden for insufficient scope errors, rather than 401 Unauthorized.

**Test updates:**

* Updated existing tests to expect the `insufficient_scope` error when the `openid` scope is missing or incorrectly formatted, instead of returning only the `sub` claim. [[1]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL173-R173) [[2]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL185-R191) [[3]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL205-R206) [[4]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL628-R626) [[5]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL641-R645) [[6]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL662-R660)
* Added new tests for scenarios where the `openid` scope is missing but other scopes are present, and for case sensitivity in scope matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UserInfo endpoint now requires the openid scope; requests missing it return 403 Forbidden with an insufficient_scope error.
  * Scope validation strengthened to correctly detect malformed or missing scope data and respond with insufficient_scope.

* **Tests**
  * Expanded and updated tests and integration scenarios to cover openid scope enforcement and related success/error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Related issue:
- https://github.com/asgardeo/thunder/issues/1378