### PR TITLE
Remove Session Cleanup of WebAuthn Session Data Table

### DIFF
--- a/backend/internal/authn/passkey/init.go
+++ b/backend/internal/authn/passkey/init.go
@@ -27,8 +27,5 @@ func Initialize(userSvc user.UserServiceInterface) PasskeyServiceInterface {
 	// Create the session store
 	sessionStore := newSessionStore()
 
-	// Start the periodic cleanup routine for expired sessions
-	startSessionCleanup(sessionStore)
-
 	return newPasskeyService(userSvc, sessionStore)
 }

--- a/backend/internal/authn/passkey/session.go
+++ b/backend/internal/authn/passkey/session.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/system/log"
 )
 
 const (
@@ -32,8 +31,6 @@ const (
 	sessionKeyLength = 32
 	// sessionTTLSeconds is the session time-to-live in seconds.
 	sessionTTLSeconds = 120
-	// cleanupIntervalMinutes is the interval for cleaning up expired sessions.
-	cleanupIntervalMinutes = 5
 )
 
 // generateSessionKey generates a random base64-encoded session key.
@@ -43,27 +40,6 @@ func generateSessionKey() (string, error) {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(bytes), nil
-}
-
-// startSessionCleanup starts a background routine to periodically clean up expired sessions.
-func startSessionCleanup(store sessionStoreInterface) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "WebAuthnSessionCleanup"))
-	logger.Debug("Starting session cleanup routine")
-
-	go func() {
-		ticker := time.NewTicker(cleanupIntervalMinutes * time.Minute)
-		defer ticker.Stop()
-
-		for range ticker.C {
-			logger.Debug("Running expired session cleanup")
-			if err := store.deleteExpiredSessions(); err != nil {
-				logger.Error("Failed to cleanup expired sessions", log.Error(err))
-			}
-		}
-	}()
-
-	logger.Debug("Session cleanup routine started",
-		log.Int("intervalMinutes", cleanupIntervalMinutes))
 }
 
 // storeSessionData stores session data in the database and returns a session key.

--- a/backend/internal/authn/passkey/session_test.go
+++ b/backend/internal/authn/passkey/session_test.go
@@ -310,10 +310,4 @@ func (suite *SessionUtilsTestSuite) TestSessionConstants() {
 	// Verify session constants are reasonable
 	suite.Equal(32, sessionKeyLength, "Session key should be 32 bytes")
 	suite.Equal(120, sessionTTLSeconds, "Session TTL should be 120 seconds (2 minutes)")
-	suite.Equal(5, cleanupIntervalMinutes, "Cleanup interval should be 5 minutes")
-
-	// Verify cleanup interval is longer than session TTL
-	cleanupSeconds := cleanupIntervalMinutes * 60
-	suite.Greater(cleanupSeconds, sessionTTLSeconds,
-		"Cleanup interval should be longer than session TTL")
 }

--- a/backend/internal/authn/passkey/store.go
+++ b/backend/internal/authn/passkey/store.go
@@ -40,7 +40,6 @@ type sessionStoreInterface interface {
 	) error
 	retrieveSession(sessionKey string) (*sessionData, string, string, error)
 	deleteSession(sessionKey string) error
-	deleteExpiredSessions() error
 }
 
 // sessionStore provides the WebAuthn session store functionality using database.
@@ -163,26 +162,6 @@ func (s *sessionStore) deleteSession(sessionKey string) error {
 
 	s.logger.Debug("WebAuthn session deleted successfully",
 		log.String("sessionKey", log.MaskString(sessionKey)))
-
-	return nil
-}
-
-// deleteExpiredSessions removes all expired WebAuthn sessions from the database.
-func (s *sessionStore) deleteExpiredSessions() error {
-	dbClient, err := s.dbProvider.GetRuntimeDBClient()
-	if err != nil {
-		s.logger.Error("Failed to get database client", log.Error(err))
-		return err
-	}
-
-	now := time.Now()
-	_, err = dbClient.Execute(queryDeleteExpiredSessions, now, s.deploymentID)
-	if err != nil {
-		s.logger.Error("Failed to delete expired WebAuthn sessions", log.Error(err))
-		return err
-	}
-
-	s.logger.Debug("Deleted expired WebAuthn sessions")
 
 	return nil
 }

--- a/backend/internal/authn/passkey/store_constants.go
+++ b/backend/internal/authn/passkey/store_constants.go
@@ -59,9 +59,3 @@ var queryDeleteSession = dbmodel.DBQuery{
 	ID:    "WEBAUTHN-SS-03",
 	Query: "DELETE FROM WEBAUTHN_SESSION WHERE SESSION_KEY = $1 AND DEPLOYMENT_ID = $2",
 }
-
-// queryDeleteExpiredSessions is the query to delete expired WebAuthn sessions.
-var queryDeleteExpiredSessions = dbmodel.DBQuery{
-	ID:    "WEBAUTHN-SS-04",
-	Query: "DELETE FROM WEBAUTHN_SESSION WHERE EXPIRY_TIME <= $1 AND DEPLOYMENT_ID = $2",
-}

--- a/backend/internal/authn/passkey/store_test.go
+++ b/backend/internal/authn/passkey/store_test.go
@@ -323,36 +323,6 @@ func (suite *SessionStoreTestSuite) TestDeleteSession_ExecuteError() {
 	suite.Error(err)
 }
 
-func (suite *SessionStoreTestSuite) TestDeleteExpiredSessions_Success() {
-	suite.mockDBProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.On("Execute", mock.AnythingOfType("model.DBQuery"),
-		mock.AnythingOfType("time.Time"), "test-deployment-id").
-		Return(int64(5), nil).Once()
-
-	err := suite.store.deleteExpiredSessions()
-
-	suite.NoError(err)
-}
-
-func (suite *SessionStoreTestSuite) TestDeleteExpiredSessions_DBClientError() {
-	suite.mockDBProvider.On("GetRuntimeDBClient").Return(nil, assert.AnError).Once()
-
-	err := suite.store.deleteExpiredSessions()
-
-	suite.Error(err)
-}
-
-func (suite *SessionStoreTestSuite) TestDeleteExpiredSessions_ExecuteError() {
-	suite.mockDBProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.On("Execute", mock.AnythingOfType("model.DBQuery"),
-		mock.AnythingOfType("time.Time"), "test-deployment-id").
-		Return(int64(0), assert.AnError).Once()
-
-	err := suite.store.deleteExpiredSessions()
-
-	suite.Error(err)
-}
-
 func (suite *SessionStoreTestSuite) TestSerializeSessionData_MinimalData() {
 	sessionData := &sessionData{
 		Challenge:        "challenge123",


### PR DESCRIPTION
### Purpose
This pull request removes the background cleanup routine and related code for expired WebAuthn sessions.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1367

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the automatic background session cleanup mechanism for passkey (periodic cleanup, startup/init hooks, and related DB delete path).
* **Tests**
  * Removed tests and validations that verified cleanup intervals and expired-session deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->