### PR TITLE
Fix Windows E2E sample app startup in the workflow

### DIFF
--- a/.github/workflows/windows-build-validation.yml
+++ b/.github/workflows/windows-build-validation.yml
@@ -362,6 +362,10 @@ jobs:
             Remove-Item -Path $extractedDir.FullName -Recurse -Force
           }
 
+      - name: 📦 Install serve globally
+        shell: bash
+        run: npm install -g serve
+
       - name: 📱 Start Sample App
         shell: bash
         run: |
@@ -374,11 +378,11 @@ jobs:
 
           if [ -f "$cert_file" ] && [ -f "$key_file" ]; then
             echo "Using HTTPS with SSL certificates"
-            npx serve -s "$dist_path" -l 3000 --ssl-cert "$cert_file" --ssl-key "$key_file" > sample-app.log 2>&1 &
+            serve -s "$dist_path" -l 3000 --ssl-cert "$cert_file" --ssl-key "$key_file" > sample-app.log 2>&1 &
             protocol="https"
           else
             echo "No SSL certificates found, using HTTP"
-            npx serve -s "$dist_path" -l 3000 > sample-app.log 2>&1 &
+            serve -s "$dist_path" -l 3000 > sample-app.log 2>&1 &
             protocol="http"
           fi
           sleep 5


### PR DESCRIPTION
### Purpose
This pull request updates the Windows build validation workflow to improve how the sample app is served during CI runs. The main change is to install the `serve` package globally and use it directly instead of running it with `npx`. This should improve reliability and performance in the workflow.

**Workflow improvements:**

* Added a step to install the `serve` package globally using `npm install -g serve` in the `.github/workflows/windows-build-validation.yml` file.
* Updated the commands that start the sample app to use the globally installed `serve` instead of `npx serve`, both for HTTPS (with SSL certificates) and HTTP cases.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Windows build validation workflow updated to install and use a globally available static server for starting the sample app (HTTPS and HTTP), improving startup reliability and provisioning during Windows E2E runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->