### PR TITLE
Fix on the fly passkey registration ending up in infinite loops because of unnecessary onFailure options.

### DIFF
--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_passkey.json
@@ -66,8 +66,7 @@
       "executor": {
         "name": "IdentifyingExecutor"
       },
-      "onSuccess": "passkey_challenge",
-      "onFailure": "prompt_passkey_identifier"
+      "onSuccess": "passkey_challenge"
     },
     {
       "id": "passkey_challenge",
@@ -90,8 +89,7 @@
         "name": "PasskeyAuthExecutor",
         "mode": "verify"
       },
-      "onSuccess": "auth_assert",
-      "onFailure": "choose_auth_method"
+      "onSuccess": "auth_assert"
     },
     {
       "id": "prompt_password_for_registration",
@@ -119,8 +117,7 @@
       "executor": {
         "name": "BasicAuthExecutor"
       },
-      "onSuccess": "passkey_register_start",
-      "onFailure": "prompt_password_for_registration"
+      "onSuccess": "passkey_register_start"
     },
     {
       "id": "passkey_register_start",
@@ -133,8 +130,7 @@
         "name": "PasskeyAuthExecutor",
         "mode": "register_start"
       },
-      "onSuccess": "passkey_register_finish",
-      "onFailure": "choose_auth_method"
+      "onSuccess": "passkey_register_finish"
     },
     {
       "id": "passkey_register_finish",
@@ -143,8 +139,7 @@
         "name": "PasskeyAuthExecutor",
         "mode": "register_finish"
       },
-      "onSuccess": "auth_assert",
-      "onFailure": "choose_auth_method"
+      "onSuccess": "auth_assert"
     },
     {
       "id": "basic_auth",
@@ -152,8 +147,7 @@
       "executor": {
         "name": "BasicAuthExecutor"
       },
-      "onSuccess": "auth_assert",
-      "onFailure": "choose_auth_method"
+      "onSuccess": "auth_assert"
     },
     {
       "id": "auth_assert",


### PR DESCRIPTION
### Purpose
This pull request simplifies the authentication flow configuration in `auth_flow_basic_passkey.json` by removing all `onFailure` transitions from several authentication tasks. Now, only `onSuccess` transitions are defined, which streamlines the flow and reduces complexity.

Key changes to authentication flow transitions:

* Removed all `onFailure` transitions from the following steps, so they only specify `onSuccess`:
  - `prompt_passkey_identifier`
  - `passkey_challenge`
  - `prompt_password_for_registration`
  - `passkey_register_start`
  - `passkey_register_finish`
  - `basic_auth`

### Related Issues
- https://github.com/asgardeo/thunder/issues/1374

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Authentication Updates**
  * Simplified authentication flows by removing select failure handlers, ensuring flows follow success paths consistently.
  * No changes to successful outcomes; sign-in and passkey registration behavior remains intact while reducing redundant failure handling and improving predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->