### PR TITLE
Add declarative resource support for themes and layouts

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -147,8 +147,17 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	}
 
 	// Initialize theme and layout services
-	themeMgtService := thememgt.Initialize(mux)
-	layoutMgtService := layoutmgt.Initialize(mux)
+	themeMgtService, themeExporter, err := thememgt.Initialize(mux)
+	if err != nil {
+		logger.Fatal("Failed to initialize ThemeMgtService", log.Error(err))
+	}
+	exporters = append(exporters, themeExporter)
+
+	layoutMgtService, layoutExporter, err := layoutmgt.Initialize(mux)
+	if err != nil {
+		logger.Fatal("Failed to initialize LayoutMgtService", log.Error(err))
+	}
+	exporters = append(exporters, layoutExporter)
 
 	applicationService, applicationExporter, err := application.Initialize(
 		mux, certservice, flowMgtService, themeMgtService, layoutMgtService, userSchemaService)

--- a/backend/internal/design/layout/mgt/declarative_resource.go
+++ b/backend/internal/design/layout/mgt/declarative_resource.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package layoutmgt
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	resourceTypeLayout = "layout"
+	paramTypeLayout    = "Layout"
+)
+
+// layoutExporter implements declarativeresource.ResourceExporter for layouts.
+type layoutExporter struct {
+	service LayoutMgtServiceInterface
+}
+
+// newLayoutExporter creates a new layout exporter.
+func newLayoutExporter(service LayoutMgtServiceInterface) *layoutExporter {
+	return &layoutExporter{service: service}
+}
+
+// GetResourceType returns the resource type for layouts.
+func (e *layoutExporter) GetResourceType() string {
+	return resourceTypeLayout
+}
+
+// GetParameterizerType returns the parameterizer type for layouts.
+func (e *layoutExporter) GetParameterizerType() string {
+	return paramTypeLayout
+}
+
+// GetAllResourceIDs retrieves all layout IDs.
+func (e *layoutExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+	layoutList, err := e.service.GetLayoutList(100, 0) // Get a large number to fetch all
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(layoutList.Layouts))
+	for _, layout := range layoutList.Layouts {
+		ids = append(ids, layout.ID)
+	}
+	return ids, nil
+}
+
+// GetResourceByID retrieves a layout by its ID.
+func (e *layoutExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+	layout, err := e.service.GetLayout(id)
+	if err != nil {
+		return nil, "", err
+	}
+	return layout, layout.DisplayName, nil
+}
+
+// ValidateResource validates a layout resource.
+func (e *layoutExporter) ValidateResource(
+	resource interface{}, id string, logger *log.Logger,
+) (string, *declarativeresource.ExportError) {
+	layout, ok := resource.(*Layout)
+	if !ok {
+		return "", declarativeresource.CreateTypeError(resourceTypeLayout, id)
+	}
+
+	err := declarativeresource.ValidateResourceName(
+		layout.DisplayName, resourceTypeLayout, id, "LAYOUT_VALIDATION_ERROR", logger,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if len(layout.Layout) == 0 {
+		logger.Warn("Layout has no layout configuration",
+			log.String("layoutID", id), log.String("displayName", layout.DisplayName))
+	}
+
+	return layout.DisplayName, nil
+}
+
+// GetResourceRules returns the parameterization rules for layouts.
+func (e *layoutExporter) GetResourceRules() *declarativeresource.ResourceRules {
+	return &declarativeresource.ResourceRules{}
+}
+
+// loadDeclarativeResources loads declarative layout resources from files.
+func loadDeclarativeResources(layoutStore layoutMgtStoreInterface) error {
+	// Type assert to access Storer interface for resource loading
+	fileBasedStore, ok := layoutStore.(*layoutFileBasedStore)
+	if !ok {
+		return fmt.Errorf("failed to assert layoutStore to *layoutFileBasedStore")
+	}
+
+	resourceConfig := declarativeresource.ResourceConfig{
+		ResourceType:  "Layout",
+		DirectoryName: "layouts",
+		Parser:        parseToLayoutWrapper,
+		Validator:     validateLayoutWrapper,
+		IDExtractor: func(data interface{}) string {
+			if layout, ok := data.(*Layout); ok {
+				return layout.ID
+			}
+			return ""
+		},
+	}
+
+	loader := declarativeresource.NewResourceLoader(resourceConfig, fileBasedStore)
+	if err := loader.LoadResources(); err != nil {
+		return fmt.Errorf("failed to load layout resources: %w", err)
+	}
+
+	return nil
+}
+
+// parseToLayoutWrapper wraps parseToLayout to match ResourceConfig.Parser signature.
+func parseToLayoutWrapper(data []byte) (interface{}, error) {
+	return parseToLayout(data)
+}
+
+// parseToLayout converts YAML data into a Layout object.
+func parseToLayout(data []byte) (*Layout, error) {
+	var layoutRequest layoutRequestWithID
+
+	err := yaml.Unmarshal(data, &layoutRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert layout to JSON bytes
+	var layoutJSON json.RawMessage
+	if layoutRequest.Layout != nil {
+		// Handle both map structure and string format
+		switch v := layoutRequest.Layout.(type) {
+		case string:
+			// JSON string format
+			layoutJSON = []byte(v)
+		default:
+			// Map structure - marshal to JSON
+			layoutBytes, err := json.Marshal(layoutRequest.Layout)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal layout to JSON: %w", err)
+			}
+			layoutJSON = layoutBytes
+		}
+	}
+
+	layout := &Layout{
+		ID:          layoutRequest.ID,
+		DisplayName: layoutRequest.DisplayName,
+		Description: layoutRequest.Description,
+		Layout:      layoutJSON,
+		CreatedAt:   "",
+		UpdatedAt:   "",
+	}
+
+	return layout, nil
+}
+
+// validateLayoutWrapper wraps validateLayoutForDeclarativeResource to match ResourceConfig.Validator signature.
+func validateLayoutWrapper(dto interface{}) error {
+	layout, ok := dto.(*Layout)
+	if !ok {
+		return fmt.Errorf("invalid type: expected *Layout")
+	}
+	return validateLayoutForDeclarativeResource(layout)
+}
+
+// validateLayoutForDeclarativeResource validates a layout for declarative resource loading.
+func validateLayoutForDeclarativeResource(layout *Layout) error {
+	if strings.TrimSpace(layout.DisplayName) == "" {
+		return fmt.Errorf("layout display name is required")
+	}
+
+	if strings.TrimSpace(layout.ID) == "" {
+		return fmt.Errorf("layout ID is required")
+	}
+
+	if len(layout.Layout) == 0 {
+		return fmt.Errorf("layout configuration is required for '%s'", layout.DisplayName)
+	}
+
+	// Validate that layout is valid JSON
+	var layoutConfig interface{}
+	if err := json.Unmarshal(layout.Layout, &layoutConfig); err != nil {
+		return fmt.Errorf("invalid layout JSON for '%s': %w", layout.DisplayName, err)
+	}
+
+	return nil
+}

--- a/backend/internal/design/layout/mgt/declarative_resource_test.go
+++ b/backend/internal/design/layout/mgt/declarative_resource_test.go
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package layoutmgt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type DeclarativeResourceTestSuite struct {
+	suite.Suite
+}
+
+func TestDeclarativeResourceTestSuite(t *testing.T) {
+	suite.Run(t, new(DeclarativeResourceTestSuite))
+}
+
+func (s *DeclarativeResourceTestSuite) SetupSuite() {
+	// Create temporary directory for tests
+	tempDir := s.T().TempDir()
+
+	// Initialize ThunderRuntime once for all tests
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+	}
+	config.ResetThunderRuntime()
+	err := config.InitializeThunderRuntime(tempDir, testConfig)
+	s.Require().NoError(err, "Failed to initialize ThunderRuntime")
+}
+
+func (s *DeclarativeResourceTestSuite) TearDownSuite() {
+	// Clean up ThunderRuntime after all tests
+	config.ResetThunderRuntime()
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetResourceType() {
+	exporter := &layoutExporter{}
+	s.Equal("layout", exporter.GetResourceType())
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetParameterizerType() {
+	exporter := &layoutExporter{}
+	s.Equal("Layout", exporter.GetParameterizerType())
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetResourceRules() {
+	exporter := &layoutExporter{}
+	rules := exporter.GetResourceRules()
+
+	s.NotNil(rules)
+	// Layout field is exported as JSON string, not expanded to YAML structure
+	s.Empty(rules.DynamicPropertyFields)
+	s.Nil(rules.Variables)
+	s.Nil(rules.ArrayVariables)
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_ValidateResource_InvalidType() {
+	exporter := &layoutExporter{}
+
+	name, err := exporter.ValidateResource("not a layout", "layout1", nil)
+
+	s.NotNil(err)
+	s.Empty(name)
+	s.Equal("layout", err.ResourceType)
+	s.Equal("layout1", err.ResourceID)
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetAllResourceIDs_Success() {
+	// Arrange
+	mockService := NewLayoutMgtServiceInterfaceMock(s.T())
+	layoutList := &LayoutList{
+		Layouts: []Layout{
+			{ID: "layout-001", DisplayName: "Layout 1"},
+			{ID: "layout-002", DisplayName: "Layout 2"},
+			{ID: "layout-003", DisplayName: "Layout 3"},
+		},
+	}
+	mockService.EXPECT().GetLayoutList(100, 0).Return(layoutList, nil).Once()
+	exporter := &layoutExporter{service: mockService}
+
+	// Act
+	ids, svcErr := exporter.GetAllResourceIDs()
+
+	// Assert
+	s.Nil(svcErr)
+	s.Len(ids, 3)
+	s.Equal("layout-001", ids[0])
+	s.Equal("layout-002", ids[1])
+	s.Equal("layout-003", ids[2])
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetAllResourceIDs_ServiceError() {
+	// Arrange
+	serviceErr := &serviceerror.ServiceError{Error: "Database error"}
+	mockService := NewLayoutMgtServiceInterfaceMock(s.T())
+	mockService.EXPECT().GetLayoutList(100, 0).Return(&LayoutList{}, serviceErr).Once()
+	exporter := &layoutExporter{service: mockService}
+
+	// Act
+	ids, svcErr := exporter.GetAllResourceIDs()
+
+	// Assert
+	s.NotNil(svcErr)
+	s.Nil(ids)
+	s.Equal(serviceErr, svcErr)
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetAllResourceIDs_EmptyList() {
+	// Arrange
+	mockService := NewLayoutMgtServiceInterfaceMock(s.T())
+	mockService.EXPECT().GetLayoutList(100, 0).Return(&LayoutList{Layouts: []Layout{}}, nil).Once()
+	exporter := &layoutExporter{service: mockService}
+
+	// Act
+	ids, svcErr := exporter.GetAllResourceIDs()
+
+	// Assert
+	s.Nil(svcErr)
+	s.Empty(ids)
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetResourceByID_Success() {
+	// Arrange
+	layoutConfig := map[string]interface{}{"type": "centered"}
+	layoutJSON, _ := json.Marshal(layoutConfig)
+	mockService := NewLayoutMgtServiceInterfaceMock(s.T())
+	layout := &Layout{
+		ID:          "layout-001",
+		DisplayName: "Centered Layout",
+		Description: "A centered layout",
+		Layout:      layoutJSON,
+	}
+	mockService.EXPECT().GetLayout("layout-001").Return(layout, nil).Once()
+	exporter := &layoutExporter{service: mockService}
+
+	// Act
+	resource, displayName, svcErr := exporter.GetResourceByID("layout-001")
+
+	// Assert
+	s.Nil(svcErr)
+	s.NotNil(resource)
+	s.Equal("Centered Layout", displayName)
+
+	retrievedLayout, ok := resource.(*Layout)
+	s.True(ok)
+	s.Equal("layout-001", retrievedLayout.ID)
+	s.Equal("Centered Layout", retrievedLayout.DisplayName)
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetResourceByID_NotFound() {
+	// Arrange
+	serviceErr := &serviceerror.ServiceError{Error: "Layout not found"}
+	mockService := NewLayoutMgtServiceInterfaceMock(s.T())
+	mockService.EXPECT().GetLayout("non-existent").Return(&Layout{}, serviceErr).Once()
+	exporter := &layoutExporter{service: mockService}
+
+	// Act
+	resource, displayName, svcErr := exporter.GetResourceByID("non-existent")
+
+	// Assert
+	s.NotNil(svcErr)
+	s.Nil(resource)
+	s.Empty(displayName)
+	s.Equal(serviceErr, svcErr)
+}
+
+func (s *DeclarativeResourceTestSuite) TestParseToLayout() {
+	yamlData := []byte(`
+id: layout-001
+displayName: Centered Layout
+description: A centered layout configuration
+layout:
+  type: centered
+  components:
+    - type: logo
+      position: top
+    - type: form
+      position: center
+`)
+
+	layout, err := parseToLayout(yamlData)
+
+	s.NoError(err)
+	s.NotNil(layout)
+	s.Equal("layout-001", layout.ID)
+	s.Equal("Centered Layout", layout.DisplayName)
+	s.Equal("A centered layout configuration", layout.Description)
+	s.NotEmpty(layout.Layout)
+
+	// Verify layout JSON is parseable
+	var layoutConfig map[string]interface{}
+	err = json.Unmarshal(layout.Layout, &layoutConfig)
+	s.NoError(err)
+	s.Equal("centered", layoutConfig["type"])
+}
+
+func (s *DeclarativeResourceTestSuite) TestParseToLayout_InvalidYAML() {
+	yamlData := []byte(`invalid: yaml: data:`)
+
+	layout, err := parseToLayout(yamlData)
+
+	s.Error(err)
+	s.Nil(layout)
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateLayoutForDeclarativeResource_Success() {
+	layoutConfig := map[string]interface{}{"type": "centered"}
+	layoutJSON, _ := json.Marshal(layoutConfig)
+
+	layout := &Layout{
+		ID:          "layout1",
+		DisplayName: "Test Layout",
+		Description: "A test layout",
+		Layout:      layoutJSON,
+	}
+
+	err := validateLayoutForDeclarativeResource(layout)
+
+	s.NoError(err)
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateLayoutForDeclarativeResource_EmptyDisplayName() {
+	layout := &Layout{
+		ID:          "layout1",
+		DisplayName: "   ",
+		Layout:      json.RawMessage(`{"type": "centered"}`),
+	}
+
+	err := validateLayoutForDeclarativeResource(layout)
+
+	s.Error(err)
+	s.Contains(err.Error(), "display name is required")
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateLayoutForDeclarativeResource_EmptyID() {
+	layout := &Layout{
+		ID:          "",
+		DisplayName: "Layout",
+		Layout:      json.RawMessage(`{"type": "centered"}`),
+	}
+
+	err := validateLayoutForDeclarativeResource(layout)
+
+	s.Error(err)
+	s.Contains(err.Error(), "ID is required")
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateLayoutForDeclarativeResource_EmptyLayout() {
+	layout := &Layout{
+		ID:          "layout1",
+		DisplayName: "Test",
+		Layout:      json.RawMessage{},
+	}
+
+	err := validateLayoutForDeclarativeResource(layout)
+
+	s.Error(err)
+	s.Contains(err.Error(), "configuration is required")
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateLayoutForDeclarativeResource_InvalidJSON() {
+	layout := &Layout{
+		ID:          "layout1",
+		DisplayName: "Test",
+		Layout:      json.RawMessage(`{invalid json}`),
+	}
+
+	err := validateLayoutForDeclarativeResource(layout)
+
+	s.Error(err)
+	s.Contains(err.Error(), "invalid layout JSON")
+}
+
+func (s *DeclarativeResourceTestSuite) TestLoadDeclarativeResources_Integration() {
+	// Create file-based store with test configuration
+	genericStore := declarativeresource.NewGenericFileBasedStoreForTest(entity.KeyTypeLayout)
+	store := &layoutFileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+
+	// This should not panic even with empty directory
+	err := loadDeclarativeResources(store)
+
+	// Error is expected if directory doesn't exist, which is acceptable for this test
+	// We're verifying that the function can be called without panicking
+	_ = err
+}
+
+func (s *DeclarativeResourceTestSuite) TestLayoutExporter_ValidateResource_EmptyLayoutWarning() {
+	// Use the singleton logger which is already initialized in SetupSuite
+	testLogger := log.GetLogger()
+
+	exporter := &layoutExporter{}
+
+	layout := &Layout{
+		ID:          "layout1",
+		DisplayName: "Layout Without Config",
+		Description: "This layout has no configuration",
+		Layout:      json.RawMessage{},
+	}
+
+	// Even with empty layout, validation should succeed (just logs warning)
+	name, err := exporter.ValidateResource(layout, "layout1", testLogger)
+
+	// The empty layout should not cause validation error in ValidateResource
+	// (it logs a warning instead)
+	s.Nil(err)
+	s.Equal("Layout Without Config", name)
+}
+
+func (s *DeclarativeResourceTestSuite) TestParseToLayoutWrapper() {
+	yamlData := []byte(`
+id: layout-wrapper-test
+displayName: Wrapper Test Layout
+description: Testing wrapper
+layout:
+  type: fullscreen
+`)
+
+	result, err := parseToLayoutWrapper(yamlData)
+
+	s.NoError(err)
+	s.NotNil(result)
+
+	layout, ok := result.(*Layout)
+	s.True(ok)
+	s.Equal("layout-wrapper-test", layout.ID)
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateLayoutWrapper() {
+	layout := &Layout{
+		ID:          "layout1",
+		DisplayName: "Test",
+		Layout:      json.RawMessage(`{"type": "centered"}`),
+	}
+
+	err := validateLayoutWrapper(layout)
+	s.NoError(err)
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateLayoutWrapper_InvalidType() {
+	err := validateLayoutWrapper("not a layout")
+	s.Error(err)
+	s.Contains(err.Error(), "invalid type")
+}

--- a/backend/internal/design/layout/mgt/file_based_store.go
+++ b/backend/internal/design/layout/mgt/file_based_store.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package layoutmgt
+
+import (
+	"errors"
+
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
+)
+
+type layoutFileBasedStore struct {
+	*declarativeresource.GenericFileBasedStore
+}
+
+// Create implements declarativeresource.Storer interface for resource loader
+func (f *layoutFileBasedStore) Create(id string, data interface{}) error {
+	layout, ok := data.(*Layout)
+	if !ok {
+		declarativeresource.LogTypeAssertionError("layout", id)
+		return errors.New("invalid data type: expected *Layout")
+	}
+	createReq := CreateLayoutRequest{
+		DisplayName: layout.DisplayName,
+		Description: layout.Description,
+		Layout:      layout.Layout,
+	}
+	return f.CreateLayout(id, createReq)
+}
+
+// CreateLayout implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) CreateLayout(id string, layout CreateLayoutRequest) error {
+	layoutData := &Layout{
+		ID:          id,
+		DisplayName: layout.DisplayName,
+		Description: layout.Description,
+		Layout:      layout.Layout,
+		CreatedAt:   "",
+		UpdatedAt:   "",
+	}
+	return f.GenericFileBasedStore.Create(id, layoutData)
+}
+
+// DeleteLayout implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) DeleteLayout(id string) error {
+	return errors.New("deleteLayout is not supported in file-based store")
+}
+
+// GetLayout implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) GetLayout(id string) (Layout, error) {
+	data, err := f.GenericFileBasedStore.Get(id)
+	if err != nil {
+		return Layout{}, err
+	}
+	layout, ok := data.(*Layout)
+	if !ok {
+		declarativeresource.LogTypeAssertionError("layout", id)
+		return Layout{}, errors.New("layout data corrupted")
+	}
+	return *layout, nil
+}
+
+// GetLayoutList implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) GetLayoutList(limit, offset int) ([]Layout, error) {
+	// Validate input parameters to prevent panics
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		return []Layout{}, nil
+	}
+
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return nil, err
+	}
+
+	layoutList := make([]Layout, 0)
+	for _, item := range list {
+		if layout, ok := item.Data.(*Layout); ok {
+			layoutList = append(layoutList, *layout)
+		}
+	}
+
+	// Apply pagination
+	start := offset
+	if start >= len(layoutList) {
+		return []Layout{}, nil
+	}
+
+	end := start + limit
+	if end > len(layoutList) {
+		end = len(layoutList)
+	}
+	return layoutList[start:end], nil
+}
+
+// GetLayoutListCount implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) GetLayoutListCount() (int, error) {
+	count, err := f.GenericFileBasedStore.Count()
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// IsLayoutExist implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) IsLayoutExist(id string) (bool, error) {
+	_, err := f.GetLayout(id)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// UpdateLayout implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) UpdateLayout(id string, layout UpdateLayoutRequest) error {
+	return errors.New("updateLayout is not supported in file-based store")
+}
+
+// GetApplicationsCountByLayoutID implements layoutMgtStoreInterface.
+func (f *layoutFileBasedStore) GetApplicationsCountByLayoutID(id string) (int, error) {
+	// In declarative mode, we don't track application references in the file-based store
+	return 0, nil
+}
+
+// newLayoutFileBasedStore creates a new instance of a file-based store.
+func newLayoutFileBasedStore() layoutMgtStoreInterface {
+	genericStore := declarativeresource.NewGenericFileBasedStore(entity.KeyTypeLayout)
+	return &layoutFileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+}

--- a/backend/internal/design/layout/mgt/file_based_store_test.go
+++ b/backend/internal/design/layout/mgt/file_based_store_test.go
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package layoutmgt
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// LayoutFileBasedStoreTestSuite contains comprehensive tests for the file-based layout store.
+type LayoutFileBasedStoreTestSuite struct {
+	suite.Suite
+	store *layoutFileBasedStore
+}
+
+// TestLayoutFileBasedStoreTestSuite runs the file-based store test suite.
+func TestLayoutFileBasedStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(LayoutFileBasedStoreTestSuite))
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) SetupSuite() {
+	// Create temporary directory for tests
+	tempDir := suite.T().TempDir()
+
+	// Initialize ThunderRuntime once for all tests
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+	}
+	config.ResetThunderRuntime()
+	err := config.InitializeThunderRuntime(tempDir, testConfig)
+	suite.Require().NoError(err, "Failed to initialize ThunderRuntime")
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TearDownSuite() {
+	// Clean up ThunderRuntime after all tests
+	config.ResetThunderRuntime()
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) SetupTest() {
+	genericStore := declarativeresource.NewGenericFileBasedStoreForTest(entity.KeyTypeLayout)
+	suite.store = &layoutFileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) createTestLayout(displayName string) CreateLayoutRequest {
+	layoutConfig := map[string]interface{}{
+		"type": "centered",
+		"components": []map[string]string{
+			{"type": "logo", "position": "top"},
+			{"type": "form", "position": "center"},
+		},
+	}
+	layoutJSON, err := json.Marshal(layoutConfig)
+	suite.Require().NoError(err, "Failed to marshal test layout config")
+
+	return CreateLayoutRequest{
+		DisplayName: displayName,
+		Description: "Test layout",
+		Layout:      layoutJSON,
+	}
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestCreateLayout_Success() {
+	// Arrange
+	layoutReq := suite.createTestLayout("Centered Layout")
+
+	// Act
+	err := suite.store.CreateLayout("layout-001", layoutReq)
+
+	// Assert
+	suite.NoError(err)
+
+	// Verify layout was created
+	retrieved, err := suite.store.GetLayout("layout-001")
+	suite.NoError(err)
+	suite.Equal("layout-001", retrieved.ID)
+	suite.Equal("Centered Layout", retrieved.DisplayName)
+	suite.Equal("Test layout", retrieved.Description)
+	suite.NotEmpty(retrieved.Layout)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayout_Success() {
+	// Arrange
+	layoutReq := suite.createTestLayout("Sidebar Layout")
+	_ = suite.store.CreateLayout("layout-002", layoutReq)
+
+	// Act
+	retrieved, err := suite.store.GetLayout("layout-002")
+
+	// Assert
+	suite.NoError(err)
+	suite.Equal("layout-002", retrieved.ID)
+	suite.Equal("Sidebar Layout", retrieved.DisplayName)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayout_NotFound() {
+	// Act
+	retrieved, err := suite.store.GetLayout("non-existent")
+
+	// Assert
+	suite.Error(err)
+	suite.Empty(retrieved.ID)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_Success() {
+	// Arrange
+	layout1 := suite.createTestLayout("Layout 1")
+	layout2 := suite.createTestLayout("Layout 2")
+	layout3 := suite.createTestLayout("Layout 3")
+	_ = suite.store.CreateLayout("layout-003", layout1)
+	_ = suite.store.CreateLayout("layout-004", layout2)
+	_ = suite.store.CreateLayout("layout-005", layout3)
+
+	// Act
+	layouts, err := suite.store.GetLayoutList(10, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(layouts, 3)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_WithPagination() {
+	// Arrange
+	for i := 1; i <= 5; i++ {
+		layoutReq := suite.createTestLayout(fmt.Sprintf("Layout %d", i))
+		_ = suite.store.CreateLayout(fmt.Sprintf("layout-%03d", i), layoutReq)
+	}
+
+	// Act - Get first 2 layouts
+	layouts, err := suite.store.GetLayoutList(2, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(layouts, 2)
+
+	// Act - Get next 2 layouts
+	layouts, err = suite.store.GetLayoutList(2, 2)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(layouts, 2)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_EmptyStore() {
+	// Act
+	layouts, err := suite.store.GetLayoutList(10, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(layouts)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutListCount_Success() {
+	// Arrange
+	layout1 := suite.createTestLayout("Layout 6")
+	layout2 := suite.createTestLayout("Layout 7")
+	_ = suite.store.CreateLayout("layout-006", layout1)
+	_ = suite.store.CreateLayout("layout-007", layout2)
+
+	// Act
+	count, err := suite.store.GetLayoutListCount()
+
+	// Assert
+	suite.NoError(err)
+	suite.Equal(2, count)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutExist_True() {
+	// Arrange
+	layoutReq := suite.createTestLayout("Existing Layout")
+	_ = suite.store.CreateLayout("layout-008", layoutReq)
+
+	// Act
+	exists, err := suite.store.IsLayoutExist("layout-008")
+
+	// Assert
+	suite.NoError(err)
+	suite.True(exists)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestIsLayoutExist_False() {
+	// Act
+	exists, err := suite.store.IsLayoutExist("non-existent")
+
+	// Assert
+	suite.NoError(err)
+	suite.False(exists)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestUpdateLayout_NotSupported() {
+	// Arrange
+	layoutReq := suite.createTestLayout("Update Test")
+
+	// Act
+	err := suite.store.UpdateLayout("layout-009", UpdateLayoutRequest{
+		DisplayName: "Updated Name",
+		Description: "Updated description",
+		Layout:      layoutReq.Layout,
+	})
+
+	// Assert
+	suite.Error(err)
+	suite.Contains(err.Error(), "not supported")
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestDeleteLayout_NotSupported() {
+	// Act
+	err := suite.store.DeleteLayout("layout-001")
+
+	// Assert
+	suite.Error(err)
+	suite.Contains(err.Error(), "not supported")
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetApplicationsCountByLayoutID() {
+	// Act
+	count, err := suite.store.GetApplicationsCountByLayoutID("layout-001")
+
+	// Assert
+	suite.NoError(err)
+	suite.Equal(0, count)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestCreate_StorerInterface() {
+	// Arrange
+	layoutConfig := map[string]interface{}{
+		"type": "fullscreen",
+	}
+	layoutJSON, _ := json.Marshal(layoutConfig)
+	layout := &Layout{
+		ID:          "layout-010",
+		DisplayName: "Fullscreen Layout",
+		Description: "Test",
+		Layout:      layoutJSON,
+	}
+
+	// Act
+	err := suite.store.Create("layout-010", layout)
+
+	// Assert
+	suite.NoError(err)
+
+	// Verify
+	retrieved, err := suite.store.GetLayout("layout-010")
+	suite.NoError(err)
+	suite.Equal("layout-010", retrieved.ID)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestCreate_InvalidType() {
+	// Arrange - pass wrong type to Create
+	invalidData := "not a layout"
+
+	// Act
+	err := suite.store.Create("layout-invalid", invalidData)
+
+	// Assert
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid data type")
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_NegativeOffset() {
+	// Arrange
+	layout1 := suite.createTestLayout("Layout A")
+	layout2 := suite.createTestLayout("Layout B")
+	_ = suite.store.CreateLayout("layout-a", layout1)
+	_ = suite.store.CreateLayout("layout-b", layout2)
+
+	// Act - negative offset should be clamped to 0
+	layouts, err := suite.store.GetLayoutList(10, -5)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(layouts, 2) // Should return all layouts
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_ZeroLimit() {
+	// Arrange
+	layout1 := suite.createTestLayout("Layout C")
+	_ = suite.store.CreateLayout("layout-c", layout1)
+
+	// Act - zero limit should return empty slice
+	layouts, err := suite.store.GetLayoutList(0, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(layouts)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_NegativeLimit() {
+	// Arrange
+	layout1 := suite.createTestLayout("Layout D")
+	_ = suite.store.CreateLayout("layout-d", layout1)
+
+	// Act - negative limit should return empty slice
+	layouts, err := suite.store.GetLayoutList(-10, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(layouts)
+}
+
+func (suite *LayoutFileBasedStoreTestSuite) TestGetLayoutList_OffsetBeyondList() {
+	// Arrange
+	layout1 := suite.createTestLayout("Layout E")
+	_ = suite.store.CreateLayout("layout-e", layout1)
+
+	// Act - offset beyond list length should return empty slice
+	layouts, err := suite.store.GetLayoutList(10, 100)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(layouts)
+}

--- a/backend/internal/design/layout/mgt/model.go
+++ b/backend/internal/design/layout/mgt/model.go
@@ -22,12 +22,12 @@ import "encoding/json"
 
 // Layout represents a layout configuration.
 type Layout struct {
-	ID          string          `json:"id"`
-	DisplayName string          `json:"displayName"`
-	Description string          `json:"description,omitempty"`
-	Layout      json.RawMessage `json:"layout"`
-	CreatedAt   string          `json:"createdAt"`
-	UpdatedAt   string          `json:"updatedAt"`
+	ID          string          `json:"id" yaml:"id,omitempty"`
+	DisplayName string          `json:"displayName" yaml:"displayName"`
+	Description string          `json:"description,omitempty" yaml:"description,omitempty"`
+	Layout      json.RawMessage `json:"layout" yaml:"layout"`
+	CreatedAt   string          `json:"createdAt" yaml:"createdAt,omitempty"`
+	UpdatedAt   string          `json:"updatedAt" yaml:"updatedAt,omitempty"`
 }
 
 // LayoutListItem represents a layout item in the list response.
@@ -51,6 +51,14 @@ type UpdateLayoutRequest struct {
 	DisplayName string          `json:"displayName"`
 	Description string          `json:"description,omitempty"`
 	Layout      json.RawMessage `json:"layout"`
+}
+
+// layoutRequestWithID represents the request structure for creating a layout from file-based config.
+type layoutRequestWithID struct {
+	ID          string      `yaml:"id"`
+	DisplayName string      `yaml:"displayName"`
+	Description string      `yaml:"description,omitempty"`
+	Layout      interface{} `yaml:"layout"`
 }
 
 // LayoutListResponse represents the response for listing layout configurations with pagination.

--- a/backend/internal/design/theme/mgt/declarative_resource.go
+++ b/backend/internal/design/theme/mgt/declarative_resource.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thememgt
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	resourceTypeTheme = "theme"
+	paramTypeTheme    = "Theme"
+)
+
+// themeExporter implements declarativeresource.ResourceExporter for themes.
+type themeExporter struct {
+	service ThemeMgtServiceInterface
+}
+
+// newThemeExporter creates a new theme exporter.
+func newThemeExporter(service ThemeMgtServiceInterface) *themeExporter {
+	return &themeExporter{service: service}
+}
+
+// GetResourceType returns the resource type for themes.
+func (e *themeExporter) GetResourceType() string {
+	return resourceTypeTheme
+}
+
+// GetParameterizerType returns the parameterizer type for themes.
+func (e *themeExporter) GetParameterizerType() string {
+	return paramTypeTheme
+}
+
+// GetAllResourceIDs retrieves all theme IDs.
+func (e *themeExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+	themeList, err := e.service.GetThemeList(100, 0) // Get a large number to fetch all
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(themeList.Themes))
+	for _, theme := range themeList.Themes {
+		ids = append(ids, theme.ID)
+	}
+	return ids, nil
+}
+
+// GetResourceByID retrieves a theme by its ID.
+func (e *themeExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+	theme, err := e.service.GetTheme(id)
+	if err != nil {
+		return nil, "", err
+	}
+	return theme, theme.DisplayName, nil
+}
+
+// ValidateResource validates a theme resource.
+func (e *themeExporter) ValidateResource(
+	resource interface{}, id string, logger *log.Logger,
+) (string, *declarativeresource.ExportError) {
+	theme, ok := resource.(*Theme)
+	if !ok {
+		return "", declarativeresource.CreateTypeError(resourceTypeTheme, id)
+	}
+
+	err := declarativeresource.ValidateResourceName(
+		theme.DisplayName, resourceTypeTheme, id, "THEME_VALIDATION_ERROR", logger,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if len(theme.Theme) == 0 {
+		logger.Warn("Theme has no theme configuration",
+			log.String("themeID", id), log.String("displayName", theme.DisplayName))
+	}
+
+	return theme.DisplayName, nil
+}
+
+// GetResourceRules returns the parameterization rules for themes.
+func (e *themeExporter) GetResourceRules() *declarativeresource.ResourceRules {
+	return &declarativeresource.ResourceRules{}
+}
+
+// loadDeclarativeResources loads declarative theme resources from files.
+func loadDeclarativeResources(themeStore themeMgtStoreInterface) error {
+	// Type assert to access Storer interface for resource loading
+	fileBasedStore, ok := themeStore.(*themeFileBasedStore)
+	if !ok {
+		return fmt.Errorf("failed to assert themeStore to *themeFileBasedStore")
+	}
+
+	resourceConfig := declarativeresource.ResourceConfig{
+		ResourceType:  "Theme",
+		DirectoryName: "themes",
+		Parser:        parseToThemeWrapper,
+		Validator:     validateThemeWrapper,
+		IDExtractor: func(data interface{}) string {
+			if theme, ok := data.(*Theme); ok {
+				return theme.ID
+			}
+			return ""
+		},
+	}
+
+	loader := declarativeresource.NewResourceLoader(resourceConfig, fileBasedStore)
+	if err := loader.LoadResources(); err != nil {
+		return fmt.Errorf("failed to load theme resources: %w", err)
+	}
+
+	return nil
+}
+
+// parseToThemeWrapper wraps parseToTheme to match ResourceConfig.Parser signature.
+func parseToThemeWrapper(data []byte) (interface{}, error) {
+	return parseToTheme(data)
+}
+
+// parseToTheme converts YAML data into a Theme object.
+func parseToTheme(data []byte) (*Theme, error) {
+	var themeRequest themeRequestWithID
+
+	err := yaml.Unmarshal(data, &themeRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert theme to JSON bytes
+	var themeJSON json.RawMessage
+	if themeRequest.Theme != nil {
+		// Handle both map structure and string format
+		switch v := themeRequest.Theme.(type) {
+		case string:
+			// JSON string format
+			themeJSON = []byte(v)
+		default:
+			// Map structure - marshal to JSON
+			themeBytes, err := json.Marshal(themeRequest.Theme)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal theme to JSON: %w", err)
+			}
+			themeJSON = themeBytes
+		}
+	}
+
+	theme := &Theme{
+		ID:          themeRequest.ID,
+		DisplayName: themeRequest.DisplayName,
+		Description: themeRequest.Description,
+		Theme:       themeJSON,
+		CreatedAt:   "",
+		UpdatedAt:   "",
+	}
+
+	return theme, nil
+}
+
+// validateThemeWrapper wraps validateThemeForDeclarativeResource to match ResourceConfig.Validator signature.
+func validateThemeWrapper(dto interface{}) error {
+	theme, ok := dto.(*Theme)
+	if !ok {
+		return fmt.Errorf("invalid type: expected *Theme")
+	}
+	return validateThemeForDeclarativeResource(theme)
+}
+
+// validateThemeForDeclarativeResource validates a theme for declarative resource loading.
+func validateThemeForDeclarativeResource(theme *Theme) error {
+	if strings.TrimSpace(theme.DisplayName) == "" {
+		return fmt.Errorf("theme display name is required")
+	}
+
+	if strings.TrimSpace(theme.ID) == "" {
+		return fmt.Errorf("theme ID is required")
+	}
+
+	if len(theme.Theme) == 0 {
+		return fmt.Errorf("theme configuration is required for '%s'", theme.DisplayName)
+	}
+
+	// Validate that theme is valid JSON
+	var themeConfig interface{}
+	if err := json.Unmarshal(theme.Theme, &themeConfig); err != nil {
+		return fmt.Errorf("invalid theme JSON for '%s': %w", theme.DisplayName, err)
+	}
+
+	return nil
+}

--- a/backend/internal/design/theme/mgt/declarative_resource_test.go
+++ b/backend/internal/design/theme/mgt/declarative_resource_test.go
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thememgt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/log"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ThemeDeclarativeSuite struct {
+	suite.Suite
+}
+
+func TestThemeDeclarativeSuite(t *testing.T) {
+	suite.Run(t, new(ThemeDeclarativeSuite))
+}
+
+func (s *ThemeDeclarativeSuite) SetupSuite() {
+	// Create temporary directory for tests
+	tempDir := s.T().TempDir()
+
+	// Initialize ThunderRuntime once for all tests
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+	}
+	config.ResetThunderRuntime()
+	err := config.InitializeThunderRuntime(tempDir, testConfig)
+	s.Require().NoError(err, "Failed to initialize ThunderRuntime")
+}
+
+func (s *ThemeDeclarativeSuite) TearDownSuite() {
+	// Clean up ThunderRuntime after all tests
+	config.ResetThunderRuntime()
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetResourceType() {
+	exporter := &themeExporter{}
+	s.Equal("theme", exporter.GetResourceType())
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetParameterizerType() {
+	exporter := &themeExporter{}
+	s.Equal("Theme", exporter.GetParameterizerType())
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetResourceRules() {
+	exporter := &themeExporter{}
+	rules := exporter.GetResourceRules()
+
+	s.NotNil(rules)
+	// Theme field is exported as JSON string, not expanded to YAML structure
+	s.Empty(rules.DynamicPropertyFields)
+	s.Nil(rules.Variables)
+	s.Nil(rules.ArrayVariables)
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_ValidateResource_InvalidType() {
+	exporter := &themeExporter{}
+
+	name, err := exporter.ValidateResource("not a theme", "theme1", nil)
+
+	s.NotNil(err)
+	s.Empty(name)
+	s.Equal("theme", err.ResourceType)
+	s.Equal("theme1", err.ResourceID)
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetAllResourceIDs_Success() {
+	// Arrange
+	mockService := NewThemeMgtServiceInterfaceMock(s.T())
+	themeList := &ThemeList{
+		Themes: []Theme{
+			{ID: "theme-001", DisplayName: "Theme 1"},
+			{ID: "theme-002", DisplayName: "Theme 2"},
+			{ID: "theme-003", DisplayName: "Theme 3"},
+		},
+	}
+	mockService.EXPECT().GetThemeList(100, 0).Return(themeList, nil).Once()
+	exporter := &themeExporter{service: mockService}
+
+	// Act
+	ids, svcErr := exporter.GetAllResourceIDs()
+
+	// Assert
+	s.Nil(svcErr)
+	s.Len(ids, 3)
+	s.Equal("theme-001", ids[0])
+	s.Equal("theme-002", ids[1])
+	s.Equal("theme-003", ids[2])
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetAllResourceIDs_ServiceError() {
+	// Arrange
+	serviceErr := &serviceerror.ServiceError{Error: "Database error"}
+	mockService := NewThemeMgtServiceInterfaceMock(s.T())
+	mockService.EXPECT().GetThemeList(100, 0).Return(&ThemeList{}, serviceErr).Once()
+	exporter := &themeExporter{service: mockService}
+
+	// Act
+	ids, svcErr := exporter.GetAllResourceIDs()
+
+	// Assert
+	s.NotNil(svcErr)
+	s.Nil(ids)
+	s.Equal(serviceErr, svcErr)
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetAllResourceIDs_EmptyList() {
+	// Arrange
+	mockService := NewThemeMgtServiceInterfaceMock(s.T())
+	mockService.EXPECT().GetThemeList(100, 0).Return(&ThemeList{Themes: []Theme{}}, nil).Once()
+	exporter := &themeExporter{service: mockService}
+
+	// Act
+	ids, svcErr := exporter.GetAllResourceIDs()
+
+	// Assert
+	s.Nil(svcErr)
+	s.Empty(ids)
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetResourceByID_Success() {
+	// Arrange
+	themeConfig := map[string]interface{}{"primaryColor": "#1976d2"}
+	themeJSON, _ := json.Marshal(themeConfig)
+	mockService := NewThemeMgtServiceInterfaceMock(s.T())
+	theme := &Theme{
+		ID:          "theme-001",
+		DisplayName: "Blue Theme",
+		Description: "A blue theme",
+		Theme:       themeJSON,
+	}
+	mockService.EXPECT().GetTheme("theme-001").Return(theme, nil).Once()
+	exporter := &themeExporter{service: mockService}
+
+	// Act
+	resource, displayName, svcErr := exporter.GetResourceByID("theme-001")
+
+	// Assert
+	s.Nil(svcErr)
+	s.NotNil(resource)
+	s.Equal("Blue Theme", displayName)
+
+	retrievedTheme, ok := resource.(*Theme)
+	s.True(ok)
+	s.Equal("theme-001", retrievedTheme.ID)
+	s.Equal("Blue Theme", retrievedTheme.DisplayName)
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_GetResourceByID_NotFound() {
+	// Arrange
+	serviceErr := &serviceerror.ServiceError{Error: "Theme not found"}
+	mockService := NewThemeMgtServiceInterfaceMock(s.T())
+	mockService.EXPECT().GetTheme("non-existent").Return(&Theme{}, serviceErr).Once()
+	exporter := &themeExporter{service: mockService}
+
+	// Act
+	resource, displayName, svcErr := exporter.GetResourceByID("non-existent")
+
+	// Assert
+	s.NotNil(svcErr)
+	s.Nil(resource)
+	s.Empty(displayName)
+	s.Equal(serviceErr, svcErr)
+}
+
+func (s *ThemeDeclarativeSuite) TestParseToTheme() {
+	yamlData := []byte(`
+id: theme-001
+displayName: Blue Theme
+description: A beautiful blue theme
+theme:
+  primaryColor: "#1976d2"
+  secondaryColor: "#dc004e"
+`)
+
+	theme, err := parseToTheme(yamlData)
+
+	s.NoError(err)
+	s.NotNil(theme)
+	s.Equal("theme-001", theme.ID)
+	s.Equal("Blue Theme", theme.DisplayName)
+	s.Equal("A beautiful blue theme", theme.Description)
+	s.NotEmpty(theme.Theme)
+
+	// Verify theme JSON is parseable
+	var themeConfig map[string]interface{}
+	err = json.Unmarshal(theme.Theme, &themeConfig)
+	s.NoError(err)
+	s.Equal("#1976d2", themeConfig["primaryColor"])
+}
+
+func (s *ThemeDeclarativeSuite) TestParseToTheme_InvalidYAML() {
+	yamlData := []byte(`invalid: yaml: data:`)
+
+	theme, err := parseToTheme(yamlData)
+
+	s.Error(err)
+	s.Nil(theme)
+}
+
+func (s *ThemeDeclarativeSuite) TestValidateThemeForDeclarativeResource_Success() {
+	themeConfig := map[string]interface{}{"primaryColor": "#1976d2"}
+	themeJSON, _ := json.Marshal(themeConfig)
+
+	theme := &Theme{
+		ID:          "theme1",
+		DisplayName: "Test Theme",
+		Description: "A test theme",
+		Theme:       themeJSON,
+	}
+
+	err := validateThemeForDeclarativeResource(theme)
+
+	s.NoError(err)
+}
+
+func (s *ThemeDeclarativeSuite) TestValidateThemeForDeclarativeResource_EmptyDisplayName() {
+	theme := &Theme{
+		ID:          "theme1",
+		DisplayName: "",
+		Theme:       json.RawMessage(`{"color": "blue"}`),
+	}
+
+	err := validateThemeForDeclarativeResource(theme)
+
+	s.Error(err)
+	s.Contains(err.Error(), "display name is required")
+}
+
+func (s *ThemeDeclarativeSuite) TestValidateThemeForDeclarativeResource_EmptyID() {
+	theme := &Theme{
+		ID:          "",
+		DisplayName: "Test",
+		Theme:       json.RawMessage(`{"color": "blue"}`),
+	}
+
+	err := validateThemeForDeclarativeResource(theme)
+
+	s.Error(err)
+	s.Contains(err.Error(), "ID is required")
+}
+
+func (s *ThemeDeclarativeSuite) TestValidateThemeForDeclarativeResource_EmptyTheme() {
+	theme := &Theme{
+		ID:          "theme1",
+		DisplayName: "Test",
+		Theme:       json.RawMessage{},
+	}
+
+	err := validateThemeForDeclarativeResource(theme)
+
+	s.Error(err)
+	s.Contains(err.Error(), "configuration is required")
+}
+
+func (s *ThemeDeclarativeSuite) TestValidateThemeForDeclarativeResource_InvalidJSON() {
+	theme := &Theme{
+		ID:          "theme1",
+		DisplayName: "Test",
+		Theme:       json.RawMessage(`{invalid json}`),
+	}
+
+	err := validateThemeForDeclarativeResource(theme)
+
+	s.Error(err)
+	s.Contains(err.Error(), "invalid theme JSON")
+}
+
+func (s *ThemeDeclarativeSuite) TestLoadDeclarativeResources_Integration() {
+	// Create file-based store with test configuration
+	genericStore := declarativeresource.NewGenericFileBasedStoreForTest(entity.KeyTypeTheme)
+	store := &themeFileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+
+	// This should not panic even with empty directory
+	err := loadDeclarativeResources(store)
+
+	// Error is expected if directory doesn't exist, which is acceptable for this test
+	// We're verifying that the function can be called without panicking
+	_ = err
+}
+
+func (s *ThemeDeclarativeSuite) TestThemeExporter_ValidateResource_EmptyThemeWarning() {
+	// Use the singleton logger which is already initialized in SetupSuite
+	testLogger := log.GetLogger()
+
+	exporter := &themeExporter{}
+
+	theme := &Theme{
+		ID:          "theme1",
+		DisplayName: "Theme Without Config",
+		Description: "This theme has no configuration",
+		Theme:       json.RawMessage{},
+	}
+
+	// Even with empty theme, validation should succeed (just logs warning)
+	name, err := exporter.ValidateResource(theme, "theme1", testLogger)
+
+	// The empty theme should not cause validation error in ValidateResource
+	// (it logs a warning instead)
+	s.Nil(err)
+	s.Equal("Theme Without Config", name)
+}
+
+func (s *ThemeDeclarativeSuite) TestParseToThemeWrapper() {
+	yamlData := []byte(`
+id: theme-wrapper-test
+displayName: Wrapper Test Theme
+description: Testing wrapper
+theme:
+  color: red
+`)
+
+	result, err := parseToThemeWrapper(yamlData)
+
+	s.NoError(err)
+	s.NotNil(result)
+
+	theme, ok := result.(*Theme)
+	s.True(ok)
+	s.Equal("theme-wrapper-test", theme.ID)
+}
+
+func (s *ThemeDeclarativeSuite) TestValidateThemeWrapper() {
+	theme := &Theme{
+		ID:          "theme1",
+		DisplayName: "Test",
+		Theme:       json.RawMessage(`{"color": "blue"}`),
+	}
+
+	err := validateThemeWrapper(theme)
+	s.NoError(err)
+}
+
+func (s *ThemeDeclarativeSuite) TestValidateThemeWrapper_InvalidType() {
+	err := validateThemeWrapper("not a theme")
+	s.Error(err)
+	s.Contains(err.Error(), "invalid type")
+}

--- a/backend/internal/design/theme/mgt/file_based_store.go
+++ b/backend/internal/design/theme/mgt/file_based_store.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thememgt
+
+import (
+	"errors"
+
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
+)
+
+type themeFileBasedStore struct {
+	*declarativeresource.GenericFileBasedStore
+}
+
+// Create implements declarativeresource.Storer interface for resource loader
+func (f *themeFileBasedStore) Create(id string, data interface{}) error {
+	theme, ok := data.(*Theme)
+	if !ok {
+		declarativeresource.LogTypeAssertionError("theme", id)
+		return errors.New("invalid data type: expected *Theme")
+	}
+	createReq := CreateThemeRequest{
+		DisplayName: theme.DisplayName,
+		Description: theme.Description,
+		Theme:       theme.Theme,
+	}
+	return f.CreateTheme(id, createReq)
+}
+
+// CreateTheme implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) CreateTheme(id string, theme CreateThemeRequest) error {
+	themeData := &Theme{
+		ID:          id,
+		DisplayName: theme.DisplayName,
+		Description: theme.Description,
+		Theme:       theme.Theme,
+		CreatedAt:   "",
+		UpdatedAt:   "",
+	}
+	return f.GenericFileBasedStore.Create(id, themeData)
+}
+
+// DeleteTheme implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) DeleteTheme(id string) error {
+	return errors.New("deleteTheme is not supported in file-based store")
+}
+
+// GetTheme implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) GetTheme(id string) (Theme, error) {
+	data, err := f.GenericFileBasedStore.Get(id)
+	if err != nil {
+		return Theme{}, err
+	}
+	theme, ok := data.(*Theme)
+	if !ok {
+		declarativeresource.LogTypeAssertionError("theme", id)
+		return Theme{}, errors.New("theme data corrupted")
+	}
+	return *theme, nil
+}
+
+// GetThemeList implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) GetThemeList(limit, offset int) ([]Theme, error) {
+	// Validate input parameters to prevent panics
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		return []Theme{}, nil
+	}
+
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return nil, err
+	}
+
+	themeList := make([]Theme, 0)
+	for _, item := range list {
+		if theme, ok := item.Data.(*Theme); ok {
+			themeList = append(themeList, *theme)
+		}
+	}
+
+	// Apply pagination
+	start := offset
+	if start >= len(themeList) {
+		return []Theme{}, nil
+	}
+
+	end := start + limit
+	if end > len(themeList) {
+		end = len(themeList)
+	}
+	return themeList[start:end], nil
+}
+
+// GetThemeListCount implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) GetThemeListCount() (int, error) {
+	count, err := f.GenericFileBasedStore.Count()
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// IsThemeExist implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) IsThemeExist(id string) (bool, error) {
+	_, err := f.GetTheme(id)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// UpdateTheme implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) UpdateTheme(id string, theme UpdateThemeRequest) error {
+	return errors.New("updateTheme is not supported in file-based store")
+}
+
+// GetApplicationsCountByThemeID implements themeMgtStoreInterface.
+func (f *themeFileBasedStore) GetApplicationsCountByThemeID(id string) (int, error) {
+	// In declarative mode, we don't track application references in the file-based store
+	return 0, nil
+}
+
+// newThemeFileBasedStore creates a new instance of a file-based store.
+func newThemeFileBasedStore() themeMgtStoreInterface {
+	genericStore := declarativeresource.NewGenericFileBasedStore(entity.KeyTypeTheme)
+	return &themeFileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+}

--- a/backend/internal/design/theme/mgt/file_based_store_test.go
+++ b/backend/internal/design/theme/mgt/file_based_store_test.go
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thememgt
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	"github.com/asgardeo/thunder/internal/system/declarative_resource/entity"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// ThemeFileBasedStoreTestSuite contains comprehensive tests for the file-based theme store.
+type ThemeFileBasedStoreTestSuite struct {
+	suite.Suite
+	store *themeFileBasedStore
+}
+
+// TestThemeFileBasedStoreTestSuite runs the file-based store test suite.
+func TestThemeFileBasedStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(ThemeFileBasedStoreTestSuite))
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) SetupSuite() {
+	// Create temporary directory for tests
+	tempDir := suite.T().TempDir()
+
+	// Initialize ThunderRuntime once for all tests
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+	}
+	config.ResetThunderRuntime()
+	err := config.InitializeThunderRuntime(tempDir, testConfig)
+	suite.Require().NoError(err, "Failed to initialize ThunderRuntime")
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TearDownSuite() {
+	// Clean up ThunderRuntime after all tests
+	config.ResetThunderRuntime()
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) SetupTest() {
+	genericStore := declarativeresource.NewGenericFileBasedStoreForTest(entity.KeyTypeTheme)
+	suite.store = &themeFileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) createTestTheme(displayName string) CreateThemeRequest {
+	themeConfig := map[string]interface{}{
+		"primaryColor":    "#1976d2",
+		"secondaryColor":  "#dc004e",
+		"backgroundColor": "#ffffff",
+	}
+	themeJSON, err := json.Marshal(themeConfig)
+	suite.Require().NoError(err, "Failed to marshal test theme config")
+
+	return CreateThemeRequest{
+		DisplayName: displayName,
+		Description: "Test theme",
+		Theme:       themeJSON,
+	}
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestCreateTheme_Success() {
+	// Arrange
+	themeReq := suite.createTestTheme("Blue Theme")
+
+	// Act
+	err := suite.store.CreateTheme("theme-001", themeReq)
+
+	// Assert
+	suite.NoError(err)
+
+	// Verify theme was created
+	retrieved, err := suite.store.GetTheme("theme-001")
+	suite.NoError(err)
+	suite.Equal("theme-001", retrieved.ID)
+	suite.Equal("Blue Theme", retrieved.DisplayName)
+	suite.Equal("Test theme", retrieved.Description)
+	suite.NotEmpty(retrieved.Theme)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetTheme_Success() {
+	// Arrange
+	themeReq := suite.createTestTheme("Red Theme")
+	_ = suite.store.CreateTheme("theme-002", themeReq)
+
+	// Act
+	retrieved, err := suite.store.GetTheme("theme-002")
+
+	// Assert
+	suite.NoError(err)
+	suite.Equal("theme-002", retrieved.ID)
+	suite.Equal("Red Theme", retrieved.DisplayName)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetTheme_NotFound() {
+	// Act
+	retrieved, err := suite.store.GetTheme("non-existent")
+
+	// Assert
+	suite.Error(err)
+	suite.Empty(retrieved.ID)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_Success() {
+	// Arrange
+	theme1 := suite.createTestTheme("Theme 1")
+	theme2 := suite.createTestTheme("Theme 2")
+	theme3 := suite.createTestTheme("Theme 3")
+	_ = suite.store.CreateTheme("theme-003", theme1)
+	_ = suite.store.CreateTheme("theme-004", theme2)
+	_ = suite.store.CreateTheme("theme-005", theme3)
+
+	// Act
+	themes, err := suite.store.GetThemeList(10, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(themes, 3)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_WithPagination() {
+	// Arrange
+	for i := 1; i <= 5; i++ {
+		themeReq := suite.createTestTheme(fmt.Sprintf("Theme %d", i))
+		_ = suite.store.CreateTheme(fmt.Sprintf("theme-%03d", i), themeReq)
+	}
+
+	// Act - Get first 2 themes
+	themes, err := suite.store.GetThemeList(2, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(themes, 2)
+
+	// Act - Get next 2 themes
+	themes, err = suite.store.GetThemeList(2, 2)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(themes, 2)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_EmptyStore() {
+	// Act
+	themes, err := suite.store.GetThemeList(10, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(themes)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeListCount_Success() {
+	// Arrange
+	theme1 := suite.createTestTheme("Theme 6")
+	theme2 := suite.createTestTheme("Theme 7")
+	_ = suite.store.CreateTheme("theme-006", theme1)
+	_ = suite.store.CreateTheme("theme-007", theme2)
+
+	// Act
+	count, err := suite.store.GetThemeListCount()
+
+	// Assert
+	suite.NoError(err)
+	suite.Equal(2, count)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeExist_True() {
+	// Arrange
+	themeReq := suite.createTestTheme("Existing Theme")
+	_ = suite.store.CreateTheme("theme-008", themeReq)
+
+	// Act
+	exists, err := suite.store.IsThemeExist("theme-008")
+
+	// Assert
+	suite.NoError(err)
+	suite.True(exists)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestIsThemeExist_False() {
+	// Act
+	exists, err := suite.store.IsThemeExist("non-existent")
+
+	// Assert
+	suite.NoError(err)
+	suite.False(exists)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestUpdateTheme_NotSupported() {
+	// Arrange
+	themeReq := suite.createTestTheme("Update Test")
+
+	// Act
+	err := suite.store.UpdateTheme("theme-009", UpdateThemeRequest{
+		DisplayName: "Updated Name",
+		Description: "Updated description",
+		Theme:       themeReq.Theme,
+	})
+
+	// Assert
+	suite.Error(err)
+	suite.Contains(err.Error(), "not supported")
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestDeleteTheme_NotSupported() {
+	// Act
+	err := suite.store.DeleteTheme("theme-001")
+
+	// Assert
+	suite.Error(err)
+	suite.Contains(err.Error(), "not supported")
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetApplicationsCountByThemeID() {
+	// Act
+	count, err := suite.store.GetApplicationsCountByThemeID("theme-001")
+
+	// Assert
+	suite.NoError(err)
+	suite.Equal(0, count)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestCreate_StorerInterface() {
+	// Arrange
+	themeConfig := map[string]interface{}{
+		"primaryColor": "#00ff00",
+	}
+	themeJSON, _ := json.Marshal(themeConfig)
+	theme := &Theme{
+		ID:          "theme-010",
+		DisplayName: "Green Theme",
+		Description: "Test",
+		Theme:       themeJSON,
+	}
+
+	// Act
+	err := suite.store.Create("theme-010", theme)
+
+	// Assert
+	suite.NoError(err)
+
+	// Verify
+	retrieved, err := suite.store.GetTheme("theme-010")
+	suite.NoError(err)
+	suite.Equal("theme-010", retrieved.ID)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestCreate_InvalidType() {
+	// Arrange - pass wrong type to Create
+	invalidData := "not a theme"
+
+	// Act
+	err := suite.store.Create("theme-invalid", invalidData)
+
+	// Assert
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid data type")
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_NegativeOffset() {
+	// Arrange
+	theme1 := suite.createTestTheme("Theme A")
+	theme2 := suite.createTestTheme("Theme B")
+	_ = suite.store.CreateTheme("theme-a", theme1)
+	_ = suite.store.CreateTheme("theme-b", theme2)
+
+	// Act - negative offset should be clamped to 0
+	themes, err := suite.store.GetThemeList(10, -5)
+
+	// Assert
+	suite.NoError(err)
+	suite.Len(themes, 2) // Should return all themes
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_ZeroLimit() {
+	// Arrange
+	theme1 := suite.createTestTheme("Theme C")
+	_ = suite.store.CreateTheme("theme-c", theme1)
+
+	// Act - zero limit should return empty slice
+	themes, err := suite.store.GetThemeList(0, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(themes)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_NegativeLimit() {
+	// Arrange
+	theme1 := suite.createTestTheme("Theme D")
+	_ = suite.store.CreateTheme("theme-d", theme1)
+
+	// Act - negative limit should return empty slice
+	themes, err := suite.store.GetThemeList(-10, 0)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(themes)
+}
+
+func (suite *ThemeFileBasedStoreTestSuite) TestGetThemeList_OffsetBeyondList() {
+	// Arrange
+	theme1 := suite.createTestTheme("Theme E")
+	_ = suite.store.CreateTheme("theme-e", theme1)
+
+	// Act - offset beyond list length should return empty slice
+	themes, err := suite.store.GetThemeList(10, 100)
+
+	// Assert
+	suite.NoError(err)
+	suite.Empty(themes)
+}

--- a/backend/internal/design/theme/mgt/model.go
+++ b/backend/internal/design/theme/mgt/model.go
@@ -22,12 +22,12 @@ import "encoding/json"
 
 // Theme represents a theme configuration.
 type Theme struct {
-	ID          string          `json:"id"`
-	DisplayName string          `json:"displayName"`
-	Description string          `json:"description"`
-	Theme       json.RawMessage `json:"theme"`
-	CreatedAt   string          `json:"createdAt"`
-	UpdatedAt   string          `json:"updatedAt"`
+	ID          string          `json:"id" yaml:"id,omitempty"`
+	DisplayName string          `json:"displayName" yaml:"displayName"`
+	Description string          `json:"description" yaml:"description,omitempty"`
+	Theme       json.RawMessage `json:"theme" yaml:"theme"`
+	CreatedAt   string          `json:"createdAt" yaml:"createdAt,omitempty"`
+	UpdatedAt   string          `json:"updatedAt" yaml:"updatedAt,omitempty"`
 }
 
 // ThemeListItem represents a theme item in the list response.
@@ -51,6 +51,14 @@ type UpdateThemeRequest struct {
 	DisplayName string          `json:"displayName"`
 	Description string          `json:"description"`
 	Theme       json.RawMessage `json:"theme"`
+}
+
+// themeRequestWithID represents the request structure for creating a theme from file-based config.
+type themeRequestWithID struct {
+	ID          string      `yaml:"id"`
+	DisplayName string      `yaml:"displayName"`
+	Description string      `yaml:"description,omitempty"`
+	Theme       interface{} `yaml:"theme"`
 }
 
 // ThemeListResponse represents the response for listing theme configurations with pagination.

--- a/backend/internal/system/declarative_resource/entity/entity_store.go
+++ b/backend/internal/system/declarative_resource/entity/entity_store.go
@@ -37,6 +37,8 @@ const (
 	KeyTypeOU                 KeyType = "ou"
 	KeyTypeFlow               KeyType = "flow"
 	KeyTypeTranslation        KeyType = "translation"
+	KeyTypeTheme              KeyType = "theme"
+	KeyTypeLayout             KeyType = "layout"
 )
 
 // String returns the string representation of KeyType
@@ -48,7 +50,7 @@ func (kt KeyType) String() string {
 func (kt KeyType) IsValid() bool {
 	switch kt {
 	case KeyTypeApplication, KeyTypeNotification, KeyTypeIDP, KeyTypeNotificationSender,
-		KeyTypeUserSchema, KeyTypeOU, KeyTypeFlow, KeyTypeTranslation:
+		KeyTypeUserSchema, KeyTypeOU, KeyTypeFlow, KeyTypeTranslation, KeyTypeTheme, KeyTypeLayout:
 		return true
 	default:
 		return false

--- a/backend/internal/system/export/model.go
+++ b/backend/internal/system/export/model.go
@@ -29,6 +29,8 @@ type ExportRequest struct {
 	OrganizationUnits   []string `json:"organization_units,omitempty"`
 	Flows               []string `json:"flows,omitempty"`
 	Translations        []string `json:"translations,omitempty"`
+	Layouts             []string `json:"layouts,omitempty"`
+	Themes              []string `json:"themes,omitempty"`
 
 	Options *ExportOptions `json:"options,omitempty"`
 }

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -38,6 +38,8 @@ const (
 	resourceTypeOU                 = "organization_unit"
 	resourceTypeFlow               = "flow"
 	resourceTypeTranslation        = "translation"
+	resourceTypeLayout             = "layout"
+	resourceTypeTheme              = "theme"
 )
 
 // parameterizerInterface defines the interface for template parameterization.
@@ -106,6 +108,8 @@ func (es *exportService) ExportResources(request *ExportRequest) (*ExportRespons
 		resourceTypeOU:                 request.OrganizationUnits,
 		resourceTypeFlow:               request.Flows,
 		resourceTypeTranslation:        request.Translations,
+		resourceTypeLayout:             request.Layouts,
+		resourceTypeTheme:              request.Themes,
 	}
 
 	// Export resources using the registry


### PR DESCRIPTION
### Purpose
Add declarative resources support for Layouts and Themes
- Read from declarative resources

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/1376

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative file-based support for layouts and themes with loading, parsing, validation and exportable resources.
  * Layouts and themes can be included in system exports.

* **Improvements**
  * Initialization now returns exporters and has stronger error handling for theme/layout init paths.
  * YAML support and serialization tags added for layout and theme objects.

* **Tests**
  * Extensive unit and integration tests for declarative loading, parsing, validation and file-based stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->