### PR TITLE
Fix child OU save bug

### DIFF
--- a/frontend/apps/thunder-develop/src/features/organization-units/pages/OrganizationUnitEditPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/pages/OrganizationUnitEditPage.tsx
@@ -120,6 +120,7 @@ export default function OrganizationUnitEditPage(): JSX.Element {
       handle: editedOU.handle ?? organizationUnit.handle,
       name: editedOU.name ?? organizationUnit.name,
       description: editedOU.description !== undefined ? editedOU.description : organizationUnit.description,
+      parent: organizationUnit.parent ?? null,
     };
 
     try {


### PR DESCRIPTION
### Purpose
This pull request makes a small update to the `OrganizationUnitEditPage` component to ensure that the `parent` property is always included in the organization unit payload, defaulting to `null` if not present.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed organization unit updates to properly include parent relationship information in save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->