### PR TITLE
Update concurrency levels for release perf test

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -936,7 +936,7 @@ jobs:
                     BRANCH: 'main',
                     MODE: 'FULL',
                     USE_DELAYS: 'true',
-                    CONCURRENCY: '50-3000',
+                    CONCURRENCY: '50-1000',
                     PUSH_BENCHMARKS_TO_GITHUB: pushBenchmarkToGitHub
                   }
                 });


### PR DESCRIPTION
### Purpose

Performance test runs triggered after a release times out due to hitting the maximum running time of 6 hours for GH pipelines. This PR reduces the concurrency levels tested to prevent that from happening. With the resources available in our perf testing setup, higher concurrency levels (1000+) are anyway not expected to be handled.

### Approach

* Reduced the `CONCURRENCY` setting in `.github/workflows/release-builder.yml` from `'50-3000'` to `'50-1000'` to limit the number of concurrent operations during the release build process. 

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Lowered the maximum concurrency setting for performance test runs in the release workflow from 3000 to 1000, reducing the upper bound for concurrent test dispatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->