### PR TITLE
Fix child OU save bug

### DIFF
--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -388,9 +388,11 @@ func (ous *organizationUnitService) updateOUInternal(
 		return OrganizationUnit{}, err
 	}
 
+	parentChanged := !stringPtrEqual(existingOU.Parent, request.Parent)
+
 	var nameConflict bool
 	var err error
-	if existingOU.Parent != request.Parent || existingOU.Name != request.Name {
+	if parentChanged || existingOU.Name != request.Name {
 		nameConflict, err = ous.ouStore.CheckOrganizationUnitNameConflict(request.Name, request.Parent)
 		if err != nil {
 			logger.Error("Failed to check organization unit name conflict", log.Error(err))
@@ -403,7 +405,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	}
 
 	var handleConflict bool
-	if existingOU.Parent != request.Parent || existingOU.Handle != request.Handle {
+	if parentChanged || existingOU.Handle != request.Handle {
 		handleConflict, err = ous.ouStore.CheckOrganizationUnitHandleConflict(request.Handle, request.Parent)
 		if err != nil {
 			logger.Error("Failed to check organization unit handle conflict", log.Error(err))
@@ -871,4 +873,15 @@ func buildOrganizationUnitListResponse(items interface{}, totalCount, limit, off
 		Links:             buildPaginationLinks(limit, offset, totalCount),
 	}
 	return response, nil
+}
+
+// stringPtrEqual compares two string pointers by their values.
+func stringPtrEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }


### PR DESCRIPTION
### Purpose
This pull request improves how parent organization unit changes are detected and handled in the `organizationUnitService`. The main enhancement is the introduction of a helper function to accurately compare string pointers, ensuring correct conflict checks when updating organization units.

Improvements to parent change detection and conflict handling:

* Added the `stringPtrEqual` helper function to compare string pointers by value, preventing incorrect conflict checks when parent values are nil or different (`backend/internal/ou/service.go`).
* Updated parent change detection logic in `updateOUInternal` to use `stringPtrEqual`, ensuring more reliable identification of parent changes (`backend/internal/ou/service.go`).
* Modified name and handle conflict checks in `updateOUInternal` to use the new parent change detection, improving accuracy of conflict validation (`backend/internal/ou/service.go`).

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update behavior improved so name and handle conflict checks properly run when parent assignments change; added a helper to compare optional string values and ensured unchanged parent/description are preserved on no-op updates.

* **Tests**
  * Added unit tests covering same-vs-changed parent scenarios, optional-string comparison edge cases, and updated test setup for parent IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->