### PR TITLE
Add foreign key pragma configs for sqlite

### DIFF
--- a/backend/cmd/server/repository/conf/deployment.yaml
+++ b/backend/cmd/server/repository/conf/deployment.yaml
@@ -11,7 +11,7 @@ database:
   identity:
     type: "sqlite"
     path: "repository/database/thunderdb.db"
-    options: "_journal_mode=WAL&_busy_timeout=5000"
+    options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
     max_open_conns: 500
     max_idle_conns: 100
     conn_max_lifetime: 3600
@@ -19,7 +19,7 @@ database:
   runtime:
     type: "sqlite"
     path: "repository/database/runtimedb.db"
-    options: "_journal_mode=WAL&_busy_timeout=5000"
+    options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
     max_open_conns: 500
     max_idle_conns: 100
     conn_max_lifetime: 3600
@@ -27,7 +27,7 @@ database:
   user:
     type: "sqlite"
     path: "repository/database/userdb.db"
-    options: "_journal_mode=WAL&_busy_timeout=5000"
+    options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
     max_open_conns: 500
     max_idle_conns: 100
     conn_max_lifetime: 3600

--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -26,7 +26,7 @@
       "password": "",
       "sslmode": "",
       "path": "repository/database/thunderdb.db",
-      "options": "_journal_mode=WAL&_busy_timeout=5000",
+      "options": "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)",
       "max_open_conns": 500,
       "max_idle_conns": 100,
       "conn_max_lifetime": 3600
@@ -40,7 +40,7 @@
       "password": "",
       "sslmode": "",
       "path": "repository/database/runtimedb.db",
-      "options": "_journal_mode=WAL&_busy_timeout=5000",
+      "options": "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)",
       "max_open_conns": 500,
       "max_idle_conns": 100,
       "conn_max_lifetime": 3600
@@ -54,7 +54,7 @@
       "password": "",
       "sslmode": "",
       "path": "repository/database/userdb.db",
-      "options": "_journal_mode=WAL&_busy_timeout=5000",
+      "options": "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)",
       "max_open_conns": 500,
       "max_idle_conns": 100,
       "conn_max_lifetime": 3600

--- a/docs/__backup__/deployment-patterns/kubernetes/kubernetes-deployment.md
+++ b/docs/__backup__/deployment-patterns/kubernetes/kubernetes-deployment.md
@@ -218,15 +218,15 @@ configuration:
     identity:
       type: sqlite
       sqlitePath: repository/database/thunderdb.db
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000"
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
     runtime:
       type: sqlite
       sqlitePath: repository/database/runtimedb.db
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000"
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
     user:
       type: sqlite
       sqlitePath: repository/database/userdb.db
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000"  
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"  
 ```
 
 ### Update Strategy

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -323,8 +323,8 @@ Each database section (`identity`, `runtime`, `user`) supports these fields:
 | `configuration.crypto.keys[].certFile`            | Signing certificate file path                                                                         | `repository/resources/security/signing.cert` |
 | `configuration.crypto.keys[].keyFile`             | Signing key file path                                                                                 | `repository/resources/security/signing.key`  |
 | `configuration.database.identity.type`            | Identity database type (postgres or sqlite)                                                           | `postgres`                   |
-| `configuration.database.identity.sqlitePath`      | SQLite database path (for sqlite only)                                                                | `repository/database/thunderdb.db` |
-| `configuration.database.identity.sqliteOptions`   | SQLite options (for sqlite only)                                                                      | `_journal_mode=WAL&_busy_timeout=5000` |
+| `configuration.database.identity.sqlitePath`      | SQLite database path (for SQLite only)                                                                | `repository/database/thunderdb.db` |
+| `configuration.database.identity.sqliteOptions`   | SQLite options (for SQLite only)                                                                      | `_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)` |
 | `configuration.database.identity.name`            | Postgres database name (for postgres only)                                                            | `thunderdb`                  |
 | `configuration.database.identity.host`            | Postgres host (for postgres only)                                                                     | `localhost` |
 | `configuration.database.identity.port`            | Postgres port (for postgres only)                                                                     | `5432`                       |
@@ -337,8 +337,8 @@ Each database section (`identity`, `runtime`, `user`) supports these fields:
 | `configuration.database.identity.max_idle_conns`  | Maximum number of idle connections in the pool                                                        | `100`                        |
 | `configuration.database.identity.conn_max_lifetime` | Maximum lifetime of a connection in seconds                                                         | `3600`                       |
 | `configuration.database.runtime.type`             | Runtime database type (postgres or sqlite)                                                            | `postgres`                   |
-| `configuration.database.runtime.sqlitePath`       | SQLite database path (for sqlite only)                                                                | `repository/database/runtimedb.db` |
-| `configuration.database.runtime.sqliteOptions`    | SQLite options (for sqlite only)                                                                      | `_journal_mode=WAL&_busy_timeout=5000` |
+| `configuration.database.runtime.sqlitePath`       | SQLite database path (for SQLite only)                                                                | `repository/database/runtimedb.db` |
+| `configuration.database.runtime.sqliteOptions`    | SQLite options (for SQLite only)                                                                      | `_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)` |
 | `configuration.database.runtime.name`             | Postgres database name (for postgres only)                                                            | `runtimedb`                  |
 | `configuration.database.runtime.host`             | Postgres host (for postgres only)                                                                     | `localhost` |
 | `configuration.database.runtime.port`             | Postgres port (for postgres only)                                                                     | `5432`                      |
@@ -351,8 +351,8 @@ Each database section (`identity`, `runtime`, `user`) supports these fields:
 | `configuration.database.runtime.max_idle_conns`   | Maximum number of idle connections in the pool                                                        | `100`                        |
 | `configuration.database.runtime.conn_max_lifetime` | Maximum lifetime of a connection in seconds                                                          | `3600`                       |
 | `configuration.database.user.type`                | User database type (postgres or sqlite)                                                               | `postgres`                   |
-| `configuration.database.user.sqlitePath`          | SQLite database path (for sqlite only)                                                                | `repository/database/userdb.db` |
-| `configuration.database.user.sqliteOptions`       | SQLite options (for sqlite only)                                                                      | `_journal_mode=WAL&_busy_timeout=5000` |
+| `configuration.database.user.sqlitePath`          | SQLite database path (for SQLite only)                                                                | `repository/database/userdb.db` |
+| `configuration.database.user.sqliteOptions`       | SQLite options (for SQLite only)                                                                      | `_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)` |
 | `configuration.database.user.name`                | Postgres database name (for postgres only)                                                            | `userdb`                     |
 | `configuration.database.user.host`                | Postgres host (for postgres only)                                                                     | `localhost` |
 | `configuration.database.user.port`                | Postgres port (for postgres only)                                                                     | `5432`                       |

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -160,7 +160,7 @@ configuration:
       type: "postgres" # postgres or sqlite
       # Below two parameters are only required for sqlite
       sqlitePath: "repository/database/thunderdb.db" # Only required for sqlite
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)" # Only required for sqlite
       # Below parameters are only required for Postgres
       name: "thunderdb" 
       host: "localhost" 
@@ -177,7 +177,7 @@ configuration:
       type: "postgres" # postgres or sqlite
       # Below two parameters are only required for sqlite
       sqlitePath: "repository/database/runtimedb.db" # Only required for sqlite
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)" # Only required for sqlite
       # Below parameters are only required for Postgres
       name: "runtimedb" 
       host: "localhost" 
@@ -193,7 +193,7 @@ configuration:
       type: "postgres" # postgres or sqlite
       # Below two parameters are only required for sqlite
       sqlitePath: "repository/database/userdb.db" # Only required for sqlite
-      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000" # Only required for sqlite
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)" # Only required for sqlite
       # Below parameters are only required for Postgres
       name: "userdb" 
       host: "localhost" 

--- a/tests/integration/resources/deployment.yaml
+++ b/tests/integration/resources/deployment.yaml
@@ -10,15 +10,15 @@ database:
   identity:
     type: "sqlite"
     path: "repository/database/thunderdb.db"
-    options: "_journal_mode=WAL&_busy_timeout=60000"
+    options: "_journal_mode=WAL&_busy_timeout=60000&_pragma=foreign_keys(1)"
   runtime:
     type: "sqlite"
     path: "repository/database/runtimedb.db"
-    options: "_journal_mode=WAL&_busy_timeout=60000"
+    options: "_journal_mode=WAL&_busy_timeout=60000&_pragma=foreign_keys(1)"
   user:
     type: "sqlite"
     path: "repository/database/userdb.db"
-    options: "_journal_mode=WAL&_busy_timeout=60000"
+    options: "_journal_mode=WAL&_busy_timeout=60000&_pragma=foreign_keys(1)"
 
 flow:
   max_version_history: 3
@@ -27,4 +27,3 @@ passkey:
   allowed_origins:
     - "https://localhost:8095"
     - "http://localhost:8095"
-


### PR DESCRIPTION
### Purpose
This pull request updates the SQLite database configuration across multiple files to explicitly enable foreign key constraints by default. This is achieved by adding the SQLite PRAGMA statement for foreign keys to the `options` (or equivalent) field for each database. The change ensures that all SQLite databases (`identity`, `runtime`, and `user`) consistently enforce foreign key constraints, which improves data integrity.

### Approach
Add SQLite PRAGMA statement for foreign keys to the `options`

### Related Issues
- https://github.com/asgardeo/thunder/issues/1369

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Enabled SQLite foreign key enforcement by appending the foreign_keys pragma to connection options for identity, runtime, and user databases.

* **Documentation**
  * Updated deployment and Helm docs to reflect the updated SQLite connection options.

* **Tests**
  * Updated integration deployment resources to use the revised SQLite options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->