### PR TITLE
Composite store support for IdP

### DIFF
--- a/backend/internal/idp/composite_store.go
+++ b/backend/internal/idp/composite_store.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import (
+	"context"
+	"errors"
+
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+)
+
+var (
+	// ErrIDPIsImmutable is returned when trying to modify or delete an immutable (file-based) IDP.
+	ErrIDPIsImmutable = errors.New("identity provider is immutable")
+)
+
+// compositeIDPStore implements a composite store that combines file-based (immutable) and database (mutable) stores.
+// - Read operations query both stores and merge results
+// - Write operations (Create/Update/Delete) only affect the database store
+// - Declarative IDPs (from YAML files) cannot be modified or deleted
+type compositeIDPStore struct {
+	fileStore idpStoreInterface
+	dbStore   idpStoreInterface
+}
+
+// newCompositeIDPStore creates a new composite store with both file-based and database stores.
+func newCompositeIDPStore(fileStore, dbStore idpStoreInterface) *compositeIDPStore {
+	return &compositeIDPStore{
+		fileStore: fileStore,
+		dbStore:   dbStore,
+	}
+}
+
+// CreateIdentityProvider creates a new identity provider in the database store only.
+func (c *compositeIDPStore) CreateIdentityProvider(ctx context.Context, idp IDPDTO) error {
+	return c.dbStore.CreateIdentityProvider(ctx, idp)
+}
+
+// GetIdentityProviderList retrieves identity providers from both stores and merges the results.
+// Database IDPs are marked as mutable (IsReadOnly=false), file-based IDPs as immutable (IsReadOnly=true).
+func (c *compositeIDPStore) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, error) {
+	dbIDPs, err := c.dbStore.GetIdentityProviderList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	fileIDPs, err := c.fileStore.GetIdentityProviderList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeAndDeduplicateIDPs(dbIDPs, fileIDPs), nil
+}
+
+// GetIdentityProvider retrieves an identity provider by ID from either store.
+// Checks database store first, then falls back to file store.
+func (c *compositeIDPStore) GetIdentityProvider(ctx context.Context, idpID string) (*IDPDTO, error) {
+	return declarativeresource.CompositeGetHelper(
+		func() (*IDPDTO, error) { return c.dbStore.GetIdentityProvider(ctx, idpID) },
+		func() (*IDPDTO, error) { return c.fileStore.GetIdentityProvider(ctx, idpID) },
+		ErrIDPNotFound,
+	)
+}
+
+// GetIdentityProviderByName retrieves an identity provider by name from either store.
+// Checks database store first, then falls back to file store.
+func (c *compositeIDPStore) GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error) {
+	return declarativeresource.CompositeGetHelper(
+		func() (*IDPDTO, error) { return c.dbStore.GetIdentityProviderByName(ctx, idpName) },
+		func() (*IDPDTO, error) { return c.fileStore.GetIdentityProviderByName(ctx, idpName) },
+		ErrIDPNotFound,
+	)
+}
+
+// UpdateIdentityProvider updates an identity provider in the database store only.
+// Returns an error if the IDP is declarative (exists in file store).
+func (c *compositeIDPStore) UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error {
+	return declarativeresource.CompositeUpdateHelper(
+		idp,
+		func(dto *IDPDTO) string { return dto.ID },
+		func(idpID string) (bool, error) {
+			_, err := c.fileStore.GetIdentityProvider(ctx, idpID)
+			if err == nil {
+				return true, nil // Found in file store
+			}
+			if errors.Is(err, ErrIDPNotFound) {
+				return false, nil // Not found, safe to update
+			}
+			return false, err // Other error
+		},
+		func(dto *IDPDTO) error {
+			return c.dbStore.UpdateIdentityProvider(ctx, dto)
+		},
+		ErrIDPIsImmutable,
+	)
+}
+
+// DeleteIdentityProvider deletes an identity provider from the database store only.
+// Returns an error if the IDP is declarative (exists in file store).
+func (c *compositeIDPStore) DeleteIdentityProvider(ctx context.Context, idpID string) error {
+	return declarativeresource.CompositeDeleteHelper(
+		idpID,
+		func(id string) (bool, error) {
+			_, err := c.fileStore.GetIdentityProvider(ctx, id)
+			if err == nil {
+				return true, nil // Found in file store
+			}
+			if errors.Is(err, ErrIDPNotFound) {
+				return false, nil // Not found, safe to delete
+			}
+			return false, err // Other error
+		},
+		func(id string) error {
+			return c.dbStore.DeleteIdentityProvider(ctx, id)
+		},
+		ErrIDPIsImmutable,
+	)
+}
+
+// mergeAndDeduplicateIDPs merges IDPs from both stores and removes duplicates by ID.
+// Database IDPs are marked as mutable (IsReadOnly=false), file-based IDPs as immutable (IsReadOnly=true).
+// While duplicates shouldn't exist by design, this provides defensive programming.
+func mergeAndDeduplicateIDPs(dbIDPs, fileIDPs []BasicIDPDTO) []BasicIDPDTO {
+	seen := make(map[string]bool)
+	result := make([]BasicIDPDTO, 0, len(dbIDPs)+len(fileIDPs))
+
+	// Add DB IDPs first (they take precedence) - mark as mutable (IsReadOnly=false)
+	for i := range dbIDPs {
+		if !seen[dbIDPs[i].ID] {
+			seen[dbIDPs[i].ID] = true
+			dbIDPs[i].IsReadOnly = false
+			result = append(result, dbIDPs[i])
+		}
+	}
+
+	// Add file IDPs if not already present - mark as immutable (IsReadOnly=true)
+	for i := range fileIDPs {
+		if !seen[fileIDPs[i].ID] {
+			seen[fileIDPs[i].ID] = true
+			fileIDPs[i].IsReadOnly = true
+			result = append(result, fileIDPs[i])
+		}
+	}
+
+	return result
+}

--- a/backend/internal/idp/composite_store_test.go
+++ b/backend/internal/idp/composite_store_test.go
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CompositeIDPStoreTestSuite struct {
+	suite.Suite
+	fileStore      *idpStoreInterfaceMock
+	dbStore        *idpStoreInterfaceMock
+	compositeStore *compositeIDPStore
+}
+
+const (
+	compositeStoreTestIDPName = "Test IDP"
+	compositeStoreTestIDPID   = "idp-123"
+)
+
+func TestCompositeIDPStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(CompositeIDPStoreTestSuite))
+}
+
+func (s *CompositeIDPStoreTestSuite) SetupTest() {
+	s.fileStore = newIdpStoreInterfaceMock(s.T())
+	s.dbStore = newIdpStoreInterfaceMock(s.T())
+	s.compositeStore = newCompositeIDPStore(s.fileStore, s.dbStore)
+}
+
+// TestCreateIdentityProvider_CreatesInDBStoreOnly verifies that Create only goes to DB store
+func (s *CompositeIDPStoreTestSuite) TestCreateIdentityProvider_CreatesInDBStoreOnly() {
+	idp := IDPDTO{
+		ID:          "test-id",
+		Name:        compositeStoreTestIDPName,
+		Description: "Test Description",
+		Type:        IDPTypeOIDC,
+	}
+
+	s.dbStore.On("CreateIdentityProvider", context.Background(), idp).Return(nil)
+
+	err := s.compositeStore.CreateIdentityProvider(context.Background(), idp)
+
+	s.NoError(err)
+	s.dbStore.AssertCalled(s.T(), "CreateIdentityProvider", context.Background(), idp)
+	s.fileStore.AssertNotCalled(s.T(), "CreateIdentityProvider")
+}
+
+// TestGetIdentityProvider_ReturnsFromDBFirst verifies DB store is queried first
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvider_ReturnsFromDBFirst() {
+	idpID := compositeStoreTestIDPID
+	dbIDP := &IDPDTO{
+		ID:   idpID,
+		Name: "DB IDP",
+		Type: IDPTypeOIDC,
+	}
+
+	s.dbStore.On("GetIdentityProvider", context.Background(), idpID).Return(dbIDP, nil)
+
+	result, err := s.compositeStore.GetIdentityProvider(context.Background(), idpID)
+
+	s.NoError(err)
+	s.Equal(dbIDP, result)
+	s.dbStore.AssertCalled(s.T(), "GetIdentityProvider", context.Background(), idpID)
+	// File store should not be called since DB returned successfully
+	s.fileStore.AssertNotCalled(s.T(), "GetIdentityProvider")
+}
+
+// TestGetIdentityProvider_FallsBackToFileStore verifies fallback when DB store fails
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvider_FallsBackToFileStore() {
+	idpID := compositeStoreTestIDPID
+	fileIDP := &IDPDTO{
+		ID:   idpID,
+		Name: "File IDP",
+		Type: IDPTypeOIDC,
+	}
+
+	s.dbStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.fileStore.On("GetIdentityProvider", context.Background(), idpID).Return(fileIDP, nil)
+
+	result, err := s.compositeStore.GetIdentityProvider(context.Background(), idpID)
+
+	s.NoError(err)
+	s.Equal(fileIDP, result)
+	s.dbStore.AssertCalled(s.T(), "GetIdentityProvider", context.Background(), idpID)
+	s.fileStore.AssertCalled(s.T(), "GetIdentityProvider", context.Background(), idpID)
+}
+
+// TestGetIdentityProvider_ReturnsErrorWhenNotInBothStores verifies error when not found
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvider_ReturnsErrorWhenNotInBothStores() {
+	idpID := compositeStoreTestIDPID
+
+	s.dbStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.fileStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
+
+	result, err := s.compositeStore.GetIdentityProvider(context.Background(), idpID)
+
+	s.Error(err)
+	s.Nil(result)
+	s.True(errors.Is(err, ErrIDPNotFound))
+}
+
+// TestGetIdentityProviderByName_ReturnsFromDBFirst verifies DB store is queried first for name lookup
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderByName_ReturnsFromDBFirst() {
+	idpName := compositeStoreTestIDPName
+	dbIDP := &IDPDTO{
+		ID:   "db-123",
+		Name: idpName,
+		Type: IDPTypeOIDC,
+	}
+
+	s.dbStore.On("GetIdentityProviderByName", context.Background(), idpName).Return(dbIDP, nil)
+
+	result, err := s.compositeStore.GetIdentityProviderByName(context.Background(), idpName)
+
+	s.NoError(err)
+	s.Equal(dbIDP, result)
+	s.dbStore.AssertCalled(s.T(), "GetIdentityProviderByName", context.Background(), idpName)
+	s.fileStore.AssertNotCalled(s.T(), "GetIdentityProviderByName")
+}
+
+// TestGetIdentityProviderByName_FallsBackToFileStore verifies fallback for name lookup
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderByName_FallsBackToFileStore() {
+	idpName := compositeStoreTestIDPName
+	fileIDP := &IDPDTO{
+		ID:   "file-123",
+		Name: idpName,
+		Type: IDPTypeOIDC,
+	}
+
+	s.dbStore.On("GetIdentityProviderByName", context.Background(), idpName).Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.fileStore.On("GetIdentityProviderByName", context.Background(), idpName).Return(fileIDP, nil)
+
+	result, err := s.compositeStore.GetIdentityProviderByName(context.Background(), idpName)
+
+	s.NoError(err)
+	s.Equal(fileIDP, result)
+}
+
+// TestGetIdentityProviderList_MergesAndDeduplicates verifies list merging from both stores
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_MergesAndDeduplicates() {
+	dbIDPs := []BasicIDPDTO{
+		{ID: "db-1", Name: "DB IDP 1", Type: IDPTypeOIDC},
+		{ID: "db-2", Name: "DB IDP 2", Type: IDPTypeOIDC},
+	}
+	fileIDPs := []BasicIDPDTO{
+		{ID: "file-1", Name: "File IDP 1", Type: IDPTypeOIDC},
+		{ID: "file-2", Name: "File IDP 2", Type: IDPTypeOIDC},
+	}
+
+	s.dbStore.On("GetIdentityProviderList", context.Background()).Return(dbIDPs, nil)
+	s.fileStore.On("GetIdentityProviderList", context.Background()).Return(fileIDPs, nil)
+
+	result, err := s.compositeStore.GetIdentityProviderList(context.Background())
+
+	s.NoError(err)
+	s.Len(result, 4)
+	resultByID := make(map[string]BasicIDPDTO, len(result))
+	for _, idp := range result {
+		resultByID[idp.ID] = idp
+	}
+
+	// Verify DB IDPs are present and marked as mutable
+	for _, expectedID := range []string{"db-1", "db-2"} {
+		idp, ok := resultByID[expectedID]
+		s.True(ok, "Expected DB IDP missing", expectedID)
+		if ok {
+			s.False(idp.IsReadOnly, "DB IDP should be marked as mutable")
+		}
+	}
+
+	// Verify file IDPs are present and marked as immutable
+	for _, expectedID := range []string{"file-1", "file-2"} {
+		idp, ok := resultByID[expectedID]
+		s.True(ok, "Expected file IDP missing", expectedID)
+		if ok {
+			s.True(idp.IsReadOnly, "File IDP should be marked as immutable")
+		}
+	}
+}
+
+// TestGetIdentityProviderList_DeduplicatesOnIDConflict verifies deduplication of IDs
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_DeduplicatesOnIDConflict() {
+	dbIDPs := []BasicIDPDTO{
+		{ID: "shared-id", Name: "DB IDP", Type: IDPTypeOIDC},
+		{ID: "db-2", Name: "DB IDP 2", Type: IDPTypeOIDC},
+	}
+	fileIDPs := []BasicIDPDTO{
+		{ID: "shared-id", Name: "File IDP", Type: IDPTypeOIDC},
+		{ID: "file-2", Name: "File IDP 2", Type: IDPTypeOIDC},
+	}
+
+	s.dbStore.On("GetIdentityProviderList", context.Background()).Return(dbIDPs, nil)
+	s.fileStore.On("GetIdentityProviderList", context.Background()).Return(fileIDPs, nil)
+
+	result, err := s.compositeStore.GetIdentityProviderList(context.Background())
+
+	s.NoError(err)
+	s.Len(result, 3) // Only 3 unique IDs
+	resultByID := make(map[string]BasicIDPDTO, len(result))
+	for _, idp := range result {
+		resultByID[idp.ID] = idp
+	}
+
+	// Verify shared ID takes DB version (first added)
+	sharedIDP, ok := resultByID["shared-id"]
+	s.True(ok, "Expected shared IDP missing")
+	if ok {
+		s.Equal("DB IDP", sharedIDP.Name)
+		s.False(sharedIDP.IsReadOnly)
+	}
+
+	dbIDP, ok := resultByID["db-2"]
+	s.True(ok, "Expected DB IDP missing")
+	if ok {
+		s.False(dbIDP.IsReadOnly, "DB IDP should be marked as mutable")
+	}
+
+	fileIDP, ok := resultByID["file-2"]
+	s.True(ok, "Expected file IDP missing")
+	if ok {
+		s.True(fileIDP.IsReadOnly, "File IDP should be marked as immutable")
+	}
+}
+
+// TestGetIdentityProviderList_HandlesEmptyStores verifies empty results are handled
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_HandlesEmptyStores() {
+	s.dbStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, nil)
+	s.fileStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, nil)
+
+	result, err := s.compositeStore.GetIdentityProviderList(context.Background())
+
+	s.NoError(err)
+	s.Len(result, 0)
+}
+
+// TestGetIdentityProviderList_HandlesDBStoreError verifies error handling
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_HandlesDBStoreError() {
+	s.dbStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, errors.New("DB error"))
+
+	result, err := s.compositeStore.GetIdentityProviderList(context.Background())
+
+	s.Error(err)
+	s.Nil(result)
+}
+
+// TestGetIdentityProviderList_HandlesFileStoreError verifies error handling
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_HandlesFileStoreError() {
+	dbIDPs := []BasicIDPDTO{
+		{ID: "db-1", Name: "DB IDP 1", Type: IDPTypeOIDC},
+	}
+	s.dbStore.On("GetIdentityProviderList", context.Background()).Return(dbIDPs, nil)
+	s.fileStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, errors.New("File error"))
+
+	result, err := s.compositeStore.GetIdentityProviderList(context.Background())
+
+	s.Error(err)
+	s.Nil(result)
+}
+
+// TestUpdateIdentityProvider_UpdatesInDBStoreOnly verifies Update only goes to DB store
+func (s *CompositeIDPStoreTestSuite) TestUpdateIdentityProvider_UpdatesInDBStoreOnly() {
+	idp := &IDPDTO{
+		ID:          "idp-123",
+		Name:        "Updated IDP",
+		Description: "Updated Description",
+		Type:        IDPTypeOIDC,
+	}
+
+	// Mock fileStore check for immutability (should not find it)
+	s.fileStore.On("GetIdentityProvider", context.Background(), idp.ID).Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.dbStore.On("UpdateIdentityProvider", context.Background(), idp).Return(nil)
+
+	err := s.compositeStore.UpdateIdentityProvider(context.Background(), idp)
+
+	s.NoError(err)
+	s.fileStore.AssertCalled(s.T(), "GetIdentityProvider", context.Background(), idp.ID)
+	s.dbStore.AssertCalled(s.T(), "UpdateIdentityProvider", context.Background(), idp)
+	s.fileStore.AssertNotCalled(s.T(), "UpdateIdentityProvider")
+}
+
+// TestDeleteIdentityProvider_DeletesFromDBStoreOnly verifies Delete only goes to DB store
+func (s *CompositeIDPStoreTestSuite) TestDeleteIdentityProvider_DeletesFromDBStoreOnly() {
+	idpID := "idp-123"
+
+	// Mock fileStore check for immutability (should not find it)
+	s.fileStore.On("GetIdentityProvider", context.Background(), idpID).Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.dbStore.On("DeleteIdentityProvider", context.Background(), idpID).Return(nil)
+
+	err := s.compositeStore.DeleteIdentityProvider(context.Background(), idpID)
+
+	s.NoError(err)
+	s.fileStore.AssertCalled(s.T(), "GetIdentityProvider", context.Background(), idpID)
+	s.dbStore.AssertCalled(s.T(), "DeleteIdentityProvider", context.Background(), idpID)
+	s.fileStore.AssertNotCalled(s.T(), "DeleteIdentityProvider")
+}
+
+// TestMergeAndDeduplicateIDPs_CorrectlyMarksReadOnlyFlags verifies read-only flag assignment
+func (s *CompositeIDPStoreTestSuite) TestMergeAndDeduplicateIDPs_CorrectlyMarksReadOnlyFlags() {
+	dbIDPs := []BasicIDPDTO{
+		{ID: "db-1", Name: "DB IDP", Type: IDPTypeOIDC},
+	}
+	fileIDPs := []BasicIDPDTO{
+		{ID: "file-1", Name: "File IDP", Type: IDPTypeOIDC},
+	}
+
+	result := mergeAndDeduplicateIDPs(dbIDPs, fileIDPs)
+
+	s.Len(result, 2)
+
+	// Find and verify DB IDP
+	for _, idp := range result {
+		if idp.ID == "db-1" {
+			s.False(idp.IsReadOnly, "DB IDP should be mutable")
+		}
+		if idp.ID == "file-1" {
+			s.True(idp.IsReadOnly, "File IDP should be immutable")
+		}
+	}
+}
+
+// TestMergeAndDeduplicateIDPs_PreservesDuplicatesPreference verifies DB precedence over file
+func (s *CompositeIDPStoreTestSuite) TestMergeAndDeduplicateIDPs_PreservesDuplicatesPreference() {
+	dbIDPs := []BasicIDPDTO{
+		{ID: "shared", Name: "DB Name", Type: IDPTypeOIDC},
+	}
+	fileIDPs := []BasicIDPDTO{
+		{ID: "shared", Name: "File Name", Type: IDPTypeOIDC},
+	}
+
+	result := mergeAndDeduplicateIDPs(dbIDPs, fileIDPs)
+
+	s.Len(result, 1)
+	s.Equal("DB Name", result[0].Name)
+	s.False(result[0].IsReadOnly)
+}

--- a/backend/internal/idp/error_constants.go
+++ b/backend/internal/idp/error_constants.go
@@ -92,4 +92,11 @@ var (
 		Error:            "Invalid request format",
 		ErrorDescription: "The request body is malformed or contains invalid data",
 	}
+	// ErrorIDPDeclarativeReadOnly is the error returned when attempting to modify a declarative (immutable) IDP.
+	ErrorIDPDeclarativeReadOnly = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "IDP-1010",
+		Error:            "Identity provider is immutable",
+		ErrorDescription: "The requested identity provider is declarative and cannot be modified or deleted",
+	}
 )

--- a/backend/internal/idp/handler.go
+++ b/backend/internal/idp/handler.go
@@ -103,6 +103,7 @@ func (ih *idpHandler) HandleIDPListRequest(w http.ResponseWriter, r *http.Reques
 			Name:        idp.Name,
 			Description: idp.Description,
 			Type:        string(idp.Type),
+			IsReadOnly:  idp.IsReadOnly,
 		})
 	}
 

--- a/backend/internal/idp/init.go
+++ b/backend/internal/idp/init.go
@@ -21,7 +21,10 @@ package idp
 
 import (
 	"net/http"
+	"strings"
 
+	"github.com/asgardeo/thunder/internal/system/config"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -31,11 +34,9 @@ import (
 // Initialize initializes the IDP service and registers its routes.
 func Initialize(mux *http.ServeMux) (IDPServiceInterface, declarativeresource.ResourceExporter, error) {
 	// Create store based on configuration
-	var idpStore idpStoreInterface
-	if declarativeresource.IsDeclarativeModeEnabled() {
-		idpStore = newIDPFileBasedStore()
-	} else {
-		idpStore = newIDPStore()
+	idpStore, err := initializeStore()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Get transactioner from DB provider
@@ -51,19 +52,112 @@ func Initialize(mux *http.ServeMux) (IDPServiceInterface, declarativeresource.Re
 
 	idpService := newIDPService(idpStore, transactioner)
 
-	// Load declarative resources if enabled
-	if declarativeresource.IsDeclarativeModeEnabled() {
-		if err := loadDeclarativeResources(idpStore); err != nil {
-			return nil, nil, err
-		}
-	}
-
 	idpHandler := newIDPHandler(idpService)
 	registerRoutes(mux, idpHandler)
 
 	// Create and return exporter
 	exporter := newIDPExporter(idpService)
 	return idpService, exporter, nil
+}
+
+// Store Selection (based on identity_provider.store configuration):
+//
+// 1. MUTABLE mode (store: "mutable"):
+//   - Uses database store only (idpStore)
+//   - Supports full CRUD operations (Create/Read/Update/Delete)
+//   - All IDPs are mutable
+//   - Export functionality exports DB-backed IDPs
+//
+// 2. IMMUTABLE mode (store: "declarative"):
+//   - Uses file-based store only (from YAML resources)
+//   - All IDPs are immutable (read-only)
+//   - No create/update/delete operations allowed
+//   - Export functionality not applicable
+//
+// 3. COMPOSITE mode (store: "composite" - hybrid):
+//   - Uses both file-based store (immutable) + database store (mutable)
+//   - YAML resources are loaded into file-based store (immutable, read-only)
+//   - Database store handles runtime IDPs (mutable)
+//   - Reads check both stores (merged results)
+//   - Writes only go to database store
+//   - Declarative IDPs cannot be updated or deleted
+//   - Export only exports DB-backed IDPs (not YAML)
+//
+// Configuration Fallback:
+// - If identity_provider.store is not specified, falls back to global declarative_resources.enabled:
+//   - If declarative_resources.enabled = true: behaves as IMMUTABLE mode
+//   - If declarative_resources.enabled = false: behaves as MUTABLE mode
+func initializeStore() (idpStoreInterface, error) {
+	var idpStore idpStoreInterface
+
+	storeMode := getIdentityProviderStoreMode()
+
+	switch storeMode {
+	case serverconst.StoreModeComposite:
+		fileStore := newIDPFileBasedStore()
+		dbStore := newIDPStore()
+		idpStore = newCompositeIDPStore(fileStore, dbStore)
+		if err := loadDeclarativeResources(fileStore); err != nil {
+			return nil, err
+		}
+
+	case serverconst.StoreModeDeclarative:
+		fileStore := newIDPFileBasedStore()
+		idpStore = fileStore
+
+		if err := loadDeclarativeResources(fileStore); err != nil {
+			return nil, err
+		}
+
+	default:
+		idpStore = newIDPStore()
+	}
+
+	return idpStore, nil
+}
+
+// getIdentityProviderStoreMode determines the store mode for identity providers.
+//
+// Resolution order:
+//  1. If IdentityProvider.Store is explicitly configured, use it
+//  2. Otherwise, fall back to global DeclarativeResources.Enabled:
+//     - If enabled: return "declarative"
+//     - If disabled: return "mutable"
+//
+// Returns normalized store mode: "mutable", "declarative", or "composite"
+func getIdentityProviderStoreMode() serverconst.StoreMode {
+	cfg := config.GetThunderRuntime().Config
+	// Check if service-level configuration is explicitly set
+	if cfg.IdentityProvider.Store != "" {
+		mode := serverconst.StoreMode(strings.ToLower(strings.TrimSpace(cfg.IdentityProvider.Store)))
+		// Validate and normalize
+		switch mode {
+		case serverconst.StoreModeMutable, serverconst.StoreModeDeclarative, serverconst.StoreModeComposite:
+			return mode
+		}
+	}
+
+	// Fall back to global declarative resources setting
+	if declarativeresource.IsDeclarativeModeEnabled() {
+		return serverconst.StoreModeDeclarative
+	}
+
+	return serverconst.StoreModeMutable
+}
+
+// isCompositeModeEnabled checks if composite store mode is enabled for identity providers.
+func isCompositeModeEnabled() bool {
+	return getIdentityProviderStoreMode() == serverconst.StoreModeComposite
+}
+
+// isMutableModeEnabled checks if mutable-only store mode is enabled for identity providers.
+func isMutableModeEnabled() bool {
+	return getIdentityProviderStoreMode() == serverconst.StoreModeMutable
+}
+
+// isDeclarativeModeEnabled checks if immutable-only store mode is enabled for identity providers.
+func isDeclarativeModeEnabled() bool {
+	return getIdentityProviderStoreMode() == serverconst.StoreModeDeclarative
 }
 
 // RegisterRoutes registers the routes for identity provider operations.

--- a/backend/internal/idp/init_test.go
+++ b/backend/internal/idp/init_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/config"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
 
@@ -677,4 +678,124 @@ properties:
 	_, _, err = Initialize(mux)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load identity provider resources")
+}
+
+// TestGetIdentityProviderStoreMode_MutableMode verifies mutable mode detection
+func (s *IDPInitTestSuite) TestGetIdentityProviderStoreMode_MutableMode() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+		IdentityProvider: config.IdentityProviderConfig{
+			Store: "mutable",
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	mode := getIdentityProviderStoreMode()
+
+	s.NotZero(mode)
+	s.Equal(mode, serverconst.StoreModeMutable)
+}
+
+// TestGetIdentityProviderStoreMode_DeclarativeMode verifies declarative mode detection
+func (s *IDPInitTestSuite) TestGetIdentityProviderStoreMode_DeclarativeMode() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: true,
+		},
+		IdentityProvider: config.IdentityProviderConfig{
+			Store: "declarative",
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	mode := getIdentityProviderStoreMode()
+
+	s.NotZero(mode)
+	s.Equal(mode, serverconst.StoreModeDeclarative)
+}
+
+// TestGetIdentityProviderStoreMode_CompositeMode verifies composite mode detection
+func (s *IDPInitTestSuite) TestGetIdentityProviderStoreMode_CompositeMode() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+		IdentityProvider: config.IdentityProviderConfig{
+			Store: "composite",
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	mode := getIdentityProviderStoreMode()
+
+	s.NotZero(mode)
+	s.Equal(mode, serverconst.StoreModeComposite)
+}
+
+// TestGetIdentityProviderStoreMode_FallbackToGlobalSetting verifies fallback behavior
+func (s *IDPInitTestSuite) TestGetIdentityProviderStoreMode_FallbackToGlobalSetting() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: true,
+		},
+		IdentityProvider: config.IdentityProviderConfig{
+			Store: "", // Empty means use global setting
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	mode := getIdentityProviderStoreMode()
+
+	s.Equal(mode, serverconst.StoreModeDeclarative)
+}
+
+// TestIsCompositeModeEnabled verifies composite mode flag
+func (s *IDPInitTestSuite) TestIsCompositeModeEnabled() {
+	testConfig := &config.Config{
+		IdentityProvider: config.IdentityProviderConfig{
+			Store: "composite",
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	enabled := isCompositeModeEnabled()
+
+	s.True(enabled)
+}
+
+// TestIsMutableModeEnabled verifies mutable mode flag
+func (s *IDPInitTestSuite) TestIsMutableModeEnabled() {
+	testConfig := &config.Config{
+		IdentityProvider: config.IdentityProviderConfig{
+			Store: "mutable",
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	enabled := isMutableModeEnabled()
+
+	s.True(enabled)
+}
+
+// TestIsDeclarativeModeEnabled verifies declarative mode flag
+func (s *IDPInitTestSuite) TestIsDeclarativeModeEnabled() {
+	testConfig := &config.Config{
+		IdentityProvider: config.IdentityProviderConfig{
+			Store: "declarative",
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	enabled := isDeclarativeModeEnabled()
+
+	s.True(enabled)
 }

--- a/backend/internal/idp/model.go
+++ b/backend/internal/idp/model.go
@@ -35,6 +35,7 @@ type BasicIDPDTO struct {
 	Name        string
 	Description string
 	Type        IDPType
+	IsReadOnly  bool
 }
 
 // idpRequest represents the request payload for creating or updating an identity provider.
@@ -60,6 +61,7 @@ type basicIDPResponse struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Type        string `json:"type"`
+	IsReadOnly  bool   `json:"is_read_only,omitempty"`
 }
 
 // idpRequestWithID represents the request payload for creating an identity provider from file-based config.

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -251,6 +251,16 @@ type OrganizationUnitConfig struct {
 	Store string `yaml:"store" json:"store"`
 }
 
+// IdentityProviderConfig holds the identity provider service configuration.
+type IdentityProviderConfig struct {
+	// Store defines the storage mode for identity providers.
+	// Valid values: "mutable", "declarative", "composite" (hybrid mode)
+	// If not specified, falls back to global DeclarativeResources.Enabled setting:
+	//   - If DeclarativeResources.Enabled = true: behaves as "declarative"
+	//   - If DeclarativeResources.Enabled = false: behaves as "mutable"
+	Store string `yaml:"store" json:"store"`
+}
+
 // ApplicationConfig holds the application service configuration.
 type ApplicationConfig struct {
 	// Store defines the storage mode for applications.
@@ -310,6 +320,7 @@ type Config struct {
 	DeclarativeResources DeclarativeResources   `yaml:"declarative_resources" json:"declarative_resources"`
 	Resource             ResourceConfig         `yaml:"resource" json:"resource"`
 	OrganizationUnit     OrganizationUnitConfig `yaml:"organization_unit" json:"organization_unit"`
+	IdentityProvider     IdentityProviderConfig `yaml:"identity_provider" json:"identity_provider"`
 	Application          ApplicationConfig      `yaml:"application" json:"application"`
 	Observability        ObservabilityConfig    `yaml:"observability" json:"observability"`
 	Passkey              PasskeyConfig          `yaml:"passkey" json:"passkey"`


### PR DESCRIPTION
### Purpose
Composite store support for IdP

### Approach
This pull request introduces a composite store for identity provider (IDP) management, allowing the service to support three modes: mutable (database only), declarative (file-based only), and composite (hybrid). The composite mode enables reads from both file-based (immutable) and database (mutable) stores, while writes affect only the database store. The changes include new store logic, error handling for immutable IDPs, extensive unit tests for the composite store, and configuration-driven mode selection.

**Composite Store Implementation and Logic:**

* Added `compositeIDPStore` in `composite_store.go` to merge file-based (immutable) and database (mutable) stores, with reads querying both and writes affecting only the database. Includes helper methods for merging and deduplication, and marks IDPs as mutable or immutable based on their source.
* Updated `init.go` to introduce configuration-driven store mode selection (`mutable`, `declarative`, `composite`), with fallback to global settings. Includes new helper functions for mode detection and store initialization.

**Error Handling Enhancements:**

* Added a new error constant `ErrorIDPDeclarativeReadOnly` for attempts to modify or delete declarative (immutable) IDPs, improving clarity and robustness of error reporting.

**Testing Improvements:**

* Introduced `composite_store_test.go` with comprehensive unit tests for composite store behavior, including read/write routing, merging, deduplication, and error handling.
* Expanded `init_test.go` to test mode detection, configuration fallback, and helper functions for store mode flags.
* Adjusted service constructor tests to support the new composite store signature.
* Updated imports in `init_test.go` to support new constants.

These changes collectively enable flexible IDP storage modes, robust error handling for immutable resources, and thorough test coverage for new behaviors.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1422

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composite mode: read IDPs from file (immutable) and DB (mutable); merged listings deduplicate with DB precedence and expose IsReadOnly per entry. Writes always go to DB; immutable entries cannot be changed.

* **Config**
  * New identity_provider.store option to select composite, declarative, or mutable modes.

* **Errors**
  * New read-only error returned for attempts to modify/delete declarative IDPs.

* **Tests**
  * Extensive tests covering composite behavior, merging/deduplication, immutability enforcement, and mode detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->