### PR TITLE
Add Gateway API HTTPRoute support in helm chart

### DIFF
--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -194,6 +194,7 @@ The following table lists the configurable parameters of the Thunder chart and t
 
 | Name                                  | Description                                                     | Default                      |
 | ------------------------------------- | --------------------------------------------------------------- | ---------------------------- |
+| `ingress.enabled`                     | Enable Ingress resource                                         | `true`                       |
 | `ingress.className`                   | Ingress controller class                                        | `nginx`                      |
 | `ingress.hostname`                    | Default host for the ingress resource                           | `thunder.local`              |
 | `ingress.paths[0].path`               | Path for the ingress resource                                   | `/`                          |
@@ -201,6 +202,15 @@ The following table lists the configurable parameters of the Thunder chart and t
 | `ingress.tlsSecretsName`              | TLS secret name for HTTPS                                       | `thunder-tls`                |
 | `ingress.commonAnnotations`           | Common annotations for ingress                                  | See values.yaml              |
 | `ingress.customAnnotations`           | Custom annotations for ingress                                  | `{}`                         |
+
+### HTTPRoute Parameters
+
+| Name                                  | Description                                                                  | Default                      |
+| ------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------- |
+| `httproute.enabled`                   | Enable Gateway API HTTPRoute resource (alternative to Ingress)               | `false`                      |
+| `httproute.annotations`               | Annotations for the HTTPRoute resource                                       | `{}`                         |
+| `httproute.parentRefs`                | Gateway references this route attaches to (required when enabled)            | `[]`                         |
+| `httproute.hostnames`                 | Hostnames this route responds to                                             | `[]`                         |
 
 ### Database Password Management
 
@@ -296,7 +306,6 @@ Each database section (`identity`, `runtime`, `user`) supports these fields:
 | `password`             | Direct password value. When Thunder reads config directly, this may also be an env var placeholder (`{{.VAR}}`) or file reference (`file://path`). When using the auto-generated Secret, the value is stored **as-is** in the Secret and such placeholders are **not** resolved. | `"mypassword"` or `"{{.DB_PASSWORD}}"` or `"file:///secrets/pass"` |
 | `passwordRef.name`     | Kubernetes Secret name (optional, defaults to `<release-name>-db-credentials` for auto-convert)                                               | `"my-db-secrets"`            |
 | `passwordRef.key`      | Secret key name. When set, `password` field is ignored and external Secret is used                                                            | `"identity-password"`        |
-
 ### Thunder Configuration Parameters
 
 | Name                                              | Description                                                                                           | Default                      |

--- a/install/helm/templates/httproute.yaml
+++ b/install/helm/templates/httproute.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.httproute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "thunder.fullname" . }}-httproute
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunder.labels" . | nindent 4 }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "thunder.fullname" . }}-service
+          port: {{ .Values.service.port }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+{{- end }}

--- a/install/helm/templates/ingress.yaml
+++ b/install/helm/templates/ingress.yaml
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -51,3 +52,4 @@ spec:
     - {{ .Values.ingress.hostname | quote }}
     secretName: {{ .Values.ingress.tlsSecretsName  }}
   {{- end }}
+{{- end }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -87,6 +87,7 @@ service:
   port: 8090
 
 ingress:
+  enabled: true
   className: "nginx"
   commonAnnotations: &commonAnnotations
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
@@ -109,6 +110,17 @@ ingress:
     - path: /
       pathType: Prefix
   tlsSecretsName: "thunder-tls"
+
+# Gateway API HTTPRoute configuration (alternative to Ingress)
+httproute:
+  enabled: false
+  annotations: {}
+  # parentRefs specify which Gateway(s) this route attaches to
+  parentRefs: []
+    # - name: my-gateway
+    #   namespace: gateway-ns
+  hostnames: []
+    # - thunder.example.com
 
 # Thunder specific configurations
 configuration:


### PR DESCRIPTION
fixes #1400

clusters running Gateway API don't have a native way to configure routing through the chart right now. this adds HTTPRoute as an alternative to traditional Ingress.

changes:
- gate existing ingress template behind `ingress.enabled` (defaults to `true`, no breaking change)
- add `httproute.yaml` template for Gateway API HTTPRoute resources
- add `httproute` section in values.yaml with `parentRefs`, `hostnames`, and `annotations`

users can enable either or both:

```yaml
# traditional ingress (default, unchanged)
ingress:
  enabled: true

# gateway api httproute
ingress:
  enabled: false
httproute:
  enabled: true
  parentRefs:
    - name: my-gateway
  hostnames:
    - thunder.example.com
```

tested with `helm template` against both configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTTPRoute configuration support with customizable annotations, parent references, and hostnames
  * Made routing configuration more flexible with conditional enablement of Ingress and HTTPRoute resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->