### PR TITLE
Improve declarative resources in OU

### DIFF
--- a/backend/internal/ou/declarative_resource.go
+++ b/backend/internal/ou/declarative_resource.go
@@ -199,28 +199,13 @@ func parseToOUWrapper(data []byte) (interface{}, error) {
 
 // parseToOU parses YAML data to OrganizationUnit.
 func parseToOU(data []byte) (*OrganizationUnit, error) {
-	var ouRequest struct {
-		ID          string  `yaml:"id"`
-		Handle      string  `yaml:"handle"`
-		Name        string  `yaml:"name"`
-		Description string  `yaml:"description,omitempty"`
-		Parent      *string `yaml:"parent,omitempty"`
-	}
-
-	err := yaml.Unmarshal(data, &ouRequest)
+	var ou OrganizationUnit
+	err := yaml.Unmarshal(data, &ou)
 	if err != nil {
 		return nil, err
 	}
 
-	ou := &OrganizationUnit{
-		ID:          ouRequest.ID,
-		Handle:      ouRequest.Handle,
-		Name:        ouRequest.Name,
-		Description: ouRequest.Description,
-		Parent:      ouRequest.Parent,
-	}
-
-	return ou, nil
+	return &ou, nil
 }
 
 // validateOUWrapper wraps validateOU to match ResourceConfig.Validator signature.

--- a/backend/internal/ou/service_declarative_mode_test.go
+++ b/backend/internal/ou/service_declarative_mode_test.go
@@ -35,9 +35,10 @@ type DeclarativeModeServiceTestSuite struct {
 
 func (suite *DeclarativeModeServiceTestSuite) SetupTest() {
 	// Initialize runtime with declarative mode enabled
+	config.ResetThunderRuntime()
 	testConfig := &config.Config{
-		OrganizationUnit: config.OrganizationUnitConfig{
-			Store: "declarative", // Explicit declarative mode
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: true,
 		},
 	}
 	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
@@ -45,6 +46,10 @@ func (suite *DeclarativeModeServiceTestSuite) SetupTest() {
 	// Create service with mock store (store won't be called in declarative mode)
 	mockStore := new(organizationUnitStoreInterfaceMock)
 	suite.service = newOrganizationUnitService(mockStore)
+}
+
+func (suite *DeclarativeModeServiceTestSuite) TearDownTest() {
+	config.ResetThunderRuntime()
 }
 
 func (suite *DeclarativeModeServiceTestSuite) TestCreateOrganizationUnit_FailsInDeclarativeMode() {


### PR DESCRIPTION
### Purpose
Following changes are done in OU declarative resources
- Use the existing struct when parsing the YAML file
- Change the check in update and delete paths

### Approach
This pull request refines how the system handles updates and deletions of Organization Units (OUs) in declarative and composite modes. The main changes ensure that OUs managed declaratively cannot be modified or deleted, and the logic for these checks is now more precise and testable. Additionally, test setups and mocks have been improved for clarity and correctness.

**Declarative/composite mode enforcement:**

* Updated `UpdateOrganizationUnitByPath` and `DeleteOrganizationUnitByPath` methods in `service.go` to check if an OU is declarative using `IsOrganizationUnitDeclarative`, and block modifications if so, rather than relying on a global declarative mode flag. This allows for composite mode support and more granular enforcement. [[1]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510L332-L336) [[2]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510R346-R350) [[3]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510L483-L487) [[4]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510R497-R501)

**Parsing and configuration:**

* Simplified YAML parsing in `parseToOU` by directly unmarshalling into the `OrganizationUnit` struct, reducing code complexity.
* Updated test configuration to use the new `DeclarativeResources.Enabled` flag and added a `TearDownTest` method to reset runtime state between tests, ensuring reliable test isolation. [[1]](diffhunk://#diff-78303e60962a596172514a2111ef61fadf58b357ab3a55cbdfbca1c481263122R38-R41) [[2]](diffhunk://#diff-78303e60962a596172514a2111ef61fadf58b357ab3a55cbdfbca1c481263122R51-R54)

**Testing improvements:**

* Enhanced unit tests to cover cases where declarative OUs cannot be updated or deleted, ensuring the new logic is correctly enforced. [[1]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569R1193-R1209) [[2]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569R1412-R1428)
* Adjusted mock expectations in update and delete tests to account for additional calls to `IsOrganizationUnitDeclarative` introduced by the refactor. [[1]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L1182-R1182) [[2]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L1364-R1381) [[3]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L1382-R1399)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified YAML parsing for organization unit data handling
  * Moved declarative resource protections from a global switch to checks per organization unit, ensuring declarative units cannot be modified or deleted

* **Tests**
  * Added and adjusted tests to validate per-unit declarative protections for updates and deletions
  * Improved test setup and teardown to reset runtime state between tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->