### PR TITLE
Userschema service context propagation and transection usage

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -45,6 +45,7 @@ import (
 	"github.com/asgardeo/thunder/internal/role"
 	"github.com/asgardeo/thunder/internal/system/crypto/hash"
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
+	"github.com/asgardeo/thunder/internal/system/database/provider"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/export"
 	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
@@ -96,7 +97,13 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	exporters = append(exporters, ouExporter)
 
 	hashService := hash.Initialize()
-	userSchemaService, userSchemaExporter, err := userschema.Initialize(mux, ouService)
+	dbProvider := provider.GetDBProvider()
+	transactioner, err := dbProvider.GetConfigDBTransactioner()
+	if err != nil {
+		logger.Fatal("Failed to get config DB transactioner", log.Error(err))
+	}
+
+	userSchemaService, userSchemaExporter, err := userschema.Initialize(mux, ouService, transactioner)
 	if err != nil {
 		logger.Fatal("Failed to initialize UserSchemaService", log.Error(err))
 	}

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -792,7 +792,8 @@ func (as *applicationService) validateAllowedUserTypes(allowedUserTypes []string
 	offset := 0
 
 	for {
-		userSchemaList, svcErr := as.userSchemaService.GetUserSchemaList(limit, offset)
+		// TODO: Pass context from the caller
+		userSchemaList, svcErr := as.userSchemaService.GetUserSchemaList(context.TODO(), limit, offset)
 		if svcErr != nil {
 			logger.Error("Failed to retrieve user schema list for validation",
 				log.String("error", svcErr.Error), log.String("code", svcErr.Code))

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -3288,7 +3288,7 @@ func (suite *ServiceTestSuite) TestValidateAllowedUserTypes_EmptyString() {
 
 	// Mock GetUserSchemaList to return empty list (first call)
 	mockUserSchemaService.EXPECT().
-		GetUserSchemaList(mock.Anything, 0).
+		GetUserSchemaList(mock.Anything, mock.Anything, 0).
 		Return(&userschema.UserSchemaListResponse{
 			TotalResults: 0,
 			Count:        0,
@@ -3321,7 +3321,7 @@ func (suite *ServiceTestSuite) TestValidateAllowedUserTypes_EmptyStringWithValid
 
 	// Mock GetUserSchemaList to return a list with one valid user type
 	mockUserSchemaService.EXPECT().
-		GetUserSchemaList(mock.Anything, 0).
+		GetUserSchemaList(mock.Anything, mock.Anything, 0).
 		Return(&userschema.UserSchemaListResponse{
 			TotalResults: 1,
 			Count:        1,

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -515,7 +516,7 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 	// Filter allowed user types to only those with self-registration enabled
 	selfRegEnabledSchemas := make([]userschema.UserSchema, 0)
 	for _, userType := range ctx.Application.AllowedUserTypes {
-		userSchema, svcErr := o.userSchemaService.GetUserSchemaByName(userType)
+		userSchema, svcErr := o.userSchemaService.GetUserSchemaByName(context.TODO(), userType)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ClientErrorType {
 				execResp.Status = common.ExecFailure

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
@@ -943,7 +944,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithou
 			Code: authncm.ErrorUserNotFound.Code,
 			Type: serviceerror.ClientErrorType,
 		})
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "INTERNAL").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 		Return(&userschema.UserSchema{
 			Name:                  "INTERNAL",
 			AllowSelfRegistration: true,
@@ -1129,7 +1130,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "INTERNAL").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 		Return(&userschema.UserSchema{
 			Name:                  "INTERNAL",
 			AllowSelfRegistration: true,
@@ -1160,7 +1161,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 			name:             "NoSelfRegistrationEnabled",
 			allowedUserTypes: []string{"INTERNAL"},
 			mockSetup: func() {
-				suite.mockUserSchemaService.On("GetUserSchemaByName", "INTERNAL").
+				suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 					Return(&userschema.UserSchema{
 						Name:                  "INTERNAL",
 						AllowSelfRegistration: false,
@@ -1172,13 +1173,13 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 			name:             "MultipleSelfRegistrationEnabled",
 			allowedUserTypes: []string{"INTERNAL", "CUSTOMER"},
 			mockSetup: func() {
-				suite.mockUserSchemaService.On("GetUserSchemaByName", "INTERNAL").
+				suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 					Return(&userschema.UserSchema{
 						Name:                  "INTERNAL",
 						AllowSelfRegistration: true,
 						OrganizationUnitID:    "ou-123",
 					}, nil).Once()
-				suite.mockUserSchemaService.On("GetUserSchemaByName", "CUSTOMER").
+				suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "CUSTOMER").
 					Return(&userschema.UserSchema{
 						Name:                  "CUSTOMER",
 						AllowSelfRegistration: true,
@@ -1229,7 +1230,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_GetU
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "INTERNAL").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 		Return(nil, &serviceerror.ServiceError{
 			Type:             serviceerror.ServerErrorType,
 			Code:             "SCHEMA-5000",
@@ -1436,7 +1437,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 
 			if tt.userSchemas != nil {
 				for userType, schema := range tt.userSchemas {
-					suite.mockUserSchemaService.On("GetUserSchemaByName", userType).Return(schema, nil)
+					suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, userType).Return(schema, nil)
 				}
 			}
 

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
@@ -1130,7 +1131,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWit
 			Code: authncm.ErrorUserNotFound.Code,
 			Type: serviceerror.ClientErrorType,
 		})
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "INTERNAL").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "INTERNAL").
 		Return(&userschema.UserSchema{
 			Name:                  "INTERNAL",
 			AllowSelfRegistration: true,

--- a/backend/internal/flow/executor/user_type_resolver_test.go
+++ b/backend/internal/flow/executor/user_type_resolver_test.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -235,7 +236,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_Succ
 				OrganizationUnitID:    tc.expectedOUID,
 				AllowSelfRegistration: true,
 			}
-			suite.mockUserSchemaService.On("GetUserSchemaByName", tc.providedUserType).
+			suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), tc.providedUserType).
 				Return(userSchema, nil)
 
 			result, err := suite.executor.Execute(ctx)
@@ -272,7 +273,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_NoOU
 		OrganizationUnitID:    "",
 		AllowSelfRegistration: true,
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(userSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -328,7 +329,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_OURe
 		Error:            "Internal Server Error",
 		ErrorDescription: "Failed to retrieve OU",
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(nil, svcErr)
 
 	result, err := suite.executor.Execute(ctx)
@@ -380,7 +381,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_Succes
 		OrganizationUnitID:    "ou-123",
 		AllowSelfRegistration: true,
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(userSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -413,7 +414,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_NoOU()
 		OrganizationUnitID:    "",
 		AllowSelfRegistration: true,
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(userSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -443,7 +444,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_OUReso
 		Error:            "Internal Server Error",
 		ErrorDescription: "Failed to retrieve OU",
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(nil, svcErr)
 
 	result, err := suite.executor.Execute(ctx)
@@ -475,7 +476,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_Pro
 			OrganizationUnitID:    "ou-" + userType,
 			AllowSelfRegistration: true,
 		}
-		suite.mockUserSchemaService.On("GetUserSchemaByName", userType).
+		suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), userType).
 			Return(userSchema, nil)
 	}
 
@@ -520,7 +521,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_EmptyUserTypeInput() {
 			OrganizationUnitID:    "ou-" + userType,
 			AllowSelfRegistration: true,
 		}
-		suite.mockUserSchemaService.On("GetUserSchemaByName", userType).
+		suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), userType).
 			Return(userSchema, nil)
 	}
 
@@ -560,7 +561,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_Self
 		OrganizationUnitID:    "ou-123",
 		AllowSelfRegistration: false,
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "employee").
 		Return(userSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -591,7 +592,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_SelfRe
 		OrganizationUnitID:    "ou-123",
 		AllowSelfRegistration: false,
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", mock.Anything, "employee").
 		Return(userSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -636,11 +637,11 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_Onl
 		AllowSelfRegistration: false,
 	}
 
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(employeeSchema, nil)
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "customer").
 		Return(customerSchema, nil)
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "partner").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "partner").
 		Return(partnerSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -680,9 +681,9 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_NoS
 		AllowSelfRegistration: false,
 	}
 
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(employeeSchema, nil)
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "customer").
 		Return(customerSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -721,9 +722,9 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_Sch
 		ErrorDescription: "Failed to retrieve schema",
 	}
 
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(employeeSchema, nil)
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "customer").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "customer").
 		Return(nil, svcErr)
 
 	result, err := suite.executor.Execute(ctx)
@@ -743,10 +744,10 @@ func (suite *UserTypeResolverTestSuite) TestGetUserSchemaAndOU_Success() {
 		OrganizationUnitID:    "ou-123",
 		AllowSelfRegistration: true,
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(userSchema, nil)
 
-	schema, ouID, err := suite.executor.getUserSchemaAndOU("employee")
+	schema, ouID, err := suite.executor.getUserSchemaAndOU(context.TODO(), "employee")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), schema)
@@ -764,10 +765,10 @@ func (suite *UserTypeResolverTestSuite) TestGetUserSchemaAndOU_NoOUFound() {
 		OrganizationUnitID:    "",
 		AllowSelfRegistration: true,
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(userSchema, nil)
 
-	schema, ouID, err := suite.executor.getUserSchemaAndOU("employee")
+	schema, ouID, err := suite.executor.getUserSchemaAndOU(context.TODO(), "employee")
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), schema)
@@ -785,10 +786,10 @@ func (suite *UserTypeResolverTestSuite) TestGetUserSchemaAndOU_SchemaNotFound() 
 		Error:            "Not Found",
 		ErrorDescription: "User schema not found",
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(nil, svcErr)
 
-	schema, ouID, err := suite.executor.getUserSchemaAndOU("employee")
+	schema, ouID, err := suite.executor.getUserSchemaAndOU(context.TODO(), "employee")
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), schema)
@@ -814,7 +815,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_UserTypeP
 		Name:               "employee",
 		OrganizationUnitID: "ou-123",
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "employee").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "employee").
 		Return(userSchema, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -847,7 +848,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_UserTypeP
 		Error:            "Not Found",
 		ErrorDescription: "User schema not found",
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaByName", "invalid_user").
+	suite.mockUserSchemaService.On("GetUserSchemaByName", context.TODO(), "invalid_user").
 		Return(nil, svcErr)
 
 	result, err := suite.executor.Execute(ctx)
@@ -874,7 +875,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 	emptyList := &userschema.UserSchemaListResponse{
 		Schemas: []userschema.UserSchemaListItem{},
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaList", 100, 0).
+	suite.mockUserSchemaService.On("GetUserSchemaList", context.TODO(), 100, 0).
 		Return(emptyList, nil)
 
 	result, err := suite.executor.Execute(ctx)
@@ -899,7 +900,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 		Type:  serviceerror.ServerErrorType,
 		Error: "Simulated Error",
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaList", 100, 0).
+	suite.mockUserSchemaService.On("GetUserSchemaList", context.TODO(), 100, 0).
 		Return(nil, svcErr)
 
 	result, err := suite.executor.Execute(ctx)
@@ -927,7 +928,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 			{Name: "customer"},
 		},
 	}
-	suite.mockUserSchemaService.On("GetUserSchemaList", 100, 0).
+	suite.mockUserSchemaService.On("GetUserSchemaList", context.TODO(), 100, 0).
 		Return(schemaList, nil)
 
 	result, err := suite.executor.Execute(ctx)

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -117,8 +117,9 @@ func (s *flowExecService) Execute(ctx context.Context,
 		}
 	}
 
-	// Set trace ID and HTTP context to context
+	// Set trace ID and HTTP context to engine context
 	context.TraceID = traceID
+	context.Context = ctx
 	context.HTTPContext = ctx
 
 	flowStep, flowErr := s.flowEngine.Execute(context)

--- a/backend/internal/system/database/provider/dbclient_test.go
+++ b/backend/internal/system/database/provider/dbclient_test.go
@@ -53,7 +53,7 @@ func (suite *DBClientTestSuite) SetupTest() {
 	}
 
 	db := model.NewDB(suite.mockDB)
-	suite.dbClient = NewDBClient(db, "mock")
+	suite.dbClient = NewDBClient(db, "mock", "test")
 }
 
 func (suite *DBClientTestSuite) TearDownTest() {
@@ -294,7 +294,7 @@ func (suite *DBClientTestSuite) TestQueryContextWithTransaction() {
 	suite.mock.ExpectQuery("SELECT id FROM users").WillReturnRows(rows)
 
 	tx, _ := suite.mockDB.Begin()
-	ctx := transaction.WithTx(context.Background(), tx)
+	ctx := transaction.WithKeyedTx(context.Background(), "test", tx)
 
 	results, err := suite.dbClient.QueryContext(ctx, testQuery)
 
@@ -352,7 +352,7 @@ func (suite *DBClientTestSuite) TestExecuteContextWithTransaction() {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	tx, _ := suite.mockDB.Begin()
-	ctx := transaction.WithTx(context.Background(), tx)
+	ctx := transaction.WithKeyedTx(context.Background(), "test", tx)
 
 	rowsAffected, err := suite.dbClient.ExecuteContext(ctx, testQuery, args...)
 

--- a/backend/internal/system/database/provider/dbprovider_test.go
+++ b/backend/internal/system/database/provider/dbprovider_test.go
@@ -71,7 +71,7 @@ func (suite *DBProviderTestSuite) TestGetUserDBTransactioner_Success() {
 
 	// Manually construct the provider with an initialized client
 	provider := &dbProvider{
-		userClient: NewDBClient(model.NewDB(db), "postgres"),
+		userClient: NewDBClient(model.NewDB(db), "postgres", "user"),
 	}
 
 	// Test getting the transactioner
@@ -90,7 +90,7 @@ func (suite *DBProviderTestSuite) TestGetRuntimeDBTransactioner_Success() {
 
 	// Manually construct the provider with an initialized client
 	provider := &dbProvider{
-		runtimeClient: NewDBClient(model.NewDB(db), "postgres"),
+		runtimeClient: NewDBClient(model.NewDB(db), "postgres", "runtime"),
 	}
 
 	// Test getting the transactioner

--- a/backend/internal/system/database/transaction/transactioner_test.go
+++ b/backend/internal/system/database/transaction/transactioner_test.go
@@ -45,7 +45,7 @@ func (suite *TransactionerTestSuite) SetupTest() {
 
 	suite.db = db
 	suite.mock = mock
-	suite.transactioner = NewTransactioner(db)
+	suite.transactioner = NewTransactioner(db, "test")
 }
 
 func (suite *TransactionerTestSuite) TearDownTest() {
@@ -63,8 +63,8 @@ func (suite *TransactionerTestSuite) TestTransact_Success() {
 	err := suite.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		executed = true
 		// Verify transaction is in context
-		suite.True(HasTx(txCtx))
-		suite.NotNil(TxFromContext(txCtx))
+		suite.True(HasKeyedTx(txCtx, "test"))
+		suite.NotNil(KeyedTxFromContext(txCtx, "test"))
 		return nil
 	})
 
@@ -125,15 +125,15 @@ func (suite *TransactionerTestSuite) TestTransact_NestedTransaction() {
 
 	err := suite.transactioner.Transact(ctx, func(txCtx1 context.Context) error {
 		outerExecuted = true
-		suite.True(HasTx(txCtx1))
-		tx1 := TxFromContext(txCtx1)
+		suite.True(HasKeyedTx(txCtx1, "test"))
+		tx1 := KeyedTxFromContext(txCtx1, "test")
 		suite.NotNil(tx1)
 
 		// Nested call - should reuse the same transaction
 		err := suite.transactioner.Transact(txCtx1, func(txCtx2 context.Context) error {
 			innerExecuted = true
-			suite.True(HasTx(txCtx2))
-			tx2 := TxFromContext(txCtx2)
+			suite.True(HasKeyedTx(txCtx2, "test"))
+			tx2 := KeyedTxFromContext(txCtx2, "test")
 			suite.NotNil(tx2)
 
 			// Should be the same transaction
@@ -211,7 +211,7 @@ func (suite *TransactionerTestSuite) TestTransact_CommitError() {
 	executed := false
 	err := suite.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		executed = true
-		suite.True(HasTx(txCtx))
+		suite.True(HasKeyedTx(txCtx, "test"))
 		return nil
 	})
 

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -1502,7 +1503,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_Success() {
 		Schema:                []byte(`{"type":"object","properties":{"email":{"type":"string"}}}`),
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema1").Return(mockSchema, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(mockSchema, nil)
 
 	result, err := suite.exportService.ExportResources(request)
 
@@ -1541,8 +1542,8 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_Multiple() {
 		Schema:                []byte(`{"type":"object","properties":{"empId":{"type":"string"}}}`),
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema1").Return(mockSchema1, nil)
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema2").Return(mockSchema2, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(mockSchema1, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema2").Return(mockSchema2, nil)
 
 	result, err := suite.exportService.ExportResources(request)
 
@@ -1587,9 +1588,9 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_Wildcard() {
 		},
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(100, 0).Return(mockSchemaList, nil)
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema1").Return(mockSchema1, nil)
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema2").Return(mockSchema2, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(mockSchemaList, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(mockSchema1, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema2").Return(mockSchema2, nil)
 
 	result, err := suite.exportService.ExportResources(request)
 
@@ -1613,7 +1614,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_NotFound() {
 		Error: "User schema not found",
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("non-existent-schema").Return(nil, schemaError)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "non-existent-schema").Return(nil, schemaError)
 
 	result, err := suite.exportService.ExportResources(request)
 
@@ -1639,7 +1640,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_EmptyName() {
 		Schema:                []byte(`{"type":"object"}`),
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema-no-name").Return(mockSchema, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema-no-name").Return(mockSchema, nil)
 
 	result, err := suite.exportService.ExportResources(request)
 
@@ -1665,7 +1666,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_NoSchema() {
 		Schema:                []byte{}, // Empty schema
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema-no-def").Return(mockSchema, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema-no-def").Return(mockSchema, nil)
 
 	result, err := suite.exportService.ExportResources(request)
 
@@ -1717,10 +1718,10 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_WildcardPartialFailur
 		Error: "User schema not found",
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(100, 0).Return(mockSchemaList, nil)
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema1").Return(mockSchema1, nil)
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema2").Return(nil, schemaError)
-	suite.mockUserSchemaService.EXPECT().GetUserSchema("schema3").Return(mockSchema3, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(mockSchemaList, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(mockSchema1, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema2").Return(nil, schemaError)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema3").Return(mockSchema3, nil)
 
 	result, err := suite.exportService.ExportResources(request)
 
@@ -2072,7 +2073,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_UserSchema(
 		Schema:                []byte(`{"type":"object","properties":{"email":{"type":"string"}}}`),
 	}
 
-	suite.mockUserSchemaService.EXPECT().GetUserSchema(schemaID).Return(mockSchema, nil)
+	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, schemaID).Return(mockSchema, nil)
 
 	exporter, exists := suite.exportService.(*exportService).registry.Get(resourceTypeUserSchema)
 	assert.True(suite.T(), exists, "User schema exporter should be registered")

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -70,7 +70,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(false, &serviceerror.ServiceError{
 						Code:  "USRS-5000",
 						Type:  serviceerror.ServerErrorType,
@@ -95,7 +95,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(false, &userschema.ErrorUserSchemaNotFound).
 					Once()
 
@@ -116,7 +116,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(false, &serviceerror.ServiceError{
 						Code:  "USRS-5000",
 						Type:  serviceerror.ServerErrorType,
@@ -141,7 +141,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(false, nil).
 					Once()
 
@@ -162,11 +162,11 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
-					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(false, &serviceerror.ServiceError{
 						Code:  "USRS-5000",
 						Type:  serviceerror.ServerErrorType,
@@ -189,11 +189,11 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
-					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(false, &userschema.ErrorUserSchemaNotFound).
 					Once()
 
@@ -218,13 +218,13 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return(&existingUserID, nil).
 					Once()
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
-					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Run(func(args mock.Arguments) {
-						identify := args.Get(2).(func(map[string]interface{}) (*string, error))
+						identify := args.Get(3).(func(map[string]interface{}) (*string, error))
 
 						id, err := identify(map[string]interface{}{"email": "employee@example.com"})
 						require.NoError(t, err)
@@ -258,13 +258,13 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return((*string)(nil), nil).
 					Once()
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
-					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Run(func(args mock.Arguments) {
-						identify := args.Get(2).(func(map[string]interface{}) (*string, error))
+						identify := args.Get(3).(func(map[string]interface{}) (*string, error))
 
 						id, err := identify(map[string]interface{}{"email": "employee@example.com"})
 						require.NoError(t, err)
@@ -296,13 +296,13 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return((*string)(nil), errors.New("store failure")).
 					Once()
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
-					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Run(func(args mock.Arguments) {
-						identify := args.Get(2).(func(map[string]interface{}) (*string, error))
+						identify := args.Get(3).(func(map[string]interface{}) (*string, error))
 
 						id, err := identify(map[string]interface{}{"email": "employee@example.com"})
 						require.Error(t, err)
@@ -341,13 +341,13 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return(&existingUserID, nil).
 					Once()
 				schemaMock.
-					On("ValidateUser", testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
-					On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+					On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Run(func(args mock.Arguments) {
-						identify := args.Get(2).(func(map[string]interface{}) (*string, error))
+						identify := args.Get(3).(func(map[string]interface{}) (*string, error))
 
 						id, err := identify(map[string]interface{}{"email": "employee@example.com"})
 						require.NoError(t, err)
@@ -487,7 +487,7 @@ func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
 
 				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userSchemaMock.
-					On("GetUserSchemaByName", testUserType).
+					On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{
 						OrganizationUnitID: parentOU,
 					}, (*serviceerror.ServiceError)(nil)).
@@ -517,7 +517,7 @@ func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
 
 				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userSchemaMock.
-					On("GetUserSchemaByName", testUserType).
+					On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{
 						OrganizationUnitID: parentOU,
 					}, (*serviceerror.ServiceError)(nil)).
@@ -549,7 +549,7 @@ func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
 
 				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userSchemaMock.
-					On("GetUserSchemaByName", testUserType).
+					On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{
 						OrganizationUnitID: parentOU,
 					}, (*serviceerror.ServiceError)(nil)).
@@ -581,7 +581,7 @@ func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
 
 				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userSchemaMock.
-					On("GetUserSchemaByName", testUserType).
+					On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{
 						OrganizationUnitID: parentOU,
 					}, (*serviceerror.ServiceError)(nil)).
@@ -608,7 +608,7 @@ func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
 
 				userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userSchemaMock.
-					On("GetUserSchemaByName", testUserType).
+					On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{
 						OrganizationUnitID: "e5c3aa8a-d7df-46f8-9f3f-bb3245c95d7c",
 					}, (*serviceerror.ServiceError)(nil)).
@@ -632,7 +632,7 @@ func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
 			service, _ := tc.setup(t)
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
 
-			err := service.validateOrganizationUnitForUserType(tc.userType, tc.ouID, logger)
+			err := service.validateOrganizationUnitForUserType(context.TODO(), tc.userType, tc.ouID, logger)
 			if tc.expectedErr == nil {
 				require.Nil(t, err)
 				return
@@ -732,13 +732,13 @@ func TestUserService_CreateUser_UsesTransactionAndStore(t *testing.T) {
 	ouServiceMock.On("IsOrganizationUnitExists", testOrgID).Return(true, (*serviceerror.ServiceError)(nil)).Once()
 
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-	userSchemaMock.On("GetUserSchemaByName", testUserType).
+	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OrganizationUnitID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 
@@ -786,13 +786,13 @@ func TestUserService_CreateUser_PropagatesStoreError(t *testing.T) {
 	ouServiceMock.On("IsOrganizationUnitExists", testOrgID).Return(true, (*serviceerror.ServiceError)(nil)).Once()
 
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-	userSchemaMock.On("GetUserSchemaByName", testUserType).
+	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OrganizationUnitID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 
@@ -830,13 +830,13 @@ func TestUserService_CreateUser_TransactionerError(t *testing.T) {
 	ouServiceMock.On("IsOrganizationUnitExists", testOrgID).Return(true, (*serviceerror.ServiceError)(nil)).Once()
 
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-	userSchemaMock.On("GetUserSchemaByName", testUserType).
+	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OrganizationUnitID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 
@@ -1497,7 +1497,7 @@ func TestUserService_UpdateUserAttributes_SchemaValidationFails(t *testing.T) {
 
 	schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 	schemaMock.
-		On("ValidateUser", testUserType, mock.Anything).
+		On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 		Return(false, &userschema.ErrorUserSchemaNotFound).
 		Once()
 
@@ -1525,11 +1525,11 @@ func TestUserService_UpdateUserAttributes_Succeeds(t *testing.T) {
 
 	schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 	schemaMock.
-		On("ValidateUser", testUserType, mock.Anything).
+		On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 	schemaMock.
-		On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+		On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 
@@ -1613,12 +1613,12 @@ func TestUserService_UpdateUser(t *testing.T) {
 	ouServiceMock.On("IsOrganizationUnitExists", testOrgID).Return(true, (*serviceerror.ServiceError)(nil)).Once()
 
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
-	userSchemaMock.On("GetUserSchemaByName", testUserType).
+	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OrganizationUnitID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
-	userSchemaMock.On("ValidateUserUniqueness", testUserType, mock.Anything, mock.Anything).
+	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
 
 	txMock := &fakeTransactioner{}
@@ -2017,13 +2017,13 @@ func TestUserService_Validation_EdgeCases(t *testing.T) {
 	service := &userService{}
 
 	t.Run("ValidateOU_InvalidUUID", func(t *testing.T) {
-		err := service.validateOrganizationUnitForUserType("customer", "invalid-uuid", nil)
+		err := service.validateOrganizationUnitForUserType(context.TODO(), "customer", "invalid-uuid", nil)
 		require.NotNil(t, err)
 		require.Equal(t, ErrorInvalidOrganizationUnitID.Code, err.Code)
 	})
 
 	t.Run("ValidateOU_EmptyOU", func(t *testing.T) {
-		err := service.validateOrganizationUnitForUserType("customer", "", nil)
+		err := service.validateOrganizationUnitForUserType(context.TODO(), "customer", "", nil)
 		require.NotNil(t, err)
 		require.Equal(t, ErrorInvalidOrganizationUnitID.Code, err.Code)
 	})
@@ -2112,9 +2112,14 @@ func TestUserService_MoreErrorCases(t *testing.T) {
 		// Mock all validation steps in the transaction with broad matches to ensure they hit
 		ouServiceMock.On("IsOrganizationUnitExists", mock.Anything).Return(true, nil).Maybe()
 		ouServiceMock.On("IsParent", mock.Anything, mock.Anything).Return(true, nil).Maybe()
-		userSchemaMock.On("GetUserSchemaByName", mock.Anything).Return(&userschema.UserSchema{}, nil).Maybe()
-		userSchemaMock.On("ValidateUser", mock.Anything, mock.Anything).Return(true, nil).Maybe()
-		userSchemaMock.On("ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything).
+		userSchemaMock.On("GetUserSchemaByName", mock.Anything, mock.Anything).
+			Return(&userschema.UserSchema{}, nil).Maybe()
+		userSchemaMock.On(
+			"ValidateUser", mock.Anything, mock.Anything, mock.Anything,
+		).Return(true, nil).Maybe()
+		userSchemaMock.On(
+			"ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		).
 			Return(true, nil).Maybe()
 		storeMock.On("IdentifyUser", mock.Anything, mock.Anything).Return(nil, ErrUserNotFound).Maybe()
 

--- a/backend/internal/userschema/declarative_resource.go
+++ b/backend/internal/userschema/declarative_resource.go
@@ -19,6 +19,7 @@
 package userschema
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -64,7 +65,7 @@ func (e *UserSchemaExporter) GetParameterizerType() string {
 
 // GetAllResourceIDs retrieves all user schema IDs.
 func (e *UserSchemaExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
-	response, err := e.service.GetUserSchemaList(serverconst.MaxPageSize, 0)
+	response, err := e.service.GetUserSchemaList(context.TODO(), serverconst.MaxPageSize, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +78,7 @@ func (e *UserSchemaExporter) GetAllResourceIDs() ([]string, *serviceerror.Servic
 
 // GetResourceByID retrieves a user schema by its ID.
 func (e *UserSchemaExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
-	schema, err := e.service.GetUserSchema(id)
+	schema, err := e.service.GetUserSchema(context.TODO(), id)
 	if err != nil {
 		return nil, "", err
 	}

--- a/backend/internal/userschema/declarative_resource_test.go
+++ b/backend/internal/userschema/declarative_resource_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
@@ -70,7 +71,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_Success() {
 		},
 	}
 
-	s.mockService.EXPECT().GetUserSchemaList(100, 0).Return(expectedResponse, nil)
+	s.mockService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(expectedResponse, nil)
 
 	ids, err := s.exporter.GetAllResourceIDs()
 
@@ -86,7 +87,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_Error() {
 		Error: "test error",
 	}
 
-	s.mockService.EXPECT().GetUserSchemaList(100, 0).Return(nil, expectedError)
+	s.mockService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(nil, expectedError)
 
 	ids, err := s.exporter.GetAllResourceIDs()
 
@@ -99,7 +100,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
 		Schemas: []userschema.UserSchemaListItem{},
 	}
 
-	s.mockService.EXPECT().GetUserSchemaList(100, 0).Return(expectedResponse, nil)
+	s.mockService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(expectedResponse, nil)
 
 	ids, err := s.exporter.GetAllResourceIDs()
 
@@ -113,7 +114,7 @@ func (s *UserSchemaExporterTestSuite) TestGetResourceByID_Success() {
 		Name: "Test Schema",
 	}
 
-	s.mockService.EXPECT().GetUserSchema("schema1").Return(expectedSchema, nil)
+	s.mockService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(expectedSchema, nil)
 
 	resource, name, err := s.exporter.GetResourceByID("schema1")
 
@@ -128,7 +129,7 @@ func (s *UserSchemaExporterTestSuite) TestGetResourceByID_Error() {
 		Error: "test error",
 	}
 
-	s.mockService.EXPECT().GetUserSchema("schema1").Return(nil, expectedError)
+	s.mockService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(nil, expectedError)
 
 	resource, name, err := s.exporter.GetResourceByID("schema1")
 

--- a/backend/internal/userschema/file_based_store.go
+++ b/backend/internal/userschema/file_based_store.go
@@ -19,6 +19,7 @@
 package userschema
 
 import (
+	"context"
 	"errors"
 
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
@@ -32,21 +33,21 @@ type userSchemaFileBasedStore struct {
 // Create implements declarative_resource.Storer interface for resource loader
 func (f *userSchemaFileBasedStore) Create(id string, data interface{}) error {
 	schema := data.(*UserSchema)
-	return f.CreateUserSchema(*schema)
+	return f.CreateUserSchema(context.TODO(), *schema)
 }
 
 // CreateUserSchema implements userSchemaStoreInterface.
-func (f *userSchemaFileBasedStore) CreateUserSchema(schema UserSchema) error {
+func (f *userSchemaFileBasedStore) CreateUserSchema(ctx context.Context, schema UserSchema) error {
 	return f.GenericFileBasedStore.Create(schema.ID, &schema)
 }
 
 // DeleteUserSchemaByID implements userSchemaStoreInterface.
-func (f *userSchemaFileBasedStore) DeleteUserSchemaByID(id string) error {
+func (f *userSchemaFileBasedStore) DeleteUserSchemaByID(ctx context.Context, id string) error {
 	return errors.New("DeleteUserSchemaByID is not supported in file-based store")
 }
 
 // GetUserSchemaByID implements userSchemaStoreInterface.
-func (f *userSchemaFileBasedStore) GetUserSchemaByID(schemaID string) (UserSchema, error) {
+func (f *userSchemaFileBasedStore) GetUserSchemaByID(ctx context.Context, schemaID string) (UserSchema, error) {
 	data, err := f.GenericFileBasedStore.Get(schemaID)
 	if err != nil {
 		return UserSchema{}, ErrUserSchemaNotFound
@@ -60,7 +61,7 @@ func (f *userSchemaFileBasedStore) GetUserSchemaByID(schemaID string) (UserSchem
 }
 
 // GetUserSchemaByName implements userSchemaStoreInterface.
-func (f *userSchemaFileBasedStore) GetUserSchemaByName(schemaName string) (UserSchema, error) {
+func (f *userSchemaFileBasedStore) GetUserSchemaByName(ctx context.Context, schemaName string) (UserSchema, error) {
 	data, err := f.GenericFileBasedStore.GetByField(schemaName, func(d interface{}) string {
 		return d.(*UserSchema).Name
 	})
@@ -71,7 +72,9 @@ func (f *userSchemaFileBasedStore) GetUserSchemaByName(schemaName string) (UserS
 }
 
 // GetUserSchemaList implements userSchemaStoreInterface.
-func (f *userSchemaFileBasedStore) GetUserSchemaList(limit, offset int) ([]UserSchemaListItem, error) {
+func (f *userSchemaFileBasedStore) GetUserSchemaList(
+	ctx context.Context, limit, offset int,
+) ([]UserSchemaListItem, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -104,12 +107,12 @@ func (f *userSchemaFileBasedStore) GetUserSchemaList(limit, offset int) ([]UserS
 }
 
 // GetUserSchemaListCount implements userSchemaStoreInterface.
-func (f *userSchemaFileBasedStore) GetUserSchemaListCount() (int, error) {
+func (f *userSchemaFileBasedStore) GetUserSchemaListCount(ctx context.Context) (int, error) {
 	return f.GenericFileBasedStore.Count()
 }
 
 // UpdateUserSchemaByID implements userSchemaStoreInterface.
-func (f *userSchemaFileBasedStore) UpdateUserSchemaByID(schemaID string, schema UserSchema) error {
+func (f *userSchemaFileBasedStore) UpdateUserSchemaByID(ctx context.Context, schemaID string, schema UserSchema) error {
 	return errors.New("UpdateUserSchemaByID is not supported in file-based store")
 }
 

--- a/backend/internal/userschema/file_based_store_test.go
+++ b/backend/internal/userschema/file_based_store_test.go
@@ -19,6 +19,7 @@
 package userschema
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -62,11 +63,11 @@ func (suite *FileBasedStoreTestSuite) TestCreateUserSchema() {
 		Schema:                json.RawMessage(schemaJSON),
 	}
 
-	err := suite.store.CreateUserSchema(schema)
+	err := suite.store.CreateUserSchema(context.Background(), schema)
 	assert.NoError(suite.T(), err)
 
 	// Verify schema was stored
-	retrieved, err := suite.store.GetUserSchemaByID("schema-1")
+	retrieved, err := suite.store.GetUserSchemaByID(context.Background(), "schema-1")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), schema.ID, retrieved.ID)
 	assert.Equal(suite.T(), schema.Name, retrieved.Name)
@@ -85,18 +86,18 @@ func (suite *FileBasedStoreTestSuite) TestCreateUserSchema_DuplicateID() {
 	}
 
 	// Create first schema
-	err := suite.store.CreateUserSchema(schema)
+	err := suite.store.CreateUserSchema(context.Background(), schema)
 	assert.NoError(suite.T(), err)
 
 	// Try to create duplicate - should succeed in file-based store as it doesn't check duplicates
-	err = suite.store.CreateUserSchema(schema)
+	err = suite.store.CreateUserSchema(context.Background(), schema)
 	// File-based store may allow duplicate or return error depending on implementation
 	// Just verify it doesn't panic
 	_ = err
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetUserSchemaByID_NotFound() {
-	_, err := suite.store.GetUserSchemaByID("non-existent-id")
+	_, err := suite.store.GetUserSchemaByID(context.Background(), "non-existent-id")
 	assert.Error(suite.T(), err)
 }
 
@@ -110,18 +111,18 @@ func (suite *FileBasedStoreTestSuite) TestGetUserSchemaByName() {
 		Schema:                json.RawMessage(schemaJSON),
 	}
 
-	err := suite.store.CreateUserSchema(schema)
+	err := suite.store.CreateUserSchema(context.Background(), schema)
 	assert.NoError(suite.T(), err)
 
 	// Get by name
-	retrieved, err := suite.store.GetUserSchemaByName("basic_schema")
+	retrieved, err := suite.store.GetUserSchemaByName(context.Background(), "basic_schema")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), schema.ID, retrieved.ID)
 	assert.Equal(suite.T(), schema.Name, retrieved.Name)
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetUserSchemaByName_NotFound() {
-	_, err := suite.store.GetUserSchemaByName("non-existent-name")
+	_, err := suite.store.GetUserSchemaByName(context.Background(), "non-existent-name")
 	assert.Error(suite.T(), err)
 }
 
@@ -152,12 +153,12 @@ func (suite *FileBasedStoreTestSuite) TestGetUserSchemaList() {
 		},
 	}
 	for _, schema := range schemas {
-		err := suite.store.CreateUserSchema(schema)
+		err := suite.store.CreateUserSchema(context.Background(), schema)
 		assert.NoError(suite.T(), err)
 	}
 
 	// Get list with pagination
-	list, err := suite.store.GetUserSchemaList(10, 0)
+	list, err := suite.store.GetUserSchemaList(context.Background(), 10, 0)
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), list, 3)
 }
@@ -173,28 +174,28 @@ func (suite *FileBasedStoreTestSuite) TestGetUserSchemaList_WithPagination() {
 			AllowSelfRegistration: true,
 			Schema:                json.RawMessage(schemaJSON),
 		}
-		err := suite.store.CreateUserSchema(schema)
+		err := suite.store.CreateUserSchema(context.Background(), schema)
 		assert.NoError(suite.T(), err)
 	}
 
 	// Get first page
-	list, err := suite.store.GetUserSchemaList(2, 0)
+	list, err := suite.store.GetUserSchemaList(context.Background(), 2, 0)
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), list, 2)
 
 	// Get second page
-	list, err = suite.store.GetUserSchemaList(2, 2)
+	list, err = suite.store.GetUserSchemaList(context.Background(), 2, 2)
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), list, 2)
 
 	// Get last page
-	list, err = suite.store.GetUserSchemaList(2, 4)
+	list, err = suite.store.GetUserSchemaList(context.Background(), 2, 4)
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), list, 1)
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetUserSchemaList_EmptyStore() {
-	list, err := suite.store.GetUserSchemaList(10, 0)
+	list, err := suite.store.GetUserSchemaList(context.Background(), 10, 0)
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), list, 0)
 }
@@ -209,20 +210,20 @@ func (suite *FileBasedStoreTestSuite) TestUpdateUserSchemaByID_ReturnsError() {
 		Schema:                json.RawMessage(schemaJSON),
 	}
 
-	err := suite.store.UpdateUserSchemaByID("schema-1", schema)
+	err := suite.store.UpdateUserSchemaByID(context.Background(), "schema-1", schema)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "not supported")
 }
 
 func (suite *FileBasedStoreTestSuite) TestDeleteUserSchemaByID_ReturnsError() {
-	err := suite.store.DeleteUserSchemaByID("schema-1")
+	err := suite.store.DeleteUserSchemaByID(context.Background(), "schema-1")
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "not supported")
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetUserSchemaListCount() {
 	// Initially empty
-	count, err := suite.store.GetUserSchemaListCount()
+	count, err := suite.store.GetUserSchemaListCount(context.Background())
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 0, count)
 
@@ -236,12 +237,12 @@ func (suite *FileBasedStoreTestSuite) TestGetUserSchemaListCount() {
 			AllowSelfRegistration: true,
 			Schema:                json.RawMessage(schemaJSON),
 		}
-		err := suite.store.CreateUserSchema(schema)
+		err := suite.store.CreateUserSchema(context.Background(), schema)
 		assert.NoError(suite.T(), err)
 	}
 
 	// Check count
-	count, err = suite.store.GetUserSchemaListCount()
+	count, err = suite.store.GetUserSchemaListCount(context.Background())
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 3, count)
 }

--- a/backend/internal/userschema/handler.go
+++ b/backend/internal/userschema/handler.go
@@ -45,6 +45,7 @@ func newUserSchemaHandler(userSchemaService UserSchemaServiceInterface) *userSch
 
 // HandleUserSchemaListRequest handles the user schema list request.
 func (h *userSchemaHandler) HandleUserSchemaListRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaHandlerLoggerComponentName))
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
@@ -57,7 +58,7 @@ func (h *userSchemaHandler) HandleUserSchemaListRequest(w http.ResponseWriter, r
 		limit = serverconst.DefaultPageSize
 	}
 
-	userSchemaListResponse, svcErr := h.userSchemaService.GetUserSchemaList(limit, offset)
+	userSchemaListResponse, svcErr := h.userSchemaService.GetUserSchemaList(ctx, limit, offset)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return
@@ -73,6 +74,7 @@ func (h *userSchemaHandler) HandleUserSchemaListRequest(w http.ResponseWriter, r
 
 // HandleUserSchemaPostRequest handles the user schema creation request.
 func (h *userSchemaHandler) HandleUserSchemaPostRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaHandlerLoggerComponentName))
 
 	createRequest, err := sysutils.DecodeJSONBody[CreateUserSchemaRequest](r)
@@ -89,7 +91,7 @@ func (h *userSchemaHandler) HandleUserSchemaPostRequest(w http.ResponseWriter, r
 
 	sanitizedRequest := h.sanitizeCreateUserSchemaRequest(*createRequest)
 
-	createdUserSchema, svcErr := h.userSchemaService.CreateUserSchema(sanitizedRequest)
+	createdUserSchema, svcErr := h.userSchemaService.CreateUserSchema(ctx, sanitizedRequest)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return
@@ -103,6 +105,7 @@ func (h *userSchemaHandler) HandleUserSchemaPostRequest(w http.ResponseWriter, r
 
 // HandleUserSchemaGetRequest handles the user schema get request.
 func (h *userSchemaHandler) HandleUserSchemaGetRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaHandlerLoggerComponentName))
 
 	schemaID, idValidationFailed := extractAndValidateSchemaID(w, r)
@@ -110,7 +113,7 @@ func (h *userSchemaHandler) HandleUserSchemaGetRequest(w http.ResponseWriter, r 
 		return
 	}
 
-	userSchema, svcErr := h.userSchemaService.GetUserSchema(schemaID)
+	userSchema, svcErr := h.userSchemaService.GetUserSchema(ctx, schemaID)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return
@@ -123,6 +126,7 @@ func (h *userSchemaHandler) HandleUserSchemaGetRequest(w http.ResponseWriter, r 
 
 // HandleUserSchemaPutRequest handles the user schema update request.
 func (h *userSchemaHandler) HandleUserSchemaPutRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaHandlerLoggerComponentName))
 
 	schemaID, idValidationFailed := extractAndValidateSchemaID(w, r)
@@ -135,7 +139,7 @@ func (h *userSchemaHandler) HandleUserSchemaPutRequest(w http.ResponseWriter, r 
 		return
 	}
 
-	updatedUserSchema, svcErr := h.userSchemaService.UpdateUserSchema(schemaID, sanitizedRequest)
+	updatedUserSchema, svcErr := h.userSchemaService.UpdateUserSchema(ctx, schemaID, sanitizedRequest)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return
@@ -149,6 +153,7 @@ func (h *userSchemaHandler) HandleUserSchemaPutRequest(w http.ResponseWriter, r 
 
 // HandleUserSchemaDeleteRequest handles the user schema delete request.
 func (h *userSchemaHandler) HandleUserSchemaDeleteRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaHandlerLoggerComponentName))
 
 	schemaID, idValidationFailed := extractAndValidateSchemaID(w, r)
@@ -156,7 +161,7 @@ func (h *userSchemaHandler) HandleUserSchemaDeleteRequest(w http.ResponseWriter,
 		return
 	}
 
-	svcErr := h.userSchemaService.DeleteUserSchema(schemaID)
+	svcErr := h.userSchemaService.DeleteUserSchema(ctx, schemaID)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return

--- a/backend/internal/userschema/init.go
+++ b/backend/internal/userschema/init.go
@@ -23,6 +23,7 @@ import (
 
 	oupkg "github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
@@ -31,6 +32,7 @@ import (
 func Initialize(
 	mux *http.ServeMux,
 	ouService oupkg.OrganizationUnitServiceInterface,
+	transactioner transaction.Transactioner,
 ) (UserSchemaServiceInterface, declarativeresource.ResourceExporter, error) {
 	var userSchemaStore userSchemaStoreInterface
 	if config.GetThunderRuntime().Config.DeclarativeResources.Enabled {
@@ -39,7 +41,7 @@ func Initialize(
 		userSchemaStore = newUserSchemaStore()
 	}
 
-	userSchemaService := newUserSchemaService(ouService, userSchemaStore)
+	userSchemaService := newUserSchemaService(ouService, userSchemaStore, transactioner)
 
 	if config.GetThunderRuntime().Config.DeclarativeResources.Enabled {
 		if err := loadDeclarativeResources(userSchemaStore, ouService); err != nil {

--- a/backend/internal/userschema/userSchemaStoreInterface_mock_test.go
+++ b/backend/internal/userschema/userSchemaStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package userschema
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *userSchemaStoreInterfaceMock) EXPECT() *userSchemaStoreInterfaceMock_E
 }
 
 // CreateUserSchema provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) CreateUserSchema(userSchema UserSchema) error {
-	ret := _mock.Called(userSchema)
+func (_mock *userSchemaStoreInterfaceMock) CreateUserSchema(ctx context.Context, userSchema UserSchema) error {
+	ret := _mock.Called(ctx, userSchema)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUserSchema")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(UserSchema) error); ok {
-		r0 = returnFunc(userSchema)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, UserSchema) error); ok {
+		r0 = returnFunc(ctx, userSchema)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,9 +60,10 @@ type userSchemaStoreInterfaceMock_CreateUserSchema_Call struct {
 }
 
 // CreateUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userSchema UserSchema
-func (_e *userSchemaStoreInterfaceMock_Expecter) CreateUserSchema(userSchema interface{}) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
-	return &userSchemaStoreInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", userSchema)}
+func (_e *userSchemaStoreInterfaceMock_Expecter) CreateUserSchema(ctx interface{}, userSchema interface{}) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
+	return &userSchemaStoreInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", ctx, userSchema)}
 }
 
 func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Run(run func(userSchema UserSchema)) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
@@ -87,16 +90,16 @@ func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) RunAndReturn(run f
 }
 
 // DeleteUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) DeleteUserSchemaByID(schemaID string) error {
-	ret := _mock.Called(schemaID)
+func (_mock *userSchemaStoreInterfaceMock) DeleteUserSchemaByID(ctx context.Context, schemaID string) error {
+	ret := _mock.Called(ctx, schemaID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteUserSchemaByID")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, schemaID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -109,9 +112,10 @@ type userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call struct {
 }
 
 // DeleteUserSchemaByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
-func (_e *userSchemaStoreInterfaceMock_Expecter) DeleteUserSchemaByID(schemaID interface{}) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
-	return &userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call{Call: _e.mock.On("DeleteUserSchemaByID", schemaID)}
+func (_e *userSchemaStoreInterfaceMock_Expecter) DeleteUserSchemaByID(ctx interface{}, schemaID interface{}) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
+	return &userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call{Call: _e.mock.On("DeleteUserSchemaByID", ctx, schemaID)}
 }
 
 func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Run(run func(schemaID string)) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
@@ -138,8 +142,8 @@ func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) RunAndReturn(r
 }
 
 // GetUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByID(schemaID string) (UserSchema, error) {
-	ret := _mock.Called(schemaID)
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByID(ctx context.Context, schemaID string) (UserSchema, error) {
+	ret := _mock.Called(ctx, schemaID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaByID")
@@ -147,16 +151,16 @@ func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByID(schemaID string) (U
 
 	var r0 UserSchema
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (UserSchema, error)); ok {
-		return returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (UserSchema, error)); ok {
+		return returnFunc(ctx, schemaID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) UserSchema); ok {
-		r0 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) UserSchema); ok {
+		r0 = returnFunc(ctx, schemaID)
 	} else {
 		r0 = ret.Get(0).(UserSchema)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, schemaID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -169,9 +173,10 @@ type userSchemaStoreInterfaceMock_GetUserSchemaByID_Call struct {
 }
 
 // GetUserSchemaByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByID(schemaID interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaByID_Call{Call: _e.mock.On("GetUserSchemaByID", schemaID)}
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByID(ctx interface{}, schemaID interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaByID_Call{Call: _e.mock.On("GetUserSchemaByID", ctx, schemaID)}
 }
 
 func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Run(run func(schemaID string)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
@@ -198,8 +203,8 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) RunAndReturn(run 
 }
 
 // GetUserSchemaByName provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByName(name string) (UserSchema, error) {
-	ret := _mock.Called(name)
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByName(ctx context.Context, name string) (UserSchema, error) {
+	ret := _mock.Called(ctx, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaByName")
@@ -207,16 +212,16 @@ func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByName(name string) (Use
 
 	var r0 UserSchema
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (UserSchema, error)); ok {
-		return returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (UserSchema, error)); ok {
+		return returnFunc(ctx, name)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) UserSchema); ok {
-		r0 = returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) UserSchema); ok {
+		r0 = returnFunc(ctx, name)
 	} else {
 		r0 = ret.Get(0).(UserSchema)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(name)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -229,9 +234,10 @@ type userSchemaStoreInterfaceMock_GetUserSchemaByName_Call struct {
 }
 
 // GetUserSchemaByName is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByName(name interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", name)}
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByName(ctx interface{}, name interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", ctx, name)}
 }
 
 func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Run(run func(name string)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
@@ -258,8 +264,8 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(ru
 }
 
 // GetUserSchemaList provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaList(limit int, offset int) ([]UserSchemaListItem, error) {
-	ret := _mock.Called(limit, offset)
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaList(ctx context.Context, limit int, offset int) ([]UserSchemaListItem, error) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaList")
@@ -267,18 +273,18 @@ func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaList(limit int, offset i
 
 	var r0 []UserSchemaListItem
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]UserSchemaListItem, error)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]UserSchemaListItem, error)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []UserSchemaListItem); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []UserSchemaListItem); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]UserSchemaListItem)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -291,10 +297,11 @@ type userSchemaStoreInterfaceMock_GetUserSchemaList_Call struct {
 }
 
 // GetUserSchemaList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaList(limit interface{}, offset interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", limit, offset)}
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaList(ctx interface{}, limit interface{}, offset interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", ctx, limit, offset)}
 }
 
 func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Run(run func(limit int, offset int)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
@@ -326,8 +333,8 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run 
 }
 
 // GetUserSchemaListCount provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaListCount() (int, error) {
-	ret := _mock.Called()
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaListCount")
@@ -335,16 +342,16 @@ func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaListCount() (int, error)
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -357,8 +364,9 @@ type userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call struct {
 }
 
 // GetUserSchemaListCount is a helper method to define mock.On call
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaListCount() *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call{Call: _e.mock.On("GetUserSchemaListCount")}
+//   - ctx context.Context
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaListCount(ctx interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call{Call: _e.mock.On("GetUserSchemaListCount", ctx)}
 }
 
 func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Run(run func()) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
@@ -379,16 +387,16 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) RunAndReturn
 }
 
 // UpdateUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) UpdateUserSchemaByID(schemaID string, userSchema UserSchema) error {
-	ret := _mock.Called(schemaID, userSchema)
+func (_mock *userSchemaStoreInterfaceMock) UpdateUserSchemaByID(ctx context.Context, schemaID string, userSchema UserSchema) error {
+	ret := _mock.Called(ctx, schemaID, userSchema)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateUserSchemaByID")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, UserSchema) error); ok {
-		r0 = returnFunc(schemaID, userSchema)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UserSchema) error); ok {
+		r0 = returnFunc(ctx, schemaID, userSchema)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -401,10 +409,11 @@ type userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call struct {
 }
 
 // UpdateUserSchemaByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
 //   - userSchema UserSchema
-func (_e *userSchemaStoreInterfaceMock_Expecter) UpdateUserSchemaByID(schemaID interface{}, userSchema interface{}) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
-	return &userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call{Call: _e.mock.On("UpdateUserSchemaByID", schemaID, userSchema)}
+func (_e *userSchemaStoreInterfaceMock_Expecter) UpdateUserSchemaByID(ctx interface{}, schemaID interface{}, userSchema interface{}) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
+	return &userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call{Call: _e.mock.On("UpdateUserSchemaByID", ctx, schemaID, userSchema)}
 }
 
 func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Run(run func(schemaID string, userSchema UserSchema)) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {

--- a/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
@@ -5,6 +5,7 @@
 package userschemamock
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -40,8 +41,8 @@ func (_m *UserSchemaServiceInterfaceMock) EXPECT() *UserSchemaServiceInterfaceMo
 }
 
 // CreateUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) CreateUserSchema(request userschema.CreateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *UserSchemaServiceInterfaceMock) CreateUserSchema(ctx context.Context, request userschema.CreateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUserSchema")
@@ -49,18 +50,18 @@ func (_mock *UserSchemaServiceInterfaceMock) CreateUserSchema(request userschema
 
 	var r0 *userschema.UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(userschema.CreateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, userschema.CreateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(userschema.CreateUserSchemaRequest) *userschema.UserSchema); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, userschema.CreateUserSchemaRequest) *userschema.UserSchema); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*userschema.UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(userschema.CreateUserSchemaRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, userschema.CreateUserSchemaRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -75,9 +76,10 @@ type UserSchemaServiceInterfaceMock_CreateUserSchema_Call struct {
 }
 
 // CreateUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request userschema.CreateUserSchemaRequest
-func (_e *UserSchemaServiceInterfaceMock_Expecter) CreateUserSchema(request interface{}) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", request)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) CreateUserSchema(ctx interface{}, request interface{}) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", ctx, request)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) Run(run func(request userschema.CreateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
@@ -104,16 +106,16 @@ func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) RunAndReturn(run
 }
 
 // DeleteUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) DeleteUserSchema(schemaID string) *serviceerror.ServiceError {
-	ret := _mock.Called(schemaID)
+func (_mock *UserSchemaServiceInterfaceMock) DeleteUserSchema(ctx context.Context, schemaID string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, schemaID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteUserSchema")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, schemaID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -128,9 +130,10 @@ type UserSchemaServiceInterfaceMock_DeleteUserSchema_Call struct {
 }
 
 // DeleteUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
-func (_e *UserSchemaServiceInterfaceMock_Expecter) DeleteUserSchema(schemaID interface{}) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_DeleteUserSchema_Call{Call: _e.mock.On("DeleteUserSchema", schemaID)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) DeleteUserSchema(ctx interface{}, schemaID interface{}) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_DeleteUserSchema_Call{Call: _e.mock.On("DeleteUserSchema", ctx, schemaID)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) Run(run func(schemaID string)) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
@@ -157,8 +160,8 @@ func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) RunAndReturn(run
 }
 
 // GetUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(schemaID string) (*userschema.UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(schemaID)
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(ctx context.Context, schemaID string) (*userschema.UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, schemaID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchema")
@@ -166,18 +169,18 @@ func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(schemaID string) (*us
 
 	var r0 *userschema.UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, schemaID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *userschema.UserSchema); ok {
-		r0 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *userschema.UserSchema); ok {
+		r0 = returnFunc(ctx, schemaID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*userschema.UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, schemaID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -192,9 +195,10 @@ type UserSchemaServiceInterfaceMock_GetUserSchema_Call struct {
 }
 
 // GetUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
-func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchema(schemaID interface{}) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_GetUserSchema_Call{Call: _e.mock.On("GetUserSchema", schemaID)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchema(ctx interface{}, schemaID interface{}) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchema_Call{Call: _e.mock.On("GetUserSchema", ctx, schemaID)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) Run(run func(schemaID string)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
@@ -221,8 +225,8 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) RunAndReturn(run fu
 }
 
 // GetUserSchemaByName provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(schemaName string) (*userschema.UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(schemaName)
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(ctx context.Context, schemaName string) (*userschema.UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, schemaName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaByName")
@@ -230,18 +234,18 @@ func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(schemaName stri
 
 	var r0 *userschema.UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(schemaName)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, schemaName)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *userschema.UserSchema); ok {
-		r0 = returnFunc(schemaName)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *userschema.UserSchema); ok {
+		r0 = returnFunc(ctx, schemaName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*userschema.UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(schemaName)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, schemaName)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -256,9 +260,10 @@ type UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call struct {
 }
 
 // GetUserSchemaByName is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaName string
-func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaByName(schemaName interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
-	return &UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", schemaName)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaByName(ctx interface{}, schemaName interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", ctx, schemaName)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Run(run func(schemaName string)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
@@ -285,8 +290,8 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(
 }
 
 // GetUserSchemaList provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(limit int, offset int) (*userschema.UserSchemaListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(limit, offset)
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(ctx context.Context, limit int, offset int) (*userschema.UserSchemaListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaList")
@@ -294,18 +299,18 @@ func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(limit int, offset
 
 	var r0 *userschema.UserSchemaListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(int, int) (*userschema.UserSchemaListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*userschema.UserSchemaListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) *userschema.UserSchemaListResponse); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *userschema.UserSchemaListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*userschema.UserSchemaListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -320,10 +325,11 @@ type UserSchemaServiceInterfaceMock_GetUserSchemaList_Call struct {
 }
 
 // GetUserSchemaList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaList(limit interface{}, offset interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
-	return &UserSchemaServiceInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", limit, offset)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaList(ctx interface{}, limit interface{}, offset interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", ctx, limit, offset)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) Run(run func(limit int, offset int)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
@@ -355,8 +361,8 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) RunAndReturn(ru
 }
 
 // UpdateUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) UpdateUserSchema(schemaID string, request userschema.UpdateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(schemaID, request)
+func (_mock *UserSchemaServiceInterfaceMock) UpdateUserSchema(ctx context.Context, schemaID string, request userschema.UpdateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, schemaID, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateUserSchema")
@@ -364,18 +370,18 @@ func (_mock *UserSchemaServiceInterfaceMock) UpdateUserSchema(schemaID string, r
 
 	var r0 *userschema.UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, userschema.UpdateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(schemaID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, userschema.UpdateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, schemaID, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, userschema.UpdateUserSchemaRequest) *userschema.UserSchema); ok {
-		r0 = returnFunc(schemaID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, userschema.UpdateUserSchemaRequest) *userschema.UserSchema); ok {
+		r0 = returnFunc(ctx, schemaID, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*userschema.UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, userschema.UpdateUserSchemaRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(schemaID, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, userschema.UpdateUserSchemaRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, schemaID, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -390,10 +396,11 @@ type UserSchemaServiceInterfaceMock_UpdateUserSchema_Call struct {
 }
 
 // UpdateUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
 //   - request userschema.UpdateUserSchemaRequest
-func (_e *UserSchemaServiceInterfaceMock_Expecter) UpdateUserSchema(schemaID interface{}, request interface{}) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_UpdateUserSchema_Call{Call: _e.mock.On("UpdateUserSchema", schemaID, request)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) UpdateUserSchema(ctx interface{}, schemaID interface{}, request interface{}) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_UpdateUserSchema_Call{Call: _e.mock.On("UpdateUserSchema", ctx, schemaID, request)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) Run(run func(schemaID string, request userschema.UpdateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
@@ -425,8 +432,8 @@ func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) RunAndReturn(run
 }
 
 // ValidateUser provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError) {
-	ret := _mock.Called(userType, userAttributes)
+func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, userAttributes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateUser")
@@ -434,16 +441,16 @@ func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(userType string, userA
 
 	var r0 bool
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage) (bool, *serviceerror.ServiceError)); ok {
-		return returnFunc(userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, userAttributes)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage) bool); ok {
-		r0 = returnFunc(userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) bool); ok {
+		r0 = returnFunc(ctx, userType, userAttributes)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, json.RawMessage) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(userType, userAttributes)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, userAttributes)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -458,10 +465,11 @@ type UserSchemaServiceInterfaceMock_ValidateUser_Call struct {
 }
 
 // ValidateUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userType string
 //   - userAttributes json.RawMessage
-func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(userType interface{}, userAttributes interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
-	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", userType, userAttributes)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(ctx interface{}, userType interface{}, userAttributes interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", ctx, userType, userAttributes)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(userType string, userAttributes json.RawMessage)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
@@ -493,8 +501,8 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run fun
 }
 
 // ValidateUserUniqueness provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) ValidateUserUniqueness(userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError) {
-	ret := _mock.Called(userType, userAttributes, identifyUser)
+func (_mock *UserSchemaServiceInterfaceMock) ValidateUserUniqueness(ctx context.Context, userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, userAttributes, identifyUser)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateUserUniqueness")
@@ -502,16 +510,16 @@ func (_mock *UserSchemaServiceInterfaceMock) ValidateUserUniqueness(userType str
 
 	var r0 bool
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage, func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)); ok {
-		return returnFunc(userType, userAttributes, identifyUser)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, userAttributes, identifyUser)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage, func(map[string]interface{}) (*string, error)) bool); ok {
-		r0 = returnFunc(userType, userAttributes, identifyUser)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, func(map[string]interface{}) (*string, error)) bool); ok {
+		r0 = returnFunc(ctx, userType, userAttributes, identifyUser)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, json.RawMessage, func(map[string]interface{}) (*string, error)) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(userType, userAttributes, identifyUser)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage, func(map[string]interface{}) (*string, error)) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, userAttributes, identifyUser)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -526,11 +534,12 @@ type UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call struct {
 }
 
 // ValidateUserUniqueness is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userType string
 //   - userAttributes json.RawMessage
 //   - identifyUser func(map[string]interface{}) (*string, error)
-func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUserUniqueness(userType interface{}, userAttributes interface{}, identifyUser interface{}) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
-	return &UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call{Call: _e.mock.On("ValidateUserUniqueness", userType, userAttributes, identifyUser)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUserUniqueness(ctx interface{}, userType interface{}, userAttributes interface{}, identifyUser interface{}) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
+	return &UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call{Call: _e.mock.On("ValidateUserUniqueness", ctx, userType, userAttributes, identifyUser)}
 }
 
 func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) Run(run func(userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error))) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {


### PR DESCRIPTION
### Purpose
As we have introduced the transection architecture, we are adapting our services to use transections. In this PR we have updated the userschema service to use transactions.


Sub Issue : https://github.com/asgardeo/thunder/issues/1426
Parent issue : https://github.com/asgardeo/thunder/issues/282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Propagated per-request context across backend flows for more reliable request handling, cancellation, and clearer request-scoped behavior.
  * Introduced transactional handling for user schema operations to ensure atomic updates and safer rollbacks.
  * Added per-database transaction scoping in the database layer to improve multi-database safety and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->