### PR TITLE
Update Go version to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ To try out the Client Credentials flow, follow these steps:
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Node.js 24+
 
 ---
@@ -324,7 +324,7 @@ To try out the Client Credentials flow, follow these steps:
 
 ### Prerequisites
 
-- Go 1.24+
+- Go 1.26+
 - Node.js 24+
 
 ### Start Thunder in Development Mode

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/asgardeo/thunder
 
-go 1.25
+go 1.26
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/asgardeo/thunder/tests/integration
 
-go 1.25
+go 1.26
 
 require github.com/stretchr/testify v1.10.0
 

--- a/tools/i18n-extractor/go.mod
+++ b/tools/i18n-extractor/go.mod
@@ -1,3 +1,3 @@
 module github.com/asgardeo/thunder/tools/i18n-extractor
 
-go 1.25
+go 1.26


### PR DESCRIPTION
This pull request updates the Go version requirement across the codebase from 1.25 (and 1.24 in one place) to 1.26. This ensures consistency and leverages improvements or features available in Go 1.26.

Dependency and documentation updates:

* Updated the Go version in all `go.mod` files (`backend/go.mod`, `tests/integration/go.mod`, `tools/i18n-extractor/go.mod`) to require Go 1.26. [[1]](diffhunk://#diff-10e03f00c5bf8508d67e327c7a19879247498e8392ec699e9a05afcd36a8ed1fL3-R3) [[2]](diffhunk://#diff-5538d8f5d625ca8382e8217119e8e03a7a589eba7300256f8c9fbe8722948830L3-R3) [[3]](diffhunk://#diff-53c2ded7cfbeeeb3a3ade9ac225bb088a11e2ab8715323218f27dbf85514d540L3-R3)
* Updated the `README.md` to reflect the new Go 1.26+ requirement in the prerequisites section, replacing previous mentions of Go 1.24+ and 1.25+. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L307-R307) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L327-R327)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain requirement to 1.26 across backend, integration tests, and development tools. Documentation updated to reflect the new Go prerequisite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->