### PR TITLE
Add scope_claims, Scopes, and UserInfo to declartive resource parsing

### DIFF
--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -187,6 +187,9 @@ func parseToApplicationDTO(data []byte) (*model.ApplicationDTO, error) {
 					PKCERequired:            config.OAuthAppConfig.PKCERequired,
 					PublicClient:            config.OAuthAppConfig.PublicClient,
 					Token:                   config.OAuthAppConfig.Token,
+					Scopes:                  config.OAuthAppConfig.Scopes,
+					UserInfo:                config.OAuthAppConfig.UserInfo,
+					ScopeClaims:             config.OAuthAppConfig.ScopeClaims,
 				},
 			}
 			inboundAuthConfigDTOs = append(inboundAuthConfigDTOs, inboundAuthConfigDTO)


### PR DESCRIPTION
### Purpose
Add scope_claims, Scopes, and UserInfo to declartive resource parsing

### Approach
This pull request addresses a bug where certain OAuth2 fields (`scopes`, `user_info`, and `scope_claims`) were not being properly parsed and included in the application DTO, as described in GitHub issue #1445. The changes ensure these fields are now correctly handled, and comprehensive tests have been added to verify the fix and prevent regressions.

**Bug Fixes and Parsing Improvements:**

* Fixed the parsing logic in `parseToApplicationDTO` to correctly include the `Scopes`, `UserInfo`, and `ScopeClaims` fields from the OAuth2 config into the resulting DTO.

**Testing Enhancements:**

* Added new test cases to `init_test.go` to verify that `Scopes`, `UserInfo`, and `ScopeClaims` fields are properly parsed and included in the DTO, covering various scenarios including custom claims and the exact scenario from GitHub issue #1445.
* Added a comprehensive test that exercises all OAuth fields, ensuring that the fix works for complete configurations.
* Removed an unrelated test for MCP server initialization to focus the test suite on declarative resource parsing.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1445

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inbound OAuth parsing now includes and preserves Scopes, UserInfo, and ScopeClaims from YAML so these settings reliably appear in application configuration.

* **Tests**
  * Added suite-based YAML parsing tests covering Scopes, ScopeClaims, UserInfo, combined OAuth scenarios, redirect URIs, and a regression case to prevent future breakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->