### PR TITLE
Skip inline comments when parsing config in setup scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -185,9 +185,9 @@ read_config() {
         PUBLIC_URL=$(yq eval '.server.public_url // ""' "$config_file" 2>/dev/null)
     else
         # Fallback: basic parsing with grep/awk
-        HOSTNAME=$(grep -E '^\s*hostname:' "$config_file" | awk -F':' '{gsub(/[[:space:]"'\'']/,"",$2); print $2}' | head -1)
-        PORT=$(grep -E '^\s*port:' "$config_file" | awk -F':' '{gsub(/[[:space:]]/,"",$2); print $2}' | head -1)
-        PUBLIC_URL=$(grep -E '^\s*public_url:' "$config_file" | grep -o '"[^"]*"' | tr -d '"' | head -1)
+        HOSTNAME=$(grep -E '^\s*hostname:' "$config_file" | sed 's/#.*//' | awk -F':' '{gsub(/[[:space:]"'\'']/,"",$2); print $2}' | head -1)
+        PORT=$(grep -E '^\s*port:' "$config_file" | sed 's/#.*//' | awk -F':' '{gsub(/[[:space:]]/,"",$2); print $2}' | head -1)
+        PUBLIC_URL=$(grep -E '^\s*public_url:' "$config_file" | sed 's/#.*//' | grep -o '"[^"]*"' | tr -d '"' | head -1)
 
         # Check for http_only
         if grep -q 'http_only.*true' "$config_file" 2>/dev/null; then


### PR DESCRIPTION
### Purpose
This pull request improves the robustness of the config file parsing logic in the `setup.sh` script by ensuring that inline comments are ignored when extracting values for `hostname`, `port`, and `public_url`. This prevents potential errors when config values are followed by comments.

Improvements to config parsing:

* Updated the fallback parsing logic for `hostname`, `port`, and `public_url` in `setup.sh` to strip out inline comments using `sed` before extracting values. This ensures that configuration values are correctly parsed even if comments are present on the same line.

Fix https://github.com/asgardeo/thunder/issues/1451


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration parsing now correctly ignores comment lines when the fallback parser is used, preventing commented entries from affecting hostname, port, and public URL detection.
  * Improves reliability of configuration loading in environments where the primary parser is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->