### PR TITLE
Improve skip security middleware handling

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -136,12 +136,8 @@ func (suite *CreateSecurityMiddlewareTestSuite) TestCreateSecurityMiddleware_Wit
 			// Execute
 			handler := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
 
-			// Assert
-			if tc.expectSecuritySkip {
-				assert.Nil(suite.T(), handler, "Handler should be nil when security is skipped")
-			} else {
-				assert.NotNil(suite.T(), handler, "Handler should not be nil when security is enabled")
-			}
+			// Assert - handler is always returned now, regardless of skip security flag
+			assert.NotNil(suite.T(), handler, "Handler should always be non-nil")
 
 			// Cleanup for next iteration
 			_ = os.Unsetenv("THUNDER_SKIP_SECURITY")
@@ -171,7 +167,7 @@ func (suite *CreateSecurityMiddlewareTestSuite) TestCreateSecurityMiddleware_Run
 	// Disable security
 	_ = os.Setenv("THUNDER_SKIP_SECURITY", "true")
 	handler2 := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
-	assert.Nil(suite.T(), handler2, "Second handler should be nil when security is disabled")
+	assert.NotNil(suite.T(), handler2, "Second handler should not be nil (skipSecurity is handled internally)")
 
 	// Re-enable security
 	_ = os.Unsetenv("THUNDER_SKIP_SECURITY")


### PR DESCRIPTION
This pull request refactors how the `THUNDER_SKIP_SECURITY` environment variable is handled in the backend server. Instead of disabling the security middleware entirely, the flag now causes the middleware to allow all requests to proceed, even if authentication or authorization fails. This change centralizes the skip logic in the security service, improves logging, and updates related tests to match the new behavior.

**Security Middleware Refactor:**

* The `THUNDER_SKIP_SECURITY` flag no longer disables the security middleware at the server level; instead, it is checked within the security service, which logs a warning and allows requests to proceed without enforcement if the flag is set. [[1]](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408L185-R187) [[2]](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408L229-L242) [[3]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aR45) [[4]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aR63-R83) [[5]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aL173-R207)

* The `securityService` now has a `skipSecurity` field, which is set based on the environment variable, and the `handleAuthError` method allows requests to continue when `skipSecurity` is enabled, even in the case of authentication or authorization failures. [[1]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aR45) [[2]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aR63-R83) [[3]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aL89-R114) [[4]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aL106-R125) [[5]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aL173-R207)

**Test Updates:**

* Tests for the security middleware and service have been updated to assert that the handler is always returned and that requests are allowed to proceed when `THUNDER_SKIP_SECURITY` is set, regardless of authentication or authorization outcome. [[1]](diffhunk://#diff-8dc808d5120359d7b7dcc4a9d1f877a326e5e9428eedc8c70ba2bd03b70b9842L139-R140) [[2]](diffhunk://#diff-8dc808d5120359d7b7dcc4a9d1f877a326e5e9428eedc8c70ba2bd03b70b9842L174-R170) [[3]](diffhunk://#diff-26ef0ee1fff32423b261939280c08043cbd7389677b4208a68db8f1143086d0bR593-R693)

* New tests verify that, with the skip flag enabled, requests without tokens, with invalid tokens, or with insufficient scopes are all allowed, and that context enrichment still occurs if authentication succeeds.

**Codebase Cleanliness:**

* Removed redundant imports and refactored logger initialization for consistency. [[1]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aR26) [[2]](diffhunk://#diff-3c2f2d4dde228277dd417c9aa976e3933d286b168bda29b0b001a816a3e2174aR63-R83) [[3]](diffhunk://#diff-26ef0ee1fff32423b261939280c08043cbd7389677b4208a68db8f1143086d0bR25)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Security middleware is now consistently initialized at startup and always wrapped by access logging for predictable request handling.
  * An environment-driven skip-security mode is recognized internally and emits a clear production warning when active.

* **Tests**
  * Added coverage for skip-security scenarios: no token, invalid token, insufficient scopes, and context enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->