### PR TITLE
Add authorization for DCR endpoint

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -82,6 +82,9 @@
     },
     "authorization_code": {
       "validity_period": 600
+    },
+    "dcr": {
+      "insecure": false
     }
   },
   "flow": {

--- a/backend/internal/oauth/oauth2/dcr/error_constants.go
+++ b/backend/internal/oauth/oauth2/dcr/error_constants.go
@@ -61,4 +61,13 @@ var (
 		Error:            "Server error",
 		ErrorDescription: "An unexpected error occurred while processing the request",
 	}
+
+	// ErrorUnauthorized is the error returned when the request lacks valid authentication
+	// or the authenticated caller does not hold required permissions.
+	ErrorUnauthorized = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "unauthorized_client",
+		Error:            "Unauthorized",
+		ErrorDescription: "Authentication with sufficient permissions is required to register a client",
+	}
 )

--- a/backend/internal/oauth/oauth2/dcr/init_test.go
+++ b/backend/internal/oauth/oauth2/dcr/init_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
 )
 
@@ -40,6 +41,11 @@ func TestInitTestSuite(t *testing.T) {
 
 func (suite *InitTestSuite) SetupTest() {
 	suite.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
+	_ = config.InitializeThunderRuntime("test", &config.Config{})
+}
+
+func (suite *InitTestSuite) TearDownTest() {
+	config.ResetThunderRuntime()
 }
 
 func (suite *InitTestSuite) TestInitialize() {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -123,10 +123,16 @@ type AuthorizationCodeConfig struct {
 	ValidityPeriod int64 `yaml:"validity_period" json:"validity_period"`
 }
 
+// DCRConfig holds the Dynamic Client Registration configuration.
+type DCRConfig struct {
+	Insecure bool `yaml:"insecure" json:"insecure"`
+}
+
 // OAuthConfig holds the OAuth configuration details.
 type OAuthConfig struct {
 	RefreshToken      RefreshTokenConfig      `yaml:"refresh_token" json:"refresh_token"`
 	AuthorizationCode AuthorizationCodeConfig `yaml:"authorization_code" json:"authorization_code"`
+	DCR               DCRConfig               `yaml:"dcr" json:"dcr"`
 }
 
 // FlowConfig holds the configuration details for the flow service.

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -109,6 +109,8 @@ oauth:
     validity_period: {{ .Values.configuration.oauth.refreshToken.validityPeriod }}
   authorization_code:
     validity_period: {{ .Values.configuration.oauth.authorizationCode.validityPeriod }}
+  dcr:
+    insecure: {{ .Values.configuration.oauth.dcr.insecure }}
 
 flow:
   default_auth_flow_handle: {{ .Values.configuration.flow.defaultAuthFlowHandle | quote }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -240,6 +240,8 @@ configuration:
       validityPeriod: 86400
     authorizationCode:
       validityPeriod: 600
+    dcr:
+      insecure: false
 
   # Flow configuration
   flow:

--- a/tests/integration/oauth/dcr/dcr_test.go
+++ b/tests/integration/oauth/dcr/dcr_test.go
@@ -257,6 +257,12 @@ func (ts *DCRTestSuite) TestDCRRegistrationInvalidJSON() {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
+	token, err := testutils.GetAccessToken()
+	if err != nil {
+		ts.T().Fatalf("Failed to obtain access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
 	resp, err := client.Do(req)
 	if err != nil {
 		ts.T().Fatalf("Failed to send request: %v", err)
@@ -313,6 +319,12 @@ func (ts *DCRTestSuite) registerClient(request DCRRegistrationRequest) (*DCRRegi
 		ts.T().Fatalf("Failed to create request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	token, err := testutils.GetAccessToken()
+	if err != nil {
+		ts.T().Fatalf("Failed to obtain access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -499,6 +511,12 @@ func (ts *DCRTestSuite) registerClientWithError(request DCRRegistrationRequest) 
 		ts.T().Fatalf("Failed to create request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	token, err := testutils.GetAccessToken()
+	if err != nil {
+		ts.T().Fatalf("Failed to obtain access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -1210,6 +1228,10 @@ func (ts *DCRTestSuite) TestDCRRegistrationEmptyRequest() {
 	ts.Require().NoError(err, "Failed to create request")
 	req.Header.Set("Content-Type", "application/json")
 
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err, "Failed to obtain access token")
+	req.Header.Set("Authorization", "Bearer "+token)
+
 	resp, err := client.Do(req)
 	ts.Require().NoError(err, "Failed to send request")
 	defer resp.Body.Close()
@@ -1238,6 +1260,10 @@ func (ts *DCRTestSuite) TestDCRRegistrationNullRedirectURIs() {
 	req, err := http.NewRequest("POST", testServerURL+dcrEndpoint, bytes.NewReader(requestJSON))
 	ts.Require().NoError(err)
 	req.Header.Set("Content-Type", "application/json")
+
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err)
+	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := client.Do(req)
 	ts.Require().NoError(err)


### PR DESCRIPTION
This pull request introduces a configurable security mechanism for Dynamic Client Registration (DCR) in the OAuth2 module. The main change is the addition of the `openDCR` configuration option, which determines whether DCR registration requires authentication and specific permissions. When `openDCR` is set to `false`, only authenticated users with the `system` permission can register clients; otherwise, registration is open. The implementation includes updates to configuration files, handler logic, error handling, and comprehensive tests for various authorization scenarios.

---
---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
The DCR endpoint (`POST /oauth2/dcr/register`) is now secured by default. The new `dcr.secure` configuration flag (default: `true`) controls whether authentication is required for client registration.

#### 💥 Impact
Any client currently calling `/oauth2/dcr/register` without a Bearer token will receive `401 unauthorized_client`. Deployments that relied on open DCR registration will break.

#### 🔄 Migration Guide

**Option 1 — Restore previous open behaviour**

Local dev (`deployment.yaml`):
```yaml
oauth:
  dcr:
    secure: false
```

Helm (`values.yaml`):
```yaml
configuration:
  oauth:
    dcr:
      secure: false
```

**Option 2 — Use secured DCR (recommended)**

Obtain an access token with the `system` scope, then pass it on the registration request:
```
POST /oauth2/dcr/register
Authorization: Bearer <access_token>
```

---

---

**DCR Security and Authorization Enhancements:**

* Added `openDCR` configuration option to `OAuthConfig` and all relevant config files (`default.json`, `deployment.yaml`, `values.yaml`), allowing control over whether DCR registration requires authentication and permissions. [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR130) [[2]](diffhunk://#diff-beec713bb8f44ef8633de8d745de6dcd555593b5cd0758d7788470fee3b2d974L85-R86) [[3]](diffhunk://#diff-f2cb3073a4637c871c6a543d4e76655f861053c8b63ebfc66ed958980466eb34R112) [[4]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eR243)
* Updated `HandleDCRRegistration` in `handler.go` to enforce authorization checks based on the `openDCR` setting, requiring a valid token with the `system` permission when `openDCR` is `false`.
* Introduced `checkDCRAuthorization` method to encapsulate permission logic and return appropriate error responses.
* Added new error constant `ErrorUnauthorized` for unauthorized DCR registration attempts.

**Testing Improvements:**

* Extended `handler_test.go` with tests covering all DCR authorization scenarios: no token, insufficient permissions, and valid `system` permission, ensuring correct behavior when `openDCR` is `false`. Also added setup and teardown for config initialization/reset. [[1]](diffhunk://#diff-eb828b0470966bcb64465b920960d9eb63188dab257274532b846cd6ef0cb73eR293-R370) [[2]](diffhunk://#diff-eb828b0470966bcb64465b920960d9eb63188dab257274532b846cd6ef0cb73eR51-R58)
* Updated `init_test.go` to initialize and reset config for test isolation.

**Dependency and Import Updates:**

* Added necessary imports for config and security modules in handler and test files to support new logic. [[1]](diffhunk://#diff-d6fb7a93d44e424b62b9bfee3d7db914ab97a37e5fda141d4856774153aeb301R23-R27) [[2]](diffhunk://#diff-eb828b0470966bcb64465b920960d9eb63188dab257274532b846cd6ef0cb73eR23) [[3]](diffhunk://#diff-eb828b0470966bcb64465b920960d9eb63188dab257274532b846cd6ef0cb73eR33-R35) [[4]](diffhunk://#diff-93d846f941d0938929fc7e456cfdecaec175de46e319eb8029dba9557875a15cR29)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable Dynamic Client Registration (DCR) mode (open vs. restricted) via config flag.

* **Bug Fixes / Behavior**
  * Registration endpoint enforces access checks and returns unauthorized when caller lacks permissions in restricted mode.

* **Tests**
  * Added unit and integration tests covering restricted DCR paths and authenticated registration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->