### PR TITLE
Update clients of credentials authenticate endpoint

### DIFF
--- a/docs/__backup__/authentication/client-orchestrated-flow/authentication.md
+++ b/docs/__backup__/authentication/client-orchestrated-flow/authentication.md
@@ -45,8 +45,12 @@ The credentials authentication API allows you to authenticate users by providing
     ```bash
     curl -kL -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' https://localhost:8090/auth/credentials/authenticate \
     -d '{
-        "username": "thor",
-        "password": "<password>"
+        "identifiers": {
+            "username": "thor"
+        },
+        "credentials": {
+            "password": "<password>"
+        }
     }'
     ```
 
@@ -66,8 +70,12 @@ The credentials authentication API allows you to authenticate users by providing
     ```bash
     curl -kL -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' https://localhost:8090/auth/credentials/authenticate \
     -d '{
-        "username": "thor",
-        "password": "<password>",
+        "identifiers": {
+            "username": "thor"
+        },
+        "credentials": {
+            "password": "<password>"
+        },
         "assertion": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
     }'
     ```
@@ -527,8 +535,12 @@ Example:
 ```bash
 curl -kL -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' https://localhost:8090/auth/credentials/authenticate \
 -d '{
-    "username": "thor",
-    "password": "<password>",
+    "identifiers": {
+        "username": "thor"
+    },
+    "credentials": {
+        "password": "<password>"
+    },
     "skip_assertion": true
 }'
 ```

--- a/samples/api/postman/authentication/authentication_demo.json
+++ b/samples/api/postman/authentication/authentication_demo.json
@@ -1,10 +1,9 @@
 {
   "info": {
-    "_postman_id": "28f739e9-1857-41d7-9605-c2779603228b",
+    "_postman_id": "4daf4513-cbd8-4634-a0b6-5610c8d4d2ce",
     "name": "Demo - Authentication",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "15629984",
-    "_collection_link": "https://go.postman.co/collection/15629984-28f739e9-1857-41d7-9605-c2779603228b?source=collection_link"
+    "_exporter_id": "18934058"
   },
   "item": [
     {
@@ -1394,7 +1393,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"username\": \"{{demoLoginUser1Username}}\",\n  \"password\": \"{{demoLoginUser1Password}}\"\n//   \"skip_assertion\": false\n}",
+                  "raw": "{\n    \"identifiers\": {\n        \"username\": \"{{demoLoginUser1Username}}\"\n    },\n    \"credentials\": {\n        \"password\": \"{{demoLoginUser1Password}}\"\n    }\n    //   \"skip_assertion\": false\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -1431,7 +1430,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"email\": \"{{demoLoginUser1Email}}\",\n  \"password\": \"{{demoLoginUser1Password}}\",\n  \"skip_assertion\": true\n}",
+                  "raw": "{\n    \"identifiers\": {\n        \"email\": \"{{demoLoginUser1Email}}\"\n    },\n    \"credentials\": {\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"skip_assertion\": true\n}",
                   "options": {
                     "raw": {
                       "language": "json"

--- a/samples/apps/react-api-based-sample/src/pages/SignInPage.tsx
+++ b/samples/apps/react-api-based-sample/src/pages/SignInPage.tsx
@@ -75,8 +75,12 @@ function SignInPage() {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            username: formData.username,
-            password: formData.password,
+            identifiers: {
+              username: formData.username,
+            },
+            credentials: {
+              password: formData.password,
+            },
           }),
         }
       );


### PR DESCRIPTION
### Purpose

This pull request updates the authentication API documentation, Postman demo collection, and the React sample app to use a new request format for credentials authentication. Instead of sending top-level `username` and `password` fields, requests now use nested `identifiers` and `credentials` objects. This change ensures consistency across documentation, sample code, and API usage.

### Approach

**Authentication API request format update:**

* Updated all authentication API request examples in `authentication.md` to use `identifiers` and `credentials` objects instead of top-level `username` and `password` fields. [[1]](diffhunk://#diff-5d1d8c0f134163e60bc4429a0b74fa532f710593174d629df9426e267321d921L48-R53) [[2]](diffhunk://#diff-5d1d8c0f134163e60bc4429a0b74fa532f710593174d629df9426e267321d921L69-R78) [[3]](diffhunk://#diff-5d1d8c0f134163e60bc4429a0b74fa532f710593174d629df9426e267321d921L530-R543)

**Postman demo collection update:**

* Modified request bodies in `authentication_demo.json` to use the new `identifiers` and `credentials` structure for both username and email-based authentication examples. [[1]](diffhunk://#diff-37ae3069ffc66119a68594750bb80a356645db1191a847b79fbb709d2d1ec82aL1397-R1396) [[2]](diffhunk://#diff-37ae3069ffc66119a68594750bb80a356645db1191a847b79fbb709d2d1ec82aL1434-R1433)
* Updated Postman collection metadata (IDs and exporter info) to reflect the latest export.

**React sample app update:**

* Changed the sign-in API call in `SignInPage.tsx` to send `identifiers` and `credentials` objects in the request body.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1291

### Related PRs
- https://github.com/asgardeo/thunder/pull/1420

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated authentication examples to use a nested payload format: identifiers (username/email) and credentials (password) instead of flat fields.
  * Postman collection and sample app examples updated so request bodies match the new nested JSON shape.
  * Guidance and examples adjusted; endpoints and behaviors remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->