### PR TITLE
Add pagination support for Organization Unit tree picker

### DIFF
--- a/frontend/apps/thunder-develop/src/features/organization-units/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
@@ -189,6 +189,50 @@ describe('OrganizationUnitDeleteDialog', () => {
     expect(screen.getByText('Cancel')).toBeInTheDocument();
     expect(screen.getByText('Delete')).toBeInTheDocument();
   });
+
+  it('should use error message when response has no description', async () => {
+    const onError = vi.fn();
+    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
+      options.onError(
+        Object.assign(new Error('Something went wrong'), {
+          response: {data: {code: 'ERR', message: 'fail'}},
+        }),
+      );
+    });
+
+    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('Something went wrong');
+    });
+  });
+
+  it('should use fallback when error message is only whitespace', async () => {
+    const onError = vi.fn();
+    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
+      options.onError(new Error('   '));
+    });
+
+    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('Failed to delete organization unit. Please try again.');
+    });
+  });
+
+  it('should render warning disclaimer alert', () => {
+    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} />);
+
+    expect(
+      screen.getByText(
+        'Warning: All associated data, configurations, and user assignments will be permanently removed.',
+      ),
+    ).toBeInTheDocument();
+  });
 });
 
 describe('OrganizationUnitDeleteDialog - pending state', () => {

--- a/frontend/apps/thunder-develop/src/features/organization-units/components/__tests__/OrganizationUnitTreePicker.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/components/__tests__/OrganizationUnitTreePicker.test.tsx
@@ -1,0 +1,563 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {screen, fireEvent, waitFor, renderWithProviders} from '@thunder/test-utils';
+import OrganizationUnitTreePicker from '../OrganizationUnitTreePicker';
+import type {OrganizationUnitListResponse} from '../../models/responses';
+
+// Mock logger — stable reference to avoid useCallback churn
+const stableLogger = {error: vi.fn(), info: vi.fn(), debug: vi.fn()};
+vi.mock('@thunder/logger/react', () => ({
+  useLogger: () => stableLogger,
+}));
+
+// Mock the API hook
+const mockUseGetOrganizationUnits = vi.fn();
+vi.mock('../../api/useGetOrganizationUnits', () => ({
+  default: () =>
+    mockUseGetOrganizationUnits() as {
+      data: OrganizationUnitListResponse | undefined;
+      isLoading: boolean;
+      error: Error | null;
+    },
+}));
+
+// Mock Asgardeo — stable reference to avoid useCallback churn
+const mockHttpRequest = vi.fn();
+const stableHttp = {request: mockHttpRequest};
+vi.mock('@asgardeo/react', () => ({
+  useAsgardeo: () => ({http: stableHttp}),
+}));
+
+// Mock config — stable reference to avoid useCallback churn
+const stableConfig = {getServerUrl: () => 'http://localhost:8080'};
+vi.mock('@thunder/shared-contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunder/shared-contexts')>();
+  return {
+    ...actual,
+    useConfig: () => stableConfig,
+  };
+});
+
+// Mock translations — stable t function to avoid useCallback churn
+const translations: Record<string, string> = {
+  'organizationUnits:treePicker.empty': 'No organization units available',
+  'organizationUnits:listing.treeView.noChildren': 'No child organization units',
+  'organizationUnits:listing.treeView.loadMore': 'Load more',
+  'common:status.loading': 'Loading...',
+};
+const stableT = (key: string): string => translations[key] ?? key;
+const stableTranslation = {t: stableT};
+vi.mock('react-i18next', () => ({
+  useTranslation: () => stableTranslation,
+}));
+
+describe('OrganizationUnitTreePicker', () => {
+  const mockOUData: OrganizationUnitListResponse = {
+    totalResults: 2,
+    startIndex: 1,
+    count: 2,
+    organizationUnits: [
+      {id: 'ou-1', handle: 'root', name: 'Root Organization', description: 'Root OU', parent: null},
+      {id: 'ou-2', handle: 'engineering', name: 'Engineering', description: null, parent: null},
+    ],
+  };
+
+  const defaultProps = {
+    value: '',
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: mockOUData,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('should render tree with organization unit names', async () => {
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+      expect(screen.getByText('Engineering')).toBeInTheDocument();
+    });
+  });
+
+  it('should show loading spinner when data is loading', () => {
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('should show empty message when no organization units', () => {
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: {
+        totalResults: 0,
+        startIndex: 1,
+        count: 0,
+        organizationUnits: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    expect(screen.getByText('No organization units available')).toBeInTheDocument();
+  });
+
+  it('should display handles for tree items', async () => {
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('root')).toBeInTheDocument();
+      expect(screen.getByText('engineering')).toBeInTheDocument();
+    });
+  });
+
+  it('should render avatars for tree items', async () => {
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    const avatars = document.querySelectorAll('.MuiAvatar-root');
+    expect(avatars.length).toBeGreaterThan(0);
+  });
+
+  it('should call onChange when a tree item is selected', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} onChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Root Organization'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('ou-1');
+    });
+  });
+
+  it('should not call onChange when clicking a placeholder item', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} onChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    // Placeholder items are not directly clickable via text, so verify no unexpected calls
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should pass id prop to tree view', async () => {
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} id="test-picker" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    expect(document.getElementById('test-picker')).toBeInTheDocument();
+  });
+
+  it('should display helper text when provided', async () => {
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} helperText="Select a parent" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Select a parent')).toBeInTheDocument();
+    });
+  });
+
+  it('should display helper text with error styling when error is true', async () => {
+    renderWithProviders(
+      <OrganizationUnitTreePicker {...defaultProps} helperText="This field is required" error />,
+    );
+
+    await waitFor(() => {
+      const helperText = screen.getByText('This field is required');
+      expect(helperText).toBeInTheDocument();
+    });
+  });
+
+  it('should not display helper text when not provided', async () => {
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    // No helper text element should be present
+    expect(screen.queryByText('Select a parent')).not.toBeInTheDocument();
+  });
+
+  it('should fetch and display child OUs when a node is expanded', async () => {
+    const childOUResponse: OrganizationUnitListResponse = {
+      totalResults: 1,
+      startIndex: 1,
+      count: 1,
+      organizationUnits: [
+        {id: 'ou-child-1', handle: 'child1', name: 'Fetched Child', description: 'A child', parent: 'ou-1'},
+      ],
+    };
+
+    mockHttpRequest.mockResolvedValue({data: childOUResponse});
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    // Click the expand icon on the first tree item
+    const expandIcons = document.querySelectorAll('.MuiTreeItem-iconContainer');
+    expect(expandIcons.length).toBeGreaterThan(0);
+    fireEvent.click(expandIcons[0]);
+
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Fetched Child')).toBeInTheDocument();
+    });
+  });
+
+  it('should show "no children" placeholder when expanded node has no children', async () => {
+    const emptyChildResponse: OrganizationUnitListResponse = {
+      totalResults: 0,
+      startIndex: 1,
+      count: 0,
+      organizationUnits: [],
+    };
+
+    mockHttpRequest.mockResolvedValue({data: emptyChildResponse});
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    const expandIcons = document.querySelectorAll('.MuiTreeItem-iconContainer');
+    fireEvent.click(expandIcons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('No child organization units')).toBeInTheDocument();
+    });
+  });
+
+  it('should log error when fetching child OUs fails', async () => {
+    mockHttpRequest.mockRejectedValue(new Error('Network failure'));
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    const expandIcons = document.querySelectorAll('.MuiTreeItem-iconContainer');
+    fireEvent.click(expandIcons[0]);
+
+    await waitFor(() => {
+      expect(stableLogger.error).toHaveBeenCalledWith(
+        'Failed to load child organization units',
+        expect.objectContaining({parentId: 'ou-1'}),
+      );
+    });
+  });
+
+  it('should show load more button when there are more root items', async () => {
+    const paginatedData: OrganizationUnitListResponse = {
+      totalResults: 50,
+      startIndex: 1,
+      count: 2,
+      organizationUnits: [
+        {id: 'ou-1', handle: 'root', name: 'Root Organization', description: null, parent: null},
+        {id: 'ou-2', handle: 'engineering', name: 'Engineering', description: null, parent: null},
+      ],
+    };
+
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: paginatedData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+  });
+
+  it('should fetch more root items when load more button is clicked', async () => {
+    const paginatedData: OrganizationUnitListResponse = {
+      totalResults: 50,
+      startIndex: 1,
+      count: 2,
+      organizationUnits: [
+        {id: 'ou-1', handle: 'root', name: 'Root Organization', description: null, parent: null},
+        {id: 'ou-2', handle: 'engineering', name: 'Engineering', description: null, parent: null},
+      ],
+    };
+
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: paginatedData,
+      isLoading: false,
+      error: null,
+    });
+
+    const nextPageResponse: OrganizationUnitListResponse = {
+      totalResults: 50,
+      startIndex: 3,
+      count: 2,
+      organizationUnits: [
+        {id: 'ou-3', handle: 'sales', name: 'Sales', description: null, parent: null},
+        {id: 'ou-4', handle: 'marketing', name: 'Marketing', description: null, parent: null},
+      ],
+    };
+
+    mockHttpRequest.mockResolvedValue({data: nextPageResponse});
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Load more'));
+
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalled();
+    });
+  });
+
+  it('should trigger load more via keyboard Enter key', async () => {
+    const paginatedData: OrganizationUnitListResponse = {
+      totalResults: 50,
+      startIndex: 1,
+      count: 2,
+      organizationUnits: [
+        {id: 'ou-1', handle: 'root', name: 'Root Organization', description: null, parent: null},
+        {id: 'ou-2', handle: 'engineering', name: 'Engineering', description: null, parent: null},
+      ],
+    };
+
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: paginatedData,
+      isLoading: false,
+      error: null,
+    });
+
+    mockHttpRequest.mockResolvedValue({
+      data: {
+        totalResults: 50,
+        startIndex: 3,
+        count: 2,
+        organizationUnits: [
+          {id: 'ou-3', handle: 'sales', name: 'Sales', description: null, parent: null},
+        ],
+      },
+    });
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+
+    const loadMoreButton = screen.getByText('Load more').closest('[role="button"]')!;
+    fireEvent.keyDown(loadMoreButton, {key: 'Enter'});
+
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalled();
+    });
+  });
+
+  it('should trigger load more via keyboard Space key', async () => {
+    const paginatedData: OrganizationUnitListResponse = {
+      totalResults: 50,
+      startIndex: 1,
+      count: 2,
+      organizationUnits: [
+        {id: 'ou-1', handle: 'root', name: 'Root Organization', description: null, parent: null},
+        {id: 'ou-2', handle: 'engineering', name: 'Engineering', description: null, parent: null},
+      ],
+    };
+
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: paginatedData,
+      isLoading: false,
+      error: null,
+    });
+
+    mockHttpRequest.mockResolvedValue({
+      data: {
+        totalResults: 50,
+        startIndex: 3,
+        count: 2,
+        organizationUnits: [
+          {id: 'ou-3', handle: 'sales', name: 'Sales', description: null, parent: null},
+        ],
+      },
+    });
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+
+    const loadMoreButton = screen.getByText('Load more').closest('[role="button"]')!;
+    fireEvent.keyDown(loadMoreButton, {key: ' '});
+
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalled();
+    });
+  });
+
+  it('should show load more for child items when there are more children', async () => {
+    const childOUResponse: OrganizationUnitListResponse = {
+      totalResults: 50,
+      startIndex: 1,
+      count: 1,
+      organizationUnits: [
+        {id: 'ou-child-1', handle: 'child1', name: 'Fetched Child', description: null, parent: 'ou-1'},
+      ],
+    };
+
+    mockHttpRequest.mockResolvedValue({data: childOUResponse});
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    const expandIcons = document.querySelectorAll('.MuiTreeItem-iconContainer');
+    fireEvent.click(expandIcons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fetched Child')).toBeInTheDocument();
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+  });
+
+  it('should log error when root load more fails', async () => {
+    const paginatedData: OrganizationUnitListResponse = {
+      totalResults: 50,
+      startIndex: 1,
+      count: 2,
+      organizationUnits: [
+        {id: 'ou-1', handle: 'root', name: 'Root Organization', description: null, parent: null},
+        {id: 'ou-2', handle: 'engineering', name: 'Engineering', description: null, parent: null},
+      ],
+    };
+
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: paginatedData,
+      isLoading: false,
+      error: null,
+    });
+
+    mockHttpRequest.mockRejectedValue(new Error('Network failure'));
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Load more')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Load more'));
+
+    await waitFor(() => {
+      expect(stableLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  it('should not expand item when it is already loaded', async () => {
+    const childOUResponse: OrganizationUnitListResponse = {
+      totalResults: 1,
+      startIndex: 1,
+      count: 1,
+      organizationUnits: [
+        {id: 'ou-child-1', handle: 'child1', name: 'Fetched Child', description: null, parent: 'ou-1'},
+      ],
+    };
+
+    mockHttpRequest.mockResolvedValue({data: childOUResponse});
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    // First expansion - triggers fetch
+    const expandIcons = document.querySelectorAll('.MuiTreeItem-iconContainer');
+    fireEvent.click(expandIcons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fetched Child')).toBeInTheDocument();
+    });
+
+    const callCount = mockHttpRequest.mock.calls.length;
+
+    // Collapse
+    const collapseIcons = document.querySelectorAll('.MuiTreeItem-iconContainer');
+    fireEvent.click(collapseIcons[0]);
+
+    // Expand again - should not trigger another fetch
+    const expandIcons2 = document.querySelectorAll('.MuiTreeItem-iconContainer');
+    fireEvent.click(expandIcons2[0]);
+
+    // Wait a bit and verify no additional HTTP calls
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalledTimes(callCount);
+    });
+  });
+
+  it('should highlight selected item', async () => {
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} value="ou-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Root Organization')).toBeInTheDocument();
+    });
+
+    // The Mui-selected class should be applied to the selected item
+    const selectedElements = document.querySelectorAll('.Mui-selected');
+    expect(selectedElements.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -422,6 +422,7 @@ const translations = {
     'listing.treeView.loadError': 'Failed to load child organization units',
     'listing.treeView.addChild': 'Add Child OU',
     'listing.treeView.addChildOrganizationUnit': 'Add Child Organization Unit',
+    'listing.treeView.loadMore': 'Load more',
     'listing.columns.name': 'Name',
     'listing.columns.handle': 'Handle',
     'listing.columns.description': 'Description',


### PR DESCRIPTION
### Purpose
This pull request introduces a "Load More" pagination feature to the organization unit tree views, improving performance and user experience when browsing large lists of organization units. The main changes include the addition of "Load More" nodes at both the root and child levels, state management for paginated loading, and UI/UX enhancements for loading indicators.

**Pagination and Load More Functionality:**

- Added constants and logic for "Load More" nodes (`LOAD_MORE_SUFFIX`, `ROOT_PARENT_ID`, `ROOT_LOAD_MORE_ID`, `PAGE_SIZE`) to support paginated loading of organization units in both `OrganizationUnitTreePicker` and `OrganizationUnitsTreeView`. [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R35-R38) [[2]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R54-R57)
- Implemented state management for offsets and loading states (`childOffsets`, `rootOffset`, `loadMoreLoadingItems`, `rootLoadMoreLoading`) to track pagination progress and loading status. [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R302-R305) [[2]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R445-R448)
- Introduced helper functions to append paginated children and handle "Load More" events, including fetching additional pages and updating the tree structure accordingly. [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R89-R195) [[2]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3L266-R498)

**UI/UX Improvements:**

- Enhanced tree item components (`PickerTreeItem`, `CustomTreeItem`) to render "Load More" nodes with proper loading indicators and click/keyboard handlers for accessibility. [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R89-R195) [[2]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R129-R212)
- Updated loading indicators: replaced inline loading spinners with loading icons on expand/collapse controls for better visual feedback. [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R237-R244) [[2]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3L170) [[3]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R328-R336) [[4]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7L294)

**Integration and Event Handling:**

- Integrated new props and event handlers (`onLoadMore`, `loadMoreLoadingItems`) into the tree view components to support seamless interaction with the "Load More" functionality. [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R567-R572) [[2]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R105-R111)
- Ensured selection logic ignores "Load More" nodes, preventing accidental selection of pagination items.

These changes collectively provide a scalable and responsive way to navigate large organization unit hierarchies.

**References:**
- Pagination and Load More Functionality: [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R35-R38) [[2]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R54-R57) [[3]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R302-R305) [[4]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R445-R448) [[5]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R89-R195) [[6]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3L266-R498)
- UI/UX Improvements: [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R89-R195) [[2]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R129-R212) [[3]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R237-R244) [[4]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3L170) [[5]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R328-R336) [[6]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7L294)
- Integration and Event Handling: [[1]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3R567-R572) [[2]](diffhunk://#diff-f01732d2bebbd8547dadb8da4cd107cba5b7bb7ec93efe997891f54f5589b2e7R105-R111) [[3]](diffhunk://#diff-40f9bf7ca7960bd139d4533c28d89d175813960a4d5db7aa48a82034ea58aaa3L284-R519)

### Related Issues
- https://github.com/asgardeo/thunder/issues/1490

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand pagination for the organization unit tree with "Load more" at root and per-parent levels, plus per-item loading indicators and selectable load-more actions.

* **Tests**
  * Extensive unit tests for picker and tree view covering pagination, loading states, keyboard accessibility, selection, error handling, and navigation flows.

* **Documentation**
  * Added localized "Load more" label for the tree view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->