### PR TITLE
Co-locate thunder-gate unit tests with source files

### DIFF
--- a/frontend/apps/thunder-gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
@@ -19,7 +19,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@thunder/test-utils';
 import userEvent from '@testing-library/user-event';
-import AcceptInviteBox from '../../../components/AcceptInvite/AcceptInviteBox';
+import AcceptInviteBox from '../AcceptInviteBox';
 
 // Mock useDesign
 const mockUseDesign = vi.fn();

--- a/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignIn.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignIn.test.tsx
@@ -18,14 +18,14 @@
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import SignIn from '../../../components/SignIn/SignIn';
+import SignIn from '../SignIn';
 
 // Mock child components
-vi.mock('../../../components/SignIn/SignInBox', () => ({
+vi.mock('../SignInBox', () => ({
   default: () => <div data-testid="signin-box">SignInBox</div>,
 }));
 
-vi.mock('../../../components/SignIn/SignInSlogan', () => ({
+vi.mock('../SignInSlogan', () => ({
   default: () => <div data-testid="signin-slogan">SignInSlogan</div>,
 }));
 

--- a/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignInBox.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignInBox.test.tsx
@@ -19,7 +19,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@thunder/test-utils';
 import userEvent from '@testing-library/user-event';
-import SignInBox from '../../../components/SignIn/SignInBox';
+import SignInBox from '../SignInBox';
 // Mock useDesign
 const mockUseDesign = vi.fn();
 vi.mock('@thunder/shared-design', () => ({

--- a/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignInSlogan.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignInSlogan.test.tsx
@@ -18,7 +18,7 @@
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import SignInSlogan from '../../../components/SignIn/SignInSlogan';
+import SignInSlogan from '../SignInSlogan';
 
 describe('SignInSlogan', () => {
   beforeEach(() => {

--- a/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUp.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUp.test.tsx
@@ -18,26 +18,26 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import AcceptInvitePage from '../../pages/AcceptInvitePage';
+import SignUp from '../SignUp';
 
-// Mock the AcceptInviteBox component
-vi.mock('../../components/AcceptInvite/AcceptInviteBox', () => ({
-  default: () => <div data-testid="accept-invite-box">AcceptInviteBox Component</div>,
+// Mock child component
+vi.mock('../SignUpBox', () => ({
+  default: () => <div data-testid="signup-box">SignUpBox</div>,
 }));
 
-describe('AcceptInvitePage', () => {
+describe('SignUp', () => {
   it('renders without crashing', () => {
-    const {container} = render(<AcceptInvitePage />);
+    const {container} = render(<SignUp />);
     expect(container).toBeInTheDocument();
   });
 
-  it('renders AcceptInviteBox component', () => {
-    render(<AcceptInvitePage />);
-    expect(screen.getByTestId('accept-invite-box')).toBeInTheDocument();
+  it('renders SignUpBox component', () => {
+    render(<SignUp />);
+    expect(screen.getByTestId('signup-box')).toBeInTheDocument();
   });
 
   it('renders main element', () => {
-    render(<AcceptInvitePage />);
+    render(<SignUp />);
     const main = screen.getByRole('main');
     expect(main).toBeInTheDocument();
   });

--- a/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
@@ -19,7 +19,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@thunder/test-utils';
 import userEvent from '@testing-library/user-event';
-import SignUpBox from '../../../components/SignUp/SignUpBox';
+import SignUpBox from '../SignUpBox';
 
 // Mock useDesign
 const mockUseDesign = vi.fn();

--- a/frontend/apps/thunder-gate/src/config/__tests__/appRoutes.test.tsx
+++ b/frontend/apps/thunder-gate/src/config/__tests__/appRoutes.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import appRoutes, {type AppRoute} from '../../config/appRoutes';
+import appRoutes, {type AppRoute} from '../appRoutes';
 import ROUTES from '../../constants/routes';
 
 describe('appRoutes', () => {

--- a/frontend/apps/thunder-gate/src/constants/__tests__/routes.test.ts
+++ b/frontend/apps/thunder-gate/src/constants/__tests__/routes.test.ts
@@ -17,7 +17,7 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import ROUTES, {type Routes} from '../../constants/routes';
+import ROUTES, {type Routes} from '../routes';
 
 describe('ROUTES', () => {
   it('exports ROUTES object', () => {

--- a/frontend/apps/thunder-gate/src/layouts/__tests__/DefaultLayout.test.tsx
+++ b/frontend/apps/thunder-gate/src/layouts/__tests__/DefaultLayout.test.tsx
@@ -19,7 +19,7 @@
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {MemoryRouter, Routes, Route} from 'react-router';
-import DefaultLayout from '../../layouts/DefaultLayout';
+import DefaultLayout from '../DefaultLayout';
 
 describe('DefaultLayout', () => {
   it('renders without crashing', () => {

--- a/frontend/apps/thunder-gate/src/pages/__tests__/AcceptInvitePage.test.tsx
+++ b/frontend/apps/thunder-gate/src/pages/__tests__/AcceptInvitePage.test.tsx
@@ -18,21 +18,27 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import SignInPage from '../../pages/SignInPage';
+import AcceptInvitePage from '../AcceptInvitePage';
 
-// Mock the SignIn component
-vi.mock('../../components/SignIn/SignIn', () => ({
-  default: () => <div data-testid="signin-component">SignIn Component</div>,
+// Mock the AcceptInviteBox component
+vi.mock('../../components/AcceptInvite/AcceptInviteBox', () => ({
+  default: () => <div data-testid="accept-invite-box">AcceptInviteBox Component</div>,
 }));
 
-describe('SignInPage', () => {
+describe('AcceptInvitePage', () => {
   it('renders without crashing', () => {
-    const {container} = render(<SignInPage />);
+    const {container} = render(<AcceptInvitePage />);
     expect(container).toBeInTheDocument();
   });
 
-  it('renders SignIn component', () => {
-    render(<SignInPage />);
-    expect(screen.getByTestId('signin-component')).toBeInTheDocument();
+  it('renders AcceptInviteBox component', () => {
+    render(<AcceptInvitePage />);
+    expect(screen.getByTestId('accept-invite-box')).toBeInTheDocument();
+  });
+
+  it('renders main element', () => {
+    render(<AcceptInvitePage />);
+    const main = screen.getByRole('main');
+    expect(main).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/pages/__tests__/ErrorPage.test.tsx
+++ b/frontend/apps/thunder-gate/src/pages/__tests__/ErrorPage.test.tsx
@@ -18,7 +18,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import ErrorPage from '../../pages/ErrorPage';
+import ErrorPage from '../ErrorPage';
 
 // Mock the Error component
 vi.mock('../../components/Error/Error', () => ({

--- a/frontend/apps/thunder-gate/src/pages/__tests__/InviteAcceptancePage.test.tsx
+++ b/frontend/apps/thunder-gate/src/pages/__tests__/InviteAcceptancePage.test.tsx
@@ -18,7 +18,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import InviteAcceptancePage from '../../pages/InviteAcceptancePage';
+import InviteAcceptancePage from '../InviteAcceptancePage';
 
 // Mock the AcceptInviteBox component
 vi.mock('../../components/AcceptInvite/AcceptInviteBox', () => ({

--- a/frontend/apps/thunder-gate/src/pages/__tests__/SignInPage.test.tsx
+++ b/frontend/apps/thunder-gate/src/pages/__tests__/SignInPage.test.tsx
@@ -18,27 +18,21 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import SignUp from '../../../components/SignUp/SignUp';
+import SignInPage from '../SignInPage';
 
-// Mock child component
-vi.mock('../../../components/SignUp/SignUpBox', () => ({
-  default: () => <div data-testid="signup-box">SignUpBox</div>,
+// Mock the SignIn component
+vi.mock('../../components/SignIn/SignIn', () => ({
+  default: () => <div data-testid="signin-component">SignIn Component</div>,
 }));
 
-describe('SignUp', () => {
+describe('SignInPage', () => {
   it('renders without crashing', () => {
-    const {container} = render(<SignUp />);
+    const {container} = render(<SignInPage />);
     expect(container).toBeInTheDocument();
   });
 
-  it('renders SignUpBox component', () => {
-    render(<SignUp />);
-    expect(screen.getByTestId('signup-box')).toBeInTheDocument();
-  });
-
-  it('renders main element', () => {
-    render(<SignUp />);
-    const main = screen.getByRole('main');
-    expect(main).toBeInTheDocument();
+  it('renders SignIn component', () => {
+    render(<SignInPage />);
+    expect(screen.getByTestId('signin-component')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/pages/__tests__/SignUpPage.test.tsx
+++ b/frontend/apps/thunder-gate/src/pages/__tests__/SignUpPage.test.tsx
@@ -18,7 +18,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@thunder/test-utils';
-import SignUpPage from '../../pages/SignUpPage';
+import SignUpPage from '../SignUpPage';
 
 // Mock the SignUp component
 vi.mock('../../components/SignUp/SignUp', () => ({

--- a/frontend/apps/thunder-gate/src/utils/__tests__/getIntegrationIcon.test.tsx
+++ b/frontend/apps/thunder-gate/src/utils/__tests__/getIntegrationIcon.test.tsx
@@ -18,7 +18,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import getIntegrationIcon from '../../utils/getIntegrationIcon';
+import getIntegrationIcon from '../getIntegrationIcon';
 
 // Mock the icons
 vi.mock('@wso2/oxygen-ui-icons-react', () => ({


### PR DESCRIPTION
## Summary
- Moved 14 test files from centralized `src/__tests__/` to co-located `__tests__/` subdirectories alongside source files
- Updated relative import paths in all moved files
- Aligns thunder-gate test structure with thunder-develop's convention for consistency

## Test plan
- [x] All 18 test files pass (249 tests) via `pnpm --filter @thunder/gate test`
- [ ] Verify CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized and shortened module import paths across many test files for improved consistency and maintainability; no changes to test logic, behavior, or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->