### PR TITLE
Use go 1.26 syntax

### DIFF
--- a/backend/internal/flow/executor/identifying_executor_test.go
+++ b/backend/internal/flow/executor/identifying_executor_test.go
@@ -76,7 +76,7 @@ func (suite *IdentifyingExecutorTestSuite) TestIdentifyUser_Success() {
 		RuntimeData: make(map[string]string),
 	}
 	// Use package-level testUserID constant
-	suite.mockUserProvider.On("IdentifyUser", filters).Return(stringPtr(testUserID), nil)
+	suite.mockUserProvider.On("IdentifyUser", filters).Return(new(testUserID), nil)
 
 	result, err := suite.executor.IdentifyUser(filters, execResp)
 
@@ -154,7 +154,7 @@ func (suite *IdentifyingExecutorTestSuite) TestIdentifyUser_FilterNonSearchableA
 	// Use package-level testUserID constant
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		"username": "testuser",
-	}).Return(stringPtr(testUserID), nil)
+	}).Return(new(testUserID), nil)
 
 	result, err := suite.executor.IdentifyUser(filters, execResp)
 
@@ -213,7 +213,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_UserInputs() {
 
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		"username": "testuser",
-	}).Return(stringPtr(testUserID), nil)
+	}).Return(new(testUserID), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -238,7 +238,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_RuntimeData() {
 
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		"username": "testuser",
-	}).Return(stringPtr(testUserID), nil)
+	}).Return(new(testUserID), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -554,8 +554,4 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_UserInputsPriorityOverRun
 			suite.mockUserProvider.AssertExpectations(suite.T())
 		})
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/backend/internal/ou/service_test.go
+++ b/backend/internal/ou/service_test.go
@@ -231,10 +231,6 @@ func (suite *OrganizationUnitServiceTestSuite) assertOUListResponse(
 	}
 }
 
-func strPtr(value string) *string {
-	return &value
-}
-
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitList() {
 	testCases := []struct {
 		name       string
@@ -707,7 +703,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 	suite.Run("returns true for direct parent", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
 		store.On("GetOrganizationUnit", childID).
-			Return(OrganizationUnit{ID: childID, Parent: strPtr(parentID)}, nil).
+			Return(OrganizationUnit{ID: childID, Parent: new(parentID)}, nil).
 			Once()
 
 		service := suite.newService(store)
@@ -721,10 +717,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 	suite.Run("returns true for ancestor", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
 		store.On("GetOrganizationUnit", childID).
-			Return(OrganizationUnit{ID: childID, Parent: strPtr("mid-1")}, nil).
+			Return(OrganizationUnit{ID: childID, Parent: new("mid-1")}, nil).
 			Once()
 		store.On("GetOrganizationUnit", "mid-1").
-			Return(OrganizationUnit{ID: "mid-1", Parent: strPtr(parentID)}, nil).
+			Return(OrganizationUnit{ID: "mid-1", Parent: new(parentID)}, nil).
 			Once()
 
 		service := suite.newService(store)
@@ -738,7 +734,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 	suite.Run("returns false when parent not in hierarchy", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
 		store.On("GetOrganizationUnit", childID).
-			Return(OrganizationUnit{ID: childID, Parent: strPtr("mid-1")}, nil).
+			Return(OrganizationUnit{ID: childID, Parent: new("mid-1")}, nil).
 			Once()
 		store.On("GetOrganizationUnit", "mid-1").
 			Return(OrganizationUnit{ID: "mid-1"}, nil).
@@ -964,7 +960,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			request: OrganizationUnitRequest{
 				Handle: "root",
 				Name:   "Root",
-				Parent: strPtr("ou-1"),
+				Parent: new("ou-1"),
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
@@ -1858,10 +1854,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CheckCircularDepend
 	parentID := testParentID
 
 	store.On("GetOrganizationUnit", parentID).
-		Return(OrganizationUnit{ID: parentID, Parent: strPtr("grand")}, nil).
+		Return(OrganizationUnit{ID: parentID, Parent: new("grand")}, nil).
 		Once()
 	store.On("GetOrganizationUnit", "grand").
-		Return(OrganizationUnit{ID: "grand", Parent: strPtr("ou-1")}, nil).
+		Return(OrganizationUnit{ID: "grand", Parent: new("ou-1")}, nil).
 		Once()
 
 	err := service.checkCircularDependency("ou-1", &parentID)
@@ -1923,7 +1919,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			Handle:      "finance",
 			Name:        "Finance",
 			Description: "updated",
-			Parent:      strPtr(parentID),
+			Parent:      new(parentID),
 		})
 
 		suite.Require().Nil(err)
@@ -1974,7 +1970,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 		result, err := service.UpdateOrganizationUnit(testOUID, OrganizationUnitRequest{
 			Handle: "finance",
 			Name:   "Finance",
-			Parent: strPtr(parentID),
+			Parent: new(parentID),
 		})
 
 		suite.Require().Nil(err)

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -42,11 +42,6 @@ const (
 	testWrongResourceID  = "res-wrong"
 )
 
-// Helper function to create string pointers
-func stringPtr(s string) *string {
-	return &s
-}
-
 // matchResourceServer is a matcher function that compares ResourceServer ignoring the Delimiter field
 // since it's set by the service before calling the store.
 func matchResourceServer(expected ResourceServer) interface{} {
@@ -1982,7 +1977,7 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 		{
 			name:             "Success_WithParent",
 			resourceServerID: "rs-123",
-			parentID:         stringPtr(testParentResourceID),
+			parentID:         new(testParentResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -2005,7 +2000,7 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 		{
 			name:             "Success_EmptyParent",
 			resourceServerID: "rs-123",
-			parentID:         stringPtr(""),
+			parentID:         new(""),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -2050,7 +2045,7 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 		{
 			name:             "Error_ParentResourceNotFound",
 			resourceServerID: "rs-123",
-			parentID:         stringPtr(testParentResourceID),
+			parentID:         new(testParentResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -2078,7 +2073,7 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 		{
 			name:             "Error_CheckParentError",
 			resourceServerID: "rs-123",
-			parentID:         stringPtr(testParentResourceID),
+			parentID:         new(testParentResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -2753,7 +2748,7 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 		{
 			name:             "Success_AtResource",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			actionID:         "action-123",
 			action: Action{
 				Name:        testUpdatedName,
@@ -2812,7 +2807,7 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 		{
 			name:             "Error_EmptyResourceID",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(""),
+			resourceID:       new(""),
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks:       func() {},
@@ -2834,7 +2829,7 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 		{
 			name:             "Error_ResourceNotFound",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
@@ -2864,7 +2859,7 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 		{
 			name:             "Error_ActionNotFound_AtResource",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
@@ -2897,7 +2892,7 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction() {
 		{
 			name:             "Error_CheckResourceError",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			actionID:         "action-123",
 			action:           Action{Description: testNewDescription},
 			setupMocks: func() {
@@ -3435,7 +3430,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Success_AtResource",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -3462,7 +3457,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Success_EmptyList",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -3485,7 +3480,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Error_EmptyResourceID",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(""),
+			resourceID:       new(""),
 			limit:            30,
 			offset:           0,
 			setupMocks:       func() {},
@@ -3494,7 +3489,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Error_ResourceServerNotFound",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -3507,7 +3502,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Error_ResourceNotFound",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -3523,7 +3518,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Error_CheckResourceServerError",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -3536,7 +3531,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Error_CheckResourceError",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -3551,7 +3546,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Error_CountError",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {
@@ -3571,7 +3566,7 @@ func (suite *ResourceServiceTestSuite) TestGetActionListAtResource() {
 		{
 			name:             "Error_ListError",
 			resourceServerID: "rs-123",
-			resourceID:       stringPtr(testResourceID),
+			resourceID:       new(testResourceID),
 			limit:            30,
 			offset:           0,
 			setupMocks: func() {


### PR DESCRIPTION
### Purpose
This pull request refactors several test files to remove redundant helper functions for creating string pointers. Instead, it uses Go's built-in `new(string)` function directly in test cases. This change results in cleaner and more idiomatic test code, reducing duplication and simplifying maintenance.

Key changes include:

**Test Helper Cleanup:**
- Removed custom helper functions like `stringPtr` and `strPtr` from test files, replacing their usage with the built-in `new(string)` for creating string pointers. [[1]](diffhunk://#diff-a88573ea757cfc3355977dec9b7f8625abbb69713793d57cc0f95f69d494c343L558-L561) [[2]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L234-L237) [[3]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L45-L49)

**Test Case Updates:**
- Updated all relevant test cases in `identifying_executor_test.go`, `service_test.go` (OU and resource), and related files to use `new(string)` instead of the removed helpers. This includes setting up mocks and constructing test data with string pointers. [[1]](diffhunk://#diff-a88573ea757cfc3355977dec9b7f8625abbb69713793d57cc0f95f69d494c343L79-R79) [[2]](diffhunk://#diff-a88573ea757cfc3355977dec9b7f8625abbb69713793d57cc0f95f69d494c343L157-R157) [[3]](diffhunk://#diff-a88573ea757cfc3355977dec9b7f8625abbb69713793d57cc0f95f69d494c343L216-R216) [[4]](diffhunk://#diff-a88573ea757cfc3355977dec9b7f8625abbb69713793d57cc0f95f69d494c343L241-R241) [[5]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L710-R706) [[6]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L724-R723) [[7]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L741-R737) [[8]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L967-R963) [[9]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L1861-R1860) [[10]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L1926-R1922) [[11]](diffhunk://#diff-9ba61e1bbdd078c743e485ea4bf5a7454bee00e459fc0fe4bc7eee52ebef2569L1977-R1973) [[12]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L1985-R1980) [[13]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2008-R2003) [[14]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2053-R2048) [[15]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2081-R2076) [[16]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2756-R2751) [[17]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2815-R2810) [[18]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2837-R2832) [[19]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2867-R2862) [[20]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L2900-R2895) [[21]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3438-R3433) [[22]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3465-R3460) [[23]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3488-R3483) [[24]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3497-R3492) [[25]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3510-R3505) [[26]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3526-R3521) [[27]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3539-R3534) [[28]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3554-R3549) [[29]](diffhunk://#diff-398eaae7edf05dd55603249e45bac595f3ce8e2c3b3c0cf599119f46b1c5e275L3574-R3569)

These changes make the test codebase more consistent and leverage standard library features for pointer creation.

### Related PR 
- https://github.com/asgardeo/thunder/pull/1437

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal test infrastructure refactoring across backend services with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->