### PR TITLE
Pass context through resource export service

### DIFF
--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -19,6 +19,7 @@
 package application
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -65,7 +66,7 @@ func (e *ApplicationExporter) GetParameterizerType() string {
 
 // GetAllResourceIDs retrieves all application IDs.
 // In composite mode, this excludes declarative (YAML-based) applications.
-func (e *ApplicationExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *ApplicationExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	apps, err := e.service.GetApplicationList()
 	if err != nil {
 		return nil, err
@@ -81,7 +82,9 @@ func (e *ApplicationExporter) GetAllResourceIDs() ([]string, *serviceerror.Servi
 }
 
 // GetResourceByID retrieves an application by its ID.
-func (e *ApplicationExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *ApplicationExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
 	app, err := e.service.GetApplication(id)
 	if err != nil {
 		return nil, "", err

--- a/backend/internal/application/declarative_resource_test.go
+++ b/backend/internal/application/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package application_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,7 @@ func (s *ApplicationExporterTestSuite) TestGetAllResourceIDs_Success() {
 
 	s.mockService.EXPECT().GetApplicationList().Return(expectedApps, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 2)
@@ -88,7 +89,7 @@ func (s *ApplicationExporterTestSuite) TestGetAllResourceIDs_Error() {
 
 	s.mockService.EXPECT().GetApplicationList().Return(nil, expectedError)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), ids)
 	assert.Equal(s.T(), expectedError, err)
@@ -101,7 +102,7 @@ func (s *ApplicationExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
 
 	s.mockService.EXPECT().GetApplicationList().Return(expectedApps, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 0)
@@ -115,7 +116,7 @@ func (s *ApplicationExporterTestSuite) TestGetResourceByID_Success() {
 
 	s.mockService.EXPECT().GetApplication("app1").Return(expectedApp, nil)
 
-	resource, name, err := s.exporter.GetResourceByID("app1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "app1")
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test App", name)
@@ -130,7 +131,7 @@ func (s *ApplicationExporterTestSuite) TestGetResourceByID_Error() {
 
 	s.mockService.EXPECT().GetApplication("app1").Return(nil, expectedError)
 
-	resource, name, err := s.exporter.GetResourceByID("app1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "app1")
 
 	assert.Nil(s.T(), resource)
 	assert.Empty(s.T(), name)

--- a/backend/internal/design/layout/mgt/declarative_resource.go
+++ b/backend/internal/design/layout/mgt/declarative_resource.go
@@ -19,6 +19,7 @@
 package layoutmgt
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -56,7 +57,7 @@ func (e *layoutExporter) GetParameterizerType() string {
 }
 
 // GetAllResourceIDs retrieves all layout IDs.
-func (e *layoutExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *layoutExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	layoutList, err := e.service.GetLayoutList(100, 0) // Get a large number to fetch all
 	if err != nil {
 		return nil, err
@@ -69,7 +70,9 @@ func (e *layoutExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceErr
 }
 
 // GetResourceByID retrieves a layout by its ID.
-func (e *layoutExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *layoutExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
 	layout, err := e.service.GetLayout(id)
 	if err != nil {
 		return nil, "", err

--- a/backend/internal/design/layout/mgt/declarative_resource_test.go
+++ b/backend/internal/design/layout/mgt/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package layoutmgt
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -105,7 +106,7 @@ func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetAllResourceIDs_Succ
 	exporter := &layoutExporter{service: mockService}
 
 	// Act
-	ids, svcErr := exporter.GetAllResourceIDs()
+	ids, svcErr := exporter.GetAllResourceIDs(context.Background())
 
 	// Assert
 	s.Nil(svcErr)
@@ -123,7 +124,7 @@ func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetAllResourceIDs_Serv
 	exporter := &layoutExporter{service: mockService}
 
 	// Act
-	ids, svcErr := exporter.GetAllResourceIDs()
+	ids, svcErr := exporter.GetAllResourceIDs(context.Background())
 
 	// Assert
 	s.NotNil(svcErr)
@@ -138,7 +139,7 @@ func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetAllResourceIDs_Empt
 	exporter := &layoutExporter{service: mockService}
 
 	// Act
-	ids, svcErr := exporter.GetAllResourceIDs()
+	ids, svcErr := exporter.GetAllResourceIDs(context.Background())
 
 	// Assert
 	s.Nil(svcErr)
@@ -160,7 +161,7 @@ func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetResourceByID_Succes
 	exporter := &layoutExporter{service: mockService}
 
 	// Act
-	resource, displayName, svcErr := exporter.GetResourceByID("layout-001")
+	resource, displayName, svcErr := exporter.GetResourceByID(context.Background(), "layout-001")
 
 	// Assert
 	s.Nil(svcErr)
@@ -181,7 +182,7 @@ func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetResourceByID_NotFou
 	exporter := &layoutExporter{service: mockService}
 
 	// Act
-	resource, displayName, svcErr := exporter.GetResourceByID("non-existent")
+	resource, displayName, svcErr := exporter.GetResourceByID(context.Background(), "non-existent")
 
 	// Assert
 	s.NotNil(svcErr)

--- a/backend/internal/design/theme/mgt/declarative_resource.go
+++ b/backend/internal/design/theme/mgt/declarative_resource.go
@@ -19,6 +19,7 @@
 package thememgt
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -56,7 +57,7 @@ func (e *themeExporter) GetParameterizerType() string {
 }
 
 // GetAllResourceIDs retrieves all theme IDs.
-func (e *themeExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *themeExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	themeList, err := e.service.GetThemeList(100, 0) // Get a large number to fetch all
 	if err != nil {
 		return nil, err
@@ -69,7 +70,9 @@ func (e *themeExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceErro
 }
 
 // GetResourceByID retrieves a theme by its ID.
-func (e *themeExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *themeExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
 	theme, err := e.service.GetTheme(id)
 	if err != nil {
 		return nil, "", err

--- a/backend/internal/design/theme/mgt/declarative_resource_test.go
+++ b/backend/internal/design/theme/mgt/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package thememgt
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -105,7 +106,7 @@ func (s *ThemeDeclarativeSuite) TestThemeExporter_GetAllResourceIDs_Success() {
 	exporter := &themeExporter{service: mockService}
 
 	// Act
-	ids, svcErr := exporter.GetAllResourceIDs()
+	ids, svcErr := exporter.GetAllResourceIDs(context.Background())
 
 	// Assert
 	s.Nil(svcErr)
@@ -123,7 +124,7 @@ func (s *ThemeDeclarativeSuite) TestThemeExporter_GetAllResourceIDs_ServiceError
 	exporter := &themeExporter{service: mockService}
 
 	// Act
-	ids, svcErr := exporter.GetAllResourceIDs()
+	ids, svcErr := exporter.GetAllResourceIDs(context.Background())
 
 	// Assert
 	s.NotNil(svcErr)
@@ -138,7 +139,7 @@ func (s *ThemeDeclarativeSuite) TestThemeExporter_GetAllResourceIDs_EmptyList() 
 	exporter := &themeExporter{service: mockService}
 
 	// Act
-	ids, svcErr := exporter.GetAllResourceIDs()
+	ids, svcErr := exporter.GetAllResourceIDs(context.Background())
 
 	// Assert
 	s.Nil(svcErr)
@@ -160,7 +161,7 @@ func (s *ThemeDeclarativeSuite) TestThemeExporter_GetResourceByID_Success() {
 	exporter := &themeExporter{service: mockService}
 
 	// Act
-	resource, displayName, svcErr := exporter.GetResourceByID("theme-001")
+	resource, displayName, svcErr := exporter.GetResourceByID(context.Background(), "theme-001")
 
 	// Assert
 	s.Nil(svcErr)
@@ -181,7 +182,7 @@ func (s *ThemeDeclarativeSuite) TestThemeExporter_GetResourceByID_NotFound() {
 	exporter := &themeExporter{service: mockService}
 
 	// Act
-	resource, displayName, svcErr := exporter.GetResourceByID("non-existent")
+	resource, displayName, svcErr := exporter.GetResourceByID(context.Background(), "non-existent")
 
 	// Assert
 	s.NotNil(svcErr)

--- a/backend/internal/flow/mgt/declarative_resource.go
+++ b/backend/internal/flow/mgt/declarative_resource.go
@@ -19,6 +19,7 @@
 package flowmgt
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/asgardeo/thunder/internal/flow/common"
@@ -60,7 +61,7 @@ func (e *FlowGraphExporter) GetParameterizerType() string {
 }
 
 // GetAllResourceIDs retrieves all flow graph IDs.
-func (e *FlowGraphExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *FlowGraphExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	flows, err := e.service.ListFlows(10000, 0, common.FlowType(""))
 	if err != nil {
 		return nil, err
@@ -73,7 +74,9 @@ func (e *FlowGraphExporter) GetAllResourceIDs() ([]string, *serviceerror.Service
 }
 
 // GetResourceByID retrieves a flow graph by its ID.
-func (e *FlowGraphExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *FlowGraphExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
 	flow, err := e.service.GetFlow(id)
 	if err != nil {
 		return nil, "", err

--- a/backend/internal/flow/mgt/declarative_resource_test.go
+++ b/backend/internal/flow/mgt/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package flowmgt
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -185,7 +186,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_GetAllResourceIDs()
 	mockService.EXPECT().ListFlows(10000, 0, common.FlowType("")).Return(listResponse, nil)
 
 	exporter := newFlowGraphExporter(mockService)
-	ids, err := exporter.GetAllResourceIDs()
+	ids, err := exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 2)
@@ -205,7 +206,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_GetAllResourceIDs_E
 	mockService.EXPECT().ListFlows(10000, 0, common.FlowType("")).Return(nil, expectedError)
 
 	exporter := newFlowGraphExporter(mockService)
-	ids, err := exporter.GetAllResourceIDs()
+	ids, err := exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), ids)
 	assert.Equal(s.T(), expectedError, err)
@@ -223,7 +224,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_GetAllResourceIDs_E
 	mockService.EXPECT().ListFlows(10000, 0, common.FlowType("")).Return(listResponse, nil)
 
 	exporter := newFlowGraphExporter(mockService)
-	ids, err := exporter.GetAllResourceIDs()
+	ids, err := exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 0)
@@ -241,7 +242,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_GetResourceByID() {
 	mockService.EXPECT().GetFlow("flow-001").Return(flow, nil)
 
 	exporter := newFlowGraphExporter(mockService)
-	resource, name, err := exporter.GetResourceByID("flow-001")
+	resource, name, err := exporter.GetResourceByID(context.Background(), "flow-001")
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), flow, resource)
@@ -260,7 +261,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_GetResourceByID_Err
 	mockService.EXPECT().GetFlow("flow-001").Return(nil, expectedError)
 
 	exporter := newFlowGraphExporter(mockService)
-	resource, name, err := exporter.GetResourceByID("flow-001")
+	resource, name, err := exporter.GetResourceByID(context.Background(), "flow-001")
 
 	assert.Nil(s.T(), resource)
 	assert.Empty(s.T(), name)
@@ -562,12 +563,12 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporterIntegration() {
 	exporter := newFlowGraphExporter(mockService)
 
 	// Get all IDs
-	ids, err := exporter.GetAllResourceIDs()
+	ids, err := exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 1)
 
 	// Get resource by ID
-	resource, name, err := exporter.GetResourceByID(ids[0])
+	resource, name, err := exporter.GetResourceByID(context.Background(), ids[0])
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), flow, resource)
 	assert.Equal(s.T(), "Authentication Flow", name)
@@ -942,7 +943,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowExport_WithComplexMeta() {
 	mockService.EXPECT().GetFlow("test-flow-001").Return(complexFlow, nil)
 
 	exporter := newFlowGraphExporter(mockService)
-	resource, name, err := exporter.GetResourceByID("test-flow-001")
+	resource, name, err := exporter.GetResourceByID(context.Background(), "test-flow-001")
 
 	require.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test Flow with Complex Meta", name)

--- a/backend/internal/idp/declarative_resource.go
+++ b/backend/internal/idp/declarative_resource.go
@@ -19,6 +19,7 @@
 package idp
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -65,7 +66,7 @@ func (e *IDPExporter) GetParameterizerType() string {
 }
 
 // GetAllResourceIDs retrieves all identity provider IDs.
-func (e *IDPExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *IDPExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	idps, err := e.service.GetIdentityProviderList()
 	if err != nil {
 		return nil, err
@@ -78,7 +79,9 @@ func (e *IDPExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError)
 }
 
 // GetResourceByID retrieves an identity provider by its ID.
-func (e *IDPExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *IDPExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
 	idpDTO, err := e.service.GetIdentityProvider(id)
 	if err != nil {
 		return nil, "", err

--- a/backend/internal/idp/declarative_resource_test.go
+++ b/backend/internal/idp/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package idp_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +71,7 @@ func (s *IDPExporterTestSuite) TestGetAllResourceIDs_Success() {
 
 	s.mockService.EXPECT().GetIdentityProviderList().Return(expectedIDPs, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 2)
@@ -86,7 +87,7 @@ func (s *IDPExporterTestSuite) TestGetAllResourceIDs_Error() {
 
 	s.mockService.EXPECT().GetIdentityProviderList().Return(nil, expectedError)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), ids)
 	assert.Equal(s.T(), expectedError, err)
@@ -97,7 +98,7 @@ func (s *IDPExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
 
 	s.mockService.EXPECT().GetIdentityProviderList().Return(expectedIDPs, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 0)
@@ -111,7 +112,7 @@ func (s *IDPExporterTestSuite) TestGetResourceByID_Success() {
 
 	s.mockService.EXPECT().GetIdentityProvider("idp1").Return(expectedIDP, nil)
 
-	resource, name, err := s.exporter.GetResourceByID("idp1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "idp1")
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test IDP", name)
@@ -126,7 +127,7 @@ func (s *IDPExporterTestSuite) TestGetResourceByID_Error() {
 
 	s.mockService.EXPECT().GetIdentityProvider("idp1").Return(nil, expectedError)
 
-	resource, name, err := s.exporter.GetResourceByID("idp1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "idp1")
 
 	assert.Nil(s.T(), resource)
 	assert.Empty(s.T(), name)

--- a/backend/internal/notification/declarative_resource.go
+++ b/backend/internal/notification/declarative_resource.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -66,7 +67,7 @@ func (e *NotificationSenderExporter) GetParameterizerType() string {
 }
 
 // GetAllResourceIDs retrieves all notification sender IDs.
-func (e *NotificationSenderExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *NotificationSenderExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	senders, err := e.service.ListSenders()
 	if err != nil {
 		return nil, err
@@ -79,7 +80,9 @@ func (e *NotificationSenderExporter) GetAllResourceIDs() ([]string, *serviceerro
 }
 
 // GetResourceByID retrieves a notification sender by its ID.
-func (e *NotificationSenderExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *NotificationSenderExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
 	sender, err := e.service.GetSender(id)
 	if err != nil {
 		return nil, "", err

--- a/backend/internal/notification/declarative_resource_test.go
+++ b/backend/internal/notification/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package notification_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,7 +72,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetAllResourceIDs_Success() {
 
 	s.mockService.EXPECT().ListSenders().Return(expectedSenders, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 2)
@@ -87,7 +88,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetAllResourceIDs_Error() {
 
 	s.mockService.EXPECT().ListSenders().Return(nil, expectedError)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), ids)
 	assert.Equal(s.T(), expectedError, err)
@@ -98,7 +99,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetAllResourceIDs_EmptyList() 
 
 	s.mockService.EXPECT().ListSenders().Return(expectedSenders, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 0)
@@ -112,7 +113,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetResourceByID_Success() {
 
 	s.mockService.EXPECT().GetSender("sender1").Return(expectedSender, nil)
 
-	resource, name, err := s.exporter.GetResourceByID("sender1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "sender1")
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test Sender", name)
@@ -127,7 +128,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetResourceByID_Error() {
 
 	s.mockService.EXPECT().GetSender("sender1").Return(nil, expectedError)
 
-	resource, name, err := s.exporter.GetResourceByID("sender1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "sender1")
 
 	assert.Nil(s.T(), resource)
 	assert.Empty(s.T(), name)

--- a/backend/internal/ou/declarative_resource.go
+++ b/backend/internal/ou/declarative_resource.go
@@ -19,6 +19,7 @@
 package ou
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -66,7 +67,7 @@ func (e *OUExporter) GetParameterizerType() string {
 // GetAllResourceIDs retrieves all organization unit IDs from the database store.
 // Note: This only exports DB-backed OUs (runtime OUs). YAML-based declarative resources
 // are not included in the export as they are already defined in YAML files.
-func (e *OUExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *OUExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	// Get all OUs by requesting a large limit from the service
 	// In composite mode, this returns OUs from both file-based and database stores
 	ous, err := e.service.GetOrganizationUnitList(serverconst.MaxPageSize, 0)
@@ -129,7 +130,7 @@ func (e *OUExporter) getAllChildIDs(parentID string) ([]string, *serviceerror.Se
 }
 
 // GetResourceByID retrieves an organization unit by its ID.
-func (e *OUExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *OUExporter) GetResourceByID(ctx context.Context, id string) (interface{}, string, *serviceerror.ServiceError) {
 	ou, err := e.service.GetOrganizationUnit(id)
 	if err != nil {
 		return nil, "", err

--- a/backend/internal/ou/declarative_resource_test.go
+++ b/backend/internal/ou/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package ou
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -64,7 +65,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByID() {
 
 	s.mockService.EXPECT().GetOrganizationUnit("test-ou-1").Return(ou, (*serviceerror.ServiceError)(nil))
 
-	resource, name, err := s.exporter.GetResourceByID("test-ou-1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "test-ou-1")
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test OU", name)
 	assert.NotNil(s.T(), resource)
@@ -267,7 +268,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_NoOUs() {
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Empty(s.T(), ids)
 }
@@ -302,7 +303,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_RootOUsOnly() {
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 2)
 	assert.Contains(s.T(), ids, "root-1")
@@ -351,7 +352,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_WithChildren() {
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 3)
 	assert.Contains(s.T(), ids, "root-1")
@@ -410,7 +411,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithCh
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 4)
 	assert.Contains(s.T(), ids, "root-1")
@@ -426,7 +427,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_ErrorGettingList() 
 		&serviceerror.InternalServerError,
 	)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), ids)
 	assert.Equal(s.T(), serviceerror.InternalServerError.Code, err.Code)
@@ -452,7 +453,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_ErrorGettingChildre
 		&serviceerror.InternalServerError,
 	)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), ids)
 }
@@ -500,7 +501,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_DeepNesting() {
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 5)
 	for i := 1; i <= 5; i++ {
@@ -560,7 +561,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPer
 		OrganizationUnits: []OrganizationUnitBasic{},
 	}, (*serviceerror.ServiceError)(nil))
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 4)
 	assert.Contains(s.T(), ids, "root-1")

--- a/backend/internal/system/declarative_resource/exporter.go
+++ b/backend/internal/system/declarative_resource/exporter.go
@@ -19,6 +19,8 @@
 package declarativeresource
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
@@ -40,11 +42,11 @@ type ResourceExporter interface {
 	GetParameterizerType() string
 
 	// GetAllResourceIDs retrieves all resource IDs for wildcard export
-	GetAllResourceIDs() ([]string, *serviceerror.ServiceError)
+	GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError)
 
 	// GetResourceByID retrieves a single resource by its ID
 	// Returns: resource object, resource name, error
-	GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError)
+	GetResourceByID(ctx context.Context, id string) (interface{}, string, *serviceerror.ServiceError)
 
 	// ValidateResource validates the resource and extracts its name
 	// Returns: resource name, export error

--- a/backend/internal/system/export/handler.go
+++ b/backend/internal/system/export/handler.go
@@ -58,7 +58,7 @@ func (eh *exportHandler) HandleExportRequest(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Export resources using the export service
-	exportResponse, svcErr := eh.service.ExportResources(exportRequest)
+	exportResponse, svcErr := eh.service.ExportResources(r.Context(), exportRequest)
 	if svcErr != nil {
 		eh.handleError(w, svcErr)
 		return
@@ -98,7 +98,7 @@ func (eh *exportHandler) HandleExportJSONRequest(w http.ResponseWriter, r *http.
 	}
 
 	// Export resources using the export service
-	exportResponse, svcErr := eh.service.ExportResources(exportRequest)
+	exportResponse, svcErr := eh.service.ExportResources(r.Context(), exportRequest)
 	if svcErr != nil {
 		eh.handleError(w, svcErr)
 		return
@@ -124,7 +124,7 @@ func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.R
 	}
 
 	// Export resources using the export service
-	exportResponse, svcErr := eh.service.ExportResources(exportRequest)
+	exportResponse, svcErr := eh.service.ExportResources(r.Context(), exportRequest)
 	if svcErr != nil {
 		eh.handleError(w, svcErr)
 		return

--- a/backend/internal/system/export/registry_test.go
+++ b/backend/internal/system/export/registry_test.go
@@ -19,6 +19,7 @@
 package export
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -118,12 +119,12 @@ func (m *mockResourceExporter) GetParameterizerType() string {
 	return m.paramType
 }
 
-func (m *mockResourceExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (m *mockResourceExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	return m.getAllIDs, m.getAllErr
 }
 
 func (m *mockResourceExporter) GetResourceByID(
-	id string,
+	ctx context.Context, id string,
 ) (interface{}, string, *serviceerror.ServiceError) {
 	return m.resourceByID, m.resourceNameByID, m.getByIDErr
 }

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -19,6 +19,7 @@
 package export
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -122,7 +123,7 @@ func TestExportServiceTestSuite(t *testing.T) {
 
 // TestExportResources_NilRequest tests ExportResources with nil request.
 func (suite *ExportServiceTestSuite) TestExportResources_NilRequest() {
-	result, err := suite.exportService.ExportResources(nil)
+	result, err := suite.exportService.ExportResources(context.Background(), nil)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -134,7 +135,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_NilRequest() {
 func (suite *ExportServiceTestSuite) TestExportResources_EmptyRequest() {
 	request := &ExportRequest{}
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -157,7 +158,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_DefaultOptions() {
 
 	suite.appServiceMock.EXPECT().GetApplication(appID).Return(mockApp, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -183,7 +184,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_ApplicationNotFound() {
 
 	suite.appServiceMock.EXPECT().GetApplication(appID).Return(nil, appError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -246,7 +247,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplicatio
 
 	suite.appServiceMock.EXPECT().GetApplication(appID).Return(mockApp, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -289,7 +290,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_MultipleApplications() 
 	suite.appServiceMock.EXPECT().GetApplication(testApp1ID).Return(mockApp1, nil)
 	suite.appServiceMock.EXPECT().GetApplication(testApp2ID).Return(mockApp2, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -322,7 +323,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_PartialFailure() {
 	suite.appServiceMock.EXPECT().GetApplication(app1ID).Return(mockApp1, nil)
 	suite.appServiceMock.EXPECT().GetApplication(app2ID).Return(nil, appError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -376,7 +377,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications() 
 	suite.appServiceMock.EXPECT().GetApplication(testApp2ID).Return(mockApp2, nil)
 	suite.appServiceMock.EXPECT().GetApplication(testApp3ID).Return(mockApp3, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -402,7 +403,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications_Li
 
 	suite.appServiceMock.EXPECT().GetApplicationList().Return(nil, listError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -427,7 +428,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications_Em
 
 	suite.appServiceMock.EXPECT().GetApplicationList().Return(mockAppList, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -476,7 +477,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_WildcardApplications_Pa
 	suite.appServiceMock.EXPECT().GetApplication(testApp2ID).Return(nil, appError)
 	suite.appServiceMock.EXPECT().GetApplication(testApp3ID).Return(mockApp3, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -509,7 +510,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Succes
 
 	suite.idpServiceMock.EXPECT().GetIdentityProvider(idpID).Return(mockIDP, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -547,7 +548,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Multip
 		IdentityProviders: []string{"idp1", "idp2"},
 		Options:           &ExportOptions{Format: "yaml"},
 	}
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	suite.assertMultipleResourcesExport(result, err, 2, "identity_provider")
 }
@@ -586,7 +587,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Wildca
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp1").Return(mockIDP1, nil)
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp2").Return(mockIDP2, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -621,7 +622,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_Mixed_ApplicationsAndID
 	suite.appServiceMock.EXPECT().GetApplication(testAppID).Return(mockApp, nil)
 	suite.idpServiceMock.EXPECT().GetIdentityProvider(testIDPID).Return(mockIDP, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -649,7 +650,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_NotFou
 
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("non-existent-idp").Return(nil, idpError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Should return error since no valid resources found
 	assert.NotNil(suite.T(), err)
@@ -698,7 +699,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Wildca
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp2").Return(nil, idpError)
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp3").Return(mockIDP3, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -729,7 +730,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_NoProp
 
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp-no-props").Return(mockIDP, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Should succeed even with no properties
 	assert.Nil(suite.T(), err)
@@ -758,7 +759,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_EmptyN
 
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp-no-name").Return(mockIDP, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Should return error since name is required
 	assert.NotNil(suite.T(), err)
@@ -796,7 +797,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 
 	suite.idpServiceMock.EXPECT().GetIdentityProvider(idpID).Return(mockIDP, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -855,7 +856,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 
 	suite.idpServiceMock.EXPECT().GetIdentityProvider(idpID).Return(mockIDP, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -915,7 +916,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_PartialFailure_Detailed
 	suite.appServiceMock.EXPECT().GetApplication(app1ID).Return(mockApp1, nil)
 	suite.appServiceMock.EXPECT().GetApplication(app2ID).Return(nil, appError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Verify successful export
 	assert.Nil(suite.T(), err)
@@ -970,7 +971,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Partia
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp2-not-found").Return(nil, idpError)
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp3").Return(mockIDP3, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Verify partial success
 	assert.Nil(suite.T(), err)
@@ -1035,7 +1036,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_MixedResources_WithErro
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp1").Return(mockIDP1, nil)
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp2-not-found").Return(nil, idpError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Verify partial success
 	assert.Nil(suite.T(), err)
@@ -1093,7 +1094,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_FileSizeCalculation() {
 	suite.appServiceMock.EXPECT().GetApplication(testApp1ID).Return(mockApp1, nil)
 	suite.appServiceMock.EXPECT().GetApplication(testApp2ID).Return(mockApp2, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1167,7 +1168,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_TemplateGenerationError
 	// Create a new export service with the mock parameterizer
 	exportServiceWithMock := newExportService(exporters, mockParameterizer)
 
-	result, err := exportServiceWithMock.ExportResources(request)
+	result, err := exportServiceWithMock.ExportResources(context.Background(), request)
 
 	// When all resources fail template generation, service returns error
 	assert.NotNil(suite.T(), err)
@@ -1198,7 +1199,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_WithCustomFolderStructu
 
 	suite.appServiceMock.EXPECT().GetApplication(testApp1ID).Return(mockApp, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1243,7 +1244,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_WithGroupByTypeStructur
 	suite.appServiceMock.EXPECT().GetApplication(testApp2ID).Return(mockApp2, nil)
 	suite.idpServiceMock.EXPECT().GetIdentityProvider("idp1").Return(mockIDP, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1286,7 +1287,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Success() {
 
 	suite.mockNotificationService.EXPECT().GetSender("sender1").Return(mockSender, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1324,7 +1325,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Multiple() {
 		NotificationSenders: []string{"sender1", "sender2"},
 		Options:             &ExportOptions{Format: "yaml"},
 	}
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	suite.assertMultipleResourcesExport(result, err, 2, "notification_sender")
 }
@@ -1360,7 +1361,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Wildcard() {
 	suite.mockNotificationService.EXPECT().GetSender("sender1").Return(mockSender1, nil)
 	suite.mockNotificationService.EXPECT().GetSender("sender2").Return(mockSender2, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1384,7 +1385,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_NotFound() {
 
 	suite.mockNotificationService.EXPECT().GetSender("non-existent-sender").Return(nil, senderError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1410,7 +1411,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_EmptyName() {
 
 	suite.mockNotificationService.EXPECT().GetSender("sender-no-name").Return(mockSender, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1435,7 +1436,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_NoProperties(
 
 	suite.mockNotificationService.EXPECT().GetSender("sender-no-props").Return(mockSender, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Should succeed even with no properties
 	assert.Nil(suite.T(), err)
@@ -1477,7 +1478,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_WildcardParti
 	suite.mockNotificationService.EXPECT().GetSender("sender1").Return(mockSender1, nil)
 	suite.mockNotificationService.EXPECT().GetSender("sender3").Return(mockSender3, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1505,7 +1506,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_Success() {
 
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(mockSchema, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1545,7 +1546,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_Multiple() {
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(mockSchema1, nil)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema2").Return(mockSchema2, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1592,7 +1593,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_Wildcard() {
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(mockSchema1, nil)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema2").Return(mockSchema2, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1616,7 +1617,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_NotFound() {
 
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "non-existent-schema").Return(nil, schemaError)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1642,7 +1643,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_EmptyName() {
 
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema-no-name").Return(mockSchema, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1668,7 +1669,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_NoSchema() {
 
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema-no-def").Return(mockSchema, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	// Should succeed even with no schema definition
 	assert.Nil(suite.T(), err)
@@ -1723,7 +1724,7 @@ func (suite *ExportServiceTestSuite) TestExportUserSchemas_WildcardPartialFailur
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema2").Return(nil, schemaError)
 	suite.mockUserSchemaService.EXPECT().GetUserSchema(mock.Anything, "schema3").Return(mockSchema3, nil)
 
-	result, err := suite.exportService.ExportResources(request)
+	result, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1768,7 +1769,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Success() {
 		Format: formatYAML,
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -1810,7 +1811,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleRes
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{app1ID, app2ID, app3ID}, options)
 
 	assert.Len(suite.T(), files, 3)
@@ -1833,7 +1834,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_ResourceNot
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -1866,7 +1867,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_PartialSucc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{validAppID, invalidAppID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -1906,7 +1907,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardSuc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 2)
@@ -1927,7 +1928,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFai
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -1947,7 +1948,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardEmp
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -1973,7 +1974,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithGroupBy
 		},
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2000,7 +2001,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithCustomF
 		},
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2024,7 +2025,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_IdentityPro
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{idpID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2052,7 +2053,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{senderID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2080,7 +2081,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_UserSchema(
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{schemaID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2095,7 +2096,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EmptyResour
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -2118,7 +2119,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_JSONFormatF
 		Format: formatJSON, // JSON not yet implemented
 	}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{appID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2163,7 +2164,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Flow() {
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{flowID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2257,7 +2258,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowWithCom
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{flowID}, options)
 
 	assert.Len(suite.T(), files, 1)
@@ -2302,7 +2303,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{testFlow1ID, testFlow2ID}, options)
 
 	assert.Len(suite.T(), files, 2)
@@ -2323,7 +2324,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowNotFoun
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{flowID}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -2388,7 +2389,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 2)
@@ -2406,7 +2407,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(
+	files, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
 		exporter, []string{"*"}, options)
 
 	assert.Len(suite.T(), files, 0)
@@ -2439,7 +2440,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_FlowOnly() {
 		},
 	}
 
-	response, err := suite.exportService.ExportResources(request)
+	response, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), response)
@@ -2484,7 +2485,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_MixedWithFlows() {
 		},
 	}
 
-	response, err := suite.exportService.ExportResources(request)
+	response, err := suite.exportService.ExportResources(context.Background(), request)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), response)

--- a/backend/internal/system/i18n/mgt/declarative_resource.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource.go
@@ -19,6 +19,7 @@
 package mgt
 
 import (
+	"context"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -55,7 +56,7 @@ func (e *TranslationExporter) GetParameterizerType() string {
 
 // GetAllResourceIDs retrieves all languages from the database store.
 // One file per language.
-func (e *TranslationExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
+func (e *TranslationExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	// Get all translations from store
 	languages, err := e.store.GetDistinctLanguages()
 	if err != nil {
@@ -69,7 +70,9 @@ func (e *TranslationExporter) GetAllResourceIDs() ([]string, *serviceerror.Servi
 }
 
 // GetResourceByID retrieves all translations for a specific language.
-func (e *TranslationExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *TranslationExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
 	translations, err := e.store.GetTranslations()
 	if err != nil {
 		return nil, "", &serviceerror.ServiceError{

--- a/backend/internal/system/i18n/mgt/declarative_resource_test.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package mgt
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -79,7 +80,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByID() {
 
 	s.mockStore.On("GetTranslations").Return(translations, nil)
 
-	resource, name, err := s.exporter.GetResourceByID("en-US")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "en-US")
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "en-US", name)
 	assert.NotNil(s.T(), resource)
@@ -94,7 +95,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByID() {
 func (s *DeclarativeResourceTestSuite) TestGetResourceByID_NotFound() {
 	s.mockStore.On("GetTranslations").Return(map[string]map[string]Translation{}, nil)
 
-	_, _, err := s.exporter.GetResourceByID("fr-FR")
+	_, _, err := s.exporter.GetResourceByID(context.Background(), "fr-FR")
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "TRANSLATION_NOT_FOUND", err.Code)
 }
@@ -102,7 +103,7 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceByID_NotFound() {
 func (s *DeclarativeResourceTestSuite) TestGetResourceByID_StoreError() {
 	s.mockStore.On("GetTranslations").Return(nil, errors.New("db error"))
 
-	_, _, err := s.exporter.GetResourceByID("en-US")
+	_, _, err := s.exporter.GetResourceByID(context.Background(), "en-US")
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "I18N_FETCH_ERROR", err.Code)
 }
@@ -157,7 +158,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs() {
 	languages := []string{"en-US", "fr-FR"}
 	s.mockStore.On("GetDistinctLanguages").Return(languages, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 2)
 	assert.Contains(s.T(), ids, "en-US")
@@ -167,7 +168,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs() {
 func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_StoreError() {
 	s.mockStore.On("GetDistinctLanguages").Return(nil, errors.New("db error"))
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), ids)
 	assert.Equal(s.T(), "I18N_EXPORT_ERROR", err.Code)

--- a/backend/internal/userschema/declarative_resource.go
+++ b/backend/internal/userschema/declarative_resource.go
@@ -64,8 +64,8 @@ func (e *UserSchemaExporter) GetParameterizerType() string {
 }
 
 // GetAllResourceIDs retrieves all user schema IDs.
-func (e *UserSchemaExporter) GetAllResourceIDs() ([]string, *serviceerror.ServiceError) {
-	response, err := e.service.GetUserSchemaList(context.TODO(), serverconst.MaxPageSize, 0)
+func (e *UserSchemaExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+	response, err := e.service.GetUserSchemaList(ctx, serverconst.MaxPageSize, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +77,10 @@ func (e *UserSchemaExporter) GetAllResourceIDs() ([]string, *serviceerror.Servic
 }
 
 // GetResourceByID retrieves a user schema by its ID.
-func (e *UserSchemaExporter) GetResourceByID(id string) (interface{}, string, *serviceerror.ServiceError) {
-	schema, err := e.service.GetUserSchema(context.TODO(), id)
+func (e *UserSchemaExporter) GetResourceByID(ctx context.Context, id string) (
+	interface{}, string, *serviceerror.ServiceError,
+) {
+	schema, err := e.service.GetUserSchema(ctx, id)
 	if err != nil {
 		return nil, "", err
 	}

--- a/backend/internal/userschema/declarative_resource_test.go
+++ b/backend/internal/userschema/declarative_resource_test.go
@@ -19,6 +19,7 @@
 package userschema_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -73,7 +74,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_Success() {
 
 	s.mockService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(expectedResponse, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 2)
@@ -89,7 +90,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_Error() {
 
 	s.mockService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(nil, expectedError)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), ids)
 	assert.Equal(s.T(), expectedError, err)
@@ -102,7 +103,7 @@ func (s *UserSchemaExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
 
 	s.mockService.EXPECT().GetUserSchemaList(mock.Anything, 100, 0).Return(expectedResponse, nil)
 
-	ids, err := s.exporter.GetAllResourceIDs()
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
 	assert.Nil(s.T(), err)
 	assert.Len(s.T(), ids, 0)
@@ -116,7 +117,7 @@ func (s *UserSchemaExporterTestSuite) TestGetResourceByID_Success() {
 
 	s.mockService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(expectedSchema, nil)
 
-	resource, name, err := s.exporter.GetResourceByID("schema1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "schema1")
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test Schema", name)
@@ -131,7 +132,7 @@ func (s *UserSchemaExporterTestSuite) TestGetResourceByID_Error() {
 
 	s.mockService.EXPECT().GetUserSchema(mock.Anything, "schema1").Return(nil, expectedError)
 
-	resource, name, err := s.exporter.GetResourceByID("schema1")
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "schema1")
 
 	assert.Nil(s.T(), resource)
 	assert.Empty(s.T(), name)


### PR DESCRIPTION
### Purpose
This pull request updates the resource exporter interfaces in the application, layout, theme, and flow modules to accept a `context.Context` parameter for improved context propagation and cancellation support. Corresponding test files have also been updated to use the new method signatures.

Interface changes for context propagation:

* Updated the `GetAllResourceIDs` and `GetResourceByID` methods in `ApplicationExporter`, `layoutExporter`, `themeExporter`, and `FlowGraphExporter` to accept a `context.Context` parameter. This change allows for better handling of request context and cancellation throughout the resource management code. [[1]](diffhunk://#diff-1955a9101a83b05b0cac13128df7592dc70733113a9bc9254a853a85b9a1b1b5L68-R69) [[2]](diffhunk://#diff-1955a9101a83b05b0cac13128df7592dc70733113a9bc9254a853a85b9a1b1b5L84-R87) [[3]](diffhunk://#diff-f9719ecea8746be2a4893704fe5fd20afb57122d999063428a28749458ee4a0fL59-R60) [[4]](diffhunk://#diff-f9719ecea8746be2a4893704fe5fd20afb57122d999063428a28749458ee4a0fL72-R75) [[5]](diffhunk://#diff-92e5cf33135b546c44829721bcdc87dacf4ccc32fd29724ed2b7c121a64ed4a1L59-R60) [[6]](diffhunk://#diff-92e5cf33135b546c44829721bcdc87dacf4ccc32fd29724ed2b7c121a64ed4a1L72-R75) [[7]](diffhunk://#diff-6118e7897cfd65d1c17cafa0d5dda5ca801e64d7c07e9e880be5e60198d35bcbL63-R64) [[8]](diffhunk://#diff-6118e7897cfd65d1c17cafa0d5dda5ca801e64d7c07e9e880be5e60198d35bcbL76-R79)

Test updates for new method signatures:

* Modified all relevant test cases in `declarative_resource_test.go` files for application, layout, theme, and flow modules to pass `context.Background()` to the updated methods, ensuring compatibility and correctness of tests with the new interface. [[1]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cL75-R76) [[2]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cL91-R92) [[3]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cL104-R105) [[4]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cL118-R119) [[5]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cL133-R134) [[6]](diffhunk://#diff-5cc241da86a17213226c5c24ccb71179f7db2a9db0058889a0fb62b98326f860L108-R109) [[7]](diffhunk://#diff-5cc241da86a17213226c5c24ccb71179f7db2a9db0058889a0fb62b98326f860L126-R127) [[8]](diffhunk://#diff-5cc241da86a17213226c5c24ccb71179f7db2a9db0058889a0fb62b98326f860L141-R142) [[9]](diffhunk://#diff-5cc241da86a17213226c5c24ccb71179f7db2a9db0058889a0fb62b98326f860L163-R164) [[10]](diffhunk://#diff-5cc241da86a17213226c5c24ccb71179f7db2a9db0058889a0fb62b98326f860L184-R185) [[11]](diffhunk://#diff-cd293b090ff1ab8c05738fe7563f79866c23d3f45a335e5265d3fc15be898a27L108-R109) [[12]](diffhunk://#diff-cd293b090ff1ab8c05738fe7563f79866c23d3f45a335e5265d3fc15be898a27L126-R127) [[13]](diffhunk://#diff-cd293b090ff1ab8c05738fe7563f79866c23d3f45a335e5265d3fc15be898a27L141-R142) [[14]](diffhunk://#diff-cd293b090ff1ab8c05738fe7563f79866c23d3f45a335e5265d3fc15be898a27L163-R164) [[15]](diffhunk://#diff-cd293b090ff1ab8c05738fe7563f79866c23d3f45a335e5265d3fc15be898a27L184-R185) [[16]](diffhunk://#diff-b8e79598a43476a7787f559ae629a0b1de9c72e903d800bf624389d370396f7fL188-R189) [[17]](diffhunk://#diff-b8e79598a43476a7787f559ae629a0b1de9c72e903d800bf624389d370396f7fL208-R209) [[18]](diffhunk://#diff-b8e79598a43476a7787f559ae629a0b1de9c72e903d800bf624389d370396f7fL226-R227) [[19]](diffhunk://#diff-b8e79598a43476a7787f559ae629a0b1de9c72e903d800bf624389d370396f7fL244-R245) [[20]](diffhunk://#diff-b8e79598a43476a7787f559ae629a0b1de9c72e903d800bf624389d370396f7fL263-R264)

Dependency imports:

* Added `context` package imports to all affected resource and test files to support the new parameter. [[1]](diffhunk://#diff-1955a9101a83b05b0cac13128df7592dc70733113a9bc9254a853a85b9a1b1b5R22) [[2]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cR22) [[3]](diffhunk://#diff-f9719ecea8746be2a4893704fe5fd20afb57122d999063428a28749458ee4a0fR22) [[4]](diffhunk://#diff-5cc241da86a17213226c5c24ccb71179f7db2a9db0058889a0fb62b98326f860R22) [[5]](diffhunk://#diff-92e5cf33135b546c44829721bcdc87dacf4ccc32fd29724ed2b7c121a64ed4a1R22) [[6]](diffhunk://#diff-cd293b090ff1ab8c05738fe7563f79866c23d3f45a335e5265d3fc15be898a27R22) [[7]](diffhunk://#diff-6118e7897cfd65d1c17cafa0d5dda5ca801e64d7c07e9e880be5e60198d35bcbR22) [[8]](diffhunk://#diff-b8e79598a43476a7787f559ae629a0b1de9c72e903d800bf624389d370396f7fR22)


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Export flow and exporters now propagate request context so export operations respect cancellation and timeouts; handlers and service calls thread request lifecycle through the export path.
  * Tests updated to exercise context-aware exports to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->