### PR TITLE
Add meta for default-basic-passkey-flow

### DIFF
--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic_passkey.json
@@ -11,6 +11,62 @@
     {
       "id": "choose_auth_method",
       "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "type": "TEXT",
+            "id": "text_001",
+            "label": "Sign In",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_basic",
+            "components": [
+              {
+                "id": "input_username",
+                "ref": "username",
+                "type": "TEXT_INPUT",
+                "label": "Username",
+                "required": true,
+                "placeholder": "Enter your username"
+              },
+              {
+                "id": "input_password",
+                "ref": "password",
+                "type": "PASSWORD_INPUT",
+                "label": "Password",
+                "required": true,
+                "placeholder": "Enter your password"
+              },
+              {
+                "type": "ACTION",
+                "id": "action_basic",
+                "label": "Sign In",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          },
+          {
+            "type": "DIVIDER",
+            "id": "divider_001"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_passkey",
+            "components": [
+              {
+                "type": "ACTION",
+                "id": "action_passkey",
+                "label": "Sign in with Passkey",
+                "variant": "SECONDARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
       "prompts": [
         {
           "inputs": [
@@ -43,6 +99,37 @@
     {
       "id": "prompt_passkey_identifier",
       "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "type": "TEXT",
+            "id": "text_002",
+            "label": "Sign in with Passkey",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_identifier",
+            "components": [
+              {
+                "id": "passkey_username",
+                "ref": "username",
+                "type": "TEXT_INPUT",
+                "label": "Username",
+                "required": true,
+                "placeholder": "Enter your username"
+              },
+              {
+                "type": "ACTION",
+                "id": "action_continue",
+                "label": "Continue",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
       "prompts": [
         {
           "inputs": [
@@ -94,6 +181,43 @@
     {
       "id": "prompt_password_for_registration",
       "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "type": "TEXT",
+            "id": "text_004",
+            "label": "Register Passkey",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "TEXT",
+            "id": "text_005",
+            "label": "No passkey found for your account. Enter your password to register a new passkey.",
+            "variant": "BODY"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_password_reg",
+            "components": [
+              {
+                "id": "reg_password",
+                "ref": "password",
+                "type": "PASSWORD_INPUT",
+                "label": "Password",
+                "required": true,
+                "placeholder": "Enter your password"
+              },
+              {
+                "type": "ACTION",
+                "id": "action_verify_password",
+                "label": "Register Passkey",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
       "prompts": [
         {
           "inputs": [


### PR DESCRIPTION
### Purpose
Fixes the bug where thunder gate keeps loading because of missing meta in the default flow.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual organization and layout of authentication screens with structured components for clearer hierarchy.
  * Enhanced login method selection by adding distinct sections for credentials, a divider, and a clear "Sign in with Passkey" action.
  * Updated password + passkey registration prompts with clearer headings, explanatory text, focused input fields, and dedicated action buttons for better guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->