### PR TITLE
Notification service context propagation and transection usage

### DIFF
--- a/backend/internal/authn/AuthenticationServiceInterface_mock_test.go
+++ b/backend/internal/authn/AuthenticationServiceInterface_mock_test.go
@@ -5,6 +5,8 @@
 package authn
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/idp"
 	common0 "github.com/asgardeo/thunder/internal/notification/common"
@@ -380,8 +382,8 @@ func (_c *AuthenticationServiceInterfaceMock_FinishPasskeyRegistration_Call) Run
 }
 
 // SendOTP provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) SendOTP(senderID string, channel common0.ChannelType, recipient string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(senderID, channel, recipient)
+func (_mock *AuthenticationServiceInterfaceMock) SendOTP(ctx context.Context, senderID string, channel common0.ChannelType, recipient string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, senderID, channel, recipient)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendOTP")
@@ -389,16 +391,16 @@ func (_mock *AuthenticationServiceInterfaceMock) SendOTP(senderID string, channe
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, common0.ChannelType, string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common0.ChannelType, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, senderID, channel, recipient)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, common0.ChannelType, string) string); ok {
-		r0 = returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common0.ChannelType, string) string); ok {
+		r0 = returnFunc(ctx, senderID, channel, recipient)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, common0.ChannelType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common0.ChannelType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, senderID, channel, recipient)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -413,31 +415,37 @@ type AuthenticationServiceInterfaceMock_SendOTP_Call struct {
 }
 
 // SendOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - senderID string
 //   - channel common0.ChannelType
 //   - recipient string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) SendOTP(senderID interface{}, channel interface{}, recipient interface{}) *AuthenticationServiceInterfaceMock_SendOTP_Call {
-	return &AuthenticationServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", senderID, channel, recipient)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) SendOTP(ctx interface{}, senderID interface{}, channel interface{}, recipient interface{}) *AuthenticationServiceInterfaceMock_SendOTP_Call {
+	return &AuthenticationServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", ctx, senderID, channel, recipient)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) Run(run func(senderID string, channel common0.ChannelType, recipient string)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) Run(run func(ctx context.Context, senderID string, channel common0.ChannelType, recipient string)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 common0.ChannelType
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(common0.ChannelType)
+			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common0.ChannelType
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common0.ChannelType)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -448,7 +456,7 @@ func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) Return(s string, serv
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(senderID string, channel common0.ChannelType, recipient string) (string, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(context.Context, string, common0.ChannelType, string) (string, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -682,8 +690,8 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) RunA
 }
 
 // VerifyOTP provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) VerifyOTP(sessionToken string, skipAssertion bool, existingAssertion string, otp string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(sessionToken, skipAssertion, existingAssertion, otp)
+func (_mock *AuthenticationServiceInterfaceMock) VerifyOTP(ctx context.Context, sessionToken string, skipAssertion bool, existingAssertion string, otp string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyOTP")
@@ -691,18 +699,18 @@ func (_mock *AuthenticationServiceInterfaceMock) VerifyOTP(sessionToken string, 
 
 	var r0 *common.AuthenticationResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(sessionToken, skipAssertion, existingAssertion, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, bool, string, string) *common.AuthenticationResponse); ok {
-		r0 = returnFunc(sessionToken, skipAssertion, existingAssertion, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool, string, string) *common.AuthenticationResponse); ok {
+		r0 = returnFunc(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthenticationResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, bool, string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(sessionToken, skipAssertion, existingAssertion, otp)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, bool, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -717,37 +725,43 @@ type AuthenticationServiceInterfaceMock_VerifyOTP_Call struct {
 }
 
 // VerifyOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sessionToken string
 //   - skipAssertion bool
 //   - existingAssertion string
 //   - otp string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) VerifyOTP(sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, otp interface{}) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
-	return &AuthenticationServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", sessionToken, skipAssertion, existingAssertion, otp)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, otp interface{}) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
+	return &AuthenticationServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, sessionToken, skipAssertion, existingAssertion, otp)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) Run(run func(sessionToken string, skipAssertion bool, existingAssertion string, otp string)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, sessionToken string, skipAssertion bool, existingAssertion string, otp string)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 bool
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(bool)
+			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 bool
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(bool)
 		}
 		var arg3 string
 		if args[3] != nil {
 			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -758,7 +772,7 @@ func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) Return(authenticati
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(sessionToken string, skipAssertion bool, existingAssertion string, otp string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(context.Context, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -75,13 +75,14 @@ func (ah *authenticationHandler) HandleCredentialsAuthRequest(w http.ResponseWri
 
 // HandleSendSMSOTPRequest handles the send SMS OTP authentication request.
 func (ah *authenticationHandler) HandleSendSMSOTPRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	otpRequest, err := sysutils.DecodeJSONBody[SendOTPAuthRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	sessionToken, svcErr := ah.authService.SendOTP(otpRequest.SenderID, notifcommon.ChannelTypeSMS,
+	sessionToken, svcErr := ah.authService.SendOTP(ctx, otpRequest.SenderID, notifcommon.ChannelTypeSMS,
 		otpRequest.Recipient)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
@@ -97,13 +98,14 @@ func (ah *authenticationHandler) HandleSendSMSOTPRequest(w http.ResponseWriter, 
 
 // HandleVerifySMSOTPRequest handles the verify SMS OTP authentication request.
 func (ah *authenticationHandler) HandleVerifySMSOTPRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	otpRequest, err := sysutils.DecodeJSONBody[VerifyOTPAuthRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	authResponse, svcErr := ah.authService.VerifyOTP(otpRequest.SessionToken, otpRequest.SkipAssertion,
+	authResponse, svcErr := ah.authService.VerifyOTP(ctx, otpRequest.SessionToken, otpRequest.SkipAssertion,
 		otpRequest.Assertion, otpRequest.OTP)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)

--- a/backend/internal/authn/handler_test.go
+++ b/backend/internal/authn/handler_test.go
@@ -318,7 +318,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleSendSMSOTPRequestSuccess(
 	}
 	sessionToken := testSessionTkn
 
-	suite.mockService.On("SendOTP", otpRequest.SenderID, mock.Anything, otpRequest.Recipient).
+	suite.mockService.On("SendOTP", mock.Anything, otpRequest.SenderID, mock.Anything, otpRequest.Recipient).
 		Return(sessionToken, nil)
 
 	body, _ := json.Marshal(otpRequest)
@@ -360,7 +360,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleSendSMSOTPRequestServiceE
 		ErrorDescription: "Failed to send OTP",
 	}
 
-	suite.mockService.On("SendOTP", mock.Anything, mock.Anything, mock.Anything).Return("", serviceError)
+	suite.mockService.On("SendOTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", serviceError)
 
 	body, _ := json.Marshal(otpRequest)
 	req := httptest.NewRequest(http.MethodPost, "/authenticate/otp/send", bytes.NewReader(body))
@@ -388,7 +388,8 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleVerifySMSOTPRequestSucces
 		Assertion:        "jwt-token",
 	}
 
-	suite.mockService.On("VerifyOTP", otpRequest.SessionToken, otpRequest.SkipAssertion, "", otpRequest.OTP).
+	suite.mockService.On("VerifyOTP", mock.Anything, otpRequest.SessionToken,
+		otpRequest.SkipAssertion, "", otpRequest.OTP).
 		Return(authResponse, nil)
 
 	body, _ := json.Marshal(otpRequest)
@@ -426,7 +427,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleVerifySMSOTPRequestServic
 	}
 	serviceError := &otp.ErrorIncorrectOTP
 
-	suite.mockService.On("VerifyOTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	suite.mockService.On("VerifyOTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, serviceError)
 
 	body, _ := json.Marshal(otpRequest)

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -20,6 +20,7 @@
 package authn
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -54,9 +55,9 @@ var crossAllowedIDPTypes = []idp.IDPType{idp.IDPTypeOAuth, idp.IDPTypeOIDC}
 type AuthenticationServiceInterface interface {
 	AuthenticateWithCredentials(identifiers, credentials map[string]interface{},
 		skipAssertion bool, existingAssertion string) (*common.AuthenticationResponse, *serviceerror.ServiceError)
-	SendOTP(senderID string, channel notifcommon.ChannelType, recipient string) (
+	SendOTP(ctx context.Context, senderID string, channel notifcommon.ChannelType, recipient string) (
 		string, *serviceerror.ServiceError)
-	VerifyOTP(sessionToken string, skipAssertion bool, existingAssertion, otp string) (
+	VerifyOTP(ctx context.Context, sessionToken string, skipAssertion bool, existingAssertion, otp string) (
 		*common.AuthenticationResponse, *serviceerror.ServiceError)
 	StartIDPAuthentication(requestedType idp.IDPType, idpID string) (
 		*IDPAuthInitData, *serviceerror.ServiceError)
@@ -175,18 +176,18 @@ func (as *authenticationService) AuthenticateWithCredentials(identifiers, creden
 }
 
 // SendOTP sends an OTP to the specified recipient for authentication.
-func (as *authenticationService) SendOTP(senderID string, channel notifcommon.ChannelType,
+func (as *authenticationService) SendOTP(ctx context.Context, senderID string, channel notifcommon.ChannelType,
 	recipient string) (string, *serviceerror.ServiceError) {
-	return as.otpService.SendOTP(senderID, channel, recipient)
+	return as.otpService.SendOTP(ctx, senderID, channel, recipient)
 }
 
 // VerifyOTP verifies an OTP and returns the authenticated user.
-func (as *authenticationService) VerifyOTP(sessionToken string, skipAssertion bool,
+func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken string, skipAssertion bool,
 	existingAssertion, otpCode string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
 	logger.Debug("Verifying OTP for authentication")
 
-	user, svcErr := as.otpService.VerifyOTP(sessionToken, otpCode)
+	user, svcErr := as.otpService.VerifyOTP(ctx, sessionToken, otpCode)
 	if svcErr != nil {
 		return nil, svcErr
 	}

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -503,7 +504,7 @@ func (s *smsOTPAuthExecutor) generateAndSendOTP(mobileNumber string, ctx *core.N
 		Channel:   string(notifcommon.ChannelTypeSMS),
 	}
 
-	sendResult, svcErr := s.otpService.SendOTP(sendOTPRequest)
+	sendResult, svcErr := s.otpService.SendOTP(context.TODO(), sendOTPRequest)
 	if svcErr != nil {
 		return fmt.Errorf("failed to send OTP: %s", svcErr.ErrorDescription)
 	}
@@ -578,7 +579,7 @@ func (s *smsOTPAuthExecutor) validateOTP(ctx *core.NodeContext, execResp *common
 		OTPCode:      providedOTP,
 	}
 
-	verifyResult, svcErr := s.otpService.VerifyOTP(verifyOTPRequest)
+	verifyResult, svcErr := s.otpService.VerifyOTP(context.TODO(), verifyOTPRequest)
 	if svcErr != nil {
 		logger.Error("Failed to verify OTP", log.String("userID", userID), log.Any("serviceError", svcErr))
 		return fmt.Errorf("failed to verify OTP: %s", svcErr.ErrorDescription)

--- a/backend/internal/group/GroupServiceInterface_mock_test.go
+++ b/backend/internal/group/GroupServiceInterface_mock_test.go
@@ -629,82 +629,6 @@ func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(
 	return _c
 }
 
-// UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, groupID, request)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateGroup")
-	}
-
-	var r0 *Group
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateGroupRequest) (*Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, groupID, request)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateGroupRequest) *Group); ok {
-		r0 = returnFunc(ctx, groupID, request)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*Group)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, UpdateGroupRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, groupID, request)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// GroupServiceInterfaceMock_UpdateGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGroup'
-type GroupServiceInterfaceMock_UpdateGroup_Call struct {
-	*mock.Call
-}
-
-// UpdateGroup is a helper method to define mock.On call
-//   - ctx context.Context
-//   - groupID string
-//   - request UpdateGroupRequest
-func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(ctx interface{}, groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, groupID, request)}
-}
-
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, groupID string, request UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 UpdateGroupRequest
-		if args[2] != nil {
-			arg2 = args[2].(UpdateGroupRequest)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Return(group *Group, serviceError *serviceerror.ServiceError) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	_c.Call.Return(group, serviceError)
-	return _c
-}
-
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // RemoveGroupMembers provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) RemoveGroupMembers(ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, groupID, members)
@@ -777,6 +701,82 @@ func (_c *GroupServiceInterfaceMock_RemoveGroupMembers_Call) Return(group *Group
 }
 
 func (_c *GroupServiceInterfaceMock_RemoveGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_RemoveGroupMembers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID, request)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateGroup")
+	}
+
+	var r0 *Group
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateGroupRequest) (*Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID, request)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateGroupRequest) *Group); ok {
+		r0 = returnFunc(ctx, groupID, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Group)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, UpdateGroupRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID, request)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_UpdateGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGroup'
+type GroupServiceInterfaceMock_UpdateGroup_Call struct {
+	*mock.Call
+}
+
+// UpdateGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupID string
+//   - request UpdateGroupRequest
+func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(ctx interface{}, groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, groupID, request)}
+}
+
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, groupID string, request UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 UpdateGroupRequest
+		if args[2] != nil {
+			arg2 = args[2].(UpdateGroupRequest)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Return(group *Group, serviceError *serviceerror.ServiceError) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	_c.Call.Return(group, serviceError)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/notification/NotificationSenderMgtSvcInterface_mock_test.go
+++ b/backend/internal/notification/NotificationSenderMgtSvcInterface_mock_test.go
@@ -5,6 +5,8 @@
 package notification
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *NotificationSenderMgtSvcInterfaceMock) EXPECT() *NotificationSenderMgt
 }
 
 // CreateSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) CreateSender(sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(sender)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) CreateSender(ctx context.Context, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, sender)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateSender")
@@ -47,18 +49,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) CreateSender(sender common.N
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, sender)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, sender)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(sender)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, sender)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,19 +75,25 @@ type NotificationSenderMgtSvcInterfaceMock_CreateSender_Call struct {
 }
 
 // CreateSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sender common.NotificationSenderDTO
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) CreateSender(sender interface{}) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_CreateSender_Call{Call: _e.mock.On("CreateSender", sender)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) CreateSender(ctx interface{}, sender interface{}) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_CreateSender_Call{Call: _e.mock.On("CreateSender", ctx, sender)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) Run(run func(sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) Run(run func(ctx context.Context, sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.NotificationSenderDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.NotificationSenderDTO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 common.NotificationSenderDTO
+		if args[1] != nil {
+			arg1 = args[1].(common.NotificationSenderDTO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -96,22 +104,22 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) Return(notifi
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) RunAndReturn(run func(sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) RunAndReturn(run func(ctx context.Context, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) DeleteSender(id string) *serviceerror.ServiceError {
-	ret := _mock.Called(id)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) DeleteSender(ctx context.Context, id string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteSender")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -126,19 +134,25 @@ type NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call struct {
 }
 
 // DeleteSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) DeleteSender(id interface{}) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call{Call: _e.mock.On("DeleteSender", id)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) DeleteSender(ctx interface{}, id interface{}) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call{Call: _e.mock.On("DeleteSender", ctx, id)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) Run(run func(id string)) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) Run(run func(ctx context.Context, id string)) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -149,14 +163,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) Return(servic
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) RunAndReturn(run func(id string) *serviceerror.ServiceError) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) RunAndReturn(run func(ctx context.Context, id string) *serviceerror.ServiceError) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSender(id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(id)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSender(ctx context.Context, id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSender")
@@ -164,18 +178,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSender(id string) (*commo
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -190,19 +204,25 @@ type NotificationSenderMgtSvcInterfaceMock_GetSender_Call struct {
 }
 
 // GetSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSender(id interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_GetSender_Call{Call: _e.mock.On("GetSender", id)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSender(ctx interface{}, id interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_GetSender_Call{Call: _e.mock.On("GetSender", ctx, id)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) Run(run func(id string)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) Run(run func(ctx context.Context, id string)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -213,14 +233,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) Return(notificat
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) RunAndReturn(run func(id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) RunAndReturn(run func(ctx context.Context, id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetSenderByName provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSenderByName(name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(name)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSenderByName")
@@ -228,18 +248,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSenderByName(name string)
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, name)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(name)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, name)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -254,19 +274,25 @@ type NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call struct {
 }
 
 // GetSenderByName is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSenderByName(name interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call{Call: _e.mock.On("GetSenderByName", name)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSenderByName(ctx interface{}, name interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call{Call: _e.mock.On("GetSenderByName", ctx, name)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) Run(run func(name string)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) Run(run func(ctx context.Context, name string)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -277,14 +303,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) Return(not
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) RunAndReturn(run func(name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) RunAndReturn(run func(ctx context.Context, name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListSenders provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) ListSenders() ([]common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called()
+func (_mock *NotificationSenderMgtSvcInterfaceMock) ListSenders(ctx context.Context) ([]common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListSenders")
@@ -292,18 +318,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) ListSenders() ([]common.Noti
 
 	var r0 []common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func() ([]common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() []common.NotificationSenderDTO); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() *serviceerror.ServiceError); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -318,13 +344,20 @@ type NotificationSenderMgtSvcInterfaceMock_ListSenders_Call struct {
 }
 
 // ListSenders is a helper method to define mock.On call
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) ListSenders() *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_ListSenders_Call{Call: _e.mock.On("ListSenders")}
+//   - ctx context.Context
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) ListSenders(ctx interface{}) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_ListSenders_Call{Call: _e.mock.On("ListSenders", ctx)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) Run(run func()) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) Run(run func(ctx context.Context)) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -334,14 +367,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) Return(notific
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) RunAndReturn(run func() ([]common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) RunAndReturn(run func(ctx context.Context) ([]common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) UpdateSender(id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(id, sender)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) UpdateSender(ctx context.Context, id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, sender)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSender")
@@ -349,18 +382,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) UpdateSender(id string, send
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(id, sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, sender)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(id, sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, id, sender)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id, sender)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, sender)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -375,25 +408,31 @@ type NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call struct {
 }
 
 // UpdateSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - sender common.NotificationSenderDTO
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) UpdateSender(id interface{}, sender interface{}) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call{Call: _e.mock.On("UpdateSender", id, sender)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) UpdateSender(ctx interface{}, id interface{}, sender interface{}) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call{Call: _e.mock.On("UpdateSender", ctx, id, sender)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) Run(run func(id string, sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) Run(run func(ctx context.Context, id string, sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 common.NotificationSenderDTO
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(common.NotificationSenderDTO)
+			arg1 = args[1].(string)
+		}
+		var arg2 common.NotificationSenderDTO
+		if args[2] != nil {
+			arg2 = args[2].(common.NotificationSenderDTO)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -404,7 +443,7 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) Return(notifi
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) RunAndReturn(run func(id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) RunAndReturn(run func(ctx context.Context, id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/notification/OTPServiceInterface_mock_test.go
+++ b/backend/internal/notification/OTPServiceInterface_mock_test.go
@@ -5,6 +5,8 @@
 package notification
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *OTPServiceInterfaceMock) EXPECT() *OTPServiceInterfaceMock_Expecter {
 }
 
 // SendOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) SendOTP(request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *OTPServiceInterfaceMock) SendOTP(ctx context.Context, request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendOTP")
@@ -47,18 +49,18 @@ func (_mock *OTPServiceInterfaceMock) SendOTP(request common.SendOTPDTO) (*commo
 
 	var r0 *common.SendOTPResultDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.SendOTPDTO) *common.SendOTPResultDTO); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.SendOTPDTO) *common.SendOTPResultDTO); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.SendOTPResultDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.SendOTPDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.SendOTPDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,19 +75,25 @@ type OTPServiceInterfaceMock_SendOTP_Call struct {
 }
 
 // SendOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request common.SendOTPDTO
-func (_e *OTPServiceInterfaceMock_Expecter) SendOTP(request interface{}) *OTPServiceInterfaceMock_SendOTP_Call {
-	return &OTPServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", request)}
+func (_e *OTPServiceInterfaceMock_Expecter) SendOTP(ctx interface{}, request interface{}) *OTPServiceInterfaceMock_SendOTP_Call {
+	return &OTPServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", ctx, request)}
 }
 
-func (_c *OTPServiceInterfaceMock_SendOTP_Call) Run(run func(request common.SendOTPDTO)) *OTPServiceInterfaceMock_SendOTP_Call {
+func (_c *OTPServiceInterfaceMock_SendOTP_Call) Run(run func(ctx context.Context, request common.SendOTPDTO)) *OTPServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.SendOTPDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.SendOTPDTO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 common.SendOTPDTO
+		if args[1] != nil {
+			arg1 = args[1].(common.SendOTPDTO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -96,14 +104,14 @@ func (_c *OTPServiceInterfaceMock_SendOTP_Call) Return(sendOTPResultDTO *common.
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_SendOTP_Call {
+func (_c *OTPServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(context.Context, common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) VerifyOTP(request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *OTPServiceInterfaceMock) VerifyOTP(ctx context.Context, request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyOTP")
@@ -111,18 +119,18 @@ func (_mock *OTPServiceInterfaceMock) VerifyOTP(request common.VerifyOTPDTO) (*c
 
 	var r0 *common.VerifyOTPResultDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.VerifyOTPDTO) *common.VerifyOTPResultDTO); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) *common.VerifyOTPResultDTO); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.VerifyOTPResultDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.VerifyOTPDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.VerifyOTPDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -137,19 +145,25 @@ type OTPServiceInterfaceMock_VerifyOTP_Call struct {
 }
 
 // VerifyOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request common.VerifyOTPDTO
-func (_e *OTPServiceInterfaceMock_Expecter) VerifyOTP(request interface{}) *OTPServiceInterfaceMock_VerifyOTP_Call {
-	return &OTPServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", request)}
+func (_e *OTPServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, request interface{}) *OTPServiceInterfaceMock_VerifyOTP_Call {
+	return &OTPServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, request)}
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(request common.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, request common.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.VerifyOTPDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.VerifyOTPDTO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 common.VerifyOTPDTO
+		if args[1] != nil {
+			arg1 = args[1].(common.VerifyOTPDTO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -160,7 +174,7 @@ func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Return(verifyOTPResultDTO *com
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(context.Context, common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/notification/declarative_resource.go
+++ b/backend/internal/notification/declarative_resource.go
@@ -68,7 +68,7 @@ func (e *NotificationSenderExporter) GetParameterizerType() string {
 
 // GetAllResourceIDs retrieves all notification sender IDs.
 func (e *NotificationSenderExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
-	senders, err := e.service.ListSenders()
+	senders, err := e.service.ListSenders(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (e *NotificationSenderExporter) GetAllResourceIDs(ctx context.Context) ([]s
 func (e *NotificationSenderExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *serviceerror.ServiceError,
 ) {
-	sender, err := e.service.GetSender(id)
+	sender, err := e.service.GetSender(ctx, id)
 	if err != nil {
 		return nil, "", err
 	}

--- a/backend/internal/notification/declarative_resource_test.go
+++ b/backend/internal/notification/declarative_resource_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/notification"
@@ -70,7 +71,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetAllResourceIDs_Success() {
 		{ID: "sender2", Name: "Sender 2"},
 	}
 
-	s.mockService.EXPECT().ListSenders().Return(expectedSenders, nil)
+	s.mockService.EXPECT().ListSenders(mock.Anything).Return(expectedSenders, nil)
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
@@ -86,7 +87,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetAllResourceIDs_Error() {
 		Error: "test error",
 	}
 
-	s.mockService.EXPECT().ListSenders().Return(nil, expectedError)
+	s.mockService.EXPECT().ListSenders(mock.Anything).Return(nil, expectedError)
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
@@ -97,7 +98,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetAllResourceIDs_Error() {
 func (s *NotificationSenderExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
 	expectedSenders := []common.NotificationSenderDTO{}
 
-	s.mockService.EXPECT().ListSenders().Return(expectedSenders, nil)
+	s.mockService.EXPECT().ListSenders(mock.Anything).Return(expectedSenders, nil)
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
@@ -111,7 +112,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetResourceByID_Success() {
 		Name: "Test Sender",
 	}
 
-	s.mockService.EXPECT().GetSender("sender1").Return(expectedSender, nil)
+	s.mockService.EXPECT().GetSender(mock.Anything, "sender1").Return(expectedSender, nil)
 
 	resource, name, err := s.exporter.GetResourceByID(context.Background(), "sender1")
 
@@ -126,7 +127,7 @@ func (s *NotificationSenderExporterTestSuite) TestGetResourceByID_Error() {
 		Error: "test error",
 	}
 
-	s.mockService.EXPECT().GetSender("sender1").Return(nil, expectedError)
+	s.mockService.EXPECT().GetSender(mock.Anything, "sender1").Return(nil, expectedError)
 
 	resource, name, err := s.exporter.GetResourceByID(context.Background(), "sender1")
 

--- a/backend/internal/notification/file_based_store.go
+++ b/backend/internal/notification/file_based_store.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	"errors"
 
 	"github.com/asgardeo/thunder/internal/notification/common"
@@ -33,21 +34,22 @@ type notificationFileBasedStore struct {
 // Create implements declarativeresource.Storer interface for resource loader
 func (f *notificationFileBasedStore) Create(id string, data interface{}) error {
 	sender := data.(*common.NotificationSenderDTO)
-	return f.createSender(*sender)
+	return f.createSender(context.TODO(), *sender)
 }
 
 // createSender implements notificationStoreInterface.
-func (f *notificationFileBasedStore) createSender(sender common.NotificationSenderDTO) error {
+func (f *notificationFileBasedStore) createSender(ctx context.Context, sender common.NotificationSenderDTO) error {
 	return f.GenericFileBasedStore.Create(sender.ID, &sender)
 }
 
 // deleteSender implements notificationStoreInterface.
-func (f *notificationFileBasedStore) deleteSender(id string) error {
+func (f *notificationFileBasedStore) deleteSender(ctx context.Context, id string) error {
 	return errors.New("deleteSender is not supported in file-based store")
 }
 
 // getSenderByID implements notificationStoreInterface.
-func (f *notificationFileBasedStore) getSenderByID(id string) (*common.NotificationSenderDTO, error) {
+func (f *notificationFileBasedStore) getSenderByID(
+	ctx context.Context, id string) (*common.NotificationSenderDTO, error) {
 	data, err := f.GenericFileBasedStore.Get(id)
 	if err != nil {
 		return nil, err
@@ -61,7 +63,8 @@ func (f *notificationFileBasedStore) getSenderByID(id string) (*common.Notificat
 }
 
 // getSenderByName implements notificationStoreInterface.
-func (f *notificationFileBasedStore) getSenderByName(name string) (*common.NotificationSenderDTO, error) {
+func (f *notificationFileBasedStore) getSenderByName(
+	ctx context.Context, name string) (*common.NotificationSenderDTO, error) {
 	data, err := f.GenericFileBasedStore.GetByField(name, func(d interface{}) string {
 		return d.(*common.NotificationSenderDTO).Name
 	})
@@ -72,7 +75,7 @@ func (f *notificationFileBasedStore) getSenderByName(name string) (*common.Notif
 }
 
 // listSenders implements notificationStoreInterface.
-func (f *notificationFileBasedStore) listSenders() ([]common.NotificationSenderDTO, error) {
+func (f *notificationFileBasedStore) listSenders(ctx context.Context) ([]common.NotificationSenderDTO, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -88,7 +91,8 @@ func (f *notificationFileBasedStore) listSenders() ([]common.NotificationSenderD
 }
 
 // updateSender implements notificationStoreInterface.
-func (f *notificationFileBasedStore) updateSender(id string, sender common.NotificationSenderDTO) error {
+func (f *notificationFileBasedStore) updateSender(
+	ctx context.Context, id string, sender common.NotificationSenderDTO) error {
 	return errors.New("updateSender is not supported in file-based store")
 }
 

--- a/backend/internal/notification/init_test.go
+++ b/backend/internal/notification/init_test.go
@@ -47,6 +47,7 @@ func TestInitTestSuite(t *testing.T) {
 }
 
 func (suite *InitTestSuite) SetupSuite() {
+	config.ResetThunderRuntime()
 	testConfig := &config.Config{
 		JWT: config.JWTConfig{
 			Issuer:         "test-issuer",
@@ -55,6 +56,12 @@ func (suite *InitTestSuite) SetupSuite() {
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
 				Key: testCryptoKey,
+			},
+		},
+		Database: config.DatabaseConfig{
+			Identity: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
 			},
 		},
 	}
@@ -67,6 +74,10 @@ func (suite *InitTestSuite) SetupSuite() {
 func (suite *InitTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mux = http.NewServeMux()
+}
+
+func (suite *InitTestSuite) TearDownSuite() {
+	config.ResetThunderRuntime()
 }
 
 func (suite *InitTestSuite) TestInitialize() {
@@ -190,6 +201,12 @@ properties:
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
 				Key: testCryptoKey,
+			},
+		},
+		Database: config.DatabaseConfig{
+			Identity: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
 			},
 		},
 	}
@@ -505,6 +522,12 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesEnabled_Inval
 				Key: testCryptoKey,
 			},
 		},
+		Database: config.DatabaseConfig{
+			Identity: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+		},
 	}
 	err = config.InitializeThunderRuntime("", suiteConfig)
 	suite.NoError(err)
@@ -569,6 +592,12 @@ properties:
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
 				Key: testCryptoKey,
+			},
+		},
+		Database: config.DatabaseConfig{
+			Identity: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
 			},
 		},
 	}

--- a/backend/internal/notification/message_handler.go
+++ b/backend/internal/notification/message_handler.go
@@ -49,8 +49,9 @@ func newMessageNotificationSenderHandler(
 
 // HandleSenderListRequest handles the request to list all message notification senders
 func (h *messageNotificationSenderHandler) HandleSenderListRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
-	senders, svcErr := h.mgtService.ListSenders()
+	senders, svcErr := h.mgtService.ListSenders(ctx)
 	if svcErr != nil {
 		h.handleError(w, svcErr, "")
 		return
@@ -72,6 +73,7 @@ func (h *messageNotificationSenderHandler) HandleSenderListRequest(w http.Respon
 
 // HandleSenderCreateRequest handles the request to create a new message notification sender
 func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
 	sender, err := sysutils.DecodeJSONBody[common.NotificationSenderRequest](r)
 	if err != nil {
@@ -86,7 +88,7 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 		return
 	}
 
-	createdSender, svcErr := h.mgtService.CreateSender(*senderDTO)
+	createdSender, svcErr := h.mgtService.CreateSender(ctx, *senderDTO)
 	if svcErr != nil {
 		if svcErr.Code == ErrorDuplicateSenderName.Code {
 			errResp := apierror.ErrorResponse{
@@ -115,13 +117,14 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 
 // HandleSenderGetRequest handles the request to get a message notification sender by ID
 func (h *messageNotificationSenderHandler) HandleSenderGetRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
 	id := r.PathValue("id")
 	if !h.validateSenderID(w, id) {
 		return
 	}
 
-	sender, svcErr := h.mgtService.GetSender(id)
+	sender, svcErr := h.mgtService.GetSender(ctx, id)
 	if svcErr != nil {
 		h.handleError(w, svcErr, "")
 		return
@@ -148,6 +151,7 @@ func (h *messageNotificationSenderHandler) HandleSenderGetRequest(w http.Respons
 
 // HandleSenderUpdateRequest handles the request to update a message notification sender
 func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
 	id := r.PathValue("id")
 	if !h.validateSenderID(w, id) {
@@ -167,7 +171,7 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 		return
 	}
 
-	updatedSender, svcErr := h.mgtService.UpdateSender(id, *senderDTO)
+	updatedSender, svcErr := h.mgtService.UpdateSender(ctx, id, *senderDTO)
 	if svcErr != nil {
 		h.handleError(w, svcErr, "")
 		return
@@ -185,12 +189,13 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 
 // HandleSenderDeleteRequest handles the request to delete a message notification sender
 func (h *messageNotificationSenderHandler) HandleSenderDeleteRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	id := r.PathValue("id")
 	if !h.validateSenderID(w, id) {
 		return
 	}
 
-	svcErr := h.mgtService.DeleteSender(id)
+	svcErr := h.mgtService.DeleteSender(ctx, id)
 	if svcErr != nil {
 		h.handleError(w, svcErr, "")
 		return
@@ -201,6 +206,7 @@ func (h *messageNotificationSenderHandler) HandleSenderDeleteRequest(w http.Resp
 
 // HandleOTPSendRequest handles the request to send an OTP.
 func (h *messageNotificationSenderHandler) HandleOTPSendRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	request, err := sysutils.DecodeJSONBody[common.SendOTPRequest](r)
 	if err != nil {
 		h.handleError(w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
@@ -208,7 +214,7 @@ func (h *messageNotificationSenderHandler) HandleOTPSendRequest(w http.ResponseW
 	}
 
 	otpDTO := common.SendOTPDTO(*request)
-	resultDTO, svcErr := h.otpService.SendOTP(otpDTO)
+	resultDTO, svcErr := h.otpService.SendOTP(ctx, otpDTO)
 	if svcErr != nil {
 		h.handleError(w, svcErr, "")
 		return
@@ -224,6 +230,7 @@ func (h *messageNotificationSenderHandler) HandleOTPSendRequest(w http.ResponseW
 
 // HandleOTPVerifyRequest handles the request to verify an OTP.
 func (h *messageNotificationSenderHandler) HandleOTPVerifyRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	request, err := sysutils.DecodeJSONBody[common.VerifyOTPRequest](r)
 	if err != nil {
 		h.handleError(w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
@@ -231,7 +238,7 @@ func (h *messageNotificationSenderHandler) HandleOTPVerifyRequest(w http.Respons
 	}
 
 	verifyDTO := common.VerifyOTPDTO(*request)
-	resultDTO, svcErr := h.otpService.VerifyOTP(verifyDTO)
+	resultDTO, svcErr := h.otpService.VerifyOTP(ctx, verifyDTO)
 	if svcErr != nil {
 		h.handleError(w, svcErr, "")
 		return

--- a/backend/internal/notification/mgt_service.go
+++ b/backend/internal/notification/mgt_service.go
@@ -20,7 +20,11 @@
 package notification
 
 import (
+	"context"
+	"errors"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
+	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -29,25 +33,28 @@ import (
 
 // NotificationSenderMgtSvcInterface defines the interface for managing notification senders.
 type NotificationSenderMgtSvcInterface interface {
-	CreateSender(sender common.NotificationSenderDTO) (*common.NotificationSenderDTO,
+	CreateSender(ctx context.Context, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO,
 		*serviceerror.ServiceError)
-	ListSenders() ([]common.NotificationSenderDTO, *serviceerror.ServiceError)
-	GetSender(id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)
-	GetSenderByName(name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)
-	UpdateSender(id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO,
+	ListSenders(ctx context.Context) ([]common.NotificationSenderDTO, *serviceerror.ServiceError)
+	GetSender(ctx context.Context, id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)
+	GetSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)
+	UpdateSender(ctx context.Context, id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO,
 		*serviceerror.ServiceError)
-	DeleteSender(id string) *serviceerror.ServiceError
+	DeleteSender(ctx context.Context, id string) *serviceerror.ServiceError
 }
 
 // notificationSenderMgtService implements the NotificationSenderMgtSvcInterface.
 type notificationSenderMgtService struct {
 	notificationStore notificationStoreInterface
+	transactioner     transaction.Transactioner
 }
 
 // newNotificationSenderMgtService returns a new instance of NotificationSenderMgtSvcInterface.
-func newNotificationSenderMgtService(store notificationStoreInterface) NotificationSenderMgtSvcInterface {
+func newNotificationSenderMgtService(
+	store notificationStoreInterface, tx transaction.Transactioner) NotificationSenderMgtSvcInterface {
 	return &notificationSenderMgtService{
 		notificationStore: store,
+		transactioner:     tx,
 	}
 }
 
@@ -55,12 +62,14 @@ func newNotificationSenderMgtService(store notificationStoreInterface) Notificat
 // [Deprecated: use dependency injection to get the instance instead].
 // TODO: Remove this when the flow executors are migrated to the di pattern.
 func NewNotificationSenderMgtService() NotificationSenderMgtSvcInterface {
-	return newNotificationSenderMgtService(newNotificationStore())
+	// Fallback to a default db behavior for deprecated call
+	return newNotificationSenderMgtService(newNotificationStore(), nil)
 }
 
 // CreateSender creates a new notification sender.
 func (s *notificationSenderMgtService) CreateSender(
-	sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ctx context.Context, sender common.NotificationSenderDTO) (
+	*common.NotificationSenderDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
 	logger.Debug("Creating notification sender", log.String("name", sender.Name))
 
@@ -72,31 +81,44 @@ func (s *notificationSenderMgtService) CreateSender(
 		return nil, err
 	}
 
-	// Check if sender with same name already exists
-	senderRetv, err := s.notificationStore.getSenderByName(sender.Name)
-	if err != nil {
-		logger.Error("Failed to retrieve notification sender", log.String("name", sender.Name),
-			log.Error(err))
-		return nil, &ErrorInternalServerError
-	}
-	if senderRetv != nil {
-		logger.Debug("Notification sender already exists", log.String("name", sender.Name),
-			log.String("id", senderRetv.ID))
-		return nil, &ErrorDuplicateSenderName
-	}
-
 	id, err := sysutils.GenerateUUIDv7()
 	if err != nil {
 		logger.Error("Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
-
 	sender.ID = id
 
-	// Create the sender
-	err = s.notificationStore.createSender(sender)
-	if err != nil {
-		logger.Error("Failed to create notification sender", log.Error(err))
+	var dbErr serviceerror.ServiceError
+	transactErr := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		// Check if sender with same name already exists
+		senderRetv, err := s.notificationStore.getSenderByName(txCtx, sender.Name)
+		if err != nil {
+			logger.Error("Failed to retrieve notification sender", log.String("name", sender.Name),
+				log.Error(err))
+			dbErr = ErrorInternalServerError
+			return err
+		}
+		if senderRetv != nil {
+			logger.Debug("Notification sender already exists", log.String("name", sender.Name),
+				log.String("id", senderRetv.ID))
+			dbErr = ErrorDuplicateSenderName
+			return errors.New("sender already exists")
+		}
+
+		// Create the sender
+		err = s.notificationStore.createSender(txCtx, sender)
+		if err != nil {
+			logger.Error("Failed to create notification sender", log.Error(err))
+			dbErr = ErrorInternalServerError
+			return err
+		}
+		return nil
+	})
+
+	if transactErr != nil {
+		if dbErr.Code != "" {
+			return nil, &dbErr
+		}
 		return nil, &ErrorInternalServerError
 	}
 
@@ -111,12 +133,12 @@ func (s *notificationSenderMgtService) CreateSender(
 }
 
 // ListSenders retrieves all notification senders.
-func (s *notificationSenderMgtService) ListSenders() ([]common.NotificationSenderDTO,
+func (s *notificationSenderMgtService) ListSenders(ctx context.Context) ([]common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
 	logger.Debug("Listing all notification senders")
 
-	senders, err := s.notificationStore.listSenders()
+	senders, err := s.notificationStore.listSenders(ctx)
 	if err != nil {
 		logger.Error("Failed to list notification senders", log.Error(err))
 		return nil, &ErrorInternalServerError
@@ -126,7 +148,7 @@ func (s *notificationSenderMgtService) ListSenders() ([]common.NotificationSende
 }
 
 // GetSender retrieves a notification sender by ID.
-func (s *notificationSenderMgtService) GetSender(id string) (*common.NotificationSenderDTO,
+func (s *notificationSenderMgtService) GetSender(ctx context.Context, id string) (*common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
 	logger.Debug("Retrieving notification sender", log.String("id", id))
@@ -135,7 +157,7 @@ func (s *notificationSenderMgtService) GetSender(id string) (*common.Notificatio
 		return nil, &ErrorInvalidSenderID
 	}
 
-	sender, err := s.notificationStore.getSenderByID(id)
+	sender, err := s.notificationStore.getSenderByID(ctx, id)
 	if err != nil {
 		logger.Error("Failed to retrieve notification sender", log.String("id", id), log.Error(err))
 		return nil, &ErrorInternalServerError
@@ -145,7 +167,7 @@ func (s *notificationSenderMgtService) GetSender(id string) (*common.Notificatio
 }
 
 // GetSenderByName retrieves a notification sender by name.
-func (s *notificationSenderMgtService) GetSenderByName(name string) (*common.NotificationSenderDTO,
+func (s *notificationSenderMgtService) GetSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
 	logger.Debug("Retrieving notification sender by name", log.String("name", name))
@@ -154,7 +176,7 @@ func (s *notificationSenderMgtService) GetSenderByName(name string) (*common.Not
 		return nil, &ErrorInvalidSenderName
 	}
 
-	sender, err := s.notificationStore.getSenderByName(name)
+	sender, err := s.notificationStore.getSenderByName(ctx, name)
 	if err != nil {
 		logger.Error("Failed to retrieve notification sender", log.String("name", name), log.Error(err))
 		return nil, &ErrorInternalServerError
@@ -164,7 +186,7 @@ func (s *notificationSenderMgtService) GetSenderByName(name string) (*common.Not
 }
 
 // UpdateSender updates an existing notification sender
-func (s *notificationSenderMgtService) UpdateSender(id string,
+func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id string,
 	sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
 	logger.Debug("Updating notification sender", log.String("id", id), log.String("name", sender.Name))
@@ -180,42 +202,60 @@ func (s *notificationSenderMgtService) UpdateSender(id string,
 		return nil, err
 	}
 
-	// Check if sender exists
-	senderRetv, err := s.notificationStore.getSenderByID(id)
-	if err != nil {
-		logger.Error("Failed to retrieve notification sender", log.String("id", id), log.Error(err))
-		return nil, &ErrorInternalServerError
-	}
-	if senderRetv == nil {
-		logger.Debug("Notification sender not found", log.String("id", id))
-		return nil, &ErrorSenderNotFound
-	}
-
-	// If the name is being updated, check for duplicates
-	if sender.Name != senderRetv.Name {
-		senderWithUpdatedName, err := s.notificationStore.getSenderByName(sender.Name)
+	var dbErr serviceerror.ServiceError
+	transactErr := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		// Check if sender exists
+		senderRetv, err := s.notificationStore.getSenderByID(txCtx, id)
 		if err != nil {
-			logger.Error("Failed to retrieve notification sender", log.String("name", sender.Name),
-				log.Error(err))
-			return nil, &ErrorInternalServerError
+			logger.Error("Failed to retrieve notification sender", log.String("id", id), log.Error(err))
+			dbErr = ErrorInternalServerError
+			return err
 		}
-		if senderWithUpdatedName != nil && senderWithUpdatedName.ID != id {
-			logger.Debug("Another sender with the same name already exists",
-				log.String("name", sender.Name), log.String("existingID", senderWithUpdatedName.ID))
-			return nil, &ErrorDuplicateSenderName
+		if senderRetv == nil {
+			logger.Debug("Notification sender not found", log.String("id", id))
+			dbErr = ErrorSenderNotFound
+			return errors.New("sender not found")
 		}
-	}
 
-	// Ensure the type is not changed
-	if sender.Type != senderRetv.Type {
-		logger.Debug("Attempting to change sender type", log.String("id", id),
-			log.String("originalType", string(senderRetv.Type)), log.String("newType", string(sender.Type)))
-		return nil, &ErrorSenderTypeUpdateNotAllowed
-	}
+		// If the name is being updated, check for duplicates
+		if sender.Name != senderRetv.Name {
+			senderWithUpdatedName, err := s.notificationStore.getSenderByName(txCtx, sender.Name)
+			if err != nil {
+				logger.Error("Failed to retrieve notification sender", log.String("name", sender.Name),
+					log.Error(err))
+				dbErr = ErrorInternalServerError
+				return err
+			}
+			if senderWithUpdatedName != nil && senderWithUpdatedName.ID != id {
+				logger.Debug("Another sender with the same name already exists",
+					log.String("name", sender.Name), log.String("existingID", senderWithUpdatedName.ID))
+				dbErr = ErrorDuplicateSenderName
+				return errors.New("duplicate name")
+			}
+		}
 
-	// Update the sender
-	if err := s.notificationStore.updateSender(id, sender); err != nil {
-		logger.Error("Failed to update notification sender", log.String("id", id), log.Error(err))
+		// Ensure the type is not changed
+		if sender.Type != senderRetv.Type {
+			logger.Debug("Attempting to change sender type", log.String("id", id),
+				log.String("originalType", string(senderRetv.Type)), log.String("newType", string(sender.Type)))
+			dbErr = ErrorSenderTypeUpdateNotAllowed
+			return errors.New("cannot change type")
+		}
+
+		// Update the sender
+		if err := s.notificationStore.updateSender(txCtx, id, sender); err != nil {
+			logger.Error("Failed to update notification sender", log.String("id", id), log.Error(err))
+			dbErr = ErrorInternalServerError
+			return err
+		}
+
+		return nil
+	})
+
+	if transactErr != nil {
+		if dbErr.Code != "" {
+			return nil, &dbErr
+		}
 		return nil, &ErrorInternalServerError
 	}
 
@@ -230,7 +270,7 @@ func (s *notificationSenderMgtService) UpdateSender(id string,
 }
 
 // DeleteSender deletes a notification sender
-func (s *notificationSenderMgtService) DeleteSender(id string) *serviceerror.ServiceError {
+func (s *notificationSenderMgtService) DeleteSender(ctx context.Context, id string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
 	logger.Debug("Deleting notification sender", log.String("id", id))
 
@@ -242,8 +282,20 @@ func (s *notificationSenderMgtService) DeleteSender(id string) *serviceerror.Ser
 		return &ErrorInvalidSenderID
 	}
 
-	if err := s.notificationStore.deleteSender(id); err != nil {
-		logger.Error("Failed to delete notification sender", log.String("id", id), log.Error(err))
+	var dbErr serviceerror.ServiceError
+	transactErr := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		if err := s.notificationStore.deleteSender(txCtx, id); err != nil {
+			logger.Error("Failed to delete notification sender", log.String("id", id), log.Error(err))
+			dbErr = ErrorInternalServerError
+			return err
+		}
+		return nil
+	})
+
+	if transactErr != nil {
+		if dbErr.Code != "" {
+			return &dbErr
+		}
 		return &ErrorInternalServerError
 	}
 

--- a/backend/internal/notification/mgt_service_test.go
+++ b/backend/internal/notification/mgt_service_test.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -48,6 +49,7 @@ func TestNotificationSenderMgtServiceTestSuite(t *testing.T) {
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) SetupSuite() {
+	config.ResetThunderRuntime()
 	testConfig := &config.Config{
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
@@ -61,22 +63,27 @@ func (suite *NotificationSenderMgtServiceTestSuite) SetupSuite() {
 	}
 }
 
+func (suite *NotificationSenderMgtServiceTestSuite) TearDownSuite() {
+	config.ResetThunderRuntime()
+}
+
 func (suite *NotificationSenderMgtServiceTestSuite) SetupTest() {
 	suite.mockStore = newNotificationStoreInterfaceMock(suite.T())
 	suite.service = &notificationSenderMgtService{
 		notificationStore: suite.mockStore,
+		transactioner:     &fakeTransactioner{},
 	}
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender() {
 	sender := suite.getValidTwilioSender()
 
-	suite.mockStore.EXPECT().getSenderByName(sender.Name).Return(nil, nil).Once()
-	suite.mockStore.EXPECT().createSender(mock.MatchedBy(func(s common.NotificationSenderDTO) bool {
+	suite.mockStore.EXPECT().getSenderByName(mock.Anything, sender.Name).Return(nil, nil).Once()
+	suite.mockStore.EXPECT().createSender(mock.Anything, mock.MatchedBy(func(s common.NotificationSenderDTO) bool {
 		return s.Name == sender.Name && s.ID != ""
 	})).Return(nil).Once()
 
-	result, err := suite.service.CreateSender(sender)
+	result, err := suite.service.CreateSender(context.TODO(), sender)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(sender.Name, result.Name)
@@ -98,7 +105,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailure
 			setupMock: func(m *notificationStoreInterfaceMock, s common.NotificationSenderDTO) {
 				existing := s
 				existing.ID = "existing-id"
-				m.EXPECT().getSenderByName(s.Name).Return(&existing, nil).Once()
+				m.EXPECT().getSenderByName(mock.Anything, s.Name).Return(&existing, nil).Once()
 			},
 			expectedErrCode: ErrorDuplicateSenderName.Code,
 		},
@@ -108,7 +115,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailure
 				return s
 			},
 			setupMock: func(m *notificationStoreInterfaceMock, s common.NotificationSenderDTO) {
-				m.EXPECT().getSenderByName(s.Name).Return(nil, errors.New("database error")).Once()
+				m.EXPECT().getSenderByName(mock.Anything, s.Name).Return(nil, errors.New("database error")).Once()
 			},
 			expectedErrCode: ErrorInternalServerError.Code,
 		},
@@ -118,8 +125,8 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailure
 				return s
 			},
 			setupMock: func(m *notificationStoreInterfaceMock, s common.NotificationSenderDTO) {
-				m.EXPECT().getSenderByName(s.Name).Return(nil, nil).Once()
-				m.EXPECT().createSender(mock.Anything).Return(errors.New("database error")).Once()
+				m.EXPECT().getSenderByName(mock.Anything, s.Name).Return(nil, nil).Once()
+				m.EXPECT().createSender(mock.Anything, mock.Anything).Return(errors.New("database error")).Once()
 			},
 			expectedErrCode: ErrorInternalServerError.Code,
 		},
@@ -146,7 +153,10 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailure
 	for _, tc := range cases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			mockStore := newNotificationStoreInterfaceMock(t)
-			svc := &notificationSenderMgtService{notificationStore: mockStore}
+			svc := &notificationSenderMgtService{
+				notificationStore: mockStore,
+				transactioner:     &fakeTransactioner{},
+			}
 
 			sender := suite.getValidTwilioSender()
 			sender = tc.inputMod(sender)
@@ -155,7 +165,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailure
 				tc.setupMock(mockStore, sender)
 			}
 
-			result, err := svc.CreateSender(sender)
+			result, err := svc.CreateSender(context.TODO(), sender)
 			require := require.New(t)
 			require.Nil(result)
 			require.NotNil(err)
@@ -173,27 +183,27 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders() {
 	senders[0].ID = "id1"
 	senders[1].ID = "id2"
 
-	suite.mockStore.EXPECT().listSenders().Return(senders, nil).Once()
+	suite.mockStore.EXPECT().listSenders(mock.Anything).Return(senders, nil).Once()
 
-	result, err := suite.service.ListSenders()
+	result, err := suite.service.ListSenders(context.TODO())
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Len(result, 2)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders_EmptyList() {
-	suite.mockStore.EXPECT().listSenders().Return([]common.NotificationSenderDTO{}, nil).Once()
+	suite.mockStore.EXPECT().listSenders(mock.Anything).Return([]common.NotificationSenderDTO{}, nil).Once()
 
-	result, err := suite.service.ListSenders()
+	result, err := suite.service.ListSenders(context.TODO())
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Len(result, 0)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders_StoreError() {
-	suite.mockStore.EXPECT().listSenders().Return(nil, errors.New("database error")).Once()
+	suite.mockStore.EXPECT().listSenders(mock.Anything).Return(nil, errors.New("database error")).Once()
 
-	result, err := suite.service.ListSenders()
+	result, err := suite.service.ListSenders(context.TODO())
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -202,24 +212,24 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders_StoreError()
 func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender() {
 	sender := suite.getValidTwilioSender()
 	sender.ID = testSenderID
-	suite.mockStore.EXPECT().getSenderByID(testSenderID).Return(&sender, nil).Once()
+	suite.mockStore.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&sender, nil).Once()
 
-	result, err := suite.service.GetSender(testSenderID)
+	result, err := suite.service.GetSender(context.TODO(), testSenderID)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(testSenderID, result.ID)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_NotFound() {
-	suite.mockStore.EXPECT().getSenderByID(testSenderID).Return(nil, nil).Once()
+	suite.mockStore.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(nil, nil).Once()
 
-	result, err := suite.service.GetSender(testSenderID)
+	result, err := suite.service.GetSender(context.TODO(), testSenderID)
 	suite.Nil(err)
 	suite.Nil(result)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_EmptyID() {
-	result, err := suite.service.GetSender("")
+	result, err := suite.service.GetSender(context.TODO(), "")
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -227,9 +237,9 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_EmptyID() {
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_StoreError() {
-	suite.mockStore.EXPECT().getSenderByID(testSenderID).Return(nil, errors.New("database error")).Once()
+	suite.mockStore.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(nil, errors.New("database error")).Once()
 
-	result, err := suite.service.GetSender(testSenderID)
+	result, err := suite.service.GetSender(context.TODO(), testSenderID)
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -248,7 +258,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName() {
 			setup: func(m *notificationStoreInterfaceMock) {
 				sender := suite.getValidTwilioSender()
 				sender.ID = testSenderID
-				m.EXPECT().getSenderByName("Test Twilio Sender").Return(&sender, nil).Once()
+				m.EXPECT().getSenderByName(mock.Anything, "Test Twilio Sender").Return(&sender, nil).Once()
 			},
 			arg:      "Test Twilio Sender",
 			wantName: "Test Twilio Sender",
@@ -256,7 +266,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName() {
 		{
 			name: "SenderNotFound",
 			setup: func(m *notificationStoreInterfaceMock) {
-				m.EXPECT().getSenderByName("NonExistent").Return(nil, nil).Once()
+				m.EXPECT().getSenderByName(mock.Anything, "NonExistent").Return(nil, nil).Once()
 			},
 			arg:      "NonExistent",
 			wantName: "",
@@ -266,13 +276,16 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName() {
 	for _, tc := range cases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			mockStore := newNotificationStoreInterfaceMock(t)
-			svc := &notificationSenderMgtService{notificationStore: mockStore}
+			svc := &notificationSenderMgtService{
+				notificationStore: mockStore,
+				transactioner:     &fakeTransactioner{},
+			}
 
 			if tc.setup != nil {
 				tc.setup(mockStore)
 			}
 
-			result, err := svc.GetSenderByName(tc.arg)
+			result, err := svc.GetSenderByName(context.TODO(), tc.arg)
 			require := require.New(t)
 			require.Nil(err)
 			if tc.wantName == "" {
@@ -303,7 +316,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName_WithFail
 			name: "StoreError",
 			arg:  "Test",
 			setup: func(m *notificationStoreInterfaceMock) {
-				m.EXPECT().getSenderByName("Test").Return(nil, errors.New("database error")).Once()
+				m.EXPECT().getSenderByName(mock.Anything, "Test").Return(nil, errors.New("database error")).Once()
 			},
 			expectedErrCode: ErrorInternalServerError.Code,
 		},
@@ -312,13 +325,16 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName_WithFail
 	for _, tc := range cases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			mockStore := newNotificationStoreInterfaceMock(t)
-			svc := &notificationSenderMgtService{notificationStore: mockStore}
+			svc := &notificationSenderMgtService{
+				notificationStore: mockStore,
+				transactioner:     &fakeTransactioner{},
+			}
 
 			if tc.setup != nil {
 				tc.setup(mockStore)
 			}
 
-			result, err := svc.GetSenderByName(tc.arg)
+			result, err := svc.GetSenderByName(context.TODO(), tc.arg)
 			require := require.New(t)
 			require.Nil(result)
 			require.NotNil(err)
@@ -338,8 +354,8 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender() {
 			setupMock: func(m *notificationStoreInterfaceMock, s common.NotificationSenderDTO) {
 				existing := s
 				existing.ID = testSenderID
-				m.EXPECT().getSenderByID(testSenderID).Return(&existing, nil).Once()
-				m.EXPECT().updateSender(testSenderID, s).Return(nil).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&existing, nil).Once()
+				m.EXPECT().updateSender(mock.Anything, testSenderID, s).Return(nil).Once()
 			},
 		},
 		{
@@ -348,9 +364,9 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender() {
 				existing := s
 				existing.ID = testSenderID
 				existing.Name = testSenderOldName
-				m.EXPECT().getSenderByID(testSenderID).Return(&existing, nil).Once()
-				m.EXPECT().getSenderByName(testSenderUpdatedName).Return(nil, nil).Once()
-				m.EXPECT().updateSender(testSenderID, s).Return(nil).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&existing, nil).Once()
+				m.EXPECT().getSenderByName(mock.Anything, testSenderUpdatedName).Return(nil, nil).Once()
+				m.EXPECT().updateSender(mock.Anything, testSenderID, s).Return(nil).Once()
 			},
 		},
 		{
@@ -361,9 +377,9 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender() {
 				existing.Name = testSenderOldName
 				same := s
 				same.ID = testSenderID
-				m.EXPECT().getSenderByID(testSenderID).Return(&existing, nil).Once()
-				m.EXPECT().getSenderByName(testSenderUpdatedName).Return(&same, nil).Once()
-				m.EXPECT().updateSender(testSenderID, s).Return(nil).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&existing, nil).Once()
+				m.EXPECT().getSenderByName(mock.Anything, testSenderUpdatedName).Return(&same, nil).Once()
+				m.EXPECT().updateSender(mock.Anything, testSenderID, s).Return(nil).Once()
 			},
 		},
 	}
@@ -371,7 +387,10 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender() {
 	for _, tc := range cases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			mockStore := newNotificationStoreInterfaceMock(t)
-			svc := &notificationSenderMgtService{notificationStore: mockStore}
+			svc := &notificationSenderMgtService{
+				notificationStore: mockStore,
+				transactioner:     &fakeTransactioner{},
+			}
 
 			sender := suite.getValidTwilioSender()
 			if tc.name != "NoNameChange" {
@@ -380,7 +399,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender() {
 
 			tc.setupMock(mockStore, sender)
 
-			result, err := svc.UpdateSender(testSenderID, sender)
+			result, err := svc.UpdateSender(context.TODO(), testSenderID, sender)
 			require := require.New(t)
 			require.Nil(err)
 			require.NotNil(result)
@@ -409,8 +428,8 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 				another := s
 				another.ID = "another-id"
 				another.Name = testSenderUpdatedName
-				m.EXPECT().getSenderByID(testSenderID).Return(&existing, nil).Once()
-				m.EXPECT().getSenderByName(testSenderUpdatedName).Return(&another, nil).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&existing, nil).Once()
+				m.EXPECT().getSenderByName(mock.Anything, testSenderUpdatedName).Return(&another, nil).Once()
 			},
 			expectedErrCode: ErrorDuplicateSenderName.Code,
 		},
@@ -420,7 +439,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 				return s
 			},
 			setupMock: func(m *notificationStoreInterfaceMock, s common.NotificationSenderDTO) {
-				m.EXPECT().getSenderByID(testSenderID).Return(nil, nil).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(nil, nil).Once()
 			},
 			expectedErrCode: ErrorSenderNotFound.Code,
 		},
@@ -442,7 +461,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 				existing := s
 				existing.ID = testSenderID
 				existing.Type = common.NotificationSenderType("legacy-type")
-				m.EXPECT().getSenderByID(testSenderID).Return(&existing, nil).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&existing, nil).Once()
 			},
 			expectedErrCode: ErrorSenderTypeUpdateNotAllowed.Code,
 		},
@@ -454,8 +473,8 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 			setupMock: func(m *notificationStoreInterfaceMock, s common.NotificationSenderDTO) {
 				existing := s
 				existing.ID = testSenderID
-				m.EXPECT().getSenderByID(testSenderID).Return(&existing, nil).Once()
-				m.EXPECT().updateSender(testSenderID, s).Return(errors.New("database error")).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&existing, nil).Once()
+				m.EXPECT().updateSender(mock.Anything, testSenderID, s).Return(errors.New("database error")).Once()
 			},
 			expectedErrCode: ErrorInternalServerError.Code,
 		},
@@ -465,7 +484,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 				return s
 			},
 			setupMock: func(m *notificationStoreInterfaceMock, s common.NotificationSenderDTO) {
-				m.EXPECT().getSenderByID(testSenderID).Return(nil, errors.New("database error")).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(nil, errors.New("database error")).Once()
 			},
 			expectedErrCode: ErrorInternalServerError.Code,
 		},
@@ -479,8 +498,9 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 				existing := s
 				existing.ID = testSenderID
 				existing.Name = testSenderOldName
-				m.EXPECT().getSenderByID(testSenderID).Return(&existing, nil).Once()
-				m.EXPECT().getSenderByName(testSenderUpdatedName).Return(nil, errors.New("database error")).Once()
+				m.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&existing, nil).Once()
+				m.EXPECT().getSenderByName(mock.Anything, testSenderUpdatedName).
+					Return(nil, errors.New("database error")).Once()
 			},
 			expectedErrCode: ErrorInternalServerError.Code,
 		},
@@ -498,13 +518,16 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 	for _, tc := range cases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			mockStore := newNotificationStoreInterfaceMock(t)
-			svc := &notificationSenderMgtService{notificationStore: mockStore}
+			svc := &notificationSenderMgtService{
+				notificationStore: mockStore,
+				transactioner:     &fakeTransactioner{},
+			}
 
 			sender := suite.getValidTwilioSender()
 			sender = tc.inputMod(sender)
 
 			if tc.name == "EmptyID" {
-				result, err := svc.UpdateSender("", sender)
+				result, err := svc.UpdateSender(context.TODO(), "", sender)
 				require := require.New(t)
 				require.Nil(result)
 				require.NotNil(err)
@@ -516,7 +539,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 				tc.setupMock(mockStore, sender)
 			}
 
-			result, err := svc.UpdateSender(testSenderID, sender)
+			result, err := svc.UpdateSender(context.TODO(), testSenderID, sender)
 			require := require.New(t)
 			require.Nil(result)
 			require.NotNil(err)
@@ -527,20 +550,20 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender() {
-	suite.mockStore.EXPECT().deleteSender(testSenderID).Return(nil).Once()
-	err := suite.service.DeleteSender(testSenderID)
+	suite.mockStore.EXPECT().deleteSender(mock.Anything, testSenderID).Return(nil).Once()
+	err := suite.service.DeleteSender(context.TODO(), testSenderID)
 	suite.Nil(err)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender_EmptyID() {
-	err := suite.service.DeleteSender("")
+	err := suite.service.DeleteSender(context.TODO(), "")
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidSenderID.Code, err.Code)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender_StoreError() {
-	suite.mockStore.EXPECT().deleteSender(testSenderID).Return(errors.New("database error")).Once()
-	err := suite.service.DeleteSender(testSenderID)
+	suite.mockStore.EXPECT().deleteSender(context.TODO(), testSenderID).Return(errors.New("database error")).Once()
+	err := suite.service.DeleteSender(context.TODO(), testSenderID)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
 }
@@ -557,7 +580,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_Declarative
 	config.GetThunderRuntime().Config.DeclarativeResources.Enabled = true
 
 	sender := suite.getValidTwilioSender()
-	result, err := suite.service.CreateSender(sender)
+	result, err := suite.service.CreateSender(context.TODO(), sender)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -576,7 +599,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_Declarative
 	config.GetThunderRuntime().Config.DeclarativeResources.Enabled = true
 
 	sender := suite.getValidTwilioSender()
-	result, err := suite.service.UpdateSender(testSenderID, sender)
+	result, err := suite.service.UpdateSender(context.TODO(), testSenderID, sender)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -594,7 +617,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender_Declarative
 	// Enable declarative resources
 	config.GetThunderRuntime().Config.DeclarativeResources.Enabled = true
 
-	err := suite.service.DeleteSender(testSenderID)
+	err := suite.service.DeleteSender(context.TODO(), testSenderID)
 
 	suite.NotNil(err)
 	suite.Equal("DCR-1003", err.Code)
@@ -631,4 +654,16 @@ func (suite *NotificationSenderMgtServiceTestSuite) getValidVonageSender() commo
 			createTestProperty("sender_id", "TestSender", false),
 		},
 	}
+}
+
+// fakeTransactioner is a light-weight test double to capture transaction usage without sql mock plumbing.
+type fakeTransactioner struct {
+	err error
+}
+
+func (f *fakeTransactioner) Transact(ctx context.Context, txFunc func(context.Context) error) error {
+	if f.err != nil {
+		return f.err
+	}
+	return txFunc(ctx)
 }

--- a/backend/internal/notification/notificationStoreInterface_mock_test.go
+++ b/backend/internal/notification/notificationStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package notification
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,16 +39,16 @@ func (_m *notificationStoreInterfaceMock) EXPECT() *notificationStoreInterfaceMo
 }
 
 // createSender provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) createSender(sender common.NotificationSenderDTO) error {
-	ret := _mock.Called(sender)
+func (_mock *notificationStoreInterfaceMock) createSender(ctx context.Context, sender common.NotificationSenderDTO) error {
+	ret := _mock.Called(ctx, sender)
 
 	if len(ret) == 0 {
 		panic("no return value specified for createSender")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(common.NotificationSenderDTO) error); ok {
-		r0 = returnFunc(sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.NotificationSenderDTO) error); ok {
+		r0 = returnFunc(ctx, sender)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,298 +61,17 @@ type notificationStoreInterfaceMock_createSender_Call struct {
 }
 
 // createSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sender common.NotificationSenderDTO
-func (_e *notificationStoreInterfaceMock_Expecter) createSender(sender interface{}) *notificationStoreInterfaceMock_createSender_Call {
-	return &notificationStoreInterfaceMock_createSender_Call{Call: _e.mock.On("createSender", sender)}
+func (_e *notificationStoreInterfaceMock_Expecter) createSender(ctx interface{}, sender interface{}) *notificationStoreInterfaceMock_createSender_Call {
+	return &notificationStoreInterfaceMock_createSender_Call{Call: _e.mock.On("createSender", ctx, sender)}
 }
 
-func (_c *notificationStoreInterfaceMock_createSender_Call) Run(run func(sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_createSender_Call {
+func (_c *notificationStoreInterfaceMock_createSender_Call) Run(run func(ctx context.Context, sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_createSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.NotificationSenderDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.NotificationSenderDTO)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_createSender_Call) Return(err error) *notificationStoreInterfaceMock_createSender_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_createSender_Call) RunAndReturn(run func(sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_createSender_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// deleteSender provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) deleteSender(id string) error {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for deleteSender")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// notificationStoreInterfaceMock_deleteSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deleteSender'
-type notificationStoreInterfaceMock_deleteSender_Call struct {
-	*mock.Call
-}
-
-// deleteSender is a helper method to define mock.On call
-//   - id string
-func (_e *notificationStoreInterfaceMock_Expecter) deleteSender(id interface{}) *notificationStoreInterfaceMock_deleteSender_Call {
-	return &notificationStoreInterfaceMock_deleteSender_Call{Call: _e.mock.On("deleteSender", id)}
-}
-
-func (_c *notificationStoreInterfaceMock_deleteSender_Call) Run(run func(id string)) *notificationStoreInterfaceMock_deleteSender_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_deleteSender_Call) Return(err error) *notificationStoreInterfaceMock_deleteSender_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_deleteSender_Call) RunAndReturn(run func(id string) error) *notificationStoreInterfaceMock_deleteSender_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// getSenderByID provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) getSenderByID(id string) (*common.NotificationSenderDTO, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for getSenderByID")
-	}
-
-	var r0 *common.NotificationSenderDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common.NotificationSenderDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// notificationStoreInterfaceMock_getSenderByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByID'
-type notificationStoreInterfaceMock_getSenderByID_Call struct {
-	*mock.Call
-}
-
-// getSenderByID is a helper method to define mock.On call
-//   - id string
-func (_e *notificationStoreInterfaceMock_Expecter) getSenderByID(id interface{}) *notificationStoreInterfaceMock_getSenderByID_Call {
-	return &notificationStoreInterfaceMock_getSenderByID_Call{Call: _e.mock.On("getSenderByID", id)}
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Run(run func(id string)) *notificationStoreInterfaceMock_getSenderByID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByID_Call {
-	_c.Call.Return(notificationSenderDTO, err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByID_Call) RunAndReturn(run func(id string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// getSenderByName provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) getSenderByName(name string) (*common.NotificationSenderDTO, error) {
-	ret := _mock.Called(name)
-
-	if len(ret) == 0 {
-		panic("no return value specified for getSenderByName")
-	}
-
-	var r0 *common.NotificationSenderDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, error)); ok {
-		return returnFunc(name)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(name)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common.NotificationSenderDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(name)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// notificationStoreInterfaceMock_getSenderByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByName'
-type notificationStoreInterfaceMock_getSenderByName_Call struct {
-	*mock.Call
-}
-
-// getSenderByName is a helper method to define mock.On call
-//   - name string
-func (_e *notificationStoreInterfaceMock_Expecter) getSenderByName(name interface{}) *notificationStoreInterfaceMock_getSenderByName_Call {
-	return &notificationStoreInterfaceMock_getSenderByName_Call{Call: _e.mock.On("getSenderByName", name)}
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Run(run func(name string)) *notificationStoreInterfaceMock_getSenderByName_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByName_Call {
-	_c.Call.Return(notificationSenderDTO, err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByName_Call) RunAndReturn(run func(name string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByName_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// listSenders provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) listSenders() ([]common.NotificationSenderDTO, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for listSenders")
-	}
-
-	var r0 []common.NotificationSenderDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]common.NotificationSenderDTO, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() []common.NotificationSenderDTO); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.NotificationSenderDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// notificationStoreInterfaceMock_listSenders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'listSenders'
-type notificationStoreInterfaceMock_listSenders_Call struct {
-	*mock.Call
-}
-
-// listSenders is a helper method to define mock.On call
-func (_e *notificationStoreInterfaceMock_Expecter) listSenders() *notificationStoreInterfaceMock_listSenders_Call {
-	return &notificationStoreInterfaceMock_listSenders_Call{Call: _e.mock.On("listSenders")}
-}
-
-func (_c *notificationStoreInterfaceMock_listSenders_Call) Run(run func()) *notificationStoreInterfaceMock_listSenders_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_listSenders_Call) Return(notificationSenderDTOs []common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_listSenders_Call {
-	_c.Call.Return(notificationSenderDTOs, err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_listSenders_Call) RunAndReturn(run func() ([]common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_listSenders_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// updateSender provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) updateSender(id string, sender common.NotificationSenderDTO) error {
-	ret := _mock.Called(id, sender)
-
-	if len(ret) == 0 {
-		panic("no return value specified for updateSender")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, common.NotificationSenderDTO) error); ok {
-		r0 = returnFunc(id, sender)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// notificationStoreInterfaceMock_updateSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'updateSender'
-type notificationStoreInterfaceMock_updateSender_Call struct {
-	*mock.Call
-}
-
-// updateSender is a helper method to define mock.On call
-//   - id string
-//   - sender common.NotificationSenderDTO
-func (_e *notificationStoreInterfaceMock_Expecter) updateSender(id interface{}, sender interface{}) *notificationStoreInterfaceMock_updateSender_Call {
-	return &notificationStoreInterfaceMock_updateSender_Call{Call: _e.mock.On("updateSender", id, sender)}
-}
-
-func (_c *notificationStoreInterfaceMock_updateSender_Call) Run(run func(id string, sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_updateSender_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 common.NotificationSenderDTO
 		if args[1] != nil {
@@ -364,12 +85,330 @@ func (_c *notificationStoreInterfaceMock_updateSender_Call) Run(run func(id stri
 	return _c
 }
 
+func (_c *notificationStoreInterfaceMock_createSender_Call) Return(err error) *notificationStoreInterfaceMock_createSender_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_createSender_Call) RunAndReturn(run func(ctx context.Context, sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_createSender_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// deleteSender provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) deleteSender(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for deleteSender")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// notificationStoreInterfaceMock_deleteSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deleteSender'
+type notificationStoreInterfaceMock_deleteSender_Call struct {
+	*mock.Call
+}
+
+// deleteSender is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *notificationStoreInterfaceMock_Expecter) deleteSender(ctx interface{}, id interface{}) *notificationStoreInterfaceMock_deleteSender_Call {
+	return &notificationStoreInterfaceMock_deleteSender_Call{Call: _e.mock.On("deleteSender", ctx, id)}
+}
+
+func (_c *notificationStoreInterfaceMock_deleteSender_Call) Run(run func(ctx context.Context, id string)) *notificationStoreInterfaceMock_deleteSender_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_deleteSender_Call) Return(err error) *notificationStoreInterfaceMock_deleteSender_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_deleteSender_Call) RunAndReturn(run func(ctx context.Context, id string) error) *notificationStoreInterfaceMock_deleteSender_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getSenderByID provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) getSenderByID(ctx context.Context, id string) (*common.NotificationSenderDTO, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for getSenderByID")
+	}
+
+	var r0 *common.NotificationSenderDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.NotificationSenderDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// notificationStoreInterfaceMock_getSenderByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByID'
+type notificationStoreInterfaceMock_getSenderByID_Call struct {
+	*mock.Call
+}
+
+// getSenderByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *notificationStoreInterfaceMock_Expecter) getSenderByID(ctx interface{}, id interface{}) *notificationStoreInterfaceMock_getSenderByID_Call {
+	return &notificationStoreInterfaceMock_getSenderByID_Call{Call: _e.mock.On("getSenderByID", ctx, id)}
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Run(run func(ctx context.Context, id string)) *notificationStoreInterfaceMock_getSenderByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByID_Call {
+	_c.Call.Return(notificationSenderDTO, err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getSenderByName provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) getSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO, error) {
+	ret := _mock.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for getSenderByName")
+	}
+
+	var r0 *common.NotificationSenderDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, error)); ok {
+		return returnFunc(ctx, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.NotificationSenderDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// notificationStoreInterfaceMock_getSenderByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByName'
+type notificationStoreInterfaceMock_getSenderByName_Call struct {
+	*mock.Call
+}
+
+// getSenderByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *notificationStoreInterfaceMock_Expecter) getSenderByName(ctx interface{}, name interface{}) *notificationStoreInterfaceMock_getSenderByName_Call {
+	return &notificationStoreInterfaceMock_getSenderByName_Call{Call: _e.mock.On("getSenderByName", ctx, name)}
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Run(run func(ctx context.Context, name string)) *notificationStoreInterfaceMock_getSenderByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByName_Call {
+	_c.Call.Return(notificationSenderDTO, err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByName_Call) RunAndReturn(run func(ctx context.Context, name string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// listSenders provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) listSenders(ctx context.Context) ([]common.NotificationSenderDTO, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for listSenders")
+	}
+
+	var r0 []common.NotificationSenderDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]common.NotificationSenderDTO, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.NotificationSenderDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// notificationStoreInterfaceMock_listSenders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'listSenders'
+type notificationStoreInterfaceMock_listSenders_Call struct {
+	*mock.Call
+}
+
+// listSenders is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *notificationStoreInterfaceMock_Expecter) listSenders(ctx interface{}) *notificationStoreInterfaceMock_listSenders_Call {
+	return &notificationStoreInterfaceMock_listSenders_Call{Call: _e.mock.On("listSenders", ctx)}
+}
+
+func (_c *notificationStoreInterfaceMock_listSenders_Call) Run(run func(ctx context.Context)) *notificationStoreInterfaceMock_listSenders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_listSenders_Call) Return(notificationSenderDTOs []common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_listSenders_Call {
+	_c.Call.Return(notificationSenderDTOs, err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_listSenders_Call) RunAndReturn(run func(ctx context.Context) ([]common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_listSenders_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// updateSender provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) updateSender(ctx context.Context, id string, sender common.NotificationSenderDTO) error {
+	ret := _mock.Called(ctx, id, sender)
+
+	if len(ret) == 0 {
+		panic("no return value specified for updateSender")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.NotificationSenderDTO) error); ok {
+		r0 = returnFunc(ctx, id, sender)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// notificationStoreInterfaceMock_updateSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'updateSender'
+type notificationStoreInterfaceMock_updateSender_Call struct {
+	*mock.Call
+}
+
+// updateSender is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - sender common.NotificationSenderDTO
+func (_e *notificationStoreInterfaceMock_Expecter) updateSender(ctx interface{}, id interface{}, sender interface{}) *notificationStoreInterfaceMock_updateSender_Call {
+	return &notificationStoreInterfaceMock_updateSender_Call{Call: _e.mock.On("updateSender", ctx, id, sender)}
+}
+
+func (_c *notificationStoreInterfaceMock_updateSender_Call) Run(run func(ctx context.Context, id string, sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_updateSender_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 common.NotificationSenderDTO
+		if args[2] != nil {
+			arg2 = args[2].(common.NotificationSenderDTO)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *notificationStoreInterfaceMock_updateSender_Call) Return(err error) *notificationStoreInterfaceMock_updateSender_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *notificationStoreInterfaceMock_updateSender_Call) RunAndReturn(run func(id string, sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_updateSender_Call {
+func (_c *notificationStoreInterfaceMock_updateSender_Call) RunAndReturn(run func(ctx context.Context, id string, sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_updateSender_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -38,8 +39,8 @@ var otpUseOnlyNumericChars = true
 
 // OTPServiceInterface defines the interface for OTP operations.
 type OTPServiceInterface interface {
-	SendOTP(request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)
-	VerifyOTP(request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)
+	SendOTP(ctx context.Context, request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)
+	VerifyOTP(ctx context.Context, request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)
 }
 
 // otpService implements the OTPServiceInterface.
@@ -60,7 +61,8 @@ func newOTPService(notifSenderSvc NotificationSenderMgtSvcInterface,
 }
 
 // SendOTP sends an OTP to the specified recipient using the provided sender.
-func (s *otpService) SendOTP(otpDTO common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
+func (s *otpService) SendOTP(
+	ctx context.Context, otpDTO common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "OTPService"))
 	logger.Debug("Sending OTP", log.String("recipient", log.MaskString(otpDTO.Recipient)),
 		log.String("channel", otpDTO.Channel), log.String("senderId", otpDTO.SenderID))
@@ -69,7 +71,7 @@ func (s *otpService) SendOTP(otpDTO common.SendOTPDTO) (*common.SendOTPResultDTO
 		return nil, err
 	}
 
-	sender, svcErr := s.senderMgtService.GetSender(otpDTO.SenderID)
+	sender, svcErr := s.senderMgtService.GetSender(ctx, otpDTO.SenderID)
 	if svcErr != nil {
 		if svcErr.Code == ErrorSenderNotFound.Code {
 			return nil, &ErrorSenderNotFound
@@ -122,7 +124,8 @@ func (s *otpService) SendOTP(otpDTO common.SendOTPDTO) (*common.SendOTPResultDTO
 }
 
 // VerifyOTP verifies the provided OTP against the session token.
-func (s *otpService) VerifyOTP(otpDTO common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
+func (s *otpService) VerifyOTP(
+	ctx context.Context, otpDTO common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "OTPService"))
 	logger.Debug("Verifying OTP")
 

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -99,7 +100,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_EmptyRecipient() {
 		Channel:   "sms",
 	}
 
-	result, err := suite.service.SendOTP(request)
+	result, err := suite.service.SendOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -113,7 +114,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_EmptySenderID() {
 		Channel:   "sms",
 	}
 
-	result, err := suite.service.SendOTP(request)
+	result, err := suite.service.SendOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -127,7 +128,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_EmptyChannel() {
 		Channel:   "",
 	}
 
-	result, err := suite.service.SendOTP(request)
+	result, err := suite.service.SendOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -141,7 +142,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_UnsupportedChannel() {
 		Channel:   "email",
 	}
 
-	result, err := suite.service.SendOTP(request)
+	result, err := suite.service.SendOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -155,9 +156,9 @@ func (suite *OTPServiceTestSuite) TestSendOTP_SenderNotFound() {
 		Channel:   "sms",
 	}
 
-	suite.mockSenderService.On("GetSender", "sender-123").Return(nil, nil).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(nil, nil).Once()
 
-	result, err := suite.service.SendOTP(request)
+	result, err := suite.service.SendOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -171,10 +172,10 @@ func (suite *OTPServiceTestSuite) TestSendOTP_SenderServiceError() {
 		Channel:   "sms",
 	}
 
-	suite.mockSenderService.On("GetSender", "sender-123").
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").
 		Return(nil, &ErrorInternalServerError).Once()
 
-	result, err := suite.service.SendOTP(request)
+	result, err := suite.service.SendOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -187,7 +188,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_EmptySessionToken() {
 		OTPCode:      "123456",
 	}
 
-	result, err := suite.service.VerifyOTP(request)
+	result, err := suite.service.VerifyOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -200,7 +201,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_EmptyOTPCode() {
 		OTPCode:      "",
 	}
 
-	result, err := suite.service.VerifyOTP(request)
+	result, err := suite.service.VerifyOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -217,7 +218,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_InvalidSessionToken() {
 	suite.mockJWTService.EXPECT().VerifyJWT("invalid-token", "otp-svc", mock.Anything).
 		Return(&ErrorInvalidSessionToken).Once()
 
-	result, err := suite.service.VerifyOTP(request)
+	result, err := suite.service.VerifyOTP(context.Background(), request)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -284,7 +285,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateOTPError() {
 	}
 
 	sender := suite.getValidSender()
-	suite.mockSenderService.On("GetSender", "sender-123").Return(sender, nil).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
 	// replace crypto/rand.Reader to force generateOTP to return an error
 	orig := cryptorand.Reader
@@ -295,7 +296,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateOTPError() {
 	// mm := messagemock.NewMessageClientInterfaceMock(suite.T())
 	suite.service.clientProvider = newNotificationClientProviderInterfaceMock(suite.T())
 
-	res, err := suite.service.SendOTP(req)
+	res, err := suite.service.SendOTP(context.Background(), req)
 
 	suite.Nil(res)
 	suite.NotNil(err)
@@ -310,7 +311,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_Success() {
 	}
 
 	sender := suite.getValidSender()
-	suite.mockSenderService.On("GetSender", "sender-123").Return(sender, nil).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
 	mm := messagemock.NewMessageClientInterfaceMock(suite.T())
 	mm.EXPECT().SendSMS(mock.Anything).Return(nil).Once()
@@ -321,7 +322,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_Success() {
 	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return("session-token-123", int64(0), nil).Once()
 
-	res, err := suite.service.SendOTP(req)
+	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(err)
 	suite.NotNil(res)
 	suite.Equal("session-token-123", res.SessionToken)
@@ -334,7 +335,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_SendSMSError() {
 		Channel:   "sms",
 	}
 	sender := suite.getValidSender()
-	suite.mockSenderService.On("GetSender", "sender-123").Return(sender, nil).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
 	mm := messagemock.NewMessageClientInterfaceMock(suite.T())
 	mm.EXPECT().SendSMS(mock.Anything).Return(errors.New("send failed")).Once()
@@ -342,7 +343,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_SendSMSError() {
 	cp.EXPECT().GetMessageClient(mock.Anything).Return(mm, nil).Once()
 	suite.service.clientProvider = cp
 
-	res, err := suite.service.SendOTP(req)
+	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -355,7 +356,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateJWTError() {
 		Channel:   "sms",
 	}
 	sender := suite.getValidSender()
-	suite.mockSenderService.On("GetSender", "sender-123").Return(sender, nil).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
 	mm := messagemock.NewMessageClientInterfaceMock(suite.T())
 	mm.EXPECT().SendSMS(mock.Anything).Return(nil).Once()
@@ -366,7 +367,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateJWTError() {
 	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return("", int64(0), &ErrorInternalServerError).Once()
 
-	res, err := suite.service.SendOTP(req)
+	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -397,7 +398,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_Success() {
 	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: otpValue}
-	res, err := suite.service.VerifyOTP(req)
+	res, err := suite.service.VerifyOTP(context.Background(), req)
 	suite.Nil(err)
 	suite.NotNil(res)
 	suite.Equal(common.OTPVerifyStatusVerified, res.Status)
@@ -429,7 +430,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_Expired() {
 	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: otpValue}
-	res, err := suite.service.VerifyOTP(req)
+	res, err := suite.service.VerifyOTP(context.Background(), req)
 	suite.Nil(err)
 	suite.NotNil(res)
 	suite.Equal(common.OTPVerifyStatusInvalid, res.Status)
@@ -443,14 +444,14 @@ func (suite *OTPServiceTestSuite) TestSendOTP_ClientProviderError() {
 	}
 
 	sender := suite.getValidSender()
-	suite.mockSenderService.On("GetSender", "sender-123").Return(sender, nil).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
 	// client provider returns a service error
 	cp := newNotificationClientProviderInterfaceMock(suite.T())
 	cp.EXPECT().GetMessageClient(mock.Anything).Return(nil, &ErrorInternalServerError).Once()
 	suite.service.clientProvider = cp
 
-	res, err := suite.service.SendOTP(req)
+	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -464,13 +465,13 @@ func (suite *OTPServiceTestSuite) TestSendOTP_ClientProviderNilClient() {
 	}
 
 	sender := suite.getValidSender()
-	suite.mockSenderService.On("GetSender", "sender-123").Return(sender, nil).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
 	cp := newNotificationClientProviderInterfaceMock(suite.T())
 	cp.EXPECT().GetMessageClient(mock.Anything).Return(nil, nil).Once()
 	suite.service.clientProvider = cp
 
-	res, err := suite.service.SendOTP(req)
+	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -488,7 +489,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_MissingOTPData() {
 	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: "123456"}
-	res, err := suite.service.VerifyOTP(req)
+	res, err := suite.service.VerifyOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidSessionToken.Code, err.Code)
@@ -500,7 +501,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_BadPayloadDecode() {
 	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: "123456"}
-	res, err := suite.service.VerifyOTP(req)
+	res, err := suite.service.VerifyOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidSessionToken.Code, err.Code)
@@ -533,7 +534,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_Mismatch() {
 	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: otpValue}
-	res, err := suite.service.VerifyOTP(req)
+	res, err := suite.service.VerifyOTP(context.Background(), req)
 	suite.Nil(err)
 	suite.NotNil(res)
 	suite.Equal(common.OTPVerifyStatusInvalid, res.Status)
@@ -546,9 +547,9 @@ func (suite *OTPServiceTestSuite) TestSendOTP_SenderServiceError_NotFound() {
 		Channel:   "sms",
 	}
 
-	suite.mockSenderService.On("GetSender", "sender-123").Return(nil, &ErrorSenderNotFound).Once()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(nil, &ErrorSenderNotFound).Once()
 
-	res, err := suite.service.SendOTP(req)
+	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorSenderNotFound.Code, err.Code)
@@ -576,7 +577,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_UnmarshalError() {
 	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: "123456"}
-	res, err := suite.service.VerifyOTP(req)
+	res, err := suite.service.VerifyOTP(context.Background(), req)
 	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidSessionToken.Code, err.Code)

--- a/backend/internal/notification/store.go
+++ b/backend/internal/notification/store.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/asgardeo/thunder/internal/notification/common"
@@ -36,12 +37,12 @@ var (
 
 // notificationStoreInterface defines the interface for notification sender storage operations.
 type notificationStoreInterface interface {
-	createSender(sender common.NotificationSenderDTO) error
-	listSenders() ([]common.NotificationSenderDTO, error)
-	getSenderByID(id string) (*common.NotificationSenderDTO, error)
-	getSenderByName(name string) (*common.NotificationSenderDTO, error)
-	updateSender(id string, sender common.NotificationSenderDTO) error
-	deleteSender(id string) error
+	createSender(ctx context.Context, sender common.NotificationSenderDTO) error
+	listSenders(ctx context.Context) ([]common.NotificationSenderDTO, error)
+	getSenderByID(ctx context.Context, id string) (*common.NotificationSenderDTO, error)
+	getSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO, error)
+	updateSender(ctx context.Context, id string, sender common.NotificationSenderDTO) error
+	deleteSender(ctx context.Context, id string) error
 }
 
 // notificationStore is the implementation of notificationStoreInterface.
@@ -59,7 +60,7 @@ func newNotificationStore() notificationStoreInterface {
 }
 
 // createSender creates a new notification sender.
-func (s *notificationStore) createSender(sender common.NotificationSenderDTO) error {
+func (s *notificationStore) createSender(ctx context.Context, sender common.NotificationSenderDTO) error {
 	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
@@ -74,7 +75,7 @@ func (s *notificationStore) createSender(sender common.NotificationSenderDTO) er
 		}
 	}
 
-	_, err = dbClient.Execute(queryCreateNotificationSender, sender.Name, sender.ID,
+	_, err = dbClient.ExecuteContext(ctx, queryCreateNotificationSender, sender.Name, sender.ID,
 		sender.Description, string(sender.Type), string(sender.Provider), propertiesJSON, s.deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
@@ -84,13 +85,13 @@ func (s *notificationStore) createSender(sender common.NotificationSenderDTO) er
 }
 
 // listSenders retrieves all notification senders
-func (s *notificationStore) listSenders() ([]common.NotificationSenderDTO, error) {
+func (s *notificationStore) listSenders(ctx context.Context) ([]common.NotificationSenderDTO, error) {
 	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetAllNotificationSenders, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetAllNotificationSenders, s.deploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -126,17 +127,17 @@ func (s *notificationStore) listSenders() ([]common.NotificationSenderDTO, error
 }
 
 // getSenderByID retrieves a notification sender by ID.
-func (s *notificationStore) getSenderByID(id string) (*common.NotificationSenderDTO, error) {
-	return s.getSender(queryGetNotificationSenderByID, id)
+func (s *notificationStore) getSenderByID(ctx context.Context, id string) (*common.NotificationSenderDTO, error) {
+	return s.getSender(ctx, queryGetNotificationSenderByID, id)
 }
 
 // getSenderByName retrieves a notification sender by name
-func (s *notificationStore) getSenderByName(name string) (*common.NotificationSenderDTO, error) {
-	return s.getSender(queryGetNotificationSenderByName, name)
+func (s *notificationStore) getSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO, error) {
+	return s.getSender(ctx, queryGetNotificationSenderByName, name)
 }
 
 // getSender retrieves a notification sender by a specific identifier (ID or name).
-func (s *notificationStore) getSender(query dbmodel.DBQuery,
+func (s *notificationStore) getSender(ctx context.Context, query dbmodel.DBQuery,
 	identifier string) (*common.NotificationSenderDTO, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationStore"))
 
@@ -145,7 +146,7 @@ func (s *notificationStore) getSender(query dbmodel.DBQuery,
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(query, identifier, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, query, identifier, s.deploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -183,7 +184,7 @@ func (s *notificationStore) getSender(query dbmodel.DBQuery,
 }
 
 // updateSender updates an existing notification sender.
-func (s *notificationStore) updateSender(id string, sender common.NotificationSenderDTO) error {
+func (s *notificationStore) updateSender(ctx context.Context, id string, sender common.NotificationSenderDTO) error {
 	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
@@ -198,7 +199,7 @@ func (s *notificationStore) updateSender(id string, sender common.NotificationSe
 		}
 	}
 
-	_, err = dbClient.Execute(queryUpdateNotificationSender, sender.Name, sender.Description,
+	_, err = dbClient.ExecuteContext(ctx, queryUpdateNotificationSender, sender.Name, sender.Description,
 		string(sender.Provider), propertiesJSON, id, string(sender.Type), s.deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
@@ -208,7 +209,7 @@ func (s *notificationStore) updateSender(id string, sender common.NotificationSe
 }
 
 // deleteSender deletes a notification sender.
-func (s *notificationStore) deleteSender(id string) error {
+func (s *notificationStore) deleteSender(ctx context.Context, id string) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationStore"))
 
 	dbClient, err := s.dbProvider.GetConfigDBClient()
@@ -216,7 +217,7 @@ func (s *notificationStore) deleteSender(id string) error {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	rowsAffected, err := dbClient.Execute(queryDeleteNotificationSender, id, s.deploymentID)
+	rowsAffected, err := dbClient.ExecuteContext(ctx, queryDeleteNotificationSender, id, s.deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to execute delete query: %w", err)
 	}

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -1285,7 +1285,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Success() {
 		Properties:  []cmodels.Property{*mockProperty},
 	}
 
-	suite.mockNotificationService.EXPECT().GetSender("sender1").Return(mockSender, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender1").Return(mockSender, nil)
 
 	result, err := suite.exportService.ExportResources(context.Background(), request)
 
@@ -1318,8 +1318,8 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Multiple() {
 		Properties: []cmodels.Property{*mockProperty2},
 	}
 
-	suite.mockNotificationService.EXPECT().GetSender("sender1").Return(mockSender1, nil)
-	suite.mockNotificationService.EXPECT().GetSender("sender2").Return(mockSender2, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender1").Return(mockSender1, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender2").Return(mockSender2, nil)
 
 	request := &ExportRequest{
 		NotificationSenders: []string{"sender1", "sender2"},
@@ -1357,9 +1357,9 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_Wildcard() {
 
 	mockSenderList := []common.NotificationSenderDTO{*mockSender1, *mockSender2}
 
-	suite.mockNotificationService.EXPECT().ListSenders().Return(mockSenderList, nil)
-	suite.mockNotificationService.EXPECT().GetSender("sender1").Return(mockSender1, nil)
-	suite.mockNotificationService.EXPECT().GetSender("sender2").Return(mockSender2, nil)
+	suite.mockNotificationService.EXPECT().ListSenders(mock.Anything).Return(mockSenderList, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender1").Return(mockSender1, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender2").Return(mockSender2, nil)
 
 	result, err := suite.exportService.ExportResources(context.Background(), request)
 
@@ -1383,7 +1383,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_NotFound() {
 		Error: "Notification sender not found",
 	}
 
-	suite.mockNotificationService.EXPECT().GetSender("non-existent-sender").Return(nil, senderError)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "non-existent-sender").Return(nil, senderError)
 
 	result, err := suite.exportService.ExportResources(context.Background(), request)
 
@@ -1409,7 +1409,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_EmptyName() {
 		Properties: []cmodels.Property{*mockProperty},
 	}
 
-	suite.mockNotificationService.EXPECT().GetSender("sender-no-name").Return(mockSender, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender-no-name").Return(mockSender, nil)
 
 	result, err := suite.exportService.ExportResources(context.Background(), request)
 
@@ -1434,7 +1434,7 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_NoProperties(
 		Properties: []cmodels.Property{}, // Empty properties
 	}
 
-	suite.mockNotificationService.EXPECT().GetSender("sender-no-props").Return(mockSender, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender-no-props").Return(mockSender, nil)
 
 	result, err := suite.exportService.ExportResources(context.Background(), request)
 
@@ -1474,9 +1474,9 @@ func (suite *ExportServiceTestSuite) TestExportNotificationSenders_WildcardParti
 	// Create list with 3 senders but sender2 will fail to retrieve
 	mockSenderList := []common.NotificationSenderDTO{*mockSender1, *mockSender3}
 
-	suite.mockNotificationService.EXPECT().ListSenders().Return(mockSenderList, nil)
-	suite.mockNotificationService.EXPECT().GetSender("sender1").Return(mockSender1, nil)
-	suite.mockNotificationService.EXPECT().GetSender("sender3").Return(mockSender3, nil)
+	suite.mockNotificationService.EXPECT().ListSenders(mock.Anything).Return(mockSenderList, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender1").Return(mockSender1, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, "sender3").Return(mockSender3, nil)
 
 	result, err := suite.exportService.ExportResources(context.Background(), request)
 
@@ -2046,7 +2046,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 		Properties: []cmodels.Property{*mockProperty},
 	}
 
-	suite.mockNotificationService.EXPECT().GetSender(senderID).Return(mockSender, nil)
+	suite.mockNotificationService.EXPECT().GetSender(mock.Anything, senderID).Return(mockSender, nil)
 
 	exporter, exists := suite.exportService.(*exportService).registry.Get(resourceTypeNotificationSender)
 	assert.True(suite.T(), exists, "Notification sender exporter should be registered")

--- a/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
+++ b/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
@@ -5,6 +5,7 @@
 package userschema
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
@@ -39,8 +40,8 @@ func (_m *UserSchemaServiceInterfaceMock) EXPECT() *UserSchemaServiceInterfaceMo
 }
 
 // CreateUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) CreateUserSchema(request CreateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *UserSchemaServiceInterfaceMock) CreateUserSchema(ctx context.Context, request CreateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUserSchema")
@@ -48,18 +49,18 @@ func (_mock *UserSchemaServiceInterfaceMock) CreateUserSchema(request CreateUser
 
 	var r0 *UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(CreateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(CreateUserSchemaRequest) *UserSchema); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateUserSchemaRequest) *UserSchema); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(CreateUserSchemaRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, CreateUserSchemaRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -74,19 +75,25 @@ type UserSchemaServiceInterfaceMock_CreateUserSchema_Call struct {
 }
 
 // CreateUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request CreateUserSchemaRequest
-func (_e *UserSchemaServiceInterfaceMock_Expecter) CreateUserSchema(request interface{}) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", request)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) CreateUserSchema(ctx interface{}, request interface{}) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", ctx, request)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) Run(run func(request CreateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) Run(run func(ctx context.Context, request CreateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 CreateUserSchemaRequest
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(CreateUserSchemaRequest)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 CreateUserSchemaRequest
+		if args[1] != nil {
+			arg1 = args[1].(CreateUserSchemaRequest)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -97,22 +104,22 @@ func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) Return(userSchem
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(request CreateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(ctx context.Context, request CreateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) DeleteUserSchema(schemaID string) *serviceerror.ServiceError {
-	ret := _mock.Called(schemaID)
+func (_mock *UserSchemaServiceInterfaceMock) DeleteUserSchema(ctx context.Context, schemaID string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, schemaID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteUserSchema")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, schemaID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -127,19 +134,25 @@ type UserSchemaServiceInterfaceMock_DeleteUserSchema_Call struct {
 }
 
 // DeleteUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
-func (_e *UserSchemaServiceInterfaceMock_Expecter) DeleteUserSchema(schemaID interface{}) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_DeleteUserSchema_Call{Call: _e.mock.On("DeleteUserSchema", schemaID)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) DeleteUserSchema(ctx interface{}, schemaID interface{}) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_DeleteUserSchema_Call{Call: _e.mock.On("DeleteUserSchema", ctx, schemaID)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) Run(run func(schemaID string)) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) Run(run func(ctx context.Context, schemaID string)) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -150,14 +163,14 @@ func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) Return(serviceEr
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) RunAndReturn(run func(schemaID string) *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) RunAndReturn(run func(ctx context.Context, schemaID string) *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(schemaID string) (*UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(schemaID)
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(ctx context.Context, schemaID string) (*UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, schemaID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchema")
@@ -165,18 +178,18 @@ func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(schemaID string) (*Us
 
 	var r0 *UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, schemaID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *UserSchema); ok {
-		r0 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *UserSchema); ok {
+		r0 = returnFunc(ctx, schemaID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(schemaID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, schemaID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -191,19 +204,25 @@ type UserSchemaServiceInterfaceMock_GetUserSchema_Call struct {
 }
 
 // GetUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
-func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchema(schemaID interface{}) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_GetUserSchema_Call{Call: _e.mock.On("GetUserSchema", schemaID)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchema(ctx interface{}, schemaID interface{}) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchema_Call{Call: _e.mock.On("GetUserSchema", ctx, schemaID)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) Run(run func(schemaID string)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) Run(run func(ctx context.Context, schemaID string)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -214,14 +233,14 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) Return(userSchema *
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) RunAndReturn(run func(schemaID string) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) RunAndReturn(run func(ctx context.Context, schemaID string) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUserSchemaByName provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(schemaName string) (*UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(schemaName)
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(ctx context.Context, schemaName string) (*UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, schemaName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaByName")
@@ -229,18 +248,18 @@ func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaByName(schemaName stri
 
 	var r0 *UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(schemaName)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, schemaName)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *UserSchema); ok {
-		r0 = returnFunc(schemaName)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *UserSchema); ok {
+		r0 = returnFunc(ctx, schemaName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(schemaName)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, schemaName)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -255,19 +274,25 @@ type UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call struct {
 }
 
 // GetUserSchemaByName is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaName string
-func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaByName(schemaName interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
-	return &UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", schemaName)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaByName(ctx interface{}, schemaName interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", ctx, schemaName)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Run(run func(schemaName string)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Run(run func(ctx context.Context, schemaName string)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -278,14 +303,14 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Return(userSc
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(schemaName string) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(ctx context.Context, schemaName string) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUserSchemaList provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(limit int, offset int) (*UserSchemaListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(limit, offset)
+func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(ctx context.Context, limit int, offset int) (*UserSchemaListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserSchemaList")
@@ -293,18 +318,18 @@ func (_mock *UserSchemaServiceInterfaceMock) GetUserSchemaList(limit int, offset
 
 	var r0 *UserSchemaListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(int, int) (*UserSchemaListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*UserSchemaListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) *UserSchemaListResponse); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *UserSchemaListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*UserSchemaListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -319,25 +344,31 @@ type UserSchemaServiceInterfaceMock_GetUserSchemaList_Call struct {
 }
 
 // GetUserSchemaList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaList(limit interface{}, offset interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
-	return &UserSchemaServiceInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", limit, offset)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaList(ctx interface{}, limit interface{}, offset interface{}) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
+	return &UserSchemaServiceInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", ctx, limit, offset)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) Run(run func(limit int, offset int)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) Run(run func(ctx context.Context, limit int, offset int)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -348,14 +379,14 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) Return(userSche
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(limit int, offset int) (*UserSchemaListResponse, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*UserSchemaListResponse, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) UpdateUserSchema(schemaID string, request UpdateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError) {
-	ret := _mock.Called(schemaID, request)
+func (_mock *UserSchemaServiceInterfaceMock) UpdateUserSchema(ctx context.Context, schemaID string, request UpdateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, schemaID, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateUserSchema")
@@ -363,18 +394,18 @@ func (_mock *UserSchemaServiceInterfaceMock) UpdateUserSchema(schemaID string, r
 
 	var r0 *UserSchema
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, UpdateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)); ok {
-		return returnFunc(schemaID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, schemaID, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, UpdateUserSchemaRequest) *UserSchema); ok {
-		r0 = returnFunc(schemaID, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, UpdateUserSchemaRequest) *UserSchema); ok {
+		r0 = returnFunc(ctx, schemaID, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*UserSchema)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, UpdateUserSchemaRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(schemaID, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, UpdateUserSchemaRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, schemaID, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -389,25 +420,31 @@ type UserSchemaServiceInterfaceMock_UpdateUserSchema_Call struct {
 }
 
 // UpdateUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - schemaID string
 //   - request UpdateUserSchemaRequest
-func (_e *UserSchemaServiceInterfaceMock_Expecter) UpdateUserSchema(schemaID interface{}, request interface{}) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
-	return &UserSchemaServiceInterfaceMock_UpdateUserSchema_Call{Call: _e.mock.On("UpdateUserSchema", schemaID, request)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) UpdateUserSchema(ctx interface{}, schemaID interface{}, request interface{}) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
+	return &UserSchemaServiceInterfaceMock_UpdateUserSchema_Call{Call: _e.mock.On("UpdateUserSchema", ctx, schemaID, request)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) Run(run func(schemaID string, request UpdateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) Run(run func(ctx context.Context, schemaID string, request UpdateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 UpdateUserSchemaRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(UpdateUserSchemaRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 UpdateUserSchemaRequest
+		if args[2] != nil {
+			arg2 = args[2].(UpdateUserSchemaRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -418,14 +455,14 @@ func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) Return(userSchem
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) RunAndReturn(run func(schemaID string, request UpdateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) RunAndReturn(run func(ctx context.Context, schemaID string, request UpdateUserSchemaRequest) (*UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateUser provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError) {
-	ret := _mock.Called(userType, userAttributes)
+func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, userAttributes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateUser")
@@ -433,16 +470,16 @@ func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(userType string, userA
 
 	var r0 bool
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage) (bool, *serviceerror.ServiceError)); ok {
-		return returnFunc(userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, userAttributes)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage) bool); ok {
-		r0 = returnFunc(userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) bool); ok {
+		r0 = returnFunc(ctx, userType, userAttributes)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, json.RawMessage) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(userType, userAttributes)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, userAttributes)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -457,25 +494,31 @@ type UserSchemaServiceInterfaceMock_ValidateUser_Call struct {
 }
 
 // ValidateUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userType string
 //   - userAttributes json.RawMessage
-func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(userType interface{}, userAttributes interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
-	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", userType, userAttributes)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(ctx interface{}, userType interface{}, userAttributes interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", ctx, userType, userAttributes)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(userType string, userAttributes json.RawMessage)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 json.RawMessage
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(json.RawMessage)
+			arg1 = args[1].(string)
+		}
+		var arg2 json.RawMessage
+		if args[2] != nil {
+			arg2 = args[2].(json.RawMessage)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -486,14 +529,14 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Return(b bool, servi
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateUserUniqueness provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) ValidateUserUniqueness(userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError) {
-	ret := _mock.Called(userType, userAttributes, identifyUser)
+func (_mock *UserSchemaServiceInterfaceMock) ValidateUserUniqueness(ctx context.Context, userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, userAttributes, identifyUser)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateUserUniqueness")
@@ -501,16 +544,16 @@ func (_mock *UserSchemaServiceInterfaceMock) ValidateUserUniqueness(userType str
 
 	var r0 bool
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage, func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)); ok {
-		return returnFunc(userType, userAttributes, identifyUser)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, userAttributes, identifyUser)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage, func(map[string]interface{}) (*string, error)) bool); ok {
-		r0 = returnFunc(userType, userAttributes, identifyUser)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, func(map[string]interface{}) (*string, error)) bool); ok {
+		r0 = returnFunc(ctx, userType, userAttributes, identifyUser)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, json.RawMessage, func(map[string]interface{}) (*string, error)) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(userType, userAttributes, identifyUser)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage, func(map[string]interface{}) (*string, error)) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, userAttributes, identifyUser)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -525,31 +568,37 @@ type UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call struct {
 }
 
 // ValidateUserUniqueness is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userType string
 //   - userAttributes json.RawMessage
 //   - identifyUser func(map[string]interface{}) (*string, error)
-func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUserUniqueness(userType interface{}, userAttributes interface{}, identifyUser interface{}) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
-	return &UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call{Call: _e.mock.On("ValidateUserUniqueness", userType, userAttributes, identifyUser)}
+func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUserUniqueness(ctx interface{}, userType interface{}, userAttributes interface{}, identifyUser interface{}) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
+	return &UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call{Call: _e.mock.On("ValidateUserUniqueness", ctx, userType, userAttributes, identifyUser)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) Run(run func(userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error))) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error))) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 json.RawMessage
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(json.RawMessage)
+			arg1 = args[1].(string)
 		}
-		var arg2 func(map[string]interface{}) (*string, error)
+		var arg2 json.RawMessage
 		if args[2] != nil {
-			arg2 = args[2].(func(map[string]interface{}) (*string, error))
+			arg2 = args[2].(json.RawMessage)
+		}
+		var arg3 func(map[string]interface{}) (*string, error)
+		if args[3] != nil {
+			arg3 = args[3].(func(map[string]interface{}) (*string, error))
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -560,7 +609,7 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) Return(b b
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) RunAndReturn(run func(userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/userschema/userSchemaStoreInterface_mock_test.go
+++ b/backend/internal/userschema/userSchemaStoreInterface_mock_test.go
@@ -66,14 +66,19 @@ func (_e *userSchemaStoreInterfaceMock_Expecter) CreateUserSchema(ctx interface{
 	return &userSchemaStoreInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", ctx, userSchema)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Run(run func(userSchema UserSchema)) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
+func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Run(run func(ctx context.Context, userSchema UserSchema)) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 UserSchema
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(UserSchema)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 UserSchema
+		if args[1] != nil {
+			arg1 = args[1].(UserSchema)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -84,7 +89,7 @@ func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Return(err error) 
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(userSchema UserSchema) error) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
+func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(ctx context.Context, userSchema UserSchema) error) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -118,14 +123,19 @@ func (_e *userSchemaStoreInterfaceMock_Expecter) DeleteUserSchemaByID(ctx interf
 	return &userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call{Call: _e.mock.On("DeleteUserSchemaByID", ctx, schemaID)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Run(run func(schemaID string)) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
+func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Run(run func(ctx context.Context, schemaID string)) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -136,7 +146,7 @@ func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Return(err err
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) RunAndReturn(run func(schemaID string) error) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
+func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) RunAndReturn(run func(ctx context.Context, schemaID string) error) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -179,14 +189,19 @@ func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByID(ctx interface
 	return &userSchemaStoreInterfaceMock_GetUserSchemaByID_Call{Call: _e.mock.On("GetUserSchemaByID", ctx, schemaID)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Run(run func(schemaID string)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Run(run func(ctx context.Context, schemaID string)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -197,7 +212,7 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Return(userSchema
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) RunAndReturn(run func(schemaID string) (UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) RunAndReturn(run func(ctx context.Context, schemaID string) (UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -240,14 +255,19 @@ func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByName(ctx interfa
 	return &userSchemaStoreInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", ctx, name)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Run(run func(name string)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Run(run func(ctx context.Context, name string)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -258,7 +278,7 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Return(userSche
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(name string) (UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(ctx context.Context, name string) (UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -304,19 +324,24 @@ func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaList(ctx interface
 	return &userSchemaStoreInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", ctx, limit, offset)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Run(run func(limit int, offset int)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Run(run func(ctx context.Context, limit int, offset int)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -327,7 +352,7 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Return(userSchema
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(limit int, offset int) ([]UserSchemaListItem, error)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]UserSchemaListItem, error)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -369,9 +394,15 @@ func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaListCount(ctx inte
 	return &userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call{Call: _e.mock.On("GetUserSchemaListCount", ctx)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Run(run func()) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Run(run func(ctx context.Context)) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -381,7 +412,7 @@ func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Return(n int
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) RunAndReturn(run func() (int, error)) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -416,19 +447,24 @@ func (_e *userSchemaStoreInterfaceMock_Expecter) UpdateUserSchemaByID(ctx interf
 	return &userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call{Call: _e.mock.On("UpdateUserSchemaByID", ctx, schemaID, userSchema)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Run(run func(schemaID string, userSchema UserSchema)) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
+func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Run(run func(ctx context.Context, schemaID string, userSchema UserSchema)) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 UserSchema
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(UserSchema)
+			arg1 = args[1].(string)
+		}
+		var arg2 UserSchema
+		if args[2] != nil {
+			arg2 = args[2].(UserSchema)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -439,7 +475,7 @@ func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Return(err err
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) RunAndReturn(run func(schemaID string, userSchema UserSchema) error) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
+func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) RunAndReturn(run func(ctx context.Context, schemaID string, userSchema UserSchema) error) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/authnmock/AuthenticationServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/authnmock/AuthenticationServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package authnmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn"
 	"github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/idp"
@@ -117,7 +119,7 @@ func (_c *AuthenticationServiceInterfaceMock_AuthenticateWithCredentials_Call) R
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_AuthenticateWithCredentials_Call) RunAndReturn(run func(identifiers map[string]interface{}, credentials map[string]interface{}, skipAssertion bool, existingAssertion string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_AuthenticateWithCredentials_Call {
+func (_c *AuthenticationServiceInterfaceMock_AuthenticateWithCredentials_Call) RunAndReturn(run func(map[string]interface{}, map[string]interface{}, bool, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_AuthenticateWithCredentials_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -205,7 +207,7 @@ func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Retur
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) RunAndReturn(run func(requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) RunAndReturn(run func(idp.IDPType, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -299,7 +301,7 @@ func (_c *AuthenticationServiceInterfaceMock_FinishPasskeyAuthentication_Call) R
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_FinishPasskeyAuthentication_Call) RunAndReturn(run func(credentialID string, credentialType string, response authn.PasskeyCredentialResponseDTO, sessionToken string, skipAssertion bool, existingAssertion string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishPasskeyAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_FinishPasskeyAuthentication_Call) RunAndReturn(run func(string, string, authn.PasskeyCredentialResponseDTO, string, bool, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishPasskeyAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -375,14 +377,14 @@ func (_c *AuthenticationServiceInterfaceMock_FinishPasskeyRegistration_Call) Ret
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_FinishPasskeyRegistration_Call) RunAndReturn(run func(credential authn.PasskeyPublicKeyCredentialDTO, sessionToken string, credentialName string) (interface{}, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishPasskeyRegistration_Call {
+func (_c *AuthenticationServiceInterfaceMock_FinishPasskeyRegistration_Call) RunAndReturn(run func(authn.PasskeyPublicKeyCredentialDTO, string, string) (interface{}, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishPasskeyRegistration_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // SendOTP provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) SendOTP(senderID string, channel common0.ChannelType, recipient string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(senderID, channel, recipient)
+func (_mock *AuthenticationServiceInterfaceMock) SendOTP(ctx context.Context, senderID string, channel common0.ChannelType, recipient string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, senderID, channel, recipient)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendOTP")
@@ -390,16 +392,16 @@ func (_mock *AuthenticationServiceInterfaceMock) SendOTP(senderID string, channe
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, common0.ChannelType, string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common0.ChannelType, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, senderID, channel, recipient)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, common0.ChannelType, string) string); ok {
-		r0 = returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common0.ChannelType, string) string); ok {
+		r0 = returnFunc(ctx, senderID, channel, recipient)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, common0.ChannelType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common0.ChannelType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, senderID, channel, recipient)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -414,31 +416,37 @@ type AuthenticationServiceInterfaceMock_SendOTP_Call struct {
 }
 
 // SendOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - senderID string
 //   - channel common0.ChannelType
 //   - recipient string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) SendOTP(senderID interface{}, channel interface{}, recipient interface{}) *AuthenticationServiceInterfaceMock_SendOTP_Call {
-	return &AuthenticationServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", senderID, channel, recipient)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) SendOTP(ctx interface{}, senderID interface{}, channel interface{}, recipient interface{}) *AuthenticationServiceInterfaceMock_SendOTP_Call {
+	return &AuthenticationServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", ctx, senderID, channel, recipient)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) Run(run func(senderID string, channel common0.ChannelType, recipient string)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) Run(run func(ctx context.Context, senderID string, channel common0.ChannelType, recipient string)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 common0.ChannelType
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(common0.ChannelType)
+			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common0.ChannelType
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common0.ChannelType)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -449,7 +457,7 @@ func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) Return(s string, serv
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(senderID string, channel common0.ChannelType, recipient string) (string, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(context.Context, string, common0.ChannelType, string) (string, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -519,7 +527,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) Return
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) RunAndReturn(run func(requestedType idp.IDPType, idpID string) (*authn.IDPAuthInitData, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) RunAndReturn(run func(idp.IDPType, string) (*authn.IDPAuthInitData, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -589,7 +597,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyAuthentication_Call) Re
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartPasskeyAuthentication_Call) RunAndReturn(run func(userID string, relyingPartyID string) (interface{}, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartPasskeyAuthentication_Call) RunAndReturn(run func(string, string) (interface{}, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -677,14 +685,14 @@ func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) Retu
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) RunAndReturn(run func(userID string, relyingPartyID string, relyingPartyName string, authSelection *authn.PasskeyAuthenticatorSelectionDTO, attestation string) (interface{}, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call) RunAndReturn(run func(string, string, string, *authn.PasskeyAuthenticatorSelectionDTO, string) (interface{}, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartPasskeyRegistration_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyOTP provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) VerifyOTP(sessionToken string, skipAssertion bool, existingAssertion string, otp string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(sessionToken, skipAssertion, existingAssertion, otp)
+func (_mock *AuthenticationServiceInterfaceMock) VerifyOTP(ctx context.Context, sessionToken string, skipAssertion bool, existingAssertion string, otp string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyOTP")
@@ -692,18 +700,18 @@ func (_mock *AuthenticationServiceInterfaceMock) VerifyOTP(sessionToken string, 
 
 	var r0 *common.AuthenticationResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(sessionToken, skipAssertion, existingAssertion, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, bool, string, string) *common.AuthenticationResponse); ok {
-		r0 = returnFunc(sessionToken, skipAssertion, existingAssertion, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool, string, string) *common.AuthenticationResponse); ok {
+		r0 = returnFunc(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthenticationResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, bool, string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(sessionToken, skipAssertion, existingAssertion, otp)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, bool, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, sessionToken, skipAssertion, existingAssertion, otp)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -718,37 +726,43 @@ type AuthenticationServiceInterfaceMock_VerifyOTP_Call struct {
 }
 
 // VerifyOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sessionToken string
 //   - skipAssertion bool
 //   - existingAssertion string
 //   - otp string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) VerifyOTP(sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, otp interface{}) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
-	return &AuthenticationServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", sessionToken, skipAssertion, existingAssertion, otp)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, otp interface{}) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
+	return &AuthenticationServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, sessionToken, skipAssertion, existingAssertion, otp)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) Run(run func(sessionToken string, skipAssertion bool, existingAssertion string, otp string)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, sessionToken string, skipAssertion bool, existingAssertion string, otp string)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 bool
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(bool)
+			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 bool
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(bool)
 		}
 		var arg3 string
 		if args[3] != nil {
 			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -759,7 +773,7 @@ func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) Return(authenticati
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(sessionToken string, skipAssertion bool, existingAssertion string, otp string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
+func (_c *AuthenticationServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(context.Context, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/otpmock/OTPAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/otpmock/OTPAuthnServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package otpmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
@@ -39,8 +41,8 @@ func (_m *OTPAuthnServiceInterfaceMock) EXPECT() *OTPAuthnServiceInterfaceMock_E
 }
 
 // SendOTP provides a mock function for the type OTPAuthnServiceInterfaceMock
-func (_mock *OTPAuthnServiceInterfaceMock) SendOTP(senderID string, channel common.ChannelType, recipient string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(senderID, channel, recipient)
+func (_mock *OTPAuthnServiceInterfaceMock) SendOTP(ctx context.Context, senderID string, channel common.ChannelType, recipient string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, senderID, channel, recipient)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendOTP")
@@ -48,16 +50,16 @@ func (_mock *OTPAuthnServiceInterfaceMock) SendOTP(senderID string, channel comm
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, common.ChannelType, string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.ChannelType, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, senderID, channel, recipient)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, common.ChannelType, string) string); ok {
-		r0 = returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.ChannelType, string) string); ok {
+		r0 = returnFunc(ctx, senderID, channel, recipient)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, common.ChannelType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(senderID, channel, recipient)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.ChannelType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, senderID, channel, recipient)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,31 +74,37 @@ type OTPAuthnServiceInterfaceMock_SendOTP_Call struct {
 }
 
 // SendOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - senderID string
 //   - channel common.ChannelType
 //   - recipient string
-func (_e *OTPAuthnServiceInterfaceMock_Expecter) SendOTP(senderID interface{}, channel interface{}, recipient interface{}) *OTPAuthnServiceInterfaceMock_SendOTP_Call {
-	return &OTPAuthnServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", senderID, channel, recipient)}
+func (_e *OTPAuthnServiceInterfaceMock_Expecter) SendOTP(ctx interface{}, senderID interface{}, channel interface{}, recipient interface{}) *OTPAuthnServiceInterfaceMock_SendOTP_Call {
+	return &OTPAuthnServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", ctx, senderID, channel, recipient)}
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_SendOTP_Call) Run(run func(senderID string, channel common.ChannelType, recipient string)) *OTPAuthnServiceInterfaceMock_SendOTP_Call {
+func (_c *OTPAuthnServiceInterfaceMock_SendOTP_Call) Run(run func(ctx context.Context, senderID string, channel common.ChannelType, recipient string)) *OTPAuthnServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 common.ChannelType
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(common.ChannelType)
+			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.ChannelType
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.ChannelType)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -107,14 +115,14 @@ func (_c *OTPAuthnServiceInterfaceMock_SendOTP_Call) Return(s string, serviceErr
 	return _c
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(senderID string, channel common.ChannelType, recipient string) (string, *serviceerror.ServiceError)) *OTPAuthnServiceInterfaceMock_SendOTP_Call {
+func (_c *OTPAuthnServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(context.Context, string, common.ChannelType, string) (string, *serviceerror.ServiceError)) *OTPAuthnServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyOTP provides a mock function for the type OTPAuthnServiceInterfaceMock
-func (_mock *OTPAuthnServiceInterfaceMock) VerifyOTP(sessionToken string, otp string) (*userprovider.User, *serviceerror.ServiceError) {
-	ret := _mock.Called(sessionToken, otp)
+func (_mock *OTPAuthnServiceInterfaceMock) VerifyOTP(ctx context.Context, sessionToken string, otp string) (*userprovider.User, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, sessionToken, otp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyOTP")
@@ -122,18 +130,18 @@ func (_mock *OTPAuthnServiceInterfaceMock) VerifyOTP(sessionToken string, otp st
 
 	var r0 *userprovider.User
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) (*userprovider.User, *serviceerror.ServiceError)); ok {
-		return returnFunc(sessionToken, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*userprovider.User, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, sessionToken, otp)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) *userprovider.User); ok {
-		r0 = returnFunc(sessionToken, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *userprovider.User); ok {
+		r0 = returnFunc(ctx, sessionToken, otp)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*userprovider.User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(sessionToken, otp)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, sessionToken, otp)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -148,25 +156,31 @@ type OTPAuthnServiceInterfaceMock_VerifyOTP_Call struct {
 }
 
 // VerifyOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sessionToken string
 //   - otp string
-func (_e *OTPAuthnServiceInterfaceMock_Expecter) VerifyOTP(sessionToken interface{}, otp interface{}) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
-	return &OTPAuthnServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", sessionToken, otp)}
+func (_e *OTPAuthnServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, sessionToken interface{}, otp interface{}) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
+	return &OTPAuthnServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, sessionToken, otp)}
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) Run(run func(sessionToken string, otp string)) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, sessionToken string, otp string)) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -177,7 +191,7 @@ func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) Return(user *userprovider
 	return _c
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(sessionToken string, otp string) (*userprovider.User, *serviceerror.ServiceError)) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(context.Context, string, string) (*userprovider.User, *serviceerror.ServiceError)) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
+++ b/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
@@ -630,82 +630,6 @@ func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(
 	return _c
 }
 
-// UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
-func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, groupID, request)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateGroup")
-	}
-
-	var r0 *group.Group
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, groupID, request)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.UpdateGroupRequest) *group.Group); ok {
-		r0 = returnFunc(ctx, groupID, request)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*group.Group)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, group.UpdateGroupRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, groupID, request)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// GroupServiceInterfaceMock_UpdateGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGroup'
-type GroupServiceInterfaceMock_UpdateGroup_Call struct {
-	*mock.Call
-}
-
-// UpdateGroup is a helper method to define mock.On call
-//   - ctx context.Context
-//   - groupID string
-//   - request group.UpdateGroupRequest
-func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(ctx interface{}, groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, groupID, request)}
-}
-
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, groupID string, request group.UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 group.UpdateGroupRequest
-		if args[2] != nil {
-			arg2 = args[2].(group.UpdateGroupRequest)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Return(group1 *group.Group, serviceError *serviceerror.ServiceError) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	_c.Call.Return(group1, serviceError)
-	return _c
-}
-
-func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // RemoveGroupMembers provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) RemoveGroupMembers(ctx context.Context, groupID string, members []group.Member) (*group.Group, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, groupID, members)
@@ -778,6 +702,82 @@ func (_c *GroupServiceInterfaceMock_RemoveGroupMembers_Call) Return(group1 *grou
 }
 
 func (_c *GroupServiceInterfaceMock_RemoveGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, members []group.Member) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_RemoveGroupMembers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupID, request)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateGroup")
+	}
+
+	var r0 *group.Group
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupID, request)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, group.UpdateGroupRequest) *group.Group); ok {
+		r0 = returnFunc(ctx, groupID, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*group.Group)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, group.UpdateGroupRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID, request)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_UpdateGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGroup'
+type GroupServiceInterfaceMock_UpdateGroup_Call struct {
+	*mock.Call
+}
+
+// UpdateGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupID string
+//   - request group.UpdateGroupRequest
+func (_e *GroupServiceInterfaceMock_Expecter) UpdateGroup(ctx interface{}, groupID interface{}, request interface{}) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	return &GroupServiceInterfaceMock_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, groupID, request)}
+}
+
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Run(run func(ctx context.Context, groupID string, request group.UpdateGroupRequest)) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 group.UpdateGroupRequest
+		if args[2] != nil {
+			arg2 = args[2].(group.UpdateGroupRequest)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) Return(group1 *group.Group, serviceError *serviceerror.ServiceError) *GroupServiceInterfaceMock_UpdateGroup_Call {
+	_c.Call.Return(group1, serviceError)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_UpdateGroup_Call) RunAndReturn(run func(ctx context.Context, groupID string, request group.UpdateGroupRequest) (*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_UpdateGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
+++ b/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
@@ -38,6 +38,69 @@ func (_m *groupStoreInterfaceMock) EXPECT() *groupStoreInterfaceMock_Expecter {
 	return &groupStoreInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
+// AddGroupMembers provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) AddGroupMembers(ctx context.Context, groupID string, members []group.Member) error {
+	ret := _mock.Called(ctx, groupID, members)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddGroupMembers")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []group.Member) error); ok {
+		r0 = returnFunc(ctx, groupID, members)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// groupStoreInterfaceMock_AddGroupMembers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddGroupMembers'
+type groupStoreInterfaceMock_AddGroupMembers_Call struct {
+	*mock.Call
+}
+
+// AddGroupMembers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupID string
+//   - members []group.Member
+func (_e *groupStoreInterfaceMock_Expecter) AddGroupMembers(ctx interface{}, groupID interface{}, members interface{}) *groupStoreInterfaceMock_AddGroupMembers_Call {
+	return &groupStoreInterfaceMock_AddGroupMembers_Call{Call: _e.mock.On("AddGroupMembers", ctx, groupID, members)}
+}
+
+func (_c *groupStoreInterfaceMock_AddGroupMembers_Call) Run(run func(ctx context.Context, groupID string, members []group.Member)) *groupStoreInterfaceMock_AddGroupMembers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []group.Member
+		if args[2] != nil {
+			arg2 = args[2].([]group.Member)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_AddGroupMembers_Call) Return(err error) *groupStoreInterfaceMock_AddGroupMembers_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_AddGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, members []group.Member) error) *groupStoreInterfaceMock_AddGroupMembers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CheckGroupNameConflictForCreate provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) CheckGroupNameConflictForCreate(ctx context.Context, name string, organizationUnitID string) error {
 	ret := _mock.Called(ctx, name, organizationUnitID)
@@ -772,6 +835,69 @@ func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) Return(
 }
 
 func (_c *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call) RunAndReturn(run func(ctx context.Context, organizationUnitID string) (int, error)) *groupStoreInterfaceMock_GetGroupsByOrganizationUnitCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveGroupMembers provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) RemoveGroupMembers(ctx context.Context, groupID string, members []group.Member) error {
+	ret := _mock.Called(ctx, groupID, members)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveGroupMembers")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []group.Member) error); ok {
+		r0 = returnFunc(ctx, groupID, members)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// groupStoreInterfaceMock_RemoveGroupMembers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveGroupMembers'
+type groupStoreInterfaceMock_RemoveGroupMembers_Call struct {
+	*mock.Call
+}
+
+// RemoveGroupMembers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupID string
+//   - members []group.Member
+func (_e *groupStoreInterfaceMock_Expecter) RemoveGroupMembers(ctx interface{}, groupID interface{}, members interface{}) *groupStoreInterfaceMock_RemoveGroupMembers_Call {
+	return &groupStoreInterfaceMock_RemoveGroupMembers_Call{Call: _e.mock.On("RemoveGroupMembers", ctx, groupID, members)}
+}
+
+func (_c *groupStoreInterfaceMock_RemoveGroupMembers_Call) Run(run func(ctx context.Context, groupID string, members []group.Member)) *groupStoreInterfaceMock_RemoveGroupMembers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []group.Member
+		if args[2] != nil {
+			arg2 = args[2].([]group.Member)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_RemoveGroupMembers_Call) Return(err error) *groupStoreInterfaceMock_RemoveGroupMembers_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_RemoveGroupMembers_Call) RunAndReturn(run func(ctx context.Context, groupID string, members []group.Member) error) *groupStoreInterfaceMock_RemoveGroupMembers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/notification/notificationmock/NotificationSenderMgtSvcInterface_mock.go
+++ b/backend/tests/mocks/notification/notificationmock/NotificationSenderMgtSvcInterface_mock.go
@@ -5,6 +5,8 @@
 package notificationmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *NotificationSenderMgtSvcInterfaceMock) EXPECT() *NotificationSenderMgt
 }
 
 // CreateSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) CreateSender(sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(sender)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) CreateSender(ctx context.Context, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, sender)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateSender")
@@ -47,18 +49,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) CreateSender(sender common.N
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, sender)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, sender)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(sender)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, sender)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,19 +75,25 @@ type NotificationSenderMgtSvcInterfaceMock_CreateSender_Call struct {
 }
 
 // CreateSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sender common.NotificationSenderDTO
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) CreateSender(sender interface{}) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_CreateSender_Call{Call: _e.mock.On("CreateSender", sender)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) CreateSender(ctx interface{}, sender interface{}) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_CreateSender_Call{Call: _e.mock.On("CreateSender", ctx, sender)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) Run(run func(sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) Run(run func(ctx context.Context, sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.NotificationSenderDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.NotificationSenderDTO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 common.NotificationSenderDTO
+		if args[1] != nil {
+			arg1 = args[1].(common.NotificationSenderDTO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -96,22 +104,22 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) Return(notifi
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) RunAndReturn(run func(sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call) RunAndReturn(run func(ctx context.Context, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_CreateSender_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) DeleteSender(id string) *serviceerror.ServiceError {
-	ret := _mock.Called(id)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) DeleteSender(ctx context.Context, id string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteSender")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -126,19 +134,25 @@ type NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call struct {
 }
 
 // DeleteSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) DeleteSender(id interface{}) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call{Call: _e.mock.On("DeleteSender", id)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) DeleteSender(ctx interface{}, id interface{}) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call{Call: _e.mock.On("DeleteSender", ctx, id)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) Run(run func(id string)) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) Run(run func(ctx context.Context, id string)) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -149,14 +163,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) Return(servic
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) RunAndReturn(run func(id string) *serviceerror.ServiceError) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call) RunAndReturn(run func(ctx context.Context, id string) *serviceerror.ServiceError) *NotificationSenderMgtSvcInterfaceMock_DeleteSender_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSender(id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(id)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSender(ctx context.Context, id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSender")
@@ -164,18 +178,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSender(id string) (*commo
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -190,19 +204,25 @@ type NotificationSenderMgtSvcInterfaceMock_GetSender_Call struct {
 }
 
 // GetSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSender(id interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_GetSender_Call{Call: _e.mock.On("GetSender", id)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSender(ctx interface{}, id interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_GetSender_Call{Call: _e.mock.On("GetSender", ctx, id)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) Run(run func(id string)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) Run(run func(ctx context.Context, id string)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -213,14 +233,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) Return(notificat
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) RunAndReturn(run func(id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSender_Call) RunAndReturn(run func(ctx context.Context, id string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSender_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetSenderByName provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSenderByName(name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(name)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSenderByName")
@@ -228,18 +248,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) GetSenderByName(name string)
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, name)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(name)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, name)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -254,19 +274,25 @@ type NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call struct {
 }
 
 // GetSenderByName is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSenderByName(name interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call{Call: _e.mock.On("GetSenderByName", name)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) GetSenderByName(ctx interface{}, name interface{}) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call{Call: _e.mock.On("GetSenderByName", ctx, name)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) Run(run func(name string)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) Run(run func(ctx context.Context, name string)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -277,14 +303,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) Return(not
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) RunAndReturn(run func(name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call) RunAndReturn(run func(ctx context.Context, name string) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_GetSenderByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListSenders provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) ListSenders() ([]common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called()
+func (_mock *NotificationSenderMgtSvcInterfaceMock) ListSenders(ctx context.Context) ([]common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListSenders")
@@ -292,18 +318,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) ListSenders() ([]common.Noti
 
 	var r0 []common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func() ([]common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() []common.NotificationSenderDTO); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() *serviceerror.ServiceError); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -318,13 +344,20 @@ type NotificationSenderMgtSvcInterfaceMock_ListSenders_Call struct {
 }
 
 // ListSenders is a helper method to define mock.On call
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) ListSenders() *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_ListSenders_Call{Call: _e.mock.On("ListSenders")}
+//   - ctx context.Context
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) ListSenders(ctx interface{}) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_ListSenders_Call{Call: _e.mock.On("ListSenders", ctx)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) Run(run func()) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) Run(run func(ctx context.Context)) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -334,14 +367,14 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) Return(notific
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) RunAndReturn(run func() ([]common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call) RunAndReturn(run func(ctx context.Context) ([]common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_ListSenders_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateSender provides a mock function for the type NotificationSenderMgtSvcInterfaceMock
-func (_mock *NotificationSenderMgtSvcInterfaceMock) UpdateSender(id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(id, sender)
+func (_mock *NotificationSenderMgtSvcInterfaceMock) UpdateSender(ctx context.Context, id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, sender)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSender")
@@ -349,18 +382,18 @@ func (_mock *NotificationSenderMgtSvcInterfaceMock) UpdateSender(id string, send
 
 	var r0 *common.NotificationSenderDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(id, sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, sender)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(id, sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.NotificationSenderDTO) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, id, sender)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.NotificationSenderDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(id, sender)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.NotificationSenderDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, sender)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -375,25 +408,31 @@ type NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call struct {
 }
 
 // UpdateSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - sender common.NotificationSenderDTO
-func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) UpdateSender(id interface{}, sender interface{}) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
-	return &NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call{Call: _e.mock.On("UpdateSender", id, sender)}
+func (_e *NotificationSenderMgtSvcInterfaceMock_Expecter) UpdateSender(ctx interface{}, id interface{}, sender interface{}) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
+	return &NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call{Call: _e.mock.On("UpdateSender", ctx, id, sender)}
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) Run(run func(id string, sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) Run(run func(ctx context.Context, id string, sender common.NotificationSenderDTO)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 common.NotificationSenderDTO
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(common.NotificationSenderDTO)
+			arg1 = args[1].(string)
+		}
+		var arg2 common.NotificationSenderDTO
+		if args[2] != nil {
+			arg2 = args[2].(common.NotificationSenderDTO)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -404,7 +443,7 @@ func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) Return(notifi
 	return _c
 }
 
-func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) RunAndReturn(run func(id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
+func (_c *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call) RunAndReturn(run func(ctx context.Context, id string, sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError)) *NotificationSenderMgtSvcInterfaceMock_UpdateSender_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/notification/notificationmock/OTPServiceInterface_mock.go
+++ b/backend/tests/mocks/notification/notificationmock/OTPServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package notificationmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *OTPServiceInterfaceMock) EXPECT() *OTPServiceInterfaceMock_Expecter {
 }
 
 // SendOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) SendOTP(request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *OTPServiceInterfaceMock) SendOTP(ctx context.Context, request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendOTP")
@@ -47,18 +49,18 @@ func (_mock *OTPServiceInterfaceMock) SendOTP(request common.SendOTPDTO) (*commo
 
 	var r0 *common.SendOTPResultDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.SendOTPDTO) *common.SendOTPResultDTO); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.SendOTPDTO) *common.SendOTPResultDTO); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.SendOTPResultDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.SendOTPDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.SendOTPDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,19 +75,25 @@ type OTPServiceInterfaceMock_SendOTP_Call struct {
 }
 
 // SendOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request common.SendOTPDTO
-func (_e *OTPServiceInterfaceMock_Expecter) SendOTP(request interface{}) *OTPServiceInterfaceMock_SendOTP_Call {
-	return &OTPServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", request)}
+func (_e *OTPServiceInterfaceMock_Expecter) SendOTP(ctx interface{}, request interface{}) *OTPServiceInterfaceMock_SendOTP_Call {
+	return &OTPServiceInterfaceMock_SendOTP_Call{Call: _e.mock.On("SendOTP", ctx, request)}
 }
 
-func (_c *OTPServiceInterfaceMock_SendOTP_Call) Run(run func(request common.SendOTPDTO)) *OTPServiceInterfaceMock_SendOTP_Call {
+func (_c *OTPServiceInterfaceMock_SendOTP_Call) Run(run func(ctx context.Context, request common.SendOTPDTO)) *OTPServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.SendOTPDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.SendOTPDTO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 common.SendOTPDTO
+		if args[1] != nil {
+			arg1 = args[1].(common.SendOTPDTO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -96,14 +104,14 @@ func (_c *OTPServiceInterfaceMock_SendOTP_Call) Return(sendOTPResultDTO *common.
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_SendOTP_Call {
+func (_c *OTPServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(context.Context, common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_SendOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) VerifyOTP(request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *OTPServiceInterfaceMock) VerifyOTP(ctx context.Context, request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyOTP")
@@ -111,18 +119,18 @@ func (_mock *OTPServiceInterfaceMock) VerifyOTP(request common.VerifyOTPDTO) (*c
 
 	var r0 *common.VerifyOTPResultDTO
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.VerifyOTPDTO) *common.VerifyOTPResultDTO); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) *common.VerifyOTPResultDTO); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.VerifyOTPResultDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.VerifyOTPDTO) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.VerifyOTPDTO) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -137,19 +145,25 @@ type OTPServiceInterfaceMock_VerifyOTP_Call struct {
 }
 
 // VerifyOTP is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request common.VerifyOTPDTO
-func (_e *OTPServiceInterfaceMock_Expecter) VerifyOTP(request interface{}) *OTPServiceInterfaceMock_VerifyOTP_Call {
-	return &OTPServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", request)}
+func (_e *OTPServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, request interface{}) *OTPServiceInterfaceMock_VerifyOTP_Call {
+	return &OTPServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, request)}
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(request common.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, request common.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.VerifyOTPDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.VerifyOTPDTO)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 common.VerifyOTPDTO
+		if args[1] != nil {
+			arg1 = args[1].(common.VerifyOTPDTO)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -160,7 +174,7 @@ func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Return(verifyOTPResultDTO *com
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(context.Context, common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/notification/notificationmock/notificationStoreInterface_mock.go
+++ b/backend/tests/mocks/notification/notificationmock/notificationStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package notificationmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/notification/common"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,16 +39,16 @@ func (_m *notificationStoreInterfaceMock) EXPECT() *notificationStoreInterfaceMo
 }
 
 // createSender provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) createSender(sender common.NotificationSenderDTO) error {
-	ret := _mock.Called(sender)
+func (_mock *notificationStoreInterfaceMock) createSender(ctx context.Context, sender common.NotificationSenderDTO) error {
+	ret := _mock.Called(ctx, sender)
 
 	if len(ret) == 0 {
 		panic("no return value specified for createSender")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(common.NotificationSenderDTO) error); ok {
-		r0 = returnFunc(sender)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.NotificationSenderDTO) error); ok {
+		r0 = returnFunc(ctx, sender)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,298 +61,17 @@ type notificationStoreInterfaceMock_createSender_Call struct {
 }
 
 // createSender is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sender common.NotificationSenderDTO
-func (_e *notificationStoreInterfaceMock_Expecter) createSender(sender interface{}) *notificationStoreInterfaceMock_createSender_Call {
-	return &notificationStoreInterfaceMock_createSender_Call{Call: _e.mock.On("createSender", sender)}
+func (_e *notificationStoreInterfaceMock_Expecter) createSender(ctx interface{}, sender interface{}) *notificationStoreInterfaceMock_createSender_Call {
+	return &notificationStoreInterfaceMock_createSender_Call{Call: _e.mock.On("createSender", ctx, sender)}
 }
 
-func (_c *notificationStoreInterfaceMock_createSender_Call) Run(run func(sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_createSender_Call {
+func (_c *notificationStoreInterfaceMock_createSender_Call) Run(run func(ctx context.Context, sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_createSender_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.NotificationSenderDTO
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.NotificationSenderDTO)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_createSender_Call) Return(err error) *notificationStoreInterfaceMock_createSender_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_createSender_Call) RunAndReturn(run func(sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_createSender_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// deleteSender provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) deleteSender(id string) error {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for deleteSender")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// notificationStoreInterfaceMock_deleteSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deleteSender'
-type notificationStoreInterfaceMock_deleteSender_Call struct {
-	*mock.Call
-}
-
-// deleteSender is a helper method to define mock.On call
-//   - id string
-func (_e *notificationStoreInterfaceMock_Expecter) deleteSender(id interface{}) *notificationStoreInterfaceMock_deleteSender_Call {
-	return &notificationStoreInterfaceMock_deleteSender_Call{Call: _e.mock.On("deleteSender", id)}
-}
-
-func (_c *notificationStoreInterfaceMock_deleteSender_Call) Run(run func(id string)) *notificationStoreInterfaceMock_deleteSender_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_deleteSender_Call) Return(err error) *notificationStoreInterfaceMock_deleteSender_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_deleteSender_Call) RunAndReturn(run func(id string) error) *notificationStoreInterfaceMock_deleteSender_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// getSenderByID provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) getSenderByID(id string) (*common.NotificationSenderDTO, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for getSenderByID")
-	}
-
-	var r0 *common.NotificationSenderDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common.NotificationSenderDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// notificationStoreInterfaceMock_getSenderByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByID'
-type notificationStoreInterfaceMock_getSenderByID_Call struct {
-	*mock.Call
-}
-
-// getSenderByID is a helper method to define mock.On call
-//   - id string
-func (_e *notificationStoreInterfaceMock_Expecter) getSenderByID(id interface{}) *notificationStoreInterfaceMock_getSenderByID_Call {
-	return &notificationStoreInterfaceMock_getSenderByID_Call{Call: _e.mock.On("getSenderByID", id)}
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Run(run func(id string)) *notificationStoreInterfaceMock_getSenderByID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByID_Call {
-	_c.Call.Return(notificationSenderDTO, err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByID_Call) RunAndReturn(run func(id string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// getSenderByName provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) getSenderByName(name string) (*common.NotificationSenderDTO, error) {
-	ret := _mock.Called(name)
-
-	if len(ret) == 0 {
-		panic("no return value specified for getSenderByName")
-	}
-
-	var r0 *common.NotificationSenderDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*common.NotificationSenderDTO, error)); ok {
-		return returnFunc(name)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) *common.NotificationSenderDTO); ok {
-		r0 = returnFunc(name)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common.NotificationSenderDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(name)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// notificationStoreInterfaceMock_getSenderByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByName'
-type notificationStoreInterfaceMock_getSenderByName_Call struct {
-	*mock.Call
-}
-
-// getSenderByName is a helper method to define mock.On call
-//   - name string
-func (_e *notificationStoreInterfaceMock_Expecter) getSenderByName(name interface{}) *notificationStoreInterfaceMock_getSenderByName_Call {
-	return &notificationStoreInterfaceMock_getSenderByName_Call{Call: _e.mock.On("getSenderByName", name)}
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Run(run func(name string)) *notificationStoreInterfaceMock_getSenderByName_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByName_Call {
-	_c.Call.Return(notificationSenderDTO, err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_getSenderByName_Call) RunAndReturn(run func(name string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByName_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// listSenders provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) listSenders() ([]common.NotificationSenderDTO, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for listSenders")
-	}
-
-	var r0 []common.NotificationSenderDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]common.NotificationSenderDTO, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() []common.NotificationSenderDTO); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.NotificationSenderDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// notificationStoreInterfaceMock_listSenders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'listSenders'
-type notificationStoreInterfaceMock_listSenders_Call struct {
-	*mock.Call
-}
-
-// listSenders is a helper method to define mock.On call
-func (_e *notificationStoreInterfaceMock_Expecter) listSenders() *notificationStoreInterfaceMock_listSenders_Call {
-	return &notificationStoreInterfaceMock_listSenders_Call{Call: _e.mock.On("listSenders")}
-}
-
-func (_c *notificationStoreInterfaceMock_listSenders_Call) Run(run func()) *notificationStoreInterfaceMock_listSenders_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_listSenders_Call) Return(notificationSenderDTOs []common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_listSenders_Call {
-	_c.Call.Return(notificationSenderDTOs, err)
-	return _c
-}
-
-func (_c *notificationStoreInterfaceMock_listSenders_Call) RunAndReturn(run func() ([]common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_listSenders_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// updateSender provides a mock function for the type notificationStoreInterfaceMock
-func (_mock *notificationStoreInterfaceMock) updateSender(id string, sender common.NotificationSenderDTO) error {
-	ret := _mock.Called(id, sender)
-
-	if len(ret) == 0 {
-		panic("no return value specified for updateSender")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, common.NotificationSenderDTO) error); ok {
-		r0 = returnFunc(id, sender)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// notificationStoreInterfaceMock_updateSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'updateSender'
-type notificationStoreInterfaceMock_updateSender_Call struct {
-	*mock.Call
-}
-
-// updateSender is a helper method to define mock.On call
-//   - id string
-//   - sender common.NotificationSenderDTO
-func (_e *notificationStoreInterfaceMock_Expecter) updateSender(id interface{}, sender interface{}) *notificationStoreInterfaceMock_updateSender_Call {
-	return &notificationStoreInterfaceMock_updateSender_Call{Call: _e.mock.On("updateSender", id, sender)}
-}
-
-func (_c *notificationStoreInterfaceMock_updateSender_Call) Run(run func(id string, sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_updateSender_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 common.NotificationSenderDTO
 		if args[1] != nil {
@@ -364,12 +85,330 @@ func (_c *notificationStoreInterfaceMock_updateSender_Call) Run(run func(id stri
 	return _c
 }
 
+func (_c *notificationStoreInterfaceMock_createSender_Call) Return(err error) *notificationStoreInterfaceMock_createSender_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_createSender_Call) RunAndReturn(run func(ctx context.Context, sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_createSender_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// deleteSender provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) deleteSender(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for deleteSender")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// notificationStoreInterfaceMock_deleteSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deleteSender'
+type notificationStoreInterfaceMock_deleteSender_Call struct {
+	*mock.Call
+}
+
+// deleteSender is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *notificationStoreInterfaceMock_Expecter) deleteSender(ctx interface{}, id interface{}) *notificationStoreInterfaceMock_deleteSender_Call {
+	return &notificationStoreInterfaceMock_deleteSender_Call{Call: _e.mock.On("deleteSender", ctx, id)}
+}
+
+func (_c *notificationStoreInterfaceMock_deleteSender_Call) Run(run func(ctx context.Context, id string)) *notificationStoreInterfaceMock_deleteSender_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_deleteSender_Call) Return(err error) *notificationStoreInterfaceMock_deleteSender_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_deleteSender_Call) RunAndReturn(run func(ctx context.Context, id string) error) *notificationStoreInterfaceMock_deleteSender_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getSenderByID provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) getSenderByID(ctx context.Context, id string) (*common.NotificationSenderDTO, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for getSenderByID")
+	}
+
+	var r0 *common.NotificationSenderDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.NotificationSenderDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// notificationStoreInterfaceMock_getSenderByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByID'
+type notificationStoreInterfaceMock_getSenderByID_Call struct {
+	*mock.Call
+}
+
+// getSenderByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *notificationStoreInterfaceMock_Expecter) getSenderByID(ctx interface{}, id interface{}) *notificationStoreInterfaceMock_getSenderByID_Call {
+	return &notificationStoreInterfaceMock_getSenderByID_Call{Call: _e.mock.On("getSenderByID", ctx, id)}
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Run(run func(ctx context.Context, id string)) *notificationStoreInterfaceMock_getSenderByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByID_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByID_Call {
+	_c.Call.Return(notificationSenderDTO, err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getSenderByName provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) getSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO, error) {
+	ret := _mock.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for getSenderByName")
+	}
+
+	var r0 *common.NotificationSenderDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*common.NotificationSenderDTO, error)); ok {
+		return returnFunc(ctx, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.NotificationSenderDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// notificationStoreInterfaceMock_getSenderByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getSenderByName'
+type notificationStoreInterfaceMock_getSenderByName_Call struct {
+	*mock.Call
+}
+
+// getSenderByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *notificationStoreInterfaceMock_Expecter) getSenderByName(ctx interface{}, name interface{}) *notificationStoreInterfaceMock_getSenderByName_Call {
+	return &notificationStoreInterfaceMock_getSenderByName_Call{Call: _e.mock.On("getSenderByName", ctx, name)}
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Run(run func(ctx context.Context, name string)) *notificationStoreInterfaceMock_getSenderByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByName_Call) Return(notificationSenderDTO *common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_getSenderByName_Call {
+	_c.Call.Return(notificationSenderDTO, err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_getSenderByName_Call) RunAndReturn(run func(ctx context.Context, name string) (*common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_getSenderByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// listSenders provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) listSenders(ctx context.Context) ([]common.NotificationSenderDTO, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for listSenders")
+	}
+
+	var r0 []common.NotificationSenderDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]common.NotificationSenderDTO, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []common.NotificationSenderDTO); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.NotificationSenderDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// notificationStoreInterfaceMock_listSenders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'listSenders'
+type notificationStoreInterfaceMock_listSenders_Call struct {
+	*mock.Call
+}
+
+// listSenders is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *notificationStoreInterfaceMock_Expecter) listSenders(ctx interface{}) *notificationStoreInterfaceMock_listSenders_Call {
+	return &notificationStoreInterfaceMock_listSenders_Call{Call: _e.mock.On("listSenders", ctx)}
+}
+
+func (_c *notificationStoreInterfaceMock_listSenders_Call) Run(run func(ctx context.Context)) *notificationStoreInterfaceMock_listSenders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_listSenders_Call) Return(notificationSenderDTOs []common.NotificationSenderDTO, err error) *notificationStoreInterfaceMock_listSenders_Call {
+	_c.Call.Return(notificationSenderDTOs, err)
+	return _c
+}
+
+func (_c *notificationStoreInterfaceMock_listSenders_Call) RunAndReturn(run func(ctx context.Context) ([]common.NotificationSenderDTO, error)) *notificationStoreInterfaceMock_listSenders_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// updateSender provides a mock function for the type notificationStoreInterfaceMock
+func (_mock *notificationStoreInterfaceMock) updateSender(ctx context.Context, id string, sender common.NotificationSenderDTO) error {
+	ret := _mock.Called(ctx, id, sender)
+
+	if len(ret) == 0 {
+		panic("no return value specified for updateSender")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.NotificationSenderDTO) error); ok {
+		r0 = returnFunc(ctx, id, sender)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// notificationStoreInterfaceMock_updateSender_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'updateSender'
+type notificationStoreInterfaceMock_updateSender_Call struct {
+	*mock.Call
+}
+
+// updateSender is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - sender common.NotificationSenderDTO
+func (_e *notificationStoreInterfaceMock_Expecter) updateSender(ctx interface{}, id interface{}, sender interface{}) *notificationStoreInterfaceMock_updateSender_Call {
+	return &notificationStoreInterfaceMock_updateSender_Call{Call: _e.mock.On("updateSender", ctx, id, sender)}
+}
+
+func (_c *notificationStoreInterfaceMock_updateSender_Call) Run(run func(ctx context.Context, id string, sender common.NotificationSenderDTO)) *notificationStoreInterfaceMock_updateSender_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 common.NotificationSenderDTO
+		if args[2] != nil {
+			arg2 = args[2].(common.NotificationSenderDTO)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *notificationStoreInterfaceMock_updateSender_Call) Return(err error) *notificationStoreInterfaceMock_updateSender_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *notificationStoreInterfaceMock_updateSender_Call) RunAndReturn(run func(id string, sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_updateSender_Call {
+func (_c *notificationStoreInterfaceMock_updateSender_Call) RunAndReturn(run func(ctx context.Context, id string, sender common.NotificationSenderDTO) error) *notificationStoreInterfaceMock_updateSender_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
@@ -82,14 +82,19 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) CreateUserSchema(ctx interfac
 	return &UserSchemaServiceInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", ctx, request)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) Run(run func(request userschema.CreateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) Run(run func(ctx context.Context, request userschema.CreateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 userschema.CreateUserSchemaRequest
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(userschema.CreateUserSchemaRequest)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 userschema.CreateUserSchemaRequest
+		if args[1] != nil {
+			arg1 = args[1].(userschema.CreateUserSchemaRequest)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -100,7 +105,7 @@ func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) Return(userSchem
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(request userschema.CreateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(ctx context.Context, request userschema.CreateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_CreateUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -136,14 +141,19 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) DeleteUserSchema(ctx interfac
 	return &UserSchemaServiceInterfaceMock_DeleteUserSchema_Call{Call: _e.mock.On("DeleteUserSchema", ctx, schemaID)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) Run(run func(schemaID string)) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) Run(run func(ctx context.Context, schemaID string)) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -154,7 +164,7 @@ func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) Return(serviceEr
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) RunAndReturn(run func(schemaID string) *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call) RunAndReturn(run func(ctx context.Context, schemaID string) *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_DeleteUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -201,14 +211,19 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchema(ctx interface{}
 	return &UserSchemaServiceInterfaceMock_GetUserSchema_Call{Call: _e.mock.On("GetUserSchema", ctx, schemaID)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) Run(run func(schemaID string)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) Run(run func(ctx context.Context, schemaID string)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -219,7 +234,7 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) Return(userSchema *
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) RunAndReturn(run func(schemaID string) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchema_Call) RunAndReturn(run func(ctx context.Context, schemaID string) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -266,14 +281,19 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaByName(ctx inter
 	return &UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", ctx, schemaName)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Run(run func(schemaName string)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Run(run func(ctx context.Context, schemaName string)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -284,7 +304,7 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) Return(userSc
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(schemaName string) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(ctx context.Context, schemaName string) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -332,19 +352,24 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUserSchemaList(ctx interfa
 	return &UserSchemaServiceInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", ctx, limit, offset)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) Run(run func(limit int, offset int)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) Run(run func(ctx context.Context, limit int, offset int)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -355,7 +380,7 @@ func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) Return(userSche
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(limit int, offset int) (*userschema.UserSchemaListResponse, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
+func (_c *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*userschema.UserSchemaListResponse, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUserSchemaList_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -403,19 +428,24 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) UpdateUserSchema(ctx interfac
 	return &UserSchemaServiceInterfaceMock_UpdateUserSchema_Call{Call: _e.mock.On("UpdateUserSchema", ctx, schemaID, request)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) Run(run func(schemaID string, request userschema.UpdateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) Run(run func(ctx context.Context, schemaID string, request userschema.UpdateUserSchemaRequest)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 userschema.UpdateUserSchemaRequest
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(userschema.UpdateUserSchemaRequest)
+			arg1 = args[1].(string)
+		}
+		var arg2 userschema.UpdateUserSchemaRequest
+		if args[2] != nil {
+			arg2 = args[2].(userschema.UpdateUserSchemaRequest)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -426,7 +456,7 @@ func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) Return(userSchem
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) RunAndReturn(run func(schemaID string, request userschema.UpdateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
+func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) RunAndReturn(run func(ctx context.Context, schemaID string, request userschema.UpdateUserSchemaRequest) (*userschema.UserSchema, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -472,19 +502,24 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(ctx interface{},
 	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", ctx, userType, userAttributes)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(userType string, userAttributes json.RawMessage)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 json.RawMessage
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(json.RawMessage)
+			arg1 = args[1].(string)
+		}
+		var arg2 json.RawMessage
+		if args[2] != nil {
+			arg2 = args[2].(json.RawMessage)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -495,7 +530,7 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Return(b bool, servi
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -542,24 +577,29 @@ func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUserUniqueness(ctx in
 	return &UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call{Call: _e.mock.On("ValidateUserUniqueness", ctx, userType, userAttributes, identifyUser)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) Run(run func(userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error))) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error))) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 json.RawMessage
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(json.RawMessage)
+			arg1 = args[1].(string)
 		}
-		var arg2 func(map[string]interface{}) (*string, error)
+		var arg2 json.RawMessage
 		if args[2] != nil {
-			arg2 = args[2].(func(map[string]interface{}) (*string, error))
+			arg2 = args[2].(json.RawMessage)
+		}
+		var arg3 func(map[string]interface{}) (*string, error)
+		if args[3] != nil {
+			arg3 = args[3].(func(map[string]interface{}) (*string, error))
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -570,7 +610,7 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) Return(b b
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) RunAndReturn(run func(userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage, identifyUser func(map[string]interface{}) (*string, error)) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUserUniqueness_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/userschemamock/userSchemaStoreInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/userSchemaStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package userschemamock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/userschema"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,16 +39,16 @@ func (_m *userSchemaStoreInterfaceMock) EXPECT() *userSchemaStoreInterfaceMock_E
 }
 
 // CreateUserSchema provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) CreateUserSchema(userSchema userschema.UserSchema) error {
-	ret := _mock.Called(userSchema)
+func (_mock *userSchemaStoreInterfaceMock) CreateUserSchema(ctx context.Context, userSchema userschema.UserSchema) error {
+	ret := _mock.Called(ctx, userSchema)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUserSchema")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(userschema.UserSchema) error); ok {
-		r0 = returnFunc(userSchema)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, userschema.UserSchema) error); ok {
+		r0 = returnFunc(ctx, userSchema)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,360 +61,17 @@ type userSchemaStoreInterfaceMock_CreateUserSchema_Call struct {
 }
 
 // CreateUserSchema is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userSchema userschema.UserSchema
-func (_e *userSchemaStoreInterfaceMock_Expecter) CreateUserSchema(userSchema interface{}) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
-	return &userSchemaStoreInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", userSchema)}
+func (_e *userSchemaStoreInterfaceMock_Expecter) CreateUserSchema(ctx interface{}, userSchema interface{}) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
+	return &userSchemaStoreInterfaceMock_CreateUserSchema_Call{Call: _e.mock.On("CreateUserSchema", ctx, userSchema)}
 }
 
-func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Run(run func(userSchema userschema.UserSchema)) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
+func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Run(run func(ctx context.Context, userSchema userschema.UserSchema)) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 userschema.UserSchema
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(userschema.UserSchema)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Return(err error) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(userSchema userschema.UserSchema) error) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) DeleteUserSchemaByID(schemaID string) error {
-	ret := _mock.Called(schemaID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteUserSchemaByID")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(schemaID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteUserSchemaByID'
-type userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call struct {
-	*mock.Call
-}
-
-// DeleteUserSchemaByID is a helper method to define mock.On call
-//   - schemaID string
-func (_e *userSchemaStoreInterfaceMock_Expecter) DeleteUserSchemaByID(schemaID interface{}) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
-	return &userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call{Call: _e.mock.On("DeleteUserSchemaByID", schemaID)}
-}
-
-func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Run(run func(schemaID string)) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Return(err error) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) RunAndReturn(run func(schemaID string) error) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByID(schemaID string) (userschema.UserSchema, error) {
-	ret := _mock.Called(schemaID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserSchemaByID")
-	}
-
-	var r0 userschema.UserSchema
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (userschema.UserSchema, error)); ok {
-		return returnFunc(schemaID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) userschema.UserSchema); ok {
-		r0 = returnFunc(schemaID)
-	} else {
-		r0 = ret.Get(0).(userschema.UserSchema)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(schemaID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// userSchemaStoreInterfaceMock_GetUserSchemaByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaByID'
-type userSchemaStoreInterfaceMock_GetUserSchemaByID_Call struct {
-	*mock.Call
-}
-
-// GetUserSchemaByID is a helper method to define mock.On call
-//   - schemaID string
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByID(schemaID interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaByID_Call{Call: _e.mock.On("GetUserSchemaByID", schemaID)}
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Run(run func(schemaID string)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Return(userSchema userschema.UserSchema, err error) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
-	_c.Call.Return(userSchema, err)
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) RunAndReturn(run func(schemaID string) (userschema.UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetUserSchemaByName provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByName(name string) (userschema.UserSchema, error) {
-	ret := _mock.Called(name)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserSchemaByName")
-	}
-
-	var r0 userschema.UserSchema
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (userschema.UserSchema, error)); ok {
-		return returnFunc(name)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) userschema.UserSchema); ok {
-		r0 = returnFunc(name)
-	} else {
-		r0 = ret.Get(0).(userschema.UserSchema)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(name)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// userSchemaStoreInterfaceMock_GetUserSchemaByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaByName'
-type userSchemaStoreInterfaceMock_GetUserSchemaByName_Call struct {
-	*mock.Call
-}
-
-// GetUserSchemaByName is a helper method to define mock.On call
-//   - name string
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByName(name interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", name)}
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Run(run func(name string)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Return(userSchema userschema.UserSchema, err error) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
-	_c.Call.Return(userSchema, err)
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(name string) (userschema.UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetUserSchemaList provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaList(limit int, offset int) ([]userschema.UserSchemaListItem, error) {
-	ret := _mock.Called(limit, offset)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserSchemaList")
-	}
-
-	var r0 []userschema.UserSchemaListItem
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]userschema.UserSchemaListItem, error)); ok {
-		return returnFunc(limit, offset)
-	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []userschema.UserSchemaListItem); ok {
-		r0 = returnFunc(limit, offset)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]userschema.UserSchemaListItem)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// userSchemaStoreInterfaceMock_GetUserSchemaList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaList'
-type userSchemaStoreInterfaceMock_GetUserSchemaList_Call struct {
-	*mock.Call
-}
-
-// GetUserSchemaList is a helper method to define mock.On call
-//   - limit int
-//   - offset int
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaList(limit interface{}, offset interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", limit, offset)}
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Run(run func(limit int, offset int)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
-		if args[0] != nil {
-			arg0 = args[0].(int)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Return(userSchemaListItems []userschema.UserSchemaListItem, err error) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
-	_c.Call.Return(userSchemaListItems, err)
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(limit int, offset int) ([]userschema.UserSchemaListItem, error)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetUserSchemaListCount provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaListCount() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserSchemaListCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaListCount'
-type userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call struct {
-	*mock.Call
-}
-
-// GetUserSchemaListCount is a helper method to define mock.On call
-func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaListCount() *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
-	return &userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call{Call: _e.mock.On("GetUserSchemaListCount")}
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Run(run func()) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Return(n int, err error) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) RunAndReturn(run func() (int, error)) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
-func (_mock *userSchemaStoreInterfaceMock) UpdateUserSchemaByID(schemaID string, userSchema userschema.UserSchema) error {
-	ret := _mock.Called(schemaID, userSchema)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateUserSchemaByID")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, userschema.UserSchema) error); ok {
-		r0 = returnFunc(schemaID, userSchema)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUserSchemaByID'
-type userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call struct {
-	*mock.Call
-}
-
-// UpdateUserSchemaByID is a helper method to define mock.On call
-//   - schemaID string
-//   - userSchema userschema.UserSchema
-func (_e *userSchemaStoreInterfaceMock_Expecter) UpdateUserSchemaByID(schemaID interface{}, userSchema interface{}) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
-	return &userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call{Call: _e.mock.On("UpdateUserSchemaByID", schemaID, userSchema)}
-}
-
-func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Run(run func(schemaID string, userSchema userschema.UserSchema)) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 userschema.UserSchema
 		if args[1] != nil {
@@ -426,12 +85,398 @@ func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Run(run func(s
 	return _c
 }
 
+func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) Return(err error) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_CreateUserSchema_Call) RunAndReturn(run func(ctx context.Context, userSchema userschema.UserSchema) error) *userSchemaStoreInterfaceMock_CreateUserSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
+func (_mock *userSchemaStoreInterfaceMock) DeleteUserSchemaByID(ctx context.Context, schemaID string) error {
+	ret := _mock.Called(ctx, schemaID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUserSchemaByID")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, schemaID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteUserSchemaByID'
+type userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call struct {
+	*mock.Call
+}
+
+// DeleteUserSchemaByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - schemaID string
+func (_e *userSchemaStoreInterfaceMock_Expecter) DeleteUserSchemaByID(ctx interface{}, schemaID interface{}) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
+	return &userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call{Call: _e.mock.On("DeleteUserSchemaByID", ctx, schemaID)}
+}
+
+func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Run(run func(ctx context.Context, schemaID string)) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) Return(err error) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call) RunAndReturn(run func(ctx context.Context, schemaID string) error) *userSchemaStoreInterfaceMock_DeleteUserSchemaByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByID(ctx context.Context, schemaID string) (userschema.UserSchema, error) {
+	ret := _mock.Called(ctx, schemaID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserSchemaByID")
+	}
+
+	var r0 userschema.UserSchema
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (userschema.UserSchema, error)); ok {
+		return returnFunc(ctx, schemaID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) userschema.UserSchema); ok {
+		r0 = returnFunc(ctx, schemaID)
+	} else {
+		r0 = ret.Get(0).(userschema.UserSchema)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, schemaID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userSchemaStoreInterfaceMock_GetUserSchemaByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaByID'
+type userSchemaStoreInterfaceMock_GetUserSchemaByID_Call struct {
+	*mock.Call
+}
+
+// GetUserSchemaByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - schemaID string
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByID(ctx interface{}, schemaID interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaByID_Call{Call: _e.mock.On("GetUserSchemaByID", ctx, schemaID)}
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Run(run func(ctx context.Context, schemaID string)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) Return(userSchema userschema.UserSchema, err error) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
+	_c.Call.Return(userSchema, err)
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call) RunAndReturn(run func(ctx context.Context, schemaID string) (userschema.UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserSchemaByName provides a mock function for the type userSchemaStoreInterfaceMock
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaByName(ctx context.Context, name string) (userschema.UserSchema, error) {
+	ret := _mock.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserSchemaByName")
+	}
+
+	var r0 userschema.UserSchema
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (userschema.UserSchema, error)); ok {
+		return returnFunc(ctx, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) userschema.UserSchema); ok {
+		r0 = returnFunc(ctx, name)
+	} else {
+		r0 = ret.Get(0).(userschema.UserSchema)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userSchemaStoreInterfaceMock_GetUserSchemaByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaByName'
+type userSchemaStoreInterfaceMock_GetUserSchemaByName_Call struct {
+	*mock.Call
+}
+
+// GetUserSchemaByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaByName(ctx interface{}, name interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaByName_Call{Call: _e.mock.On("GetUserSchemaByName", ctx, name)}
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Run(run func(ctx context.Context, name string)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) Return(userSchema userschema.UserSchema, err error) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Return(userSchema, err)
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call) RunAndReturn(run func(ctx context.Context, name string) (userschema.UserSchema, error)) *userSchemaStoreInterfaceMock_GetUserSchemaByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserSchemaList provides a mock function for the type userSchemaStoreInterfaceMock
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaList(ctx context.Context, limit int, offset int) ([]userschema.UserSchemaListItem, error) {
+	ret := _mock.Called(ctx, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserSchemaList")
+	}
+
+	var r0 []userschema.UserSchemaListItem
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]userschema.UserSchemaListItem, error)); ok {
+		return returnFunc(ctx, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []userschema.UserSchemaListItem); ok {
+		r0 = returnFunc(ctx, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]userschema.UserSchemaListItem)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userSchemaStoreInterfaceMock_GetUserSchemaList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaList'
+type userSchemaStoreInterfaceMock_GetUserSchemaList_Call struct {
+	*mock.Call
+}
+
+// GetUserSchemaList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - limit int
+//   - offset int
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaList(ctx interface{}, limit interface{}, offset interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaList_Call{Call: _e.mock.On("GetUserSchemaList", ctx, limit, offset)}
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Run(run func(ctx context.Context, limit int, offset int)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) Return(userSchemaListItems []userschema.UserSchemaListItem, err error) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
+	_c.Call.Return(userSchemaListItems, err)
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]userschema.UserSchemaListItem, error)) *userSchemaStoreInterfaceMock_GetUserSchemaList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserSchemaListCount provides a mock function for the type userSchemaStoreInterfaceMock
+func (_mock *userSchemaStoreInterfaceMock) GetUserSchemaListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserSchemaListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserSchemaListCount'
+type userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call struct {
+	*mock.Call
+}
+
+// GetUserSchemaListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *userSchemaStoreInterfaceMock_Expecter) GetUserSchemaListCount(ctx interface{}) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
+	return &userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call{Call: _e.mock.On("GetUserSchemaListCount", ctx)}
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Run(run func(ctx context.Context)) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) Return(n int, err error) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *userSchemaStoreInterfaceMock_GetUserSchemaListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateUserSchemaByID provides a mock function for the type userSchemaStoreInterfaceMock
+func (_mock *userSchemaStoreInterfaceMock) UpdateUserSchemaByID(ctx context.Context, schemaID string, userSchema userschema.UserSchema) error {
+	ret := _mock.Called(ctx, schemaID, userSchema)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUserSchemaByID")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, userschema.UserSchema) error); ok {
+		r0 = returnFunc(ctx, schemaID, userSchema)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUserSchemaByID'
+type userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call struct {
+	*mock.Call
+}
+
+// UpdateUserSchemaByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - schemaID string
+//   - userSchema userschema.UserSchema
+func (_e *userSchemaStoreInterfaceMock_Expecter) UpdateUserSchemaByID(ctx interface{}, schemaID interface{}, userSchema interface{}) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
+	return &userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call{Call: _e.mock.On("UpdateUserSchemaByID", ctx, schemaID, userSchema)}
+}
+
+func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Run(run func(ctx context.Context, schemaID string, userSchema userschema.UserSchema)) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 userschema.UserSchema
+		if args[2] != nil {
+			arg2 = args[2].(userschema.UserSchema)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) Return(err error) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) RunAndReturn(run func(schemaID string, userSchema userschema.UserSchema) error) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
+func (_c *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call) RunAndReturn(run func(ctx context.Context, schemaID string, userSchema userschema.UserSchema) error) *userSchemaStoreInterfaceMock_UpdateUserSchemaByID_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
As we have introduced the transection architecture, we are adapting our services to use transections. In this PR we have updated the cert service to use transactions.


Sub Issue : https://github.com/asgardeo/thunder/issues/1431
Parent issue : https://github.com/asgardeo/thunder/issues/282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Propagated per-request context across OTP and notification sender flows to enable cancellation, timeouts and more reliable request-scoped behavior.
  * Notification sender management now supports transactional execution for safer create/update/delete operations.
* **Chores**
  * Tests and mock scaffolding updated to align with the new context-aware APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->