### PR TITLE
Fix authnprovider dependency in auth assert executor

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -156,7 +156,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	flowFactory, graphCache := flowcore.Initialize()
 	execRegistry := executor.Initialize(flowFactory, ouService,
 		idpService, otpService, jwtService, authSvcRegistry, authZService, userSchemaService, observabilitySvc,
-		groupService, roleService, userProvider, authnProvider)
+		groupService, roleService, userProvider)
 
 	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(mux, mcpServer, flowFactory, execRegistry, graphCache)
 	if err != nil {

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -20,7 +20,6 @@ package executor
 
 import (
 	"github.com/asgardeo/thunder/internal/authn"
-	"github.com/asgardeo/thunder/internal/authnprovider"
 	"github.com/asgardeo/thunder/internal/authz"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
@@ -32,6 +31,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/observability"
 	"github.com/asgardeo/thunder/internal/userprovider"
+
 	"github.com/asgardeo/thunder/internal/userschema"
 )
 
@@ -49,7 +49,6 @@ func Initialize(
 	groupService group.GroupServiceInterface,
 	roleService role.RoleServiceInterface,
 	userProvider userprovider.UserProviderInterface,
-	authnProvider authnprovider.AuthnProviderInterface,
 ) ExecutorRegistryInterface {
 	reg := newExecutorRegistry()
 	reg.RegisterExecutor(ExecutorNameBasicAuth, newBasicAuthExecutor(
@@ -76,7 +75,7 @@ func Initialize(
 
 	reg.RegisterExecutor(ExecutorNameAttributeCollect, newAttributeCollector(flowFactory, userProvider))
 	reg.RegisterExecutor(ExecutorNameAuthAssert, newAuthAssertExecutor(flowFactory, jwtService,
-		ouService, authRegistry.AuthAssertGenerator, authnProvider, userProvider))
+		ouService, authRegistry.AuthAssertGenerator, authRegistry.CredentialsAuthnService, userProvider))
 	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService))
 	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory))
 	reg.RegisterExecutor(ExecutorNameUserTypeResolver, newUserTypeResolver(flowFactory, userSchemaService))


### PR DESCRIPTION
### Purpose

This pull request refactors the authentication assertion executor to use the `CredentialsAuthnServiceInterface` for retrieving user attributes instead of the previous `AuthnProviderInterface`. The change is reflected throughout the executor implementation and its associated tests, and the dependency is now passed via the service registry. This streamlines the authentication flow and aligns the codebase with updated service interfaces.

### Approach

**Executor Refactor:**

* The `authAssertExecutor` now uses `credsAuthSvc` (`CredentialsAuthnServiceInterface`) instead of `authnProvider` (`AuthnProviderInterface`) for fetching user attributes. All method calls and struct fields have been updated accordingly. [[1]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL52-R53) [[2]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL65-R66) [[3]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL79-R80) [[4]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL321-R326)
* The `Initialize` function in `executor/init.go` no longer takes an `authnProvider` parameter and instead registers the `CredentialsAuthnService` from the registry for the authentication assertion executor. [[1]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06L52) [[2]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06L79-R78)

**Test Updates:**

* Test mocks and test setup in `auth_assert_executor_test.go` have been updated to use `CredentialsAuthnServiceInterfaceMock` instead of `AuthnProviderInterfaceMock`, and all relevant test assertions and expectations have been changed to match the new interface. [[1]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L41-R41) [[2]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L53-R53) [[3]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L70-R70) [[4]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L79-R79) [[5]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L105-R105) [[6]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L451-R451) [[7]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L460-R460)

**Code Cleanup:**

* Removed unused imports and parameters related to `authnprovider` from the executor package. [[1]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06L23) [[2]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06R34)

**Service Registration:**

* The `registerServices` function in `servicemanager.go` no longer passes `authnProvider` to the executor initialization, reflecting the updated dependency.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal authentication wiring migrated to a credentials-based auth service and initialization interfaces simplified.

* **Tests**
  * Unit tests updated and extended to cover token-based attribute fetch success and failure scenarios.

* **Impact**
  * No user-facing behavior changes; internal maintainability and modularity improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->