### PR TITLE
Implement Schema-driven credential attributes logic

### DIFF
--- a/api/user.yaml
+++ b/api/user.yaml
@@ -991,6 +991,10 @@ paths:
                   type: "string"
                   required: true
                   unique: true
+                password:
+                  type: "string"
+                  required: true
+                  credential: true
                 company:
                   type: "string"
                 role:
@@ -1022,6 +1026,10 @@ paths:
                     type: "string"
                     required: true
                     unique: true
+                  password:
+                    type: "string"
+                    required: true
+                    credential: true
                   company:
                     type: "string"
                   role:
@@ -1106,6 +1114,7 @@ paths:
                       password:
                         type: "string"
                         required: true
+                        credential: true
                         regex: "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$"
                       employeeId:
                         type: "number"
@@ -1193,6 +1202,10 @@ paths:
                   type: "string"
                   required: true
                   unique: true
+                password:
+                  type: "string"
+                  required: true
+                  credential: true
                 age:
                   type: "number"
                 mobile:
@@ -1220,6 +1233,10 @@ paths:
                     type: "string"
                     required: true
                     unique: true
+                  password:
+                    type: "string"
+                    required: true
+                    credential: true
                   age:
                     type: "number"
                   mobile:
@@ -1556,12 +1573,12 @@ components:
           additionalProperties:
             oneOf:
               - type: object
-                description: "Leaf property definition (string, number, or boolean type)"
+                description: "Leaf property - string or number"
                 required: [type]
                 properties:
                   type:
                     type: string
-                    enum: ["string", "number", "boolean"]
+                    enum: ["string", "number"]
                     description: "Data type of the property"
                   required:
                     type: boolean
@@ -1571,6 +1588,10 @@ components:
                     type: boolean
                     default: false
                     description: "Whether this property must be unique across all users"
+                  credential:
+                    type: boolean
+                    default: false
+                    description: "Whether this property should be treated as a credential attribute"
                   enum:
                     type: array
                     items:
@@ -1579,6 +1600,19 @@ components:
                   regex:
                     type: string
                     description: "Regular expression pattern for validating the property value"
+                additionalProperties: false
+              - type: object
+                description: "Leaf property - boolean"
+                required: [type]
+                properties:
+                  type:
+                    type: string
+                    enum: ["boolean"]
+                    description: "Data type of the property"
+                  required:
+                    type: boolean
+                    default: false
+                    description: "Whether this attribute must be provided for the user type"
                 additionalProperties: false
               - type: object
                 description: "Object property definition"
@@ -1613,16 +1647,24 @@ components:
                   items:
                     oneOf:
                       - type: object
-                        description: "Array of strings, numbers, or booleans"
+                        description: "Array of strings or numbers"
                         required: [type]
                         properties:
                           type:
                             type: string
-                            enum: ["string", "number", "boolean"]
+                            enum: ["string", "number"]
                           enum:
                             type: array
                             items:
                               type: string
+                        additionalProperties: false
+                      - type: object
+                        description: "Array of booleans"
+                        required: [type]
+                        properties:
+                          type:
+                            type: string
+                            enum: ["boolean"]
                         additionalProperties: false
                       - type: object
                         description: "Array of objects"
@@ -1646,6 +1688,7 @@ components:
             password:
               type: "string"
               required: true
+              credential: true
               regex: "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$"
             age:
               type: "number"

--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -143,6 +143,11 @@ $userSchemaData = ([ordered]@{
             type = "boolean"
             required = $false
         }
+        password = @{
+            type = "string"
+            required = $true
+            credential = $true
+        }
     }
 } | ConvertTo-Json -Depth 5)
 

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -133,6 +133,11 @@ RESPONSE=$(thunder_api_call POST "/user-schemas" '{
     "phone_number_verified": {
       "type": "boolean",
       "required": false
+    },
+    "password": {
+      "type": "string",
+      "required": true,
+      "credential": true
     }
   }
 }')

--- a/backend/internal/authnprovider/default_authn_provider.go
+++ b/backend/internal/authnprovider/default_authn_provider.go
@@ -43,15 +43,7 @@ func (p *defaultAuthnProvider) Authenticate(
 	identifiers, credentials map[string]interface{},
 	metadata *AuthnMetadata,
 ) (*AuthnResult, *AuthnProviderError) {
-	request := make(user.AuthenticateUserRequest)
-	for k, v := range identifiers {
-		request[k] = v
-	}
-	for k, v := range credentials {
-		request[k] = v
-	}
-
-	authResponse, authErr := p.userSvc.AuthenticateUser(context.Background(), request)
+	authResponse, authErr := p.userSvc.AuthenticateUser(context.Background(), identifiers, credentials)
 	if authErr != nil {
 		if authErr.Type == serviceerror.ClientErrorType {
 			if authErr.Code == user.ErrorUserNotFound.Code {

--- a/backend/internal/authnprovider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/default_authn_provider_test.go
@@ -49,11 +49,6 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Success() {
 	identifiers := map[string]interface{}{"username": "testuser"}
 	credentials := map[string]interface{}{"password": "password123"}
 
-	authReq := user.AuthenticateUserRequest{
-		"username": "testuser",
-		"password": "password123",
-	}
-
 	authResp := &user.AuthenticateUserResponse{
 		ID:               "user123",
 		Type:             "customer",
@@ -68,7 +63,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Success() {
 	}
 
 	// Expect AuthenticateUser call
-	suite.mockService.On("AuthenticateUser", mock.Anything, authReq).
+	suite.mockService.On("AuthenticateUser", mock.Anything, identifiers, credentials).
 		Return(authResp, (*serviceerror.ServiceError)(nil)).Once()
 	// Expect GetUser call
 	suite.mockService.On("GetUser", mock.Anything, "user123").Return(userObj, (*serviceerror.ServiceError)(nil)).Once()
@@ -88,14 +83,10 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_UserNotFound() {
 	identifiers := map[string]interface{}{"username": "unknown"}
 	credentials := map[string]interface{}{"password": "password"}
 
-	authReq := user.AuthenticateUserRequest{
-		"username": "unknown",
-		"password": "password",
-	}
-
 	userNotFoundErr := &user.ErrorUserNotFound
 
-	suite.mockService.On("AuthenticateUser", mock.Anything, authReq).Return(nil, userNotFoundErr).Once()
+	suite.mockService.On("AuthenticateUser", mock.Anything, identifiers, credentials).
+		Return(nil, userNotFoundErr).Once()
 
 	result, err := suite.provider.Authenticate(identifiers, credentials, nil)
 
@@ -108,14 +99,9 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_AuthenticationFaile
 	identifiers := map[string]interface{}{"username": "testuser"}
 	credentials := map[string]interface{}{"password": "wrongpassword"}
 
-	authReq := user.AuthenticateUserRequest{
-		"username": "testuser",
-		"password": "wrongpassword",
-	}
-
 	authFailedErr := &user.ErrorAuthenticationFailed
 
-	suite.mockService.On("AuthenticateUser", mock.Anything, authReq).Return(nil, authFailedErr).Once()
+	suite.mockService.On("AuthenticateUser", mock.Anything, identifiers, credentials).Return(nil, authFailedErr).Once()
 
 	result, err := suite.provider.Authenticate(identifiers, credentials, nil)
 
@@ -128,14 +114,9 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_SystemError_Prepare
 	identifiers := map[string]interface{}{"username": "testuser"}
 	credentials := map[string]interface{}{"password": "password"}
 
-	authReq := user.AuthenticateUserRequest{
-		"username": "testuser",
-		"password": "password",
-	}
-
 	sysErr := &serviceerror.ServiceError{Code: "SYS_ERR", Type: serviceerror.ServerErrorType, Error: "System Error"}
 
-	suite.mockService.On("AuthenticateUser", mock.Anything, authReq).Return(nil, sysErr).Once()
+	suite.mockService.On("AuthenticateUser", mock.Anything, identifiers, credentials).Return(nil, sysErr).Once()
 
 	result, err := suite.provider.Authenticate(identifiers, credentials, nil)
 
@@ -197,11 +178,6 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_GetUserNotFound() {
 	identifiers := map[string]interface{}{"username": "testuser"}
 	credentials := map[string]interface{}{"password": "password123"}
 
-	authReq := user.AuthenticateUserRequest{
-		"username": "testuser",
-		"password": "password123",
-	}
-
 	authResp := &user.AuthenticateUserResponse{
 		ID:               "user123",
 		Type:             "customer",
@@ -209,7 +185,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_GetUserNotFound() {
 	}
 
 	// Expect AuthenticateUser call - Success
-	suite.mockService.On("AuthenticateUser", mock.Anything, authReq).
+	suite.mockService.On("AuthenticateUser", mock.Anything, identifiers, credentials).
 		Return(authResp, (*serviceerror.ServiceError)(nil)).Once()
 
 	// Expect GetUser call - Fail with UserNotFound

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -40,8 +40,8 @@ func (_m *UserServiceInterfaceMock) EXPECT() *UserServiceInterfaceMock_Expecter 
 }
 
 // AuthenticateUser provides a mock function for the type UserServiceInterfaceMock
-func (_mock *UserServiceInterfaceMock) AuthenticateUser(ctx context.Context, request AuthenticateUserRequest) (*AuthenticateUserResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, request)
+func (_mock *UserServiceInterfaceMock) AuthenticateUser(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}) (*AuthenticateUserResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, identifiers, credentials)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AuthenticateUser")
@@ -49,18 +49,18 @@ func (_mock *UserServiceInterfaceMock) AuthenticateUser(ctx context.Context, req
 
 	var r0 *AuthenticateUserResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, AuthenticateUserRequest) (*AuthenticateUserResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]interface{}, map[string]interface{}) (*AuthenticateUserResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, identifiers, credentials)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, AuthenticateUserRequest) *AuthenticateUserResponse); ok {
-		r0 = returnFunc(ctx, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]interface{}, map[string]interface{}) *AuthenticateUserResponse); ok {
+		r0 = returnFunc(ctx, identifiers, credentials)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*AuthenticateUserResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, AuthenticateUserRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]interface{}, map[string]interface{}) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, identifiers, credentials)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -76,24 +76,30 @@ type UserServiceInterfaceMock_AuthenticateUser_Call struct {
 
 // AuthenticateUser is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request AuthenticateUserRequest
-func (_e *UserServiceInterfaceMock_Expecter) AuthenticateUser(ctx interface{}, request interface{}) *UserServiceInterfaceMock_AuthenticateUser_Call {
-	return &UserServiceInterfaceMock_AuthenticateUser_Call{Call: _e.mock.On("AuthenticateUser", ctx, request)}
+//   - identifiers map[string]interface{}
+//   - credentials map[string]interface{}
+func (_e *UserServiceInterfaceMock_Expecter) AuthenticateUser(ctx interface{}, identifiers interface{}, credentials interface{}) *UserServiceInterfaceMock_AuthenticateUser_Call {
+	return &UserServiceInterfaceMock_AuthenticateUser_Call{Call: _e.mock.On("AuthenticateUser", ctx, identifiers, credentials)}
 }
 
-func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) Run(run func(ctx context.Context, request AuthenticateUserRequest)) *UserServiceInterfaceMock_AuthenticateUser_Call {
+func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) Run(run func(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{})) *UserServiceInterfaceMock_AuthenticateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 AuthenticateUserRequest
+		var arg1 map[string]interface{}
 		if args[1] != nil {
-			arg1 = args[1].(AuthenticateUserRequest)
+			arg1 = args[1].(map[string]interface{})
+		}
+		var arg2 map[string]interface{}
+		if args[2] != nil {
+			arg2 = args[2].(map[string]interface{})
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -104,7 +110,7 @@ func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) Return(authenticateUse
 	return _c
 }
 
-func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) RunAndReturn(run func(ctx context.Context, request AuthenticateUserRequest) (*AuthenticateUserResponse, *serviceerror.ServiceError)) *UserServiceInterfaceMock_AuthenticateUser_Call {
+func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) RunAndReturn(run func(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}) (*AuthenticateUserResponse, *serviceerror.ServiceError)) *UserServiceInterfaceMock_AuthenticateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/user/constants.go
+++ b/backend/internal/user/constants.go
@@ -23,27 +23,16 @@ import "slices"
 // CredentialType represents the type of credential.
 type CredentialType string
 
-// Credential type constants define the supported credential types.
+// Credential type constants for system-managed credential types.
+// System-managed credentials are not defined in user schemas.
 const (
-	CredentialTypePassword CredentialType = "password"
-	CredentialTypePin      CredentialType = "pin"
-	CredentialTypeSecret   CredentialType = "secret"
-	CredentialTypePasskey  CredentialType = "passkey"
+	CredentialTypePasskey CredentialType = "passkey"
 )
 
-// SupportedCredentialTypes defines the set of credential types that are supported.
-var SupportedCredentialTypes = []CredentialType{
-	CredentialTypePassword,
-	CredentialTypePin,
-	CredentialTypeSecret,
+// systemManagedCredentialTypes defines credential types that are managed by the system,
+// not through user schemas. These may support multiple values per user.
+var systemManagedCredentialTypes = []CredentialType{
 	CredentialTypePasskey,
-}
-
-// HashedCredentialTypes defines credential types that require hashing.
-var HashedCredentialTypes = []CredentialType{
-	CredentialTypePassword,
-	CredentialTypePin,
-	CredentialTypeSecret,
 }
 
 // String returns the string representation of the credential type.
@@ -51,12 +40,7 @@ func (ct CredentialType) String() string {
 	return string(ct)
 }
 
-// RequiresHashing checks if this credential type requires hashing.
-func (ct CredentialType) RequiresHashing() bool {
-	return slices.Contains(HashedCredentialTypes, ct)
-}
-
-// IsValid checks if the credential type is supported.
-func (ct CredentialType) IsValid() bool {
-	return slices.Contains(SupportedCredentialTypes, ct)
+// IsSystemManaged checks if the credential type is a system-managed credential type.
+func (ct CredentialType) IsSystemManaged() bool {
+	return slices.Contains(systemManagedCredentialTypes, ct)
 }

--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -104,9 +104,6 @@ type CreateUserByPathRequest struct {
 	Attributes json.RawMessage `json:"attributes,omitempty"`
 }
 
-// AuthenticateUserRequest represents the request body for authenticating a user.
-type AuthenticateUserRequest map[string]interface{}
-
 // AuthenticateUserResponse represents the response body for authenticating a user.
 type AuthenticateUserResponse struct {
 	ID               string `json:"id"`

--- a/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
+++ b/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
@@ -109,6 +109,76 @@ func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) RunAndReturn(run
 	return _c
 }
 
+// GetCredentialAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetCredentialAttributes(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCredentialAttributes")
+	}
+
+	var r0 []string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCredentialAttributes'
+type UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call struct {
+	*mock.Call
+}
+
+// GetCredentialAttributes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userType string
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetCredentialAttributes(ctx interface{}, userType interface{}) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	return &UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call{Call: _e.mock.On("GetCredentialAttributes", ctx, userType)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call) Run(run func(ctx context.Context, userType string)) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call) Return(fields []string, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	_c.Call.Return(fields, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) DeleteUserSchema(ctx context.Context, schemaID string) *serviceerror.ServiceError {
 	ret := _mock.Called(ctx, schemaID)

--- a/backend/internal/userschema/model/array.go
+++ b/backend/internal/userschema/model/array.go
@@ -35,6 +35,10 @@ func (p *array) isRequired() bool {
 	return p.required
 }
 
+func (p *array) isCredential() bool {
+	return false
+}
+
 func (p *array) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	arrayValue, ok := value.([]interface{})
 	if !ok {

--- a/backend/internal/userschema/model/boolean.go
+++ b/backend/internal/userschema/model/boolean.go
@@ -34,6 +34,10 @@ func (p *boolean) isRequired() bool {
 	return p.required
 }
 
+func (p *boolean) isCredential() bool {
+	return false
+}
+
 func (p *boolean) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	_, ok := value.(bool)
 	if !ok {

--- a/backend/internal/userschema/model/credential_test.go
+++ b/backend/internal/userschema/model/credential_test.go
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CredentialTestSuite struct {
+	suite.Suite
+}
+
+func TestCredentialTestSuite(t *testing.T) {
+	suite.Run(t, new(CredentialTestSuite))
+}
+
+func (s *CredentialTestSuite) TestIsCredential_StringProperty() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"password": {"type": "string", "credential": true},
+		"email": {"type": "string"}
+	}`))
+	s.Require().NoError(err)
+
+	s.Require().True(schema.properties["password"].isCredential())
+	s.Require().False(schema.properties["email"].isCredential())
+}
+
+func (s *CredentialTestSuite) TestIsCredential_NumberProperty() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"pin": {"type": "number", "credential": true},
+		"age": {"type": "number"}
+	}`))
+	s.Require().NoError(err)
+
+	s.Require().True(schema.properties["pin"].isCredential())
+	s.Require().False(schema.properties["age"].isCredential())
+}
+
+func (s *CredentialTestSuite) TestIsCredential_BooleanReturnsFalse() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"active": {"type": "boolean"}
+	}`))
+	s.Require().NoError(err)
+
+	s.Require().False(schema.properties["active"].isCredential())
+}
+
+func (s *CredentialTestSuite) TestIsCredential_ObjectReturnsFalse() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"address": {"type": "object", "properties": {"city": {"type": "string"}}}
+	}`))
+	s.Require().NoError(err)
+
+	s.Require().False(schema.properties["address"].isCredential())
+}
+
+func (s *CredentialTestSuite) TestIsCredential_ArrayReturnsFalse() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"tags": {"type": "array", "items": {"type": "string"}}
+	}`))
+	s.Require().NoError(err)
+
+	s.Require().False(schema.properties["tags"].isCredential())
+}
+
+func (s *CredentialTestSuite) TestGetCredentialAttributes_ReturnsOnlyCredentialProperties() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"password": {"type": "string", "credential": true},
+		"apiKey": {"type": "string", "credential": true},
+		"email": {"type": "string", "unique": true},
+		"age": {"type": "number"},
+		"active": {"type": "boolean"}
+	}`))
+	s.Require().NoError(err)
+
+	fields := schema.GetCredentialAttributes()
+	sort.Strings(fields)
+	s.Require().Equal([]string{"apiKey", "password"}, fields)
+}
+
+func (s *CredentialTestSuite) TestGetCredentialAttributes_EmptyWhenNoCredentials() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"email": {"type": "string"},
+		"age": {"type": "number"}
+	}`))
+	s.Require().NoError(err)
+
+	fields := schema.GetCredentialAttributes()
+	s.Require().Empty(fields)
+}
+
+func (s *CredentialTestSuite) TestCredentialFieldDefaultsFalse() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"name": {"type": "string"}
+	}`))
+	s.Require().NoError(err)
+
+	s.Require().False(schema.properties["name"].isCredential())
+}
+
+func (s *CredentialTestSuite) TestCredentialFieldExplicitFalse() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"name": {"type": "string", "credential": false}
+	}`))
+	s.Require().NoError(err)
+
+	s.Require().False(schema.properties["name"].isCredential())
+}
+
+func (s *CredentialTestSuite) TestCredentialFieldInvalidValue() {
+	_, err := CompileUserSchema(json.RawMessage(`{
+		"password": {"type": "string", "credential": "yes"}
+	}`))
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "'credential' field must be a boolean")
+}
+
+func (s *CredentialTestSuite) TestCredentialFieldNotAllowedOnBoolean() {
+	_, err := CompileUserSchema(json.RawMessage(`{
+		"active": {"type": "boolean", "credential": true}
+	}`))
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "invalid field 'credential'")
+}
+
+func (s *CredentialTestSuite) TestCredentialFieldNotAllowedOnObject() {
+	_, err := CompileUserSchema(json.RawMessage(`{
+		"address": {"type": "object", "credential": true, "properties": {"city": {"type": "string"}}}
+	}`))
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "invalid field 'credential'")
+}
+
+func (s *CredentialTestSuite) TestCredentialFieldNotAllowedOnArray() {
+	_, err := CompileUserSchema(json.RawMessage(`{
+		"tags": {"type": "array", "credential": true, "items": {"type": "string"}}
+	}`))
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "invalid field 'credential'")
+}

--- a/backend/internal/userschema/model/number.go
+++ b/backend/internal/userschema/model/number.go
@@ -26,13 +26,18 @@ import (
 )
 
 type number struct {
-	required bool
-	unique   bool
-	enum     map[float64]struct{}
+	required   bool
+	unique     bool
+	credential bool
+	enum       map[float64]struct{}
 }
 
 func (p *number) isRequired() bool {
 	return p.required
+}
+
+func (p *number) isCredential() bool {
+	return p.credential
 }
 
 func (p *number) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
@@ -75,10 +80,11 @@ func (p *number) validateUniqueness(
 
 func compileNumberProperty(propMap map[string]json.RawMessage) (property, error) {
 	allowedFields := map[string]struct{}{
-		"type":     {},
-		"required": {},
-		"unique":   {},
-		"enum":     {},
+		"type":       {},
+		"required":   {},
+		"unique":     {},
+		"credential": {},
+		"enum":       {},
 	}
 
 	for field := range propMap {
@@ -98,6 +104,12 @@ func compileNumberProperty(propMap map[string]json.RawMessage) (property, error)
 	if raw, exists := propMap["unique"]; exists {
 		if err := json.Unmarshal(raw, &prop.unique); err != nil {
 			return nil, fmt.Errorf("'unique' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["credential"]; exists {
+		if err := json.Unmarshal(raw, &prop.credential); err != nil {
+			return nil, fmt.Errorf("'credential' field must be a boolean")
 		}
 	}
 

--- a/backend/internal/userschema/model/object.go
+++ b/backend/internal/userschema/model/object.go
@@ -34,6 +34,10 @@ func (p *object) isRequired() bool {
 	return p.required
 }
 
+func (p *object) isCredential() bool {
+	return false
+}
+
 func (p *object) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	valueMap, ok := value.(map[string]interface{})
 	if !ok {

--- a/backend/internal/userschema/model/schema.go
+++ b/backend/internal/userschema/model/schema.go
@@ -41,6 +41,7 @@ const (
 
 type property interface {
 	isRequired() bool
+	isCredential() bool
 	validateValue(value interface{}, path string, logger *log.Logger) (bool, error)
 	validateUniqueness(value interface{}, path string,
 		identifyUser func(map[string]interface{}) (*string, error), logger *log.Logger) (bool, error)
@@ -49,6 +50,18 @@ type property interface {
 // Schema represents a user schema with a set of properties.
 type Schema struct {
 	properties map[string]property
+}
+
+// GetCredentialAttributes returns the names of top-level properties marked as credentials.
+func (cs *Schema) GetCredentialAttributes() []string {
+	var fields []string
+	for name, prop := range cs.properties {
+		if prop.isCredential() {
+			fields = append(fields, name)
+		}
+	}
+
+	return fields
 }
 
 // Validate validates the user attributes against the schema.

--- a/backend/internal/userschema/model/string.go
+++ b/backend/internal/userschema/model/string.go
@@ -27,14 +27,19 @@ import (
 )
 
 type str struct {
-	required bool
-	unique   bool
-	enum     map[string]struct{}
-	pattern  *regexp.Regexp
+	required   bool
+	unique     bool
+	credential bool
+	enum       map[string]struct{}
+	pattern    *regexp.Regexp
 }
 
 func (p *str) isRequired() bool {
 	return p.required
+}
+
+func (p *str) isCredential() bool {
+	return p.credential
 }
 
 func (p *str) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
@@ -81,12 +86,13 @@ func (p *str) validateUniqueness(
 
 func compileStringProperty(propMap map[string]json.RawMessage) (property, error) {
 	allowedFields := map[string]struct{}{
-		"type":     {},
-		"required": {},
-		"unique":   {},
-		"enum":     {},
-		"regex":    {},
-		"pattern":  {},
+		"type":       {},
+		"required":   {},
+		"unique":     {},
+		"credential": {},
+		"enum":       {},
+		"regex":      {},
+		"pattern":    {},
 	}
 
 	for field := range propMap {
@@ -106,6 +112,12 @@ func compileStringProperty(propMap map[string]json.RawMessage) (property, error)
 	if raw, exists := propMap["unique"]; exists {
 		if err := json.Unmarshal(raw, &prop.unique); err != nil {
 			return nil, fmt.Errorf("'unique' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["credential"]; exists {
+		if err := json.Unmarshal(raw, &prop.credential); err != nil {
+			return nil, fmt.Errorf("'credential' field must be a boolean")
 		}
 	}
 

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -41,8 +41,8 @@ func (_m *UserServiceInterfaceMock) EXPECT() *UserServiceInterfaceMock_Expecter 
 }
 
 // AuthenticateUser provides a mock function for the type UserServiceInterfaceMock
-func (_mock *UserServiceInterfaceMock) AuthenticateUser(ctx context.Context, request user.AuthenticateUserRequest) (*user.AuthenticateUserResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, request)
+func (_mock *UserServiceInterfaceMock) AuthenticateUser(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}) (*user.AuthenticateUserResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, identifiers, credentials)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AuthenticateUser")
@@ -50,18 +50,18 @@ func (_mock *UserServiceInterfaceMock) AuthenticateUser(ctx context.Context, req
 
 	var r0 *user.AuthenticateUserResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, user.AuthenticateUserRequest) (*user.AuthenticateUserResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]interface{}, map[string]interface{}) (*user.AuthenticateUserResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, identifiers, credentials)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, user.AuthenticateUserRequest) *user.AuthenticateUserResponse); ok {
-		r0 = returnFunc(ctx, request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]interface{}, map[string]interface{}) *user.AuthenticateUserResponse); ok {
+		r0 = returnFunc(ctx, identifiers, credentials)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*user.AuthenticateUserResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, user.AuthenticateUserRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]interface{}, map[string]interface{}) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, identifiers, credentials)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -77,24 +77,30 @@ type UserServiceInterfaceMock_AuthenticateUser_Call struct {
 
 // AuthenticateUser is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request user.AuthenticateUserRequest
-func (_e *UserServiceInterfaceMock_Expecter) AuthenticateUser(ctx interface{}, request interface{}) *UserServiceInterfaceMock_AuthenticateUser_Call {
-	return &UserServiceInterfaceMock_AuthenticateUser_Call{Call: _e.mock.On("AuthenticateUser", ctx, request)}
+//   - identifiers map[string]interface{}
+//   - credentials map[string]interface{}
+func (_e *UserServiceInterfaceMock_Expecter) AuthenticateUser(ctx interface{}, identifiers interface{}, credentials interface{}) *UserServiceInterfaceMock_AuthenticateUser_Call {
+	return &UserServiceInterfaceMock_AuthenticateUser_Call{Call: _e.mock.On("AuthenticateUser", ctx, identifiers, credentials)}
 }
 
-func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) Run(run func(ctx context.Context, request user.AuthenticateUserRequest)) *UserServiceInterfaceMock_AuthenticateUser_Call {
+func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) Run(run func(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{})) *UserServiceInterfaceMock_AuthenticateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 user.AuthenticateUserRequest
+		var arg1 map[string]interface{}
 		if args[1] != nil {
-			arg1 = args[1].(user.AuthenticateUserRequest)
+			arg1 = args[1].(map[string]interface{})
+		}
+		var arg2 map[string]interface{}
+		if args[2] != nil {
+			arg2 = args[2].(map[string]interface{})
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -105,7 +111,7 @@ func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) Return(authenticateUse
 	return _c
 }
 
-func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) RunAndReturn(run func(ctx context.Context, request user.AuthenticateUserRequest) (*user.AuthenticateUserResponse, *serviceerror.ServiceError)) *UserServiceInterfaceMock_AuthenticateUser_Call {
+func (_c *UserServiceInterfaceMock_AuthenticateUser_Call) RunAndReturn(run func(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}) (*user.AuthenticateUserResponse, *serviceerror.ServiceError)) *UserServiceInterfaceMock_AuthenticateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
@@ -110,6 +110,73 @@ func (_c *UserSchemaServiceInterfaceMock_CreateUserSchema_Call) RunAndReturn(run
 	return _c
 }
 
+// GetCredentialAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetCredentialAttributes(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCredentialAttributes")
+	}
+
+	var r0 []string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCredentialAttributes'
+type UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call struct {
+	*mock.Call
+}
+
+// GetCredentialAttributes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userType string
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetCredentialAttributes(ctx interface{}, userType interface{}) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	return &UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call{Call: _e.mock.On("GetCredentialAttributes", ctx, userType)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call) Run(run func(ctx context.Context, userType string)) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call) Return(fields []string, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	_c.Call.Return(fields, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call) RunAndReturn(run func(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetCredentialAttributes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) DeleteUserSchema(ctx context.Context, schemaID string) *serviceerror.ServiceError {
 	ret := _mock.Called(ctx, schemaID)

--- a/tests/integration/authn/credentials_auth_test.go
+++ b/tests/integration/authn/credentials_auth_test.go
@@ -51,6 +51,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 				"email": map[string]interface{}{
 					"type": "string",
@@ -65,6 +66,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 				"username": map[string]interface{}{
 					"type": "string",
@@ -79,6 +81,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 				"username": map[string]interface{}{
 					"type": "string",
@@ -99,6 +102,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 				"firstName": map[string]interface{}{
 					"type": "string",

--- a/tests/integration/authn/github_auth_test.go
+++ b/tests/integration/authn/github_auth_test.go
@@ -52,6 +52,7 @@ var githubUserSchema = testutils.UserSchema{
 		},
 		"password": map[string]interface{}{
 			"type": "string",
+			"credential": true,
 		},
 		"sub": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/authn/google_auth_test.go
+++ b/tests/integration/authn/google_auth_test.go
@@ -53,6 +53,7 @@ var googleUserSchema = testutils.UserSchema{
 		},
 		"password": map[string]interface{}{
 			"type": "string",
+			"credential": true,
 		},
 		"sub": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/authn/oauth_auth_test.go
+++ b/tests/integration/authn/oauth_auth_test.go
@@ -52,6 +52,7 @@ var oauthUserSchema = testutils.UserSchema{
 		},
 		"password": map[string]interface{}{
 			"type": "string",
+			"credential": true,
 		},
 		"sub": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/authn/oidc_auth_test.go
+++ b/tests/integration/authn/oidc_auth_test.go
@@ -51,6 +51,7 @@ var oidcUserSchema = testutils.UserSchema{
 		},
 		"password": map[string]interface{}{
 			"type": "string",
+			"credential": true,
 		},
 		"sub": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/authn/sms_otp_auth_test.go
+++ b/tests/integration/authn/sms_otp_auth_test.go
@@ -46,6 +46,7 @@ var smsOTPUserSchema = testutils.UserSchema{
 		},
 		"password": map[string]interface{}{
 			"type": "string",
+			"credential": true,
 		},
 		"email": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/flow/authentication/assurance_test.go
+++ b/tests/integration/flow/authentication/assurance_test.go
@@ -316,6 +316,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/attribute_collect_test.go
+++ b/tests/integration/flow/authentication/attribute_collect_test.go
@@ -123,6 +123,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"firstName": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/authz_test.go
+++ b/tests/integration/flow/authentication/authz_test.go
@@ -44,6 +44,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/basic_auth_test.go
+++ b/tests/integration/flow/authentication/basic_auth_test.go
@@ -177,6 +177,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/github_auth_test.go
+++ b/tests/integration/flow/authentication/github_auth_test.go
@@ -102,6 +102,7 @@ var githubUserSchema = testutils.UserSchema{
 		},
 		"password": map[string]interface{}{
 			"type": "string",
+			"credential": true,
 		},
 		"sub": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/flow/authentication/google_auth_test.go
+++ b/tests/integration/flow/authentication/google_auth_test.go
@@ -102,6 +102,7 @@ var googleUserSchema = testutils.UserSchema{
 		},
 		"password": map[string]interface{}{
 			"type": "string",
+			"credential": true,
 		},
 		"sub": map[string]interface{}{
 			"type": "string",

--- a/tests/integration/flow/authentication/http_request_executor_test.go
+++ b/tests/integration/flow/authentication/http_request_executor_test.go
@@ -210,6 +210,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/multi_action_input_binding_test.go
+++ b/tests/integration/flow/authentication/multi_action_input_binding_test.go
@@ -138,6 +138,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/prompt_actions_test.go
+++ b/tests/integration/flow/authentication/prompt_actions_test.go
@@ -206,6 +206,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/sensitive_input_cleanup_test.go
+++ b/tests/integration/flow/authentication/sensitive_input_cleanup_test.go
@@ -142,6 +142,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 		},
 	}

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -234,6 +234,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/authentication/verbose_meta_test.go
+++ b/tests/integration/flow/authentication/verbose_meta_test.go
@@ -186,6 +186,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/registration/basic_registration_test.go
+++ b/tests/integration/flow/registration/basic_registration_test.go
@@ -43,6 +43,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/registration/github_registration_test.go
+++ b/tests/integration/flow/registration/github_registration_test.go
@@ -151,6 +151,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"sub": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/registration/google_registration_test.go
+++ b/tests/integration/flow/registration/google_registration_test.go
@@ -204,6 +204,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"sub": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/registration/http_request_executor_registration_test.go
+++ b/tests/integration/flow/registration/http_request_executor_registration_test.go
@@ -201,6 +201,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -379,6 +379,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -228,6 +228,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/flow/registration/user_type_resolver_test.go
+++ b/tests/integration/flow/registration/user_type_resolver_test.go
@@ -62,7 +62,7 @@ func (ts *UserTypeResolverRuntimeTestSuite) SetupSuite() {
 		AllowSelfRegistration: true,
 		Schema: map[string]interface{}{
 			"username": map[string]interface{}{"type": "string"},
-			"password": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
 			"email":    map[string]interface{}{"type": "string"},
 		},
 	}
@@ -80,7 +80,7 @@ func (ts *UserTypeResolverRuntimeTestSuite) SetupSuite() {
 		AllowSelfRegistration: true,
 		Schema: map[string]interface{}{
 			"username": map[string]interface{}{"type": "string"},
-			"password": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
 			"email":    map[string]interface{}{"type": "string"},
 		},
 	}

--- a/tests/integration/group/group_api_test.go
+++ b/tests/integration/group/group_api_test.go
@@ -52,6 +52,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 		},
 	}

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -51,6 +51,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -64,6 +64,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/oauth/claims/claims_parameter_test.go
+++ b/tests/integration/oauth/claims/claims_parameter_test.go
@@ -51,6 +51,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/oauth/token/tokenexchange_test.go
+++ b/tests/integration/oauth/token/tokenexchange_test.go
@@ -62,6 +62,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -50,6 +50,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/projects/silver_test.go
+++ b/tests/integration/projects/silver_test.go
@@ -61,6 +61,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 			"email": map[string]interface{}{
 				"type":   "string",

--- a/tests/integration/role/roleapi_test.go
+++ b/tests/integration/role/roleapi_test.go
@@ -57,6 +57,7 @@ var (
 			},
 			"password": map[string]interface{}{
 				"type": "string",
+				"credential": true,
 			},
 		},
 	}

--- a/tests/integration/system/apiauth/api_auth_test.go
+++ b/tests/integration/system/apiauth/api_auth_test.go
@@ -76,7 +76,7 @@ func (suite *APIAuthTestSuite) SetupSuite() {
 		AllowSelfRegistration: true,
 		Schema: map[string]interface{}{
 			"username":  map[string]interface{}{"type": "string"},
-			"password":  map[string]interface{}{"type": "string"},
+			"password":  map[string]interface{}{"type": "string", "credential": true},
 			"email":     map[string]interface{}{"type": "string"},
 			"firstName": map[string]interface{}{"type": "string"},
 			"lastName":  map[string]interface{}{"type": "string"},

--- a/tests/integration/user/user_indexed_attributes_test.go
+++ b/tests/integration/user/user_indexed_attributes_test.go
@@ -60,6 +60,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 			},
 		},
@@ -77,6 +78,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 			},
 		},
@@ -91,6 +93,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 			},
 		},
@@ -118,6 +121,7 @@ var (
 				},
 				"password": map[string]interface{}{
 					"type": "string",
+					"credential": true,
 				},
 			},
 		},

--- a/tests/integration/user/user_self_api_test.go
+++ b/tests/integration/user/user_self_api_test.go
@@ -66,7 +66,7 @@ func (s *SelfUserEndpointsSuite) SetupSuite() {
 		Schema: map[string]interface{}{
 			"username": map[string]interface{}{"type": "string", "required": true, "unique": true},
 			"email":    map[string]interface{}{"type": "string", "required": true, "unique": true},
-			"password": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
 		},
 	}
 	schemaID, err := testutils.CreateUserType(schema)


### PR DESCRIPTION
### Purpose
This pull request introduces significant improvements to how credential attributes are handled across the API, backend, and schema definitions. The main focus is to support schema-defined credential fields (such as passwords) in a more flexible and explicit way, and to clarify the distinction between system-managed credentials and those defined in user schemas. The changes affect the OpenAPI schema, backend service interfaces, authentication logic, and test mocks.

**API and Schema Enhancements:**

- Added a `credential: true` property to schema fields (like `password`) in `user.yaml` and default resource scripts, allowing credentials to be explicitly marked in user schemas. [[1]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1109) [[2]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1675) [[3]](diffhunk://#diff-251727c4cd4b985ce306b3bceda1a46916f4559e9aa429037689e8271628e3ceR146-R149) [[4]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aR136-R139)
- Improved the OpenAPI schema to clearly distinguish between string/number and boolean property types, including support for arrays of booleans and the new `credential` attribute. [[1]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50L1559-R1565) [[2]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1575-R1578) [[3]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1588-R1600) [[4]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50L1616-R1652)

**Backend Service and Interface Changes:**

- Refactored the authentication interface: `AuthenticateUser` now takes separate `identifiers` and `credentials` maps instead of a generic request map, improving clarity and type safety. [[1]](diffhunk://#diff-1816d6d81909221c132a034f3836ce299f3437e02570b15f14b3ced8f29da68fL46-R46) [[2]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aL64-R65) [[3]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL43-R63) [[4]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL79-R102) [[5]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL107-R113)
- Updated all related mocks and unit tests to use the new authentication method signature, ensuring test coverage for the new approach. [[1]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L52-L56) [[2]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L71-R66) [[3]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L91-R88) [[4]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L111-R103) [[5]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L131-R118) [[6]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L200-R187) [[7]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL43-R63) [[8]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL79-R102) [[9]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL107-R113)

**Credential Handling and Constants:**

- Removed hardcoded support for password, pin, and secret credential types from backend constants, focusing on system-managed credentials (like passkeys) and allowing schema-defined credentials to be handled dynamically.
- The backend now queries the schema service for credential fields when creating a user, and extracts credentials based on those fields, making the process more robust and schema-driven. [[1]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aL216-R223) [[2]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aL268-R277)

---

### Most Important Changes

#### API & Schema Improvements

* Added `credential: true` to password fields and schema property definitions in `api/user.yaml` and default resource scripts, enabling explicit marking of credential attributes in user schemas. [[1]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1109) [[2]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1675) [[3]](diffhunk://#diff-251727c4cd4b985ce306b3bceda1a46916f4559e9aa429037689e8271628e3ceR146-R149) [[4]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aR136-R139)
* Enhanced OpenAPI schema to support explicit boolean types and arrays, and to clarify property type handling and credential marking. [[1]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50L1559-R1565) [[2]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1575-R1578) [[3]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50R1588-R1600) [[4]](diffhunk://#diff-e9dcc2d5676a372054c89e2b7af3a0fabf268a67ee4df32b55b14758519ccd50L1616-R1652)

#### Backend Authentication & Service Logic

* Refactored the authentication interface to accept separate `identifiers` and `credentials` maps, improving clarity and maintainability in `AuthenticateUser` and related mocks/tests. [[1]](diffhunk://#diff-1816d6d81909221c132a034f3836ce299f3437e02570b15f14b3ced8f29da68fL46-R46) [[2]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aL64-R65) [[3]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL43-R63) [[4]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL79-R102) [[5]](diffhunk://#diff-a2e2452a4e28e947dd6312b85b2c62b916f0e38f5b1496242d881671cd5a0f4bL107-R113) [[6]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L52-L56) [[7]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L71-R66) [[8]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L91-R88) [[9]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L111-R103) [[10]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L131-R118) [[11]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L200-R187)
* On user creation, the backend now queries the schema for credential fields and extracts credentials accordingly, making credential handling schema-driven and more robust. [[1]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aL216-R223) [[2]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aL268-R277)

#### Credential Type Constants

* Cleaned up credential type constants, removing hardcoded support for password, pin, and secret types, and clarifying the distinction between system-managed and schema-defined credentials.

### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
User schema definitions must now explicitly mark credential fields (e.g., `password`) with `"credential": true`. Previously, the `password` field was treated as a credential by convention (hardcoded). Now, only fields annotated with `"credential": true` in the schema are extracted, hashed, and stored as credentials.

#### 💥 Impact
- **Existing user schemas** that define a `password` field without `"credential": true` will no longer hash or store passwords as credentials. Passwords will instead be stored as plain-text user attributes, and authentication will fail.
- **Bootstrap scripts** and any external tooling that creates user schemas via the API must be updated.
- Affects all environments (development, staging, production) that rely on password-based authentication.

#### 🔄 Migration Guide
Add `"credential": true` to any schema property that should be treated as a credential (hashed and stored separately).

**Before:**
```json
{
  "password": {
    "type": "string",
    "required": true
  }
}
```
After:

```json
{
  "password": {
    "type": "string",
    "required": true,
    "credential": true
  }
}
```

Only string and number type properties support the credential annotation. Boolean, object, and array types will reject it at schema compilation time.


### Related Issues
- Resolves https://github.com/asgardeo/thunder/issues/1545

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User schemas can mark fields (e.g., password) as credentials; admins can query credential-designated attributes per user type.
  * Default user schema now includes a credential-marked password field.

* **Chores**
  * Authentication and credential processing updated to follow schema-defined credential attributes and handle system-managed vs. schema-managed credentials.

* **Tests**
  * Added tests covering credential flag behavior and schema-driven credential discovery and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->