### PR TITLE
Add handling for THUNDER_SKIP_SECURITY environment variable in setup script

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -417,6 +417,8 @@ Write-Host "[WARN] Starting temporary server with security disabled..." -Foregro
 Write-Host ""
 
 # Export environment variable to skip security
+$hadSkipSecurity = Test-Path Env:THUNDER_SKIP_SECURITY
+$previousSkipSecurity = $env:THUNDER_SKIP_SECURITY
 $env:THUNDER_SKIP_SECURITY = "true"
 
 # Resolve thunder executable path
@@ -694,6 +696,13 @@ finally {
         try {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
         } catch { }
+    }
+
+    # Restore THUNDER_SKIP_SECURITY to its previous state
+    if (-not $hadSkipSecurity) {
+        Remove-Item Env:THUNDER_SKIP_SECURITY -ErrorAction SilentlyContinue
+    } else {
+        $env:THUNDER_SKIP_SECURITY = $previousSkipSecurity
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds proper handling for the `THUNDER_SKIP_SECURITY` environment variable in the `setup.ps1` script.

Previously, the script set `THUNDER_SKIP_SECURITY="true"` when starting the temporary server with security disabled, but it did not restore the variable to its previous state after execution.

This update:

- Stores the previous value of `THUNDER_SKIP_SECURITY`
- Sets it to `"true"` during the temporary server execution
- Restores the original value after the process completes
- Removes the variable if it was not previously defined

## Testing
#### Before
<img width="1920" height="1020" alt="Before" src="https://github.com/user-attachments/assets/adedbe8b-dbc9-41bd-9be7-def84eaa60e3" />

#### After
<img width="1920" height="1020" alt="After" src="https://github.com/user-attachments/assets/d875593c-722e-4946-b301-738bae4a217c" />

### Related Issues
- https://github.com/asgardeo/thunder/issues/1412

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated initialization script to preserve and restore the THUNDER_SKIP_SECURITY environment variable around a temporary server run, capturing prior state, setting it for the run, and restoring or removing it during cleanup so the environment returns to its original state even on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->