### PR TITLE
Resolve context conflicts in nodecontext and enginecontext

### DIFF
--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -44,7 +44,6 @@ type NodeContext struct {
 	RuntimeData    map[string]string
 	ForwardedData  map[string]interface{}
 
-	HTTPContext       context.Context
 	Application       appmodel.Application
 	AuthenticatedUser authncm.AuthenticatedUser
 	ExecutionHistory  map[string]*common.NodeExecutionRecord

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -67,17 +67,17 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	logger.Debug("Checking scope protection", log.Any("requiredScopes", requiredScopes))
 
-	// Check if HTTP context exists
-	if ctx.HTTPContext == nil {
-		logger.Debug("No HTTP context available - blocking access")
+	// Check if context exists
+	if ctx.Context == nil {
+		logger.Debug("No context available - blocking access")
 		execResp.Status = common.ExecFailure
 		execResp.FailureReason = "Insufficient permissions"
 		return execResp, nil
 	}
 
-	// Extract permissions from HTTP request context
-	userPermissions := security.GetPermissions(ctx.HTTPContext)
-	logger.Debug("Extracted permissions from HTTP context",
+	// Extract permissions from request context
+	userPermissions := security.GetPermissions(ctx.Context)
+	logger.Debug("Extracted permissions from context",
 		log.Int("permissionCount", len(userPermissions)),
 		log.String("permissions", strings.Join(userPermissions, ", ")))
 

--- a/backend/internal/flow/executor/permission_validator_test.go
+++ b/backend/internal/flow/executor/permission_validator_test.go
@@ -59,8 +59,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_DefaultScopeCheck_Success
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: httpCtx,
+		FlowID:  "test-flow",
+		Context: httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -78,8 +78,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_DefaultScopeCheck_Failure
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: httpCtx,
+		FlowID:  "test-flow",
+		Context: httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -165,7 +165,7 @@ func (suite *PermissionValidatorTestSuite) TestExecute_CustomScopeCheck_Success(
 
 			ctx := &core.NodeContext{
 				FlowID:         "test-flow",
-				HTTPContext:    httpCtx,
+				Context:        httpCtx,
 				NodeProperties: tc.nodeProps,
 			}
 
@@ -186,8 +186,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_MultipleRequiredScopes_OR
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: httpCtx,
+		FlowID:  "test-flow",
+		Context: httpCtx,
 		NodeProperties: map[string]interface{}{
 			propertyKeyRequiredScopes: []interface{}{"scopeA", "scopeB"},
 		},
@@ -208,8 +208,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_AuthorizedPermissionsChec
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: httpCtx,
+		FlowID:  "test-flow",
+		Context: httpCtx,
 		NodeProperties: map[string]interface{}{
 			propertyKeyRequiredScopes: []interface{}{"admin"},
 		},
@@ -223,8 +223,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_AuthorizedPermissionsChec
 
 func (suite *PermissionValidatorTestSuite) TestExecute_NoHTTPContext() {
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: nil,
+		FlowID:  "test-flow",
+		Context: nil,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -243,8 +243,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_EmptyScopes() {
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: httpCtx,
+		FlowID:  "test-flow",
+		Context: httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -263,8 +263,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_NoScopesInContext() {
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: httpCtx,
+		FlowID:  "test-flow",
+		Context: httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -283,8 +283,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_ScopesWithUnexpectedType(
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
-		HTTPContext: httpCtx,
+		FlowID:  "test-flow",
+		Context: httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -95,7 +95,6 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 			CurrentNodeID:     ctx.CurrentNode.GetID(),
 			RuntimeData:       ctx.RuntimeData,
 			ForwardedData:     ctx.ForwardedData,
-			HTTPContext:       ctx.HTTPContext,
 			Application:       ctx.Application,
 			AuthenticatedUser: ctx.AuthenticatedUser,
 			ExecutionHistory:  ctx.ExecutionHistory,

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -50,7 +50,6 @@ type EngineContext struct {
 	Graph       core.GraphInterface
 	Application appmodel.Application
 
-	HTTPContext       context.Context
 	AuthenticatedUser authncm.AuthenticatedUser
 	Assertion         string
 	ExecutionHistory  map[string]*common.NodeExecutionRecord

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -119,7 +119,6 @@ func (s *flowExecService) Execute(ctx context.Context,
 	// Set trace ID and HTTP context to engine context
 	context.TraceID = traceID
 	context.Context = ctx
-	context.HTTPContext = ctx
 
 	flowStep, flowErr := s.flowEngine.Execute(context)
 


### PR DESCRIPTION
NodeContext and EngineContext has the request context embedded twice. In this PR we are removing one and renaming all other places.

Issue : https://github.com/asgardeo/thunder/issues/1473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal execution context propagation across flow layers and stopped forwarding request-scoped context into per-node executions, reducing exposure of request data while preserving behavior.
* **Bug Fixes**
  * Permission checks now validate and extract permissions from the generic execution context and include clearer logging when context is missing.
* **Tests**
  * Updated tests to align with the new context handling and permission validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->