### PR TITLE
Onboard Action wise system authz policy

### DIFF
--- a/backend/internal/ou/SystemAuthorizationServiceInterface_mock_test.go
+++ b/backend/internal/ou/SystemAuthorizationServiceInterface_mock_test.go
@@ -89,3 +89,8 @@ func (_m *systemAuthorizationServiceMock) GetAccessibleResources(
 	}
 	return r0, r1
 }
+
+// SetOUHierarchyResolver provides a mock function for the type systemAuthorizationServiceMock.
+func (_m *systemAuthorizationServiceMock) SetOUHierarchyResolver(resolver sysauthz.OUHierarchyResolver) {
+	_m.Called(resolver)
+}

--- a/backend/internal/ou/hierarchy_resolver.go
+++ b/backend/internal/ou/hierarchy_resolver.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"context"
+	"errors"
+
+	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/sysauthz"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
+
+const loggerComponentNameHierarchyResolver = "OUHierarchyResolver"
+
+// ouHierarchyAdapter implements sysauthz.OUHierarchyResolver using direct store access.
+// It intentionally bypasses the service layer (which applies authz checks) to avoid
+// recursive authorization calls when the policy engine traverses the OU tree.
+type ouHierarchyAdapter struct {
+	store organizationUnitStoreInterface
+}
+
+// newOUHierarchyAdapter returns a new sysauthz.OUHierarchyResolver backed by the given store.
+func newOUHierarchyAdapter(store organizationUnitStoreInterface) sysauthz.OUHierarchyResolver {
+	return &ouHierarchyAdapter{store: store}
+}
+
+// IsAncestorOrSelf returns true when ancestorOUID equals descendantOUID, or when
+// ancestorOUID appears anywhere in the parent chain above descendantOUID.
+//
+// The walk is upward from descendantOUID; reaching the root without finding ancestorOUID
+// returns false. A broken chain (OU not found) is treated as deny-safe: false is returned
+// with no error so the authz layer can decide accordingly.
+func (r *ouHierarchyAdapter) IsAncestorOrSelf(
+	ctx context.Context, ancestorOUID, descendantOUID string,
+) (bool, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameHierarchyResolver))
+
+	if ancestorOUID == "" || descendantOUID == "" {
+		return false, nil
+	}
+
+	current := descendantOUID
+	visited := make(map[string]struct{})
+	for {
+		if current == ancestorOUID {
+			return true, nil
+		}
+
+		if _, ok := visited[current]; ok {
+			logger.Error("Cyclic organization unit parent chain detected during ancestry check",
+				log.String("ouID", current))
+			return false, nil
+		}
+		visited[current] = struct{}{}
+
+		ou, err := r.store.GetOrganizationUnit(current)
+		if err != nil {
+			if errors.Is(err, ErrOrganizationUnitNotFound) {
+				// Broken chain — cannot confirm ancestry; deny-safe.
+				logger.Debug("Encountered missing organization unit during ancestry check",
+					log.String("ouID", current))
+				return false, nil
+			}
+			logger.Error("Failed to traverse organization unit hierarchy during ancestry check",
+				log.Error(err))
+			return false, &ErrorInternalServerError
+		}
+
+		if ou.Parent == nil {
+			break
+		}
+		current = *ou.Parent
+	}
+
+	return false, nil
+}
+
+// GetAncestorOUIDs returns ouID itself followed by every ancestor OU ID, walking up to
+// the root of the tree. The returned slice always contains at least ouID itself.
+//
+// If the chain is broken (an OU in the hierarchy is not found), the walk stops and a
+// ServiceError is returned so callers can handle incomplete results explicitly.
+func (r *ouHierarchyAdapter) GetAncestorOUIDs(
+	ctx context.Context, ouID string,
+) ([]string, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameHierarchyResolver))
+
+	if ouID == "" {
+		return []string{}, nil
+	}
+
+	var result []string
+	current := ouID
+	visited := make(map[string]struct{})
+
+	for {
+		if _, ok := visited[current]; ok {
+			logger.Error("Cyclic organization unit parent chain detected while collecting ancestors",
+				log.String("ouID", current))
+			return nil, &ErrorInternalServerError
+		}
+		visited[current] = struct{}{}
+
+		result = append(result, current)
+
+		ou, err := r.store.GetOrganizationUnit(current)
+		if err != nil {
+			if errors.Is(err, ErrOrganizationUnitNotFound) {
+				logger.Debug("Encountered missing organization unit while collecting ancestors",
+					log.String("ouID", current))
+				return nil, &ErrorOrganizationUnitNotFound
+			}
+			logger.Error("Failed to traverse organization unit hierarchy while collecting ancestors",
+				log.Error(err))
+			return nil, &ErrorInternalServerError
+		}
+
+		if ou.Parent == nil {
+			break
+		}
+		current = *ou.Parent
+	}
+
+	return result, nil
+}

--- a/backend/internal/ou/hierarchy_resolver_test.go
+++ b/backend/internal/ou/hierarchy_resolver_test.go
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+type HierarchyResolverTestSuite struct {
+	suite.Suite
+}
+
+func TestHierarchyResolverTestSuite(t *testing.T) {
+	suite.Run(t, new(HierarchyResolverTestSuite))
+}
+
+// ---------------------------------------------------------------------------
+// newOUHierarchyAdapter
+// ---------------------------------------------------------------------------
+
+func (suite *HierarchyResolverTestSuite) TestNewOUHierarchyAdapter_ReturnsNonNil() {
+	mockStore := newOrganizationUnitStoreInterfaceMock(suite.T())
+	resolver := newOUHierarchyAdapter(mockStore)
+	assert.NotNil(suite.T(), resolver)
+}
+
+// ---------------------------------------------------------------------------
+// IsAncestorOrSelf
+// ---------------------------------------------------------------------------
+
+func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
+	parentID := testCoverageParentOUID
+	genericErr := errors.New("database error")
+
+	tests := []struct {
+		name           string
+		ancestorOUID   string
+		descendantOUID string
+		setupMock      func(m *organizationUnitStoreInterfaceMock)
+		wantResult     bool
+		wantErr        bool
+	}{
+		{
+			name:           "EmptyAncestorOUID_ReturnsFalse",
+			ancestorOUID:   "",
+			descendantOUID: "child-ou",
+			setupMock:      func(m *organizationUnitStoreInterfaceMock) {},
+			wantResult:     false,
+		},
+		{
+			name:           "EmptyDescendantOUID_ReturnsFalse",
+			ancestorOUID:   testCoverageParentOUID,
+			descendantOUID: "",
+			setupMock:      func(m *organizationUnitStoreInterfaceMock) {},
+			wantResult:     false,
+		},
+		{
+			name:           "BothEmpty_ReturnsFalse",
+			ancestorOUID:   "",
+			descendantOUID: "",
+			setupMock:      func(m *organizationUnitStoreInterfaceMock) {},
+			wantResult:     false,
+		},
+		{
+			name:           "SameOUID_ReturnsTrue",
+			ancestorOUID:   "ou1",
+			descendantOUID: "ou1",
+			setupMock:      func(m *organizationUnitStoreInterfaceMock) {},
+			wantResult:     true,
+		},
+		{
+			name:           "DirectParent_ReturnsTrue",
+			ancestorOUID:   testCoverageParentOUID,
+			descendantOUID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{ID: "child-ou", Parent: &parentID}, nil)
+			},
+			wantResult: true,
+		},
+		{
+			name:           "Grandparent_ReturnsTrue",
+			ancestorOUID:   "root-ou",
+			descendantOUID: "grandchild-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				parentRef := testCoverageParentOUID
+				rootRef := "root-ou"
+				m.On("GetOrganizationUnit", "grandchild-ou").
+					Return(OrganizationUnit{ID: "grandchild-ou", Parent: &parentRef}, nil)
+				m.On("GetOrganizationUnit", testCoverageParentOUID).
+					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &rootRef}, nil)
+			},
+			wantResult: true,
+		},
+		{
+			name:           "UnrelatedOU_ReturnsFalse",
+			ancestorOUID:   "unrelated-ou",
+			descendantOUID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				parentRef := testCoverageParentOUID
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil)
+				// parent-ou is root (no parent).
+				m.On("GetOrganizationUnit", testCoverageParentOUID).
+					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: nil}, nil)
+			},
+			wantResult: false,
+		},
+		{
+			name:           "RootOU_NoParent_ReturnsFalse",
+			ancestorOUID:   "some-ou",
+			descendantOUID: "root-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "root-ou").
+					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
+			},
+			wantResult: false,
+		},
+		{
+			name:           "BrokenChain_OUNotFound_ReturnsFalseNoError",
+			ancestorOUID:   testCoverageParentOUID,
+			descendantOUID: "orphan-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "orphan-ou").
+					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound)
+			},
+			wantResult: false,
+		},
+		{
+			name:           "StoreError_ReturnsFalseWithError",
+			ancestorOUID:   testCoverageParentOUID,
+			descendantOUID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{}, genericErr)
+			},
+			wantResult: false,
+			wantErr:    true,
+		},
+		{
+			name:           "CyclicChain_ReturnsFalseNoError",
+			ancestorOUID:   "root-ou",
+			descendantOUID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				parentRef := testCoverageParentOUID
+				childRef := "child-ou"
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil).Times(1)
+				m.On("GetOrganizationUnit", testCoverageParentOUID).
+					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &childRef}, nil).Times(1)
+			},
+			wantResult: false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			mockStore := newOrganizationUnitStoreInterfaceMock(suite.T())
+			tt.setupMock(mockStore)
+			resolver := newOUHierarchyAdapter(mockStore)
+
+			result, svcErr := resolver.IsAncestorOrSelf(context.Background(), tt.ancestorOUID, tt.descendantOUID)
+			assert.Equal(suite.T(), tt.wantResult, result)
+			if tt.wantErr {
+				assert.NotNil(suite.T(), svcErr)
+			} else {
+				assert.Nil(suite.T(), svcErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetAncestorOUIDs
+// ---------------------------------------------------------------------------
+
+func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
+	genericErr := errors.New("database error")
+
+	tests := []struct {
+		name      string
+		ouID      string
+		setupMock func(m *organizationUnitStoreInterfaceMock)
+		wantIDs   []string
+		wantErr   bool
+	}{
+		{
+			name:      "EmptyOUID_ReturnsEmptySlice",
+			ouID:      "",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {},
+			wantIDs:   []string{},
+		},
+		{
+			name: "RootOU_NoParent_ReturnsSelf",
+			ouID: "root-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "root-ou").
+					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
+			},
+			wantIDs: []string{"root-ou"},
+		},
+		{
+			name: "ChildOU_ReturnsSelfAndParent",
+			ouID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				parentRef := testCoverageParentOUID
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil)
+				m.On("GetOrganizationUnit", testCoverageParentOUID).
+					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: nil}, nil)
+			},
+			wantIDs: []string{"child-ou", testCoverageParentOUID},
+		},
+		{
+			name: "ThreeLevelHierarchy_ReturnsSelfParentGrandparent",
+			ouID: "grandchild-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				parentRef := testCoverageParentOUID
+				rootRef := "root-ou"
+				m.On("GetOrganizationUnit", "grandchild-ou").
+					Return(OrganizationUnit{ID: "grandchild-ou", Parent: &parentRef}, nil)
+				m.On("GetOrganizationUnit", testCoverageParentOUID).
+					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &rootRef}, nil)
+				m.On("GetOrganizationUnit", "root-ou").
+					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
+			},
+			wantIDs: []string{"grandchild-ou", testCoverageParentOUID, "root-ou"},
+		},
+		{
+			name: "BrokenChain_OUNotFound_ReturnsNilAndError",
+			ouID: "orphan-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "orphan-ou").
+					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound)
+			},
+			wantErr: true,
+		},
+		{
+			name: "BrokenChainMidWalk_OUNotFound_ReturnsNilAndError",
+			ouID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				missingRef := "missing-ou"
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{ID: "child-ou", Parent: &missingRef}, nil)
+				m.On("GetOrganizationUnit", "missing-ou").
+					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound)
+			},
+			wantErr: true,
+		},
+		{
+			name: "StoreError_ReturnsNilAndError",
+			ouID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{}, genericErr)
+			},
+			wantErr: true,
+		},
+		{
+			name: "StoreErrorMidWalk_ReturnsNilAndError",
+			ouID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				parentRef := testCoverageParentOUID
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil)
+				m.On("GetOrganizationUnit", testCoverageParentOUID).
+					Return(OrganizationUnit{}, genericErr)
+			},
+			wantErr: true,
+		},
+		{
+			name: "CyclicChain_ReturnsNilAndError",
+			ouID: "child-ou",
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				parentRef := testCoverageParentOUID
+				childRef := "child-ou"
+				m.On("GetOrganizationUnit", "child-ou").
+					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil).Times(1)
+				m.On("GetOrganizationUnit", testCoverageParentOUID).
+					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &childRef}, nil).Times(1)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			mockStore := newOrganizationUnitStoreInterfaceMock(suite.T())
+			tt.setupMock(mockStore)
+			resolver := newOUHierarchyAdapter(mockStore)
+
+			ids, svcErr := resolver.GetAncestorOUIDs(context.Background(), tt.ouID)
+			if tt.wantErr {
+				assert.NotNil(suite.T(), svcErr)
+				assert.Nil(suite.T(), ids)
+			} else {
+				assert.Nil(suite.T(), svcErr)
+				assert.Equal(suite.T(), tt.wantIDs, ids)
+			}
+		})
+	}
+}

--- a/backend/internal/ou/init.go
+++ b/backend/internal/ou/init.go
@@ -29,12 +29,14 @@ import (
 )
 
 // Initialize initializes the organization unit service and registers its routes.
+// It returns the service, a hierarchy resolver (for injection into the authz service to
+// avoid an import cycle), and the declarative resource exporter.
 func Initialize(
 	mux *http.ServeMux, authzService sysauthz.SystemAuthorizationServiceInterface,
-) (OrganizationUnitServiceInterface, declarativeresource.ResourceExporter, error) {
+) (OrganizationUnitServiceInterface, sysauthz.OUHierarchyResolver, declarativeresource.ResourceExporter, error) {
 	ouStore, err := initializeStore()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	ouService := newOrganizationUnitService(authzService, ouStore)
@@ -42,9 +44,13 @@ func Initialize(
 	ouHandler := newOrganizationUnitHandler(ouService)
 	registerRoutes(mux, ouHandler)
 
+	// Create the hierarchy resolver backed directly by the store (no authz checks) so
+	// the authz service can traverse the OU tree without recursive authorization calls.
+	hierarchyResolver := newOUHierarchyAdapter(ouStore)
+
 	// Create and return exporter
 	exporter := newOUExporter(ouService)
-	return ouService, exporter, nil
+	return ouService, hierarchyResolver, exporter, nil
 }
 
 // Store Selection (based on organization_unit.store configuration):

--- a/backend/internal/ou/init_test.go
+++ b/backend/internal/ou/init_test.go
@@ -61,11 +61,12 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesDisabled() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux, nil)
+	service, resolver, exporter, err := Initialize(mux, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), resolver)
 	assert.NotNil(suite.T(), exporter)
 
 	// Verify exporter is properly created
@@ -81,11 +82,12 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesEnabled() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux, nil)
+	service, resolver, exporter, err := Initialize(mux, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), resolver)
 	assert.NotNil(suite.T(), exporter)
 
 	// Verify exporter is properly created
@@ -101,11 +103,12 @@ func (suite *InitTestSuite) TestInitialize_FileBasedStoreCreation() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux, nil)
+	service, resolver, exporter, err := Initialize(mux, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), resolver)
 	assert.NotNil(suite.T(), exporter)
 
 	// Test that the service works (would use file-based store)
@@ -121,11 +124,12 @@ func (suite *InitTestSuite) TestInitialize_DatabaseStoreCreation() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux, nil)
+	service, resolver, exporter, err := Initialize(mux, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), resolver)
 	assert.NotNil(suite.T(), exporter)
 }
 
@@ -137,11 +141,12 @@ func (suite *InitTestSuite) TestInitialize_RoutesRegistered() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux, nil)
+	service, resolver, exporter, err := Initialize(mux, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), resolver)
 	assert.NotNil(suite.T(), exporter)
 
 	// Verify routes are registered by checking if requests can be matched
@@ -157,11 +162,12 @@ func (suite *InitTestSuite) TestInitialize_ExporterInterfaceCompliance() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux, nil)
+	service, resolver, exporter, err := Initialize(mux, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
+	assert.NotNil(suite.T(), resolver)
 
 	// Verify exporter implements ResourceExporter interface
 	var _ declarativeresource.ResourceExporter = exporter
@@ -184,10 +190,11 @@ func (suite *InitTestSuite) TestInitialize_ServiceInterfaceCompliance() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux, nil)
+	service, resolver, exporter, err := Initialize(mux, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resolver)
 	assert.NotNil(suite.T(), exporter)
 
 	// Verify service implements OrganizationUnitServiceInterface
@@ -200,15 +207,17 @@ func (suite *InitTestSuite) TestInitialize_MultipleInitializations() {
 	runtime.Config.DeclarativeResources.Enabled = false
 
 	mux1 := http.NewServeMux()
-	service1, exporter1, err1 := Initialize(mux1, nil)
+	service1, resolver1, exporter1, err1 := Initialize(mux1, nil)
 	assert.NoError(suite.T(), err1)
 	assert.NotNil(suite.T(), service1)
+	assert.NotNil(suite.T(), resolver1)
 	assert.NotNil(suite.T(), exporter1)
 
 	mux2 := http.NewServeMux()
-	service2, exporter2, err2 := Initialize(mux2, nil)
+	service2, resolver2, exporter2, err2 := Initialize(mux2, nil)
 	assert.NoError(suite.T(), err2)
 	assert.NotNil(suite.T(), service2)
+	assert.NotNil(suite.T(), resolver2)
 	assert.NotNil(suite.T(), exporter2)
 
 	// Services should be different instances

--- a/backend/internal/system/security/permissions.go
+++ b/backend/internal/system/security/permissions.go
@@ -54,7 +54,7 @@ var publicPaths = []string{
 type ResourceType string
 
 // ResourceType defines the category of system resource being acted upon.
-// ResourceTypeOU, ResourceTypeUser, and ResourceTypeGroup are the supported values.
+// ResourceTypeOU, ResourceTypeUser, ResourceTypeGroup, and ResourceTypeUserSchema are the supported values.
 const (
 	// ResourceTypeOU identifies an organization unit resource.
 	ResourceTypeOU ResourceType = "ou"
@@ -62,6 +62,8 @@ const (
 	ResourceTypeUser ResourceType = "user"
 	// ResourceTypeGroup identifies a group resource.
 	ResourceTypeGroup ResourceType = "group"
+	// ResourceTypeUserSchema identifies a user schema resource.
+	ResourceTypeUserSchema ResourceType = "userschema"
 )
 
 // ---- Actions ----
@@ -104,6 +106,17 @@ const (
 	ActionDeleteGroup Action = "group:delete"
 	// ActionListGroups lists groups.
 	ActionListGroups Action = "group:list"
+
+	// ActionCreateUserSchema creates a new user schema.
+	ActionCreateUserSchema Action = "userschema:create"
+	// ActionReadUserSchema reads a user schema.
+	ActionReadUserSchema Action = "userschema:read"
+	// ActionUpdateUserSchema updates a user schema.
+	ActionUpdateUserSchema Action = "userschema:update"
+	// ActionDeleteUserSchema deletes a user schema.
+	ActionDeleteUserSchema Action = "userschema:delete"
+	// ActionListUserSchemas lists user schemas.
+	ActionListUserSchemas Action = "userschema:list"
 )
 
 // ---- Permissions ----
@@ -115,12 +128,14 @@ const SystemPermission = "system"
 // Fine-grained permissions. Each constant is a child scope of SystemPermission.
 // Hierarchy uses ":" as delimiter: "system:ou" covers "system:ou:view".
 const (
-	PermissionOU        = "system:ou"
-	PermissionOUView    = "system:ou:view"
-	PermissionUser      = "system:user"
-	PermissionUserView  = "system:user:view"
-	PermissionGroup     = "system:group"
-	PermissionGroupView = "system:group:view"
+	PermissionOU             = "system:ou"
+	PermissionOUView         = "system:ou:view"
+	PermissionUser           = "system:user"
+	PermissionUserView       = "system:user:view"
+	PermissionGroup          = "system:group"
+	PermissionGroupView      = "system:group:view"
+	PermissionUserSchema     = "system:userschema"
+	PermissionUserSchemaView = "system:userschema:view"
 )
 
 // ---- Action → Permission map ----
@@ -149,6 +164,13 @@ var actionPermissionMap = map[Action]string{
 	ActionUpdateGroup: PermissionGroup,
 	ActionDeleteGroup: PermissionGroup,
 	ActionListGroups:  PermissionGroupView,
+
+	// User schema actions.
+	ActionCreateUserSchema: PermissionUserSchema,
+	ActionReadUserSchema:   PermissionUserSchemaView,
+	ActionUpdateUserSchema: PermissionUserSchema,
+	ActionDeleteUserSchema: PermissionUserSchema,
+	ActionListUserSchemas:  PermissionUserSchemaView,
 }
 
 // ---- API → Permission map ----

--- a/backend/tests/mocks/sysauthzmock/SystemAuthorizationServiceInterface_mock.go
+++ b/backend/tests/mocks/sysauthzmock/SystemAuthorizationServiceInterface_mock.go
@@ -189,3 +189,40 @@ func (_c *SystemAuthorizationServiceInterfaceMock_IsActionAllowed_Call) RunAndRe
 	_c.Call.Return(run)
 	return _c
 }
+
+// SetOUHierarchyResolver provides a mock function for the type SystemAuthorizationServiceInterfaceMock
+func (_mock *SystemAuthorizationServiceInterfaceMock) SetOUHierarchyResolver(resolver sysauthz.OUHierarchyResolver) {
+	_mock.Called(resolver)
+}
+
+// SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetOUHierarchyResolver'
+type SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call struct {
+	*mock.Call
+}
+
+// SetOUHierarchyResolver is a helper method to define mock.On call
+//   - resolver sysauthz.OUHierarchyResolver
+func (_e *SystemAuthorizationServiceInterfaceMock_Expecter) SetOUHierarchyResolver(resolver interface{}) *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call {
+	return &SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call{Call: _e.mock.On("SetOUHierarchyResolver", resolver)}
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call) Run(run func(resolver sysauthz.OUHierarchyResolver)) *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 sysauthz.OUHierarchyResolver
+		if args[0] != nil {
+			arg0 = args[0].(sysauthz.OUHierarchyResolver)
+		}
+		run(arg0)
+	})
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call) Return() *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call) RunAndReturn(run func(resolver sysauthz.OUHierarchyResolver)) *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call {
+	_c.Call.Return(run)
+	return _c
+}


### PR DESCRIPTION
### Purpose
This pull request introduces a new hierarchy resolver for Organization Units (OUs), enabling the authorization service to traverse OU trees without causing recursive authorization checks or import cycles. The OU initialization now returns this resolver for injection into the authorization service, and all relevant tests and mocks are updated to accommodate this change. Additionally, the `ResourceType` enum is extended to include user schema resources.

Part of https://github.com/asgardeo/thunder/pull/1500

Core integration of OU hierarchy resolver:

* Added the `ouHierarchyAdapter` implementation in `hierarchy_resolver.go`, providing direct access to OU hierarchy traversal methods (`IsAncestorOrSelf`, `GetAncestorOUIDs`) for use by the authorization service, bypassing authorization checks to prevent recursion.
* Modified `init.go` so that `Initialize` returns the OU service, hierarchy resolver, and exporter, enabling two-phase initialization and injection of the resolver into the authorization service.
* Updated `servicemanager.go` to inject the hierarchy resolver into the authorization service after OU initialization, breaking the import cycle between sysauthz and ou.

Testing and mocking updates:

* Added `hierarchy_resolver_test.go` with comprehensive unit tests for the new resolver, covering ancestor checks and ancestor listing across various edge cases.
* Updated `init_test.go` to validate the presence and correctness of the hierarchy resolver in all initialization scenarios. [[1]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL64-R69) [[2]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL84-R90) [[3]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL104-R111) [[4]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL124-R132) [[5]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL140-R149) [[6]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL160-R170) [[7]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL187-R197) [[8]](diffhunk://#diff-5455e2bc566ee94c1f3a6251f007613eeea9bebd35833c0c7fbe4d3d08d7c2ffL203-R220)
* Extended the system authorization service mock to support the new `SetOUHierarchyResolver` method for testing.

Permissions and resource types:

* Added `ResourceTypeUserSchema` to the `ResourceType` enum in `permissions.go`, expanding supported resource categories.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user schema as a manageable resource with Create/Read/Update/Delete/List permissions.
  * Enabled OU-hierarchy-aware resolver so parent OUs can grant read/list visibility to descendant resources.

* **Improvements**
  * Authorization now supports per-action OU inheritance for read access with clearer policy resolution and safer fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->