### PR TITLE
Remove plain method support in pkce

### DIFF
--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -87,18 +87,20 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 		return true, constants.ErrorUnsupportedResponseType, "Unsupported response type"
 	}
 
-	// Validate PKCE parameters if required
-	if oauthApp.RequiresPKCE() && responseType == string(constants.ResponseTypeCode) {
+	// Validate PKCE parameters
+	if responseType == string(constants.ResponseTypeCode) {
 		codeChallenge := msg.RequestQueryParams[constants.RequestParamCodeChallenge]
 		codeChallengeMethod := msg.RequestQueryParams[constants.RequestParamCodeChallengeMethod]
 
-		if codeChallenge == "" {
+		if oauthApp.RequiresPKCE() && codeChallenge == "" {
 			return true, constants.ErrorInvalidRequest, "code_challenge is required for this application"
 		}
 
-		// Validate code challenge format and method
-		if err := pkce.ValidateCodeChallenge(codeChallenge, codeChallengeMethod); err != nil {
-			return true, constants.ErrorInvalidRequest, "Invalid PKCE parameters"
+		// Validate code challenge format and method if PKCE parameters are present
+		if codeChallenge != "" {
+			if err := pkce.ValidateCodeChallenge(codeChallenge, codeChallengeMethod); err != nil {
+				return true, constants.ErrorInvalidRequest, "Invalid PKCE parameters"
+			}
 		}
 	}
 	// Validate nonce length (FAPI 2.0 aligned)

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -406,8 +406,8 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCERequired_
 			constants.RequestParamClientID:            "test-client-id",
 			constants.RequestParamRedirectURI:         "https://client.example.com/callback",
 			constants.RequestParamResponseType:        string(constants.ResponseTypeCode),
-			constants.RequestParamCodeChallenge:       "invalid-challenge", // Invalid format
-			constants.RequestParamCodeChallengeMethod: "plain",             // Plain is not allowed
+			constants.RequestParamCodeChallenge:       "invalid-challenge",
+			constants.RequestParamCodeChallengeMethod: "plain", // Not supported per OAuth 2.0 Security BCP
 		},
 	}
 
@@ -451,6 +451,36 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 	assert.Empty(suite.T(), errorMessage)
 }
 
+func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCERequired_MissingCodeChallengeMethod() {
+	// Create an app that requires PKCE
+	pkceApp := &appmodel.OAuthAppConfigProcessedDTO{
+		ClientID:                "test-client-id",
+		HashedClientSecret:      "hashed-secret",
+		RedirectURIs:            []string{"https://client.example.com/callback"},
+		GrantTypes:              []constants.GrantType{constants.GrantTypeAuthorizationCode},
+		ResponseTypes:           []constants.ResponseType{constants.ResponseTypeCode},
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretPost,
+		PKCERequired:            true,
+	}
+
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:      "test-client-id",
+			constants.RequestParamRedirectURI:   "https://client.example.com/callback",
+			constants.RequestParamResponseType:  string(constants.ResponseTypeCode),
+			constants.RequestParamCodeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			// Missing code_challenge_method - should fail instead of defaulting to S256
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, pkceApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
+	assert.Equal(suite.T(), "Invalid PKCE parameters", errorMessage)
+}
+
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_PKCENotRequired() {
 	// Create an app that doesn't require PKCE
 	nonPKCEApp := &appmodel.OAuthAppConfigProcessedDTO{
@@ -478,6 +508,36 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 	assert.False(suite.T(), sendErrorToApp)
 	assert.Empty(suite.T(), errorCode)
 	assert.Empty(suite.T(), errorMessage)
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCENotRequired_InvalidPKCEParams() {
+	// Create an app that doesn't require PKCE
+	nonPKCEApp := &appmodel.OAuthAppConfigProcessedDTO{
+		ClientID:                "test-client-id",
+		HashedClientSecret:      "hashed-secret",
+		RedirectURIs:            []string{"https://client.example.com/callback"},
+		GrantTypes:              []constants.GrantType{constants.GrantTypeAuthorizationCode},
+		ResponseTypes:           []constants.ResponseType{constants.ResponseTypeCode},
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretPost,
+		PKCERequired:            false,
+	}
+
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:      "test-client-id",
+			constants.RequestParamRedirectURI:   "https://client.example.com/callback",
+			constants.RequestParamResponseType:  string(constants.ResponseTypeCode),
+			constants.RequestParamCodeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			// Missing code_challenge_method - should fail even when PKCE is not required
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, nonPKCEApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
+	assert.Equal(suite.T(), "Invalid PKCE parameters", errorMessage)
 }
 
 // Prompt Parameter Validation Tests (OIDC Core §3.1.2.1)

--- a/backend/internal/oauth/oauth2/pkce/pkce.go
+++ b/backend/internal/oauth/oauth2/pkce/pkce.go
@@ -27,8 +27,7 @@ import (
 
 // PKCE Code Challenge Methods.
 const (
-	CodeChallengeMethodPlain = "plain"
-	CodeChallengeMethodS256  = "S256"
+	CodeChallengeMethodS256 = "S256"
 )
 
 // PKCE validation errors
@@ -56,23 +55,21 @@ func isValidBase64URLChar(c rune) bool {
 }
 
 // ValidatePKCE validates the PKCE code verifier against the stored code challenge.
+// Only S256 code challenge method is supported as per OAuth 2.0 Security Best Current Practice.
 func ValidatePKCE(codeChallenge, codeChallengeMethod, codeVerifier string) error {
-	if codeChallengeMethod == "" {
-		codeChallengeMethod = CodeChallengeMethodPlain
+	if codeChallengeMethod != CodeChallengeMethodS256 {
+		return ErrInvalidChallengeMethod
 	}
 
-	if err := validatePKCEParameters(codeChallenge, codeChallengeMethod, codeVerifier); err != nil {
+	if err := validateCodeVerifier(codeVerifier); err != nil {
 		return err
 	}
 
-	switch codeChallengeMethod {
-	case CodeChallengeMethodPlain:
-		return validatePlainChallenge(codeChallenge, codeVerifier)
-	case CodeChallengeMethodS256:
-		return validateS256Challenge(codeChallenge, codeVerifier)
-	default:
-		return ErrInvalidChallengeMethod
+	if codeChallenge == "" {
+		return ErrInvalidCodeChallenge
 	}
+
+	return validateS256Challenge(codeChallenge, codeVerifier)
 }
 
 // validateCodeVerifier validates the format of a code verifier according to RFC 7636.
@@ -91,31 +88,6 @@ func validateCodeVerifier(codeVerifier string) error {
 	return nil
 }
 
-// validatePKCEParameters validates the basic format of PKCE parameters.
-func validatePKCEParameters(codeChallenge, codeChallengeMethod, codeVerifier string) error {
-	if err := validateCodeVerifier(codeVerifier); err != nil {
-		return err
-	}
-
-	if codeChallenge == "" {
-		return ErrInvalidCodeChallenge
-	}
-
-	if codeChallengeMethod != CodeChallengeMethodPlain && codeChallengeMethod != CodeChallengeMethodS256 {
-		return ErrInvalidChallengeMethod
-	}
-
-	return nil
-}
-
-// validatePlainChallenge validates a plain code challenge.
-func validatePlainChallenge(codeChallenge, codeVerifier string) error {
-	if codeChallenge != codeVerifier {
-		return ErrPKCEValidationFailed
-	}
-	return nil
-}
-
 // validateS256Challenge validates an S256 code challenge.
 func validateS256Challenge(codeChallenge, codeVerifier string) error {
 	hash := sha256.Sum256([]byte(codeVerifier))
@@ -128,65 +100,42 @@ func validateS256Challenge(codeChallenge, codeVerifier string) error {
 }
 
 // GenerateCodeChallenge generates a code challenge from a code verifier using the specified method.
+// Only S256 code challenge method is supported as per OAuth 2.0 Security Best Current Practice.
 func GenerateCodeChallenge(codeVerifier, method string) (string, error) {
 	if err := validateCodeVerifier(codeVerifier); err != nil {
 		return "", err
 	}
 
-	if method != CodeChallengeMethodPlain && method != CodeChallengeMethodS256 {
+	if method != CodeChallengeMethodS256 {
 		return "", ErrInvalidChallengeMethod
 	}
 
-	switch method {
-	case CodeChallengeMethodPlain:
-		return codeVerifier, nil
-	case CodeChallengeMethodS256:
-		hash := sha256.Sum256([]byte(codeVerifier))
-		return base64.RawURLEncoding.EncodeToString(hash[:]), nil
-	default:
-		return "", ErrInvalidChallengeMethod
-	}
+	hash := sha256.Sum256([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
 }
 
 // ValidateCodeChallenge validates the format of a code challenge according to RFC 7636.
+// Only S256 code challenge method is supported as per OAuth 2.0 Security Best Current Practice.
 func ValidateCodeChallenge(codeChallenge, codeChallengeMethod string) error {
-	if codeChallengeMethod == "" {
-		codeChallengeMethod = CodeChallengeMethodPlain
+	if codeChallengeMethod != CodeChallengeMethodS256 {
+		return ErrInvalidChallengeMethod
 	}
 
-	if codeChallengeMethod == CodeChallengeMethodPlain {
-		if len(codeChallenge) < 43 || len(codeChallenge) > 128 {
+	if len(codeChallenge) != 43 {
+		return ErrInvalidCodeChallenge
+	}
+
+	for _, c := range codeChallenge {
+		if !isValidBase64URLChar(c) {
 			return ErrInvalidCodeChallenge
 		}
-
-		for _, c := range codeChallenge {
-			if !isValidASCIIUnreserved(c) {
-				return ErrInvalidCodeChallenge
-			}
-		}
-		return nil
 	}
-
-	if codeChallengeMethod == CodeChallengeMethodS256 {
-		if len(codeChallenge) != 43 {
-			return ErrInvalidCodeChallenge
-		}
-
-		for _, c := range codeChallenge {
-			if !isValidBase64URLChar(c) {
-				return ErrInvalidCodeChallenge
-			}
-		}
-		return nil
-	}
-
-	return ErrInvalidCodeChallenge
+	return nil
 }
 
 // GetSupportedCodeChallengeMethods returns all supported PKCE code challenge methods.
 func GetSupportedCodeChallengeMethods() []string {
 	return []string{
 		CodeChallengeMethodS256,
-		CodeChallengeMethodPlain,
 	}
 }

--- a/backend/internal/oauth/oauth2/pkce/pkce_test.go
+++ b/backend/internal/oauth/oauth2/pkce/pkce_test.go
@@ -51,25 +51,17 @@ func (suite *PKCETestSuite) TestValidatePKCE() {
 			expectedError:       nil,
 		},
 		{
-			name:                "Valid plain challenge",
+			name:                "Plain method is rejected",
 			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-			codeChallengeMethod: CodeChallengeMethodPlain,
+			codeChallengeMethod: "plain",
 			codeVerifier:        "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-			expectError:         false,
-			expectedError:       nil,
+			expectError:         true,
+			expectedError:       ErrInvalidChallengeMethod,
 		},
 		{
 			name:                "Invalid S256 challenge",
 			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
 			codeChallengeMethod: CodeChallengeMethodS256,
-			codeVerifier:        "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk_different_verifier_long_enough",
-			expectError:         true,
-			expectedError:       ErrPKCEValidationFailed,
-		},
-		{
-			name:                "Invalid plain challenge",
-			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-			codeChallengeMethod: CodeChallengeMethodPlain,
 			codeVerifier:        "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk_different_verifier_long_enough",
 			expectError:         true,
 			expectedError:       ErrPKCEValidationFailed,
@@ -107,17 +99,17 @@ func (suite *PKCETestSuite) TestValidatePKCE() {
 			expectedError:       ErrInvalidCodeVerifier,
 		},
 		{
-			name:                "Default method when empty",
-			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+			name:                "Empty method is rejected",
+			codeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 			codeChallengeMethod: "",
 			codeVerifier:        "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-			expectError:         false,
-			expectedError:       nil,
+			expectError:         true,
+			expectedError:       ErrInvalidChallengeMethod,
 		},
 		{
 			name:                "Unicode characters rejected",
-			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-			codeChallengeMethod: CodeChallengeMethodPlain,
+			codeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			codeChallengeMethod: CodeChallengeMethodS256,
 			codeVerifier:        "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk中文",
 			expectError:         true,
 			expectedError:       ErrInvalidCodeVerifier,
@@ -157,11 +149,11 @@ func (suite *PKCETestSuite) TestGenerateCodeChallenge() {
 			expectedError: nil,
 		},
 		{
-			name:          "Generate plain challenge",
+			name:          "Plain method is rejected",
 			codeVerifier:  "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-			method:        CodeChallengeMethodPlain,
-			expectError:   false,
-			expectedError: nil,
+			method:        "plain",
+			expectError:   true,
+			expectedError: ErrInvalidChallengeMethod,
 		},
 		{
 			name:          "Invalid method",
@@ -217,11 +209,11 @@ func (suite *PKCETestSuite) TestValidateCodeChallenge() {
 		expectedError       error
 	}{
 		{
-			name:                "Valid plain challenge",
+			name:                "Plain method is rejected",
 			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-			codeChallengeMethod: CodeChallengeMethodPlain,
-			expectError:         false,
-			expectedError:       nil,
+			codeChallengeMethod: "plain",
+			expectError:         true,
+			expectedError:       ErrInvalidChallengeMethod,
 		},
 		{
 			name:                "Valid S256 challenge",
@@ -231,9 +223,9 @@ func (suite *PKCETestSuite) TestValidateCodeChallenge() {
 			expectedError:       nil,
 		},
 		{
-			name:                "Empty code challenge",
+			name:                "Empty code challenge with S256",
 			codeChallenge:       "",
-			codeChallengeMethod: CodeChallengeMethodPlain,
+			codeChallengeMethod: CodeChallengeMethodS256,
 			expectError:         true,
 			expectedError:       ErrInvalidCodeChallenge,
 		},
@@ -242,21 +234,14 @@ func (suite *PKCETestSuite) TestValidateCodeChallenge() {
 			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
 			codeChallengeMethod: "invalid",
 			expectError:         true,
-			expectedError:       ErrInvalidCodeChallenge,
+			expectedError:       ErrInvalidChallengeMethod,
 		},
 		{
-			name:                "Default method when empty",
-			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+			name:                "Empty method is rejected",
+			codeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 			codeChallengeMethod: "",
-			expectError:         false,
-			expectedError:       nil,
-		},
-		{
-			name:                "Plain challenge with invalid characters",
-			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk!",
-			codeChallengeMethod: CodeChallengeMethodPlain,
 			expectError:         true,
-			expectedError:       ErrInvalidCodeChallenge,
+			expectedError:       ErrInvalidChallengeMethod,
 		},
 		{
 			name:                "S256 challenge with invalid characters",
@@ -269,20 +254,6 @@ func (suite *PKCETestSuite) TestValidateCodeChallenge() {
 			name:                "S256 challenge wrong length",
 			codeChallenge:       "short",
 			codeChallengeMethod: CodeChallengeMethodS256,
-			expectError:         true,
-			expectedError:       ErrInvalidCodeChallenge,
-		},
-		{
-			name:                "Plain challenge too short",
-			codeChallenge:       "short",
-			codeChallengeMethod: CodeChallengeMethodPlain,
-			expectError:         true,
-			expectedError:       ErrInvalidCodeChallenge,
-		},
-		{
-			name:                "Unicode characters rejected",
-			codeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk中文",
-			codeChallengeMethod: CodeChallengeMethodPlain,
 			expectError:         true,
 			expectedError:       ErrInvalidCodeChallenge,
 		},
@@ -306,10 +277,10 @@ func (suite *PKCETestSuite) TestValidateCodeChallenge() {
 }
 
 func (suite *PKCETestSuite) TestValidateCodeChallenge_InvalidMethod() {
-	// Test the default case in validateCodeChallenge
+	// Test that unsupported methods are rejected
 	err := ValidateCodeChallenge("valid-challenge", "unsupported_method")
 	assert.Error(suite.T(), err)
-	assert.Equal(suite.T(), ErrInvalidCodeChallenge, err)
+	assert.Equal(suite.T(), ErrInvalidChallengeMethod, err)
 }
 
 func (suite *PKCETestSuite) TestGenerateCodeChallenge_InvalidMethod() {
@@ -344,7 +315,7 @@ func (suite *PKCETestSuite) TestGetSupportedCodeChallengeMethods() {
 	methods := GetSupportedCodeChallengeMethods()
 
 	assert.NotNil(suite.T(), methods)
-	assert.Equal(suite.T(), 2, len(methods))
+	assert.Equal(suite.T(), 1, len(methods))
 	assert.Contains(suite.T(), methods, CodeChallengeMethodS256)
-	assert.Contains(suite.T(), methods, CodeChallengeMethodPlain)
+	assert.NotContains(suite.T(), methods, "plain")
 }

--- a/docs/__backup__/standards-based/oauth2-oidc/endpoints/authorization-endpoint.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/endpoints/authorization-endpoint.md
@@ -15,8 +15,8 @@ GET /oauth2/authorize
 - `redirect_uri`: Redirect URI (must match registered URI)
 - `scope`: Space-separated scopes (URL-encoded)
 - `state`: CSRF protection token (recommended)
-- `code_challenge`: PKCE code challenge (if PKCE is used)
-- `code_challenge_method`: `"S256"` or `"plain"` (if PKCE is used)
+- `code_challenge`: PKCE code challenge (required if PKCE is used)
+- `code_challenge_method`: Must be `"S256"` (required if PKCE is used)
 - `resource`: Target resource/audience (RFC 8707, optional)
 
 ## Example

--- a/docs/__backup__/standards-based/oauth2-oidc/endpoints/authorization-server-metadata.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/endpoints/authorization-server-metadata.md
@@ -37,7 +37,7 @@ Returns OAuth 2.0 authorization server metadata including:
     "refresh_token",
     "urn:ietf:params:oauth:grant-type:token-exchange"
   ],
-  "code_challenge_methods_supported": ["S256", "plain"],
+  "code_challenge_methods_supported": ["S256"],
   "scopes_supported": ["openid", "profile", "email"],
   "introspection_endpoint": "https://localhost:8090/oauth2/introspect",
   "registration_endpoint": "https://localhost:8090/oauth2/dcr/register"

--- a/docs/__backup__/standards-based/oauth2-oidc/features/mcp-server-securing.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/features/mcp-server-securing.md
@@ -71,7 +71,7 @@ curl -kL https://localhost:8090/.well-known/oauth-authorization-server
     "refresh_token",
     "urn:ietf:params:oauth:grant-type:token-exchange"
   ],
-  "code_challenge_methods_supported": ["S256", "plain"],
+  "code_challenge_methods_supported": ["S256"],
   "scopes_supported": ["openid", "profile", "email", "mcp:read", "mcp:write"],
   "registration_endpoint": "https://localhost:8090/oauth2/dcr/register",
   "introspection_endpoint": "https://localhost:8090/oauth2/introspect"

--- a/docs/__backup__/standards-based/oauth2-oidc/features/pkce.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/features/pkce.md
@@ -24,7 +24,7 @@ Generate a random code verifier (43-128 characters, URL-safe)
 
 ### Step 2: Generate Code Challenge
 
-Create code challenge using S256 (recommended)
+Create code challenge using S256 (required)
 
 ### Step 3: Authorization Request
 
@@ -71,8 +71,9 @@ curl -kL -X POST https://localhost:8090/oauth2/token \
 ## Code Challenge Methods
 
 Thunder supports:
-- **S256**: SHA256 hash (recommended, more secure)
-- **plain**: Plain text (less secure, not recommended)
+- **S256**: SHA256 hash (required, per OAuth 2.0 Security Best Current Practice)
+
+The `plain` method is not supported as it does not provide adequate security. Per RFC 9700 (OAuth 2.0 Security Best Current Practice), clients MUST use S256 as the code challenge method.
 
 ## Application Configuration
 
@@ -89,7 +90,7 @@ Enable PKCE requirement for an application:
 }
 ```
 
-When `pkce_required` is `true`, PKCE parameters are mandatory. Additionally PKCE is checked mandatorily for `public_clients` during runtime.
+When `pkce_required` is `true`, both `code_challenge` and `code_challenge_method` parameters are mandatory in the authorization request. The `code_challenge_method` must be `S256`. Additionally, PKCE is checked mandatorily for `public_clients` during runtime.
 
 ## Related Documentation
 

--- a/docs/__backup__/standards-based/oauth2-oidc/grant-types/authorization-code.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/grant-types/authorization-code.md
@@ -225,9 +225,9 @@ https://localhost:8090/oauth2/authorize?
 - `scope`: Space-separated list of scopes (URL-encoded)
 - `state`: Random value for CSRF protection (recommended)
 
-**Optional Parameters:**
-- `code_challenge`: PKCE code challenge (if PKCE is required)
-- `code_challenge_method`: `"S256"` or `"plain"` (if PKCE is required)
+**PKCE Parameters (required if PKCE is enabled or for public clients):**
+- `code_challenge`: PKCE code challenge
+- `code_challenge_method`: Must be `"S256"`
 - `resource`: Target resource/audience (RFC 8707)
 
 ### Step 5: User Authentication
@@ -325,8 +325,7 @@ curl -kL -X POST https://localhost:8090/oauth2/token \
 ```
 
 **PKCE Code Challenge Methods:**
-- `S256`: SHA256 hash (recommended)
-- `plain`: Plain text (less secure)
+- `S256`: SHA256 hash (required, per Security Best  Practices).
 
 ## Resource Parameter (RFC 8707)
 

--- a/samples/apps/react-sdk-sample/README.md
+++ b/samples/apps/react-sdk-sample/README.md
@@ -110,7 +110,7 @@ Before running the app, ensure your Thunder application is configured with:
 
 1. **Authorized Redirect URLs**: Add your application URL (e.g., `https://localhost:3000`)
 2. **Allowed Origins**: Add your application origin for CORS
-3. **Grant Types**: Authorization Code (with PKCE recommended for SPAs)
+3. **Grant Types**: Authorization Code (with PKCE required for SPAs)
 
 ## Troubleshooting
 

--- a/tests/integration/oauth/discovery/discovery_test.go
+++ b/tests/integration/oauth/discovery/discovery_test.go
@@ -129,10 +129,9 @@ func (ts *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata_GET_Success(
 	ts.Contains(metadata.TokenEndpointAuthMethodsSupported, "client_secret_post", "Should support client_secret_post")
 	ts.Contains(metadata.TokenEndpointAuthMethodsSupported, "none", "Should support none")
 
-	// Verify supported code challenge methods
-	ts.NotEmpty(metadata.CodeChallengeMethodsSupported, "CodeChallengeMethodsSupported should not be empty")
-	ts.Contains(metadata.CodeChallengeMethodsSupported, "S256", "Should support S256 code challenge method")
-	ts.Contains(metadata.CodeChallengeMethodsSupported, "plain", "Should support plain code challenge method")
+	// Verify only S256 code challenge method is supported (plain is prohibited per OAuth 2.0 Security BCP)
+	ts.Equal([]string{"S256"}, metadata.CodeChallengeMethodsSupported,
+		"CodeChallengeMethodsSupported should contain exactly S256")
 
 	// Verify supported scopes
 	ts.NotEmpty(metadata.ScopesSupported, "ScopesSupported should not be empty")


### PR DESCRIPTION
This pull request updates the PKCE (Proof Key for Code Exchange) implementation to enforce the use of the "S256" code challenge method exclusively, in accordance with the OAuth 2.0 Security Best Current Practice (RFC 9700). The less secure "plain" method is now fully unsupported throughout the codebase, tests, and documentation.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
Removed support for the PKCE `plain` code challenge method. Only `S256` is now supported, as per [OAuth 2.0 Security Best Current Practice (RFC 9700)](https://datatracker.ietf.org/doc/html/rfc9700).

#### 💥 Impact
Clients using `code_challenge_method=plain` in authorization requests will receive an `invalid_request` error. The `plain` method is no longer advertised in the discovery endpoint.

#### 🔄 Migration Guide
Update OAuth2 clients to use `code_challenge_method=S256` (SHA-256) explicitly. 

---

**Key changes:**

PKCE Implementation Changes:
- Removed support for the "plain" code challenge method in all PKCE-related functions in `pkce.go`. Only "S256" is now accepted for validation and generation, and all logic for "plain" has been deleted. [[1]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7L30) [[2]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7R58-L75) [[3]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7L104-L118) [[4]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7R116-L170) [[5]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7L183-L190)
- The default code challenge method is now "S256" if none is provided. [[1]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7R58-L75) [[2]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7R116-L170)

Test Suite Updates:
- Updated all PKCE-related tests to expect rejection of the "plain" method, and removed or modified tests that previously validated "plain". Tests now confirm that only "S256" is supported and that "plain" is rejected with the appropriate error. [[1]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL54-R59) [[2]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL69-L76) [[3]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL110-R112) [[4]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL160-R156) [[5]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL220-R216) [[6]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL234-R228) [[7]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL245-L260) [[8]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL275-L288) [[9]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL309-R283) [[10]](diffhunk://#diff-ccc89990f1a0d410367cead4249ad7e074b32374944e6b8611d6e4d0457a703eL347-R320)

Documentation Updates:
- Updated all relevant documentation to indicate that only "S256" is supported for PKCE. References to "plain" have been removed or clarified as unsupported, and examples/metadata now list only "S256" as a valid method. [[1]](diffhunk://#diff-28cf4867f965c06b2a644707b58c5c8c907758819ba964e165439b965fe9f583L19-R19) [[2]](diffhunk://#diff-e0154ab484fe72db3cd62bb0519eeb3811201bf06e4ec0a08ed8d6c55039e93cL39-R39) [[3]](diffhunk://#diff-34821054636a0affa43a8a82f9449f6df4a4bec153d76edb0ac36740f1933692L73-R73) [[4]](diffhunk://#diff-d3f816841ff8c8287532882ec7bc74eae593edb3032aa92c813dbe393e8557fcL74-R76) [[5]](diffhunk://#diff-88ee5b8857faaad9eb2573939f2f2495d85ee0b822abcac1a31c9105ab765830L230-R230)

Integration Test Updates:
- Modified integration tests to assert that "plain" is not listed as a supported code challenge method in server metadata.

Other:
- Updated comments and error messages to clarify that "S256" is the only supported code challenge method per current security best practices. [[1]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7R58-L75) [[2]](diffhunk://#diff-ffb0e93a7044595a6798cebad8cd5ab4cccd51d913b80e0ca2c61fa5ece3aad7R116-L170)

These changes ensure the codebase is aligned with current OAuth 2.0 security recommendations and eliminates the risk associated with the less secure "plain" PKCE method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Updates**
  * Removed support for the "plain" PKCE code_challenge method—only S256 is accepted per OAuth 2.0 Security BCP (RFC 9700). Clients using "plain" will receive an error.

* **Documentation**
  * Updated authorization endpoint, server metadata, and PKCE guidance to reflect S256-only support and rationale.

* **Tests**
  * Updated unit and integration tests and test comments to validate S256-only behavior and remove "plain" expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related issue-
- https://github.com/asgardeo/thunder/issues/1592