### PR TITLE
Add `at+jwt` in access token header

### DIFF
--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -391,7 +391,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(authResponse *co
 	// Generate auth assertion JWT
 	jwtConfig := config.GetThunderRuntime().Config.JWT
 	token, _, err := as.jwtService.GenerateJWT(user.UserID, jwtConfig.Audience, jwtConfig.Issuer,
-		jwtConfig.ValidityPeriod, jwtClaims)
+		jwtConfig.ValidityPeriod, jwtClaims, jwt.TokenTypeJWT)
 	if err != nil {
 		logger.Error("Failed to generate auth assertion", log.String("error", err.Error))
 		return &serviceerror.InternalServerError
@@ -624,7 +624,7 @@ func (as *authenticationService) createSessionToken(idpID string, idpType idp.ID
 	}
 
 	jwtConfig := config.GetThunderRuntime().Config.JWT
-	token, _, err := as.jwtService.GenerateJWT("auth-svc", "auth-svc", jwtConfig.Issuer, 600, claims)
+	token, _, err := as.jwtService.GenerateJWT("auth-svc", "auth-svc", jwtConfig.Issuer, 600, claims, jwt.TokenTypeJWT)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -216,7 +216,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					})).Return(testJWTToken, int64(3600), nil).Once()
+					}), mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -251,7 +251,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 						},
 					}, nil).Once()
 				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything,
-					mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
+					mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -332,7 +332,8 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsJWTG
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", testUserID, "application",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type:             serviceerror.ServerErrorType,
 			Code:             "JWT_GENERATION_FAILED",
@@ -530,7 +531,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 						// Verify that assurance claims are present
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					})).Return(testJWTToken, int64(3600), nil).Once()
+					}), mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -557,7 +558,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 						// Verify that assurance claims are present for MFA
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					})).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
+					}), mock.Anything).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.NotEmpty(result.Assertion)
@@ -610,7 +611,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOAuthSucc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOAuth, idpID)
@@ -631,7 +633,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOIDCSucce
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOIDCService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOIDC, idpID)
@@ -651,7 +654,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGoogleSuc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGoogleService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeGoogle, idpID)
@@ -671,7 +675,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuc
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockGithubService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeGitHub, idpID)
@@ -733,7 +738,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationCrossType
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
 	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOIDC, idpID)
@@ -752,7 +758,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 	suite.mockOAuthService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type:             serviceerror.ServerErrorType,
 			Code:             "JWT_GENERATION_FAILED",
@@ -850,7 +857,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 						},
 					}, nil).Once()
 				suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything,
-					mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
+					mock.Anything, mock.Anything, mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.Equal(testJWTToken, result.Assertion)
@@ -881,7 +888,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 						// Verify that assurance claims are present for MFA
 						_, hasAssurance := claims["assurance"]
 						return hasAssurance
-					})).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
+					}), mock.Anything).Return("new_jwt_token_with_mfa", int64(3600), nil).Once()
 			},
 			validateAssertion: func(result *common.AuthenticationResponse) {
 				suite.NotEmpty(result.Assertion)
@@ -1360,7 +1367,8 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionS
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", testUserID, "application",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testJWTToken, int64(3600), nil).Once()
 
 	// Test with empty existingAssertion
@@ -1554,7 +1562,8 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTPJWTGenerationError() {
 				IAL: assert.IALLevel1,
 			},
 		}, nil).Once()
-	suite.mockJWTService.On("GenerateJWT", testUserID, "application", mock.Anything, mock.Anything, mock.Anything).
+	suite.mockJWTService.On("GenerateJWT", testUserID, "application",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
 			Type:             serviceerror.ServerErrorType,
 			Code:             "JWT_GENERATION_FAILED",
@@ -1905,7 +1914,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Suc
 	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["userType"] == "person" && claims["organizationUnit"] == testOrgUnit
-		})).Return(testJWTToken, int64(3600), nil).Once()
+		}), mock.Anything).Return(testJWTToken, int64(3600), nil).Once()
 
 	result, err := suite.service.FinishPasskeyAuthentication(
 		testCredentialID, testCredentialType, response, sessionToken, false, "")
@@ -2002,7 +2011,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Wit
 		Return(mockUpdatedResult, nil).Once()
 
 	suite.mockJWTService.On("GenerateJWT", testUserID, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything).Return("updated.jwt.token", int64(3600), nil).Once()
+		mock.Anything, mock.Anything).Return("updated.jwt.token", int64(3600), nil).Once()
 
 	result, err := suite.service.FinishPasskeyAuthentication(
 		testCredentialID, testCredentialType, response, sessionToken, false, existingAssertion)

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -196,7 +196,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 		}
 	}
 
-	token, _, err := a.jwtService.GenerateJWT(tokenSub, ctx.AppID, iss, validityPeriod, jwtClaims)
+	token, _, err := a.jwtService.GenerateJWT(tokenSub, ctx.AppID, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT)
 	if err != nil {
 		logger.Error("Failed to generate JWT token", log.String("error", err.Error))
 		return "", errors.New("failed to generate JWT token: " + err.Error)

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -141,7 +141,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 	}, nil)
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
-		mock.Anything).Return("jwt-token", int64(3600), nil)
+		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-123").
 		Return(ou.OrganizationUnit{ID: "ou-123"}, nil)
@@ -193,7 +193,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAuthorizedPermissions(
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			perms, ok := claims["authorized_permissions"]
 			return ok && perms == "read:documents write:documents"
-		})).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -234,7 +234,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserAttributes() {
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["email"] == "test@example.com" && claims["phone"] == "1234567890"
-		})).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -259,7 +259,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_JWTGenerationFails() {
 	}
 
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.ServiceError{
+		mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &serviceerror.ServiceError{
 		Type:             serviceerror.ServerErrorType,
 		Code:             "JWT_GENERATION_FAILED",
 		Error:            "JWT generation failed",
@@ -500,7 +500,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims[oauth2const.ClaimUserType] == "EXTERNAL" && claims[oauth2const.ClaimOUID] == "ou-456"
-		})).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-456").
 		Return(ou.OrganizationUnit{ID: "ou-456"}, nil)
@@ -532,7 +532,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithCustomTokenConfig() {
 	}
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", "https://test.thunder.io", int64(7200),
-		mock.Anything).Return("jwt-token", int64(7200), nil)
+		mock.Anything, mock.Anything).Return("jwt-token", int64(7200), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -571,7 +571,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 			return claims[oauth2const.ClaimOUID] == "ou-789" &&
 				claims[oauth2const.ClaimOUName] == "Engineering" &&
 				claims[oauth2const.ClaimOUHandle] == "eng"
-		})).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -641,7 +641,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 	existingUser.Attributes = attrsJSON
 	suite.mockUserProvider.On("GetUser", "user-123").Return(existingUser, nil)
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
+		mock.Anything, mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -778,7 +778,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConfiguredUserAttribut
 			hasUsername := claims["username"] == "testuser"
 			hasFirstName := claims["firstName"] == "Test"
 			return hasEmail && hasUsername && hasFirstName
-		})).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -824,7 +824,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups() {
 				return false
 			}
 			return len(groups) == 3 && groups[0] == "admin" && groups[1] == "developer" && groups[2] == "viewer"
-		})).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -863,7 +863,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_EmptyGroups() {
 			// Should NOT contain groups claim when groups list is empty
 			_, ok := claims[oauth2const.UserAttributeGroups]
 			return !ok
-		})).Return("jwt-token", int64(3600), nil)
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
 
 	resp, err := suite.executor.Execute(ctx)
 

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -287,7 +287,8 @@ func (s *otpService) createSessionToken(sessionData common.OTPSessionData) (stri
 	validityPeriod := (sessionData.ExpiryTime - time.Now().UnixMilli()) / 1000
 	jwtConfig := config.GetThunderRuntime().Config.JWT
 
-	token, _, err := s.jwtService.GenerateJWT("otp-svc", "otp-svc", jwtConfig.Issuer, validityPeriod, claims)
+	token, _, err := s.jwtService.GenerateJWT(
+		"otp-svc", "otp-svc", jwtConfig.Issuer, validityPeriod, claims, jwt.TokenTypeJWT)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate JWT token: %v", err)
 	}

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -320,7 +320,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_Success() {
 	suite.service.clientProvider = cp
 
 	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("session-token-123", int64(0), nil).Once()
+		mock.Anything, mock.Anything, mock.Anything).Return("session-token-123", int64(0), nil).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(err)
@@ -365,7 +365,7 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateJWTError() {
 	suite.service.clientProvider = cp
 
 	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything).Return("", int64(0), &ErrorInternalServerError).Once()
+		mock.Anything, mock.Anything, mock.Anything).Return("", int64(0), &ErrorInternalServerError).Once()
 
 	res, err := suite.service.SendOTP(context.Background(), req)
 	suite.Nil(res)

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -173,7 +173,6 @@ func (tam TokenEndpointAuthMethod) IsValid() bool {
 // OAuth2 token types.
 const (
 	TokenTypeBearer = "Bearer"
-	TokenTypeJWT    = "JWT"
 )
 
 // TokenTypeIdentifier defines a type for RFC 8693 token type identifiers.

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -79,6 +79,7 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		jwtClaims,
+		jwt.TokenTypeAccessToken,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate access token: %v", err)
@@ -217,6 +218,7 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		claims,
+		jwt.TokenTypeJWT,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate refresh token: %v", err)
@@ -292,6 +294,7 @@ func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.Tok
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		jwtClaims,
+		jwt.TokenTypeJWT,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ID token: %v", err)

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -110,7 +110,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_Basic() {
 				claims["client_id"] == "test-client" &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["name"] == testUserName
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -158,7 +158,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithActorClaim(
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			act, ok := claims["act"].(map[string]interface{})
 			return ok && act["sub"] == "actor123" && act["iss"] == "https://actor-issuer.com"
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -201,7 +201,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			act, ok := claims["act"].(map[string]interface{})
 			return ok && act["sub"] == "nested-actor" && act["act"] != nil
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -233,7 +233,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyScopes() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasScope := claims["scope"]
 			return !hasScope
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -265,7 +265,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyClientID()
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasClientID := claims["client_id"]
 			return !hasClientID
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -297,7 +297,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyGrantType(
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasGrantType := claims["grant_type"]
 			return !hasGrantType
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -335,7 +335,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomValidityP
 		"app123",
 		"https://thunder.io", // Thunder-level issuer always used
 		int64(7200),
-		mock.Anything,
+		mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -370,7 +370,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_JWTGenerationFail
 		"app123",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything,
+		mock.Anything, mock.Anything,
 	).Return("", int64(0), &serviceerror.ServiceError{
 		Type:             serviceerror.ServerErrorType,
 		Code:             "JWT_GENERATION_FAILED",
@@ -412,7 +412,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithClaimsLocal
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["name"] == testUserName &&
 				claims["claims_locales"] == "en-US fr-CA ja"
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(ctx)
@@ -460,7 +460,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 				claims["access_token_aud"] == testAppID &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["access_token_user_attributes"].(map[string]interface{})["name"] == testUserName
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -498,7 +498,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasUserAttrs := claims["access_token_user_attributes"]
 			return !hasUserAttrs
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -530,7 +530,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasUserAttrs := claims["access_token_user_attributes"]
 			return !hasUserAttrs // Should not include user attrs when OAuthApp is nil
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -562,7 +562,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() 
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasScope := claims["scope"]
 			return !hasScope
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -598,7 +598,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithTokenConfi
 		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything,
+		mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -638,7 +638,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasUserAttrs := claims["access_token_user_attributes"]
 			return !hasUserAttrs // Should not include user attrs when AccessToken is nil
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -672,7 +672,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFai
 		"https://thunder.io",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything,
+		mock.Anything, mock.Anything,
 	).Return("", int64(0), &serviceerror.ServiceError{
 		Type:             serviceerror.ServerErrorType,
 		Code:             "JWT_GENERATION_FAILED",
@@ -714,7 +714,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithClaimsLoca
 				claims["access_token_aud"] == testAppID &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
 				claims["access_token_claims_locales"] == "en-US fr-CA ja"
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildRefreshToken(ctx)
@@ -751,7 +751,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_Basic() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// sub is passed as first arg to GenerateJWT, not in claims map
 			return claims["auth_time"] == ctx.AuthTime
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -788,7 +788,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoAuthTime() {
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			_, hasAuthTime := claims["auth_time"]
 			return !hasAuthTime
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -831,7 +831,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithScopeClaims() {
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["name"] == testUserName && claims["email"] == "john@example.com"
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -872,7 +872,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithStandardOIDCSco
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			// Check that both name (from profile scope) and email (from email scope) are present
 			return claims["name"] == testUserName && claims["email"] == "john@example.com"
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -902,7 +902,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoUserAttributes() 
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
 			return claims["auth_time"] == ctx.AuthTime
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -943,7 +943,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_EmptyUserAttributes
 			_, hasName := claims["name"]
 			return claims["auth_time"] == ctx.AuthTime &&
 				!hasName // Should not include name if not in UserAttributes config
-		}),
+		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -980,7 +980,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_CustomValidityPerio
 		"app123",
 		"https://thunder.io",
 		int64(7200),
-		mock.Anything,
+		mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildIDToken(ctx)
@@ -1014,7 +1014,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_JWTGenerationFailed()
 		"app123",
 		"https://thunder.io",
 		int64(3600),
-		mock.Anything,
+		mock.Anything, mock.Anything,
 	).Return("", int64(0), &serviceerror.ServiceError{
 		Type:             serviceerror.ServerErrorType,
 		Code:             "JWT_GENERATION_FAILED",

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -158,6 +158,7 @@ func (s *userInfoService) generateJWSUserInfo(
 		issuer,
 		validity,
 		response,
+		jwt.TokenTypeJWT,
 	)
 	if err != nil {
 		s.logger.Error("Failed to generate signed UserInfo JWT")

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -1196,6 +1196,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 		issuer,
 		config.GetThunderRuntime().Config.JWT.ValidityPeriod,
 		mock.Anything,
+		mock.Anything,
 	).Return("signed.jwt.token", int64(0), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -1253,6 +1254,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 		"client123",
 		issuer,
 		config.GetThunderRuntime().Config.JWT.ValidityPeriod,
+		mock.Anything,
 		mock.Anything,
 	).Return("", int64(0),
 		&serviceerror.ServiceError{

--- a/backend/internal/system/jose/jwt/constants.go
+++ b/backend/internal/system/jose/jwt/constants.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package jwt
+
+const (
+	// TokenTypeJWT is the standard JWT type header value used for general-purpose JWTs.
+	TokenTypeJWT = "JWT"
+
+	// TokenTypeAccessToken is the JWT type header value for access tokens as defined in RFC 9068.
+	TokenTypeAccessToken = "at+jwt"
+)

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -527,7 +527,7 @@ func (suite *JWTServiceTestSuite) TestGenerateJWTScenarios() {
 
 			jwtService := tc.setupService()
 
-			token, iat, err := jwtService.GenerateJWT(tc.sub, tc.aud, tc.iss, tc.validity, tc.claims)
+			token, iat, err := jwtService.GenerateJWT(tc.sub, tc.aud, tc.iss, tc.validity, tc.claims, TokenTypeJWT)
 
 			if tc.expectError {
 				assert.NotNil(t, err)
@@ -1312,7 +1312,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 		{
 			name: "ValidToken",
 			setupFunc: func() string {
-				token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+				token, _, err := suite.jwtService.GenerateJWT(
+					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 				assert.Nil(suite.T(), err)
 				return token
 			},
@@ -1340,7 +1341,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 		{
 			name: "PublicKeyNotAvailable",
 			setupFunc: func() string {
-				token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+				token, _, err := suite.jwtService.GenerateJWT(
+					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 				assert.Nil(suite.T(), err)
 				return token
 			},
@@ -1370,7 +1372,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 }
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
-	validToken, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+	validToken, _, err := suite.jwtService.GenerateJWT(
+		"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 	assert.Nil(suite.T(), err)
 
 	wrongKey, _ := rsa.GenerateKey(rand.Reader, 2048)
@@ -1407,7 +1410,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
 }
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKS() {
-	token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+	token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 	assert.Nil(suite.T(), err)
 
 	testServer := suite.mockJWKSServer()
@@ -1484,7 +1487,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+				token, _, _ := suite.jwtService.GenerateJWT(
+					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorFailedToGetJWKS,
@@ -1501,7 +1505,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+				token, _, _ := suite.jwtService.GenerateJWT(
+					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorFailedToParseJWKS,
@@ -1530,7 +1535,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+				token, _, _ := suite.jwtService.GenerateJWT(
+					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorNoMatchingJWKFound,
@@ -1558,7 +1564,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 				}))
 			},
 			setupToken: func() string {
-				token, _, _ := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+				token, _, _ := suite.jwtService.GenerateJWT(
+					"test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 				return token
 			},
 			expectedError: ErrorFailedToParseJWKS,
@@ -1600,7 +1607,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSHTTPErrors() {
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSNetworkError() {
 	// Test with invalid URL to trigger network error
-	token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil)
+	token, _, err := suite.jwtService.GenerateJWT("test-subject", testAudience, testIssuer, 3600, nil, TokenTypeJWT)
 	assert.Nil(suite.T(), err)
 
 	err = suite.jwtService.VerifyJWTSignatureWithJWKS(token, "http://localhost:99999/invalid")
@@ -1835,7 +1842,7 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 			assert.Equal(t, tc.expectedAlg, jwtSvc.jwsAlg)
 
 			// Test JWT generation with ECDSA key
-			token, _, svcErr := service.GenerateJWT("test-subject", "test-aud", "test-iss", 3600, nil)
+			token, _, svcErr := service.GenerateJWT("test-subject", "test-aud", "test-iss", 3600, nil, TokenTypeJWT)
 			assert.Nil(t, svcErr)
 			assert.NotEmpty(t, token)
 
@@ -1897,7 +1904,7 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 	assert.Equal(suite.T(), jws.EdDSA, jwtSvc.jwsAlg)
 
 	// Test JWT generation with Ed25519 key
-	token, _, svcErr := service.GenerateJWT("test-subject", "test-aud", "test-iss", 3600, nil)
+	token, _, svcErr := service.GenerateJWT("test-subject", "test-aud", "test-iss", 3600, nil, TokenTypeJWT)
 	assert.Nil(suite.T(), svcErr)
 	assert.NotEmpty(suite.T(), token)
 
@@ -2164,7 +2171,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKeyAlgorithmDe
 			}
 
 			// Generate token
-			token, _, err := jwtService.GenerateJWT("test-sub", "test-aud", "test-iss", 3600, nil)
+			token, _, err := jwtService.GenerateJWT("test-sub", "test-aud", "test-iss", 3600, nil, TokenTypeJWT)
 			assert.Nil(t, err)
 
 			// Verify with public key (should detect algorithm from header)

--- a/backend/internal/system/mcp/auth/token_verifier_test.go
+++ b/backend/internal/system/mcp/auth/token_verifier_test.go
@@ -58,8 +58,9 @@ func (m *MockJWTService) GenerateJWT(
 	sub, aud, iss string,
 	validityPeriod int64,
 	claims map[string]interface{},
+	typ string,
 ) (string, int64, *serviceerror.ServiceError) {
-	args := m.Called(sub, aud, iss, validityPeriod, claims)
+	args := m.Called(sub, aud, iss, validityPeriod, claims, typ)
 	return args.String(0), args.Get(1).(int64), args.Get(2).(*serviceerror.ServiceError)
 }
 

--- a/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
+++ b/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
@@ -39,8 +39,8 @@ func (_m *JWTServiceInterfaceMock) EXPECT() *JWTServiceInterfaceMock_Expecter {
 }
 
 // GenerateJWT provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}) (string, int64, *serviceerror.ServiceError) {
-	ret := _mock.Called(sub, aud, iss, validityPeriod, claims)
+func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError) {
+	ret := _mock.Called(sub, aud, iss, validityPeriod, claims, typ)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateJWT")
@@ -49,21 +49,21 @@ func (_mock *JWTServiceInterfaceMock) GenerateJWT(sub string, aud string, iss st
 	var r0 string
 	var r1 int64
 	var r2 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, int64, map[string]interface{}) (string, int64, *serviceerror.ServiceError)); ok {
-		return returnFunc(sub, aud, iss, validityPeriod, claims)
+	if returnFunc, ok := ret.Get(0).(func(string, string, string, int64, map[string]interface{}, string) (string, int64, *serviceerror.ServiceError)); ok {
+		return returnFunc(sub, aud, iss, validityPeriod, claims, typ)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, int64, map[string]interface{}) string); ok {
-		r0 = returnFunc(sub, aud, iss, validityPeriod, claims)
+	if returnFunc, ok := ret.Get(0).(func(string, string, string, int64, map[string]interface{}, string) string); ok {
+		r0 = returnFunc(sub, aud, iss, validityPeriod, claims, typ)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string, int64, map[string]interface{}) int64); ok {
-		r1 = returnFunc(sub, aud, iss, validityPeriod, claims)
+	if returnFunc, ok := ret.Get(1).(func(string, string, string, int64, map[string]interface{}, string) int64); ok {
+		r1 = returnFunc(sub, aud, iss, validityPeriod, claims, typ)
 	} else {
 		r1 = ret.Get(1).(int64)
 	}
-	if returnFunc, ok := ret.Get(2).(func(string, string, string, int64, map[string]interface{}) *serviceerror.ServiceError); ok {
-		r2 = returnFunc(sub, aud, iss, validityPeriod, claims)
+	if returnFunc, ok := ret.Get(2).(func(string, string, string, int64, map[string]interface{}, string) *serviceerror.ServiceError); ok {
+		r2 = returnFunc(sub, aud, iss, validityPeriod, claims, typ)
 	} else {
 		if ret.Get(2) != nil {
 			r2 = ret.Get(2).(*serviceerror.ServiceError)
@@ -83,11 +83,12 @@ type JWTServiceInterfaceMock_GenerateJWT_Call struct {
 //   - iss string
 //   - validityPeriod int64
 //   - claims map[string]interface{}
-func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(sub interface{}, aud interface{}, iss interface{}, validityPeriod interface{}, claims interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
-	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", sub, aud, iss, validityPeriod, claims)}
+//   - typ string
+func (_e *JWTServiceInterfaceMock_Expecter) GenerateJWT(sub interface{}, aud interface{}, iss interface{}, validityPeriod interface{}, claims interface{}, typ interface{}) *JWTServiceInterfaceMock_GenerateJWT_Call {
+	return &JWTServiceInterfaceMock_GenerateJWT_Call{Call: _e.mock.On("GenerateJWT", sub, aud, iss, validityPeriod, claims, typ)}
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{})) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}, typ string)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -109,12 +110,17 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Run(run func(sub string, aud
 		if args[4] != nil {
 			arg4 = args[4].(map[string]interface{})
 		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -125,7 +131,7 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) Return(s string, n int64, se
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
+func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(sub string, aud string, iss string, validityPeriod int64, claims map[string]interface{}, typ string) (string, int64, *serviceerror.ServiceError)) *JWTServiceInterfaceMock_GenerateJWT_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This pull request updates the usage of the `GenerateJWT` method throughout the authentication service and its tests to support an additional `tokenType` parameter. This change ensures that JWT generation explicitly specifies the token type, improving clarity and extensibility for different JWT token types in the future. The changes affect both the main authentication logic and all related unit tests.

**Authentication logic updates:**

* Updated all calls to `jwtService.GenerateJWT` in `backend/internal/authn/service.go` and `backend/internal/flow/executor/auth_assert_executor.go` to include the new `jwt.TokenTypeJWT` parameter, ensuring that the token type is always specified when generating JWTs. [[1]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L394-R394) [[2]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L627-R627) [[3]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fL199-R199)

**Test updates:**

* Modified all mocks and expectations for `GenerateJWT` in `backend/internal/authn/service_test.go` and `backend/internal/flow/executor/auth_assert_executor_test.go` to accept the new `tokenType` argument, updating both the parameter lists and the mock matching logic. [[1]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L219-R219) [[2]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L254-R254) [[3]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L335-R335) [[4]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L533-R533) [[5]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L560-R560) [[6]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L613-R613) [[7]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L634-R634) [[8]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L654-R654) [[9]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L674-R674) [[10]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L736-R736) [[11]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L755-R755) [[12]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L853-R853) [[13]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L884-R884) [[14]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L1363-R1363) [[15]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L1557-R1557) [[16]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L1908-R1908) [[17]](diffhunk://#diff-6623ca5e8813fd558d6bbdee414eec577a6d1e55101780587717aadc723a4ce8L2005-R2005) [[18]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L144-R144) [[19]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L196-R196) [[20]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L237-R237) [[21]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L262-R262) [[22]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L503-R503) [[23]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L535-R535) [[24]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L574-R574) [[25]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L644-R644) [[26]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85L781-R781)

Related Issue:
- https://github.com/asgardeo/thunder/issues/816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable JWT token-type support (new token-type values including access-token per RFC 9068); token type is now supplied during JWT generation and defaults to "JWT".
  * Removed a duplicate JWT token-type constant from OAuth2 constants.

* **Tests**
  * Updated tests across authentication, OAuth, notification, and token flows to accommodate the new token-type parameter and adjusted mocks/expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->