### PR TITLE
Add access token validator for userinfo

### DIFF
--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -30,6 +30,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/granthandlers"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/introspect"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/token"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/userinfo"
 	"github.com/asgardeo/thunder/internal/oauth/scope"
 	"github.com/asgardeo/thunder/internal/ou"
@@ -51,12 +52,13 @@ func Initialize(
 	ouService ou.OrganizationUnitServiceInterface,
 ) {
 	jwks.Initialize(mux, pkiService)
+	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService)
 	grantHandlerProvider := granthandlers.Initialize(
-		mux, jwtService, userService, applicationService, flowExecService)
+		mux, jwtService, userService, applicationService, flowExecService, tokenBuilder, tokenValidator)
 	scopeValidator := scope.Initialize()
 	token.Initialize(mux, applicationService, grantHandlerProvider, scopeValidator, observabilitySvc)
 	introspect.Initialize(mux, jwtService)
-	userinfo.Initialize(mux, jwtService, applicationService, userService, ouService)
+	userinfo.Initialize(mux, jwtService, tokenValidator, applicationService, userService, ouService)
 	discovery.Initialize(mux)
 	dcr.Initialize(mux, applicationService)
 }

--- a/backend/internal/oauth/oauth2/granthandlers/init.go
+++ b/backend/internal/oauth/oauth2/granthandlers/init.go
@@ -36,9 +36,10 @@ func Initialize(
 	userService user.UserServiceInterface,
 	applicationService application.ApplicationServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
+	tokenBuilder tokenservice.TokenBuilderInterface,
+	tokenValidator tokenservice.TokenValidatorInterface,
 ) GrantHandlerProviderInterface {
 	authzService := authz.Initialize(mux, applicationService, jwtService, flowExecService)
-	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService)
 	grantHandlerProvider := newGrantHandlerProvider(
 		jwtService, userService, authzService, tokenBuilder, tokenValidator)
 	return grantHandlerProvider

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -101,3 +101,14 @@ type SubjectTokenClaims struct {
 	UserAttributes map[string]interface{}
 	NestedAct      map[string]interface{}
 }
+
+// AccessTokenClaims represents the validated claims from an access token.
+type AccessTokenClaims struct {
+	Sub       string
+	Iss       string
+	Aud       string
+	GrantType string
+	Scopes    []string
+	ClientID  string
+	Claims    map[string]interface{}
+}

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -88,7 +88,7 @@ func resolveTokenConfig(oauthApp *appmodel.OAuthAppConfigProcessedDTO, tokenType
 	return tokenConfig
 }
 
-// extractStringClaim safely extracts a string claim from a claims map.
+// extractStringClaim safely extracts a non-empty string claim from a claims map.
 func extractStringClaim(claims map[string]interface{}, key string) (string, error) {
 	value, ok := claims[key]
 	if !ok {
@@ -98,6 +98,10 @@ func extractStringClaim(claims map[string]interface{}, key string) (string, erro
 	strValue, ok := value.(string)
 	if !ok {
 		return "", fmt.Errorf("claim %s is not a string", key)
+	}
+
+	if strValue == "" {
+		return "", fmt.Errorf("claim %s is empty", key)
 	}
 
 	return strValue, nil

--- a/backend/internal/oauth/oauth2/userinfo/init.go
+++ b/backend/internal/oauth/oauth2/userinfo/init.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
@@ -33,11 +34,12 @@ import (
 func Initialize(
 	mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface,
+	tokenValidator tokenservice.TokenValidatorInterface,
 	applicationService application.ApplicationServiceInterface,
 	userService user.UserServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
 ) userInfoServiceInterface {
-	userInfoService := newUserInfoService(jwtService, applicationService, userService, ouService)
+	userInfoService := newUserInfoService(jwtService, tokenValidator, applicationService, userService, ouService)
 	userInfoHandler := newUserInfoHandler(userInfoService)
 	registerRoutes(mux, userInfoHandler)
 	return userInfoService

--- a/backend/internal/oauth/oauth2/userinfo/init_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/init_test.go
@@ -28,16 +28,18 @@ import (
 
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
+	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
 	usersvcmock "github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
 type InitTestSuite struct {
 	suite.Suite
-	mockJWTService  *jwtmock.JWTServiceInterfaceMock
-	mockAppService  *applicationmock.ApplicationServiceInterfaceMock
-	mockUserService *usersvcmock.UserServiceInterfaceMock
-	mockOUService   *oumock.OrganizationUnitServiceInterfaceMock
+	mockJWTService     *jwtmock.JWTServiceInterfaceMock
+	mockTokenValidator *tokenservicemock.TokenValidatorInterfaceMock
+	mockAppService     *applicationmock.ApplicationServiceInterfaceMock
+	mockUserService    *usersvcmock.UserServiceInterfaceMock
+	mockOUService      *oumock.OrganizationUnitServiceInterfaceMock
 }
 
 func TestInitTestSuite(t *testing.T) {
@@ -46,6 +48,7 @@ func TestInitTestSuite(t *testing.T) {
 
 func (suite *InitTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
+	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
 	suite.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
 	suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
 	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
@@ -54,7 +57,8 @@ func (suite *InitTestSuite) SetupTest() {
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
 
-	service := Initialize(mux, suite.mockJWTService, suite.mockAppService,
+	service := Initialize(mux, suite.mockJWTService,
+		suite.mockTokenValidator, suite.mockAppService,
 		suite.mockUserService, suite.mockOUService)
 
 	assert.NotNil(suite.T(), service)
@@ -63,7 +67,8 @@ func (suite *InitTestSuite) TestInitialize() {
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
 
-	_ = Initialize(mux, suite.mockJWTService, suite.mockAppService,
+	_ = Initialize(mux, suite.mockJWTService,
+		suite.mockTokenValidator, suite.mockAppService,
 		suite.mockUserService, suite.mockOUService)
 
 	// Verify that the routes are registered by attempting to get a handler for them.

--- a/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
@@ -37,6 +37,68 @@ func (_m *TokenValidatorInterfaceMock) EXPECT() *TokenValidatorInterfaceMock_Exp
 	return &TokenValidatorInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
+// ValidateAccessToken provides a mock function for the type TokenValidatorInterfaceMock
+func (_mock *TokenValidatorInterfaceMock) ValidateAccessToken(token string) (*tokenservice.AccessTokenClaims, error) {
+	ret := _mock.Called(token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateAccessToken")
+	}
+
+	var r0 *tokenservice.AccessTokenClaims
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*tokenservice.AccessTokenClaims, error)); ok {
+		return returnFunc(token)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *tokenservice.AccessTokenClaims); ok {
+		r0 = returnFunc(token)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tokenservice.AccessTokenClaims)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(token)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// TokenValidatorInterfaceMock_ValidateAccessToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateAccessToken'
+type TokenValidatorInterfaceMock_ValidateAccessToken_Call struct {
+	*mock.Call
+}
+
+// ValidateAccessToken is a helper method to define mock.On call
+//   - token string
+func (_e *TokenValidatorInterfaceMock_Expecter) ValidateAccessToken(token interface{}) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+	return &TokenValidatorInterfaceMock_ValidateAccessToken_Call{Call: _e.mock.On("ValidateAccessToken", token)}
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) Run(run func(token string)) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) Return(accessTokenClaims *tokenservice.AccessTokenClaims, err error) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+	_c.Call.Return(accessTokenClaims, err)
+	return _c
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) RunAndReturn(run func(token string) (*tokenservice.AccessTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ValidateRefreshToken provides a mock function for the type TokenValidatorInterfaceMock
 func (_mock *TokenValidatorInterfaceMock) ValidateRefreshToken(token string, clientID string) (*tokenservice.RefreshTokenClaims, error) {
 	ret := _mock.Called(token, clientID)


### PR DESCRIPTION
This pull request enhances the OAuth2 userinfo service by introducing stricter access token validation according to RFC 9068, centralizing access token validation logic, and improving test coverage. The key changes include using a dedicated `TokenValidatorInterface` for validating access tokens (including signature, claims, and token type), updating service and initialization logic to use this validator, and adding comprehensive tests for the new validation logic.

**Access Token Validation Improvements**
- Added a new `ValidateAccessToken` method to `TokenValidatorInterface`, which validates access tokens by checking the signature, required claims, and the `typ` header as per RFC 9068. This logic is implemented in `tokenservice/validator.go` and returns a new `AccessTokenClaims` struct. [[1]](diffhunk://#diff-ef8e3cff68ea3a4ac66f0ee805abcd05c771536d7c66506883aff62d976e76cfR34) [[2]](diffhunk://#diff-ef8e3cff68ea3a4ac66f0ee805abcd05c771536d7c66506883aff62d976e76cfR51-R94) [[3]](diffhunk://#diff-685ce261286f83a61c4112791666a21ba95d345a3e94ddfc78ad933083166b76R104-R114)
- The `userinfo` service now uses this validator instead of directly verifying JWTs, ensuring consistent and standards-compliant token validation. [[1]](diffhunk://#diff-c47ef12bf0fc6cf4c74df8479f8c2713c808a67bead7441d42b560a561b31d7cR50) [[2]](diffhunk://#diff-c47ef12bf0fc6cf4c74df8479f8c2713c808a67bead7441d42b560a561b31d7cR60-R67) [[3]](diffhunk://#diff-c47ef12bf0fc6cf4c74df8479f8c2713c808a67bead7441d42b560a561b31d7cL174-R187)

**Initialization and Dependency Injection Updates**
- Updated the initialization logic for the OAuth2 module and submodules to inject the new `TokenValidatorInterface` and `TokenBuilderInterface` where required, ensuring that all components use the new validation approach. [[1]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4R33) [[2]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4R55-R61) [[3]](diffhunk://#diff-838c1f5c81b14a0b50875260562450b7c28ff52c60ab58cfec8caa8fd9bf8d31R39-L41) [[4]](diffhunk://#diff-ddaf66ce505da9c470ce49def97cb6219c15697436fa05f4030c188927e619b4R26) [[5]](diffhunk://#diff-ddaf66ce505da9c470ce49def97cb6219c15697436fa05f4030c188927e619b4R37-R42)

**Testing Enhancements**
- Added extensive unit tests for `ValidateAccessToken`, covering success cases, missing claims, wrong token type, and verification failures.
- Updated userinfo service tests and test initialization to use a mock `TokenValidatorInterface` instead of directly mocking JWT verification, aligning tests with the new validation flow. [[1]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eR29) [[2]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eR39-R53) [[3]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eR67-R73) [[4]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL99-R113) [[5]](diffhunk://#diff-656b99bec6cba06c17022dc91a450becc4b7d5f486dd21ec7c8c5b2161d6900eL141-R151) [[6]](diffhunk://#diff-d117e7d246448bff3094f53d56a4dde1218c7bf49eea64b220e6e8af7f1f2f44R31-R39) [[7]](diffhunk://#diff-d117e7d246448bff3094f53d56a4dde1218c7bf49eea64b220e6e8af7f1f2f44R51) [[8]](diffhunk://#diff-d117e7d246448bff3094f53d56a4dde1218c7bf49eea64b220e6e8af7f1f2f44L57-R61) [[9]](diffhunk://#diff-d117e7d246448bff3094f53d56a4dde1218c7bf49eea64b220e6e8af7f1f2f44L66-R71)

Related Issue:
- https://github.com/asgardeo/thunder/issues/550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced access token validation infrastructure with improved separation of concerns.
  * Streamlined token verification flow in user information endpoint.
  * Strengthened token builder and validator dependency management across OAuth components.

* **Tests**
  * Added comprehensive test coverage for access token validation including header validation and claim extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->