### PR TITLE
1551 | Add nonce support for OIDC authorization code flow

### DIFF
--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -46,6 +46,7 @@ const (
 	jsonDataKeyUserAttributes      = "user_attributes"
 	jsonDataKeyClaimsRequest       = "claims_request"
 	jsonDataKeyClaimsLocales       = "claims_locales"
+	jsonDataKeyNonce               = "nonce"
 )
 
 // AuthorizationCodeStoreInterface defines the interface for managing authorization codes.
@@ -149,6 +150,7 @@ func (acs *authorizationCodeStore) getJSONDataBytes(authzCode AuthorizationCode)
 		jsonDataKeyCodeChallengeMethod: authzCode.CodeChallengeMethod,
 		jsonDataKeyResource:            authzCode.Resource,
 		jsonDataKeyClaimsLocales:       authzCode.ClaimsLocales,
+		jsonDataKeyNonce:               authzCode.Nonce,
 	}
 
 	// Include user attributes if present
@@ -262,6 +264,9 @@ func appendAuthzDataJSON(row map[string]interface{}, authzCode *AuthorizationCod
 	}
 	if claimsLocales, ok := authzData[jsonDataKeyClaimsLocales].(string); ok {
 		authzCode.ClaimsLocales = claimsLocales
+	}
+	if nonce, ok := authzData[jsonDataKeyNonce].(string); ok {
+		authzCode.Nonce = nonce
 	}
 
 	if userAttrs, ok := authzData[jsonDataKeyUserAttributes].(map[string]interface{}); ok && userAttrs != nil {

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -49,6 +49,7 @@ type AuthorizationCode struct {
 	Resource            string
 	ClaimsRequest       *oauth2model.ClaimsRequest
 	ClaimsLocales       string
+	Nonce               string
 }
 
 // AuthZPostRequest represents the request body for the authorization POST request.

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -123,6 +123,8 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(msg *OAuthMessage)
 	// Extract claims_locales parameter.
 	claimsLocales := msg.RequestQueryParams[oauth2const.RequestParamClaimsLocales]
 
+	nonce := msg.RequestQueryParams[oauth2const.RequestParamNonce]
+
 	if clientID == "" {
 		return nil, &AuthorizationError{
 			Code:    oauth2const.ErrorInvalidRequest,
@@ -196,6 +198,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(msg *OAuthMessage)
 		Resource:            resource,
 		ClaimsRequest:       claimsRequest,
 		ClaimsLocales:       claimsLocales,
+		Nonce:               nonce,
 	}
 
 	// Set the redirect URI if not provided in the request. Invalid cases are already handled at this point.
@@ -533,6 +536,7 @@ func createAuthorizationCode(
 		Resource:            resource,
 		ClaimsRequest:       authRequestCtx.OAuthParameters.ClaimsRequest,
 		ClaimsLocales:       authRequestCtx.OAuthParameters.ClaimsLocales,
+		Nonce:               authRequestCtx.OAuthParameters.Nonce,
 	}, nil
 }
 

--- a/backend/internal/oauth/oauth2/authz/store_constants.go
+++ b/backend/internal/oauth/oauth2/authz/store_constants.go
@@ -33,6 +33,7 @@ const (
 	jsonKeyResource            = "resource"
 	jsonKeyClaimsRequest       = "claims_request"
 	jsonKeyClaimsLocales       = "claims_locales"
+	jsonKeyNonce               = "nonce"
 )
 
 // Database column names for authorization request storage.

--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -90,6 +90,11 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 			return true, constants.ErrorInvalidRequest, "Invalid PKCE parameters"
 		}
 	}
+	// Validate nonce length (FAPI 2.0 aligned)
+	nonce := msg.RequestQueryParams[constants.RequestParamNonce]
+	if nonce != "" && len(nonce) > constants.MaxNonceLength {
+		return true, constants.ErrorInvalidRequest, "nonce exceeds maximum allowed length"
+	}
 
 	// Validate resource parameter if present
 	resource := msg.RequestQueryParams[constants.RequestParamResource]

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -54,6 +54,14 @@ const (
 	RequestParamAudience            string = "audience"
 	RequestParamClaims              string = "claims"
 	RequestParamClaimsLocales       string = "claims_locales"
+	RequestParamNonce               string = "nonce"
+)
+
+// OAuth2 request parameter validation limits.
+const (
+	// MaxNonceLength defines the maximum allowed length of the nonce parameter.
+	// Aligned with FAPI 2.0 Security Profile recommendation (64 characters).
+	MaxNonceLength = 64
 )
 
 // Server OAuth constants.

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -168,6 +168,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(tokenRequest *model.TokenReq
 			AuthTime:       authCode.TimeCreated.Unix(),
 			OAuthApp:       oauthApp,
 			ClaimsRequest:  authCode.ClaimsRequest,
+			Nonce:          authCode.Nonce,
 		})
 		if err != nil {
 			logger.Error("Failed to generate ID token", log.Error(err))

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -33,6 +33,7 @@ type OAuthParameters struct {
 	Resource            string
 	ClaimsRequest       *ClaimsRequest
 	ClaimsLocales       string
+	Nonce               string
 }
 
 // ClaimsRequest represents the OIDC claims request parameter structure.

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -315,6 +315,10 @@ func (tb *tokenBuilder) buildIDTokenClaims(ctx *IDTokenBuildContext) map[string]
 		claims["auth_time"] = ctx.AuthTime
 	}
 
+	if ctx.Nonce != "" {
+		claims[constants.RequestParamNonce] = ctx.Nonce
+	}
+
 	userAttributes := ctx.UserAttributes
 	if userAttributes == nil {
 		userAttributes = make(map[string]interface{})

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -78,6 +78,7 @@ type IDTokenBuildContext struct {
 	AuthTime       int64
 	OAuthApp       *appmodel.OAuthAppConfigProcessedDTO
 	ClaimsRequest  *oauth2model.ClaimsRequest
+	Nonce          string
 }
 
 // RefreshTokenClaims represents the validated claims from a refresh token.

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -34,20 +34,20 @@ import (
 
 // InitiateAuthorizationFlow starts the OAuth2 authorization flow
 func InitiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state string) (*http.Response, error) {
-	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, "", "", "", "", "")
+	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, "", "", "", "", "", "")
 }
 
 // InitiateAuthorizationFlowWithResource starts the OAuth2 authorization flow with resource parameter
 func InitiateAuthorizationFlowWithResource(clientID, redirectURI, responseType, scope, state,
 	resource string) (*http.Response, error) {
-	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource, "", "", "", "")
+	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource, "", "", "", "", "")
 }
 
 // InitiateAuthorizationFlowWithPKCE starts the OAuth2 authorization flow with PKCE parameters
 func InitiateAuthorizationFlowWithPKCE(clientID, redirectURI, responseType, scope, state, resource,
 	codeChallenge, codeChallengeMethod string) (*http.Response, error) {
 	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource,
-		codeChallenge, codeChallengeMethod, "", "")
+		codeChallenge, codeChallengeMethod, "", "", "")
 }
 
 // InitiateAuthorizationFlowWithClaims starts the OAuth2 authorization flow with claims parameter
@@ -55,8 +55,7 @@ func InitiateAuthorizationFlowWithClaims(
 	clientID, redirectURI, responseType, scope, state, claimsParam string,
 ) (*http.Response, error) {
 	return initiateAuthorizationFlow(
-		clientID, redirectURI, responseType, scope, state, "", "", "", claimsParam, "",
-	)
+		clientID, redirectURI, responseType, scope, state, "", "", "", claimsParam, "", "")
 }
 
 // InitiateAuthorizationFlowWithClaimsLocales starts the OAuth2 authorization flow with claims_locales parameter
@@ -64,15 +63,25 @@ func InitiateAuthorizationFlowWithClaimsLocales(
 	clientID, redirectURI, responseType, scope, state, claimsLocales string,
 ) (*http.Response, error) {
 	return initiateAuthorizationFlow(
-		clientID, redirectURI, responseType, scope, state, "", "", "", "", claimsLocales,
+		clientID, redirectURI, responseType, scope, state, "", "", "", "", claimsLocales, "",
+	)
+}
+
+// InitiateAuthorizationFlowWithNonce starts the OAuth2 authorization flow with nonce parameter
+func InitiateAuthorizationFlowWithNonce(
+	clientID, redirectURI, responseType, scope, state, nonce string,
+) (*http.Response, error) {
+	return initiateAuthorizationFlow(
+		clientID, redirectURI, responseType, scope, state,
+		"", "", "", "", "", nonce,
 	)
 }
 
 // initiateAuthorizationFlow starts the OAuth2 authorization flow with all optional parameters.
 // clientID, redirectURI, responseType, scope, and state are required parameters.
-// resource, codeChallenge, codeChallengeMethod, claimsParam, and claimsLocales are optional parameters.
+// resource, codeChallenge, codeChallengeMethod, claimsParam, and claimsLocales, and nonce are optional parameters.
 func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource,
-	codeChallenge, codeChallengeMethod, claimsParam, claimsLocales string) (*http.Response, error) {
+	codeChallenge, codeChallengeMethod, claimsParam, claimsLocales, nonce string) (*http.Response, error) {
 	authURL := TestServerURL + "/oauth2/authorize"
 	params := url.Values{}
 	params.Set("client_id", clientID)
@@ -92,6 +101,9 @@ func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state
 	}
 	if claimsLocales != "" {
 		params.Set("claims_locales", claimsLocales)
+	}
+	if nonce != "" {
+		params.Set("nonce", nonce)
 	}
 
 	req, err := http.NewRequest("GET", authURL+"?"+params.Encode(), nil)


### PR DESCRIPTION
### Purpose

This PR adds full OpenID Connect (OIDC) `nonce` support to the OAuth2 Authorization Code flow.

Previously, the `nonce` parameter sent in the `/oauth2/authorize` request was not persisted through the authorization code flow and was not included in the issued ID token.

This change ensures:

- The `nonce` parameter is accepted at the authorization endpoint
- The `nonce` is persisted within the authorization code
- The `nonce` is propagated to the ID token during token issuance
- The ID token includes the `nonce` claim when provided

This aligns the implementation with OpenID Connect Core specification requirements for replay protection and ID token validation.

---

### Approach

The implementation follows the standard OIDC flow design:

1. **Authorization Endpoint**
   - Capture the `nonce` parameter from the authorization request.
   - Store it inside the authorization request context.

2. **Authorization Code Persistence**
   - Extend the authorization code model to persist `nonce`.
   - Ensure JSON serialization/deserialization includes the new field.
   - Add unit test coverage for authorization code persistence.

3. **Token Service (ID Token Builder)**
   - Extend `IDTokenBuildContext` to include `Nonce`.
   - Populate the nonce from the authorization code during token exchange.
   - Add the `nonce` claim to the ID token only if it was originally requested.

4. **Testing**
   - Added unit tests for:
     - Authorization code JSON persistence
     - ID token building logic including nonce
   - Added integration test:
     - End-to-end authorization code flow with `nonce`
     - Validates that the issued ID token contains the expected `nonce` claim

No breaking changes were introduced.

---

### Related Issues
- https://github.com/asgardeo/thunder/issues/1551

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth2/OIDC nonce support: authorization requests may include a nonce carried through the flow and included in ID tokens when openid scope is requested.
  * Nonce is ignored when openid scope is not present.
  * Nonce request parameter and a max length validation (limit added) are enforced.

* **Tests**
  * Unit and integration tests added to validate nonce propagation, ID token inclusion, validation, and behavior without openid scope.
* **Test utilities**
  * Test helpers updated to allow initiating flows with a nonce.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->