### PR TITLE
Fix: Replace xxd with openssl in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -910,12 +910,10 @@ function ensure_crypto_file() {
     else
         echo "Default crypto key file not found. Generating new key at $KEY_FILE..."
         
-        # Generate 32-byte key (64 hex characters) using /dev/urandom
+        # Generate 32-byte key (64 hex characters) using openssl
         local NEW_KEY
-        NEW_KEY=$(head -c 32 /dev/urandom | xxd -p -c 32)
-
-        if [[ -z "$NEW_KEY" ]]; then
-            echo "ERROR: Failed to generate crypto key from /dev/urandom."
+        if ! NEW_KEY=$(openssl rand -hex 32); then
+            echo "ERROR: Failed to generate crypto key using openssl."
             exit 1
         fi
 


### PR DESCRIPTION
Removes the xxd dependency by using openssl in build.sh as openssl is already a guaranteed dependency. Fixes #1578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched build-time cryptographic key generation to an industry-standard tool for more consistent key creation.
  * Updated build logging and error messages to reflect the new generation method.
  * Preserves existing behavior: if no key exists, one is generated and persisted; no user-facing workflow changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->