### PR TITLE
Update authn provider and user provider interfaces to return service errors

### DIFF
--- a/backend/internal/authn/credentials/service.go
+++ b/backend/internal/authn/credentials/service.go
@@ -70,13 +70,13 @@ func (c *credentialsAuthnService) Authenticate(ctx context.Context, identifiers,
 	authnResult, err := c.authnProvider.Authenticate(ctx, identifiers, credentials, metadata)
 	if err != nil {
 		switch err.Code {
-		case authnprovider.ErrorCodeAuthenticationFailed:
+		case authnprovider.ErrorAuthenticationFailed.Code:
 			return nil, &ErrorInvalidCredentials
-		case authnprovider.ErrorCodeUserNotFound:
+		case authnprovider.ErrorUserNotFound.Code:
 			return nil, &common.ErrorUserNotFound
 		default:
-			c.logger.Error("Error occurred while authenticating the user", log.String("errorCode", string(err.Code)),
-				log.String("errorDescription", err.Description))
+			c.logger.Error("Error occurred while authenticating the user", log.String("errorCode", err.Code),
+				log.String("errorDescription", err.ErrorDescription))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -89,11 +89,11 @@ func (c *credentialsAuthnService) GetAttributes(ctx context.Context, token strin
 	result, err := c.authnProvider.GetAttributes(ctx, token, requestedAttributes, metadata)
 	if err != nil {
 		switch err.Code {
-		case authnprovider.ErrorCodeInvalidToken:
+		case authnprovider.ErrorInvalidToken.Code:
 			return nil, &ErrorInvalidToken
 		default:
-			c.logger.Error("Error occurred while getting attributes", log.String("errorCode", string(err.Code)),
-				log.String("errorDescription", err.Description))
+			c.logger.Error("Error occurred while getting attributes", log.String("errorCode", err.Code),
+				log.String("errorDescription", err.ErrorDescription))
 			return nil, &serviceerror.InternalServerError
 		}
 	}

--- a/backend/internal/authn/credentials/service_test.go
+++ b/backend/internal/authn/credentials/service_test.go
@@ -171,8 +171,8 @@ func (suite *CredentialsAuthnServiceTestSuite) TestAuthenticateFailures() {
 			credentials: map[string]interface{}{"password": "testpass"},
 			setupMock: func(m *authnprovidermock.AuthnProviderInterfaceMock) {
 				m.On("Authenticate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(nil, authnprovider.NewError(
-						authnprovider.ErrorCodeUserNotFound, "User not found", "user not found description"))
+					Return(nil, serviceerror.CustomServiceError(
+						authnprovider.ErrorUserNotFound, "user not found description"))
 			},
 			expectedErrorCode: common.ErrorUserNotFound.Code,
 		},
@@ -182,9 +182,8 @@ func (suite *CredentialsAuthnServiceTestSuite) TestAuthenticateFailures() {
 			credentials: map[string]interface{}{"password": "wrongpass"},
 			setupMock: func(m *authnprovidermock.AuthnProviderInterfaceMock) {
 				m.On("Authenticate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(nil, authnprovider.NewError(
-						authnprovider.ErrorCodeAuthenticationFailed, "Invalid credentials",
-						"invalid credentials description"))
+					Return(nil, serviceerror.CustomServiceError(
+						authnprovider.ErrorAuthenticationFailed, "invalid credentials description"))
 			},
 			expectedErrorCode: ErrorInvalidCredentials.Code,
 		},
@@ -222,8 +221,8 @@ func (suite *CredentialsAuthnServiceTestSuite) TestAuthenticateWithServiceErrors
 			credentials: map[string]interface{}{"password": "testpass"},
 			setupMock: func(m *authnprovidermock.AuthnProviderInterfaceMock) {
 				m.On("Authenticate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(nil, authnprovider.NewError(
-						authnprovider.ErrorCodeSystemError, "System error", "Database failure"))
+					Return(nil, serviceerror.CustomServiceError(
+						authnprovider.ErrorSystemError, "Database failure"))
 			},
 			expectedErrorCode: serviceerror.InternalServerError.Code,
 		},
@@ -233,8 +232,11 @@ func (suite *CredentialsAuthnServiceTestSuite) TestAuthenticateWithServiceErrors
 			credentials: map[string]interface{}{"password": "testpass"},
 			setupMock: func(m *authnprovidermock.AuthnProviderInterfaceMock) {
 				m.On("Authenticate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(nil, authnprovider.NewError(
-						"UNKNOWN_CODE", "Unknown error", "Something went wrong"))
+					Return(nil, &serviceerror.ServiceError{
+						Type:             serviceerror.ServerErrorType,
+						Code:             "UNKNOWN_CODE",
+						Error:            "Unknown error",
+						ErrorDescription: "Something went wrong"})
 			},
 			expectedErrorCode: serviceerror.InternalServerError.Code,
 		},
@@ -350,7 +352,7 @@ func (suite *CredentialsAuthnServiceTestSuite) TestGetAttributesFailures() {
 			name: "InvalidToken",
 			setupMock: func() {
 				suite.mockAuthnProvider.On("GetAttributes", mock.Anything, token, requestedAttributes, mock.Anything).
-					Return(nil, authnprovider.NewError(authnprovider.ErrorCodeInvalidToken, "Invalid token",
+					Return(nil, serviceerror.CustomServiceError(authnprovider.ErrorInvalidToken,
 						"Token is expired or invalid"))
 			},
 			expectedErrorCode: ErrorInvalidToken.Code,
@@ -359,7 +361,7 @@ func (suite *CredentialsAuthnServiceTestSuite) TestGetAttributesFailures() {
 			name: "SystemError",
 			setupMock: func() {
 				suite.mockAuthnProvider.On("GetAttributes", mock.Anything, token, requestedAttributes, mock.Anything).
-					Return(nil, authnprovider.NewError(authnprovider.ErrorCodeSystemError, "System error",
+					Return(nil, serviceerror.CustomServiceError(authnprovider.ErrorSystemError,
 						"DB connection failed"))
 			},
 			expectedErrorCode: serviceerror.InternalServerError.Code,

--- a/backend/internal/authn/oauth/service.go
+++ b/backend/internal/authn/oauth/service.go
@@ -270,12 +270,12 @@ func (s *oAuthAuthnService) GetInternalUser(sub string) (*userprovider.User, *se
 	}
 	userID, upErr := s.userProvider.IdentifyUser(filters)
 	if upErr != nil {
-		if upErr.Code == userprovider.ErrorCodeUserNotFound {
+		if upErr.Code == userprovider.ErrorUserNotFound.Code {
 			logger.Debug("No user found for the provided sub claim")
 			return nil, &common.ErrorUserNotFound
 		}
-		logger.Error("Error while identifying user", log.String("errorCode", string(upErr.Code)),
-			log.String("description", upErr.Description))
+		logger.Error("Error while identifying user", log.String("errorCode", upErr.Code),
+			log.String("description", upErr.ErrorDescription))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -286,11 +286,11 @@ func (s *oAuthAuthnService) GetInternalUser(sub string) (*userprovider.User, *se
 
 	user, upErr := s.userProvider.GetUser(*userID)
 	if upErr != nil {
-		if upErr.Code == userprovider.ErrorCodeUserNotFound {
+		if upErr.Code == userprovider.ErrorUserNotFound.Code {
 			return nil, &common.ErrorUserNotFound
 		}
-		logger.Error("Error while retrieving user", log.String("errorCode", string(upErr.Code)),
-			log.String("description", upErr.Description))
+		logger.Error("Error while retrieving user", log.String("errorCode", upErr.Code),
+			log.String("description", upErr.ErrorDescription))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/authn/oauth/service_test.go
+++ b/backend/internal/authn/oauth/service_test.go
@@ -535,7 +535,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestGetInternalUserWithError_EmptySub()
 }
 
 func (suite *OAuthAuthnServiceTestSuite) TestGetInternalUserWithError_UserNotFound() {
-	upErr := &userprovider.UserProviderError{Code: userprovider.ErrorCodeUserNotFound}
+	upErr := &userprovider.ErrorUserNotFound
 	suite.mockUserProvider.On("IdentifyUser", mock.Anything).Return(nil, upErr)
 
 	result, err := suite.service.GetInternalUser(testSub)
@@ -553,10 +553,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestGetInternalUserWithServiceError() {
 		{
 			name: "IdentifyServerError",
 			mockSetup: func(m *userprovidermock.UserProviderInterfaceMock) {
-				serverErr := &userprovider.UserProviderError{
-					Code:    userprovider.ErrorCodeSystemError,
-					Message: "Database unavailable",
-				}
+				serverErr := serviceerror.CustomServiceError(
+					userprovider.ErrorSystemError, "Database unavailable")
 				m.On("IdentifyUser", mock.Anything).Return(nil, serverErr)
 			},
 			expectedErrCode: serviceerror.InternalServerError.Code,
@@ -565,10 +563,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestGetInternalUserWithServiceError() {
 			name: "GetUserServerError",
 			mockSetup: func(m *userprovidermock.UserProviderInterfaceMock) {
 				userID := "user123"
-				serverErr := &userprovider.UserProviderError{
-					Code:    userprovider.ErrorCodeSystemError,
-					Message: "Database unavailable",
-				}
+				serverErr := serviceerror.CustomServiceError(
+					userprovider.ErrorSystemError, "Database unavailable")
 				m.On("IdentifyUser", mock.Anything).Return(&userID, nil)
 				m.On("GetUser", userID).Return(nil, serverErr)
 			},
@@ -577,7 +573,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestGetInternalUserWithServiceError() {
 		{
 			name: "IdentifyNilUserID",
 			mockSetup: func(m *userprovidermock.UserProviderInterfaceMock) {
-				m.On("IdentifyUser", mock.Anything).Return(nil, (*userprovider.UserProviderError)(nil))
+				m.On("IdentifyUser", mock.Anything).Return(nil, (*serviceerror.ServiceError)(nil))
 			},
 			expectedErrCode: common.ErrorUserNotFound.Code,
 		},

--- a/backend/internal/authn/otp/service.go
+++ b/backend/internal/authn/otp/service.go
@@ -214,17 +214,17 @@ func (s *otpAuthnService) resolveUser(recipient string, channel notifcommon.Chan
 }
 
 // handleUserProviderError handles errors from the user provider.
-func (s *otpAuthnService) handleUserProviderError(upErr *userprovider.UserProviderError,
+func (s *otpAuthnService) handleUserProviderError(upErr *serviceerror.ServiceError,
 	logger *log.Logger) *serviceerror.ServiceError {
-	if upErr.Code == userprovider.ErrorCodeUserNotFound {
+	if upErr.Code == userprovider.ErrorUserNotFound.Code {
 		return &common.ErrorUserNotFound
 	}
-	if upErr.Code == userprovider.ErrorCodeSystemError {
+	if upErr.Code == userprovider.ErrorSystemError.Code {
 		logger.Error("Error occurred while retrieving user", log.Any("error", upErr))
 		return &serviceerror.InternalServerError
 	}
 	return serviceerror.CustomServiceError(ErrorClientErrorWhileResolvingUser,
-		fmt.Sprintf("An error occurred while retrieving user: %s", upErr.Description))
+		fmt.Sprintf("An error occurred while retrieving user: %s", upErr.ErrorDescription))
 }
 
 // getMetadata returns the authenticator metadata for OTP authenticator.

--- a/backend/internal/authn/otp/service_test.go
+++ b/backend/internal/authn/otp/service_test.go
@@ -287,10 +287,8 @@ func (suite *OTPAuthnServiceTestSuite) TestVerifyOTPWithUserServiceError() {
 		Status:    notifcommon.OTPVerifyStatusVerified,
 		Recipient: "+1234567890",
 	}
-	serverErr := &userprovider.UserProviderError{
-		Code:        userprovider.ErrorCodeSystemError,
-		Description: "Database unavailable",
-	}
+	serverErr := serviceerror.CustomServiceError(
+		userprovider.ErrorSystemError, "Database unavailable")
 
 	// Prepare a userID for cases that require a valid identify result
 	userID := "user123"
@@ -298,15 +296,15 @@ func (suite *OTPAuthnServiceTestSuite) TestVerifyOTPWithUserServiceError() {
 	tests := []struct {
 		name         string
 		identifyRet  *string
-		identifyErr  *userprovider.UserProviderError
+		identifyErr  *serviceerror.ServiceError
 		getUserRet   *userprovider.User
-		getUserErr   *userprovider.UserProviderError
+		getUserErr   *serviceerror.ServiceError
 		expectedCode string
 	}{
 		{
 			"NonExistentUser",
 			nil,
-			&userprovider.UserProviderError{Code: userprovider.ErrorCodeUserNotFound},
+			&userprovider.ErrorUserNotFound,
 			nil,
 			nil,
 			common.ErrorUserNotFound.Code,
@@ -330,7 +328,7 @@ func (suite *OTPAuthnServiceTestSuite) TestVerifyOTPWithUserServiceError() {
 		{
 			"UserIDNil",
 			nil,
-			(*userprovider.UserProviderError)(nil),
+			(*serviceerror.ServiceError)(nil),
 			nil,
 			nil,
 			common.ErrorUserNotFound.Code,

--- a/backend/internal/authnprovider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/default_authn_provider_test.go
@@ -94,7 +94,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_UserNotFound() {
 
 	suite.Nil(result)
 	suite.NotNil(err)
-	suite.Equal(ErrorCodeUserNotFound, err.Code)
+	suite.Equal(ErrorUserNotFound.Code, err.Code)
 }
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_AuthenticationFailed() {
@@ -109,7 +109,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_AuthenticationFaile
 
 	suite.Nil(result)
 	suite.NotNil(err)
-	suite.Equal(ErrorCodeAuthenticationFailed, err.Code)
+	suite.Equal(ErrorAuthenticationFailed.Code, err.Code)
 }
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_SystemError_Prepare() {
@@ -124,7 +124,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_SystemError_Prepare
 
 	suite.Nil(result)
 	suite.NotNil(err)
-	suite.Equal(ErrorCodeSystemError, err.Code)
+	suite.Equal(ErrorSystemError.Code, err.Code)
 }
 
 func (suite *DefaultAuthnProviderTestSuite) TestGetAttributes_Success_All() {
@@ -182,7 +182,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestGetAttributes_InvalidToken() {
 
 	suite.Nil(result)
 	suite.NotNil(err)
-	suite.Equal(ErrorCodeInvalidToken, err.Code)
+	suite.Equal(ErrorInvalidToken.Code, err.Code)
 }
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_GetUserNotFound() {
@@ -207,5 +207,5 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_GetUserNotFound() {
 
 	suite.Nil(result)
 	suite.NotNil(err)
-	suite.Equal(ErrorCodeUserNotFound, err.Code)
+	suite.Equal(ErrorUserNotFound.Code, err.Code)
 }

--- a/backend/internal/authnprovider/error_constants_test.go
+++ b/backend/internal/authnprovider/error_constants_test.go
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authnprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
+
+func TestErrorCode_IsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     ErrorCode
+		expected bool
+	}{
+		{
+			name:     "Valid code - CodeSystemError",
+			code:     CodeSystemError,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeAuthenticationFailed",
+			code:     CodeAuthenticationFailed,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeUserNotFound",
+			code:     CodeUserNotFound,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeInvalidToken",
+			code:     CodeInvalidToken,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeNotImplemented",
+			code:     CodeNotImplemented,
+			expected: true,
+		},
+		{
+			name:     "Invalid code - random string",
+			code:     ErrorCode("INVALID-001"),
+			expected: false,
+		},
+		{
+			name:     "Invalid code - empty string",
+			code:     ErrorCode(""),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.code.IsValid()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewError_ValidCodes(t *testing.T) {
+	tests := []struct {
+		name                string
+		code                ErrorCode
+		description         string
+		expectedCode        string
+		expectedType        serviceerror.ServiceErrorType
+		expectedError       string
+		expectedDescription string
+	}{
+		{
+			name:                "CodeSystemError",
+			code:                CodeSystemError,
+			description:         "Custom system error description",
+			expectedCode:        "AUP-0001",
+			expectedType:        serviceerror.ServerErrorType,
+			expectedError:       "System error",
+			expectedDescription: "Custom system error description",
+		},
+		{
+			name:                "CodeAuthenticationFailed",
+			code:                CodeAuthenticationFailed,
+			description:         "Invalid username or password",
+			expectedCode:        "AUP-0002",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "Authentication failed",
+			expectedDescription: "Invalid username or password",
+		},
+		{
+			name:                "CodeUserNotFound",
+			code:                CodeUserNotFound,
+			description:         "User does not exist",
+			expectedCode:        "AUP-0003",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "User not found",
+			expectedDescription: "User does not exist",
+		},
+		{
+			name:                "CodeInvalidToken",
+			code:                CodeInvalidToken,
+			description:         "Token has expired",
+			expectedCode:        "AUP-0004",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "Invalid token",
+			expectedDescription: "Token has expired",
+		},
+		{
+			name:                "CodeNotImplemented",
+			code:                CodeNotImplemented,
+			description:         "Feature is coming soon",
+			expectedCode:        "AUP-0005",
+			expectedType:        serviceerror.ServerErrorType,
+			expectedError:       "Not implemented",
+			expectedDescription: "Feature is coming soon",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewError(tt.code, tt.description)
+
+			assert.NotNil(t, err)
+			assert.Equal(t, tt.expectedCode, err.Code)
+			assert.Equal(t, tt.expectedType, err.Type)
+			assert.Equal(t, tt.expectedError, err.Error)
+			assert.Equal(t, tt.expectedDescription, err.ErrorDescription)
+		})
+	}
+}
+
+func TestNewError_InvalidCode_DefaultsToSystemError(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        ErrorCode
+		description string
+	}{
+		{
+			name:        "Invalid code - random string",
+			code:        ErrorCode("INVALID-001"),
+			description: "This should default to system error",
+		},
+		{
+			name:        "Invalid code - empty string",
+			code:        ErrorCode(""),
+			description: "Empty code defaults to system error",
+		},
+		{
+			name:        "Invalid code - wrong prefix",
+			code:        ErrorCode("UP-0001"),
+			description: "Wrong prefix defaults to system error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewError(tt.code, tt.description)
+
+			assert.NotNil(t, err)
+			// Should default to CodeSystemError
+			assert.Equal(t, "AUP-0001", err.Code)
+			assert.Equal(t, serviceerror.ServerErrorType, err.Type)
+			assert.Equal(t, "System error", err.Error)
+			assert.Equal(t, tt.description, err.ErrorDescription)
+		})
+	}
+}
+
+func TestNewError_PreservesDescription(t *testing.T) {
+	descriptions := []string{
+		"Simple description",
+		"",
+		"Description with special characters: !@#$%^&*()",
+		"Multi-line\ndescription\nwith\nnewlines",
+	}
+
+	for _, desc := range descriptions {
+		t.Run("Description: "+desc, func(t *testing.T) {
+			err := NewError(CodeSystemError, desc)
+			assert.Equal(t, desc, err.ErrorDescription)
+		})
+	}
+}
+
+func TestNewError_TypeAndErrorFieldsAreImmutable(t *testing.T) {
+	// Test that for each code, the Type and Error fields are always the same
+	// regardless of the description provided
+	err1 := NewError(CodeAuthenticationFailed, "Description 1")
+	err2 := NewError(CodeAuthenticationFailed, "Description 2")
+
+	assert.Equal(t, err1.Code, err2.Code)
+	assert.Equal(t, err1.Type, err2.Type)
+	assert.Equal(t, err1.Error, err2.Error)
+	assert.NotEqual(t, err1.ErrorDescription, err2.ErrorDescription)
+}
+
+func TestNewError_AllCodesHaveCorrectTypeMapping(t *testing.T) {
+	// Verify that client error codes map to ClientErrorType
+	clientErrorCodes := []ErrorCode{
+		CodeAuthenticationFailed,
+		CodeUserNotFound,
+		CodeInvalidToken,
+	}
+
+	for _, code := range clientErrorCodes {
+		t.Run(string(code)+" is ClientErrorType", func(t *testing.T) {
+			err := NewError(code, "test")
+			assert.Equal(t, serviceerror.ClientErrorType, err.Type)
+		})
+	}
+
+	// Verify that server error codes map to ServerErrorType
+	serverErrorCodes := []ErrorCode{
+		CodeSystemError,
+		CodeNotImplemented,
+	}
+
+	for _, code := range serverErrorCodes {
+		t.Run(string(code)+" is ServerErrorType", func(t *testing.T) {
+			err := NewError(code, "test")
+			assert.Equal(t, serviceerror.ServerErrorType, err.Type)
+		})
+	}
+}

--- a/backend/internal/authnprovider/interface.go
+++ b/backend/internal/authnprovider/interface.go
@@ -18,12 +18,16 @@
 
 package authnprovider
 
-import "context"
+import (
+	"context"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
 
 // AuthnProviderInterface defines the interface for authentication providers.
 type AuthnProviderInterface interface {
 	Authenticate(ctx context.Context, identifiers, credentials map[string]interface{}, metadata *AuthnMetadata) (
-		*AuthnResult, *AuthnProviderError)
+		*AuthnResult, *serviceerror.ServiceError)
 	GetAttributes(ctx context.Context, token string, requestedAttributes *RequestedAttributes,
-		metadata *GetAttributesMetadata) (*GetAttributesResult, *AuthnProviderError)
+		metadata *GetAttributesMetadata) (*GetAttributesResult, *serviceerror.ServiceError)
 }

--- a/backend/internal/flow/executor/attribute_collector.go
+++ b/backend/internal/flow/executor/attribute_collector.go
@@ -277,7 +277,7 @@ func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
 	}
 
 	if _, err := a.userProvider.UpdateUser(userID, updatedUser); err != nil {
-		return fmt.Errorf("failed to update user attributes: %s", err.Message)
+		return fmt.Errorf("failed to update user attributes: %s", err.Error)
 	}
 	logger.Debug("User attributes updated successfully", log.String("userID", userID))
 
@@ -293,7 +293,7 @@ func (a *attributeCollector) getUserFromStore(ctx *core.NodeContext) (*userprovi
 
 	user, err := a.userProvider.GetUser(userID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user by ID: %s", err.Message)
+		return nil, fmt.Errorf("failed to get user by ID: %s", err.Error)
 	}
 
 	return user, nil

--- a/backend/internal/flow/executor/attribute_collector_test.go
+++ b/backend/internal/flow/executor/attribute_collector_test.go
@@ -29,6 +29,7 @@ import (
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/userprovidermock"
@@ -232,7 +233,7 @@ func (suite *AttributeCollectorTestSuite) TestExecute_UpdateUserFails() {
 
 	suite.mockUserProvider.On("GetUser", testUserID).Return(existingUser, nil)
 	suite.mockUserProvider.On("UpdateUser", testUserID, mock.Anything).
-		Return(nil, &userprovider.UserProviderError{Message: "update failed"})
+		Return(nil, serviceerror.CustomServiceError(userprovider.ErrorSystemError, "update failed"))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -329,7 +330,7 @@ func (suite *AttributeCollectorTestSuite) TestGetUserAttributes_UserNotFound() {
 	}
 
 	suite.mockUserProvider.On("GetUser", testUserID).
-		Return(nil, &userprovider.UserProviderError{Message: "user not found"})
+		Return(nil, &userprovider.ErrorUserNotFound)
 
 	result, err := suite.executor.getUserAttributes(ctx)
 

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -355,7 +355,7 @@ func (a *authAssertExecutor) getUserAttributes(ctx context.Context, userID strin
 	if err != nil {
 		logger.Error("Failed to fetch user attributes",
 			log.String("userID", userID), log.Any("error", err))
-		return nil, errors.New("something went wrong while fetching user attributes: " + err.Error())
+		return nil, errors.New("something went wrong while fetching user attributes: " + err.ErrorDescription)
 	}
 	jsonAttrs = res.Attributes
 
@@ -414,7 +414,7 @@ func (a *authAssertExecutor) appendGroupsToClaims(
 	if err != nil {
 		logger.Error("Failed to fetch user groups",
 			log.String("userID", userID), log.Any("error", err))
-		return errors.New("something went wrong while fetching user groups: " + err.Description)
+		return errors.New("something went wrong while fetching user groups: " + err.ErrorDescription)
 	}
 
 	userGroups := make([]string, 0, len(groups.Groups))

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -418,7 +418,7 @@ func (suite *AuthAssertExecutorTestSuite) TestGetUserAttributes_Success() {
 
 func (suite *AuthAssertExecutorTestSuite) TestGetUserAttributes_ServiceError() {
 	suite.mockUserProvider.On("GetUser", "user-123").
-		Return(nil, &userprovider.UserProviderError{Message: "user not found"})
+		Return(nil, &userprovider.ErrorUserNotFound)
 
 	resultAttrs, err := suite.executor.getUserAttributes(context.Background(), "user-123", "", nil, nil)
 
@@ -626,10 +626,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 
 	// Test case 1: GetUser returns service error
 	suite.mockUserProvider.On("GetUser", "user-123").
-		Return(nil, &userprovider.UserProviderError{
-			Message:     "user_not_found",
-			Description: "user not found",
-		})
+		Return(nil, &userprovider.ErrorUserNotFound)
 
 	_, err := suite.executor.Execute(ctx)
 
@@ -721,10 +718,7 @@ func (suite *AuthAssertExecutorTestSuite) TestAppendUserDetailsToClaims_GetUserA
 	}
 
 	suite.mockUserProvider.On("GetUser", "user-123").
-		Return(nil, &userprovider.UserProviderError{
-			Message:     "database_error",
-			Description: "failed to fetch user",
-		})
+		Return(nil, serviceerror.CustomServiceError(userprovider.ErrorSystemError, "failed to fetch user"))
 
 	_, err := suite.executor.Execute(ctx)
 
@@ -913,7 +907,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_GetUserGroupsFa
 	}
 
 	suite.mockUserProvider.On("GetUserGroups", "user-123", oauth2const.DefaultGroupListLimit, 0).
-		Return(nil, &userprovider.UserProviderError{Message: "failed to fetch groups", Description: "database error"})
+		Return(nil, serviceerror.CustomServiceError(userprovider.ErrorSystemError, "database error"))
 
 	resp, err := suite.executor.Execute(ctx)
 

--- a/backend/internal/flow/executor/basic_auth_executor.go
+++ b/backend/internal/flow/executor/basic_auth_executor.go
@@ -208,8 +208,8 @@ func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	user, err := b.userProvider.GetUser(authnResult.UserID)
 
 	if err != nil {
-		if err.Code != userprovider.ErrorCodeNotImplemented {
-			logger.Error("Failed to get user attributes", log.Error(err))
+		if err.Code != userprovider.ErrorNotImplemented.Code {
+			logger.Error("Failed to get user attributes", log.Any("error", err))
 			return nil, errors.New("failed to get user attributes")
 		}
 		logger.Debug("User provider is not implemented. User attributes will be empty.")

--- a/backend/internal/flow/executor/basic_auth_executor_test.go
+++ b/backend/internal/flow/executor/basic_auth_executor_test.go
@@ -182,7 +182,7 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_AuthenticationFlow(
 	}, mock.Anything).Return(authenticateResult, nil)
 
 	suite.mockUserProvider.On("GetUser", testUserID).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeNotImplemented, "", ""))
+		&userprovider.ErrorNotImplemented)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -232,7 +232,7 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_WithEmailAttribute(
 	}, mock.Anything).Return(authenticatedUser, nil)
 
 	suite.mockUserProvider.On("GetUser", testUserID).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeNotImplemented, "", ""))
+		&userprovider.ErrorNotImplemented)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -257,7 +257,7 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_RegistrationFlow() 
 
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		userAttributeUsername: "newuser",
-	}).Return(nil, userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+	}).Return(nil, &userprovider.ErrorUserNotFound)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -311,7 +311,7 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_WithMultipleAttribu
 	}, mock.Anything).Return(authenticatedUser, nil)
 
 	suite.mockUserProvider.On("GetUser", testUserID).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeNotImplemented, "", ""))
+		&userprovider.ErrorNotImplemented)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -515,7 +515,7 @@ func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_SuccessfulAuth
 	}, mock.Anything).Return(authenticatedUser, nil)
 
 	suite.mockUserProvider.On("GetUser", testUserID).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeNotImplemented, "", ""))
+		&userprovider.ErrorNotImplemented)
 
 	result, err := suite.executor.getAuthenticatedUser(ctx, execResp)
 
@@ -620,7 +620,7 @@ func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_Authentication
 	}, mock.Anything).Return(authenticatedUser, nil)
 
 	suite.mockUserProvider.On("GetUser", testUserID).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeNotImplemented, "", ""))
+		&userprovider.ErrorNotImplemented)
 
 	result, err := suite.executor.getAuthenticatedUser(ctx, execResp)
 
@@ -650,7 +650,7 @@ func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_RegistrationFl
 	// For registration flows, IdentifyUser should be called to check if user exists
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		userAttributeUsername: "newuser",
-	}).Return(nil, userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+	}).Return(nil, &userprovider.ErrorUserNotFound)
 
 	result, err := suite.executor.getAuthenticatedUser(ctx, execResp)
 

--- a/backend/internal/flow/executor/credential_setter_test.go
+++ b/backend/internal/flow/executor/credential_setter_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/userprovidermock"
@@ -175,7 +176,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_ServiceError() {
 	})
 
 	suite.mockUserProvider.On("UpdateUserCredentials", userID, mock.Anything).
-		Return(userprovider.NewUserProviderError(userprovider.ErrorCodeSystemError, "db error", ""))
+		Return(serviceerror.CustomServiceError(userprovider.ErrorSystemError, "db error"))
 
 	resp, err := suite.executor.Execute(ctx)
 

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -85,13 +85,13 @@ func (i *identifyingExecutor) IdentifyUser(filters map[string]interface{},
 
 	userID, err := i.userProvider.IdentifyUser(searchableFilter)
 	if err != nil {
-		if err.Code == userprovider.ErrorCodeUserNotFound {
+		if err.Code == userprovider.ErrorUserNotFound.Code {
 			logger.Debug("User not found for the provided filters")
 			execResp.Status = common.ExecFailure
 			execResp.FailureReason = failureReasonUserNotFound
 			return nil, nil
 		} else {
-			logger.Debug("Failed to identify user due to error: " + err.Error())
+			logger.Debug("Failed to identify user due to error: " + err.Error)
 			execResp.Status = common.ExecFailure
 			execResp.FailureReason = failureReasonFailedToIdentifyUser
 			return nil, nil

--- a/backend/internal/flow/executor/identifying_executor_test.go
+++ b/backend/internal/flow/executor/identifying_executor_test.go
@@ -93,7 +93,7 @@ func (suite *IdentifyingExecutorTestSuite) TestIdentifyUser_UserNotFound() {
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", filters).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 
 	result, err := suite.executor.IdentifyUser(filters, execResp)
 
@@ -111,7 +111,7 @@ func (suite *IdentifyingExecutorTestSuite) TestIdentifyUser_ServiceError() {
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", filters).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeSystemError, "", ""))
+		&userprovider.ErrorSystemError)
 
 	result, err := suite.executor.IdentifyUser(filters, execResp)
 
@@ -278,7 +278,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_IdentifyUserError
 
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		"username": "testuser",
-	}).Return(nil, userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+	}).Return(nil, &userprovider.ErrorUserNotFound)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -415,7 +415,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_UserNotFoundByAtt
 
 			suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 				tc.attribute: tc.value,
-			}).Return(nil, userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+			}).Return(nil, &userprovider.ErrorUserNotFound)
 
 			resp, err := suite.executor.Execute(ctx)
 

--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -345,7 +345,7 @@ func (p *passkeyAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	// Get user details from user provider
 	user, providerErr := p.userProvider.GetUser(userID)
 	if providerErr != nil {
-		return nil, fmt.Errorf("failed to get user details: %s", providerErr.Error())
+		return nil, fmt.Errorf("failed to get user details: %s", providerErr.Error)
 	}
 
 	// Extract user attributes

--- a/backend/internal/flow/executor/passkey_executor_test.go
+++ b/backend/internal/flow/executor/passkey_executor_test.go
@@ -758,7 +758,7 @@ func (suite *PasskeyAuthExecutorTestSuite) TestGetAuthenticatedUser_UserNotFound
 	}
 
 	suite.mockUserProvider.On("GetUser", testPasskeyUserID).Return(
-		nil, &userprovider.UserProviderError{Code: userprovider.ErrorCodeUserNotFound, Message: "User not found"})
+		nil, &userprovider.ErrorUserNotFound)
 
 	authUser, err := suite.executor.getAuthenticatedUser(ctx, execResp)
 
@@ -925,7 +925,7 @@ func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_GetAuthenticatedUse
 
 	// Simulate user not found when getting authenticated user details
 	suite.mockUserProvider.On("GetUser", testPasskeyUserID).Return(
-		nil, &userprovider.UserProviderError{Code: userprovider.ErrorCodeUserNotFound, Message: "User not found"})
+		nil, &userprovider.ErrorUserNotFound)
 
 	_, err := suite.executor.Execute(ctx)
 
@@ -952,7 +952,7 @@ func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_GetAuthenti
 
 	// Simulate user not found when getting authenticated user details
 	suite.mockUserProvider.On("GetUser", testPasskeyUserID).Return(
-		nil, &userprovider.UserProviderError{Code: userprovider.ErrorCodeUserNotFound, Message: "User not found"})
+		nil, &userprovider.ErrorUserNotFound)
 
 	_, err := suite.executor.Execute(ctx)
 

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -329,7 +329,7 @@ func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 
 	retUser, svcErr := p.userProvider.CreateUser(&newUser)
 	if svcErr != nil {
-		return nil, fmt.Errorf("failed to create user in the store: %s", svcErr.Message)
+		return nil, fmt.Errorf("failed to create user in the store: %s", svcErr.Error)
 	}
 	if retUser != nil && retUser.UserID != "" {
 		logger.Debug("User account created successfully", log.String("userID", retUser.UserID))

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -151,7 +151,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		"username": "newuser",
 		"email":    "new@example.com",
-	}).Return(nil, userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+	}).Return(nil, &userprovider.ErrorUserNotFound)
 
 	createdUser := &userprovider.User{
 		UserID:             testNewUserID,
@@ -247,9 +247,9 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", mock.Anything).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 	suite.mockUserProvider.On("CreateUser", mock.Anything).
-		Return(nil, userprovider.NewUserProviderError(userprovider.ErrorCodeSystemError, "creation failed", ""))
+		Return(nil, serviceerror.CustomServiceError(userprovider.ErrorSystemError, "creation failed"))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -526,7 +526,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_Proceed
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 	suite.mockUserProvider.On("CreateUser", mock.MatchedBy(func(u *userprovider.User) bool {
 		return u.OrganizationUnitID == testOUID && u.UserType == testUserType
 	})).Return(createdUser, nil)
@@ -583,7 +583,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserEligibleForProvision
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 	suite.mockUserProvider.On("CreateUser", mock.MatchedBy(func(u *userprovider.User) bool {
 		return u.OrganizationUnitID == testOUID && u.UserType == testUserType
 	})).Return(createdUser, nil)
@@ -629,7 +629,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAutoProvisionedFlag_
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 	suite.mockUserProvider.On("CreateUser", mock.Anything).Return(createdUser, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -774,7 +774,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_MissingInputs() {
 				"username": "newuser",
 			}
 			suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-				userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+				&userprovider.ErrorUserNotFound)
 
 			resp, err := suite.executor.Execute(ctx)
 
@@ -792,14 +792,13 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFailures() {
 	tests := []struct {
 		name               string
 		createdUser        *userprovider.User
-		createUserError    *userprovider.UserProviderError
+		createUserError    *serviceerror.ServiceError
 		expectedFailReason string
 	}{
 		{
-			name:        "ServiceReturnsError",
-			createdUser: nil,
-			createUserError: userprovider.NewUserProviderError(
-				userprovider.ErrorCodeSystemError, "Database error", ""),
+			name:               "ServiceReturnsError",
+			createdUser:        nil,
+			createUserError:    serviceerror.CustomServiceError(userprovider.ErrorSystemError, "Database error"),
 			expectedFailReason: "Failed to create user",
 		},
 		{
@@ -845,7 +844,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFailures() {
 				"username": "newuser",
 			}
 			suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-				userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+				&userprovider.ErrorUserNotFound)
 			suite.mockUserProvider.On("CreateUser", mock.Anything).
 				Return(tt.createdUser, tt.createUserError)
 
@@ -987,7 +986,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_GroupAssignmentF
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 
 	createdUser := &userprovider.User{
 		UserID:             testNewUserID,
@@ -1042,7 +1041,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_BothGroupAndRole
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 
 	createdUser := &userprovider.User{
 		UserID:             testNewUserID,
@@ -1098,7 +1097,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_RoleAssignmentFa
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 
 	createdUser := &userprovider.User{
 		UserID:             testNewUserID,
@@ -1155,7 +1154,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_GroupWithExistingMembers
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 
 	createdUser := &userprovider.User{
 		UserID:             testNewUserID,
@@ -1209,7 +1208,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_AuthFlow_AutoProvisionin
 	}
 
 	suite.mockUserProvider.On("IdentifyUser", attrs).Return(nil,
-		userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+		&userprovider.ErrorUserNotFound)
 
 	createdUser := &userprovider.User{
 		UserID:             "user-provisioned",
@@ -1265,7 +1264,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success_WithGroupAndRole
 	suite.mockUserProvider.On("IdentifyUser", map[string]interface{}{
 		"username": "newuser",
 		"email":    "new@example.com",
-	}).Return(nil, userprovider.NewUserProviderError(userprovider.ErrorCodeUserNotFound, "", ""))
+	}).Return(nil, &userprovider.ErrorUserNotFound)
 
 	createdUser := &userprovider.User{
 		UserID:             testNewUserID,

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -413,7 +413,7 @@ func (s *smsOTPAuthExecutor) resolveUserIDFromAttribute(ctx *core.NodeContext,
 		filters := map[string]interface{}{attributeName: attributeValue}
 		userID, providerErr := s.userProvider.IdentifyUser(filters)
 		if providerErr != nil {
-			return false, fmt.Errorf("failed to identify user by %s: %s", attributeName, providerErr.Error())
+			return false, fmt.Errorf("failed to identify user by %s: %s", attributeName, providerErr.Error)
 		}
 		if userID != nil && *userID != "" {
 			logger.Debug("User ID resolved from attribute", log.String("attributeName", attributeName),
@@ -446,7 +446,7 @@ func (s *smsOTPAuthExecutor) getUserMobileNumber(userID string, ctx *core.NodeCo
 	logger.Debug("Mobile number not in context, fetching from user store")
 	user, providerErr := s.userProvider.GetUser(userID)
 	if providerErr != nil {
-		return "", fmt.Errorf("failed to retrieve user details: %s", providerErr.Error())
+		return "", fmt.Errorf("failed to retrieve user details: %s", providerErr.Error)
 	}
 
 	// Extract mobile number from user attributes
@@ -640,7 +640,7 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	logger.Debug("Fetching user details from user store", log.String("userID", userID))
 	user, providerErr := s.userProvider.GetUser(userID)
 	if providerErr != nil {
-		return nil, fmt.Errorf("failed to get user details: %s", providerErr.Error())
+		return nil, fmt.Errorf("failed to get user details: %s", providerErr.Error)
 	}
 
 	// Extract user attributes

--- a/backend/internal/userprovider/disabled_user_provider.go
+++ b/backend/internal/userprovider/disabled_user_provider.go
@@ -18,14 +18,14 @@
 
 package userprovider
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
 
 // errNotImplemented is the error returned when a method is not implemented.
-var errNotImplemented = NewUserProviderError(
-	ErrorCodeNotImplemented,
-	"Method Not Implemented",
-	"The method is not implemented by the user provider.",
-)
+var errNotImplemented = NewError(CodeNotImplemented, "This feature is not implemented")
 
 // disabledUserProvider is a user provider that returns an error for all methods.
 type disabledUserProvider struct{}
@@ -36,37 +36,38 @@ func newDisabledUserProvider() UserProviderInterface {
 }
 
 // IdentifyUser returns a not implemented error.
-func (p *disabledUserProvider) IdentifyUser(filters map[string]interface{}) (*string, *UserProviderError) {
+func (p *disabledUserProvider) IdentifyUser(filters map[string]interface{}) (*string, *serviceerror.ServiceError) {
 	return nil, errNotImplemented
 }
 
 // GetUser returns a not implemented error.
-func (p *disabledUserProvider) GetUser(userID string) (*User, *UserProviderError) {
+func (p *disabledUserProvider) GetUser(userID string) (*User, *serviceerror.ServiceError) {
 	return nil, errNotImplemented
 }
 
 // GetUserGroups returns a not implemented error.
 func (p *disabledUserProvider) GetUserGroups(userID string, limit, offset int) (*UserGroupListResponse,
-	*UserProviderError) {
+	*serviceerror.ServiceError) {
 	return nil, errNotImplemented
 }
 
 // UpdateUser returns a not implemented error.
-func (p *disabledUserProvider) UpdateUser(userID string, user *User) (*User, *UserProviderError) {
+func (p *disabledUserProvider) UpdateUser(userID string, user *User) (*User, *serviceerror.ServiceError) {
 	return nil, errNotImplemented
 }
 
 // CreateUser returns a not implemented error.
-func (p *disabledUserProvider) CreateUser(user *User) (*User, *UserProviderError) {
+func (p *disabledUserProvider) CreateUser(user *User) (*User, *serviceerror.ServiceError) {
 	return nil, errNotImplemented
 }
 
 // UpdateUserCredentials returns a not implemented error.
-func (p *disabledUserProvider) UpdateUserCredentials(userID string, credentials json.RawMessage) *UserProviderError {
+func (p *disabledUserProvider) UpdateUserCredentials(userID string, credentials json.RawMessage,
+) *serviceerror.ServiceError {
 	return errNotImplemented
 }
 
 // DeleteUser returns a not implemented error.
-func (p *disabledUserProvider) DeleteUser(userID string) *UserProviderError {
+func (p *disabledUserProvider) DeleteUser(userID string) *serviceerror.ServiceError {
 	return errNotImplemented
 }

--- a/backend/internal/userprovider/error_constants.go
+++ b/backend/internal/userprovider/error_constants.go
@@ -18,37 +18,130 @@
 
 package userprovider
 
-// ErrorCode represents an error code.
-type ErrorCode string
-
-// UserProviderError represents an error returned by the user provider.
-type UserProviderError struct {
-	Code        ErrorCode `json:"code"`
-	Message     string    `json:"message"`
-	Description string    `json:"description"`
-}
-
-func (e *UserProviderError) Error() string {
-	return e.Message + ": " + e.Description
-}
-
-// Error codes.
-const (
-	ErrorCodeSystemError              ErrorCode = "UP-0001"
-	ErrorCodeUserNotFound             ErrorCode = "UP-0002"
-	ErrorCodeInvalidRequestFormat     ErrorCode = "UP-0003"
-	ErrorCodeOrganizationUnitMismatch ErrorCode = "UP-0004"
-	ErrorCodeAttributeConflict        ErrorCode = "UP-0005"
-	ErrorCodeMissingRequiredFields    ErrorCode = "UP-0006"
-	ErrorCodeMissingCredentials       ErrorCode = "UP-0007"
-	ErrorCodeNotImplemented           ErrorCode = "UP-0008"
+import (
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
 
-// NewUserProviderError creates a new user provider error.
-func NewUserProviderError(code ErrorCode, message string, description string) *UserProviderError {
-	return &UserProviderError{
-		Code:        code,
-		Message:     message,
-		Description: description,
+// ErrorCode represents a user provider error code.
+type ErrorCode string
+
+// Predefined error codes for user provider.
+// Implementors should use these constants with NewError().
+const (
+	CodeSystemError              ErrorCode = "UP-0001"
+	CodeUserNotFound             ErrorCode = "UP-0002"
+	CodeInvalidRequestFormat     ErrorCode = "UP-0003"
+	CodeOrganizationUnitMismatch ErrorCode = "UP-0004"
+	CodeAttributeConflict        ErrorCode = "UP-0005"
+	CodeMissingRequiredFields    ErrorCode = "UP-0006"
+	CodeMissingCredentials       ErrorCode = "UP-0007"
+	CodeNotImplemented           ErrorCode = "UP-0008"
+)
+
+// errorDefinition holds the fixed Type and Error message for each error code.
+type errorDefinition struct {
+	Type  serviceerror.ServiceErrorType
+	Error string
+}
+
+// validErrorCodes maps error codes to their fixed Type and Error message.
+var validErrorCodes = map[ErrorCode]errorDefinition{
+	CodeSystemError:              {serviceerror.ServerErrorType, "System error"},
+	CodeUserNotFound:             {serviceerror.ClientErrorType, "User not found"},
+	CodeInvalidRequestFormat:     {serviceerror.ClientErrorType, "Invalid request format"},
+	CodeOrganizationUnitMismatch: {serviceerror.ClientErrorType, "Organization unit mismatch"},
+	CodeAttributeConflict:        {serviceerror.ClientErrorType, "Attribute conflict"},
+	CodeMissingRequiredFields:    {serviceerror.ClientErrorType, "Missing required fields"},
+	CodeMissingCredentials:       {serviceerror.ClientErrorType, "Missing credentials"},
+	CodeNotImplemented:           {serviceerror.ServerErrorType, "Not implemented"},
+}
+
+// IsValid checks if the error code is a valid predefined code.
+func (ec ErrorCode) IsValid() bool {
+	_, ok := validErrorCodes[ec]
+	return ok
+}
+
+// NewError creates a ServiceError with the given code and description.
+// If the code is not valid (not defined in validErrorCodes), it defaults to CodeSystemError.
+// The Type and Error fields are set based on the predefined values for the code.
+func NewError(code ErrorCode, description string) *serviceerror.ServiceError {
+	if !code.IsValid() {
+		code = CodeSystemError
+	}
+
+	def := validErrorCodes[code]
+	return &serviceerror.ServiceError{
+		Type:             def.Type,
+		Code:             string(code),
+		Error:            def.Error,
+		ErrorDescription: description,
 	}
 }
+
+// User provider errors.
+var (
+	// ErrorSystemError is the error returned when a system error occurs.
+	ErrorSystemError = serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "UP-0001",
+		Error:            "System error",
+		ErrorDescription: "An unexpected system error occurred",
+	}
+
+	// ErrorUserNotFound is the error returned when the user is not found.
+	ErrorUserNotFound = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "UP-0002",
+		Error:            "User not found",
+		ErrorDescription: "The requested user could not be found",
+	}
+
+	// ErrorInvalidRequestFormat is the error returned when the request format is invalid.
+	ErrorInvalidRequestFormat = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "UP-0003",
+		Error:            "Invalid request format",
+		ErrorDescription: "The request format is invalid",
+	}
+
+	// ErrorOrganizationUnitMismatch is the error returned when organization unit does not match.
+	ErrorOrganizationUnitMismatch = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "UP-0004",
+		Error:            "Organization unit mismatch",
+		ErrorDescription: "The organization unit does not match",
+	}
+
+	// ErrorAttributeConflict is the error returned when there is an attribute conflict.
+	ErrorAttributeConflict = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "UP-0005",
+		Error:            "Attribute conflict",
+		ErrorDescription: "One or more attributes conflict with existing values",
+	}
+
+	// ErrorMissingRequiredFields is the error returned when required fields are missing.
+	ErrorMissingRequiredFields = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "UP-0006",
+		Error:            "Missing required fields",
+		ErrorDescription: "One or more required fields are missing",
+	}
+
+	// ErrorMissingCredentials is the error returned when credentials are missing.
+	ErrorMissingCredentials = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "UP-0007",
+		Error:            "Missing credentials",
+		ErrorDescription: "Credentials are missing or invalid",
+	}
+
+	// ErrorNotImplemented is the error returned when a feature is not implemented.
+	ErrorNotImplemented = serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "UP-0008",
+		Error:            "Not implemented",
+		ErrorDescription: "This feature is not implemented",
+	}
+)

--- a/backend/internal/userprovider/error_constants_test.go
+++ b/backend/internal/userprovider/error_constants_test.go
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package userprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
+
+func TestErrorCode_IsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     ErrorCode
+		expected bool
+	}{
+		{
+			name:     "Valid code - CodeSystemError",
+			code:     CodeSystemError,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeUserNotFound",
+			code:     CodeUserNotFound,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeInvalidRequestFormat",
+			code:     CodeInvalidRequestFormat,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeOrganizationUnitMismatch",
+			code:     CodeOrganizationUnitMismatch,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeAttributeConflict",
+			code:     CodeAttributeConflict,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeMissingRequiredFields",
+			code:     CodeMissingRequiredFields,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeMissingCredentials",
+			code:     CodeMissingCredentials,
+			expected: true,
+		},
+		{
+			name:     "Valid code - CodeNotImplemented",
+			code:     CodeNotImplemented,
+			expected: true,
+		},
+		{
+			name:     "Invalid code - random string",
+			code:     ErrorCode("INVALID-001"),
+			expected: false,
+		},
+		{
+			name:     "Invalid code - empty string",
+			code:     ErrorCode(""),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.code.IsValid()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewError_ValidCodes(t *testing.T) {
+	tests := []struct {
+		name                string
+		code                ErrorCode
+		description         string
+		expectedCode        string
+		expectedType        serviceerror.ServiceErrorType
+		expectedError       string
+		expectedDescription string
+	}{
+		{
+			name:                "CodeSystemError",
+			code:                CodeSystemError,
+			description:         "Custom system error description",
+			expectedCode:        "UP-0001",
+			expectedType:        serviceerror.ServerErrorType,
+			expectedError:       "System error",
+			expectedDescription: "Custom system error description",
+		},
+		{
+			name:                "CodeUserNotFound",
+			code:                CodeUserNotFound,
+			description:         "User does not exist",
+			expectedCode:        "UP-0002",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "User not found",
+			expectedDescription: "User does not exist",
+		},
+		{
+			name:                "CodeInvalidRequestFormat",
+			code:                CodeInvalidRequestFormat,
+			description:         "Request body is malformed",
+			expectedCode:        "UP-0003",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "Invalid request format",
+			expectedDescription: "Request body is malformed",
+		},
+		{
+			name:                "CodeOrganizationUnitMismatch",
+			code:                CodeOrganizationUnitMismatch,
+			description:         "Organization unit does not match user",
+			expectedCode:        "UP-0004",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "Organization unit mismatch",
+			expectedDescription: "Organization unit does not match user",
+		},
+		{
+			name:                "CodeAttributeConflict",
+			code:                CodeAttributeConflict,
+			description:         "Email already exists",
+			expectedCode:        "UP-0005",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "Attribute conflict",
+			expectedDescription: "Email already exists",
+		},
+		{
+			name:                "CodeMissingRequiredFields",
+			code:                CodeMissingRequiredFields,
+			description:         "Username is required",
+			expectedCode:        "UP-0006",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "Missing required fields",
+			expectedDescription: "Username is required",
+		},
+		{
+			name:                "CodeMissingCredentials",
+			code:                CodeMissingCredentials,
+			description:         "Password is required",
+			expectedCode:        "UP-0007",
+			expectedType:        serviceerror.ClientErrorType,
+			expectedError:       "Missing credentials",
+			expectedDescription: "Password is required",
+		},
+		{
+			name:                "CodeNotImplemented",
+			code:                CodeNotImplemented,
+			description:         "Feature is coming soon",
+			expectedCode:        "UP-0008",
+			expectedType:        serviceerror.ServerErrorType,
+			expectedError:       "Not implemented",
+			expectedDescription: "Feature is coming soon",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewError(tt.code, tt.description)
+
+			assert.NotNil(t, err)
+			assert.Equal(t, tt.expectedCode, err.Code)
+			assert.Equal(t, tt.expectedType, err.Type)
+			assert.Equal(t, tt.expectedError, err.Error)
+			assert.Equal(t, tt.expectedDescription, err.ErrorDescription)
+		})
+	}
+}
+
+func TestNewError_InvalidCode_DefaultsToSystemError(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        ErrorCode
+		description string
+	}{
+		{
+			name:        "Invalid code - random string",
+			code:        ErrorCode("INVALID-001"),
+			description: "This should default to system error",
+		},
+		{
+			name:        "Invalid code - empty string",
+			code:        ErrorCode(""),
+			description: "Empty code defaults to system error",
+		},
+		{
+			name:        "Invalid code - wrong prefix",
+			code:        ErrorCode("AUP-0001"),
+			description: "Wrong prefix defaults to system error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewError(tt.code, tt.description)
+
+			assert.NotNil(t, err)
+			// Should default to CodeSystemError
+			assert.Equal(t, "UP-0001", err.Code)
+			assert.Equal(t, serviceerror.ServerErrorType, err.Type)
+			assert.Equal(t, "System error", err.Error)
+			assert.Equal(t, tt.description, err.ErrorDescription)
+		})
+	}
+}
+
+func TestNewError_PreservesDescription(t *testing.T) {
+	descriptions := []string{
+		"Simple description",
+		"",
+		"Description with special characters: !@#$%^&*()",
+		"Multi-line\ndescription\nwith\nnewlines",
+	}
+
+	for _, desc := range descriptions {
+		t.Run("Description: "+desc, func(t *testing.T) {
+			err := NewError(CodeSystemError, desc)
+			assert.Equal(t, desc, err.ErrorDescription)
+		})
+	}
+}
+
+func TestNewError_TypeAndErrorFieldsAreImmutable(t *testing.T) {
+	// Test that for each code, the Type and Error fields are always the same
+	// regardless of the description provided
+	err1 := NewError(CodeUserNotFound, "Description 1")
+	err2 := NewError(CodeUserNotFound, "Description 2")
+
+	assert.Equal(t, err1.Code, err2.Code)
+	assert.Equal(t, err1.Type, err2.Type)
+	assert.Equal(t, err1.Error, err2.Error)
+	assert.NotEqual(t, err1.ErrorDescription, err2.ErrorDescription)
+}
+
+func TestNewError_AllCodesHaveCorrectTypeMapping(t *testing.T) {
+	// Verify that client error codes map to ClientErrorType
+	clientErrorCodes := []ErrorCode{
+		CodeUserNotFound,
+		CodeInvalidRequestFormat,
+		CodeOrganizationUnitMismatch,
+		CodeAttributeConflict,
+		CodeMissingRequiredFields,
+		CodeMissingCredentials,
+	}
+
+	for _, code := range clientErrorCodes {
+		t.Run(string(code)+" is ClientErrorType", func(t *testing.T) {
+			err := NewError(code, "test")
+			assert.Equal(t, serviceerror.ClientErrorType, err.Type)
+		})
+	}
+
+	// Verify that server error codes map to ServerErrorType
+	serverErrorCodes := []ErrorCode{
+		CodeSystemError,
+		CodeNotImplemented,
+	}
+
+	for _, code := range serverErrorCodes {
+		t.Run(string(code)+" is ServerErrorType", func(t *testing.T) {
+			err := NewError(code, "test")
+			assert.Equal(t, serviceerror.ServerErrorType, err.Type)
+		})
+	}
+}

--- a/backend/internal/userprovider/interface.go
+++ b/backend/internal/userprovider/interface.go
@@ -18,15 +18,19 @@
 
 package userprovider
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+)
 
 // UserProviderInterface defines the interface for user providers.
 type UserProviderInterface interface {
-	IdentifyUser(filters map[string]interface{}) (*string, *UserProviderError)
-	GetUser(userID string) (*User, *UserProviderError)
-	GetUserGroups(userID string, limit, offset int) (*UserGroupListResponse, *UserProviderError)
-	UpdateUser(userID string, user *User) (*User, *UserProviderError)
-	CreateUser(user *User) (*User, *UserProviderError)
-	UpdateUserCredentials(userID string, credentials json.RawMessage) *UserProviderError
-	DeleteUser(userID string) *UserProviderError
+	IdentifyUser(filters map[string]interface{}) (*string, *serviceerror.ServiceError)
+	GetUser(userID string) (*User, *serviceerror.ServiceError)
+	GetUserGroups(userID string, limit, offset int) (*UserGroupListResponse, *serviceerror.ServiceError)
+	UpdateUser(userID string, user *User) (*User, *serviceerror.ServiceError)
+	CreateUser(user *User) (*User, *serviceerror.ServiceError)
+	UpdateUserCredentials(userID string, credentials json.RawMessage) *serviceerror.ServiceError
+	DeleteUser(userID string) *serviceerror.ServiceError
 }

--- a/backend/tests/mocks/authnprovidermock/AuthnProviderInterface_mock.go
+++ b/backend/tests/mocks/authnprovidermock/AuthnProviderInterface_mock.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/asgardeo/thunder/internal/authnprovider"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -39,7 +40,7 @@ func (_m *AuthnProviderInterfaceMock) EXPECT() *AuthnProviderInterfaceMock_Expec
 }
 
 // Authenticate provides a mock function for the type AuthnProviderInterfaceMock
-func (_mock *AuthnProviderInterfaceMock) Authenticate(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}, metadata *authnprovider.AuthnMetadata) (*authnprovider.AuthnResult, *authnprovider.AuthnProviderError) {
+func (_mock *AuthnProviderInterfaceMock) Authenticate(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}, metadata *authnprovider.AuthnMetadata) (*authnprovider.AuthnResult, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, identifiers, credentials, metadata)
 
 	if len(ret) == 0 {
@@ -47,8 +48,8 @@ func (_mock *AuthnProviderInterfaceMock) Authenticate(ctx context.Context, ident
 	}
 
 	var r0 *authnprovider.AuthnResult
-	var r1 *authnprovider.AuthnProviderError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]interface{}, map[string]interface{}, *authnprovider.AuthnMetadata) (*authnprovider.AuthnResult, *authnprovider.AuthnProviderError)); ok {
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]interface{}, map[string]interface{}, *authnprovider.AuthnMetadata) (*authnprovider.AuthnResult, *serviceerror.ServiceError)); ok {
 		return returnFunc(ctx, identifiers, credentials, metadata)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]interface{}, map[string]interface{}, *authnprovider.AuthnMetadata) *authnprovider.AuthnResult); ok {
@@ -58,11 +59,11 @@ func (_mock *AuthnProviderInterfaceMock) Authenticate(ctx context.Context, ident
 			r0 = ret.Get(0).(*authnprovider.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]interface{}, map[string]interface{}, *authnprovider.AuthnMetadata) *authnprovider.AuthnProviderError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]interface{}, map[string]interface{}, *authnprovider.AuthnMetadata) *serviceerror.ServiceError); ok {
 		r1 = returnFunc(ctx, identifiers, credentials, metadata)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*authnprovider.AuthnProviderError)
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
 		}
 	}
 	return r0, r1
@@ -110,18 +111,18 @@ func (_c *AuthnProviderInterfaceMock_Authenticate_Call) Run(run func(ctx context
 	return _c
 }
 
-func (_c *AuthnProviderInterfaceMock_Authenticate_Call) Return(authnResult *authnprovider.AuthnResult, authnProviderError *authnprovider.AuthnProviderError) *AuthnProviderInterfaceMock_Authenticate_Call {
-	_c.Call.Return(authnResult, authnProviderError)
+func (_c *AuthnProviderInterfaceMock_Authenticate_Call) Return(authnResult *authnprovider.AuthnResult, serviceError *serviceerror.ServiceError) *AuthnProviderInterfaceMock_Authenticate_Call {
+	_c.Call.Return(authnResult, serviceError)
 	return _c
 }
 
-func (_c *AuthnProviderInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}, metadata *authnprovider.AuthnMetadata) (*authnprovider.AuthnResult, *authnprovider.AuthnProviderError)) *AuthnProviderInterfaceMock_Authenticate_Call {
+func (_c *AuthnProviderInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, identifiers map[string]interface{}, credentials map[string]interface{}, metadata *authnprovider.AuthnMetadata) (*authnprovider.AuthnResult, *serviceerror.ServiceError)) *AuthnProviderInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetAttributes provides a mock function for the type AuthnProviderInterfaceMock
-func (_mock *AuthnProviderInterfaceMock) GetAttributes(ctx context.Context, token string, requestedAttributes *authnprovider.RequestedAttributes, metadata *authnprovider.GetAttributesMetadata) (*authnprovider.GetAttributesResult, *authnprovider.AuthnProviderError) {
+func (_mock *AuthnProviderInterfaceMock) GetAttributes(ctx context.Context, token string, requestedAttributes *authnprovider.RequestedAttributes, metadata *authnprovider.GetAttributesMetadata) (*authnprovider.GetAttributesResult, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, token, requestedAttributes, metadata)
 
 	if len(ret) == 0 {
@@ -129,8 +130,8 @@ func (_mock *AuthnProviderInterfaceMock) GetAttributes(ctx context.Context, toke
 	}
 
 	var r0 *authnprovider.GetAttributesResult
-	var r1 *authnprovider.AuthnProviderError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *authnprovider.RequestedAttributes, *authnprovider.GetAttributesMetadata) (*authnprovider.GetAttributesResult, *authnprovider.AuthnProviderError)); ok {
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *authnprovider.RequestedAttributes, *authnprovider.GetAttributesMetadata) (*authnprovider.GetAttributesResult, *serviceerror.ServiceError)); ok {
 		return returnFunc(ctx, token, requestedAttributes, metadata)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *authnprovider.RequestedAttributes, *authnprovider.GetAttributesMetadata) *authnprovider.GetAttributesResult); ok {
@@ -140,11 +141,11 @@ func (_mock *AuthnProviderInterfaceMock) GetAttributes(ctx context.Context, toke
 			r0 = ret.Get(0).(*authnprovider.GetAttributesResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *authnprovider.RequestedAttributes, *authnprovider.GetAttributesMetadata) *authnprovider.AuthnProviderError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *authnprovider.RequestedAttributes, *authnprovider.GetAttributesMetadata) *serviceerror.ServiceError); ok {
 		r1 = returnFunc(ctx, token, requestedAttributes, metadata)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*authnprovider.AuthnProviderError)
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
 		}
 	}
 	return r0, r1
@@ -192,12 +193,12 @@ func (_c *AuthnProviderInterfaceMock_GetAttributes_Call) Run(run func(ctx contex
 	return _c
 }
 
-func (_c *AuthnProviderInterfaceMock_GetAttributes_Call) Return(getAttributesResult *authnprovider.GetAttributesResult, authnProviderError *authnprovider.AuthnProviderError) *AuthnProviderInterfaceMock_GetAttributes_Call {
-	_c.Call.Return(getAttributesResult, authnProviderError)
+func (_c *AuthnProviderInterfaceMock_GetAttributes_Call) Return(getAttributesResult *authnprovider.GetAttributesResult, serviceError *serviceerror.ServiceError) *AuthnProviderInterfaceMock_GetAttributes_Call {
+	_c.Call.Return(getAttributesResult, serviceError)
 	return _c
 }
 
-func (_c *AuthnProviderInterfaceMock_GetAttributes_Call) RunAndReturn(run func(ctx context.Context, token string, requestedAttributes *authnprovider.RequestedAttributes, metadata *authnprovider.GetAttributesMetadata) (*authnprovider.GetAttributesResult, *authnprovider.AuthnProviderError)) *AuthnProviderInterfaceMock_GetAttributes_Call {
+func (_c *AuthnProviderInterfaceMock_GetAttributes_Call) RunAndReturn(run func(ctx context.Context, token string, requestedAttributes *authnprovider.RequestedAttributes, metadata *authnprovider.GetAttributesMetadata) (*authnprovider.GetAttributesResult, *serviceerror.ServiceError)) *AuthnProviderInterfaceMock_GetAttributes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/userprovidermock/UserProviderInterface_mock.go
+++ b/backend/tests/mocks/userprovidermock/UserProviderInterface_mock.go
@@ -7,6 +7,7 @@ package userprovidermock
 import (
 	"encoding/json"
 
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -39,7 +40,7 @@ func (_m *UserProviderInterfaceMock) EXPECT() *UserProviderInterfaceMock_Expecte
 }
 
 // CreateUser provides a mock function for the type UserProviderInterfaceMock
-func (_mock *UserProviderInterfaceMock) CreateUser(user *userprovider.User) (*userprovider.User, *userprovider.UserProviderError) {
+func (_mock *UserProviderInterfaceMock) CreateUser(user *userprovider.User) (*userprovider.User, *serviceerror.ServiceError) {
 	ret := _mock.Called(user)
 
 	if len(ret) == 0 {
@@ -47,8 +48,8 @@ func (_mock *UserProviderInterfaceMock) CreateUser(user *userprovider.User) (*us
 	}
 
 	var r0 *userprovider.User
-	var r1 *userprovider.UserProviderError
-	if returnFunc, ok := ret.Get(0).(func(*userprovider.User) (*userprovider.User, *userprovider.UserProviderError)); ok {
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(*userprovider.User) (*userprovider.User, *serviceerror.ServiceError)); ok {
 		return returnFunc(user)
 	}
 	if returnFunc, ok := ret.Get(0).(func(*userprovider.User) *userprovider.User); ok {
@@ -58,11 +59,11 @@ func (_mock *UserProviderInterfaceMock) CreateUser(user *userprovider.User) (*us
 			r0 = ret.Get(0).(*userprovider.User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*userprovider.User) *userprovider.UserProviderError); ok {
+	if returnFunc, ok := ret.Get(1).(func(*userprovider.User) *serviceerror.ServiceError); ok {
 		r1 = returnFunc(user)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*userprovider.UserProviderError)
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
 		}
 	}
 	return r0, r1
@@ -92,30 +93,30 @@ func (_c *UserProviderInterfaceMock_CreateUser_Call) Run(run func(user *userprov
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_CreateUser_Call) Return(user1 *userprovider.User, userProviderError *userprovider.UserProviderError) *UserProviderInterfaceMock_CreateUser_Call {
-	_c.Call.Return(user1, userProviderError)
+func (_c *UserProviderInterfaceMock_CreateUser_Call) Return(user1 *userprovider.User, serviceError *serviceerror.ServiceError) *UserProviderInterfaceMock_CreateUser_Call {
+	_c.Call.Return(user1, serviceError)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_CreateUser_Call) RunAndReturn(run func(user *userprovider.User) (*userprovider.User, *userprovider.UserProviderError)) *UserProviderInterfaceMock_CreateUser_Call {
+func (_c *UserProviderInterfaceMock_CreateUser_Call) RunAndReturn(run func(user *userprovider.User) (*userprovider.User, *serviceerror.ServiceError)) *UserProviderInterfaceMock_CreateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteUser provides a mock function for the type UserProviderInterfaceMock
-func (_mock *UserProviderInterfaceMock) DeleteUser(userID string) *userprovider.UserProviderError {
+func (_mock *UserProviderInterfaceMock) DeleteUser(userID string) *serviceerror.ServiceError {
 	ret := _mock.Called(userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteUser")
 	}
 
-	var r0 *userprovider.UserProviderError
-	if returnFunc, ok := ret.Get(0).(func(string) *userprovider.UserProviderError); ok {
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
 		r0 = returnFunc(userID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*userprovider.UserProviderError)
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
 		}
 	}
 	return r0
@@ -145,18 +146,18 @@ func (_c *UserProviderInterfaceMock_DeleteUser_Call) Run(run func(userID string)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_DeleteUser_Call) Return(userProviderError *userprovider.UserProviderError) *UserProviderInterfaceMock_DeleteUser_Call {
-	_c.Call.Return(userProviderError)
+func (_c *UserProviderInterfaceMock_DeleteUser_Call) Return(serviceError *serviceerror.ServiceError) *UserProviderInterfaceMock_DeleteUser_Call {
+	_c.Call.Return(serviceError)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_DeleteUser_Call) RunAndReturn(run func(userID string) *userprovider.UserProviderError) *UserProviderInterfaceMock_DeleteUser_Call {
+func (_c *UserProviderInterfaceMock_DeleteUser_Call) RunAndReturn(run func(userID string) *serviceerror.ServiceError) *UserProviderInterfaceMock_DeleteUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUser provides a mock function for the type UserProviderInterfaceMock
-func (_mock *UserProviderInterfaceMock) GetUser(userID string) (*userprovider.User, *userprovider.UserProviderError) {
+func (_mock *UserProviderInterfaceMock) GetUser(userID string) (*userprovider.User, *serviceerror.ServiceError) {
 	ret := _mock.Called(userID)
 
 	if len(ret) == 0 {
@@ -164,8 +165,8 @@ func (_mock *UserProviderInterfaceMock) GetUser(userID string) (*userprovider.Us
 	}
 
 	var r0 *userprovider.User
-	var r1 *userprovider.UserProviderError
-	if returnFunc, ok := ret.Get(0).(func(string) (*userprovider.User, *userprovider.UserProviderError)); ok {
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string) (*userprovider.User, *serviceerror.ServiceError)); ok {
 		return returnFunc(userID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(string) *userprovider.User); ok {
@@ -175,11 +176,11 @@ func (_mock *UserProviderInterfaceMock) GetUser(userID string) (*userprovider.Us
 			r0 = ret.Get(0).(*userprovider.User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *userprovider.UserProviderError); ok {
+	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
 		r1 = returnFunc(userID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*userprovider.UserProviderError)
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
 		}
 	}
 	return r0, r1
@@ -209,18 +210,18 @@ func (_c *UserProviderInterfaceMock_GetUser_Call) Run(run func(userID string)) *
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_GetUser_Call) Return(user *userprovider.User, userProviderError *userprovider.UserProviderError) *UserProviderInterfaceMock_GetUser_Call {
-	_c.Call.Return(user, userProviderError)
+func (_c *UserProviderInterfaceMock_GetUser_Call) Return(user *userprovider.User, serviceError *serviceerror.ServiceError) *UserProviderInterfaceMock_GetUser_Call {
+	_c.Call.Return(user, serviceError)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_GetUser_Call) RunAndReturn(run func(userID string) (*userprovider.User, *userprovider.UserProviderError)) *UserProviderInterfaceMock_GetUser_Call {
+func (_c *UserProviderInterfaceMock_GetUser_Call) RunAndReturn(run func(userID string) (*userprovider.User, *serviceerror.ServiceError)) *UserProviderInterfaceMock_GetUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUserGroups provides a mock function for the type UserProviderInterfaceMock
-func (_mock *UserProviderInterfaceMock) GetUserGroups(userID string, limit int, offset int) (*userprovider.UserGroupListResponse, *userprovider.UserProviderError) {
+func (_mock *UserProviderInterfaceMock) GetUserGroups(userID string, limit int, offset int) (*userprovider.UserGroupListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(userID, limit, offset)
 
 	if len(ret) == 0 {
@@ -228,8 +229,8 @@ func (_mock *UserProviderInterfaceMock) GetUserGroups(userID string, limit int, 
 	}
 
 	var r0 *userprovider.UserGroupListResponse
-	var r1 *userprovider.UserProviderError
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) (*userprovider.UserGroupListResponse, *userprovider.UserProviderError)); ok {
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string, int, int) (*userprovider.UserGroupListResponse, *serviceerror.ServiceError)); ok {
 		return returnFunc(userID, limit, offset)
 	}
 	if returnFunc, ok := ret.Get(0).(func(string, int, int) *userprovider.UserGroupListResponse); ok {
@@ -239,11 +240,11 @@ func (_mock *UserProviderInterfaceMock) GetUserGroups(userID string, limit int, 
 			r0 = ret.Get(0).(*userprovider.UserGroupListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) *userprovider.UserProviderError); ok {
+	if returnFunc, ok := ret.Get(1).(func(string, int, int) *serviceerror.ServiceError); ok {
 		r1 = returnFunc(userID, limit, offset)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*userprovider.UserProviderError)
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
 		}
 	}
 	return r0, r1
@@ -285,18 +286,18 @@ func (_c *UserProviderInterfaceMock_GetUserGroups_Call) Run(run func(userID stri
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_GetUserGroups_Call) Return(userGroupListResponse *userprovider.UserGroupListResponse, userProviderError *userprovider.UserProviderError) *UserProviderInterfaceMock_GetUserGroups_Call {
-	_c.Call.Return(userGroupListResponse, userProviderError)
+func (_c *UserProviderInterfaceMock_GetUserGroups_Call) Return(userGroupListResponse *userprovider.UserGroupListResponse, serviceError *serviceerror.ServiceError) *UserProviderInterfaceMock_GetUserGroups_Call {
+	_c.Call.Return(userGroupListResponse, serviceError)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_GetUserGroups_Call) RunAndReturn(run func(userID string, limit int, offset int) (*userprovider.UserGroupListResponse, *userprovider.UserProviderError)) *UserProviderInterfaceMock_GetUserGroups_Call {
+func (_c *UserProviderInterfaceMock_GetUserGroups_Call) RunAndReturn(run func(userID string, limit int, offset int) (*userprovider.UserGroupListResponse, *serviceerror.ServiceError)) *UserProviderInterfaceMock_GetUserGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IdentifyUser provides a mock function for the type UserProviderInterfaceMock
-func (_mock *UserProviderInterfaceMock) IdentifyUser(filters map[string]interface{}) (*string, *userprovider.UserProviderError) {
+func (_mock *UserProviderInterfaceMock) IdentifyUser(filters map[string]interface{}) (*string, *serviceerror.ServiceError) {
 	ret := _mock.Called(filters)
 
 	if len(ret) == 0 {
@@ -304,8 +305,8 @@ func (_mock *UserProviderInterfaceMock) IdentifyUser(filters map[string]interfac
 	}
 
 	var r0 *string
-	var r1 *userprovider.UserProviderError
-	if returnFunc, ok := ret.Get(0).(func(map[string]interface{}) (*string, *userprovider.UserProviderError)); ok {
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(map[string]interface{}) (*string, *serviceerror.ServiceError)); ok {
 		return returnFunc(filters)
 	}
 	if returnFunc, ok := ret.Get(0).(func(map[string]interface{}) *string); ok {
@@ -315,11 +316,11 @@ func (_mock *UserProviderInterfaceMock) IdentifyUser(filters map[string]interfac
 			r0 = ret.Get(0).(*string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(map[string]interface{}) *userprovider.UserProviderError); ok {
+	if returnFunc, ok := ret.Get(1).(func(map[string]interface{}) *serviceerror.ServiceError); ok {
 		r1 = returnFunc(filters)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*userprovider.UserProviderError)
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
 		}
 	}
 	return r0, r1
@@ -349,18 +350,18 @@ func (_c *UserProviderInterfaceMock_IdentifyUser_Call) Run(run func(filters map[
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_IdentifyUser_Call) Return(s *string, userProviderError *userprovider.UserProviderError) *UserProviderInterfaceMock_IdentifyUser_Call {
-	_c.Call.Return(s, userProviderError)
+func (_c *UserProviderInterfaceMock_IdentifyUser_Call) Return(s *string, serviceError *serviceerror.ServiceError) *UserProviderInterfaceMock_IdentifyUser_Call {
+	_c.Call.Return(s, serviceError)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_IdentifyUser_Call) RunAndReturn(run func(filters map[string]interface{}) (*string, *userprovider.UserProviderError)) *UserProviderInterfaceMock_IdentifyUser_Call {
+func (_c *UserProviderInterfaceMock_IdentifyUser_Call) RunAndReturn(run func(filters map[string]interface{}) (*string, *serviceerror.ServiceError)) *UserProviderInterfaceMock_IdentifyUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateUser provides a mock function for the type UserProviderInterfaceMock
-func (_mock *UserProviderInterfaceMock) UpdateUser(userID string, user *userprovider.User) (*userprovider.User, *userprovider.UserProviderError) {
+func (_mock *UserProviderInterfaceMock) UpdateUser(userID string, user *userprovider.User) (*userprovider.User, *serviceerror.ServiceError) {
 	ret := _mock.Called(userID, user)
 
 	if len(ret) == 0 {
@@ -368,8 +369,8 @@ func (_mock *UserProviderInterfaceMock) UpdateUser(userID string, user *userprov
 	}
 
 	var r0 *userprovider.User
-	var r1 *userprovider.UserProviderError
-	if returnFunc, ok := ret.Get(0).(func(string, *userprovider.User) (*userprovider.User, *userprovider.UserProviderError)); ok {
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string, *userprovider.User) (*userprovider.User, *serviceerror.ServiceError)); ok {
 		return returnFunc(userID, user)
 	}
 	if returnFunc, ok := ret.Get(0).(func(string, *userprovider.User) *userprovider.User); ok {
@@ -379,11 +380,11 @@ func (_mock *UserProviderInterfaceMock) UpdateUser(userID string, user *userprov
 			r0 = ret.Get(0).(*userprovider.User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *userprovider.User) *userprovider.UserProviderError); ok {
+	if returnFunc, ok := ret.Get(1).(func(string, *userprovider.User) *serviceerror.ServiceError); ok {
 		r1 = returnFunc(userID, user)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*userprovider.UserProviderError)
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
 		}
 	}
 	return r0, r1
@@ -419,30 +420,30 @@ func (_c *UserProviderInterfaceMock_UpdateUser_Call) Run(run func(userID string,
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_UpdateUser_Call) Return(user1 *userprovider.User, userProviderError *userprovider.UserProviderError) *UserProviderInterfaceMock_UpdateUser_Call {
-	_c.Call.Return(user1, userProviderError)
+func (_c *UserProviderInterfaceMock_UpdateUser_Call) Return(user1 *userprovider.User, serviceError *serviceerror.ServiceError) *UserProviderInterfaceMock_UpdateUser_Call {
+	_c.Call.Return(user1, serviceError)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_UpdateUser_Call) RunAndReturn(run func(userID string, user *userprovider.User) (*userprovider.User, *userprovider.UserProviderError)) *UserProviderInterfaceMock_UpdateUser_Call {
+func (_c *UserProviderInterfaceMock_UpdateUser_Call) RunAndReturn(run func(userID string, user *userprovider.User) (*userprovider.User, *serviceerror.ServiceError)) *UserProviderInterfaceMock_UpdateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateUserCredentials provides a mock function for the type UserProviderInterfaceMock
-func (_mock *UserProviderInterfaceMock) UpdateUserCredentials(userID string, credentials json.RawMessage) *userprovider.UserProviderError {
+func (_mock *UserProviderInterfaceMock) UpdateUserCredentials(userID string, credentials json.RawMessage) *serviceerror.ServiceError {
 	ret := _mock.Called(userID, credentials)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateUserCredentials")
 	}
 
-	var r0 *userprovider.UserProviderError
-	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage) *userprovider.UserProviderError); ok {
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string, json.RawMessage) *serviceerror.ServiceError); ok {
 		r0 = returnFunc(userID, credentials)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*userprovider.UserProviderError)
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
 		}
 	}
 	return r0
@@ -478,12 +479,12 @@ func (_c *UserProviderInterfaceMock_UpdateUserCredentials_Call) Run(run func(use
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_UpdateUserCredentials_Call) Return(userProviderError *userprovider.UserProviderError) *UserProviderInterfaceMock_UpdateUserCredentials_Call {
-	_c.Call.Return(userProviderError)
+func (_c *UserProviderInterfaceMock_UpdateUserCredentials_Call) Return(serviceError *serviceerror.ServiceError) *UserProviderInterfaceMock_UpdateUserCredentials_Call {
+	_c.Call.Return(serviceError)
 	return _c
 }
 
-func (_c *UserProviderInterfaceMock_UpdateUserCredentials_Call) RunAndReturn(run func(userID string, credentials json.RawMessage) *userprovider.UserProviderError) *UserProviderInterfaceMock_UpdateUserCredentials_Call {
+func (_c *UserProviderInterfaceMock_UpdateUserCredentials_Call) RunAndReturn(run func(userID string, credentials json.RawMessage) *serviceerror.ServiceError) *UserProviderInterfaceMock_UpdateUserCredentials_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

This pull request standardizes error handling across authentication services by replacing custom error types (such as `AuthnProviderError` and `UserProviderError`) with the unified `serviceerror.ServiceError` type. It also updates error code usage to reference error constants directly and improves logging for better clarity. The changes affect both implementation and test files, ensuring consistent error propagation and handling throughout the authentication and user provider layers.

**Error handling standardization:**

* Replaced usage of custom error types (`AuthnProviderError`, `UserProviderError`) with `serviceerror.ServiceError` in authentication service implementations, including `credentials`, `oauth`, `otp`, and the default authentication provider. This ensures consistent error propagation and handling across the codebase. [[1]](diffhunk://#diff-1816d6d81909221c132a034f3836ce299f3437e02570b15f14b3ced8f29da68fL46-R69) [[2]](diffhunk://#diff-1816d6d81909221c132a034f3836ce299f3437e02570b15f14b3ced8f29da68fL101-R115) [[3]](diffhunk://#diff-496dcd3cc66dbc41407f8a7b83b86b9da390b540cc1002400f61899f5f070e22L273-R278) [[4]](diffhunk://#diff-496dcd3cc66dbc41407f8a7b83b86b9da390b540cc1002400f61899f5f070e22L289-R293) [[5]](diffhunk://#diff-c46cbab54cb788bc8af5962705e6dfd9955d286493d866c3bd5fb443fc5f7106L217-R227)
* Updated all error code checks to use the `.Code` field from error constant objects (e.g., `ErrorUserNotFound.Code` instead of `ErrorCodeUserNotFound`), improving code readability and maintainability. [[1]](diffhunk://#diff-0d03a40c9e46dcfa30e88804cc241180faf5c64b8e58876b9f708830dec04097L73-R79) [[2]](diffhunk://#diff-0d03a40c9e46dcfa30e88804cc241180faf5c64b8e58876b9f708830dec04097L92-R96) [[3]](diffhunk://#diff-496dcd3cc66dbc41407f8a7b83b86b9da390b540cc1002400f61899f5f070e22L273-R278) [[4]](diffhunk://#diff-496dcd3cc66dbc41407f8a7b83b86b9da390b540cc1002400f61899f5f070e22L289-R293) [[5]](diffhunk://#diff-c46cbab54cb788bc8af5962705e6dfd9955d286493d866c3bd5fb443fc5f7106L217-R227)

**Logging improvements:**

* Enhanced error logging by referencing the correct error fields (`err.Code`, `err.ErrorDescription`) instead of string conversions or deprecated fields, providing more accurate and descriptive log entries. [[1]](diffhunk://#diff-0d03a40c9e46dcfa30e88804cc241180faf5c64b8e58876b9f708830dec04097L73-R79) [[2]](diffhunk://#diff-0d03a40c9e46dcfa30e88804cc241180faf5c64b8e58876b9f708830dec04097L92-R96) [[3]](diffhunk://#diff-496dcd3cc66dbc41407f8a7b83b86b9da390b540cc1002400f61899f5f070e22L273-R278) [[4]](diffhunk://#diff-496dcd3cc66dbc41407f8a7b83b86b9da390b540cc1002400f61899f5f070e22L289-R293) [[5]](diffhunk://#diff-c46cbab54cb788bc8af5962705e6dfd9955d286493d866c3bd5fb443fc5f7106L217-R227)

**Test updates:**

* Refactored tests to use `serviceerror.ServiceError` and updated error code assertions to match the new error handling approach. This includes updating mock returns and expected error code checks in `credentials`, `oauth`, `otp`, and default authentication provider tests. [[1]](diffhunk://#diff-b0919c00650f9fb78ab431026899e6ba4cd01a8f875e7e152bae6a02ab5eb93fL174-R175) [[2]](diffhunk://#diff-b0919c00650f9fb78ab431026899e6ba4cd01a8f875e7e152bae6a02ab5eb93fL185-R186) [[3]](diffhunk://#diff-b0919c00650f9fb78ab431026899e6ba4cd01a8f875e7e152bae6a02ab5eb93fL225-R225) [[4]](diffhunk://#diff-b0919c00650f9fb78ab431026899e6ba4cd01a8f875e7e152bae6a02ab5eb93fL236-R239) [[5]](diffhunk://#diff-b0919c00650f9fb78ab431026899e6ba4cd01a8f875e7e152bae6a02ab5eb93fL353-R355) [[6]](diffhunk://#diff-b0919c00650f9fb78ab431026899e6ba4cd01a8f875e7e152bae6a02ab5eb93fL362-R364) [[7]](diffhunk://#diff-125a26223f29529272b0101354ea2ca3e748d303d530909825b5cac70d5d3efaL538-R538) [[8]](diffhunk://#diff-125a26223f29529272b0101354ea2ca3e748d303d530909825b5cac70d5d3efaL556-R557) [[9]](diffhunk://#diff-125a26223f29529272b0101354ea2ca3e748d303d530909825b5cac70d5d3efaL568-R567) [[10]](diffhunk://#diff-125a26223f29529272b0101354ea2ca3e748d303d530909825b5cac70d5d3efaL580-R576) [[11]](diffhunk://#diff-7996382596353c341cc36ad2caf8ffeaf6ba5ed8d4818f8dbbae385c78ca1135L290-R307) [[12]](diffhunk://#diff-7996382596353c341cc36ad2caf8ffeaf6ba5ed8d4818f8dbbae385c78ca1135L333-R331) [[13]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L97-R97) [[14]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L112-R112) [[15]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L127-R127) [[16]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L185-R185) [[17]](diffhunk://#diff-3233e24d341e53fc948dd1a513ffd5635f1e333bfd5cc6271b0e2af77fab2678L210-R210)

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified error handling across authentication and user-management for consistent error codes and messages.
* **Bug Fixes**
  * Improved error messages and logging to surface clearer, more actionable failure details.
  * Standardized error responses for token, authentication, and user-not-found scenarios.
* **Tests**
  * Expanded unit tests to cover more error scenarios and validate the new error model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->