### PR TITLE
Update token exchange error code

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -129,7 +129,7 @@ func (h *tokenExchangeGrantHandler) ValidateGrant(tokenRequest *model.TokenReque
 		if requestedType != constants.TokenTypeIdentifierAccessToken &&
 			requestedType != constants.TokenTypeIdentifierJWT {
 			return &model.ErrorResponse{
-				Error: constants.ErrorInvalidTarget,
+				Error: constants.ErrorInvalidRequest,
 				ErrorDescription: fmt.Sprintf(
 					"Requested token type '%s' is not supported. Only access tokens and JWT tokens are supported.",
 					tokenRequest.RequestedTokenType,
@@ -152,8 +152,8 @@ func (h *tokenExchangeGrantHandler) HandleGrant(tokenRequest *model.TokenRequest
 	if err != nil {
 		logger.Error("Failed to validate subject token", log.Error(err))
 		return nil, &model.ErrorResponse{
-			Error:            constants.ErrorInvalidGrant,
-			ErrorDescription: fmt.Sprintf("Invalid subject_token: %s", err.Error()),
+			Error:            constants.ErrorInvalidRequest,
+			ErrorDescription: "Invalid subject_token",
 		}
 	}
 
@@ -164,8 +164,8 @@ func (h *tokenExchangeGrantHandler) HandleGrant(tokenRequest *model.TokenRequest
 		if err != nil {
 			logger.Error("Failed to validate actor token", log.Error(err))
 			return nil, &model.ErrorResponse{
-				Error:            constants.ErrorInvalidGrant,
-				ErrorDescription: fmt.Sprintf("Invalid actor_token: %s", err.Error()),
+				Error:            constants.ErrorInvalidRequest,
+				ErrorDescription: "Invalid actor_token",
 			}
 		}
 	}

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -730,9 +730,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "Invalid subject_token")
-	assert.Contains(suite.T(), errResp.ErrorDescription, "invalid signature")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid subject_token", errResp.ErrorDescription)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectToken_MissingSubClaim() {
@@ -757,8 +756,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "missing or invalid 'sub' claim")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid subject_token", errResp.ErrorDescription)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectToken_DecodeError() {
@@ -777,8 +776,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "Invalid subject_token")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid subject_token", errResp.ErrorDescription)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectToken_Expired() {
@@ -798,8 +797,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "token has expired")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid subject_token", errResp.ErrorDescription)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectToken_NotYetValid() {
@@ -819,8 +818,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidSubjectT
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "token not yet valid")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid subject_token", errResp.ErrorDescription)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidActorToken() {
@@ -863,8 +862,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidActorTok
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "Invalid actor_token")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid actor_token", errResp.ErrorDescription)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidScope() {
@@ -1085,7 +1084,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedID
 
 	errResp := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
 	assert.Contains(suite.T(), errResp.ErrorDescription, "not supported")
 	assert.Contains(suite.T(), errResp.ErrorDescription, string(constants.TokenTypeIdentifierIDToken))
 }
@@ -1102,7 +1101,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedRe
 	// Test ValidateGrant first (which is called before HandleGrant in production)
 	errResp := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
 	assert.Contains(suite.T(), errResp.ErrorDescription, "not supported")
 	assert.Contains(suite.T(), errResp.ErrorDescription, string(constants.TokenTypeIdentifierRefreshToken))
 }
@@ -1718,8 +1717,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ThunderAuthAsse
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "auth assertion audience mismatch")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid subject_token", errResp.ErrorDescription)
 	suite.mockTokenValidator.AssertExpectations(suite.T())
 }
 
@@ -1749,8 +1748,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ThunderAuthAsse
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "missing 'aud' claim")
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Equal(suite.T(), "Invalid subject_token", errResp.ErrorDescription)
 	suite.mockTokenValidator.AssertExpectations(suite.T())
 }
 

--- a/tests/integration/oauth/token/tokenexchange_test.go
+++ b/tests/integration/oauth/token/tokenexchange_test.go
@@ -468,7 +468,7 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_InvalidSubjectToken() {
 	resp, statusCode, err := ts.exchangeToken(formData.Encode(), authHeader)
 	ts.Require().NoError(err)
 	ts.Equal(http.StatusBadRequest, statusCode)
-	ts.Equal("invalid_grant", resp.Error)
+	ts.Equal("invalid_request", resp.Error)
 	ts.Contains(resp.ErrorDescription, "Invalid subject_token")
 }
 
@@ -666,7 +666,7 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_SubjectTokenMissingIssClaim(
 	resp, statusCode, err := ts.exchangeToken(formData.Encode(), authHeader)
 	ts.Require().NoError(err)
 	ts.Equal(http.StatusBadRequest, statusCode)
-	ts.Equal("invalid_grant", resp.Error)
+	ts.Equal("invalid_request", resp.Error)
 	ts.Contains(resp.ErrorDescription, "Invalid subject_token")
 }
 
@@ -684,6 +684,6 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_SubjectTokenUnsupportedIssue
 	resp, statusCode, err := ts.exchangeToken(formData.Encode(), authHeader)
 	ts.Require().NoError(err)
 	ts.Equal(http.StatusBadRequest, statusCode)
-	ts.Equal("invalid_grant", resp.Error)
+	ts.Equal("invalid_request", resp.Error)
 	ts.Contains(resp.ErrorDescription, "Invalid subject_token")
 }


### PR DESCRIPTION
This pull request standardizes error handling in the token exchange grant flow by returning `invalid_request` errors with consistent descriptions for invalid tokens and unsupported token types. The changes also update the associated tests to expect the new error codes and messages.

**Error Handling Updates:**

* The `token_exchange.go` handler now returns `constants.ErrorInvalidRequest` instead of `constants.ErrorInvalidGrant` or `constants.ErrorInvalidTarget` for invalid subject/actor tokens and unsupported token types, and uses a uniform error description ("Invalid subject_token" or "Invalid actor_token") for these cases. [[1]](diffhunk://#diff-a3807fedb40224c399d26c24086bcf96d4afa56ebcbe1d3c1a53b7bc410a3d21L132-R132) [[2]](diffhunk://#diff-a3807fedb40224c399d26c24086bcf96d4afa56ebcbe1d3c1a53b7bc410a3d21L155-R156) [[3]](diffhunk://#diff-a3807fedb40224c399d26c24086bcf96d4afa56ebcbe1d3c1a53b7bc410a3d21L167-R168)

**Test Suite Adjustments:**

* All affected tests in `token_exchange_test.go` are updated to expect the new `invalid_request` error code and the standardized error descriptions for invalid subject and actor tokens, as well as unsupported token types. [[1]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L733-R734) [[2]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L760-R760) [[3]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L780-R780) [[4]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L801-R801) [[5]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L822-R822) [[6]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L866-R866) [[7]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L1088-R1087) [[8]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L1105-R1104) [[9]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L1721-R1721) [[10]](diffhunk://#diff-696b383206b2ec773d1b33c80d2d4be4958d5e358573cc821a218c44bf622b10L1752-R1752)

## Related Issue

Addresses 21 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized OAuth2 token-exchange error responses: failing exchanges now return a consistent error code ("invalid_request") and uniform error description ("Invalid subject_token") for various invalid-token conditions, improving clarity and predictability for clients and integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->