### PR TITLE
Improve authz code consumption logic

### DIFF
--- a/backend/internal/oauth/oauth2/authz/AuthorizationCodeStoreInterface_mock_test.go
+++ b/backend/internal/oauth/oauth2/authz/AuthorizationCodeStoreInterface_mock_test.go
@@ -35,104 +35,68 @@ func (_m *AuthorizationCodeStoreInterfaceMock) EXPECT() *AuthorizationCodeStoreI
 	return &AuthorizationCodeStoreInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
-// DeactivateAuthorizationCode provides a mock function for the type AuthorizationCodeStoreInterfaceMock
-func (_mock *AuthorizationCodeStoreInterfaceMock) DeactivateAuthorizationCode(authzCode AuthorizationCode) error {
-	ret := _mock.Called(authzCode)
+// ConsumeAuthorizationCode provides a mock function for the type AuthorizationCodeStoreInterfaceMock
+func (_mock *AuthorizationCodeStoreInterfaceMock) ConsumeAuthorizationCode(clientID string, authCode string) (bool, error) {
+	ret := _mock.Called(clientID, authCode)
 
 	if len(ret) == 0 {
-		panic("no return value specified for DeactivateAuthorizationCode")
+		panic("no return value specified for ConsumeAuthorizationCode")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(AuthorizationCode) error); ok {
-		r0 = returnFunc(authzCode)
-	} else {
-		r0 = ret.Error(0)
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) (bool, error)); ok {
+		return returnFunc(clientID, authCode)
 	}
-	return r0
+	if returnFunc, ok := ret.Get(0).(func(string, string) bool); ok {
+		r0 = returnFunc(clientID, authCode)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = returnFunc(clientID, authCode)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
-// AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeactivateAuthorizationCode'
-type AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call struct {
+// AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConsumeAuthorizationCode'
+type AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call struct {
 	*mock.Call
 }
 
-// DeactivateAuthorizationCode is a helper method to define mock.On call
-//   - authzCode AuthorizationCode
-func (_e *AuthorizationCodeStoreInterfaceMock_Expecter) DeactivateAuthorizationCode(authzCode interface{}) *AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call {
-	return &AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call{Call: _e.mock.On("DeactivateAuthorizationCode", authzCode)}
+// ConsumeAuthorizationCode is a helper method to define mock.On call
+//   - clientID string
+//   - authCode string
+func (_e *AuthorizationCodeStoreInterfaceMock_Expecter) ConsumeAuthorizationCode(clientID interface{}, authCode interface{}) *AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call {
+	return &AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call{Call: _e.mock.On("ConsumeAuthorizationCode", clientID, authCode)}
 }
 
-func (_c *AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call) Run(run func(authzCode AuthorizationCode)) *AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call {
+func (_c *AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call) Run(run func(clientID string, authCode string)) *AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 AuthorizationCode
+		var arg0 string
 		if args[0] != nil {
-			arg0 = args[0].(AuthorizationCode)
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
 }
 
-func (_c *AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call) Return(err error) *AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call {
-	_c.Call.Return(err)
+func (_c *AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call) Return(b bool, err error) *AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call {
+	_c.Call.Return(b, err)
 	return _c
 }
 
-func (_c *AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call) RunAndReturn(run func(authzCode AuthorizationCode) error) *AuthorizationCodeStoreInterfaceMock_DeactivateAuthorizationCode_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ExpireAuthorizationCode provides a mock function for the type AuthorizationCodeStoreInterfaceMock
-func (_mock *AuthorizationCodeStoreInterfaceMock) ExpireAuthorizationCode(authzCode AuthorizationCode) error {
-	ret := _mock.Called(authzCode)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ExpireAuthorizationCode")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(AuthorizationCode) error); ok {
-		r0 = returnFunc(authzCode)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExpireAuthorizationCode'
-type AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call struct {
-	*mock.Call
-}
-
-// ExpireAuthorizationCode is a helper method to define mock.On call
-//   - authzCode AuthorizationCode
-func (_e *AuthorizationCodeStoreInterfaceMock_Expecter) ExpireAuthorizationCode(authzCode interface{}) *AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call {
-	return &AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call{Call: _e.mock.On("ExpireAuthorizationCode", authzCode)}
-}
-
-func (_c *AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call) Run(run func(authzCode AuthorizationCode)) *AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 AuthorizationCode
-		if args[0] != nil {
-			arg0 = args[0].(AuthorizationCode)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call) Return(err error) *AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call) RunAndReturn(run func(authzCode AuthorizationCode) error) *AuthorizationCodeStoreInterfaceMock_ExpireAuthorizationCode_Call {
+func (_c *AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call) RunAndReturn(run func(clientID string, authCode string) (bool, error)) *AuthorizationCodeStoreInterfaceMock_ConsumeAuthorizationCode_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -252,57 +216,6 @@ func (_c *AuthorizationCodeStoreInterfaceMock_InsertAuthorizationCode_Call) Retu
 }
 
 func (_c *AuthorizationCodeStoreInterfaceMock_InsertAuthorizationCode_Call) RunAndReturn(run func(authzCode AuthorizationCode) error) *AuthorizationCodeStoreInterfaceMock_InsertAuthorizationCode_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RevokeAuthorizationCode provides a mock function for the type AuthorizationCodeStoreInterfaceMock
-func (_mock *AuthorizationCodeStoreInterfaceMock) RevokeAuthorizationCode(authzCode AuthorizationCode) error {
-	ret := _mock.Called(authzCode)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RevokeAuthorizationCode")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(AuthorizationCode) error); ok {
-		r0 = returnFunc(authzCode)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeAuthorizationCode'
-type AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call struct {
-	*mock.Call
-}
-
-// RevokeAuthorizationCode is a helper method to define mock.On call
-//   - authzCode AuthorizationCode
-func (_e *AuthorizationCodeStoreInterfaceMock_Expecter) RevokeAuthorizationCode(authzCode interface{}) *AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call {
-	return &AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call{Call: _e.mock.On("RevokeAuthorizationCode", authzCode)}
-}
-
-func (_c *AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call) Run(run func(authzCode AuthorizationCode)) *AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 AuthorizationCode
-		if args[0] != nil {
-			arg0 = args[0].(AuthorizationCode)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call) Return(err error) *AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call) RunAndReturn(run func(authzCode AuthorizationCode) error) *AuthorizationCodeStoreInterfaceMock_RevokeAuthorizationCode_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -52,10 +52,8 @@ const (
 // AuthorizationCodeStoreInterface defines the interface for managing authorization codes.
 type AuthorizationCodeStoreInterface interface {
 	InsertAuthorizationCode(authzCode AuthorizationCode) error
+	ConsumeAuthorizationCode(clientID, authCode string) (bool, error)
 	GetAuthorizationCode(clientID, authCode string) (*AuthorizationCode, error)
-	DeactivateAuthorizationCode(authzCode AuthorizationCode) error
-	RevokeAuthorizationCode(authzCode AuthorizationCode) error
-	ExpireAuthorizationCode(authzCode AuthorizationCode) error
 }
 
 // authorizationCodeStore implements the AuthorizationCodeStoreInterface for managing authorization codes.
@@ -94,6 +92,23 @@ func (acs *authorizationCodeStore) InsertAuthorizationCode(authzCode Authorizati
 	return nil
 }
 
+// ConsumeAuthorizationCode atomically consumes an active authorization code (ACTIVE → INACTIVE).
+// Returns true if this call consumed the code, false if the code was not in ACTIVE state.
+func (acs *authorizationCodeStore) ConsumeAuthorizationCode(clientID, authCode string) (bool, error) {
+	dbClient, err := acs.dbProvider.GetRuntimeDBClient()
+	if err != nil {
+		return false, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	rowsAffected, err := dbClient.Execute(queryConsumeAuthorizationCode,
+		AuthCodeStateInactive, clientID, authCode, AuthCodeStateActive, acs.deploymentID)
+	if err != nil {
+		return false, fmt.Errorf("error consuming authorization code: %w", err)
+	}
+
+	return rowsAffected > 0, nil
+}
+
 // GetAuthorizationCode retrieves an authorization code by client Id and authorization code.
 func (acs *authorizationCodeStore) GetAuthorizationCode(clientID, authCode string) (*AuthorizationCode, error) {
 	dbClient, err := acs.dbProvider.GetRuntimeDBClient()
@@ -111,33 +126,6 @@ func (acs *authorizationCodeStore) GetAuthorizationCode(clientID, authCode strin
 	row := results[0]
 
 	return buildAuthorizationCodeFromResultRow(row)
-}
-
-// DeactivateAuthorizationCode deactivates an authorization code.
-func (acs *authorizationCodeStore) DeactivateAuthorizationCode(authzCode AuthorizationCode) error {
-	return acs.updateAuthorizationCodeState(authzCode, AuthCodeStateInactive)
-}
-
-// RevokeAuthorizationCode revokes an authorization code.
-func (acs *authorizationCodeStore) RevokeAuthorizationCode(authzCode AuthorizationCode) error {
-	return acs.updateAuthorizationCodeState(authzCode, AuthCodeStateRevoked)
-}
-
-// ExpireAuthorizationCode expires an authorization code.
-func (acs *authorizationCodeStore) ExpireAuthorizationCode(authzCode AuthorizationCode) error {
-	return acs.updateAuthorizationCodeState(authzCode, AuthCodeStateExpired)
-}
-
-// updateAuthorizationCodeState updates the state of an authorization code.
-func (acs *authorizationCodeStore) updateAuthorizationCodeState(authzCode AuthorizationCode,
-	newState string) error {
-	dbClient, err := acs.dbProvider.GetRuntimeDBClient()
-	if err != nil {
-		return fmt.Errorf("failed to get database client: %w", err)
-	}
-
-	_, err = dbClient.Execute(queryUpdateAuthorizationCodeState, newState, authzCode.CodeID, acs.deploymentID)
-	return err
 }
 
 // getJSONDataBytes prepares the JSON data bytes for the authorization code.

--- a/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
@@ -249,50 +249,57 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_EmptyCode
 	suite.mockDBClient.AssertExpectations(suite.T())
 }
 
-func (suite *AuthorizationCodeStoreTestSuite) TestDeactivateAuthorizationCode_Success() {
+func (suite *AuthorizationCodeStoreTestSuite) TestConsumeAuthorizationCode_Success() {
 	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState,
-		AuthCodeStateInactive, suite.testAuthzCode.CodeID, testDeploymentID).Return(int64(1), nil)
+	suite.mockDBClient.On("Execute", queryConsumeAuthorizationCode,
+		AuthCodeStateInactive, "test-client-id", "test-code", AuthCodeStateActive, testDeploymentID).
+		Return(int64(1), nil)
 
-	err := suite.store.DeactivateAuthorizationCode(suite.testAuthzCode)
+	consumed, err := suite.store.ConsumeAuthorizationCode("test-client-id", "test-code")
 	assert.NoError(suite.T(), err)
+	assert.True(suite.T(), consumed)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
 	suite.mockDBClient.AssertExpectations(suite.T())
 }
 
-func (suite *AuthorizationCodeStoreTestSuite) TestRevokeAuthorizationCode_Success() {
+func (suite *AuthorizationCodeStoreTestSuite) TestConsumeAuthorizationCode_NotConsumed() {
 	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState,
-		AuthCodeStateRevoked, suite.testAuthzCode.CodeID, testDeploymentID).Return(int64(1), nil)
+	suite.mockDBClient.On("Execute", queryConsumeAuthorizationCode,
+		AuthCodeStateInactive, "test-client-id", "test-code", AuthCodeStateActive, testDeploymentID).
+		Return(int64(0), nil)
 
-	err := suite.store.RevokeAuthorizationCode(suite.testAuthzCode)
+	consumed, err := suite.store.ConsumeAuthorizationCode("test-client-id", "test-code")
 	assert.NoError(suite.T(), err)
+	assert.False(suite.T(), consumed)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
 	suite.mockDBClient.AssertExpectations(suite.T())
 }
 
-func (suite *AuthorizationCodeStoreTestSuite) TestExpireAuthorizationCode_Success() {
-	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState,
-		AuthCodeStateExpired, suite.testAuthzCode.CodeID, testDeploymentID).Return(int64(1), nil)
-
-	err := suite.store.ExpireAuthorizationCode(suite.testAuthzCode)
-	assert.NoError(suite.T(), err)
-
-	suite.mockdbProvider.AssertExpectations(suite.T())
-	suite.mockDBClient.AssertExpectations(suite.T())
-}
-
-func (suite *AuthorizationCodeStoreTestSuite) TestUpdateAuthorizationCodeState_Error() {
+func (suite *AuthorizationCodeStoreTestSuite) TestConsumeAuthorizationCode_DBClientError() {
 	suite.mockdbProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db client error"))
 
-	err := suite.store.DeactivateAuthorizationCode(suite.testAuthzCode)
+	consumed, err := suite.store.ConsumeAuthorizationCode("test-client-id", "test-code")
 	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "db client error")
+	assert.False(suite.T(), consumed)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
+}
+
+func (suite *AuthorizationCodeStoreTestSuite) TestConsumeAuthorizationCode_ExecuteError() {
+	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On("Execute", queryConsumeAuthorizationCode,
+		AuthCodeStateInactive, "test-client-id", "test-code", AuthCodeStateActive, testDeploymentID).
+		Return(int64(0), errors.New("execute error"))
+
+	consumed, err := suite.store.ConsumeAuthorizationCode("test-client-id", "test-code")
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "error consuming authorization code")
+	assert.False(suite.T(), consumed)
+
+	suite.mockdbProvider.AssertExpectations(suite.T())
+	suite.mockDBClient.AssertExpectations(suite.T())
 }
 
 const testTimeString = "2023-12-01 10:30:45.123456789"
@@ -674,19 +681,6 @@ func (suite *AuthorizationCodeStoreTestSuite) TestParseTimeField_InvalidStringFo
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "error parsing test_field")
 	assert.True(suite.T(), result.IsZero())
-}
-
-func (suite *AuthorizationCodeStoreTestSuite) TestUpdateAuthorizationCodeState_ExecuteError() {
-	suite.mockdbProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil)
-	suite.mockDBClient.On("Execute", queryUpdateAuthorizationCodeState, AuthCodeStateInactive,
-		suite.testAuthzCode.CodeID, testDeploymentID).Return(int64(0), errors.New("execute error"))
-
-	err := suite.store.DeactivateAuthorizationCode(suite.testAuthzCode)
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "execute error")
-
-	suite.mockdbProvider.AssertExpectations(suite.T())
-	suite.mockDBClient.AssertExpectations(suite.T())
 }
 
 func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_WithNonce() {

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -76,8 +76,14 @@ func newAuthorizeService(
 	}
 }
 
-// GetAuthorizationCodeDetails retrieves and invalidates the authorization code.
+// GetAuthorizationCodeDetails atomically consumes and retrieves the authorization code.
 func (as *authorizeService) GetAuthorizationCodeDetails(clientID string, code string) (*AuthorizationCode, error) {
+	consumed, err := as.authCodeStore.ConsumeAuthorizationCode(clientID, code)
+	if err != nil {
+		as.logger.Error("error consuming authorization code", log.Error(err))
+		return nil, errors.New("failed to consume authorization code")
+	}
+
 	authCode, err := as.authCodeStore.GetAuthorizationCode(clientID, code)
 	if err != nil {
 		if errors.Is(err, ErrAuthorizationCodeNotFound) {
@@ -86,17 +92,17 @@ func (as *authorizeService) GetAuthorizationCodeDetails(clientID string, code st
 		as.logger.Error("error retrieving authorization code", log.Error(err))
 		return nil, errors.New("failed to retrieve authorization code")
 	}
-	if authCode == nil || authCode.Code == "" {
-		return nil, errors.New("invalid authorization code")
+
+	if consumed {
+		return authCode, nil
 	}
 
-	// Invalidate the authorization code after use.
-	err = as.authCodeStore.DeactivateAuthorizationCode(*authCode)
-	if err != nil {
-		as.logger.Error("error invalidating authorization code", log.Error(err))
-		return nil, errors.New("failed to invalidate authorization code")
+	if authCode.State == AuthCodeStateInactive {
+		// TODO: Revoke all access tokens already granted for this authorization code.
+		return nil, errors.New("authorization code already used")
 	}
-	return authCode, nil
+
+	return nil, errors.New("invalid authorization code")
 }
 
 // HandleInitialAuthorizationRequest processes an initial authorization request from the client.

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -516,7 +516,21 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_CreateAu
 	assert.Equal(suite.T(), oauth2const.ErrorServerError, authErr.Code)
 }
 
+func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_ConsumeError() {
+	suite.mockAuthzCodeStore.EXPECT().ConsumeAuthorizationCode("client-id", "code").
+		Return(false, errors.New("database error"))
+
+	svc := suite.newService()
+	result, err := svc.GetAuthorizationCodeDetails("client-id", "code")
+
+	assert.Nil(suite.T(), result)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to consume authorization code")
+}
+
 func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_NotFound() {
+	suite.mockAuthzCodeStore.EXPECT().ConsumeAuthorizationCode("client-id", "invalid-code").
+		Return(false, nil)
 	suite.mockAuthzCodeStore.EXPECT().GetAuthorizationCode("client-id", "invalid-code").
 		Return(nil, ErrAuthorizationCodeNotFound)
 
@@ -529,8 +543,10 @@ func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_NotFound
 }
 
 func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_GetError() {
+	suite.mockAuthzCodeStore.EXPECT().ConsumeAuthorizationCode("client-id", "code").
+		Return(true, nil)
 	suite.mockAuthzCodeStore.EXPECT().GetAuthorizationCode("client-id", "code").
-		Return(nil, errors.New("database error"))
+		Return(nil, errors.New("db error"))
 
 	svc := suite.newService()
 	result, err := svc.GetAuthorizationCodeDetails("client-id", "code")
@@ -546,10 +562,12 @@ func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_Success(
 		Code:             "valid-code",
 		ClientID:         "client-id",
 		AuthorizedUserID: "user-123",
+		State:            AuthCodeStateInactive,
 	}
+	suite.mockAuthzCodeStore.EXPECT().ConsumeAuthorizationCode("client-id", "valid-code").
+		Return(true, nil)
 	suite.mockAuthzCodeStore.EXPECT().GetAuthorizationCode("client-id", "valid-code").
 		Return(authCode, nil)
-	suite.mockAuthzCodeStore.EXPECT().DeactivateAuthorizationCode(*authCode).Return(nil)
 
 	svc := suite.newService()
 	result, err := svc.GetAuthorizationCodeDetails("client-id", "valid-code")
@@ -560,22 +578,42 @@ func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_Success(
 	assert.Equal(suite.T(), "user-123", result.AuthorizedUserID)
 }
 
-func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_DeactivateError() {
-	authCode := &AuthorizationCode{
-		CodeID:           "code-id-123",
-		Code:             "valid-code",
-		ClientID:         "client-id",
-		AuthorizedUserID: "user-123",
+func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_ReplayDetected() {
+	existingCode := &AuthorizationCode{
+		CodeID:   "code-id-123",
+		Code:     "used-code",
+		ClientID: "client-id",
+		State:    AuthCodeStateInactive,
 	}
-	suite.mockAuthzCodeStore.EXPECT().GetAuthorizationCode("client-id", "valid-code").
-		Return(authCode, nil)
-	suite.mockAuthzCodeStore.EXPECT().DeactivateAuthorizationCode(*authCode).
-		Return(errors.New("deactivate error"))
+	suite.mockAuthzCodeStore.EXPECT().ConsumeAuthorizationCode("client-id", "used-code").
+		Return(false, nil)
+	suite.mockAuthzCodeStore.EXPECT().GetAuthorizationCode("client-id", "used-code").
+		Return(existingCode, nil)
 
 	svc := suite.newService()
-	result, err := svc.GetAuthorizationCodeDetails("client-id", "valid-code")
+	result, err := svc.GetAuthorizationCodeDetails("client-id", "used-code")
 
 	assert.Nil(suite.T(), result)
 	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "failed to invalidate authorization code")
+	assert.Contains(suite.T(), err.Error(), "authorization code already used")
+}
+
+func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_ExpiredCode() {
+	existingCode := &AuthorizationCode{
+		CodeID:   "code-id-123",
+		Code:     "expired-code",
+		ClientID: "client-id",
+		State:    AuthCodeStateExpired,
+	}
+	suite.mockAuthzCodeStore.EXPECT().ConsumeAuthorizationCode("client-id", "expired-code").
+		Return(false, nil)
+	suite.mockAuthzCodeStore.EXPECT().GetAuthorizationCode("client-id", "expired-code").
+		Return(existingCode, nil)
+
+	svc := suite.newService()
+	result, err := svc.GetAuthorizationCodeDetails("client-id", "expired-code")
+
+	assert.Nil(suite.T(), result)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "invalid authorization code")
 }

--- a/backend/internal/oauth/oauth2/authz/store_constants.go
+++ b/backend/internal/oauth/oauth2/authz/store_constants.go
@@ -55,10 +55,11 @@ var queryGetAuthorizationCode = dbmodel.DBQuery{
 		"EXPIRY_TIME FROM AUTHORIZATION_CODE WHERE CLIENT_ID = $1 AND AUTHORIZATION_CODE = $2 AND DEPLOYMENT_ID = $3",
 }
 
-// queryUpdateAuthorizationCodeState is the query to update the state of an authorization code.
-var queryUpdateAuthorizationCodeState = dbmodel.DBQuery{
-	ID:    "AZQ-ACS-03",
-	Query: "UPDATE AUTHORIZATION_CODE SET STATE = $1 WHERE CODE_ID = $2 AND DEPLOYMENT_ID = $3",
+// queryConsumeAuthorizationCode atomically consumes an authorization code (ACTIVE → INACTIVE).
+var queryConsumeAuthorizationCode = dbmodel.DBQuery{
+	ID: "AZQ-ACS-04",
+	Query: "UPDATE AUTHORIZATION_CODE SET STATE = $1 WHERE CLIENT_ID = $2 AND AUTHORIZATION_CODE = $3 " +
+		"AND STATE = $4 AND DEPLOYMENT_ID = $5",
 }
 
 // queryInsertAuthRequest is the query to insert a new authorization request context.

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -251,20 +251,6 @@ func validateAuthorizationCode(tokenRequest *model.TokenRequest,
 		}
 	}
 
-	if code.State == authz.AuthCodeStateInactive {
-		// TODO: Revoke all the tokens issued for this authorization code.
-
-		return &model.ErrorResponse{
-			Error:            constants.ErrorInvalidGrant,
-			ErrorDescription: "Inactive authorization code",
-		}
-	} else if code.State != authz.AuthCodeStateActive {
-		return &model.ErrorResponse{
-			Error:            constants.ErrorInvalidGrant,
-			ErrorDescription: "Inactive authorization code",
-		}
-	}
-
 	if code.ExpiryTime.Before(time.Now()) {
 		return &model.ErrorResponse{
 			Error:            constants.ErrorInvalidGrant,

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -415,26 +415,6 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCo
 	assert.Nil(suite.T(), err)
 }
 
-func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCode_InactiveCode() {
-	inactiveCode := suite.testAuthzCode
-	inactiveCode.State = authz.AuthCodeStateInactive
-
-	err := validateAuthorizationCode(suite.testTokenReq, inactiveCode)
-	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
-	assert.Equal(suite.T(), "Inactive authorization code", err.ErrorDescription)
-}
-
-func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCode_InvalidState() {
-	invalidStateCode := suite.testAuthzCode
-	invalidStateCode.State = "INVALID_STATE"
-
-	err := validateAuthorizationCode(suite.testTokenReq, invalidStateCode)
-	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
-	assert.Equal(suite.T(), "Inactive authorization code", err.ErrorDescription)
-}
-
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCode_ExpiredCode() {
 	expiredCode := suite.testAuthzCode
 	expiredCode.ExpiryTime = time.Now().Add(-5 * time.Minute) // Expired


### PR DESCRIPTION
This pull request refactors the authorization code store interface and its tests to simplify and clarify how authorization codes are consumed and managed. The main change is the introduction of a single `ConsumeAuthorizationCode` method, replacing several previous methods related to code state transitions. The associated test mocks and interface definitions are updated accordingly.

Key changes:

**Authorization Code Store Interface and Implementation:**
- Replaces `DeactivateAuthorizationCode`, `RevokeAuthorizationCode`, and `ExpireAuthorizationCode` with a single `ConsumeAuthorizationCode(clientID, authCode string) (bool, error)` method in both the `AuthorizationCodeStoreInterface` and its implementation. This new method atomically consumes an active authorization code, transitioning it to inactive, and returns whether the operation succeeded. [[1]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aR54-L57) [[2]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aR94-R110) [[3]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL115-L141)

**Test Mock Updates:**
- Updates the mock for `AuthorizationCodeStoreInterface` to remove the old state-changing methods and add support for `ConsumeAuthorizationCode`, including its expecter and call helpers. [[1]](diffhunk://#diff-45e1355c8a64ff5e399dccc641a4c29277cbd20066d872343380b4243cd30bf0L38-R99) [[2]](diffhunk://#diff-45e1355c8a64ff5e399dccc641a4c29277cbd20066d872343380b4243cd30bf0L258-L308)

**Test Mockery and Style Improvements:**
- Updates the `AuthorizeServiceInterfaceMock` to use the latest mockery template and style, improving type safety and clarity in mock method signatures and return value handling. [[1]](diffhunk://#diff-b38ec8800ee82e3deb76b3934ce8fd0a7c309fdbca5e5f4cb6363539c6f87a06L1-R23) [[2]](diffhunk://#diff-b38ec8800ee82e3deb76b3934ce8fd0a7c309fdbca5e5f4cb6363539c6f87a06L20-L46) [[3]](diffhunk://#diff-b38ec8800ee82e3deb76b3934ce8fd0a7c309fdbca5e5f4cb6363539c6f87a06L64-L105) [[4]](diffhunk://#diff-b38ec8800ee82e3deb76b3934ce8fd0a7c309fdbca5e5f4cb6363539c6f87a06L123-L166) [[5]](diffhunk://#diff-b38ec8800ee82e3deb76b3934ce8fd0a7c309fdbca5e5f4cb6363539c6f87a06L183-L210)

Related Issue:
Addresses 2 of #1625 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization codes are now consumed atomically to prevent replay and race conditions; clearer errors when codes are already used or invalid.

* **Refactor**
  * Simplified authorization-code lifecycle and validation flow to improve reliability and consistency.

* **Tests**
  * Expanded tests and mocks around code consumption, error paths, and replay/expiry scenarios for stronger behavioral guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->