### PR TITLE
Add URL decode for basic auth client credentials

### DIFF
--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -22,6 +22,7 @@ package clientauth
 import (
 	"encoding/base64"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/asgardeo/thunder/internal/application"
@@ -129,5 +130,15 @@ func extractBasicAuthCredentials(r *http.Request) (string, string, *authError) {
 		return "", "", errInvalidAuthorizationHeader
 	}
 
-	return credentials[0], credentials[1], nil
+	// URL-decode client credentials.
+	clientID, idErr := url.QueryUnescape(credentials[0])
+	if idErr != nil {
+		return "", "", errInvalidAuthorizationHeader
+	}
+	clientSecret, secretErr := url.QueryUnescape(credentials[1])
+	if secretErr != nil {
+		return "", "", errInvalidAuthorizationHeader
+	}
+
+	return clientID, clientSecret, nil
 }

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -19,6 +19,7 @@
 package clientauth
 
 import (
+	"encoding/base64"
 	"net/http"
 	"net/url"
 	"strings"
@@ -109,6 +110,63 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_ClientSecretBasic() {
 		assert.Equal(suite.T(), testClientID, clientInfo.ClientID)
 		assert.Equal(suite.T(), clientSecret, clientInfo.ClientSecret)
 	}
+}
+
+func (suite *ClientAuthTestSuite) TestAuthenticate_Success_ClientSecretBasic_URLEncodedCredentials() {
+	rawClientID := "client:id"
+	rawClientSecret := "secret with spaces"
+	encodedClientID := url.QueryEscape(rawClientID)
+	encodedClientSecret := url.QueryEscape(rawClientSecret)
+	hashedSecret := hash.GenerateThumbprintFromString(rawClientSecret)
+	mockApp := &appmodel.OAuthAppConfigProcessedDTO{
+		ClientID:                rawClientID,
+		HashedClientSecret:      hashedSecret,
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
+		GrantTypes:              []constants.GrantType{constants.GrantTypeAuthorizationCode},
+	}
+
+	suite.mockAppService.On("GetOAuthApplication", rawClientID).
+		Return(mockApp, nil).Once()
+
+	// Manually construct the Basic Auth header with URL-encoded credentials.
+	basicValue := base64.StdEncoding.EncodeToString([]byte(encodedClientID + ":" + encodedClientSecret))
+	req, _ := http.NewRequest("POST", "/test", nil)
+	req.Header.Set("Authorization", "Basic "+basicValue)
+
+	clientInfo, authErr := authenticate(req, suite.mockAppService)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), clientInfo)
+	if clientInfo != nil {
+		assert.Equal(suite.T(), rawClientID, clientInfo.ClientID)
+		assert.Equal(suite.T(), rawClientSecret, clientInfo.ClientSecret)
+	}
+}
+
+func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidBasicAuth_BadPercentEncoding() {
+	// Use an invalid percent-encoded value in the client ID.
+	basicValue := base64.StdEncoding.EncodeToString([]byte("client%ZZid:secret"))
+	req, _ := http.NewRequest("POST", "/test", nil)
+	req.Header.Set("Authorization", "Basic "+basicValue)
+
+	clientInfo, authErr := authenticate(req, suite.mockAppService)
+
+	assert.NotNil(suite.T(), authErr)
+	assert.Nil(suite.T(), clientInfo)
+	assert.Equal(suite.T(), errInvalidAuthorizationHeader, authErr)
+}
+
+func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidBasicAuth_BadPercentEncodingInSecret() {
+	// Client ID is valid but secret contains an invalid percent-encoded value.
+	basicValue := base64.StdEncoding.EncodeToString([]byte("validclient:secret%ZZvalue"))
+	req, _ := http.NewRequest("POST", "/test", nil)
+	req.Header.Set("Authorization", "Basic "+basicValue)
+
+	clientInfo, authErr := authenticate(req, suite.mockAppService)
+
+	assert.NotNil(suite.T(), authErr)
+	assert.Nil(suite.T(), clientInfo)
+	assert.Equal(suite.T(), errInvalidAuthorizationHeader, authErr)
 }
 
 func (suite *ClientAuthTestSuite) TestAuthenticate_Success_PublicClient() {


### PR DESCRIPTION
This pull request improves the handling of client credentials in OAuth2 Basic authentication by ensuring that credentials are properly URL-decoded, and adds comprehensive tests for both correct and malformed encodings. This enhances compatibility with clients that URL-encode credentials, and improves robustness against encoding errors.

**Client credentials decoding:**
- Updated `extractBasicAuthCredentials` in `clientauth.go` to URL-decode both the client ID and client secret extracted from the Basic Auth header, returning an error if decoding fails.
- Added an import of the `net/url` package in `clientauth.go` to support URL decoding.

**Testing improvements:**
- Added a test case to `clientauth_test.go` to verify successful authentication when credentials are URL-encoded in the Basic Auth header.
- Added a test case to ensure that invalid percent-encoding in credentials is correctly handled as an error.
- Added an import of the `encoding/base64` package in `clientauth_test.go` to support test setup for encoding credentials.

Related issue:
Fix 3 of #1625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth2 Basic authentication now URL-decodes client identifiers and secrets.
  * Malformed percent-encoding in authorization headers is rejected with an invalid authorization error.

* **Tests**
  * Added unit tests for successful URL-encoded credentials and for invalid percent-encoding error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->