### PR TITLE
Make basic auth scheme comparison case-insensitive. 

### DIFF
--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -27,6 +27,7 @@ import (
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // authenticate authenticates the OAuth2 client from the request.
@@ -114,11 +115,11 @@ func authenticate(
 // extractBasicAuthCredentials extracts the basic authentication credentials from the request header.
 func extractBasicAuthCredentials(r *http.Request) (string, string, *authError) {
 	authHeader := r.Header.Get(serverconst.AuthorizationHeaderName)
-	if !strings.HasPrefix(authHeader, serverconst.AuthSchemeBasic) {
+	if !utils.HasPrefixFold(authHeader, serverconst.AuthSchemeBasic) {
 		return "", "", errInvalidAuthorizationHeader
 	}
 
-	encodedCredentials := strings.TrimPrefix(authHeader, serverconst.AuthSchemeBasic)
+	encodedCredentials := utils.TrimPrefixFold(authHeader, serverconst.AuthSchemeBasic)
 	decodedCredentials, err := base64.StdEncoding.DecodeString(encodedCredentials)
 	if err != nil {
 		return "", "", errInvalidAuthorizationHeader

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -41,6 +41,9 @@ const TokenTypeBearer = "Bearer"
 // AuthSchemeBasic is the authentication scheme prefix used in HTTP Basic authentication.
 const AuthSchemeBasic = "Basic "
 
+// AuthSchemeBearer is the authentication scheme prefix used in HTTP Bearer authentication.
+const AuthSchemeBearer = "Bearer "
+
 // ContentTypeJSON is the content type for JSON data.
 const ContentTypeJSON = "application/json"
 

--- a/backend/internal/system/security/jwt_authenticator.go
+++ b/backend/internal/system/security/jwt_authenticator.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
+	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // jwtAuthenticator handles authentication and authorization using JWT Bearer tokens.
@@ -39,9 +40,10 @@ func newJWTAuthenticator(jwtService jwt.JWTServiceInterface) *jwtAuthenticator {
 }
 
 // CanHandle checks if the request contains a Bearer token in the Authorization header.
+// RFC 7235 §2.1: The authentication scheme token is case-insensitive.
 func (h *jwtAuthenticator) CanHandle(r *http.Request) bool {
-	authHeader := r.Header.Get("Authorization")
-	return strings.HasPrefix(authHeader, "Bearer ")
+	authHeader := r.Header.Get(constants.AuthorizationHeaderName)
+	return utils.HasPrefixFold(authHeader, constants.AuthSchemeBearer)
 }
 
 // Authenticate validates the JWT token and builds a SecurityContext.
@@ -85,11 +87,10 @@ func (h *jwtAuthenticator) Authenticate(r *http.Request) (*SecurityContext, erro
 
 // extractToken extracts the Bearer token from the Authorization header.
 func extractToken(authHeader string) (string, error) {
-	if !strings.HasPrefix(authHeader, "Bearer ") {
+	if !utils.HasPrefixFold(authHeader, constants.AuthSchemeBearer) {
 		return "", errMissingAuthHeader
 	}
-	token := strings.TrimPrefix(authHeader, "Bearer ")
-	token = strings.TrimSpace(token)
+	token := strings.TrimSpace(utils.TrimPrefixFold(authHeader, constants.AuthSchemeBearer))
 	return token, nil
 }
 

--- a/backend/internal/system/security/jwt_authenticator_test.go
+++ b/backend/internal/system/security/jwt_authenticator_test.go
@@ -81,7 +81,7 @@ func (suite *JWTAuthenticatorTestSuite) TestCanHandle() {
 		{
 			name:           "Lowercase bearer",
 			authHeader:     "bearer token123",
-			expectedResult: false,
+			expectedResult: true,
 		},
 	}
 
@@ -413,13 +413,13 @@ func (suite *JWTAuthenticatorTestSuite) TestCanHandle_EdgeCases() {
 			expectedResult: false, // Get() returns first header
 		},
 		{
-			name: "Case sensitive Bearer",
+			name: "Case insensitive BEARER",
 			setupRequest: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, "/users", nil)
 				req.Header.Set("Authorization", "BEARER token123")
 				return req
 			},
-			expectedResult: false,
+			expectedResult: true,
 		},
 	}
 

--- a/backend/internal/system/utils/stringutil.go
+++ b/backend/internal/system/utils/stringutil.go
@@ -143,6 +143,20 @@ func NumStringToBool(s string) bool {
 	return s == "1"
 }
 
+// HasPrefixFold checks whether s begins with prefix using case-insensitive comparison.
+func HasPrefixFold(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+// TrimPrefixFold returns s with the given prefix removed (case-insensitive match).
+// If s does not start with prefix (case-insensitive), s is returned unchanged.
+func TrimPrefixFold(s, prefix string) string {
+	if HasPrefixFold(s, prefix) {
+		return s[len(prefix):]
+	}
+	return s
+}
+
 // ConvertToStringSlice converts a slice of custom string types to a slice of strings.
 func ConvertToStringSlice[T ~string](items []T) []string {
 	result := make([]string, len(items))

--- a/backend/internal/system/utils/stringutil_test.go
+++ b/backend/internal/system/utils/stringutil_test.go
@@ -509,3 +509,54 @@ func (suite *StringUtilTestSuite) TestMergeStringMaps_OverlapNilValue() {
 	result := MergeStringMaps(dst, src)
 	assert.Equal(suite.T(), expected, result)
 }
+
+func (suite *StringUtilTestSuite) TestHasPrefixFold() {
+	tests := []struct {
+		name     string
+		s        string
+		prefix   string
+		expected bool
+	}{
+		{name: "Exact match", s: "Bearer token", prefix: "Bearer ", expected: true},
+		{name: "Lowercase", s: "bearer token", prefix: "Bearer ", expected: true},
+		{name: "Uppercase", s: "BEARER token", prefix: "Bearer ", expected: true},
+		{name: "Mixed case", s: "bEaReR token", prefix: "Bearer ", expected: true},
+		{name: "No match", s: "Basic token", prefix: "Bearer ", expected: false},
+		{name: "Empty string", s: "", prefix: "Bearer ", expected: false},
+		{name: "Empty prefix", s: "anything", prefix: "", expected: true},
+		{name: "String shorter than prefix", s: "Be", prefix: "Bearer ", expected: false},
+		{name: "Exact prefix only", s: "Bearer ", prefix: "Bearer ", expected: true},
+		{name: "Basic exact", s: "Basic dXNlcjpwYXNz", prefix: "Basic ", expected: true},
+		{name: "Basic lowercase", s: "basic dXNlcjpwYXNz", prefix: "Basic ", expected: true},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			assert.Equal(suite.T(), tt.expected, HasPrefixFold(tt.s, tt.prefix))
+		})
+	}
+}
+
+func (suite *StringUtilTestSuite) TestTrimPrefixFold() {
+	tests := []struct {
+		name     string
+		s        string
+		prefix   string
+		expected string
+	}{
+		{name: "Exact match", s: "Bearer token", prefix: "Bearer ", expected: "token"},
+		{name: "Lowercase", s: "bearer token", prefix: "Bearer ", expected: "token"},
+		{name: "Uppercase", s: "BEARER token", prefix: "Bearer ", expected: "token"},
+		{name: "No match", s: "Basic token", prefix: "Bearer ", expected: "Basic token"},
+		{name: "Empty string", s: "", prefix: "Bearer ", expected: ""},
+		{name: "Empty prefix", s: "anything", prefix: "", expected: "anything"},
+		{name: "Basic exact", s: "Basic dXNlcjpwYXNz", prefix: "Basic ", expected: "dXNlcjpwYXNz"},
+		{name: "Basic uppercase", s: "BASIC dXNlcjpwYXNz", prefix: "Basic ", expected: "dXNlcjpwYXNz"},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			assert.Equal(suite.T(), tt.expected, TrimPrefixFold(tt.s, tt.prefix))
+		})
+	}
+}


### PR DESCRIPTION
This pull request improves the handling of HTTP authentication scheme prefixes (such as "Bearer" and "Basic") by making their detection case-insensitive and refactoring the code to use new utility functions. This ensures compliance with RFC 7235, which specifies that authentication scheme tokens are case-insensitive. The changes also add thorough tests for the new utility functions and update the codebase and tests accordingly.

**Authentication header handling improvements:**

* Introduced new utility functions `HasPrefixFold` and `TrimPrefixFold` in `utils/stringutil.go` for case-insensitive prefix checking and trimming, and updated all uses of authentication scheme prefix checks in the OAuth2 and JWT authentication flows to use these utilities. [[1]](diffhunk://#diff-9c55681d9a2b2eb05273cb6c82527c8ec45dd65bf49e866f4e458e5997cb6a13R146-R159) [[2]](diffhunk://#diff-ef5867f4f1cd34f103d352ad1892842c5c3e5553126a09032f09225f2f77c533R30) [[3]](diffhunk://#diff-ef5867f4f1cd34f103d352ad1892842c5c3e5553126a09032f09225f2f77c533L117-R122) [[4]](diffhunk://#diff-52a6d5e55ce048be4e17341cf784031275fec70a911cc7e0e8ddbafa0858375fR27) [[5]](diffhunk://#diff-52a6d5e55ce048be4e17341cf784031275fec70a911cc7e0e8ddbafa0858375fR43-R46) [[6]](diffhunk://#diff-52a6d5e55ce048be4e17341cf784031275fec70a911cc7e0e8ddbafa0858375fL88-R93)
* Added `AuthSchemeBearer` constant (with trailing space) to `constants/server_constants.go` for consistent and clear usage of the Bearer authentication scheme.

**Testing and compliance:**

* Updated and expanded tests in `jwt_authenticator_test.go` to verify that Bearer token detection is now case-insensitive, including edge cases and different capitalizations. [[1]](diffhunk://#diff-ac377baba8df1bd2c827b76dc06d8abb80a296a41eb117a081387f5d578fa7f9L84-R84) [[2]](diffhunk://#diff-ac377baba8df1bd2c827b76dc06d8abb80a296a41eb117a081387f5d578fa7f9L416-R422)
* Added comprehensive unit tests for the new `HasPrefixFold` and `TrimPrefixFold` utility functions in `stringutil_test.go`.

Related Issue:
- 5 of #1625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Bearer token authentication now handles case-insensitive prefix matching, allowing variations like "bearer", "Bearer", and "BEARER" to be treated equivalently.

* **Tests**
  * Expanded test coverage for case-insensitive Bearer authentication validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->