### PR TITLE
Update inconsistent OAuth error codes

### DIFF
--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -64,7 +64,7 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 
 	// Validate if the authorization code grant type is allowed for the app.
 	if !oauthApp.IsAllowedGrantType(constants.GrantTypeAuthorizationCode) {
-		return true, constants.ErrorUnsupportedGrantType,
+		return true, constants.ErrorUnauthorizedClient,
 			"Authorization code grant type is not allowed for the client"
 	}
 

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -131,7 +131,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzRequest_CodeGrant
 		msg, restrictedApp)
 
 	assert.True(suite.T(), sendErrorToApp)
-	assert.Equal(suite.T(), constants.ErrorUnsupportedGrantType, errorCode)
+	assert.Equal(suite.T(), constants.ErrorUnauthorizedClient, errorCode)
 	assert.Equal(suite.T(), "Authorization code grant type is not allowed for the client", errorMessage)
 }
 

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -149,7 +149,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_MissingClientID() {
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
 	assert.Equal(suite.T(), errMissingClientID, authErr)
-	assert.Equal(suite.T(), constants.ErrorInvalidClient, authErr.ErrorCode)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, authErr.ErrorCode)
 	assert.Equal(suite.T(), "Missing client_id parameter", authErr.ErrorDescription)
 }
 

--- a/backend/internal/oauth/oauth2/clientauth/error.go
+++ b/backend/internal/oauth/oauth2/clientauth/error.go
@@ -70,9 +70,9 @@ var (
 		http.StatusBadRequest,
 	)
 	errMissingClientID = newAuthError(
-		constants.ErrorInvalidClient,
+		constants.ErrorInvalidRequest,
 		"Missing client_id parameter",
-		http.StatusUnauthorized,
+		http.StatusBadRequest,
 	)
 	errMissingClientSecret = newAuthError(
 		constants.ErrorInvalidClient,
@@ -82,6 +82,6 @@ var (
 	errUnauthorizedAuthMethod = newAuthError(
 		constants.ErrorUnauthorizedClient,
 		"Client is not allowed to use the specified token endpoint authentication method",
-		http.StatusUnauthorized,
+		http.StatusBadRequest,
 	)
 )

--- a/backend/internal/oauth/oauth2/clientauth/middleware_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/middleware_test.go
@@ -151,12 +151,12 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_MissingClie
 	middleware(handler).ServeHTTP(w, req)
 
 	// Verify error response
-	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
 
 	var response map[string]interface{}
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "invalid_client", response["error"])
+	assert.Equal(suite.T(), "invalid_request", response["error"])
 }
 
 func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_InvalidClient() {

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -71,7 +71,7 @@ func (h *authorizationCodeGrantHandler) ValidateGrant(tokenRequest *model.TokenR
 	}
 	if tokenRequest.Code == "" {
 		return &model.ErrorResponse{
-			Error:            constants.ErrorInvalidGrant,
+			Error:            constants.ErrorInvalidRequest,
 			ErrorDescription: "Authorization code is required",
 		}
 	}
@@ -229,8 +229,8 @@ func validateAuthorizationCode(tokenRequest *model.TokenRequest,
 	code authz.AuthorizationCode) *model.ErrorResponse {
 	if tokenRequest.ClientID != code.ClientID {
 		return &model.ErrorResponse{
-			Error:            constants.ErrorInvalidClient,
-			ErrorDescription: "Invalid client Id",
+			Error:            constants.ErrorInvalidGrant,
+			ErrorDescription: "Invalid authorization code",
 		}
 	}
 

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -189,7 +189,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_MissingAu
 
 	err := suite.handler.ValidateGrant(tokenReq, suite.oauthApp)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, err.Error)
 	assert.Equal(suite.T(), "Authorization code is required", err.ErrorDescription)
 }
 
@@ -386,8 +386,8 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCo
 
 	err := validateAuthorizationCode(invalidTokenReq, suite.testAuthzCode)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorInvalidClient, err.Error)
-	assert.Equal(suite.T(), "Invalid client Id", err.ErrorDescription)
+	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
+	assert.Equal(suite.T(), "Invalid authorization code", err.ErrorDescription)
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateAuthorizationCode_WrongRedirectURI() {

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -456,7 +456,7 @@ func (ts *AuthzTestSuite) TestTokenRequestValidation() {
 			RedirectURI:    redirectURI,
 			GrantType:      "authorization_code",
 			ExpectedStatus: http.StatusBadRequest,
-			ExpectedError:  "invalid_grant",
+			ExpectedError:  "invalid_request",
 		},
 		{
 			Name:           "No Client ID",
@@ -465,8 +465,8 @@ func (ts *AuthzTestSuite) TestTokenRequestValidation() {
 			Code:           validAuthzCode,
 			RedirectURI:    redirectURI,
 			GrantType:      "authorization_code",
-			ExpectedStatus: http.StatusUnauthorized,
-			ExpectedError:  "invalid_client",
+			ExpectedStatus: http.StatusBadRequest,
+			ExpectedError:  "invalid_request",
 		},
 		{
 			Name:           "No Client ID and Secret",
@@ -475,8 +475,8 @@ func (ts *AuthzTestSuite) TestTokenRequestValidation() {
 			Code:           validAuthzCode,
 			RedirectURI:    redirectURI,
 			GrantType:      "authorization_code",
-			ExpectedStatus: http.StatusUnauthorized,
-			ExpectedError:  "invalid_client",
+			ExpectedStatus: http.StatusBadRequest,
+			ExpectedError:  "invalid_request",
 		},
 		{
 			Name:           "No Client Secret",

--- a/tests/integration/oauth/token/token_test.go
+++ b/tests/integration/oauth/token/token_test.go
@@ -349,8 +349,8 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantNegativeCases() {
 			testName:       "MissingCredentialsInBody",
 			requestBody:    "grant_type=client_credentials",
 			authHeader:     "",
-			expectedStatus: http.StatusUnauthorized,
-			expectedError:  "invalid_client",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid_request",
 		},
 		{
 			testName:       "InvalidGrantType",


### PR DESCRIPTION
This pull request updates several OAuth2 error codes and HTTP status codes to better align with the OAuth2 specification and improve the accuracy of error reporting. The changes mainly focus on ensuring that the correct error codes are returned for specific client authentication and authorization scenarios.

**Error code and status updates:**

*Authorization and grant validation:*
- Changed the error code returned when an app is not allowed to use the authorization code grant type from `unsupported_grant_type` to `unauthorized_client` in both the validator logic and its corresponding test. [[1]](diffhunk://#diff-a762b101d5c30d8563a99b356634e95ea9e6a8a5a1ef436599a326e2644d7449L67-R67) [[2]](diffhunk://#diff-4b01500e615b4cd2c3bbe6b667e2097d8f38e540427bf1731808bfed70f5d56eL134-R134)
- Updated the error code for a missing authorization code in the token request from `invalid_grant` to `invalid_request`, and adjusted the related test to match. [[1]](diffhunk://#diff-353c0ae473a7f38190e1aacc728880e021da05be2fb9ceedfd844e378bee7c9eL74-R74) [[2]](diffhunk://#diff-0dcbccf58e29fcf825f6cae700867e94be259f41dad65ca474d97755fe5c4ee6L192-R192)
- Modified the error code returned when the client ID does not match the authorization code from `invalid_client` to `invalid_grant`, with an updated error message, and updated the test accordingly. [[1]](diffhunk://#diff-353c0ae473a7f38190e1aacc728880e021da05be2fb9ceedfd844e378bee7c9eL232-R233) [[2]](diffhunk://#diff-0dcbccf58e29fcf825f6cae700867e94be259f41dad65ca474d97755fe5c4ee6L389-R390)

*Client authentication:*
- Changed the error code for a missing `client_id` from `invalid_client` to `invalid_request` and the HTTP status from 401 Unauthorized to 400 Bad Request in both error definitions and related tests. [[1]](diffhunk://#diff-da3f4eb1e15438abb380580887d65e99b418b93cc86fe020902c2c255dfacf7dL73-R75) [[2]](diffhunk://#diff-79da07e121583862b00ca3a8febfe1bd80ea675a28bde34b7436bf6843fb2376L152-R152) [[3]](diffhunk://#diff-1cc89d4b5fd3b1b8e039cdeaa7c21f5848fb17f04d6ef96f7eefb5974d8a82f0L154-R159)
- Updated the HTTP status for unauthorized authentication methods from 401 Unauthorized to 400 Bad Request.

Related issue;
- Addresses 3,6,7,8,9,10 of #1625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected OAuth2 error handling throughout authorization and client authentication flows. Invalid parameter errors now return 400 Bad Request instead of 401 Unauthorized where semantically appropriate. Authorization code validation errors now return error codes properly aligned with OAuth2 specification requirements, improving clarity and consistency for client applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->