### PR TITLE
Add configuration for switching userprovider implementation

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -147,5 +147,8 @@
     "base_url": "",
     "timeout": 5,
     "max_retries": 3
+  },
+  "user_provider": {
+    "type": "default"
   }
 }

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -334,6 +334,11 @@ type AuthnProviderConfig struct {
 	Rest RestConfig `yaml:"rest" json:"rest"`
 }
 
+// UserProviderConfig holds the user provider configuration details.
+type UserProviderConfig struct {
+	Type string `yaml:"type" json:"type"`
+}
+
 // RestConfig holds the REST authentication provider configuration details.
 type RestConfig struct {
 	BaseURL  string             `yaml:"base_url" json:"base_url"`
@@ -376,6 +381,7 @@ type Config struct {
 	Observability        ObservabilityConfig    `yaml:"observability" json:"observability"`
 	Passkey              PasskeyConfig          `yaml:"passkey" json:"passkey"`
 	AuthnProvider        AuthnProviderConfig    `yaml:"authn_provider" json:"authn_provider"`
+	UserProvider         UserProviderConfig     `yaml:"user_provider" json:"user_provider"`
 	Role                 RoleConfig             `yaml:"role" json:"role"`
 	Theme                ThemeConfig            `yaml:"theme" json:"theme"`
 	Layout               LayoutConfig           `yaml:"layout" json:"layout"`

--- a/backend/internal/userprovider/init.go
+++ b/backend/internal/userprovider/init.go
@@ -25,10 +25,9 @@ import (
 
 // InitializeUserProvider initializes the user provider.
 func InitializeUserProvider(userSvc user.UserServiceInterface) UserProviderInterface {
-	authnProviderConfig := config.GetThunderRuntime().Config.AuthnProvider
-	switch authnProviderConfig.Type {
-	case "rest":
-		// user provider is disabled if authn provider is rest
+	userProviderConfig := config.GetThunderRuntime().Config.UserProvider
+	switch userProviderConfig.Type {
+	case "disabled":
 		return initializeDisabledUserProvider()
 	default:
 		return initializeDefaultUserProvider(userSvc)

--- a/backend/internal/userprovider/init_test.go
+++ b/backend/internal/userprovider/init_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package userprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/tests/mocks/usermock"
+)
+
+type InitUserProviderTestSuite struct {
+	suite.Suite
+	mockUserService *usermock.UserServiceInterfaceMock
+}
+
+func (suite *InitUserProviderTestSuite) SetupTest() {
+	suite.mockUserService = usermock.NewUserServiceInterfaceMock(suite.T())
+
+	// Initialize ThunderRuntime with a basic test config
+	testConfig := &config.Config{
+		Database: config.DatabaseConfig{
+			Identity: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+			Runtime: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+		},
+	}
+	_ = config.InitializeThunderRuntime("test", testConfig)
+}
+
+func (suite *InitUserProviderTestSuite) TearDownTest() {
+	config.ResetThunderRuntime()
+}
+
+func TestInitUserProviderTestSuite(t *testing.T) {
+	suite.Run(t, new(InitUserProviderTestSuite))
+}
+
+func (suite *InitUserProviderTestSuite) TestInitializeUserProvider_WithDisabledType() {
+	// Set user provider type to "disabled"
+	config.GetThunderRuntime().Config.UserProvider = config.UserProviderConfig{
+		Type: "disabled",
+	}
+
+	provider := InitializeUserProvider(suite.mockUserService)
+
+	// Assert that the provider is of type disabledUserProvider
+	suite.NotNil(provider)
+	_, ok := provider.(*disabledUserProvider)
+	suite.True(ok, "Expected provider to be of type *disabledUserProvider")
+}
+
+func (suite *InitUserProviderTestSuite) TestInitializeUserProvider_WithDefaultType() {
+	// Set user provider type to "default"
+	config.GetThunderRuntime().Config.UserProvider = config.UserProviderConfig{
+		Type: "default",
+	}
+
+	provider := InitializeUserProvider(suite.mockUserService)
+
+	// Assert that the provider is of type defaultUserProvider
+	suite.NotNil(provider)
+	_, ok := provider.(*defaultUserProvider)
+	suite.True(ok, "Expected provider to be of type *defaultUserProvider")
+}
+
+func (suite *InitUserProviderTestSuite) TestInitializeUserProvider_WithEmptyType() {
+	// Set user provider type to empty (should default to default provider)
+	config.GetThunderRuntime().Config.UserProvider = config.UserProviderConfig{
+		Type: "",
+	}
+
+	provider := InitializeUserProvider(suite.mockUserService)
+
+	// Assert that the provider is of type defaultUserProvider (default case)
+	suite.NotNil(provider)
+	_, ok := provider.(*defaultUserProvider)
+	suite.True(ok, "Expected provider to be of type *defaultUserProvider when type is empty")
+}
+
+func (suite *InitUserProviderTestSuite) TestInitializeUserProvider_WithUnknownType() {
+	// Set user provider type to an unknown value (should default to default provider)
+	config.GetThunderRuntime().Config.UserProvider = config.UserProviderConfig{
+		Type: "unknown",
+	}
+
+	provider := InitializeUserProvider(suite.mockUserService)
+
+	// Assert that the provider is of type defaultUserProvider (default case)
+	suite.NotNil(provider)
+	_, ok := provider.(*defaultUserProvider)
+	suite.True(ok, "Expected provider to be of type *defaultUserProvider for unknown type")
+}


### PR DESCRIPTION
### Purpose

This pull request introduces a configurable user provider to the backend system, allowing selection between different user provider implementations via configuration. The main changes add a new `user_provider` config section, update initialization logic to use this config, and provide comprehensive tests for the new behavior.

### Approach

**Configuration changes:**

* Added a new `user_provider` section to the main configuration file (`default.json`), allowing the user provider type to be specified.
* Introduced a new `UserProviderConfig` struct and added it to the main `Config` struct, enabling the backend to read and use the user provider type from configuration (`config.go`) [[1]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR337-R341) [[2]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR376).

**Initialization logic updates:**

* Updated `InitializeUserProvider` to use the new `UserProviderConfig` for determining which user provider to initialize, supporting both "disabled" and "default" types (`init.go`).

**Testing improvements:**

* Added a new test suite (`init_test.go`) that verifies the correct user provider is initialized for various configuration scenarios, including "disabled", "default", empty, and unknown types.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user provider configuration support with selectable types (default, disabled); system now initializes a sensible default when type is empty or unknown.

* **Tests**
  * Added a test suite covering user provider initialization across disabled, default, empty, and unknown configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->