### PR TITLE
Change refresh grant error for additional scopes

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -95,7 +95,10 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 		}
 	}
 
-	newTokenScopes := h.applyScopeDownscoping(tokenRequest.Scope, refreshTokenClaims.Scopes, logger)
+	newTokenScopes, scopeErr := h.validateAndApplyScopes(tokenRequest.Scope, refreshTokenClaims.Scopes, logger)
+	if scopeErr != nil {
+		return nil, scopeErr
+	}
 
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
 		Subject:        refreshTokenClaims.Sub,
@@ -206,29 +209,28 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	return nil
 }
 
-// applyScopeDownscoping applies OAuth2 scope downscoping logic.
+// validateAndApplyScopes validates and applies OAuth2 scope downscoping logic per RFC 6749 §6.
 // If no scopes are requested, all refresh token scopes are granted.
-// If scopes are requested, only the intersection with refresh token scopes is granted.
-func (h *refreshTokenGrantHandler) applyScopeDownscoping(requestedScopes string,
-	refreshTokenScopes []string, logger *log.Logger) []string {
+// If scopes are requested, they must be a subset of the original grant; otherwise an invalid_scope error is returned.
+func (h *refreshTokenGrantHandler) validateAndApplyScopes(requestedScopes string,
+	refreshTokenScopes []string, logger *log.Logger) ([]string, *model.ErrorResponse) {
 	trimmedRequestedScopes := tokenservice.ParseScopes(requestedScopes)
 
 	if len(trimmedRequestedScopes) == 0 {
 		logger.Debug("No scopes requested. Granting all scopes from refresh token",
 			log.Any("scopes", refreshTokenScopes))
-		return refreshTokenScopes
+		return refreshTokenScopes, nil
 	}
 
-	newTokenScopes := []string{}
 	for _, requestedScope := range trimmedRequestedScopes {
-		if slices.Contains(refreshTokenScopes, requestedScope) {
-			newTokenScopes = append(newTokenScopes, requestedScope)
-		} else {
-			logger.Debug("Requested scope not found in refresh token, skipping",
-				log.String("scope", requestedScope))
+		if !slices.Contains(refreshTokenScopes, requestedScope) {
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorInvalidScope,
+				ErrorDescription: "Requested scope exceeds the scope granted by the resource owner",
+			}
 		}
 	}
 
-	logger.Debug("Applied scope downscoping", log.Any("grantedScopes", newTokenScopes))
-	return newTokenScopes
+	logger.Debug("Applied scope downscoping", log.Any("grantedScopes", trimmedRequestedScopes))
+	return trimmedRequestedScopes, nil
 }

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -438,49 +438,50 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ExtractIatClaimE
 	assert.Equal(suite.T(), "Invalid refresh token", err.ErrorDescription)
 }
 
-func (suite *RefreshTokenGrantHandlerTestSuite) TestApplyScopeDownscoping_NoScopesRequested() {
+func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateAndApplyScopes_NoScopesRequested() {
 	refreshTokenScopes := []string{"read", "write", "delete"}
 	logger := log.GetLogger()
 
-	result := suite.handler.applyScopeDownscoping("", refreshTokenScopes, logger)
+	result, errResp := suite.handler.validateAndApplyScopes("", refreshTokenScopes, logger)
 
+	assert.Nil(suite.T(), errResp)
 	assert.Equal(suite.T(), refreshTokenScopes, result)
 	assert.Len(suite.T(), result, 3)
 }
 
-func (suite *RefreshTokenGrantHandlerTestSuite) TestApplyScopeDownscoping_RequestedScopesSubset() {
+func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateAndApplyScopes_RequestedScopesSubset() {
 	refreshTokenScopes := []string{"read", "write", "delete"}
 	logger := log.GetLogger()
 
-	result := suite.handler.applyScopeDownscoping("read write", refreshTokenScopes, logger)
+	result, errResp := suite.handler.validateAndApplyScopes("read write", refreshTokenScopes, logger)
 
+	assert.Nil(suite.T(), errResp)
 	assert.Len(suite.T(), result, 2)
 	assert.Contains(suite.T(), result, "read")
 	assert.Contains(suite.T(), result, "write")
 	assert.NotContains(suite.T(), result, "delete")
 }
 
-func (suite *RefreshTokenGrantHandlerTestSuite) TestApplyScopeDownscoping_SomeRequestedScopesNotInRefreshToken() {
+func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateAndApplyScopes_SomeRequestedScopesNotInRefreshToken() {
 	refreshTokenScopes := []string{"read", "write"}
 	logger := log.GetLogger()
 
-	// Request "read", "write", and "delete" - but "delete" is not in refresh token
-	result := suite.handler.applyScopeDownscoping("read write delete admin", refreshTokenScopes, logger)
+	result, errResp := suite.handler.validateAndApplyScopes("read write delete admin", refreshTokenScopes, logger)
 
-	assert.Len(suite.T(), result, 2)
-	assert.Contains(suite.T(), result, "read")
-	assert.Contains(suite.T(), result, "write")
-	assert.NotContains(suite.T(), result, "delete")
-	assert.NotContains(suite.T(), result, "admin")
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidScope, errResp.Error)
+	assert.Nil(suite.T(), result)
 }
 
-func (suite *RefreshTokenGrantHandlerTestSuite) TestApplyScopeDownscoping_NoMatchingScopes() {
+func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateAndApplyScopes_NoMatchingScopes() {
 	refreshTokenScopes := []string{"read", "write"}
 	logger := log.GetLogger()
 
-	result := suite.handler.applyScopeDownscoping("admin delete", refreshTokenScopes, logger)
+	result, errResp := suite.handler.validateAndApplyScopes("admin delete", refreshTokenScopes, logger)
 
-	assert.Empty(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidScope, errResp.Error)
+	assert.Nil(suite.T(), result)
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerated_WhenOpenIDScopePresent() {


### PR DESCRIPTION
This pull request updates the refresh token grant handling logic to enforce stricter OAuth2 scope validation in accordance with RFC 6749 §6. Now, when a client requests new scopes during a refresh token grant, the requested scopes must be a subset of the original scopes granted by the refresh token. If any requested scope exceeds the original grant, an `invalid_scope` error is returned. The tests have also been updated to reflect this stricter behavior.

**OAuth2 Scope Validation and Enforcement:**

* Replaced the `applyScopeDownscoping` method with `validateAndApplyScopes` in `refresh_token.go`, which now enforces that requested scopes must be a subset of the refresh token scopes, returning an error if not.
* Updated the `HandleGrant` method to use the new `validateAndApplyScopes` function and handle possible errors when validating requested scopes.

**Test Suite Updates:**

* Renamed and updated test methods in `refresh_token_test.go` to verify the new strict scope validation logic, including error handling when requested scopes exceed original scopes.

Related issue:
Fix 11 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth2 refresh token handler to properly validate requested scopes and return error responses for invalid scope requests instead of silently filtering them.
  * Improved RFC 6749 compliance for token refresh operations.
  * Enhanced scope validation to provide descriptive error messages when scope validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->