### PR TITLE
Add userinfo to discovery endpoints

### DIFF
--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -82,9 +82,9 @@ func (suite *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata() {
 	assert.NotEmpty(suite.T(), metadata.JWKSUri)
 	assert.NotEmpty(suite.T(), metadata.RegistrationEndpoint)
 	assert.NotEmpty(suite.T(), metadata.IntrospectionEndpoint)
+	assert.NotEmpty(suite.T(), metadata.UserInfoEndpoint)
 
 	// Verify only implemented endpoints are present
-	assert.Empty(suite.T(), metadata.UserInfoEndpoint)   // Not implemented
 	assert.Empty(suite.T(), metadata.RevocationEndpoint) // Not implemented
 
 	// Verify only implemented grant types are present

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -49,6 +49,7 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata() *OAuth2Author
 		Issuer:                            ds.getIssuer(),
 		AuthorizationEndpoint:             ds.getAuthorizationEndpoint(),
 		TokenEndpoint:                     ds.getTokenEndpoint(),
+		UserInfoEndpoint:                  ds.getUserInfoEndpoint(),
 		JWKSUri:                           ds.getJWKSUri(),
 		RegistrationEndpoint:              ds.getRegistrationEndpoint(),
 		IntrospectionEndpoint:             ds.getIntrospectionEndpoint(),
@@ -91,6 +92,10 @@ func (ds *discoveryService) getJWKSUri() string {
 
 func (ds *discoveryService) getIntrospectionEndpoint() string {
 	return ds.baseURL + constants.OAuth2IntrospectionEndpoint
+}
+
+func (ds *discoveryService) getUserInfoEndpoint() string {
+	return ds.baseURL + constants.OAuth2UserInfoEndpoint
 }
 
 func (ds *discoveryService) getRegistrationEndpoint() string {

--- a/tests/integration/oauth/discovery/discovery_test.go
+++ b/tests/integration/oauth/discovery/discovery_test.go
@@ -104,8 +104,11 @@ func (ts *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata_GET_Success(
 	ts.Contains(metadata.RegistrationEndpoint, "/oauth2/dcr/register", "RegistrationEndpoint should contain correct path")
 	ts.Contains(metadata.IntrospectionEndpoint, "/oauth2/introspect", "IntrospectionEndpoint should contain correct path")
 
+	// Verify userinfo endpoint is present
+	ts.NotEmpty(metadata.UserInfoEndpoint, "UserInfoEndpoint should be present")
+	ts.Contains(metadata.UserInfoEndpoint, "/oauth2/userinfo", "UserInfoEndpoint should contain correct path")
+
 	// Verify not implemented endpoints are empty
-	ts.Empty(metadata.UserInfoEndpoint, "UserInfoEndpoint should be empty (not implemented)")
 	ts.Empty(metadata.RevocationEndpoint, "RevocationEndpoint should be empty (not implemented)")
 
 	// Verify supported grant types


### PR DESCRIPTION
This pull request adds support for the OAuth2 UserInfo endpoint to the discovery service. The main changes ensure that the UserInfo endpoint is now included in the OAuth2 authorization server metadata and that the related test reflects this implementation.

**OAuth2 UserInfo Endpoint Support:**

* Added the `UserInfoEndpoint` to the metadata returned by `GetOAuth2AuthorizationServerMetadata` in `discovery/service.go`.
* Implemented the `getUserInfoEndpoint` method to construct the UserInfo endpoint URL in `discovery/service.go`.

**Testing Updates:**

* Updated the test `TestOAuth2AuthorizationServerMetadata` to assert that `UserInfoEndpoint` is not empty, reflecting its new implementation.

Related Issue:
15 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2 discovery metadata now includes UserInfoEndpoint, enabling clients to dynamically discover the user information endpoint for improved OpenID Connect compliance.

* **Tests**
  * Updated discovery validation tests to verify UserInfoEndpoint is properly populated and accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->