### PR TITLE
Fix OAuth2 redirect and CORS for local dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ backend/coverage_unit.html
 # IDE settings
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+# Dev configuration override (local developer settings)
+deployment.dev.yaml

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,10 @@ build_with_coverage_only:
 	@echo "================================================================"
 
 run:
-	./build.sh run $(OS) $(ARCH)
+	THUNDER_PROFILE=dev ./build.sh run $(OS) $(ARCH)
 
 run_backend:
-	./build.sh run_backend $(OS) $(ARCH)
+	THUNDER_PROFILE=dev ./build.sh run_backend $(OS) $(ARCH)
 
 run_frontend:
 	./build.sh run_frontend $(OS) $(ARCH)

--- a/README.md
+++ b/README.md
@@ -400,6 +400,52 @@ The product will now use the PostgreSQL database for its operations.
 
 </details>
 
+<details>
+<summary><h3>Development Configuration Override</h3></summary>
+
+Thunder supports a `deployment.dev.yaml` file that lets you override values from `deployment.yaml` for local development without changing the main configuration.
+
+#### Setup
+
+1. Navigate to the configuration directory:
+
+    ```bash
+    cd backend/cmd/server/repository/conf/
+    ```
+
+2. Copy the example file:
+
+    ```bash
+    cp deployment.dev.yaml.example deployment.dev.yaml
+    ```
+
+3. Edit `deployment.dev.yaml` with only the values you want to override:
+
+    ```yaml
+    # Example: Override the server port for local development
+    server:
+      port: 8443
+
+    # Example: Point the Gate Client to a separate frontend development server
+    gate_client:
+      hostname: "localhost"
+      port: 5190
+      scheme: "https"
+      path: "/gate"
+    ```
+
+4. Start the server using `make run` or `make run_backend`. These commands automatically activate the development profile.
+
+#### How It Works
+
+- **Development only** — this feature is not active in production or release builds; available only when running via `make run` or `make run_backend`.
+- The development profile is activated by the `THUNDER_PROFILE=dev` environment variable, which is set automatically by `make run` and `make run_backend`.
+- When active, the `deployment.dev.yaml` file is merged on top of `deployment.yaml`. Values in the development file take precedence.
+- The file is added to `.gitignore` and is excluded from the distribution package.
+- Include only the settings you want to override; remaining values are inherited from `deployment.yaml`.
+
+</details>
+
 </details>
 
 ---

--- a/backend/cmd/server/repository/conf/deployment.dev.yaml.example
+++ b/backend/cmd/server/repository/conf/deployment.dev.yaml.example
@@ -1,0 +1,36 @@
+# Development Configuration Overrides (Development Only)
+#
+# This file allows developers to override values from `deployment.yaml`
+# for local development without modifying the main configuration file.
+# It is NOT active in production or release builds.
+#
+# Usage:
+#   1. Copy this file and remove the `.example` extension:
+#        cp deployment.dev.yaml.example deployment.dev.yaml
+#   2. Uncomment and modify the settings you want to override.
+#   3. Run the server normally (e.g., `make run` or `make run_backend`).
+#
+# Notes:
+#   - This file is loaded only when the dev profile is active
+#     (i.e., when THUNDER_PROFILE=dev is set in the environment).
+#   - `make run` and `make run_backend` set this automatically.
+#   - Values defined here take precedence over `deployment.yaml`.
+#   - You only need to include the values you want to override.
+#   - This file is excluded from version control and will NOT be included
+#     in the Thunder distribution package.
+
+
+# Example: Override gate client for a separate frontend dev server.
+# gate_client:
+#   hostname: "localhost"
+#   port: 5190
+#   scheme: "https"
+#   path: "/gate"
+
+# Example: Add additional CORS origins for local frontend development.
+# cors:
+#   allowed_origins:
+#     - "https://localhost:3000"
+#     - "https://localhost:5190"
+#     - "https://localhost:5191"
+#     - "http://localhost:3000"

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -373,7 +373,12 @@ type Config struct {
 	Layout               LayoutConfig           `yaml:"layout" json:"layout"`
 }
 
+// devConfigFileName is the name of the optional development configuration override file.
+const devConfigFileName = "deployment.dev.yaml"
+
 // LoadConfig loads the configurations from the specified YAML file and applies defaults.
+// If a deployment.dev.yaml file exists alongside the main config, it will be loaded and
+// merged on top, allowing developers to override configuration values for local development.
 func LoadConfig(configPath string, defaultPath string, thunderHome string) (*Config, error) {
 	var cfg Config
 
@@ -395,6 +400,19 @@ func LoadConfig(configPath string, defaultPath string, thunderHome string) (*Con
 
 	// Merge user configuration with defaults
 	mergeConfigs(&cfg, &userCfg)
+
+	// Load dev configuration override if it exists and the dev profile is active.
+	if os.Getenv("THUNDER_PROFILE") == "dev" {
+		devConfigPath := deriveDevConfigPath(configPath)
+		if _, err := os.Stat(devConfigPath); err == nil {
+			devCfg, loadErr := loadUserConfig(devConfigPath, thunderHome)
+			if loadErr != nil {
+				return nil, fmt.Errorf("failed to load dev configuration override (%s): %w", devConfigPath, loadErr)
+			}
+			mergeConfigs(&cfg, &devCfg)
+		}
+	}
+
 	// Derive login_path and error_path from path if not explicitly set
 	if cfg.GateClient.Path != "" {
 		if cfg.GateClient.LoginPath == "" {
@@ -411,6 +429,13 @@ func LoadConfig(configPath string, defaultPath string, thunderHome string) (*Con
 	}
 
 	return &cfg, nil
+}
+
+// deriveDevConfigPath returns the path for the development configuration override file
+// based on the main configuration file path.
+func deriveDevConfigPath(configPath string) string {
+	dir := filepath.Dir(configPath)
+	return filepath.Join(dir, devConfigFileName)
 }
 
 // loadDefaultConfig loads the default configuration from a JSON file.

--- a/backend/internal/system/config/config_test.go
+++ b/backend/internal/system/config/config_test.go
@@ -737,6 +737,262 @@ gate_client:
 	assert.Equal(suite.T(), "/newapp/error", config5.GateClient.ErrorPath)
 }
 
+func (suite *ConfigTestSuite) TestDeriveDevConfigPath() {
+	// Test deriving dev config path from various config paths
+	tests := []struct {
+		name       string
+		configPath string
+		expected   string
+	}{
+		{
+			name:       "Standard path",
+			configPath: "/path/to/conf/deployment.yaml",
+			expected:   "/path/to/conf/deployment.dev.yaml",
+		},
+		{
+			name:       "Relative path",
+			configPath: "conf/deployment.yaml",
+			expected:   "conf/deployment.dev.yaml",
+		},
+		{
+			name:       "Current directory",
+			configPath: "deployment.yaml",
+			expected:   "deployment.dev.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := deriveDevConfigPath(tt.configPath)
+			assert.Equal(suite.T(), tt.expected, result)
+		})
+	}
+}
+
+const baseTestConfig = `
+server:
+  hostname: "base-host"
+  port: 8090
+`
+
+func (suite *ConfigTestSuite) TestLoadConfig_WithDevOverride() {
+	tempDir := suite.T().TempDir()
+	confDir := tempDir + "/conf"
+	err := os.MkdirAll(confDir, 0750)
+	suite.Require().NoError(err)
+
+	suite.setEnvVar("THUNDER_PROFILE", "dev")
+
+	// Create a base deployment.yaml
+	baseContent := `
+server:
+  hostname: "base-host"
+  port: 8090
+
+gate_client:
+  hostname: "base-gate"
+  port: 9080
+  scheme: "https"
+  path: "/gate"
+`
+	basePath := confDir + "/deployment.yaml"
+	err = os.WriteFile(basePath, []byte(baseContent), 0600)
+	suite.Require().NoError(err)
+
+	// Create a deployment.dev.yaml that overrides some values
+	devContent := `
+server:
+  hostname: "dev-host"
+  http_only: true
+
+gate_client:
+  port: 5190
+`
+	devPath := confDir + "/deployment.dev.yaml"
+	err = os.WriteFile(devPath, []byte(devContent), 0600)
+	suite.Require().NoError(err)
+
+	config, err := LoadConfig(basePath, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	// Values overridden by dev config
+	assert.Equal(suite.T(), "dev-host", config.Server.Hostname)
+	assert.Equal(suite.T(), true, config.Server.HTTPOnly)
+	assert.Equal(suite.T(), 5190, config.GateClient.Port)
+
+	// Values preserved from base config
+	assert.Equal(suite.T(), 8090, config.Server.Port)
+	assert.Equal(suite.T(), "base-gate", config.GateClient.Hostname)
+	assert.Equal(suite.T(), "https", config.GateClient.Scheme)
+	assert.Equal(suite.T(), "/gate", config.GateClient.Path)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfig_WithDevOverrideButProfileNotSet() {
+	tempDir := suite.T().TempDir()
+	confDir := tempDir + "/conf"
+	err := os.MkdirAll(confDir, 0750)
+	suite.Require().NoError(err)
+
+	// Explicitly unset the profile
+	suite.setEnvVar("THUNDER_PROFILE", "")
+
+	// Create a base deployment.yaml
+	basePath := confDir + "/deployment.yaml"
+	err = os.WriteFile(basePath, []byte(baseTestConfig), 0600)
+	suite.Require().NoError(err)
+
+	// Create a deployment.dev.yaml that overrides some values
+	devContent := `
+server:
+  hostname: "dev-host"
+`
+	devPath := confDir + "/deployment.dev.yaml"
+	err = os.WriteFile(devPath, []byte(devContent), 0600)
+	suite.Require().NoError(err)
+
+	config, err := LoadConfig(basePath, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	// Values should NOT be overridden as THUNDER_PROFILE is not 'dev'
+	assert.Equal(suite.T(), "base-host", config.Server.Hostname)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfig_WithoutDevOverride() {
+	tempDir := suite.T().TempDir()
+	confDir := tempDir + "/conf"
+	err := os.MkdirAll(confDir, 0750)
+	suite.Require().NoError(err)
+
+	suite.setEnvVar("THUNDER_PROFILE", "dev")
+
+	// Create only a base deployment.yaml (no dev override)
+	basePath := confDir + "/deployment.yaml"
+	err = os.WriteFile(basePath, []byte(baseTestConfig), 0600)
+	suite.Require().NoError(err)
+
+	config, err := LoadConfig(basePath, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	// Values from base config should be unchanged
+	assert.Equal(suite.T(), "base-host", config.Server.Hostname)
+	assert.Equal(suite.T(), 8090, config.Server.Port)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfig_WithInvalidDevOverride() {
+	tempDir := suite.T().TempDir()
+	confDir := tempDir + "/conf"
+	err := os.MkdirAll(confDir, 0750)
+	suite.Require().NoError(err)
+
+	suite.setEnvVar("THUNDER_PROFILE", "dev")
+
+	// Create a valid base deployment.yaml
+	basePath := confDir + "/deployment.yaml"
+	err = os.WriteFile(basePath, []byte(baseTestConfig), 0600)
+	suite.Require().NoError(err)
+
+	// Create an invalid deployment.dev.yaml
+	invalidDevContent := `invalid: yaml: content: [broken`
+	devPath := confDir + "/deployment.dev.yaml"
+	err = os.WriteFile(devPath, []byte(invalidDevContent), 0600)
+	suite.Require().NoError(err)
+
+	_, err = LoadConfig(basePath, "", tempDir)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to load dev configuration override")
+}
+
+func (suite *ConfigTestSuite) TestLoadConfig_DevOverrideWithEnvVars() {
+	tempDir := suite.T().TempDir()
+	confDir := tempDir + "/conf"
+	err := os.MkdirAll(confDir, 0750)
+	suite.Require().NoError(err)
+
+	suite.setEnvVar("THUNDER_PROFILE", "dev")
+
+	// Create a base deployment.yaml
+	basePath := confDir + "/deployment.yaml"
+	err = os.WriteFile(basePath, []byte(baseTestConfig), 0600)
+	suite.Require().NoError(err)
+
+	// Create a deployment.dev.yaml with environment variable references
+	devContent := `
+server:
+  hostname: "{{.DEV_HOSTNAME}}"
+`
+	devPath := confDir + "/deployment.dev.yaml"
+	err = os.WriteFile(devPath, []byte(devContent), 0600)
+	suite.Require().NoError(err)
+
+	suite.setEnvVar("DEV_HOSTNAME", "env-dev-host")
+
+	config, err := LoadConfig(basePath, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	// Dev override with env var substitution
+	assert.Equal(suite.T(), "env-dev-host", config.Server.Hostname)
+	assert.Equal(suite.T(), 8090, config.Server.Port)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfig_DevOverrideWithDefaults() {
+	tempDir := suite.T().TempDir()
+	confDir := tempDir + "/conf"
+	err := os.MkdirAll(confDir, 0750)
+	suite.Require().NoError(err)
+
+	suite.setEnvVar("THUNDER_PROFILE", "dev")
+
+	// Create a defaults JSON config
+	defaultContent := `{
+  "server": {
+    "hostname": "default-host",
+    "port": 8080,
+    "http_only": false
+  },
+  "jwt": {
+    "validity_period": 7200
+  }
+}`
+	defaultPath := suite.createTempFile(tempDir, "default*.json", defaultContent)
+
+	// Create a base deployment.yaml
+	baseContent := `
+server:
+  hostname: "user-host"
+  port: 8090
+`
+	basePath := confDir + "/deployment.yaml"
+	err = os.WriteFile(basePath, []byte(baseContent), 0600)
+	suite.Require().NoError(err)
+
+	// Create a deployment.dev.yaml
+	devContent := `
+server:
+  http_only: true
+`
+	devPath := confDir + "/deployment.dev.yaml"
+	err = os.WriteFile(devPath, []byte(devContent), 0600)
+	suite.Require().NoError(err)
+
+	config, err := LoadConfig(basePath, defaultPath, tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	// Three-layer merge: defaults -> user -> dev
+	assert.Equal(suite.T(), "user-host", config.Server.Hostname)    // From user config
+	assert.Equal(suite.T(), 8090, config.Server.Port)               // From user config
+	assert.Equal(suite.T(), true, config.Server.HTTPOnly)           // From dev override
+	assert.Equal(suite.T(), int64(7200), config.JWT.ValidityPeriod) // From defaults
+}
+
+func (suite *ConfigTestSuite) TestDevConfigFileName() {
+	assert.Equal(suite.T(), "deployment.dev.yaml", devConfigFileName)
+}
+
 func (suite *ConfigTestSuite) createTempFile(dir, pattern, content string) string {
 	tempFile, err := os.CreateTemp(dir, pattern)
 	suite.Require().NoError(err, "failed to create temp file")

--- a/build.ps1
+++ b/build.ps1
@@ -553,6 +553,13 @@ function Prepare-Backend-For-Packaging {
     Write-Host "=== Ensuring crypto file exists in the distribution ==="
     Ensure-Crypto-File -conf_dir (Join-Path $package_folder "repository/conf")
     Write-Host "================================================================"
+
+    Write-Host "=== Ensuring dev configuration override is excluded from the distribution ==="
+    $devConfigPath = Join-Path $package_folder "repository/conf/deployment.dev.yaml"
+    if (Test-Path $devConfigPath) {
+        Remove-Item -Path $devConfigPath -Force
+    }
+    Write-Host "================================================================"
 }
 
 function Prepare-Frontend-For-Packaging {

--- a/build.sh
+++ b/build.sh
@@ -407,6 +407,10 @@ function prepare_backend_for_packaging() {
     ensure_certificates "$DIST_DIR/$PRODUCT_FOLDER/$SECURITY_DIR" "signing"
     echo "================================================================"
 
+    echo "=== Ensuring dev configuration override is excluded from the distribution ==="
+    rm -f "$DIST_DIR/$PRODUCT_FOLDER/repository/conf/deployment.dev.yaml"
+    echo "================================================================"
+
     echo "=== Ensuring crypto file exists in the distribution ==="
     ensure_crypto_file "$DIST_DIR/$PRODUCT_FOLDER/$SECURITY_DIR"
     echo "================================================================"

--- a/docs/content/community/contributing/contributing-code/configure-and-run.mdx
+++ b/docs/content/community/contributing/contributing-code/configure-and-run.mdx
@@ -9,30 +9,32 @@ hide_table_of_contents: false
 
 ## Configure the Server
 
-Open `backend/cmd/server/repository/conf/deployment.yaml` in your favorite text editor and make the following changes:
+Thunder supports a development configuration override file that lets you customize settings for local development without changing the main `deployment.yaml` file.
 
-**Add CORS allowed origins:**
+:::warning Development Only
+This feature is limited to development mode (`make run` / `make run_backend`) and is not active in production or release builds.
+:::
+
+**Create your development configuration:**
+
+```bash
+cp backend/cmd/server/repository/conf/deployment.dev.yaml.example backend/cmd/server/repository/conf/deployment.dev.yaml
+```
+
+**Add CORS allowed origins and configure the Gate Client:**
 
 ```yaml
 cors:
   allowed_origins:
     - "https://localhost:5190"
     - "https://localhost:5191"
-```
 
-:::tip
-This configuration allows the Thunder Gate and Thunder Develop applications to communicate with the backend server during development.
-:::
-
-**Configure the Gate client:**
-
-```yaml
 gate_client:
   port: 5190
 ```
 
 :::tip
-This configuration points the backend server to the local Thunder Gate application for authentication.
+This file is added to `.gitignore` and is excluded from the distribution package. Include only the values you want to override — remaining values are inherited from `deployment.yaml`.
 :::
 
 ## Run the Server


### PR DESCRIPTION
Fixes #1644

## Summary

When running Thunder in local dev mode (`make run`), the OAuth2 flow redirects to `https://localhost:8090/gate/signin` (the backend) instead of `https://localhost:5190/gate/signin` (the Gate Vite dev server), resulting in a 404.

## Changes

- **`deployment.yaml`**: Add `gate_client` config pointing to port 5190 so the OAuth2 flow redirects to the Gate frontend dev server
- **`deployment.yaml`**: Add CORS allowed origins for frontend dev server ports 5190 and 5191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development configuration override system allowing local developers to customize settings without touching production configs.

* **Documentation**
  * Added detailed README and contributing guide instructions for creating and using the local development override and run workflows.

* **Chores**
  * Updated build/packaging and run scripts to use and exclude the development override from production artifacts.
  * Added the development override to ignore rules.

* **Tests**
  * Added extensive tests covering override loading, path derivation, merging, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->