### PR TITLE
Refactor OU hierarchy resolver to decouple self-inclusion logic

### DIFF
--- a/backend/internal/ou/hierarchy_resolver.go
+++ b/backend/internal/ou/hierarchy_resolver.go
@@ -42,13 +42,13 @@ func newOUHierarchyAdapter(store organizationUnitStoreInterface) sysauthz.OUHier
 	return &ouHierarchyAdapter{store: store}
 }
 
-// IsAncestorOrSelf returns true when ancestorOUID equals descendantOUID, or when
-// ancestorOUID appears anywhere in the parent chain above descendantOUID.
+// IsAncestor returns true when ancestorOUID appears anywhere in the parent
+// chain above descendantOUID.
 //
 // The walk is upward from descendantOUID; reaching the root without finding ancestorOUID
 // returns false. A broken chain (OU not found) is treated as deny-safe: false is returned
 // with no error so the authz layer can decide accordingly.
-func (r *ouHierarchyAdapter) IsAncestorOrSelf(
+func (r *ouHierarchyAdapter) IsAncestor(
 	ctx context.Context, ancestorOUID, descendantOUID string,
 ) (bool, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameHierarchyResolver))
@@ -60,10 +60,6 @@ func (r *ouHierarchyAdapter) IsAncestorOrSelf(
 	current := descendantOUID
 	visited := make(map[string]struct{})
 	for {
-		if current == ancestorOUID {
-			return true, nil
-		}
-
 		if _, ok := visited[current]; ok {
 			logger.Error("Cyclic organization unit parent chain detected during ancestry check",
 				log.String("ouID", current))
@@ -88,13 +84,16 @@ func (r *ouHierarchyAdapter) IsAncestorOrSelf(
 			break
 		}
 		current = *ou.Parent
+		if current == ancestorOUID {
+			return true, nil
+		}
 	}
 
 	return false, nil
 }
 
-// GetAncestorOUIDs returns ouID itself followed by every ancestor OU ID, walking up to
-// the root of the tree. The returned slice always contains at least ouID itself.
+// GetAncestorOUIDs returns every ancestor OU ID, walking up to
+// the root of the tree.
 //
 // If the chain is broken (an OU in the hierarchy is not found), the walk stops and a
 // ServiceError is returned so callers can handle incomplete results explicitly.
@@ -119,8 +118,6 @@ func (r *ouHierarchyAdapter) GetAncestorOUIDs(
 		}
 		visited[current] = struct{}{}
 
-		result = append(result, current)
-
 		ou, err := r.store.GetOrganizationUnit(current)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
@@ -137,6 +134,11 @@ func (r *ouHierarchyAdapter) GetAncestorOUIDs(
 			break
 		}
 		current = *ou.Parent
+		result = append(result, current)
+	}
+
+	if result == nil {
+		result = []string{}
 	}
 
 	return result, nil

--- a/backend/internal/ou/hierarchy_resolver_test.go
+++ b/backend/internal/ou/hierarchy_resolver_test.go
@@ -87,11 +87,14 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			wantResult:     false,
 		},
 		{
-			name:           "SameOUID_ReturnsTrue",
+			name:           "SameOUID_ReturnsFalse",
 			ancestorOUID:   "ou1",
 			descendantOUID: "ou1",
-			setupMock:      func(m *organizationUnitStoreInterfaceMock) {},
-			wantResult:     true,
+			setupMock: func(m *organizationUnitStoreInterfaceMock) {
+				m.On("GetOrganizationUnit", "ou1").
+					Return(OrganizationUnit{ID: "ou1", Parent: nil}, nil)
+			},
+			wantResult: false,
 		},
 		{
 			name:           "DirectParent_ReturnsTrue",
@@ -185,7 +188,7 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			tt.setupMock(mockStore)
 			resolver := newOUHierarchyAdapter(mockStore)
 
-			result, svcErr := resolver.IsAncestorOrSelf(context.Background(), tt.ancestorOUID, tt.descendantOUID)
+			result, svcErr := resolver.IsAncestor(context.Background(), tt.ancestorOUID, tt.descendantOUID)
 			assert.Equal(suite.T(), tt.wantResult, result)
 			if tt.wantErr {
 				assert.NotNil(suite.T(), svcErr)
@@ -217,16 +220,16 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			wantIDs:   []string{},
 		},
 		{
-			name: "RootOU_NoParent_ReturnsSelf",
+			name: "RootOU_NoParent_ReturnsEmpty",
 			ouID: "root-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				m.On("GetOrganizationUnit", "root-ou").
 					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
 			},
-			wantIDs: []string{"root-ou"},
+			wantIDs: []string{},
 		},
 		{
-			name: "ChildOU_ReturnsSelfAndParent",
+			name: "ChildOU_ReturnsParent",
 			ouID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
@@ -235,10 +238,10 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 				m.On("GetOrganizationUnit", testCoverageParentOUID).
 					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: nil}, nil)
 			},
-			wantIDs: []string{"child-ou", testCoverageParentOUID},
+			wantIDs: []string{testCoverageParentOUID},
 		},
 		{
-			name: "ThreeLevelHierarchy_ReturnsSelfParentGrandparent",
+			name: "ThreeLevelHierarchy_ReturnsParentGrandparent",
 			ouID: "grandchild-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
@@ -250,7 +253,7 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 				m.On("GetOrganizationUnit", "root-ou").
 					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
 			},
-			wantIDs: []string{"grandchild-ou", testCoverageParentOUID, "root-ou"},
+			wantIDs: []string{testCoverageParentOUID, "root-ou"},
 		},
 		{
 			name: "BrokenChain_OUNotFound_ReturnsNilAndError",

--- a/backend/internal/system/sysauthz/model.go
+++ b/backend/internal/system/sysauthz/model.go
@@ -32,15 +32,14 @@ import (
 // The ou package implements this interface and injects a concrete instance via
 // SystemAuthorizationServiceInterface.SetOUHierarchyResolver at application startup.
 type OUHierarchyResolver interface {
-	// IsAncestorOrSelf returns true when ancestorOUID is the same as descendantOUID, or
-	// when ancestorOUID appears anywhere in the parent chain above descendantOUID.
+	// IsAncestor returns true when ancestorOUID appears anywhere in the parent
+	// chain above descendantOUID.
 	// A non-nil ServiceError indicates a traversal failure; the caller should treat the
 	// result as false (deny-safe).
-	IsAncestorOrSelf(ctx context.Context, ancestorOUID, descendantOUID string) (bool, *serviceerror.ServiceError)
+	IsAncestor(ctx context.Context, ancestorOUID, descendantOUID string) (bool, *serviceerror.ServiceError)
 
-	// GetAncestorOUIDs returns the ouID itself followed by every ancestor OU ID walking up
-	// to the root of the tree. The list always contains at least ouID itself (when the OU
-	// has no parent). A non-nil ServiceError indicates a traversal failure.
+	// GetAncestorOUIDs returns every ancestor OU ID walking up
+	// to the root of the tree. A non-nil ServiceError indicates a traversal failure.
 	GetAncestorOUIDs(ctx context.Context, ouID string) ([]string, *serviceerror.ServiceError)
 }
 

--- a/backend/internal/system/sysauthz/policy.go
+++ b/backend/internal/system/sysauthz/policy.go
@@ -120,9 +120,12 @@ func (p *ouInheritancePolicy) isActionAllowed(ctx context.Context,
 	if callerOUID == "" {
 		return policyDecisionDenied, nil
 	}
-	// Allow if the resource's OU is an ancestor of (or the same as) the caller's OU.
-	// i.e. the caller belongs to the resource's OU or to one of its descendants.
-	isAncestor, svcErr := p.resolver.IsAncestorOrSelf(ctx, actionCtx.OuID, callerOUID)
+	if callerOUID == actionCtx.OuID {
+		return policyDecisionAllowed, nil
+	}
+	// Allow if the resource's OU is an ancestor of the caller's OU.
+	// i.e. the caller belongs to one of its descendants.
+	isAncestor, svcErr := p.resolver.IsAncestor(ctx, actionCtx.OuID, callerOUID)
 	if svcErr != nil {
 		return policyDecisionDenied, svcErr
 	}
@@ -147,7 +150,11 @@ func (p *ouInheritancePolicy) getAccessibleResources(ctx context.Context, action
 	if svcErr != nil {
 		return true, nil, svcErr
 	}
-	return true, &AccessibleResources{AllAllowed: false, IDs: ancestorIDs}, nil
+
+	resultIDs := []string{callerOUID}
+	resultIDs = append(resultIDs, ancestorIDs...)
+
+	return true, &AccessibleResources{AllAllowed: false, IDs: resultIDs}, nil
 }
 
 // inheritanceReadActions is the set of read-only actions that use OU-inheritance semantics.

--- a/backend/internal/system/sysauthz/policy_test.go
+++ b/backend/internal/system/sysauthz/policy_test.go
@@ -53,7 +53,7 @@ func (p *stubPolicy) getAccessibleResources(_ context.Context, _ security.Action
 
 // stubOUHierarchyResolver is a configurable OUHierarchyResolver for testing.
 type stubOUHierarchyResolver struct {
-	// IsAncestorOrSelf response fields.
+	// IsAncestor response fields.
 	isAncestorResult bool
 	isAncestorErr    *serviceerror.ServiceError
 
@@ -62,7 +62,7 @@ type stubOUHierarchyResolver struct {
 	ancestorIDsErr *serviceerror.ServiceError
 }
 
-func (r *stubOUHierarchyResolver) IsAncestorOrSelf(
+func (r *stubOUHierarchyResolver) IsAncestor(
 	_ context.Context, _, _ string,
 ) (bool, *serviceerror.ServiceError) {
 	return r.isAncestorResult, r.isAncestorErr
@@ -434,7 +434,7 @@ func TestOuInheritancePolicy_GetAccessibleResources(t *testing.T) {
 			ctx:            buildCtxWithOU("", "child-ou"),
 			resourceType:   security.ResourceTypeUserSchema,
 			action:         security.ActionListUserSchemas,
-			resolver:       &stubOUHierarchyResolver{ancestorIDs: []string{"child-ou", "parent-ou", "root-ou"}},
+			resolver:       &stubOUHierarchyResolver{ancestorIDs: []string{"parent-ou", "root-ou"}},
 			wantApplicable: true,
 			wantAllAllowed: false,
 			wantIDs:        []string{"child-ou", "parent-ou", "root-ou"},

--- a/backend/internal/system/sysauthz/service_test.go
+++ b/backend/internal/system/sysauthz/service_test.go
@@ -476,7 +476,7 @@ func (s *SystemAuthzTestSuite) TestInheritancePolicy_DeniesWriteFromChildOU() {
 
 func (s *SystemAuthzTestSuite) TestGetAccessibleResources_InheritancePolicy_ReturnsAncestors() {
 	resolver := &stubOUHierarchyResolver{
-		ancestorIDs: []string{"child-ou", "parent-ou", "root-ou"},
+		ancestorIDs: []string{"parent-ou", "root-ou"},
 	}
 	s.service.SetOUHierarchyResolver(resolver)
 	defer s.service.SetOUHierarchyResolver(nil)


### PR DESCRIPTION
### Purpose
This pull request updates the organizational unit (OU) hierarchy logic and its usage in the authorization system to improve semantic clarity and correctness. The main changes involve removing "self" from ancestor checks and ancestor lists, renaming methods for clarity, and updating related tests and documentation.

**Hierarchy logic changes:**

* The method `IsAncestorOrSelf` is renamed to `IsAncestor` and its semantics are changed: it now only returns `true` if the ancestor OU appears in the parent chain above the descendant OU, not if they are the same OU. [[1]](diffhunk://#diff-01a58d950f3ea7d164f1aa65a6e650feec88370522eb12930d3f36344e8f039cL45-R51) [[2]](diffhunk://#diff-01a58d950f3ea7d164f1aa65a6e650feec88370522eb12930d3f36344e8f039cL63-L66) [[3]](diffhunk://#diff-ea519a9269ac7fca0c61a2aaf82894fadb7d4b7b14483df3998cd40c14ef949eL35-R42)
* The `GetAncestorOUIDs` method no longer includes the OU itself in the returned list of ancestor IDs; it now returns only the actual ancestors. [[1]](diffhunk://#diff-01a58d950f3ea7d164f1aa65a6e650feec88370522eb12930d3f36344e8f039cR87-R96) [[2]](diffhunk://#diff-01a58d950f3ea7d164f1aa65a6e650feec88370522eb12930d3f36344e8f039cL122-L123) [[3]](diffhunk://#diff-01a58d950f3ea7d164f1aa65a6e650feec88370522eb12930d3f36344e8f039cR137-R141) [[4]](diffhunk://#diff-ea519a9269ac7fca0c61a2aaf82894fadb7d4b7b14483df3998cd40c14ef949eL35-R42)

**Authorization policy and usage updates:**

* The OU inheritance policy now explicitly allows access if the caller's OU matches the resource's OU, and otherwise checks only for true ancestor relationships using the updated `IsAncestor` method.
* The list of accessible resource OUs now always includes the caller's OU, followed by its ancestors, to reflect the new ancestor list semantics.

**Test updates:**

* All tests and stubs are updated to use the new method names and semantics, ensuring that "self" is not considered an ancestor and is not included in ancestor lists. [[1]](diffhunk://#diff-f9b7f9e052ddec340d9fcf25f7597b6b627da774de3e298ff322ba9d7aeccc21L90-R97) [[2]](diffhunk://#diff-f9b7f9e052ddec340d9fcf25f7597b6b627da774de3e298ff322ba9d7aeccc21L188-R191) [[3]](diffhunk://#diff-f9b7f9e052ddec340d9fcf25f7597b6b627da774de3e298ff322ba9d7aeccc21L220-R232) [[4]](diffhunk://#diff-f9b7f9e052ddec340d9fcf25f7597b6b627da774de3e298ff322ba9d7aeccc21L238-R244) [[5]](diffhunk://#diff-f9b7f9e052ddec340d9fcf25f7597b6b627da774de3e298ff322ba9d7aeccc21L253-R256) [[6]](diffhunk://#diff-5f095690a9a40141fb94cf7673ed9f2dfe55a6aaeb0c856e94969a35f5838a6cL56-R56) [[7]](diffhunk://#diff-5f095690a9a40141fb94cf7673ed9f2dfe55a6aaeb0c856e94969a35f5838a6cL65-R65) [[8]](diffhunk://#diff-5f095690a9a40141fb94cf7673ed9f2dfe55a6aaeb0c856e94969a35f5838a6cL437-R437) [[9]](diffhunk://#diff-958899749fa573862395e7afd41797ac6415a110436b435b309036d43444040fL479-R479)

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected organizational unit hierarchy evaluation in permission inheritance logic to properly distinguish between a unit and its ancestors.

* **Refactoring**
  * Updated authorization checks for organizational structure-based access control to align with refined hierarchy semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->