### PR TITLE
Refactor exporters structs

### DIFF
--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -36,18 +36,18 @@ const (
 	paramTypApplication     = "Application"
 )
 
-// ApplicationExporter implements declarativeresource.ResourceExporter for applications.
-type ApplicationExporter struct {
+// applicationExporter implements declarativeresource.ResourceExporter for applications.
+type applicationExporter struct {
 	service ApplicationServiceInterface
 }
 
 // newApplicationExporter creates a new application exporter.
-func newApplicationExporter(service ApplicationServiceInterface) *ApplicationExporter {
-	return &ApplicationExporter{service: service}
+func newApplicationExporter(service ApplicationServiceInterface) *applicationExporter {
+	return &applicationExporter{service: service}
 }
 
 // NewApplicationExporterForTest creates a new application exporter for testing purposes.
-func NewApplicationExporterForTest(service ApplicationServiceInterface) *ApplicationExporter {
+func NewApplicationExporterForTest(service ApplicationServiceInterface) *applicationExporter {
 	if !testing.Testing() {
 		panic("only for tests!")
 	}
@@ -55,18 +55,18 @@ func NewApplicationExporterForTest(service ApplicationServiceInterface) *Applica
 }
 
 // GetResourceType returns the resource type for applications.
-func (e *ApplicationExporter) GetResourceType() string {
+func (e *applicationExporter) GetResourceType() string {
 	return resourceTypeApplication
 }
 
 // GetParameterizerType returns the parameterizer type for applications.
-func (e *ApplicationExporter) GetParameterizerType() string {
+func (e *applicationExporter) GetParameterizerType() string {
 	return paramTypApplication
 }
 
 // GetAllResourceIDs retrieves all application IDs.
 // In composite mode, this excludes declarative (YAML-based) applications.
-func (e *ApplicationExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *applicationExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	apps, err := e.service.GetApplicationList()
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (e *ApplicationExporter) GetAllResourceIDs(ctx context.Context) ([]string, 
 }
 
 // GetResourceByID retrieves an application by its ID.
-func (e *ApplicationExporter) GetResourceByID(ctx context.Context, id string) (
+func (e *applicationExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *serviceerror.ServiceError,
 ) {
 	app, err := e.service.GetApplication(id)
@@ -93,7 +93,7 @@ func (e *ApplicationExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates an application resource.
-func (e *ApplicationExporter) ValidateResource(
+func (e *applicationExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	app, ok := resource.(*model.Application)
@@ -277,7 +277,7 @@ func validateApplicationWrapper(
 }
 
 // GetResourceRules returns the parameterization rules for applications.
-func (e *ApplicationExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *applicationExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	return &declarativeresource.ResourceRules{
 		Variables: []string{
 			"InboundAuthConfig[].OAuthAppConfig.ClientID",

--- a/backend/internal/application/declarative_resource_test.go
+++ b/backend/internal/application/declarative_resource_test.go
@@ -33,11 +33,11 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
 )
 
-// ApplicationExporterTestSuite tests the ApplicationExporter.
+// ApplicationExporterTestSuite tests the applicationExporter.
 type ApplicationExporterTestSuite struct {
 	suite.Suite
 	mockService *applicationmock.ApplicationServiceInterfaceMock
-	exporter    *application.ApplicationExporter
+	exporter    declarativeresource.ResourceExporter
 	logger      *log.Logger
 }
 
@@ -176,8 +176,4 @@ func (s *ApplicationExporterTestSuite) TestValidateResource_EmptyName() {
 	assert.Equal(s.T(), "app1", err.ResourceID)
 	assert.Equal(s.T(), "APP_VALIDATION_ERROR", err.Code)
 	assert.Contains(s.T(), err.Error, "name is empty")
-}
-
-func (s *ApplicationExporterTestSuite) TestApplicationExporterImplementsInterface() {
-	var _ declarativeresource.ResourceExporter = (*application.ApplicationExporter)(nil)
 }

--- a/backend/internal/flow/mgt/declarative_resource.go
+++ b/backend/internal/flow/mgt/declarative_resource.go
@@ -35,33 +35,33 @@ const (
 	paramTypeFlow    = "Flow"
 )
 
-// FlowGraphExporter implements declarativeresource.ResourceExporter for flow graphs.
-type FlowGraphExporter struct {
+// flowGraphExporter implements declarativeresource.ResourceExporter for flow graphs.
+type flowGraphExporter struct {
 	service FlowMgtServiceInterface
 }
 
 // newFlowGraphExporter creates a new flow graph exporter.
-func newFlowGraphExporter(service FlowMgtServiceInterface) *FlowGraphExporter {
-	return &FlowGraphExporter{service: service}
+func newFlowGraphExporter(service FlowMgtServiceInterface) *flowGraphExporter {
+	return &flowGraphExporter{service: service}
 }
 
 // NewFlowGraphExporterForTest creates a new flow graph exporter for testing purposes.
-func NewFlowGraphExporterForTest(service FlowMgtServiceInterface) *FlowGraphExporter {
+func NewFlowGraphExporterForTest(service FlowMgtServiceInterface) *flowGraphExporter {
 	return newFlowGraphExporter(service)
 }
 
 // GetResourceType returns the resource type for flow graphs.
-func (e *FlowGraphExporter) GetResourceType() string {
+func (e *flowGraphExporter) GetResourceType() string {
 	return resourceTypeFlow
 }
 
 // GetParameterizerType returns the parameterizer type for flow graphs.
-func (e *FlowGraphExporter) GetParameterizerType() string {
+func (e *flowGraphExporter) GetParameterizerType() string {
 	return paramTypeFlow
 }
 
 // GetAllResourceIDs retrieves all flow graph IDs.
-func (e *FlowGraphExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *flowGraphExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	flows, err := e.service.ListFlows(10000, 0, common.FlowType(""))
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func (e *FlowGraphExporter) GetAllResourceIDs(ctx context.Context) ([]string, *s
 }
 
 // GetResourceByID retrieves a flow graph by its ID.
-func (e *FlowGraphExporter) GetResourceByID(ctx context.Context, id string) (
+func (e *flowGraphExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *serviceerror.ServiceError,
 ) {
 	flow, err := e.service.GetFlow(id)
@@ -85,7 +85,7 @@ func (e *FlowGraphExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a flow graph resource.
-func (e *FlowGraphExporter) ValidateResource(
+func (e *flowGraphExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	flow, ok := resource.(*CompleteFlowDefinition)
@@ -103,7 +103,7 @@ func (e *FlowGraphExporter) ValidateResource(
 
 // GetResourceRules returns the parameterization rules for flow graphs.
 // Currently returns empty rules as no parameterization is needed for graphs at this stage.
-func (e *FlowGraphExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *flowGraphExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	return &declarativeresource.ResourceRules{}
 }
 

--- a/backend/internal/idp/declarative_resource.go
+++ b/backend/internal/idp/declarative_resource.go
@@ -37,18 +37,18 @@ const (
 	paramTypIdentityProvider     = "IdentityProvider"
 )
 
-// IDPExporter implements declarativeresource.ResourceExporter for identity providers.
-type IDPExporter struct {
+// idpExporter implements declarativeresource.ResourceExporter for identity providers.
+type idpExporter struct {
 	service IDPServiceInterface
 }
 
 // newIDPExporter creates a new IDP exporter.
-func newIDPExporter(service IDPServiceInterface) *IDPExporter {
-	return &IDPExporter{service: service}
+func newIDPExporter(service IDPServiceInterface) *idpExporter {
+	return &idpExporter{service: service}
 }
 
 // NewIDPExporterForTest creates a new IDP exporter for testing purposes.
-func NewIDPExporterForTest(service IDPServiceInterface) *IDPExporter {
+func NewIDPExporterForTest(service IDPServiceInterface) *idpExporter {
 	if !testing.Testing() {
 		panic("only for tests!")
 	}
@@ -56,17 +56,17 @@ func NewIDPExporterForTest(service IDPServiceInterface) *IDPExporter {
 }
 
 // GetResourceType returns the resource type for identity providers.
-func (e *IDPExporter) GetResourceType() string {
+func (e *idpExporter) GetResourceType() string {
 	return resourceTypeIdentityProvider
 }
 
 // GetParameterizerType returns the parameterizer type for identity providers.
-func (e *IDPExporter) GetParameterizerType() string {
+func (e *idpExporter) GetParameterizerType() string {
 	return paramTypIdentityProvider
 }
 
 // GetAllResourceIDs retrieves all identity provider IDs.
-func (e *IDPExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *idpExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	idps, err := e.service.GetIdentityProviderList(ctx)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (e *IDPExporter) GetAllResourceIDs(ctx context.Context) ([]string, *service
 }
 
 // GetResourceByID retrieves an identity provider by its ID.
-func (e *IDPExporter) GetResourceByID(ctx context.Context, id string) (
+func (e *idpExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *serviceerror.ServiceError,
 ) {
 	idpDTO, err := e.service.GetIdentityProvider(ctx, id)
@@ -90,7 +90,7 @@ func (e *IDPExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates an identity provider resource.
-func (e *IDPExporter) ValidateResource(
+func (e *idpExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger) (string, *declarativeresource.ExportError) {
 	idpDTO, ok := resource.(*IDPDTO)
 	if !ok {
@@ -113,7 +113,7 @@ func (e *IDPExporter) ValidateResource(
 }
 
 // GetResourceRules returns the parameterization rules for identity providers.
-func (e *IDPExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *idpExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	return &declarativeresource.ResourceRules{
 		DynamicPropertyFields: []string{"Properties"},
 	}

--- a/backend/internal/idp/declarative_resource_test.go
+++ b/backend/internal/idp/declarative_resource_test.go
@@ -34,11 +34,11 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/idp/idpmock"
 )
 
-// IDPExporterTestSuite tests the IDPExporter.
+// IDPExporterTestSuite tests the idpExporter.
 type IDPExporterTestSuite struct {
 	suite.Suite
 	mockService *idpmock.IDPServiceInterfaceMock
-	exporter    *idp.IDPExporter
+	exporter    declarativeresource.ResourceExporter
 	logger      *log.Logger
 }
 
@@ -189,8 +189,4 @@ func (s *IDPExporterTestSuite) TestValidateResource_NoProperties() {
 	// Should still succeed but log a warning
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test IDP", name)
-}
-
-func (s *IDPExporterTestSuite) TestIDPExporterImplementsInterface() {
-	var _ declarativeresource.ResourceExporter = (*idp.IDPExporter)(nil)
 }

--- a/backend/internal/notification/declarative_resource.go
+++ b/backend/internal/notification/declarative_resource.go
@@ -38,18 +38,18 @@ const (
 	paramTypNotificationSender     = "NotificationSender"
 )
 
-// NotificationSenderExporter implements declarativeresource.ResourceExporter for notification senders.
-type NotificationSenderExporter struct {
+// notificationSenderExporter implements declarativeresource.ResourceExporter for notification senders.
+type notificationSenderExporter struct {
 	service NotificationSenderMgtSvcInterface
 }
 
 // newNotificationSenderExporter creates a new notification sender exporter.
-func newNotificationSenderExporter(service NotificationSenderMgtSvcInterface) *NotificationSenderExporter {
-	return &NotificationSenderExporter{service: service}
+func newNotificationSenderExporter(service NotificationSenderMgtSvcInterface) *notificationSenderExporter {
+	return &notificationSenderExporter{service: service}
 }
 
 // NewNotificationSenderExporterForTest creates a new notification sender exporter for testing purposes.
-func NewNotificationSenderExporterForTest(service NotificationSenderMgtSvcInterface) *NotificationSenderExporter {
+func NewNotificationSenderExporterForTest(service NotificationSenderMgtSvcInterface) *notificationSenderExporter {
 	if !testing.Testing() {
 		panic("only for tests!")
 	}
@@ -57,17 +57,17 @@ func NewNotificationSenderExporterForTest(service NotificationSenderMgtSvcInterf
 }
 
 // GetResourceType returns the resource type for notification senders.
-func (e *NotificationSenderExporter) GetResourceType() string {
+func (e *notificationSenderExporter) GetResourceType() string {
 	return resourceTypeNotificationSender
 }
 
 // GetParameterizerType returns the parameterizer type for notification senders.
-func (e *NotificationSenderExporter) GetParameterizerType() string {
+func (e *notificationSenderExporter) GetParameterizerType() string {
 	return paramTypNotificationSender
 }
 
 // GetAllResourceIDs retrieves all notification sender IDs.
-func (e *NotificationSenderExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *notificationSenderExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	senders, err := e.service.ListSenders(ctx)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func (e *NotificationSenderExporter) GetAllResourceIDs(ctx context.Context) ([]s
 }
 
 // GetResourceByID retrieves a notification sender by its ID.
-func (e *NotificationSenderExporter) GetResourceByID(ctx context.Context, id string) (
+func (e *notificationSenderExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *serviceerror.ServiceError,
 ) {
 	sender, err := e.service.GetSender(ctx, id)
@@ -91,7 +91,7 @@ func (e *NotificationSenderExporter) GetResourceByID(ctx context.Context, id str
 }
 
 // ValidateResource validates a notification sender resource.
-func (e *NotificationSenderExporter) ValidateResource(
+func (e *notificationSenderExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	sender, ok := resource.(*common.NotificationSenderDTO)
@@ -115,7 +115,7 @@ func (e *NotificationSenderExporter) ValidateResource(
 }
 
 // GetResourceRules returns the parameterization rules for notification senders.
-func (e *NotificationSenderExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *notificationSenderExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	return &declarativeresource.ResourceRules{
 		DynamicPropertyFields: []string{"Properties"},
 	}

--- a/backend/internal/notification/declarative_resource_test.go
+++ b/backend/internal/notification/declarative_resource_test.go
@@ -35,11 +35,11 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/notification/notificationmock"
 )
 
-// NotificationSenderExporterTestSuite tests the NotificationSenderExporter.
+// NotificationSenderExporterTestSuite tests the notificationSenderExporter.
 type NotificationSenderExporterTestSuite struct {
 	suite.Suite
 	mockService *notificationmock.NotificationSenderMgtSvcInterfaceMock
-	exporter    *notification.NotificationSenderExporter
+	exporter    declarativeresource.ResourceExporter
 	logger      *log.Logger
 }
 
@@ -190,8 +190,4 @@ func (s *NotificationSenderExporterTestSuite) TestValidateResource_NoProperties(
 	// Should still succeed but log a warning
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test Sender", name)
-}
-
-func (s *NotificationSenderExporterTestSuite) TestNotificationSenderExporterImplementsInterface() {
-	var _ declarativeresource.ResourceExporter = (*notification.NotificationSenderExporter)(nil)
 }

--- a/backend/internal/ou/declarative_resource.go
+++ b/backend/internal/ou/declarative_resource.go
@@ -36,18 +36,18 @@ const (
 	paramTypeOU    = "OrganizationUnit"
 )
 
-// OUExporter implements declarativeresource.ResourceExporter for organization units.
-type OUExporter struct {
+// ouExporter implements declarativeresource.ResourceExporter for organization units.
+type ouExporter struct {
 	service OrganizationUnitServiceInterface
 }
 
 // newOUExporter creates a new OU exporter.
-func newOUExporter(service OrganizationUnitServiceInterface) *OUExporter {
-	return &OUExporter{service: service}
+func newOUExporter(service OrganizationUnitServiceInterface) *ouExporter {
+	return &ouExporter{service: service}
 }
 
 // NewOUExporterForTest creates a new OU exporter for testing purposes.
-func NewOUExporterForTest(service OrganizationUnitServiceInterface) *OUExporter {
+func NewOUExporterForTest(service OrganizationUnitServiceInterface) *ouExporter {
 	if !testing.Testing() {
 		panic("only for tests!")
 	}
@@ -55,19 +55,19 @@ func NewOUExporterForTest(service OrganizationUnitServiceInterface) *OUExporter 
 }
 
 // GetResourceType returns the resource type for organization units.
-func (e *OUExporter) GetResourceType() string {
+func (e *ouExporter) GetResourceType() string {
 	return resourceTypeOU
 }
 
 // GetParameterizerType returns the parameterizer type for organization units.
-func (e *OUExporter) GetParameterizerType() string {
+func (e *ouExporter) GetParameterizerType() string {
 	return paramTypeOU
 }
 
 // GetAllResourceIDs retrieves all organization unit IDs from the database store.
 // Note: This only exports DB-backed OUs (runtime OUs). YAML-based declarative resources
 // are not included in the export as they are already defined in YAML files.
-func (e *OUExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *ouExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	// Get all OUs by requesting a large limit from the service
 	// In composite mode, this returns OUs from both file-based and database stores
 	ous, err := e.service.GetOrganizationUnitList(ctx, serverconst.MaxPageSize, 0)
@@ -107,7 +107,7 @@ func (e *OUExporter) GetAllResourceIDs(ctx context.Context) ([]string, *servicee
 }
 
 // getAllChildIDs recursively retrieves all child OU IDs (excluding immutable ones).
-func (e *OUExporter) getAllChildIDs(ctx context.Context, parentID string) ([]string, *serviceerror.ServiceError) {
+func (e *ouExporter) getAllChildIDs(ctx context.Context, parentID string) ([]string, *serviceerror.ServiceError) {
 	children, err := e.service.GetOrganizationUnitChildren(ctx, parentID, serverconst.MaxPageSize, 0)
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func (e *OUExporter) getAllChildIDs(ctx context.Context, parentID string) ([]str
 }
 
 // GetResourceByID retrieves an organization unit by its ID.
-func (e *OUExporter) GetResourceByID(ctx context.Context, id string) (interface{}, string, *serviceerror.ServiceError) {
+func (e *ouExporter) GetResourceByID(ctx context.Context, id string) (interface{}, string, *serviceerror.ServiceError) {
 	ou, err := e.service.GetOrganizationUnit(ctx, id)
 	if err != nil {
 		return nil, "", err
@@ -139,7 +139,7 @@ func (e *OUExporter) GetResourceByID(ctx context.Context, id string) (interface{
 }
 
 // ValidateResource validates an organization unit resource.
-func (e *OUExporter) ValidateResource(
+func (e *ouExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	ou, ok := resource.(*OrganizationUnit)
@@ -156,7 +156,7 @@ func (e *OUExporter) ValidateResource(
 }
 
 // GetResourceRules returns the parameterization rules for organization units.
-func (e *OUExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *ouExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	// OUs typically don't have parameterizable fields
 	return &declarativeresource.ResourceRules{
 		Variables:      []string{},

--- a/backend/internal/ou/declarative_resource_test.go
+++ b/backend/internal/ou/declarative_resource_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"testing"
 
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ import (
 type DeclarativeResourceTestSuite struct {
 	suite.Suite
 	mockService *OrganizationUnitServiceInterfaceMock
-	exporter    *OUExporter
+	exporter    declarativeresource.ResourceExporter
 }
 
 func TestDeclarativeResourceTestSuite(t *testing.T) {

--- a/backend/internal/role/declarative_resource.go
+++ b/backend/internal/role/declarative_resource.go
@@ -35,29 +35,29 @@ const (
 	paramTypeRole    = "Role"
 )
 
-// RoleExporter implements declarativeresource.ResourceExporter for roles.
-type RoleExporter struct {
+// roleExporter implements declarativeresource.ResourceExporter for roles.
+type roleExporter struct {
 	service RoleServiceInterface
 }
 
 // newRoleExporter creates a new role exporter.
-func newRoleExporter(service RoleServiceInterface) *RoleExporter {
-	return &RoleExporter{service: service}
+func newRoleExporter(service RoleServiceInterface) *roleExporter {
+	return &roleExporter{service: service}
 }
 
 // GetResourceType returns the resource type for roles.
-func (e *RoleExporter) GetResourceType() string {
+func (e *roleExporter) GetResourceType() string {
 	return resourceTypeRole
 }
 
 // GetParameterizerType returns the parameterizer type for roles.
-func (e *RoleExporter) GetParameterizerType() string {
+func (e *roleExporter) GetParameterizerType() string {
 	return paramTypeRole
 }
 
 // GetAllResourceIDs retrieves all role IDs from the database store.
 // In composite mode, this excludes declarative (YAML-based) roles.
-func (e *RoleExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *roleExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	offset := 0
 	limit := serverconst.MaxPageSize
 	ids := []string{}
@@ -90,7 +90,7 @@ func (e *RoleExporter) GetAllResourceIDs(ctx context.Context) ([]string, *servic
 }
 
 // GetResourceByID retrieves a role by its ID.
-func (e *RoleExporter) GetResourceByID(
+func (e *roleExporter) GetResourceByID(
 	ctx context.Context, id string) (interface{}, string, *serviceerror.ServiceError) {
 	roleWithPermissions, err := e.service.GetRoleWithPermissions(ctx, id)
 	if err != nil {
@@ -115,7 +115,7 @@ func (e *RoleExporter) GetResourceByID(
 }
 
 // ValidateResource validates a role resource.
-func (e *RoleExporter) ValidateResource(
+func (e *roleExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	role, ok := resource.(*RoleWithPermissionsAndAssignments)
@@ -132,7 +132,7 @@ func (e *RoleExporter) ValidateResource(
 }
 
 // GetResourceRules returns the parameterization rules for roles.
-func (e *RoleExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *roleExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	return &declarativeresource.ResourceRules{
 		Variables:      []string{},
 		ArrayVariables: []string{},
@@ -265,7 +265,7 @@ func validateRoleWrapper(data interface{}, fileStore *fileBasedStore, dbStore ro
 	return nil
 }
 
-func (e *RoleExporter) getAllRoleAssignments(
+func (e *roleExporter) getAllRoleAssignments(
 	ctx context.Context,
 	roleID string,
 ) ([]RoleAssignment, *serviceerror.ServiceError) {

--- a/backend/internal/role/declarative_resource_test.go
+++ b/backend/internal/role/declarative_resource_test.go
@@ -26,15 +26,16 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
 
-// RoleExporterTestSuite contains tests for the RoleExporter.
+// RoleExporterTestSuite contains tests for the roleExporter.
 type RoleExporterTestSuite struct {
 	suite.Suite
 	mockService *RoleServiceInterfaceMock
-	exporter    *RoleExporter
+	exporter    declarativeresource.ResourceExporter
 	ctx         context.Context
 }
 

--- a/backend/internal/role/export_test.go
+++ b/backend/internal/role/export_test.go
@@ -19,6 +19,6 @@
 package role
 
 // NewRoleExporterForTest creates a new role exporter for testing purposes.
-func NewRoleExporterForTest(service RoleServiceInterface) *RoleExporter {
+func NewRoleExporterForTest(service RoleServiceInterface) *roleExporter {
 	return newRoleExporter(service)
 }

--- a/backend/internal/system/i18n/mgt/declarative_resource.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource.go
@@ -34,29 +34,29 @@ const (
 	resourceTypeTranslation = "translation"
 )
 
-// TranslationExporter implements declarativeresource.ResourceExporter for translations.
-type TranslationExporter struct {
+// translationExporter implements declarativeresource.ResourceExporter for translations.
+type translationExporter struct {
 	store i18nStoreInterface
 }
 
 // newTranslationExporter creates a new Translation exporter.
-func newTranslationExporter(store i18nStoreInterface) *TranslationExporter {
-	return &TranslationExporter{store: store}
+func newTranslationExporter(store i18nStoreInterface) *translationExporter {
+	return &translationExporter{store: store}
 }
 
 // GetResourceType returns the resource type for translations.
-func (e *TranslationExporter) GetResourceType() string {
+func (e *translationExporter) GetResourceType() string {
 	return resourceTypeTranslation
 }
 
 // GetParameterizerType returns the parameterizer type for translations.
-func (e *TranslationExporter) GetParameterizerType() string {
+func (e *translationExporter) GetParameterizerType() string {
 	return paramTypeTranslation
 }
 
 // GetAllResourceIDs retrieves all languages from the database store.
 // One file per language.
-func (e *TranslationExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *translationExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	// Get all translations from store
 	languages, err := e.store.GetDistinctLanguages()
 	if err != nil {
@@ -70,7 +70,7 @@ func (e *TranslationExporter) GetAllResourceIDs(ctx context.Context) ([]string, 
 }
 
 // GetResourceByID retrieves all translations for a specific language.
-func (e *TranslationExporter) GetResourceByID(ctx context.Context, id string) (
+func (e *translationExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *serviceerror.ServiceError,
 ) {
 	translations, err := e.store.GetTranslations()
@@ -110,7 +110,7 @@ func (e *TranslationExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a translation resource.
-func (e *TranslationExporter) ValidateResource(
+func (e *translationExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	trans, ok := resource.(*LanguageTranslations)
@@ -131,7 +131,7 @@ func (e *TranslationExporter) ValidateResource(
 }
 
 // GetResourceRules returns the parameterization rules for translations.
-func (e *TranslationExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *translationExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	return &declarativeresource.ResourceRules{
 		Variables:      []string{},
 		ArrayVariables: []string{},

--- a/backend/internal/system/i18n/mgt/declarative_resource_test.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource_test.go
@@ -36,7 +36,7 @@ import (
 type DeclarativeResourceTestSuite struct {
 	suite.Suite
 	mockStore *i18nStoreInterfaceMock
-	exporter  *TranslationExporter
+	exporter  declarativeresource.ResourceExporter
 }
 
 func TestDeclarativeResourceTestSuite(t *testing.T) {

--- a/backend/internal/userschema/declarative_resource.go
+++ b/backend/internal/userschema/declarative_resource.go
@@ -39,34 +39,34 @@ const (
 	paramTypUserSchema     = "UserSchema"
 )
 
-// UserSchemaExporter implements declarative_resource.ResourceExporter for user schemas.
-type UserSchemaExporter struct {
+// userSchemaExporter implements declarative_resource.ResourceExporter for user schemas.
+type userSchemaExporter struct {
 	service UserSchemaServiceInterface
 }
 
 // newUserSchemaExporter creates a new user schema exporter.
-func newUserSchemaExporter(service UserSchemaServiceInterface) *UserSchemaExporter {
-	return &UserSchemaExporter{service: service}
+func newUserSchemaExporter(service UserSchemaServiceInterface) *userSchemaExporter {
+	return &userSchemaExporter{service: service}
 }
 
 // NewUserSchemaExporterForTest creates a new user schema exporter for testing purposes.
-func NewUserSchemaExporterForTest(service UserSchemaServiceInterface) *UserSchemaExporter {
+func NewUserSchemaExporterForTest(service UserSchemaServiceInterface) *userSchemaExporter {
 	return newUserSchemaExporter(service)
 }
 
 // GetResourceType returns the resource type for user schemas.
-func (e *UserSchemaExporter) GetResourceType() string {
+func (e *userSchemaExporter) GetResourceType() string {
 	return resourceTypeUserSchema
 }
 
 // GetParameterizerType returns the parameterizer type for user schemas.
-func (e *UserSchemaExporter) GetParameterizerType() string {
+func (e *userSchemaExporter) GetParameterizerType() string {
 	return paramTypUserSchema
 }
 
 // GetAllResourceIDs retrieves all user schema IDs.
 // In composite mode, this excludes declarative (YAML-based) user schemas.
-func (e *UserSchemaExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
+func (e *userSchemaExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	response, err := e.service.GetUserSchemaList(ctx, serverconst.MaxPageSize, 0)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (e *UserSchemaExporter) GetAllResourceIDs(ctx context.Context) ([]string, *
 }
 
 // GetResourceByID retrieves a user schema by its ID.
-func (e *UserSchemaExporter) GetResourceByID(ctx context.Context, id string) (
+func (e *userSchemaExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *serviceerror.ServiceError,
 ) {
 	schema, err := e.service.GetUserSchema(ctx, id)
@@ -93,7 +93,7 @@ func (e *UserSchemaExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a user schema resource.
-func (e *UserSchemaExporter) ValidateResource(
+func (e *userSchemaExporter) ValidateResource(
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	schema, ok := resource.(*UserSchema)
@@ -117,7 +117,7 @@ func (e *UserSchemaExporter) ValidateResource(
 }
 
 // GetResourceRules returns the parameterization rules for user schemas.
-func (e *UserSchemaExporter) GetResourceRules() *declarativeresource.ResourceRules {
+func (e *userSchemaExporter) GetResourceRules() *declarativeresource.ResourceRules {
 	return &declarativeresource.ResourceRules{}
 }
 

--- a/backend/internal/userschema/declarative_resource_test.go
+++ b/backend/internal/userschema/declarative_resource_test.go
@@ -34,11 +34,11 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
-// UserSchemaExporterTestSuite tests the UserSchemaExporter.
+// UserSchemaExporterTestSuite tests the userSchemaExporter.
 type UserSchemaExporterTestSuite struct {
 	suite.Suite
 	mockService *userschemamock.UserSchemaServiceInterfaceMock
-	exporter    *userschema.UserSchemaExporter
+	exporter    declarativeresource.ResourceExporter
 	logger      *log.Logger
 }
 
@@ -200,8 +200,4 @@ func (s *UserSchemaExporterTestSuite) TestGetResourceRules() {
 	assert.NotNil(s.T(), rules)
 	// ResourceRules is currently an empty struct, but the function should return a valid pointer
 	assert.IsType(s.T(), &declarativeresource.ResourceRules{}, rules)
-}
-
-func (s *UserSchemaExporterTestSuite) TestUserSchemaExporterImplementsInterface() {
-	var _ declarativeresource.ResourceExporter = (*userschema.UserSchemaExporter)(nil)
 }


### PR DESCRIPTION
### Purpose
Refactor exporters structs

### Approach
This pull request refactors several resource exporter implementations across the codebase to use unexported (lowercase) struct types and updates their usage in both implementation and test files. This change enforces encapsulation, clarifies the intended usage of these types, and ensures that only the interface is exposed externally, not the concrete struct. No functional logic was changed; only type visibility and naming were updated.

### Refactoring resource exporter structs and constructors

* Changed all exported resource exporter structs (e.g., `ApplicationExporter`, `IDPExporter`, `NotificationSenderExporter`, `OUExporter`, `FlowGraphExporter`) to unexported types (e.g., `applicationExporter`, `idpExporter`, `notificationSenderExporter`, `ouExporter`, `flowGraphExporter`) in their respective files. Updated all constructor and method receivers accordingly. [[1]](diffhunk://#diff-1955a9101a83b05b0cac13128df7592dc70733113a9bc9254a853a85b9a1b1b5L39-R69) [[2]](diffhunk://#diff-d28048a6c20c8e12c559b5cd0d1d1c1ea01d55fef1f06654d933a09c9c69500dL40-R69) [[3]](diffhunk://#diff-a2c39ce9896adbf8da9db3f0cb8aa7c188187964998e4b80ab497fb714105dd2L41-R70) [[4]](diffhunk://#diff-f73a44a3603a40cbb5a1dbb87703fd21d582f813e7b627b547f1d38bfcc51697L39-R70) [[5]](diffhunk://#diff-6118e7897cfd65d1c17cafa0d5dda5ca801e64d7c07e9e880be5e60198d35bcbL38-R64)

### Updates to test suites

* Updated test suite struct comments and fields in test files to refer to the new unexported exporter types, and changed the `exporter` field to use the common `ResourceExporter` interface instead of the concrete type. [[1]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cL36-R40) [[2]](diffhunk://#diff-0ffc9452ece6071b0d8007ad759ea7f16c79ed1d75f091fc088b5b4310221756L37-R41) [[3]](diffhunk://#diff-3fa6cb0996f8710812e2520827ebe893febf0b83e01abc7ea609a1d34d0f0239L38-R42)
* Removed interface compliance assertion tests that referenced the now-unexported types. [[1]](diffhunk://#diff-7f7faddf0d586f8719df518e8c10643aeff1f0bce2968c19054f30512b91f66cL180-L183) [[2]](diffhunk://#diff-0ffc9452ece6071b0d8007ad759ea7f16c79ed1d75f091fc088b5b4310221756L193-L196) [[3]](diffhunk://#diff-3fa6cb0996f8710812e2520827ebe893febf0b83e01abc7ea609a1d34d0f0239L194-L197)

### Method receiver changes

* Updated all method receivers in resource exporter implementations to use the new unexported struct types, ensuring consistency throughout each resource module. [[1]](diffhunk://#diff-1955a9101a83b05b0cac13128df7592dc70733113a9bc9254a853a85b9a1b1b5L39-R69) [[2]](diffhunk://#diff-d28048a6c20c8e12c559b5cd0d1d1c1ea01d55fef1f06654d933a09c9c69500dL40-R69) [[3]](diffhunk://#diff-a2c39ce9896adbf8da9db3f0cb8aa7c188187964998e4b80ab497fb714105dd2L41-R70) [[4]](diffhunk://#diff-f73a44a3603a40cbb5a1dbb87703fd21d582f813e7b627b547f1d38bfcc51697L39-R70) [[5]](diffhunk://#diff-6118e7897cfd65d1c17cafa0d5dda5ca801e64d7c07e9e880be5e60198d35bcbL38-R64)

No business logic or behavior was changed; this is a structural and visibility-focused refactor.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal exporter implementations across multiple backend modules to reduce public surface area.
* **Bug Fixes / Changes**
  * Resource listing now omits read-only resources, returning only mutable resources.
  * Improved error reporting when fetching translation resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->