### PR TITLE
OU service context propagation and transection usage

### DIFF
--- a/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
+++ b/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
@@ -929,16 +929,16 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitUsersByPath_Ca
 }
 
 // IsOrganizationUnitDeclarative provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
+func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsOrganizationUnitDeclarative")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -951,19 +951,25 @@ type OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call str
 }
 
 // IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(ctx interface{}, id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", ctx, id)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(ctx context.Context, id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -974,7 +980,7 @@ func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Cal
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/ou/composite_store.go
+++ b/backend/internal/ou/composite_store.go
@@ -19,6 +19,8 @@
 package ou
 
 import (
+	"context"
+
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 )
@@ -41,22 +43,28 @@ func newCompositeOUStore(fileStore, dbStore organizationUnitStoreInterface) *com
 }
 
 // GetOrganizationUnitListCount retrieves the total count of organization units from both stores.
-func (c *compositeOUStore) GetOrganizationUnitListCount() (int, error) {
+func (c *compositeOUStore) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
 	return declarativeresource.CompositeMergeCountHelper(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount() },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount() },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount(ctx) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount(ctx) },
 	)
 }
 
 // GetOrganizationUnitList retrieves organization units from both stores with pagination.
 // Applies the 1000-record limit in composite mode to prevent memory exhaustion.
 // Returns ErrResultLimitExceededInCompositeMode if the limit is exceeded.
-func (c *compositeOUStore) GetOrganizationUnitList(limit, offset int) ([]OrganizationUnitBasic, error) {
+func (c *compositeOUStore) GetOrganizationUnitList(
+	ctx context.Context, limit, offset int,
+) ([]OrganizationUnitBasic, error) {
 	items, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount() },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount() },
-		func(count int) ([]OrganizationUnitBasic, error) { return c.dbStore.GetOrganizationUnitList(count, 0) },
-		func(count int) ([]OrganizationUnitBasic, error) { return c.fileStore.GetOrganizationUnitList(count, 0) },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount(ctx) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount(ctx) },
+		func(count int) ([]OrganizationUnitBasic, error) {
+			return c.dbStore.GetOrganizationUnitList(ctx, count, 0)
+		},
+		func(count int) ([]OrganizationUnitBasic, error) {
+			return c.fileStore.GetOrganizationUnitList(ctx, count, 0)
+		},
 		mergeAndDeduplicateOUs,
 		limit,
 		offset,
@@ -73,17 +81,19 @@ func (c *compositeOUStore) GetOrganizationUnitList(limit, offset int) ([]Organiz
 }
 
 // GetOrganizationUnitsByIDs retrieves organization units matching the given IDs from both stores.
-func (c *compositeOUStore) GetOrganizationUnitsByIDs(ids []string) ([]OrganizationUnitBasic, error) {
+func (c *compositeOUStore) GetOrganizationUnitsByIDs(
+	ctx context.Context, ids []string,
+) ([]OrganizationUnitBasic, error) {
 	if len(ids) == 0 {
 		return []OrganizationUnitBasic{}, nil
 	}
 
-	dbOUs, err := c.dbStore.GetOrganizationUnitsByIDs(ids)
+	dbOUs, err := c.dbStore.GetOrganizationUnitsByIDs(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	fileOUs, err := c.fileStore.GetOrganizationUnitsByIDs(ids)
+	fileOUs, err := c.fileStore.GetOrganizationUnitsByIDs(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -93,102 +103,106 @@ func (c *compositeOUStore) GetOrganizationUnitsByIDs(ids []string) ([]Organizati
 
 // CreateOrganizationUnit creates a new organization unit in the database store only.
 // Conflict checking and parent validation are handled at the service layer.
-func (c *compositeOUStore) CreateOrganizationUnit(ou OrganizationUnit) error {
-	return c.dbStore.CreateOrganizationUnit(ou)
+func (c *compositeOUStore) CreateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
+	return c.dbStore.CreateOrganizationUnit(ctx, ou)
 }
 
 // GetOrganizationUnit retrieves an organization unit by ID from either store.
 // Checks database store first, then falls back to file store.
-func (c *compositeOUStore) GetOrganizationUnit(id string) (OrganizationUnit, error) {
+func (c *compositeOUStore) GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, error) {
 	return declarativeresource.CompositeGetHelper(
-		func() (OrganizationUnit, error) { return c.dbStore.GetOrganizationUnit(id) },
-		func() (OrganizationUnit, error) { return c.fileStore.GetOrganizationUnit(id) },
+		func() (OrganizationUnit, error) { return c.dbStore.GetOrganizationUnit(ctx, id) },
+		func() (OrganizationUnit, error) { return c.fileStore.GetOrganizationUnit(ctx, id) },
 		ErrOrganizationUnitNotFound,
 	)
 }
 
 // GetOrganizationUnitByPath retrieves an organization unit by hierarchical path from either store.
-func (c *compositeOUStore) GetOrganizationUnitByPath(handles []string) (OrganizationUnit, error) {
+func (c *compositeOUStore) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
 	return declarativeresource.CompositeGetHelper(
-		func() (OrganizationUnit, error) { return c.dbStore.GetOrganizationUnitByPath(handles) },
-		func() (OrganizationUnit, error) { return c.fileStore.GetOrganizationUnitByPath(handles) },
+		func() (OrganizationUnit, error) { return c.dbStore.GetOrganizationUnitByPath(ctx, handles) },
+		func() (OrganizationUnit, error) { return c.fileStore.GetOrganizationUnitByPath(ctx, handles) },
 		ErrOrganizationUnitNotFound,
 	)
 }
 
 // IsOrganizationUnitExists checks if an organization unit exists in either store.
-func (c *compositeOUStore) IsOrganizationUnitExists(id string) (bool, error) {
+func (c *compositeOUStore) IsOrganizationUnitExists(ctx context.Context, id string) (bool, error) {
 	return declarativeresource.CompositeBooleanCheckHelper(
-		func() (bool, error) { return c.fileStore.IsOrganizationUnitExists(id) },
-		func() (bool, error) { return c.dbStore.IsOrganizationUnitExists(id) },
+		func() (bool, error) { return c.fileStore.IsOrganizationUnitExists(ctx, id) },
+		func() (bool, error) { return c.dbStore.IsOrganizationUnitExists(ctx, id) },
 	)
 }
 
 // IsOrganizationUnitDeclarative checks if an organization unit is immutable (exists in file store).
-func (c *compositeOUStore) IsOrganizationUnitDeclarative(id string) bool {
+func (c *compositeOUStore) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
 	return declarativeresource.CompositeIsDeclarativeHelper(
 		id,
-		func(id string) (bool, error) { return c.fileStore.IsOrganizationUnitExists(id) },
+		func(id string) (bool, error) { return c.fileStore.IsOrganizationUnitExists(ctx, id) },
 	)
 }
 
 // CheckOrganizationUnitNameConflict checks for name conflicts in both stores.
-func (c *compositeOUStore) CheckOrganizationUnitNameConflict(name string, parent *string) (bool, error) {
+func (c *compositeOUStore) CheckOrganizationUnitNameConflict(
+	ctx context.Context, name string, parent *string,
+) (bool, error) {
 	return declarativeresource.CompositeBooleanCheckHelper(
-		func() (bool, error) { return c.fileStore.CheckOrganizationUnitNameConflict(name, parent) },
-		func() (bool, error) { return c.dbStore.CheckOrganizationUnitNameConflict(name, parent) },
+		func() (bool, error) { return c.fileStore.CheckOrganizationUnitNameConflict(ctx, name, parent) },
+		func() (bool, error) { return c.dbStore.CheckOrganizationUnitNameConflict(ctx, name, parent) },
 	)
 }
 
 // CheckOrganizationUnitHandleConflict checks for handle conflicts in both stores.
-func (c *compositeOUStore) CheckOrganizationUnitHandleConflict(handle string, parent *string) (bool, error) {
+func (c *compositeOUStore) CheckOrganizationUnitHandleConflict(
+	ctx context.Context, handle string, parent *string,
+) (bool, error) {
 	return declarativeresource.CompositeBooleanCheckHelper(
-		func() (bool, error) { return c.fileStore.CheckOrganizationUnitHandleConflict(handle, parent) },
-		func() (bool, error) { return c.dbStore.CheckOrganizationUnitHandleConflict(handle, parent) },
+		func() (bool, error) { return c.fileStore.CheckOrganizationUnitHandleConflict(ctx, handle, parent) },
+		func() (bool, error) { return c.dbStore.CheckOrganizationUnitHandleConflict(ctx, handle, parent) },
 	)
 }
 
 // UpdateOrganizationUnit updates an organization unit in the database store only.
 // Immutability checks and parent validation are handled at the service layer.
-func (c *compositeOUStore) UpdateOrganizationUnit(ou OrganizationUnit) error {
-	return c.dbStore.UpdateOrganizationUnit(ou)
+func (c *compositeOUStore) UpdateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
+	return c.dbStore.UpdateOrganizationUnit(ctx, ou)
 }
 
 // DeleteOrganizationUnit deletes an organization unit from the database store only.
 // Immutability and children validation are handled at the service layer.
-func (c *compositeOUStore) DeleteOrganizationUnit(id string) error {
-	return c.dbStore.DeleteOrganizationUnit(id)
+func (c *compositeOUStore) DeleteOrganizationUnit(ctx context.Context, id string) error {
+	return c.dbStore.DeleteOrganizationUnit(ctx, id)
 }
 
 // CheckOrganizationUnitHasChildResources checks if an OU has child resources in either store.
-func (c *compositeOUStore) CheckOrganizationUnitHasChildResources(id string) (bool, error) {
+func (c *compositeOUStore) CheckOrganizationUnitHasChildResources(ctx context.Context, id string) (bool, error) {
 	return declarativeresource.CompositeBooleanCheckHelper(
-		func() (bool, error) { return c.fileStore.CheckOrganizationUnitHasChildResources(id) },
-		func() (bool, error) { return c.dbStore.CheckOrganizationUnitHasChildResources(id) },
+		func() (bool, error) { return c.fileStore.CheckOrganizationUnitHasChildResources(ctx, id) },
+		func() (bool, error) { return c.dbStore.CheckOrganizationUnitHasChildResources(ctx, id) },
 	)
 }
 
 // GetOrganizationUnitChildrenCount retrieves the count of child OUs from both stores.
-func (c *compositeOUStore) GetOrganizationUnitChildrenCount(id string) (int, error) {
+func (c *compositeOUStore) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
 	return declarativeresource.CompositeMergeCountHelper(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(id) },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(id) },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(ctx, id) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(ctx, id) },
 	)
 }
 
 // GetOrganizationUnitChildrenList retrieves child OUs from both stores with pagination.
 // Applies the 1000-record limit in composite mode to prevent memory exhaustion.
 // Returns ErrResultLimitExceededInCompositeMode if the limit is exceeded.
-func (c *compositeOUStore) GetOrganizationUnitChildrenList(
+func (c *compositeOUStore) GetOrganizationUnitChildrenList(ctx context.Context,
 	id string, limit, offset int) ([]OrganizationUnitBasic, error) {
 	items, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(id) },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(id) },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(ctx, id) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(ctx, id) },
 		func(count int) ([]OrganizationUnitBasic, error) {
-			return c.dbStore.GetOrganizationUnitChildrenList(id, count, 0)
+			return c.dbStore.GetOrganizationUnitChildrenList(ctx, id, count, 0)
 		},
 		func(count int) ([]OrganizationUnitBasic, error) {
-			return c.fileStore.GetOrganizationUnitChildrenList(id, count, 0)
+			return c.fileStore.GetOrganizationUnitChildrenList(ctx, id, count, 0)
 		},
 		mergeAndDeduplicateChildren,
 		limit,
@@ -206,23 +220,27 @@ func (c *compositeOUStore) GetOrganizationUnitChildrenList(
 }
 
 // GetOrganizationUnitUsersCount retrieves the count of users from the database store only.
-func (c *compositeOUStore) GetOrganizationUnitUsersCount(id string) (int, error) {
-	return c.dbStore.GetOrganizationUnitUsersCount(id)
+func (c *compositeOUStore) GetOrganizationUnitUsersCount(ctx context.Context, id string) (int, error) {
+	return c.dbStore.GetOrganizationUnitUsersCount(ctx, id)
 }
 
 // GetOrganizationUnitUsersList retrieves users from the database store only.
-func (c *compositeOUStore) GetOrganizationUnitUsersList(id string, limit, offset int) ([]User, error) {
-	return c.dbStore.GetOrganizationUnitUsersList(id, limit, offset)
+func (c *compositeOUStore) GetOrganizationUnitUsersList(
+	ctx context.Context, id string, limit, offset int,
+) ([]User, error) {
+	return c.dbStore.GetOrganizationUnitUsersList(ctx, id, limit, offset)
 }
 
 // GetOrganizationUnitGroupsCount retrieves the count of groups from the database store only.
-func (c *compositeOUStore) GetOrganizationUnitGroupsCount(id string) (int, error) {
-	return c.dbStore.GetOrganizationUnitGroupsCount(id)
+func (c *compositeOUStore) GetOrganizationUnitGroupsCount(ctx context.Context, id string) (int, error) {
+	return c.dbStore.GetOrganizationUnitGroupsCount(ctx, id)
 }
 
 // GetOrganizationUnitGroupsList retrieves groups from the database store only.
-func (c *compositeOUStore) GetOrganizationUnitGroupsList(id string, limit, offset int) ([]Group, error) {
-	return c.dbStore.GetOrganizationUnitGroupsList(id, limit, offset)
+func (c *compositeOUStore) GetOrganizationUnitGroupsList(
+	ctx context.Context, id string, limit, offset int,
+) ([]Group, error) {
+	return c.dbStore.GetOrganizationUnitGroupsList(ctx, id, limit, offset)
 }
 
 // mergeAndDeduplicateOUs merges root-level OUs from both stores and removes duplicates by ID.

--- a/backend/internal/ou/composite_store_test.go
+++ b/backend/internal/ou/composite_store_test.go
@@ -19,6 +19,8 @@
 package ou
 
 import (
+	"context"
+
 	"errors"
 	"testing"
 
@@ -68,7 +70,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetOrganizationUnit() {
 				// File store doesn't have this OU
 			},
 			setupDBStore: func() {
-				suite.dbStoreMock.On("GetOrganizationUnit", "db-ou-1").
+				suite.dbStoreMock.On("GetOrganizationUnit", mock.Anything, "db-ou-1").
 					Return(OrganizationUnit{
 						ID:     "db-ou-1",
 						Handle: "db-handle",
@@ -87,7 +89,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetOrganizationUnit() {
 			ouID: "file-ou-1",
 			setupFileStore: func() {
 				// Add OU to file store
-				err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+				err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 					ID:     "file-ou-1",
 					Handle: "file-handle",
 					Name:   "File OU",
@@ -95,7 +97,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetOrganizationUnit() {
 				suite.NoError(err)
 			},
 			setupDBStore: func() {
-				suite.dbStoreMock.On("GetOrganizationUnit", "file-ou-1").
+				suite.dbStoreMock.On("GetOrganizationUnit", mock.Anything, "file-ou-1").
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 					Once()
 			},
@@ -112,7 +114,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetOrganizationUnit() {
 				// OU not in file store
 			},
 			setupDBStore: func() {
-				suite.dbStoreMock.On("GetOrganizationUnit", "nonexistent").
+				suite.dbStoreMock.On("GetOrganizationUnit", mock.Anything, "nonexistent").
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 					Once()
 			},
@@ -126,7 +128,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetOrganizationUnit() {
 			tc.setupFileStore()
 			tc.setupDBStore()
 
-			got, err := suite.compositeStore.GetOrganizationUnit(tc.ouID)
+			got, err := suite.compositeStore.GetOrganizationUnit(context.Background(), tc.ouID)
 
 			if tc.wantErr {
 				suite.Error(err)
@@ -150,11 +152,11 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_CreateOrganizationUnit(
 			Name:   "New OU",
 		}
 
-		suite.dbStoreMock.On("CreateOrganizationUnit", ou).
+		suite.dbStoreMock.On("CreateOrganizationUnit", mock.Anything, ou).
 			Return(nil).
 			Once()
 
-		err := suite.compositeStore.CreateOrganizationUnit(ou)
+		err := suite.compositeStore.CreateOrganizationUnit(context.Background(), ou)
 		suite.NoError(err)
 	})
 }
@@ -168,11 +170,11 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_UpdateOrganizationUnit(
 			Name:   "Updated OU",
 		}
 
-		suite.dbStoreMock.On("UpdateOrganizationUnit", ou).
+		suite.dbStoreMock.On("UpdateOrganizationUnit", mock.Anything, ou).
 			Return(nil).
 			Once()
 
-		err := suite.compositeStore.UpdateOrganizationUnit(ou)
+		err := suite.compositeStore.UpdateOrganizationUnit(context.Background(), ou)
 		suite.NoError(err)
 	})
 }
@@ -181,11 +183,11 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_UpdateOrganizationUnit(
 func (suite *CompositeStoreTestSuite) TestCompositeStore_DeleteOrganizationUnit() {
 	suite.Run("deletes DB OU successfully", func() {
 		// Children validation is done at service layer, not store layer
-		suite.dbStoreMock.On("DeleteOrganizationUnit", "db-ou-1").
+		suite.dbStoreMock.On("DeleteOrganizationUnit", mock.Anything, "db-ou-1").
 			Return(nil).
 			Once()
 
-		err := suite.compositeStore.DeleteOrganizationUnit("db-ou-1")
+		err := suite.compositeStore.DeleteOrganizationUnit(context.Background(), "db-ou-1")
 		suite.NoError(err)
 	})
 }
@@ -193,35 +195,35 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_DeleteOrganizationUnit(
 // TestCompositeStore_IsOrganizationUnitExists tests existence checks across both stores.
 func (suite *CompositeStoreTestSuite) TestCompositeStore_IsOrganizationUnitExists() {
 	suite.Run("exists in DB store", func() {
-		suite.dbStoreMock.On("IsOrganizationUnitExists", "db-ou-1").
+		suite.dbStoreMock.On("IsOrganizationUnitExists", mock.Anything, "db-ou-1").
 			Return(true, nil).
 			Once()
 
-		exists, err := suite.compositeStore.IsOrganizationUnitExists("db-ou-1")
+		exists, err := suite.compositeStore.IsOrganizationUnitExists(context.Background(), "db-ou-1")
 		suite.NoError(err)
 		suite.True(exists)
 	})
 
 	suite.Run("exists in file store", func() {
 		// Add OU to file store
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "file-ou-1",
 			Handle: "file-handle",
 			Name:   "File OU",
 		})
 		suite.NoError(err)
 
-		exists, err := suite.compositeStore.IsOrganizationUnitExists("file-ou-1")
+		exists, err := suite.compositeStore.IsOrganizationUnitExists(context.Background(), "file-ou-1")
 		suite.NoError(err)
 		suite.True(exists)
 	})
 
 	suite.Run("not found in either store", func() {
-		suite.dbStoreMock.On("IsOrganizationUnitExists", "nonexistent").
+		suite.dbStoreMock.On("IsOrganizationUnitExists", mock.Anything, "nonexistent").
 			Return(false, nil).
 			Once()
 
-		exists, err := suite.compositeStore.IsOrganizationUnitExists("nonexistent")
+		exists, err := suite.compositeStore.IsOrganizationUnitExists(context.Background(), "nonexistent")
 		suite.NoError(err)
 		suite.False(exists)
 	})
@@ -232,18 +234,18 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ConflictChecks() {
 	suite.Run("detects name conflict in DB store", func() {
 		// File store checked first - returns false (no conflict)
 		// Then DB store checked - returns true (conflict)
-		suite.dbStoreMock.On("CheckOrganizationUnitNameConflict", "test-name", (*string)(nil)).
+		suite.dbStoreMock.On("CheckOrganizationUnitNameConflict", mock.Anything, "test-name", (*string)(nil)).
 			Return(true, nil).
 			Once()
 
-		conflict, err := suite.compositeStore.CheckOrganizationUnitNameConflict("test-name", nil)
+		conflict, err := suite.compositeStore.CheckOrganizationUnitNameConflict(context.Background(), "test-name", nil)
 		suite.NoError(err)
 		suite.True(conflict)
 	})
 
 	suite.Run("detects name conflict in file store", func() {
 		// Add OU to file store
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "file-ou-1",
 			Handle: "file-handle",
 			Name:   "Conflict Name",
@@ -254,17 +256,21 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ConflictChecks() {
 		// DB store not called since file store found conflict
 		// No mock expectation for dbStore
 
-		conflict, err := suite.compositeStore.CheckOrganizationUnitNameConflict("Conflict Name", nil)
+		conflict, err := suite.compositeStore.CheckOrganizationUnitNameConflict(
+			context.Background(), "Conflict Name", nil,
+		)
 		suite.NoError(err)
 		suite.True(conflict)
 	})
 
 	suite.Run("no name conflict in either store", func() {
-		suite.dbStoreMock.On("CheckOrganizationUnitNameConflict", "unique-name", (*string)(nil)).
+		suite.dbStoreMock.On("CheckOrganizationUnitNameConflict", mock.Anything, "unique-name", (*string)(nil)).
 			Return(false, nil).
 			Once()
 
-		conflict, err := suite.compositeStore.CheckOrganizationUnitNameConflict("unique-name", nil)
+		conflict, err := suite.compositeStore.CheckOrganizationUnitNameConflict(
+			context.Background(), "unique-name", nil,
+		)
 		suite.NoError(err)
 		suite.False(conflict)
 	})
@@ -276,18 +282,18 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ChildrenOperations() {
 		suite.SetupTest() // Fresh setup
 		parentID := "parent-ou"
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", parentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID).
 			Return(2, nil).
 			Once()
 
 		// Add parent and child to file store
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     parentID,
 			Handle: "parent",
 			Name:   "Parent",
 		})
 		suite.NoError(err)
-		err = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "file-child-1",
 			Handle: "child1",
 			Name:   "Child 1",
@@ -295,17 +301,19 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ChildrenOperations() {
 		})
 		suite.NoError(err)
 
-		count, err := suite.compositeStore.GetOrganizationUnitChildrenCount(parentID)
+		count, err := suite.compositeStore.GetOrganizationUnitChildrenCount(context.Background(), parentID)
 		suite.NoError(err)
 		suite.Equal(3, count) // 2 from DB + 1 from file
 	})
 
 	suite.Run("checks if OU has children in either store", func() {
-		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", "parent-ou").
+		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", mock.Anything, "parent-ou").
 			Return(true, nil).
 			Once()
 
-		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources("parent-ou")
+		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources(
+			context.Background(), "parent-ou",
+		)
 		suite.NoError(err)
 		suite.True(hasChildren)
 	})
@@ -315,17 +323,17 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ChildrenOperations() {
 func (suite *CompositeStoreTestSuite) TestCompositeStore_ListOperations() {
 	suite.Run("GetOrganizationUnitListCount returns count from both stores", func() {
 		// Add OUs to file store
-		_ = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		_ = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID: "file-ou-1", Handle: "file-1", Name: "File OU 1",
 		})
-		_ = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		_ = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID: "file-ou-2", Handle: "file-2", Name: "File OU 2",
 		})
 
 		// Mock DB store count - CompositeMergeCountHelper calls dbStore.GetOrganizationUnitListCount once
-		suite.dbStoreMock.On("GetOrganizationUnitListCount").Return(3, nil).Once()
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(3, nil).Once()
 
-		count, err := suite.compositeStore.GetOrganizationUnitListCount()
+		count, err := suite.compositeStore.GetOrganizationUnitListCount(context.Background())
 		suite.NoError(err)
 		suite.Equal(5, count) // 3 from DB + 2 from file
 	})
@@ -337,22 +345,22 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ListOperations() {
 		suite.compositeStore = newCompositeOUStore(suite.fileStore, suite.dbStoreMock)
 
 		// Add 1 OU to file store
-		_ = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		_ = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID: "file-ou-1", Handle: "file-1", Name: "File OU 1",
 		})
 
 		// Mock DB store - note that implementation calls count to determine how many to fetch from each
 		// dbCount will be called to fetch all from DB
-		suite.dbStoreMock.On("GetOrganizationUnitListCount").Return(2, nil).Once()
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(2, nil).Once()
 		// Then fileCount from fileStore (real store) returns 1
 		// Total = 3, so it will try to fetch all 3 (dbCount=2, fileCount=1)
-		suite.dbStoreMock.On("GetOrganizationUnitList", 2, 0).Return([]OrganizationUnitBasic{
+		suite.dbStoreMock.On("GetOrganizationUnitList", mock.Anything, 2, 0).Return([]OrganizationUnitBasic{
 			{ID: "db-ou-1", Handle: "db-1", Name: "DB OU 1"},
 			{ID: "db-ou-2", Handle: "db-2", Name: "DB OU 2"},
 		}, nil).Once()
 		// fileStore.GetOrganizationUnitList will be called with (1, 0) and return the file OU
 
-		list, err := suite.compositeStore.GetOrganizationUnitList(10, 0)
+		list, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0)
 		suite.NoError(err)
 		suite.Len(list, 3) // 2 from DB + 1 from file
 
@@ -377,25 +385,25 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ListOperations() {
 		suite.dbStoreMock = newOrganizationUnitStoreInterfaceMock(suite.T())
 		suite.compositeStore = newCompositeOUStore(fileStoreMock, suite.dbStoreMock)
 
-		suite.dbStoreMock.On("GetOrganizationUnitListCount").Return(600, nil).Once()
-		fileStoreMock.On("GetOrganizationUnitListCount").Return(700, nil).Once()
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(600, nil).Once()
+		fileStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(700, nil).Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitList(100, 900)
+		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 100, 900)
 		// When limit is exceeded (1300 > 1000), should return error
 		suite.Error(err)
 		suite.ErrorIs(err, ErrResultLimitExceededInCompositeMode)
 		suite.Nil(result)
 
-		suite.dbStoreMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything, mock.Anything)
-		fileStoreMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything, mock.Anything)
+		suite.dbStoreMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything)
+		fileStoreMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything)
 	})
 
 	suite.Run("user/group operations use DB store only", func() {
-		suite.dbStoreMock.On("GetOrganizationUnitUsersCount", "ou-1").
+		suite.dbStoreMock.On("GetOrganizationUnitUsersCount", mock.Anything, "ou-1").
 			Return(10, nil).
 			Once()
 
-		count, err := suite.compositeStore.GetOrganizationUnitUsersCount("ou-1")
+		count, err := suite.compositeStore.GetOrganizationUnitUsersCount(context.Background(), "ou-1")
 		suite.NoError(err)
 		suite.Equal(10, count)
 	})
@@ -405,24 +413,24 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ListOperations() {
 func (suite *CompositeStoreTestSuite) TestCompositeStore_IsOrganizationUnitDeclarative() {
 	suite.Run("returns true for immutable OU (exists in file store)", func() {
 		// Add OU to file store
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "immutable-ou-1",
 			Handle: "immutable-handle",
 			Name:   "Declarative OU",
 		})
 		suite.NoError(err)
 
-		isDeclarative := suite.compositeStore.IsOrganizationUnitDeclarative("immutable-ou-1")
+		isDeclarative := suite.compositeStore.IsOrganizationUnitDeclarative(context.Background(), "immutable-ou-1")
 		suite.True(isDeclarative)
 	})
 
 	suite.Run("returns false for mutable OU (not in file store)", func() {
-		isDeclarative := suite.compositeStore.IsOrganizationUnitDeclarative("db-ou-1")
+		isDeclarative := suite.compositeStore.IsOrganizationUnitDeclarative(context.Background(), "db-ou-1")
 		suite.False(isDeclarative)
 	})
 
 	suite.Run("returns false for non-existent OU", func() {
-		isDeclarative := suite.compositeStore.IsOrganizationUnitDeclarative("nonexistent")
+		isDeclarative := suite.compositeStore.IsOrganizationUnitDeclarative(context.Background(), "nonexistent")
 		suite.False(isDeclarative)
 	})
 }
@@ -465,25 +473,25 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 			{ID: "ou-2", Handle: "handle-2", Name: "OU 2"},
 		}
 
-		suite.dbStoreMock.On("GetOrganizationUnitListCount").
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitList", 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitList", mock.Anything, 2, 0).
 			Return(expectedList, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitList(10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0)
 		suite.NoError(err)
 		suite.Equal(expectedList, result)
 	})
 
 	suite.Run("propagates DB store error", func() {
 		dbErr := errors.New("database error")
-		suite.dbStoreMock.On("GetOrganizationUnitListCount").
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).
 			Return(0, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitList(10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Empty(result)
@@ -501,11 +509,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 			Name:   "Level 2 OU",
 		}
 
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", handles).
+		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handles).
 			Return(expectedOU, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitByPath(handles)
+		result, err := suite.compositeStore.GetOrganizationUnitByPath(context.Background(), handles)
 		suite.NoError(err)
 		suite.Equal(expectedOU, result)
 	})
@@ -513,14 +521,14 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 	suite.Run("falls back to file store when not in DB", func() {
 		// Create parent and child in file store
 		parentID := "file-parent"
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     parentID,
 			Handle: "level1",
 			Name:   "Parent",
 		})
 		suite.NoError(err)
 
-		err = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "file-child",
 			Handle: "level2",
 			Name:   "Child",
@@ -528,11 +536,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", handles).
+		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handles).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitByPath(handles)
+		result, err := suite.compositeStore.GetOrganizationUnitByPath(context.Background(), handles)
 		suite.NoError(err)
 		suite.Equal("file-child", result.ID)
 		suite.Equal("level2", result.Handle)
@@ -542,11 +550,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		suite.SetupTest() // Fresh setup
 		handlesTest := []string{"nonexistent1", "nonexistent2"}
 
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", handlesTest).
+		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handlesTest).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitByPath(handlesTest)
+		result, err := suite.compositeStore.GetOrganizationUnitByPath(context.Background(), handlesTest)
 		suite.Error(err)
 		suite.Equal(ErrOrganizationUnitNotFound, err)
 		suite.Empty(result.ID)
@@ -554,11 +562,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 
 	suite.Run("propagates DB errors other than not found", func() {
 		dbErr := errors.New("database connection error")
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", handles).
+		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handles).
 			Return(OrganizationUnit{}, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitByPath(handles)
+		result, err := suite.compositeStore.GetOrganizationUnitByPath(context.Background(), handles)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Empty(result.ID)
@@ -570,17 +578,19 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_CheckOrganizati
 	suite.Run("detects handle conflict in DB store", func() {
 		// File store checked first - returns false (no conflict)
 		// Then DB store checked - returns true (conflict)
-		suite.dbStoreMock.On("CheckOrganizationUnitHandleConflict", "test-handle", (*string)(nil)).
+		suite.dbStoreMock.On("CheckOrganizationUnitHandleConflict", mock.Anything, "test-handle", (*string)(nil)).
 			Return(true, nil).
 			Once()
 
-		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict("test-handle", nil)
+		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict(
+			context.Background(), "test-handle", nil,
+		)
 		suite.NoError(err)
 		suite.True(conflict)
 	})
 
 	suite.Run("detects handle conflict in file store", func() {
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "file-ou",
 			Handle: "conflict-handle",
 			Name:   "File OU",
@@ -591,28 +601,32 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_CheckOrganizati
 		// DB store not called since file store found conflict
 		// No mock expectation for dbStore
 
-		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict("conflict-handle", nil)
+		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict(
+			context.Background(), "conflict-handle", nil,
+		)
 		suite.NoError(err)
 		suite.True(conflict)
 	})
 
 	suite.Run("no handle conflict in either store", func() {
-		suite.dbStoreMock.On("CheckOrganizationUnitHandleConflict", "unique-handle", (*string)(nil)).
+		suite.dbStoreMock.On("CheckOrganizationUnitHandleConflict", mock.Anything, "unique-handle", (*string)(nil)).
 			Return(false, nil).
 			Once()
 
-		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict("unique-handle", nil)
+		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict(
+			context.Background(), "unique-handle", nil,
+		)
 		suite.NoError(err)
 		suite.False(conflict)
 	})
 
 	suite.Run("propagates DB error", func() {
 		dbErr := errors.New("db error")
-		suite.dbStoreMock.On("CheckOrganizationUnitHandleConflict", "test", (*string)(nil)).
+		suite.dbStoreMock.On("CheckOrganizationUnitHandleConflict", mock.Anything, "test", (*string)(nil)).
 			Return(false, dbErr).
 			Once()
 
-		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict("test", nil)
+		conflict, err := suite.compositeStore.CheckOrganizationUnitHandleConflict(context.Background(), "test", nil)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.False(conflict)
@@ -628,24 +642,24 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_CheckOrganizati
 	suite.Run("has children in DB store", func() {
 		// File store checked first - returns false (no children)
 		// Then DB store checked - returns true (has children)
-		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", "ou-1").
+		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 			Return(true, nil).
 			Once()
 
-		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources("ou-1")
+		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources(context.Background(), "ou-1")
 		suite.NoError(err)
 		suite.True(hasChildren)
 	})
 
 	suite.Run("has children in file store only", func() {
 		parentID := testCoverageParentOUID
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     parentID,
 			Handle: "parent",
 			Name:   "Parent",
 		})
 		suite.NoError(err)
-		err = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "child-ou",
 			Handle: "child",
 			Name:   "Child",
@@ -657,28 +671,30 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_CheckOrganizati
 		// DB store not called since file store returned true
 		// No mock expectation for dbStore
 
-		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources(parentID)
+		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources(context.Background(), parentID)
 		suite.NoError(err)
 		suite.True(hasChildren)
 	})
 
 	suite.Run("no children in either store", func() {
-		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", "childless-ou").
+		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", mock.Anything, "childless-ou").
 			Return(false, nil).
 			Once()
 
-		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources("childless-ou")
+		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources(
+			context.Background(), "childless-ou",
+		)
 		suite.NoError(err)
 		suite.False(hasChildren)
 	})
 
 	suite.Run("propagates DB error", func() {
 		dbErr := errors.New("db error")
-		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", "ou-1").
+		suite.dbStoreMock.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 			Return(false, dbErr).
 			Once()
 
-		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources("ou-1")
+		hasChildren, err := suite.compositeStore.CheckOrganizationUnitHasChildResources(context.Background(), "ou-1")
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.False(hasChildren)
@@ -697,13 +713,13 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		}
 
 		// Setup file store parent and children
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     parentID,
 			Handle: "parent",
 			Name:   "Parent",
 		})
 		suite.NoError(err)
-		err = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "file-child-1",
 			Handle: "file1",
 			Name:   "File Child 1",
@@ -711,25 +727,25 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", parentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", parentID, 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, parentID, 2, 0).
 			Return(dbChildren, nil).
 			Once()
 
 		// Request first 2 items
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(parentID, 2, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), parentID, 2, 0)
 		suite.NoError(err)
 		suite.Len(result, 2)
 	})
 
 	suite.Run("handles offset beyond total count", func() {
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", parentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID).
 			Return(2, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(parentID, 10, 100)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), parentID, 10, 100)
 		suite.NoError(err)
 		suite.Empty(result)
 	})
@@ -744,22 +760,22 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		}
 
 		// Setup file store parent
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     testParentID,
 			Handle: "parent",
 			Name:   "Parent",
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", testParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID).
 			Return(3, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", testParentID, 3, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, testParentID, 3, 0).
 			Return(dbChildren, nil).
 			Once()
 
 		// Get second page (offset=2, limit=2)
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(testParentID, 2, 2)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), testParentID, 2, 2)
 		suite.NoError(err)
 		suite.Len(result, 1) // Only 1 item remaining
 		suite.Equal("db-child-3", result[0].ID)
@@ -768,7 +784,7 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 	suite.Run("propagates DB count error", func() {
 		suite.SetupTest() // Fresh setup
 		testParentID := "count-error-parent"
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     testParentID,
 			Handle: "parent",
 			Name:   "Parent",
@@ -776,11 +792,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		suite.NoError(err)
 
 		dbErr := errors.New("count error")
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", testParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID).
 			Return(0, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(testParentID, 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), testParentID, 10, 0)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Nil(result)
@@ -790,7 +806,7 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		suite.SetupTest() // Fresh setup
 		testParentID := "error-parent"
 		// Create parent in file store
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     testParentID,
 			Handle: "parent",
 			Name:   "Parent",
@@ -798,14 +814,14 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		suite.NoError(err)
 
 		dbErr := errors.New("list error")
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", testParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", testParentID, 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, testParentID, 2, 0).
 			Return([]OrganizationUnitBasic{}, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(testParentID, 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), testParentID, 10, 0)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Nil(result)
@@ -822,13 +838,13 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		}
 
 		// Setup file store with duplicate ID
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     dedupeParentID,
 			Handle: "parent",
 			Name:   "Parent",
 		})
 		suite.NoError(err)
-		err = suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err = suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "child-1", // Same ID as DB child
 			Handle: "file-handle",
 			Name:   "File Child",
@@ -836,14 +852,14 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", dedupeParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, dedupeParentID).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", dedupeParentID, 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, dedupeParentID, 2, 0).
 			Return(dbChildren, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(dedupeParentID, 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), dedupeParentID, 10, 0)
 		suite.NoError(err)
 		// Should have 2 children (duplicate removed)
 		suite.Len(result, 2)
@@ -864,21 +880,21 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_UserAndGroupOpe
 			{ID: "user-2"},
 		}
 
-		suite.dbStoreMock.On("GetOrganizationUnitUsersList", "ou-1", 10, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitUsersList", mock.Anything, "ou-1", 10, 0).
 			Return(expectedUsers, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitUsersList("ou-1", 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitUsersList(context.Background(), "ou-1", 10, 0)
 		suite.NoError(err)
 		suite.Equal(expectedUsers, result)
 	})
 
 	suite.Run("retrieves groups count from DB store", func() {
-		suite.dbStoreMock.On("GetOrganizationUnitGroupsCount", "ou-1").
+		suite.dbStoreMock.On("GetOrganizationUnitGroupsCount", mock.Anything, "ou-1").
 			Return(5, nil).
 			Once()
 
-		count, err := suite.compositeStore.GetOrganizationUnitGroupsCount("ou-1")
+		count, err := suite.compositeStore.GetOrganizationUnitGroupsCount(context.Background(), "ou-1")
 		suite.NoError(err)
 		suite.Equal(5, count)
 	})
@@ -889,11 +905,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_UserAndGroupOpe
 			{ID: "group-2", Name: "Group 2"},
 		}
 
-		suite.dbStoreMock.On("GetOrganizationUnitGroupsList", "ou-1", 10, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitGroupsList", mock.Anything, "ou-1", 10, 0).
 			Return(expectedGroups, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitGroupsList("ou-1", 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitGroupsList(context.Background(), "ou-1", 10, 0)
 		suite.NoError(err)
 		suite.Equal(expectedGroups, result)
 	})
@@ -901,27 +917,27 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_UserAndGroupOpe
 	suite.Run("propagates errors for user/group operations", func() {
 		dbErr := errors.New("db error")
 
-		suite.dbStoreMock.On("GetOrganizationUnitUsersList", "ou-1", 10, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitUsersList", mock.Anything, "ou-1", 10, 0).
 			Return([]User{}, dbErr).
 			Once()
 
-		users, err := suite.compositeStore.GetOrganizationUnitUsersList("ou-1", 10, 0)
+		users, err := suite.compositeStore.GetOrganizationUnitUsersList(context.Background(), "ou-1", 10, 0)
 		suite.Error(err)
 		suite.Empty(users)
 
-		suite.dbStoreMock.On("GetOrganizationUnitGroupsCount", "ou-1").
+		suite.dbStoreMock.On("GetOrganizationUnitGroupsCount", mock.Anything, "ou-1").
 			Return(0, dbErr).
 			Once()
 
-		count, err := suite.compositeStore.GetOrganizationUnitGroupsCount("ou-1")
+		count, err := suite.compositeStore.GetOrganizationUnitGroupsCount(context.Background(), "ou-1")
 		suite.Error(err)
 		suite.Equal(0, count)
 
-		suite.dbStoreMock.On("GetOrganizationUnitGroupsList", "ou-1", 10, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitGroupsList", mock.Anything, "ou-1", 10, 0).
 			Return([]Group{}, dbErr).
 			Once()
 
-		groups, err := suite.compositeStore.GetOrganizationUnitGroupsList("ou-1", 10, 0)
+		groups, err := suite.compositeStore.GetOrganizationUnitGroupsList(context.Background(), "ou-1", 10, 0)
 		suite.Error(err)
 		suite.Empty(groups)
 	})
@@ -1071,7 +1087,7 @@ func (suite *CompositeStoreCoverageTestSuite) TestMergeAndDeduplicateChildren() 
 // TestCompositeStore_GetOrganizationUnitsByIDs tests retrieving OUs by IDs.
 func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganizationUnitsByIDs() {
 	suite.Run("returns empty slice when ids are empty", func() {
-		result, err := suite.compositeStore.GetOrganizationUnitsByIDs([]string{})
+		result, err := suite.compositeStore.GetOrganizationUnitsByIDs(context.Background(), []string{})
 		suite.NoError(err)
 		suite.Empty(result)
 	})
@@ -1084,7 +1100,7 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		}
 
 		// Setup file store OU
-		err := suite.fileStore.CreateOrganizationUnit(OrganizationUnit{
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
 			ID:     "file-1",
 			Handle: "file1",
 			Name:   "File 1",
@@ -1093,11 +1109,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 
 		ids := []string{"db-1", "db-2", "file-1", "non-existent"}
 
-		suite.dbStoreMock.On("GetOrganizationUnitsByIDs", ids).
+		suite.dbStoreMock.On("GetOrganizationUnitsByIDs", mock.Anything, ids).
 			Return(dbOUs, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitsByIDs(ids)
+		result, err := suite.compositeStore.GetOrganizationUnitsByIDs(context.Background(), ids)
 		suite.NoError(err)
 		suite.Len(result, 3) // 2 from DB + 1 from File
 
@@ -1127,11 +1143,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		dbErr := errors.New("db query error")
 		ids := []string{"ou-1"}
 
-		suite.dbStoreMock.On("GetOrganizationUnitsByIDs", ids).
+		suite.dbStoreMock.On("GetOrganizationUnitsByIDs", mock.Anything, ids).
 			Return([]OrganizationUnitBasic{}, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitsByIDs(ids)
+		result, err := suite.compositeStore.GetOrganizationUnitsByIDs(context.Background(), ids)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Empty(result)

--- a/backend/internal/ou/declarative_resource.go
+++ b/backend/internal/ou/declarative_resource.go
@@ -80,7 +80,7 @@ func (e *ouExporter) GetAllResourceIDs(ctx context.Context) ([]string, *servicee
 	ids := make([]string, 0, len(ous.OrganizationUnits))
 	for _, ouBasic := range ous.OrganizationUnits {
 		// Only include mutable OUs (exclude immutable ones)
-		if !e.service.IsOrganizationUnitDeclarative(ouBasic.ID) {
+		if !e.service.IsOrganizationUnitDeclarative(ctx, ouBasic.ID) {
 			ids = append(ids, ouBasic.ID)
 		}
 	}
@@ -116,7 +116,7 @@ func (e *ouExporter) getAllChildIDs(ctx context.Context, parentID string) ([]str
 	allIDs := []string{}
 	for _, childBasic := range children.OrganizationUnits {
 		// Only include mutable children (exclude immutable ones)
-		if !e.service.IsOrganizationUnitDeclarative(childBasic.ID) {
+		if !e.service.IsOrganizationUnitDeclarative(ctx, childBasic.ID) {
 			allIDs = append(allIDs, childBasic.ID)
 			grandchildIDs, err := e.getAllChildIDs(ctx, childBasic.ID)
 			if err != nil {
@@ -239,7 +239,11 @@ func validateOUWrapper(data interface{}, fileStore *fileBasedStore, dbStore orga
 
 	// Check for duplicate ID in the database store (only in composite mode)
 	if dbStore != nil {
-		if exists, err := dbStore.IsOrganizationUnitExists(ou.ID); err == nil && exists {
+		exists, err := dbStore.IsOrganizationUnitExists(context.Background(), ou.ID)
+		if err != nil {
+			return fmt.Errorf("failed to check organization unit existence for ID '%s': %w", ou.ID, err)
+		}
+		if exists {
 			return fmt.Errorf("duplicate organization unit ID '%s': "+
 				"an organization unit with this ID already exists in the database store", ou.ID)
 		}

--- a/backend/internal/ou/declarative_resource_test.go
+++ b/backend/internal/ou/declarative_resource_test.go
@@ -20,6 +20,7 @@ package ou
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -193,7 +194,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateOUWrapperDuplicateID() {
 		Name:   "Test OU 1",
 	}
 
-	err := store.CreateOrganizationUnit(*ou1)
+	err := store.CreateOrganizationUnit(context.Background(), *ou1)
 	assert.NoError(s.T(), err)
 
 	// Second OU with same ID - should fail validation
@@ -215,7 +216,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateOUWrapperDuplicateIDInDBStore
 	dbStore := newOrganizationUnitStoreInterfaceMock(s.T())
 
 	// Mock dbStore to return that the ID exists
-	dbStore.On("IsOrganizationUnitExists", "test-ou-db-duplicate").
+	dbStore.On("IsOrganizationUnitExists", mock.Anything, "test-ou-db-duplicate").
 		Return(true, nil).
 		Once()
 
@@ -240,7 +241,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateOUWrapperNoDuplicateInComposi
 	dbStore := newOrganizationUnitStoreInterfaceMock(s.T())
 
 	// Mock dbStore to return that the ID does not exist
-	dbStore.On("IsOrganizationUnitExists", "test-ou-new").
+	dbStore.On("IsOrganizationUnitExists", mock.Anything, "test-ou-new").
 		Return(false, nil).
 		Once()
 
@@ -253,6 +254,30 @@ func (s *DeclarativeResourceTestSuite) TestValidateOUWrapperNoDuplicateInComposi
 
 	err := validateOUWrapper(ou, fileStore, dbStore)
 	assert.NoError(s.T(), err)
+
+	dbStore.AssertExpectations(s.T())
+}
+
+func (s *DeclarativeResourceTestSuite) TestValidateOUWrapperErrorInDBStore() {
+	fileStore := newFileBasedStore().(*fileBasedStore)
+	dbStore := newOrganizationUnitStoreInterfaceMock(s.T())
+
+	// Mock dbStore to return an error
+	dbStore.On("IsOrganizationUnitExists", mock.Anything, "test-ou-db-error").
+		Return(false, fmt.Errorf("database connection failed")).
+		Once()
+
+	// Try to add an OU when DB check fails
+	ou := &OrganizationUnit{
+		ID:     "test-ou-db-error",
+		Handle: "test",
+		Name:   "Test OU",
+	}
+
+	err := validateOUWrapper(ou, fileStore, dbStore)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "failed to check organization unit existence")
+	assert.Contains(s.T(), err.Error(), "database connection failed")
 
 	dbStore.AssertExpectations(s.T())
 }
@@ -293,8 +318,8 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_RootOUsOnly() {
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate these are mutable OUs
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-1").Return(false)
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-2").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-2").Return(false)
 
 	// Mock GetOrganizationUnitChildren to return empty lists for both roots
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
@@ -337,7 +362,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_WithChildren() {
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate these are mutable OUs
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
 	// Mock children at each level
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
@@ -345,14 +370,14 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_WithChildren() {
 		OrganizationUnits: []OrganizationUnitBasic{childOU},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("child-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "child-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{grandchildOU},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("grandchild-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "grandchild-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "grandchild-1", 100, 0).Return(&OrganizationUnitListResponse{
@@ -395,15 +420,15 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithCh
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate these are mutable OUs
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-1").Return(false)
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-2").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-2").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{child1},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("child-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "child-1", 100, 0).Return(&OrganizationUnitListResponse{
@@ -415,7 +440,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithCh
 		OrganizationUnits: []OrganizationUnitBasic{child2},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("child-2").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-2").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "child-2", 100, 0).Return(&OrganizationUnitListResponse{
@@ -457,7 +482,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_ErrorGettingChildre
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate this is a mutable OU
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0).Return(
 		(*OrganizationUnitListResponse)(nil),
@@ -482,35 +507,35 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_DeepNesting() {
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative for all levels
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("level-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "level-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level2},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("level-2").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-2").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "level-2", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level3},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("level-3").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-3").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "level-3", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level4},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("level-4").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-4").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "level-4", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{level5},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("level-5").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-5").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "level-5", 100, 0).Return(&OrganizationUnitListResponse{
@@ -553,7 +578,7 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPer
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative for root
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
@@ -561,9 +586,9 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPer
 	}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative for all children
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("child-1").Return(false)
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("child-2").Return(false)
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("child-3").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-2").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-3").Return(false)
 
 	// Each child has no children
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
@@ -606,14 +631,14 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_ErrorGettingGrandch
 		OrganizationUnits: []OrganizationUnitBasic{rootOU},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("root-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
 		OrganizationUnits: []OrganizationUnitBasic{childOU},
 	}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().IsOrganizationUnitDeclarative("child-1").Return(false)
+	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
 
 	s.mockService.EXPECT().GetOrganizationUnitChildren(
 		mock.Anything, "child-1", 100, 0).Return(

--- a/backend/internal/ou/file_based_store.go
+++ b/backend/internal/ou/file_based_store.go
@@ -19,6 +19,7 @@
 package ou
 
 import (
+	"context"
 	"errors"
 
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
@@ -40,21 +41,21 @@ func newFileBasedStore() organizationUnitStoreInterface {
 // Create implements declarativeresource.Storer interface for resource loader
 func (f *fileBasedStore) Create(id string, data interface{}) error {
 	ou := data.(*OrganizationUnit)
-	return f.CreateOrganizationUnit(*ou)
+	return f.CreateOrganizationUnit(context.TODO(), *ou)
 }
 
 // CreateOrganizationUnit implements organizationUnitStoreInterface.
-func (f *fileBasedStore) CreateOrganizationUnit(ou OrganizationUnit) error {
+func (f *fileBasedStore) CreateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
 	return f.GenericFileBasedStore.Create(ou.ID, &ou)
 }
 
 // DeleteOrganizationUnit implements organizationUnitStoreInterface.
-func (f *fileBasedStore) DeleteOrganizationUnit(id string) error {
+func (f *fileBasedStore) DeleteOrganizationUnit(ctx context.Context, id string) error {
 	return errors.New("DeleteOrganizationUnit is not supported in file-based store")
 }
 
 // GetOrganizationUnit implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnit(id string) (OrganizationUnit, error) {
+func (f *fileBasedStore) GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, error) {
 	data, err := f.GenericFileBasedStore.Get(id)
 	if err != nil {
 		return OrganizationUnit{}, ErrOrganizationUnitNotFound
@@ -68,7 +69,7 @@ func (f *fileBasedStore) GetOrganizationUnit(id string) (OrganizationUnit, error
 }
 
 // GetOrganizationUnitByPath implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitByPath(handles []string) (OrganizationUnit, error) {
+func (f *fileBasedStore) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return OrganizationUnit{}, err
@@ -107,7 +108,9 @@ func (f *fileBasedStore) GetOrganizationUnitByPath(handles []string) (Organizati
 }
 
 // GetOrganizationUnitList implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitList(limit, offset int) ([]OrganizationUnitBasic, error) {
+func (f *fileBasedStore) GetOrganizationUnitList(
+	ctx context.Context, limit, offset int,
+) ([]OrganizationUnitBasic, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -144,7 +147,7 @@ func (f *fileBasedStore) GetOrganizationUnitList(limit, offset int) ([]Organizat
 }
 
 // GetOrganizationUnitListCount implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitListCount() (int, error) {
+func (f *fileBasedStore) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return 0, err
@@ -164,7 +167,7 @@ func (f *fileBasedStore) GetOrganizationUnitListCount() (int, error) {
 }
 
 // GetOrganizationUnitsByIDs implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitsByIDs(ids []string) ([]OrganizationUnitBasic, error) {
+func (f *fileBasedStore) GetOrganizationUnitsByIDs(ctx context.Context, ids []string) ([]OrganizationUnitBasic, error) {
 	if len(ids) == 0 {
 		return []OrganizationUnitBasic{}, nil
 	}
@@ -198,8 +201,8 @@ func (f *fileBasedStore) GetOrganizationUnitsByIDs(ids []string) ([]Organization
 }
 
 // IsOrganizationUnitExists implements organizationUnitStoreInterface.
-func (f *fileBasedStore) IsOrganizationUnitExists(id string) (bool, error) {
-	_, err := f.GetOrganizationUnit(id)
+func (f *fileBasedStore) IsOrganizationUnitExists(ctx context.Context, id string) (bool, error) {
+	_, err := f.GetOrganizationUnit(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return false, nil
@@ -211,13 +214,15 @@ func (f *fileBasedStore) IsOrganizationUnitExists(id string) (bool, error) {
 
 // IsOrganizationUnitDeclarative checks if an organization unit is immutable.
 // File-based resources are always immutable, returns true if exists.
-func (f *fileBasedStore) IsOrganizationUnitDeclarative(id string) bool {
-	exists, err := f.IsOrganizationUnitExists(id)
+func (f *fileBasedStore) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
+	exists, err := f.IsOrganizationUnitExists(ctx, id)
 	return err == nil && exists
 }
 
 // CheckOrganizationUnitNameConflict implements organizationUnitStoreInterface.
-func (f *fileBasedStore) CheckOrganizationUnitNameConflict(name string, parent *string) (bool, error) {
+func (f *fileBasedStore) CheckOrganizationUnitNameConflict(
+	ctx context.Context, name string, parent *string,
+) (bool, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return false, err
@@ -238,7 +243,9 @@ func (f *fileBasedStore) CheckOrganizationUnitNameConflict(name string, parent *
 }
 
 // CheckOrganizationUnitHandleConflict implements organizationUnitStoreInterface.
-func (f *fileBasedStore) CheckOrganizationUnitHandleConflict(handle string, parent *string) (bool, error) {
+func (f *fileBasedStore) CheckOrganizationUnitHandleConflict(
+	ctx context.Context, handle string, parent *string,
+) (bool, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return false, err
@@ -259,12 +266,12 @@ func (f *fileBasedStore) CheckOrganizationUnitHandleConflict(handle string, pare
 }
 
 // UpdateOrganizationUnit implements organizationUnitStoreInterface.
-func (f *fileBasedStore) UpdateOrganizationUnit(ou OrganizationUnit) error {
+func (f *fileBasedStore) UpdateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
 	return errors.New("UpdateOrganizationUnit is not supported in file-based store")
 }
 
 // CheckOrganizationUnitHasChildResources implements organizationUnitStoreInterface.
-func (f *fileBasedStore) CheckOrganizationUnitHasChildResources(id string) (bool, error) {
+func (f *fileBasedStore) CheckOrganizationUnitHasChildResources(ctx context.Context, id string) (bool, error) {
 	// In file-based mode, we check if there are any child OUs
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
@@ -283,7 +290,7 @@ func (f *fileBasedStore) CheckOrganizationUnitHasChildResources(id string) (bool
 }
 
 // GetOrganizationUnitChildrenCount implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitChildrenCount(id string) (int, error) {
+func (f *fileBasedStore) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return 0, err
@@ -303,7 +310,7 @@ func (f *fileBasedStore) GetOrganizationUnitChildrenCount(id string) (int, error
 
 // GetOrganizationUnitChildrenList implements organizationUnitStoreInterface.
 func (f *fileBasedStore) GetOrganizationUnitChildrenList(
-	id string, limit, offset int) ([]OrganizationUnitBasic, error) {
+	ctx context.Context, id string, limit, offset int) ([]OrganizationUnitBasic, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -339,25 +346,29 @@ func (f *fileBasedStore) GetOrganizationUnitChildrenList(
 }
 
 // GetOrganizationUnitUsersCount implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitUsersCount(id string) (int, error) {
+func (f *fileBasedStore) GetOrganizationUnitUsersCount(ctx context.Context, id string) (int, error) {
 	// In file-based mode, users are not stored with OUs
 	return 0, nil
 }
 
 // GetOrganizationUnitUsersList implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitUsersList(id string, limit, offset int) ([]User, error) {
+func (f *fileBasedStore) GetOrganizationUnitUsersList(
+	ctx context.Context, id string, limit, offset int,
+) ([]User, error) {
 	// In file-based mode, users are not stored with OUs
 	return []User{}, nil
 }
 
 // GetOrganizationUnitGroupsCount implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitGroupsCount(id string) (int, error) {
+func (f *fileBasedStore) GetOrganizationUnitGroupsCount(ctx context.Context, id string) (int, error) {
 	// In file-based mode, groups are not stored with OUs
 	return 0, nil
 }
 
 // GetOrganizationUnitGroupsList implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitGroupsList(id string, limit, offset int) ([]Group, error) {
+func (f *fileBasedStore) GetOrganizationUnitGroupsList(
+	ctx context.Context, id string, limit, offset int,
+) ([]Group, error) {
 	// In file-based mode, groups are not stored with OUs
 	return []Group{}, nil
 }

--- a/backend/internal/ou/file_based_store_test.go
+++ b/backend/internal/ou/file_based_store_test.go
@@ -19,6 +19,8 @@
 package ou
 
 import (
+	"context"
+
 	"strconv"
 	"testing"
 
@@ -60,11 +62,11 @@ func (s *FileBasedStoreTestSuite) TestCreateOrganizationUnit() {
 		Parent:      nil,
 	}
 
-	err := s.store.CreateOrganizationUnit(ou)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	assert.NoError(s.T(), err)
 
 	// Verify it was created
-	retrieved, err := s.store.GetOrganizationUnit("test-ou-1")
+	retrieved, err := s.store.GetOrganizationUnit(context.Background(), "test-ou-1")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), ou.ID, retrieved.ID)
 	assert.Equal(s.T(), ou.Name, retrieved.Name)
@@ -72,7 +74,7 @@ func (s *FileBasedStoreTestSuite) TestCreateOrganizationUnit() {
 }
 
 func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitNotFound() {
-	_, err := s.store.GetOrganizationUnit("non-existent")
+	_, err := s.store.GetOrganizationUnit(context.Background(), "non-existent")
 	assert.Error(s.T(), err)
 	assert.ErrorIs(s.T(), err, ErrOrganizationUnitNotFound)
 }
@@ -92,9 +94,9 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitList() {
 		Parent: nil,
 	}
 
-	err := s.store.CreateOrganizationUnit(ou1)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou1)
 	assert.NoError(s.T(), err)
-	err = s.store.CreateOrganizationUnit(ou2)
+	err = s.store.CreateOrganizationUnit(context.Background(), ou2)
 	assert.NoError(s.T(), err)
 
 	// Create child OU (should not be in root list)
@@ -105,11 +107,11 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitList() {
 		Name:   "Child 1",
 		Parent: &parentID,
 	}
-	err = s.store.CreateOrganizationUnit(child)
+	err = s.store.CreateOrganizationUnit(context.Background(), child)
 	assert.NoError(s.T(), err)
 
 	// Get list should only return root OUs
-	list, err := s.store.GetOrganizationUnitList(10, 0)
+	list, err := s.store.GetOrganizationUnitList(context.Background(), 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 2)
 }
@@ -121,13 +123,13 @@ func (s *FileBasedStoreTestSuite) TestUpdateNotSupported() {
 		Name:   "Test OU",
 	}
 
-	err := s.store.UpdateOrganizationUnit(ou)
+	err := s.store.UpdateOrganizationUnit(context.Background(), ou)
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "not supported")
 }
 
 func (s *FileBasedStoreTestSuite) TestDeleteNotSupported() {
-	err := s.store.DeleteOrganizationUnit("test-ou-1")
+	err := s.store.DeleteOrganizationUnit(context.Background(), "test-ou-1")
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "not supported")
 }
@@ -140,16 +142,16 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitNameConflict() {
 		Parent: nil,
 	}
 
-	err := s.store.CreateOrganizationUnit(ou)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	assert.NoError(s.T(), err)
 
 	// Check for conflict with same name and parent
-	conflict, err := s.store.CheckOrganizationUnitNameConflict("Test OU", nil)
+	conflict, err := s.store.CheckOrganizationUnitNameConflict(context.Background(), "Test OU", nil)
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), conflict)
 
 	// No conflict with different name
-	conflict, err = s.store.CheckOrganizationUnitNameConflict("Different Name", nil)
+	conflict, err = s.store.CheckOrganizationUnitNameConflict(context.Background(), "Different Name", nil)
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), conflict)
 }
@@ -162,7 +164,7 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildren() {
 		Name:   "Parent OU",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(parent)
+	err := s.store.CreateOrganizationUnit(context.Background(), parent)
 	assert.NoError(s.T(), err)
 
 	// Create children
@@ -180,18 +182,18 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildren() {
 		Parent: &parentID,
 	}
 
-	err = s.store.CreateOrganizationUnit(child1)
+	err = s.store.CreateOrganizationUnit(context.Background(), child1)
 	assert.NoError(s.T(), err)
-	err = s.store.CreateOrganizationUnit(child2)
+	err = s.store.CreateOrganizationUnit(context.Background(), child2)
 	assert.NoError(s.T(), err)
 
 	// Get children
-	children, err := s.store.GetOrganizationUnitChildrenList(testParentOUID, 10, 0)
+	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 2)
 
 	// Get children count
-	count, err := s.store.GetOrganizationUnitChildrenCount(testParentOUID)
+	count, err := s.store.GetOrganizationUnitChildrenCount(context.Background(), testParentOUID)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 2, count)
 }
@@ -219,23 +221,23 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitByPath() {
 		Parent: &engID,
 	}
 
-	err := s.store.CreateOrganizationUnit(root)
+	err := s.store.CreateOrganizationUnit(context.Background(), root)
 	assert.NoError(s.T(), err)
-	err = s.store.CreateOrganizationUnit(engineering)
+	err = s.store.CreateOrganizationUnit(context.Background(), engineering)
 	assert.NoError(s.T(), err)
-	err = s.store.CreateOrganizationUnit(backend)
+	err = s.store.CreateOrganizationUnit(context.Background(), backend)
 	assert.NoError(s.T(), err)
 
 	// Test getting by path
-	ou, err := s.store.GetOrganizationUnitByPath([]string{"root"})
+	ou, err := s.store.GetOrganizationUnitByPath(context.Background(), []string{"root"})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "root-1", ou.ID)
 
-	ou, err = s.store.GetOrganizationUnitByPath([]string{"root", "engineering"})
+	ou, err = s.store.GetOrganizationUnitByPath(context.Background(), []string{"root", "engineering"})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "eng-1", ou.ID)
 
-	ou, err = s.store.GetOrganizationUnitByPath([]string{"root", "engineering", "backend"})
+	ou, err = s.store.GetOrganizationUnitByPath(context.Background(), []string{"root", "engineering", "backend"})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "backend-1", ou.ID)
 }
@@ -247,16 +249,16 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitByPath_NotFound() {
 		Name:   "Root",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(root)
+	err := s.store.CreateOrganizationUnit(context.Background(), root)
 	assert.NoError(s.T(), err)
 
 	// Test invalid path
-	_, err = s.store.GetOrganizationUnitByPath([]string{"root", "nonexistent"})
+	_, err = s.store.GetOrganizationUnitByPath(context.Background(), []string{"root", "nonexistent"})
 	assert.Error(s.T(), err)
 	assert.ErrorIs(s.T(), err, ErrOrganizationUnitNotFound)
 
 	// Test completely invalid path
-	_, err = s.store.GetOrganizationUnitByPath([]string{"invalid"})
+	_, err = s.store.GetOrganizationUnitByPath(context.Background(), []string{"invalid"})
 	assert.Error(s.T(), err)
 	assert.ErrorIs(s.T(), err, ErrOrganizationUnitNotFound)
 }
@@ -268,16 +270,16 @@ func (s *FileBasedStoreTestSuite) TestIsOrganizationUnitExists() {
 		Name:   "Test OU",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(ou)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	assert.NoError(s.T(), err)
 
 	// Test existing OU
-	exists, err := s.store.IsOrganizationUnitExists("test-ou-1")
+	exists, err := s.store.IsOrganizationUnitExists(context.Background(), "test-ou-1")
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), exists)
 
 	// Test non-existent OU
-	exists, err = s.store.IsOrganizationUnitExists("non-existent")
+	exists, err = s.store.IsOrganizationUnitExists(context.Background(), "non-existent")
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), exists)
 }
@@ -289,16 +291,16 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitHandleConflict() {
 		Name:   "Test OU",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(ou)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	assert.NoError(s.T(), err)
 
 	// Check for conflict with same handle and parent
-	conflict, err := s.store.CheckOrganizationUnitHandleConflict("test-handle", nil)
+	conflict, err := s.store.CheckOrganizationUnitHandleConflict(context.Background(), "test-handle", nil)
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), conflict)
 
 	// No conflict with different handle
-	conflict, err = s.store.CheckOrganizationUnitHandleConflict("different-handle", nil)
+	conflict, err = s.store.CheckOrganizationUnitHandleConflict(context.Background(), "different-handle", nil)
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), conflict)
 
@@ -310,16 +312,16 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitHandleConflict() {
 		Name:   "Child",
 		Parent: &parentID,
 	}
-	err = s.store.CreateOrganizationUnit(child)
+	err = s.store.CreateOrganizationUnit(context.Background(), child)
 	assert.NoError(s.T(), err)
 
-	conflict, err = s.store.CheckOrganizationUnitHandleConflict("child-handle", &parentID)
+	conflict, err = s.store.CheckOrganizationUnitHandleConflict(context.Background(), "child-handle", &parentID)
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), conflict)
 
 	// Different parent, same handle should not conflict
 	differentParent := "different-parent"
-	conflict, err = s.store.CheckOrganizationUnitHandleConflict("child-handle", &differentParent)
+	conflict, err = s.store.CheckOrganizationUnitHandleConflict(context.Background(), "child-handle", &differentParent)
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), conflict)
 }
@@ -332,7 +334,7 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitNameConflict_WithPare
 		Name:   "Parent",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(parent)
+	err := s.store.CreateOrganizationUnit(context.Background(), parent)
 	assert.NoError(s.T(), err)
 
 	child := OrganizationUnit{
@@ -341,22 +343,22 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitNameConflict_WithPare
 		Name:   "Child Name",
 		Parent: &parentID,
 	}
-	err = s.store.CreateOrganizationUnit(child)
+	err = s.store.CreateOrganizationUnit(context.Background(), child)
 	assert.NoError(s.T(), err)
 
 	// Same name, same parent - should conflict
-	conflict, err := s.store.CheckOrganizationUnitNameConflict("Child Name", &parentID)
+	conflict, err := s.store.CheckOrganizationUnitNameConflict(context.Background(), "Child Name", &parentID)
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), conflict)
 
 	// Same name, different parent - should not conflict
 	differentParent := "different-parent"
-	conflict, err = s.store.CheckOrganizationUnitNameConflict("Child Name", &differentParent)
+	conflict, err = s.store.CheckOrganizationUnitNameConflict(context.Background(), "Child Name", &differentParent)
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), conflict)
 
 	// Same name, nil parent vs actual parent - should not conflict
-	conflict, err = s.store.CheckOrganizationUnitNameConflict("Child Name", nil)
+	conflict, err = s.store.CheckOrganizationUnitNameConflict(context.Background(), "Child Name", nil)
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), conflict)
 }
@@ -368,11 +370,11 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitHasChildResources() {
 		Name:   "Parent",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(parent)
+	err := s.store.CreateOrganizationUnit(context.Background(), parent)
 	assert.NoError(s.T(), err)
 
 	// No children initially
-	hasChildren, err := s.store.CheckOrganizationUnitHasChildResources(testParentOUID)
+	hasChildren, err := s.store.CheckOrganizationUnitHasChildResources(context.Background(), testParentOUID)
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), hasChildren)
 
@@ -384,18 +386,18 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitHasChildResources() {
 		Name:   "Child",
 		Parent: &parentID,
 	}
-	err = s.store.CreateOrganizationUnit(child)
+	err = s.store.CreateOrganizationUnit(context.Background(), child)
 	assert.NoError(s.T(), err)
 
 	// Should have children now
-	hasChildren, err = s.store.CheckOrganizationUnitHasChildResources(testParentOUID)
+	hasChildren, err = s.store.CheckOrganizationUnitHasChildResources(context.Background(), testParentOUID)
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), hasChildren)
 }
 
 func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitListCount() {
 	// Initially empty
-	count, err := s.store.GetOrganizationUnitListCount()
+	count, err := s.store.GetOrganizationUnitListCount(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 0, count)
 
@@ -412,13 +414,13 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitListCount() {
 		Name:   "Root 2",
 		Parent: nil,
 	}
-	err = s.store.CreateOrganizationUnit(root1)
+	err = s.store.CreateOrganizationUnit(context.Background(), root1)
 	assert.NoError(s.T(), err)
-	err = s.store.CreateOrganizationUnit(root2)
+	err = s.store.CreateOrganizationUnit(context.Background(), root2)
 	assert.NoError(s.T(), err)
 
 	// Should count only root OUs
-	count, err = s.store.GetOrganizationUnitListCount()
+	count, err = s.store.GetOrganizationUnitListCount(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 2, count)
 
@@ -430,11 +432,11 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitListCount() {
 		Name:   "Child",
 		Parent: &parentID,
 	}
-	err = s.store.CreateOrganizationUnit(child)
+	err = s.store.CreateOrganizationUnit(context.Background(), child)
 	assert.NoError(s.T(), err)
 
 	// Count should still be 2
-	count, err = s.store.GetOrganizationUnitListCount()
+	count, err = s.store.GetOrganizationUnitListCount(context.Background())
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 2, count)
 }
@@ -449,27 +451,27 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitList_Pagination() {
 			Name:   "Root " + iStr,
 			Parent: nil,
 		}
-		err := s.store.CreateOrganizationUnit(ou)
+		err := s.store.CreateOrganizationUnit(context.Background(), ou)
 		assert.NoError(s.T(), err)
 	}
 
 	// Test pagination - first page
-	list, err := s.store.GetOrganizationUnitList(2, 0)
+	list, err := s.store.GetOrganizationUnitList(context.Background(), 2, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 2)
 
 	// Test pagination - second page
-	list, err = s.store.GetOrganizationUnitList(2, 2)
+	list, err = s.store.GetOrganizationUnitList(context.Background(), 2, 2)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 2)
 
 	// Test pagination - last page
-	list, err = s.store.GetOrganizationUnitList(2, 4)
+	list, err = s.store.GetOrganizationUnitList(context.Background(), 2, 4)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 1)
 
 	// Test offset beyond range
-	list, err = s.store.GetOrganizationUnitList(10, 100)
+	list, err = s.store.GetOrganizationUnitList(context.Background(), 10, 100)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), list)
 }
@@ -482,7 +484,7 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildrenList_Pagination
 		Name:   "Parent",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(parent)
+	err := s.store.CreateOrganizationUnit(context.Background(), parent)
 	assert.NoError(s.T(), err)
 
 	// Create multiple children
@@ -495,49 +497,49 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildrenList_Pagination
 			Name:   "Child " + iStr,
 			Parent: &parentID,
 		}
-		err := s.store.CreateOrganizationUnit(child)
+		err := s.store.CreateOrganizationUnit(context.Background(), child)
 		assert.NoError(s.T(), err)
 	}
 
 	// Test pagination
-	children, err := s.store.GetOrganizationUnitChildrenList(testParentOUID, 2, 0)
+	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 2, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 2)
 
-	children, err = s.store.GetOrganizationUnitChildrenList(testParentOUID, 2, 2)
+	children, err = s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 2, 2)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 2)
 
 	// Test offset beyond range
-	children, err = s.store.GetOrganizationUnitChildrenList(testParentOUID, 10, 100)
+	children, err = s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 10, 100)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), children)
 }
 
 func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitUsersCount() {
 	// Users are not stored in file-based mode
-	count, err := s.store.GetOrganizationUnitUsersCount("any-id")
+	count, err := s.store.GetOrganizationUnitUsersCount(context.Background(), "any-id")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 0, count)
 }
 
 func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitUsersList() {
 	// Users are not stored in file-based mode
-	users, err := s.store.GetOrganizationUnitUsersList("any-id", 10, 0)
+	users, err := s.store.GetOrganizationUnitUsersList(context.Background(), "any-id", 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), users)
 }
 
 func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitGroupsCount() {
 	// Groups are not stored in file-based mode
-	count, err := s.store.GetOrganizationUnitGroupsCount("any-id")
+	count, err := s.store.GetOrganizationUnitGroupsCount(context.Background(), "any-id")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 0, count)
 }
 
 func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitGroupsList() {
 	// Groups are not stored in file-based mode
-	groups, err := s.store.GetOrganizationUnitGroupsList("any-id", 10, 0)
+	groups, err := s.store.GetOrganizationUnitGroupsList(context.Background(), "any-id", 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), groups)
 }
@@ -555,7 +557,7 @@ func (s *FileBasedStoreTestSuite) TestCreate_StorerInterface() {
 	assert.NoError(s.T(), err)
 
 	// Verify it was created
-	retrieved, err := s.store.GetOrganizationUnit("test-ou-1")
+	retrieved, err := s.store.GetOrganizationUnit(context.Background(), "test-ou-1")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), ou.ID, retrieved.ID)
 }
@@ -571,11 +573,11 @@ func (s *FileBasedStoreTestSuite) TestCreateAndRetrieveWithDesignFields() {
 		LogoURL:  "https://example.com/logo.png",
 	}
 
-	err := s.store.CreateOrganizationUnit(ou)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	assert.NoError(s.T(), err)
 
 	// Verify design fields are preserved on retrieval
-	retrieved, err := s.store.GetOrganizationUnit("design-ou-1")
+	retrieved, err := s.store.GetOrganizationUnit(context.Background(), "design-ou-1")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "theme-123", retrieved.ThemeID)
 	assert.Equal(s.T(), "layout-456", retrieved.LayoutID)
@@ -593,10 +595,10 @@ func (s *FileBasedStoreTestSuite) TestListIncludesDesignFields() {
 		LogoURL:  "https://example.com/list-logo.png",
 	}
 
-	err := s.store.CreateOrganizationUnit(ou)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	assert.NoError(s.T(), err)
 
-	list, err := s.store.GetOrganizationUnitList(10, 0)
+	list, err := s.store.GetOrganizationUnitList(context.Background(), 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 1)
 	assert.Equal(s.T(), "https://example.com/list-logo.png", list[0].LogoURL)
@@ -620,12 +622,12 @@ func (s *FileBasedStoreTestSuite) TestChildrenListIncludesDesignFields() {
 		LogoURL:  "https://example.com/child-logo.png",
 	}
 
-	err := s.store.CreateOrganizationUnit(parent)
+	err := s.store.CreateOrganizationUnit(context.Background(), parent)
 	assert.NoError(s.T(), err)
-	err = s.store.CreateOrganizationUnit(child)
+	err = s.store.CreateOrganizationUnit(context.Background(), child)
 	assert.NoError(s.T(), err)
 
-	children, err := s.store.GetOrganizationUnitChildrenList(parentID, 10, 0)
+	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), parentID, 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 1)
 	assert.Equal(s.T(), "https://example.com/child-logo.png", children[0].LogoURL)
@@ -663,20 +665,20 @@ func (s *FileBasedStoreTestSuite) TestFileBasedStore_GetOrganizationUnitsByIDs()
 		Parent: nil,
 	}
 
-	err := s.store.CreateOrganizationUnit(ou1)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou1)
 	s.Require().NoError(err)
-	err = s.store.CreateOrganizationUnit(ou2)
+	err = s.store.CreateOrganizationUnit(context.Background(), ou2)
 	s.Require().NoError(err)
-	err = s.store.CreateOrganizationUnit(ou3)
+	err = s.store.CreateOrganizationUnit(context.Background(), ou3)
 	s.Require().NoError(err)
 
 	// Test empty ids
-	result, err := s.store.GetOrganizationUnitsByIDs([]string{})
+	result, err := s.store.GetOrganizationUnitsByIDs(context.Background(), []string{})
 	s.Require().NoError(err)
 	s.Require().Empty(result)
 
 	// Test existing ids
-	result, err = s.store.GetOrganizationUnitsByIDs([]string{"ou-1", "ou-3"})
+	result, err = s.store.GetOrganizationUnitsByIDs(context.Background(), []string{"ou-1", "ou-3"})
 	s.Require().NoError(err)
 	s.Require().Len(result, 2)
 
@@ -686,7 +688,7 @@ func (s *FileBasedStoreTestSuite) TestFileBasedStore_GetOrganizationUnitsByIDs()
 	}
 
 	// Test partial matching ids
-	result, err = s.store.GetOrganizationUnitsByIDs([]string{"ou-2", "non-existent"})
+	result, err = s.store.GetOrganizationUnitsByIDs(context.Background(), []string{"ou-2", "non-existent"})
 	s.Require().NoError(err)
 	s.Require().Len(result, 1)
 	s.Require().Equal("ou-2", result[0].ID)
@@ -700,14 +702,14 @@ func (s *FileBasedStoreTestSuite) TestFileBasedStore_IsOrganizationUnitDeclarati
 		Name:   "Name Decl",
 		Parent: nil,
 	}
-	err := s.store.CreateOrganizationUnit(ou)
+	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	s.Require().NoError(err)
 
 	// Test existing OU
-	isDecl := s.store.IsOrganizationUnitDeclarative("ou-decl")
+	isDecl := s.store.IsOrganizationUnitDeclarative(context.Background(), "ou-decl")
 	s.Require().True(isDecl)
 
 	// Test non-existent OU
-	isDecl = s.store.IsOrganizationUnitDeclarative("non-existent")
+	isDecl = s.store.IsOrganizationUnitDeclarative(context.Background(), "non-existent")
 	s.Require().False(isDecl)
 }

--- a/backend/internal/ou/handler_test.go
+++ b/backend/internal/ou/handler_test.go
@@ -313,7 +313,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 				suite.Equal(ErrorInvalidLimit.Code, body.Code)
 			},
 			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything)
 			},
 		},
 		{
@@ -326,7 +326,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 				suite.Equal(ErrorInvalidOffset.Code, body.Code)
 			},
 			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything)
 			},
 		},
 		{
@@ -772,7 +772,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 				suite.Equal(ErrorMissingOrganizationUnitID.Code, resp.Code)
 			},
 			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "UpdateOrganizationUnit", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "UpdateOrganizationUnit", mock.Anything)
 			},
 		},
 		{
@@ -814,9 +814,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 			pathParamValue: defaultOURequestID,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On(
-						"UpdateOrganizationUnit",
-						mock.Anything,
+					On("UpdateOrganizationUnit", mock.Anything,
 						defaultOURequestID,
 						mock.MatchedBy(func(req OrganizationUnitRequest) bool {
 							return req.Handle == defaultOUHandle &&
@@ -850,9 +848,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 			pathParamValue: defaultOURequestID,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On(
-						"UpdateOrganizationUnit",
-						mock.Anything,
+					On("UpdateOrganizationUnit", mock.Anything,
 						defaultOURequestID,
 						mock.MatchedBy(func(req OrganizationUnitRequest) bool {
 							return req.Handle == defaultOUHandle &&
@@ -1288,7 +1284,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutByPathRe
 				suite.Equal(ErrorInvalidHandlePath.Code, resp.Code)
 			},
 			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
-				serviceMock.AssertNotCalled(suite.T(), "UpdateOrganizationUnitByPath", mock.Anything, mock.Anything)
+				serviceMock.AssertNotCalled(suite.T(), "UpdateOrganizationUnitByPath", mock.Anything)
 			},
 		},
 		{

--- a/backend/internal/ou/hierarchy_resolver.go
+++ b/backend/internal/ou/hierarchy_resolver.go
@@ -67,7 +67,7 @@ func (r *ouHierarchyAdapter) IsAncestor(
 		}
 		visited[current] = struct{}{}
 
-		ou, err := r.store.GetOrganizationUnit(current)
+		ou, err := r.store.GetOrganizationUnit(ctx, current)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
 				// Broken chain — cannot confirm ancestry; deny-safe.
@@ -118,7 +118,7 @@ func (r *ouHierarchyAdapter) GetAncestorOUIDs(
 		}
 		visited[current] = struct{}{}
 
-		ou, err := r.store.GetOrganizationUnit(current)
+		ou, err := r.store.GetOrganizationUnit(ctx, current)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
 				logger.Debug("Encountered missing organization unit while collecting ancestors",

--- a/backend/internal/ou/hierarchy_resolver_test.go
+++ b/backend/internal/ou/hierarchy_resolver_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -91,7 +92,7 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			ancestorOUID:   "ou1",
 			descendantOUID: "ou1",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "ou1").
+				m.On("GetOrganizationUnit", mock.Anything, "ou1").
 					Return(OrganizationUnit{ID: "ou1", Parent: nil}, nil)
 			},
 			wantResult: false,
@@ -101,7 +102,7 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			ancestorOUID:   testCoverageParentOUID,
 			descendantOUID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{ID: "child-ou", Parent: &parentID}, nil)
 			},
 			wantResult: true,
@@ -113,9 +114,9 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
 				rootRef := "root-ou"
-				m.On("GetOrganizationUnit", "grandchild-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "grandchild-ou").
 					Return(OrganizationUnit{ID: "grandchild-ou", Parent: &parentRef}, nil)
-				m.On("GetOrganizationUnit", testCoverageParentOUID).
+				m.On("GetOrganizationUnit", mock.Anything, testCoverageParentOUID).
 					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &rootRef}, nil)
 			},
 			wantResult: true,
@@ -126,10 +127,10 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			descendantOUID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil)
 				// parent-ou is root (no parent).
-				m.On("GetOrganizationUnit", testCoverageParentOUID).
+				m.On("GetOrganizationUnit", mock.Anything, testCoverageParentOUID).
 					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: nil}, nil)
 			},
 			wantResult: false,
@@ -139,7 +140,7 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			ancestorOUID:   "some-ou",
 			descendantOUID: "root-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "root-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "root-ou").
 					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
 			},
 			wantResult: false,
@@ -149,7 +150,7 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			ancestorOUID:   testCoverageParentOUID,
 			descendantOUID: "orphan-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "orphan-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "orphan-ou").
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound)
 			},
 			wantResult: false,
@@ -159,7 +160,7 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			ancestorOUID:   testCoverageParentOUID,
 			descendantOUID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{}, genericErr)
 			},
 			wantResult: false,
@@ -172,9 +173,9 @@ func (suite *HierarchyResolverTestSuite) TestIsAncestorOrSelf() {
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
 				childRef := "child-ou"
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil).Times(1)
-				m.On("GetOrganizationUnit", testCoverageParentOUID).
+				m.On("GetOrganizationUnit", mock.Anything, testCoverageParentOUID).
 					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &childRef}, nil).Times(1)
 			},
 			wantResult: false,
@@ -223,7 +224,7 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			name: "RootOU_NoParent_ReturnsEmpty",
 			ouID: "root-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "root-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "root-ou").
 					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
 			},
 			wantIDs: []string{},
@@ -233,9 +234,9 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			ouID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil)
-				m.On("GetOrganizationUnit", testCoverageParentOUID).
+				m.On("GetOrganizationUnit", mock.Anything, testCoverageParentOUID).
 					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: nil}, nil)
 			},
 			wantIDs: []string{testCoverageParentOUID},
@@ -246,11 +247,11 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
 				rootRef := "root-ou"
-				m.On("GetOrganizationUnit", "grandchild-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "grandchild-ou").
 					Return(OrganizationUnit{ID: "grandchild-ou", Parent: &parentRef}, nil)
-				m.On("GetOrganizationUnit", testCoverageParentOUID).
+				m.On("GetOrganizationUnit", mock.Anything, testCoverageParentOUID).
 					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &rootRef}, nil)
-				m.On("GetOrganizationUnit", "root-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "root-ou").
 					Return(OrganizationUnit{ID: "root-ou", Parent: nil}, nil)
 			},
 			wantIDs: []string{testCoverageParentOUID, "root-ou"},
@@ -259,7 +260,7 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			name: "BrokenChain_OUNotFound_ReturnsNilAndError",
 			ouID: "orphan-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "orphan-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "orphan-ou").
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound)
 			},
 			wantErr: true,
@@ -269,9 +270,9 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			ouID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				missingRef := "missing-ou"
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{ID: "child-ou", Parent: &missingRef}, nil)
-				m.On("GetOrganizationUnit", "missing-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "missing-ou").
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound)
 			},
 			wantErr: true,
@@ -280,7 +281,7 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			name: "StoreError_ReturnsNilAndError",
 			ouID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{}, genericErr)
 			},
 			wantErr: true,
@@ -290,9 +291,9 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			ouID: "child-ou",
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil)
-				m.On("GetOrganizationUnit", testCoverageParentOUID).
+				m.On("GetOrganizationUnit", mock.Anything, testCoverageParentOUID).
 					Return(OrganizationUnit{}, genericErr)
 			},
 			wantErr: true,
@@ -303,9 +304,9 @@ func (suite *HierarchyResolverTestSuite) TestGetAncestorOUIDs() {
 			setupMock: func(m *organizationUnitStoreInterfaceMock) {
 				parentRef := testCoverageParentOUID
 				childRef := "child-ou"
-				m.On("GetOrganizationUnit", "child-ou").
+				m.On("GetOrganizationUnit", mock.Anything, "child-ou").
 					Return(OrganizationUnit{ID: "child-ou", Parent: &parentRef}, nil).Times(1)
-				m.On("GetOrganizationUnit", testCoverageParentOUID).
+				m.On("GetOrganizationUnit", mock.Anything, testCoverageParentOUID).
 					Return(OrganizationUnit{ID: testCoverageParentOUID, Parent: &childRef}, nil).Times(1)
 			},
 			wantErr: true,

--- a/backend/internal/ou/init.go
+++ b/backend/internal/ou/init.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/database/provider"
+	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/system/sysauthz"
@@ -39,7 +41,17 @@ func Initialize(
 		return nil, nil, nil, err
 	}
 
-	ouService := newOrganizationUnitService(authzService, ouStore)
+	var transactioner transaction.Transactioner
+	storeMode := getOrganizationUnitStoreMode()
+	if storeMode == serverconst.StoreModeComposite || storeMode == serverconst.StoreModeMutable {
+		var err error
+		transactioner, err = provider.GetDBProvider().GetUserDBTransactioner()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	ouService := newOrganizationUnitService(authzService, ouStore, transactioner)
 
 	ouHandler := newOrganizationUnitHandler(ouService)
 	registerRoutes(mux, ouHandler)

--- a/backend/internal/ou/init_test.go
+++ b/backend/internal/ou/init_test.go
@@ -40,12 +40,20 @@ func TestInitTestSuite(t *testing.T) {
 func (suite *InitTestSuite) SetupTest() {
 	// Initialize ThunderRuntime for each test
 	config.ResetThunderRuntime()
+	tmpDir := suite.T().TempDir()
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{
 			Enabled: false,
 		},
+		Database: config.DatabaseConfig{
+			User: config.DataSource{
+				Type: "sqlite",
+				Path: "test.db",
+			},
+		},
 	}
-	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+	err := config.InitializeThunderRuntime(tmpDir, testConfig)
+	suite.Require().NoError(err)
 }
 
 func (suite *InitTestSuite) TearDownTest() {

--- a/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
+++ b/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package ou
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,8 +38,8 @@ func (_m *organizationUnitStoreInterfaceMock) EXPECT() *organizationUnitStoreInt
 }
 
 // CheckOrganizationUnitHandleConflict provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHandleConflict(handle string, parent *string) (bool, error) {
-	ret := _mock.Called(handle, parent)
+func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHandleConflict(ctx context.Context, handle string, parent *string) (bool, error) {
+	ret := _mock.Called(ctx, handle, parent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckOrganizationUnitHandleConflict")
@@ -45,16 +47,16 @@ func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHandleConf
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *string) (bool, error)); ok {
-		return returnFunc(handle, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (bool, error)); ok {
+		return returnFunc(ctx, handle, parent)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *string) bool); ok {
-		r0 = returnFunc(handle, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) bool); ok {
+		r0 = returnFunc(ctx, handle, parent)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *string) error); ok {
-		r1 = returnFunc(handle, parent)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) error); ok {
+		r1 = returnFunc(ctx, handle, parent)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -67,25 +69,31 @@ type organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call
 }
 
 // CheckOrganizationUnitHandleConflict is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handle string
 //   - parent *string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHandleConflict(handle interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
-	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call{Call: _e.mock.On("CheckOrganizationUnitHandleConflict", handle, parent)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHandleConflict(ctx interface{}, handle interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
+	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call{Call: _e.mock.On("CheckOrganizationUnitHandleConflict", ctx, handle, parent)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) Run(run func(handle string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) Run(run func(ctx context.Context, handle string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 *string
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*string)
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -96,14 +104,14 @@ func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) RunAndReturn(run func(handle string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) RunAndReturn(run func(ctx context.Context, handle string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CheckOrganizationUnitHasChildResources provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHasChildResources(id string) (bool, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHasChildResources(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckOrganizationUnitHasChildResources")
@@ -111,16 +119,16 @@ func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHasChildRe
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -133,19 +141,25 @@ type organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_C
 }
 
 // CheckOrganizationUnitHasChildResources is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHasChildResources(id interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
-	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call{Call: _e.mock.On("CheckOrganizationUnitHasChildResources", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHasChildResources(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
+	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call{Call: _e.mock.On("CheckOrganizationUnitHasChildResources", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -156,14 +170,14 @@ func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResour
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) RunAndReturn(run func(id string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CheckOrganizationUnitNameConflict provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitNameConflict(name string, parent *string) (bool, error) {
-	ret := _mock.Called(name, parent)
+func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitNameConflict(ctx context.Context, name string, parent *string) (bool, error) {
+	ret := _mock.Called(ctx, name, parent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckOrganizationUnitNameConflict")
@@ -171,16 +185,16 @@ func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitNameConfli
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *string) (bool, error)); ok {
-		return returnFunc(name, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (bool, error)); ok {
+		return returnFunc(ctx, name, parent)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *string) bool); ok {
-		r0 = returnFunc(name, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) bool); ok {
+		r0 = returnFunc(ctx, name, parent)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *string) error); ok {
-		r1 = returnFunc(name, parent)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) error); ok {
+		r1 = returnFunc(ctx, name, parent)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -193,25 +207,31 @@ type organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call s
 }
 
 // CheckOrganizationUnitNameConflict is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
 //   - parent *string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitNameConflict(name interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
-	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call{Call: _e.mock.On("CheckOrganizationUnitNameConflict", name, parent)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitNameConflict(ctx interface{}, name interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
+	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call{Call: _e.mock.On("CheckOrganizationUnitNameConflict", ctx, name, parent)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) Run(run func(name string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) Run(run func(ctx context.Context, name string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 *string
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*string)
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -222,22 +242,22 @@ func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_C
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) RunAndReturn(run func(name string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) RunAndReturn(run func(ctx context.Context, name string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CreateOrganizationUnit(ou OrganizationUnit) error {
-	ret := _mock.Called(ou)
+func (_mock *organizationUnitStoreInterfaceMock) CreateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
+	ret := _mock.Called(ctx, ou)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateOrganizationUnit")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(OrganizationUnit) error); ok {
-		r0 = returnFunc(ou)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, OrganizationUnit) error); ok {
+		r0 = returnFunc(ctx, ou)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -250,19 +270,25 @@ type organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call struct {
 }
 
 // CreateOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - ou OrganizationUnit
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CreateOrganizationUnit(ou interface{}) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call{Call: _e.mock.On("CreateOrganizationUnit", ou)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CreateOrganizationUnit(ctx interface{}, ou interface{}) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call{Call: _e.mock.On("CreateOrganizationUnit", ctx, ou)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) Run(run func(ou OrganizationUnit)) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) Run(run func(ctx context.Context, ou OrganizationUnit)) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 OrganizationUnit
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(OrganizationUnit)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 OrganizationUnit
+		if args[1] != nil {
+			arg1 = args[1].(OrganizationUnit)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -273,22 +299,22 @@ func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) Return
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) RunAndReturn(run func(ou OrganizationUnit) error) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, ou OrganizationUnit) error) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) DeleteOrganizationUnit(id string) error {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) DeleteOrganizationUnit(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteOrganizationUnit")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -301,19 +327,25 @@ type organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call struct {
 }
 
 // DeleteOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) DeleteOrganizationUnit(id interface{}) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call{Call: _e.mock.On("DeleteOrganizationUnit", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) DeleteOrganizationUnit(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call{Call: _e.mock.On("DeleteOrganizationUnit", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -324,14 +356,14 @@ func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) Return
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) RunAndReturn(run func(id string) error) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, id string) error) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnit(id string) (OrganizationUnit, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnit")
@@ -339,16 +371,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnit(id string) 
 
 	var r0 OrganizationUnit
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (OrganizationUnit, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (OrganizationUnit, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) OrganizationUnit); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) OrganizationUnit); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(OrganizationUnit)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -361,19 +393,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call struct {
 }
 
 // GetOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnit(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call{Call: _e.mock.On("GetOrganizationUnit", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnit(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call{Call: _e.mock.On("GetOrganizationUnit", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -384,14 +422,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) Return(or
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) RunAndReturn(run func(id string) (OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, id string) (OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitByPath provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(handles []string) (OrganizationUnit, error) {
-	ret := _mock.Called(handles)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
+	ret := _mock.Called(ctx, handles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitByPath")
@@ -399,16 +437,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(handl
 
 	var r0 OrganizationUnit
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) (OrganizationUnit, error)); ok {
-		return returnFunc(handles)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (OrganizationUnit, error)); ok {
+		return returnFunc(ctx, handles)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]string) OrganizationUnit); ok {
-		r0 = returnFunc(handles)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) OrganizationUnit); ok {
+		r0 = returnFunc(ctx, handles)
 	} else {
 		r0 = ret.Get(0).(OrganizationUnit)
 	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(handles)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, handles)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -421,19 +459,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call struct {
 }
 
 // GetOrganizationUnitByPath is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handles []string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitByPath(handles interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call{Call: _e.mock.On("GetOrganizationUnitByPath", handles)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitByPath(ctx interface{}, handles interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call{Call: _e.mock.On("GetOrganizationUnitByPath", ctx, handles)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Run(run func(handles []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Run(run func(ctx context.Context, handles []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -444,14 +488,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Ret
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) RunAndReturn(run func(handles []string) (OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) RunAndReturn(run func(ctx context.Context, handles []string) (OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(id string) (int, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenCount")
@@ -459,16 +503,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCoun
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -481,19 +525,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call st
 }
 
 // GetOrganizationUnitChildrenCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -504,14 +554,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Ca
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(id string, limit int, offset int) ([]OrganizationUnitBasic, error) {
-	ret := _mock.Called(id, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(ctx context.Context, id string, limit int, offset int) ([]OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, id, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenList")
@@ -519,18 +569,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList
 
 	var r0 []OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]OrganizationUnitBasic, error)); ok {
-		return returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, id, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []OrganizationUnitBasic); ok {
-		r0 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, id, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -543,31 +593,37 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call str
 }
 
 // GetOrganizationUnitChildrenList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", id, limit, offset)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", ctx, id, limit, offset)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -578,14 +634,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Cal
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(id string, limit int, offset int) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitGroupsCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsCount(id string) (int, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsCount(ctx context.Context, id string) (int, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitGroupsCount")
@@ -593,16 +649,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsCount(
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -615,19 +671,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call stru
 }
 
 // GetOrganizationUnitGroupsCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsCount(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call{Call: _e.mock.On("GetOrganizationUnitGroupsCount", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call{Call: _e.mock.On("GetOrganizationUnitGroupsCount", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -638,14 +700,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) RunAndReturn(run func(id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitGroupsList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsList(id string, limit int, offset int) ([]Group, error) {
-	ret := _mock.Called(id, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsList(ctx context.Context, id string, limit int, offset int) ([]Group, error) {
+	ret := _mock.Called(ctx, id, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitGroupsList")
@@ -653,18 +715,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsList(i
 
 	var r0 []Group
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]Group, error)); ok {
-		return returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]Group, error)); ok {
+		return returnFunc(ctx, id, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []Group); ok {
-		r0 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []Group); ok {
+		r0 = returnFunc(ctx, id, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -677,31 +739,37 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call struc
 }
 
 // GetOrganizationUnitGroupsList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsList(id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call{Call: _e.mock.On("GetOrganizationUnitGroupsList", id, limit, offset)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call{Call: _e.mock.On("GetOrganizationUnitGroupsList", ctx, id, limit, offset)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) Run(run func(id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -712,14 +780,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call)
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) RunAndReturn(run func(id string, limit int, offset int) ([]Group, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]Group, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(limit int, offset int) ([]OrganizationUnitBasic, error) {
-	ret := _mock.Called(limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) ([]OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -727,18 +795,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(limit i
 
 	var r0 []OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]OrganizationUnitBasic, error)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []OrganizationUnitBasic); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -751,199 +819,18 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call struct {
 }
 
 // GetOrganizationUnitList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", limit, offset)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Return(organizationUnitBasics []OrganizationUnitBasic, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	_c.Call.Return(organizationUnitBasics, err)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(limit int, offset int) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOrganizationUnitListCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOrganizationUnitListCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitListCount'
-type organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call struct {
-	*mock.Call
-}
-
-// GetOrganizationUnitListCount is a helper method to define mock.On call
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount() *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount")}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func()) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func() (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOrganizationUnitUsersCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersCount(id string) (int, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOrganizationUnitUsersCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersCount'
-type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call struct {
-	*mock.Call
-}
-
-// GetOrganizationUnitUsersCount is a helper method to define mock.On call
-//   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersCount(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call{Call: _e.mock.On("GetOrganizationUnitUsersCount", id)}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) RunAndReturn(run func(id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOrganizationUnitUsersList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersList(id string, limit int, offset int) ([]User, error) {
-	ret := _mock.Called(id, limit, offset)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOrganizationUnitUsersList")
-	}
-
-	var r0 []User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]User, error)); ok {
-		return returnFunc(id, limit, offset)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []User); ok {
-		r0 = returnFunc(id, limit, offset)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]User)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(id, limit, offset)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersList'
-type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call struct {
-	*mock.Call
-}
-
-// GetOrganizationUnitUsersList is a helper method to define mock.On call
-//   - id string
-//   - limit int
-//   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersList(id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call{Call: _e.mock.On("GetOrganizationUnitUsersList", id, limit, offset)}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) Run(run func(id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
@@ -962,19 +849,225 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) 
 	return _c
 }
 
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Return(organizationUnitBasics []OrganizationUnitBasic, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	_c.Call.Return(organizationUnitBasics, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOrganizationUnitListCount provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitListCount'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount(ctx interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount", ctx)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func(ctx context.Context)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOrganizationUnitUsersCount provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersCount(ctx context.Context, id string) (int, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitUsersCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersCount'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitUsersCount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call{Call: _e.mock.On("GetOrganizationUnitUsersCount", ctx, id)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOrganizationUnitUsersList provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersList(ctx context.Context, id string, limit int, offset int) ([]User, error) {
+	ret := _mock.Called(ctx, id, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitUsersList")
+	}
+
+	var r0 []User
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]User, error)); ok {
+		return returnFunc(ctx, id, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []User); ok {
+		r0 = returnFunc(ctx, id, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]User)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersList'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitUsersList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - limit int
+//   - offset int
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call{Call: _e.mock.On("GetOrganizationUnitUsersList", ctx, id, limit, offset)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
 func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) Return(users []User, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
 	_c.Call.Return(users, err)
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) RunAndReturn(run func(id string, limit int, offset int) ([]User, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]User, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitsByIDs provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitsByIDs(ids []string) ([]OrganizationUnitBasic, error) {
-	ret := _mock.Called(ids)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitsByIDs(ctx context.Context, ids []string) ([]OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, ids)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitsByIDs")
@@ -982,18 +1075,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitsByIDs(ids [
 
 	var r0 []OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]OrganizationUnitBasic, error)); ok {
-		return returnFunc(ids)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, ids)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []OrganizationUnitBasic); ok {
-		r0 = returnFunc(ids)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, ids)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, ids)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1006,19 +1099,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call struct {
 }
 
 // GetOrganizationUnitsByIDs is a helper method to define mock.On call
+//   - ctx context.Context
 //   - ids []string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitsByIDs(ids interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call{Call: _e.mock.On("GetOrganizationUnitsByIDs", ids)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitsByIDs(ctx interface{}, ids interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call{Call: _e.mock.On("GetOrganizationUnitsByIDs", ctx, ids)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) Run(run func(ids []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) Run(run func(ctx context.Context, ids []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1029,22 +1128,22 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) Ret
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) RunAndReturn(run func(ids []string) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) RunAndReturn(run func(ctx context.Context, ids []string) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsOrganizationUnitDeclarative provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsOrganizationUnitDeclarative")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -1057,19 +1156,25 @@ type organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call struc
 }
 
 // IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1080,14 +1185,14 @@ func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call)
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsOrganizationUnitExists provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(id string) (bool, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsOrganizationUnitExists")
@@ -1095,16 +1200,16 @@ func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(id str
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1117,19 +1222,25 @@ type organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call struct {
 }
 
 // IsOrganizationUnitExists is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitExists(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
-	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call{Call: _e.mock.On("IsOrganizationUnitExists", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitExists(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
+	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call{Call: _e.mock.On("IsOrganizationUnitExists", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1140,22 +1251,22 @@ func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Retu
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(id string) (bool, error)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) UpdateOrganizationUnit(ou OrganizationUnit) error {
-	ret := _mock.Called(ou)
+func (_mock *organizationUnitStoreInterfaceMock) UpdateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
+	ret := _mock.Called(ctx, ou)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateOrganizationUnit")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(OrganizationUnit) error); ok {
-		r0 = returnFunc(ou)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, OrganizationUnit) error); ok {
+		r0 = returnFunc(ctx, ou)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1168,19 +1279,25 @@ type organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call struct {
 }
 
 // UpdateOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - ou OrganizationUnit
-func (_e *organizationUnitStoreInterfaceMock_Expecter) UpdateOrganizationUnit(ou interface{}) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call{Call: _e.mock.On("UpdateOrganizationUnit", ou)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) UpdateOrganizationUnit(ctx interface{}, ou interface{}) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call{Call: _e.mock.On("UpdateOrganizationUnit", ctx, ou)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) Run(run func(ou OrganizationUnit)) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) Run(run func(ctx context.Context, ou OrganizationUnit)) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 OrganizationUnit
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(OrganizationUnit)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 OrganizationUnit
+		if args[1] != nil {
+			arg1 = args[1].(OrganizationUnit)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1191,7 +1308,7 @@ func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) Return
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) RunAndReturn(run func(ou OrganizationUnit) error) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, ou OrganizationUnit) error) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
+	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -47,7 +48,7 @@ type OrganizationUnitServiceInterface interface {
 	GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, *serviceerror.ServiceError)
 	GetOrganizationUnitByPath(ctx context.Context, handlePath string) (OrganizationUnit, *serviceerror.ServiceError)
 	IsOrganizationUnitExists(ctx context.Context, id string) (bool, *serviceerror.ServiceError)
-	IsOrganizationUnitDeclarative(id string) bool
+	IsOrganizationUnitDeclarative(ctx context.Context, id string) bool
 	IsParent(ctx context.Context, parentID, childID string) (bool, *serviceerror.ServiceError)
 	UpdateOrganizationUnit(
 		ctx context.Context, id string, request OrganizationUnitRequest,
@@ -79,18 +80,21 @@ type OrganizationUnitServiceInterface interface {
 
 // OrganizationUnitService provides organization unit management operations.
 type organizationUnitService struct {
-	authzService sysauthz.SystemAuthorizationServiceInterface
-	ouStore      organizationUnitStoreInterface
+	authzService  sysauthz.SystemAuthorizationServiceInterface
+	ouStore       organizationUnitStoreInterface
+	transactioner transaction.Transactioner
 }
 
 // newOrganizationUnitService creates a new instance of OrganizationUnitService.
 func newOrganizationUnitService(
 	authzService sysauthz.SystemAuthorizationServiceInterface,
 	ouStore organizationUnitStoreInterface,
+	transactioner transaction.Transactioner,
 ) OrganizationUnitServiceInterface {
 	return &organizationUnitService{
-		authzService: authzService,
-		ouStore:      ouStore,
+		authzService:  authzService,
+		ouStore:       ouStore,
+		transactioner: transactioner,
 	}
 }
 
@@ -112,25 +116,25 @@ func (ous *organizationUnitService) GetOrganizationUnitList(ctx context.Context,
 
 	// Unfiltered path: the caller can see all organization units.
 	if accessible.AllAllowed {
-		return ous.listAllOrganizationUnits(limit, offset)
+		return ous.listAllOrganizationUnits(ctx, limit, offset)
 	}
 
 	// Filtered path: the caller has a restricted set of accessible organization units.
-	return ous.listAccessibleOrganizationUnits(accessible.IDs, limit, offset)
+	return ous.listAccessibleOrganizationUnits(ctx, accessible.IDs, limit, offset)
 }
 
 // listAllOrganizationUnits retrieves organization units without authorization filtering.
 func (ous *organizationUnitService) listAllOrganizationUnits(
-	limit, offset int,
+	ctx context.Context, limit, offset int,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	totalCount, err := ous.ouStore.GetOrganizationUnitListCount()
+	totalCount, err := ous.ouStore.GetOrganizationUnitListCount(ctx)
 	if err != nil {
 		logger.Error("Failed to get organization unit count", log.Error(err))
 		return nil, &ErrorInternalServerError
 	}
 
-	ouList, err := ous.ouStore.GetOrganizationUnitList(limit, offset)
+	ouList, err := ous.ouStore.GetOrganizationUnitList(ctx, limit, offset)
 	if err != nil {
 		// Check if it's a limit exceeded error
 		if errors.Is(err, ErrResultLimitExceededInCompositeMode) {
@@ -151,7 +155,7 @@ func (ous *organizationUnitService) listAllOrganizationUnits(
 
 // listAccessibleOrganizationUnits retrieves only the organization units the caller is authorized to access.
 func (ous *organizationUnitService) listAccessibleOrganizationUnits(
-	ids []string, limit, offset int,
+	ctx context.Context, ids []string, limit, offset int,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	total := len(ids)
@@ -187,7 +191,7 @@ func (ous *organizationUnitService) listAccessibleOrganizationUnits(
 	}
 
 	// Fetch only the organization units needed for this page.
-	pageOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(pageIDs)
+	pageOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, pageIDs)
 	if err != nil {
 		logger.Error("Failed to get organization units by IDs", log.Error(err))
 		return nil, &ErrorInternalServerError
@@ -214,79 +218,99 @@ func (ous *organizationUnitService) CreateOrganizationUnit(
 		return OrganizationUnit{}, &ErrorCannotModifyDeclarativeResource
 	}
 
-	if err := ous.validateOUName(request.Name); err != nil {
-		return OrganizationUnit{}, err
-	}
+	var createdOU OrganizationUnit
+	var capturedSvcErr *serviceerror.ServiceError
 
-	if err := ous.validateOUHandle(request.Handle); err != nil {
-		return OrganizationUnit{}, err
-	}
-
-	if request.Parent != nil {
-		if svcErr := ous.checkOUAccess(ctx, security.ActionCreateOU, *request.Parent); svcErr != nil {
-			return OrganizationUnit{}, svcErr
+	err := ous.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		if svcErr := ous.validateOUName(request.Name); svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("validation error")
 		}
-		exists, err := ous.ouStore.IsOrganizationUnitExists(*request.Parent)
+
+		if svcErr := ous.validateOUHandle(request.Handle); svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("validation error")
+		}
+
+		if request.Parent != nil {
+			if svcErr := ous.checkOUAccess(txCtx, security.ActionCreateOU, *request.Parent); svcErr != nil {
+				capturedSvcErr = svcErr
+				return errors.New("authz error")
+			}
+			exists, err := ous.ouStore.IsOrganizationUnitExists(txCtx, *request.Parent)
+			if err != nil {
+				capturedSvcErr = &ErrorInternalServerError
+				return err
+			}
+			if !exists {
+				capturedSvcErr = &ErrorParentOrganizationUnitNotFound
+				return errors.New("parent not found")
+			}
+		} else {
+			if svcErr := ous.checkOUAccess(txCtx, security.ActionCreateOU, ""); svcErr != nil {
+				capturedSvcErr = svcErr
+				return errors.New("authz error")
+			}
+		}
+
+		conflict, err := ous.ouStore.CheckOrganizationUnitNameConflict(txCtx, request.Name, request.Parent)
 		if err != nil {
-			logger.Error("Failed to check parent organization unit existence", log.Error(err))
-			return OrganizationUnit{}, &ErrorInternalServerError
+			capturedSvcErr = &ErrorInternalServerError
+			return err
 		}
-		if !exists {
-			return OrganizationUnit{}, &ErrorParentOrganizationUnitNotFound
+		if conflict {
+			capturedSvcErr = &ErrorOrganizationUnitNameConflict
+			return errors.New("conflict")
 		}
-	} else {
-		if svcErr := ous.checkOUAccess(ctx, security.ActionCreateOU, ""); svcErr != nil {
-			return OrganizationUnit{}, svcErr
+
+		handleConflict, err := ous.ouStore.CheckOrganizationUnitHandleConflict(txCtx, request.Handle, request.Parent)
+		if err != nil {
+			capturedSvcErr = &ErrorInternalServerError
+			return err
 		}
-	}
+		if handleConflict {
+			capturedSvcErr = &ErrorOrganizationUnitHandleConflict
+			return errors.New("conflict")
+		}
 
-	conflict, err := ous.ouStore.CheckOrganizationUnitNameConflict(request.Name, request.Parent)
+		ouID, err := utils.GenerateUUIDv7()
+		if err != nil {
+			capturedSvcErr = &ErrorInternalServerError
+			return err
+		}
+
+		createdOU = OrganizationUnit{
+			ID:              ouID,
+			Handle:          request.Handle,
+			Name:            request.Name,
+			Description:     request.Description,
+			Parent:          request.Parent,
+			ThemeID:         request.ThemeID,
+			LayoutID:        request.LayoutID,
+			LogoURL:         request.LogoURL,
+			TosURI:          request.TosURI,
+			PolicyURI:       request.PolicyURI,
+			CookiePolicyURI: request.CookiePolicyURI,
+		}
+
+		err = ous.ouStore.CreateOrganizationUnit(txCtx, createdOU)
+		if err != nil {
+			capturedSvcErr = &ErrorInternalServerError
+			return err
+		}
+		return nil
+	})
+
+	if capturedSvcErr != nil {
+		return OrganizationUnit{}, capturedSvcErr
+	}
 	if err != nil {
-		logger.Error("Failed to check organization unit name conflict", log.Error(err))
-		return OrganizationUnit{}, &ErrorInternalServerError
-	}
-	if conflict {
-		return OrganizationUnit{}, &ErrorOrganizationUnitNameConflict
-	}
-
-	handleConflict, err := ous.ouStore.CheckOrganizationUnitHandleConflict(request.Handle, request.Parent)
-	if err != nil {
-		logger.Error("Failed to check organization unit handle conflict", log.Error(err))
-		return OrganizationUnit{}, &ErrorInternalServerError
-	}
-	if handleConflict {
-		return OrganizationUnit{}, &ErrorOrganizationUnitHandleConflict
-	}
-
-	ouID, err := utils.GenerateUUIDv7()
-	if err != nil {
-		logger.Error("Failed to generate UUID", log.Error(err))
-		return OrganizationUnit{}, &ErrorInternalServerError
-	}
-
-	ou := OrganizationUnit{
-		ID:              ouID,
-		Handle:          request.Handle,
-		Name:            request.Name,
-		Description:     request.Description,
-		Parent:          request.Parent,
-		ThemeID:         request.ThemeID,
-		LayoutID:        request.LayoutID,
-		LogoURL:         request.LogoURL,
-		TosURI:          request.TosURI,
-		PolicyURI:       request.PolicyURI,
-		CookiePolicyURI: request.CookiePolicyURI,
-	}
-
-	err = ous.ouStore.CreateOrganizationUnit(ou)
-	if err != nil {
-		logger.Error("Failed to create organization unit", log.Error(err))
 		return OrganizationUnit{}, &ErrorInternalServerError
 	}
 
-	logger.Debug("Successfully created organization unit", log.String("ouID", ouID))
+	logger.Debug("Successfully created organization unit", log.String("ouID", createdOU.ID))
 
-	return ou, nil
+	return createdOU, nil
 }
 
 // GetOrganizationUnit retrieves an organization unit by ID.
@@ -300,7 +324,7 @@ func (ous *organizationUnitService) GetOrganizationUnit(
 		return OrganizationUnit{}, svcErr
 	}
 
-	ou, err := ous.ouStore.GetOrganizationUnit(id)
+	ou, err := ous.ouStore.GetOrganizationUnit(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
@@ -324,7 +348,7 @@ func (ous *organizationUnitService) GetOrganizationUnitByPath(
 		return OrganizationUnit{}, serviceError
 	}
 
-	ou, err := ous.ouStore.GetOrganizationUnitByPath(handles)
+	ou, err := ous.ouStore.GetOrganizationUnitByPath(ctx, handles)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
@@ -347,7 +371,7 @@ func (ous *organizationUnitService) IsOrganizationUnitExists(
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	logger.Debug("Checking if organization unit exists", log.String("ouID", id))
 
-	exists, err := ous.ouStore.IsOrganizationUnitExists(id)
+	exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, id)
 	if err != nil {
 		logger.Error("Failed to check organization unit existence", log.Error(err))
 		return false, &ErrorInternalServerError
@@ -356,8 +380,8 @@ func (ous *organizationUnitService) IsOrganizationUnitExists(
 	return exists, nil
 }
 
-func (ous *organizationUnitService) IsOrganizationUnitDeclarative(id string) bool {
-	return ous.ouStore.IsOrganizationUnitDeclarative(id)
+func (ous *organizationUnitService) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
+	return ous.ouStore.IsOrganizationUnitDeclarative(ctx, id)
 }
 
 // IsParent checks whether the provided parentID is an ancestor of childID.
@@ -377,7 +401,7 @@ func (ous *organizationUnitService) IsParent(
 			return true, nil
 		}
 
-		parentOU, err := ous.ouStore.GetOrganizationUnit(*currentParent)
+		parentOU, err := ous.ouStore.GetOrganizationUnit(ctx, *currentParent)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
 				logger.Debug("Encountered missing organization unit in hierarchy", log.String("ouID", *currentParent))
@@ -409,18 +433,35 @@ func (ous *organizationUnitService) UpdateOrganizationUnit(
 		return OrganizationUnit{}, svcErr
 	}
 
-	existingOU, err := ous.ouStore.GetOrganizationUnit(id)
-	if err != nil {
-		if errors.Is(err, ErrOrganizationUnitNotFound) {
-			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
-		}
-		logger.Error("Failed to get organization unit", log.Error(err))
-		return OrganizationUnit{}, &ErrorInternalServerError
-	}
+	var updatedOU OrganizationUnit
+	var capturedSvcErr *serviceerror.ServiceError
 
-	updatedOU, serviceError := ous.updateOUInternal(id, request, existingOU, logger)
-	if serviceError != nil {
-		return OrganizationUnit{}, serviceError
+	err := ous.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		existingOU, err := ous.ouStore.GetOrganizationUnit(txCtx, id)
+		if err != nil {
+			if errors.Is(err, ErrOrganizationUnitNotFound) {
+				capturedSvcErr = &ErrorOrganizationUnitNotFound
+				return err
+			}
+			logger.Error("Failed to get organization unit", log.Error(err))
+			capturedSvcErr = &ErrorInternalServerError
+			return err
+		}
+
+		var svcErr *serviceerror.ServiceError
+		updatedOU, svcErr = ous.updateOUInternal(txCtx, id, request, existingOU, logger)
+		if svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("update error")
+		}
+		return nil
+	})
+
+	if capturedSvcErr != nil {
+		return OrganizationUnit{}, capturedSvcErr
+	}
+	if err != nil {
+		return OrganizationUnit{}, &ErrorInternalServerError
 	}
 
 	logger.Debug("Successfully updated organization unit", log.String("ouID", id))
@@ -443,41 +484,61 @@ func (ous *organizationUnitService) UpdateOrganizationUnitByPath(
 		return OrganizationUnit{}, serviceError
 	}
 
-	existingOU, err := ous.ouStore.GetOrganizationUnitByPath(handles)
-	if err != nil {
-		if errors.Is(err, ErrOrganizationUnitNotFound) {
-			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
+	var updatedOU OrganizationUnit
+	var capturedSvcErr *serviceerror.ServiceError
+
+	err := ous.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		existingOU, err := ous.ouStore.GetOrganizationUnitByPath(txCtx, handles)
+		if err != nil {
+			if errors.Is(err, ErrOrganizationUnitNotFound) {
+				capturedSvcErr = &ErrorOrganizationUnitNotFound
+				return err
+			}
+			logger.Error("Failed to get organization unit by path", log.Error(err))
+			capturedSvcErr = &ErrorInternalServerError
+			return err
 		}
-		logger.Error("Failed to get organization unit by path", log.Error(err))
+
+		if svcErr := ous.checkOUAccess(txCtx, security.ActionUpdateOU, existingOU.ID); svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("authz error")
+		}
+
+		// Check if OU is declarative (for composite mode)
+		if ous.ouStore.IsOrganizationUnitDeclarative(txCtx, existingOU.ID) {
+			capturedSvcErr = &ErrorCannotModifyDeclarativeResource
+			return errors.New("declarative resource")
+		}
+
+		var svcErr *serviceerror.ServiceError
+		updatedOU, svcErr = ous.updateOUInternal(txCtx, existingOU.ID, request, existingOU, logger)
+		if svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("update error")
+		}
+		return nil
+	})
+
+	if capturedSvcErr != nil {
+		return OrganizationUnit{}, capturedSvcErr
+	}
+	if err != nil {
 		return OrganizationUnit{}, &ErrorInternalServerError
 	}
 
-	if svcErr := ous.checkOUAccess(ctx, security.ActionUpdateOU, existingOU.ID); svcErr != nil {
-		return OrganizationUnit{}, svcErr
-	}
-
-	// Check if OU is declarative (for composite mode)
-	if ous.ouStore.IsOrganizationUnitDeclarative(existingOU.ID) {
-		return OrganizationUnit{}, &ErrorCannotModifyDeclarativeResource
-	}
-
-	updatedOU, serviceError := ous.updateOUInternal(existingOU.ID, request, existingOU, logger)
-	if serviceError != nil {
-		return OrganizationUnit{}, serviceError
-	}
-
-	logger.Debug("Successfully updated organization unit by path", log.String("ouID", existingOU.ID))
+	logger.Debug("Successfully updated organization unit by path", log.String("ouID", updatedOU.ID))
 	return updatedOU, nil
 }
 
 func (ous *organizationUnitService) updateOUInternal(
+	ctx context.Context,
 	id string,
 	request OrganizationUnitRequest,
 	existingOU OrganizationUnit,
 	logger *log.Logger,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	// Check if OU is immutable (for composite mode)
-	if ous.ouStore.IsOrganizationUnitDeclarative(id) {
+	if ous.ouStore.IsOrganizationUnitDeclarative(ctx, id) {
 		return OrganizationUnit{}, &ErrorCannotModifyDeclarativeResource
 	}
 
@@ -490,7 +551,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	}
 
 	if request.Parent != nil {
-		exists, err := ous.ouStore.IsOrganizationUnitExists(*request.Parent)
+		exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, *request.Parent)
 		if err != nil {
 			logger.Error("Failed to check parent organization unit existence", log.Error(err))
 			return OrganizationUnit{}, &ErrorInternalServerError
@@ -500,7 +561,7 @@ func (ous *organizationUnitService) updateOUInternal(
 		}
 	}
 
-	if err := ous.checkCircularDependency(id, request.Parent); err != nil {
+	if err := ous.checkCircularDependency(ctx, id, request.Parent); err != nil {
 		return OrganizationUnit{}, err
 	}
 
@@ -509,7 +570,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	var nameConflict bool
 	var err error
 	if parentChanged || existingOU.Name != request.Name {
-		nameConflict, err = ous.ouStore.CheckOrganizationUnitNameConflict(request.Name, request.Parent)
+		nameConflict, err = ous.ouStore.CheckOrganizationUnitNameConflict(ctx, request.Name, request.Parent)
 		if err != nil {
 			logger.Error("Failed to check organization unit name conflict", log.Error(err))
 			return OrganizationUnit{}, &ErrorInternalServerError
@@ -522,7 +583,7 @@ func (ous *organizationUnitService) updateOUInternal(
 
 	var handleConflict bool
 	if parentChanged || existingOU.Handle != request.Handle {
-		handleConflict, err = ous.ouStore.CheckOrganizationUnitHandleConflict(request.Handle, request.Parent)
+		handleConflict, err = ous.ouStore.CheckOrganizationUnitHandleConflict(ctx, request.Handle, request.Parent)
 		if err != nil {
 			logger.Error("Failed to check organization unit handle conflict", log.Error(err))
 			return OrganizationUnit{}, &ErrorInternalServerError
@@ -547,7 +608,7 @@ func (ous *organizationUnitService) updateOUInternal(
 		CookiePolicyURI: request.CookiePolicyURI,
 	}
 
-	err = ous.ouStore.UpdateOrganizationUnit(updatedOU)
+	err = ous.ouStore.UpdateOrganizationUnit(ctx, updatedOU)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
@@ -572,19 +633,34 @@ func (ous *organizationUnitService) DeleteOrganizationUnit(ctx context.Context, 
 		return svcErr
 	}
 
-	// Check if organization unit exists
-	exists, err := ous.ouStore.IsOrganizationUnitExists(id)
-	if err != nil {
-		logger.Error("Failed to check organization unit existence", log.Error(err))
-		return &ErrorInternalServerError
-	}
-	if !exists {
-		return &ErrorOrganizationUnitNotFound
-	}
+	var capturedSvcErr *serviceerror.ServiceError
 
-	serviceError := ous.deleteOUInternal(id, logger)
-	if serviceError != nil {
-		return serviceError
+	err := ous.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		// Check if organization unit exists
+		exists, err := ous.ouStore.IsOrganizationUnitExists(txCtx, id)
+		if err != nil {
+			logger.Error("Failed to check organization unit existence", log.Error(err))
+			capturedSvcErr = &ErrorInternalServerError
+			return err
+		}
+		if !exists {
+			capturedSvcErr = &ErrorOrganizationUnitNotFound
+			return errors.New("not found")
+		}
+
+		svcErr := ous.deleteOUInternal(txCtx, id, logger)
+		if svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("delete error")
+		}
+		return nil
+	})
+
+	if capturedSvcErr != nil {
+		return capturedSvcErr
+	}
+	if err != nil {
+		return &ErrorInternalServerError
 	}
 
 	logger.Debug("Successfully deleted organization unit", log.String("ouID", id))
@@ -607,40 +683,62 @@ func (ous *organizationUnitService) DeleteOrganizationUnitByPath(
 		return serviceError
 	}
 
-	existingOU, err := ous.ouStore.GetOrganizationUnitByPath(handles)
-	if err != nil {
-		if errors.Is(err, ErrOrganizationUnitNotFound) {
-			return &ErrorOrganizationUnitNotFound
+	var ouID string
+	var capturedSvcErr *serviceerror.ServiceError
+
+	err := ous.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		existingOU, err := ous.ouStore.GetOrganizationUnitByPath(txCtx, handles)
+		if err != nil {
+			if errors.Is(err, ErrOrganizationUnitNotFound) {
+				capturedSvcErr = &ErrorOrganizationUnitNotFound
+				return err
+			}
+			logger.Error("Failed to get organization unit by path", log.Error(err))
+			capturedSvcErr = &ErrorInternalServerError
+			return err
 		}
-		logger.Error("Failed to get organization unit by path", log.Error(err))
+		ouID = existingOU.ID
+
+		if svcErr := ous.checkOUAccess(txCtx, security.ActionDeleteOU, ouID); svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("authz error")
+		}
+
+		// Check if OU is declarative (for composite mode)
+		if ous.ouStore.IsOrganizationUnitDeclarative(txCtx, ouID) {
+			capturedSvcErr = &ErrorCannotModifyDeclarativeResource
+			return errors.New("declarative resource")
+		}
+
+		svcErr := ous.deleteOUInternal(txCtx, ouID, logger)
+		if svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("delete error")
+		}
+		return nil
+	})
+
+	if capturedSvcErr != nil {
+		return capturedSvcErr
+	}
+	if err != nil {
 		return &ErrorInternalServerError
 	}
 
-	if svcErr := ous.checkOUAccess(ctx, security.ActionDeleteOU, existingOU.ID); svcErr != nil {
-		return svcErr
-	}
-
-	// Check if OU is declarative (for composite mode)
-	if ous.ouStore.IsOrganizationUnitDeclarative(existingOU.ID) {
-		return &ErrorCannotModifyDeclarativeResource
-	}
-
-	if svcErr := ous.deleteOUInternal(existingOU.ID, logger); svcErr != nil {
-		return svcErr
-	}
-
-	logger.Debug("Successfully deleted organization unit by path", log.String("ouID", existingOU.ID))
+	logger.Debug("Successfully deleted organization unit by path", log.String("ouID", ouID))
 	return nil
 }
 
 // deleteOUInternal deletes an organization unit by ID after checking if it has child resources.
-func (ous *organizationUnitService) deleteOUInternal(id string, logger *log.Logger) *serviceerror.ServiceError {
+func (ous *organizationUnitService) deleteOUInternal(
+	ctx context.Context, id string, logger *log.Logger,
+) *serviceerror.ServiceError {
 	// Check if OU is immutable (for composite mode)
-	if ous.ouStore.IsOrganizationUnitDeclarative(id) {
+	if ous.ouStore.IsOrganizationUnitDeclarative(ctx, id) {
 		return &ErrorCannotModifyDeclarativeResource
 	}
 
-	hasChildren, err := ous.ouStore.CheckOrganizationUnitHasChildResources(id)
+	hasChildren, err := ous.ouStore.CheckOrganizationUnitHasChildResources(ctx, id)
 	if err != nil {
 		logger.Error("Failed to check if organization unit has children", log.Error(err))
 		return &ErrorInternalServerError
@@ -649,7 +747,7 @@ func (ous *organizationUnitService) deleteOUInternal(id string, logger *log.Logg
 		return &ErrorCannotDeleteOrganizationUnit
 	}
 
-	err = ous.ouStore.DeleteOrganizationUnit(id)
+	err = ous.ouStore.DeleteOrganizationUnit(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return &ErrorOrganizationUnitNotFound
@@ -685,9 +783,9 @@ func (ous *organizationUnitService) GetOrganizationUnitUsers(
 	}
 
 	items, totalCount, svcErr := ous.getResourceListWithExistenceCheck(
-		id, limit, offset, "users",
-		func(id string, limit, offset int) (interface{}, error) {
-			return ous.ouStore.GetOrganizationUnitUsersList(id, limit, offset)
+		ctx, id, limit, offset, "users",
+		func(ctx context.Context, id string, limit, offset int) (interface{}, error) {
+			return ous.ouStore.GetOrganizationUnitUsersList(ctx, id, limit, offset)
 		},
 		ous.ouStore.GetOrganizationUnitUsersCount,
 		false, // No composite error mapping for users
@@ -707,9 +805,9 @@ func (ous *organizationUnitService) GetOrganizationUnitGroups(
 	}
 
 	items, totalCount, svcErr := ous.getResourceListWithExistenceCheck(
-		id, limit, offset, "groups",
-		func(id string, limit, offset int) (interface{}, error) {
-			return ous.ouStore.GetOrganizationUnitGroupsList(id, limit, offset)
+		ctx, id, limit, offset, "groups",
+		func(ctx context.Context, id string, limit, offset int) (interface{}, error) {
+			return ous.ouStore.GetOrganizationUnitGroupsList(ctx, id, limit, offset)
 		},
 		ous.ouStore.GetOrganizationUnitGroupsCount,
 		false, // No composite error mapping for groups
@@ -729,9 +827,9 @@ func (ous *organizationUnitService) GetOrganizationUnitChildren(
 	}
 
 	items, totalCount, svcErr := ous.getResourceListWithExistenceCheck(
-		id, limit, offset, "child organization units",
-		func(id string, limit, offset int) (interface{}, error) {
-			return ous.ouStore.GetOrganizationUnitChildrenList(id, limit, offset)
+		ctx, id, limit, offset, "child organization units",
+		func(ctx context.Context, id string, limit, offset int) (interface{}, error) {
+			return ous.ouStore.GetOrganizationUnitChildrenList(ctx, id, limit, offset)
 		},
 		ous.ouStore.GetOrganizationUnitChildrenCount,
 		true, // Map composite limit error for children
@@ -754,7 +852,7 @@ func (ous *organizationUnitService) GetOrganizationUnitChildrenByPath(
 		return nil, serviceError
 	}
 
-	ou, err := ous.ouStore.GetOrganizationUnitByPath(handles)
+	ou, err := ous.ouStore.GetOrganizationUnitByPath(ctx, handles)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
@@ -778,7 +876,7 @@ func (ous *organizationUnitService) GetOrganizationUnitUsersByPath(
 		return nil, serviceError
 	}
 
-	ou, err := ous.ouStore.GetOrganizationUnitByPath(handles)
+	ou, err := ous.ouStore.GetOrganizationUnitByPath(ctx, handles)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
@@ -802,7 +900,7 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 		return nil, serviceError
 	}
 
-	ou, err := ous.ouStore.GetOrganizationUnitByPath(handles)
+	ou, err := ous.ouStore.GetOrganizationUnitByPath(ctx, handles)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
@@ -815,7 +913,9 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 }
 
 // checkCircularDependency checks if setting the parent would create a circular dependency.
-func (ous *organizationUnitService) checkCircularDependency(ouID string, parentID *string) *serviceerror.ServiceError {
+func (ous *organizationUnitService) checkCircularDependency(
+	ctx context.Context, ouID string, parentID *string,
+) *serviceerror.ServiceError {
 	if parentID == nil {
 		return nil
 	}
@@ -830,7 +930,7 @@ func (ous *organizationUnitService) checkCircularDependency(ouID string, parentI
 			return &ErrorCircularDependency
 		}
 
-		parentOU, err := ous.ouStore.GetOrganizationUnit(*currentParentID)
+		parentOU, err := ous.ouStore.GetOrganizationUnit(ctx, *currentParentID)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
 				break
@@ -941,9 +1041,9 @@ func buildPaginationLinks(limit, offset, totalCount int) []Link {
 // organization unit with existence check.
 // If mapCompositeError is true, it will map ErrResultLimitExceededInCompositeMode to ErrorResultLimitExceeded.
 func (ous *organizationUnitService) getResourceListWithExistenceCheck(
-	id string, limit, offset int, resourceType string,
-	getListFunc func(string, int, int) (interface{}, error),
-	getCountFunc func(string) (int, error),
+	ctx context.Context, id string, limit, offset int, resourceType string,
+	getListFunc func(context.Context, string, int, int) (interface{}, error),
+	getCountFunc func(context.Context, string) (int, error),
 	mapCompositeError bool,
 ) (interface{}, int, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
@@ -955,7 +1055,7 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 	}
 
 	// Check if the organization unit exists
-	exists, err := ous.ouStore.IsOrganizationUnitExists(id)
+	exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, id)
 	if err != nil {
 		logger.Error("Failed to check organization unit existence", log.Error(err))
 		return nil, 0, &ErrorInternalServerError
@@ -964,7 +1064,7 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 		return nil, 0, &ErrorOrganizationUnitNotFound
 	}
 
-	items, err := getListFunc(id, limit, offset)
+	items, err := getListFunc(ctx, id, limit, offset)
 	if err != nil {
 		// Map composite limit error if requested
 		if mapCompositeError && errors.Is(err, ErrResultLimitExceededInCompositeMode) {
@@ -974,7 +1074,7 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 		return nil, 0, &ErrorInternalServerError
 	}
 
-	totalCount, err := getCountFunc(id)
+	totalCount, err := getCountFunc(ctx, id)
 	if err != nil {
 		logger.Error("Failed to get resource count", log.String("resource_type", resourceType), log.Error(err))
 		return nil, 0, &ErrorInternalServerError

--- a/backend/internal/ou/service_declarative_mode_test.go
+++ b/backend/internal/ou/service_declarative_mode_test.go
@@ -42,11 +42,12 @@ func (suite *DeclarativeModeServiceTestSuite) SetupTest() {
 			Enabled: true,
 		},
 	}
-	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
+	suite.Require().NoError(err)
 
 	// Create service with mock store (store won't be called in declarative mode)
 	mockStore := new(organizationUnitStoreInterfaceMock)
-	suite.service = newOrganizationUnitService(nil, mockStore)
+	suite.service = newOrganizationUnitService(nil, mockStore, nil)
 }
 
 func (suite *DeclarativeModeServiceTestSuite) TearDownTest() {

--- a/backend/internal/ou/service_test.go
+++ b/backend/internal/ou/service_test.go
@@ -38,8 +38,10 @@ type OrganizationUnitServiceTestSuite struct {
 	suite.Suite
 }
 
-const testParentID = "parent"
-const testOUID = "ou-1"
+var testParentID = "parent"
+var testOUID = "ou-1"
+var testMidID = "mid-1"
+var testGrandID = "grand"
 
 func TestOUService_OrganizationUnitServiceTestSuite_Run(t *testing.T) {
 	suite.Run(t, new(OrganizationUnitServiceTestSuite))
@@ -92,12 +94,12 @@ func runOUPathListTests[Resp any](suite *OrganizationUnitServiceTestSuite, cfg p
 
 		suite.Require().Nil(resp)
 		suite.Require().Equal(ErrorInvalidHandlePath, *err)
-		store.AssertNotCalled(suite.T(), "GetOrganizationUnitByPath", mock.Anything)
+		store.AssertNumberOfCalls(suite.T(), "GetOrganizationUnitByPath", 0)
 	})
 
 	suite.Run("not found", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", cfg.validPathSlice).
+		store.On("GetOrganizationUnitByPath", mock.Anything, cfg.validPathSlice).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
@@ -110,7 +112,7 @@ func runOUPathListTests[Resp any](suite *OrganizationUnitServiceTestSuite, cfg p
 
 	suite.Run("store error", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", cfg.validPathSlice).
+		store.On("GetOrganizationUnitByPath", mock.Anything, cfg.validPathSlice).
 			Return(OrganizationUnit{}, errors.New("boom")).
 			Once()
 
@@ -147,16 +149,16 @@ func setupDefaultPathSuccess(
 	countMethod string,
 	countReturn interface{},
 ) {
-	store.On("GetOrganizationUnitByPath", []string{"root"}).
+	store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 		Return(OrganizationUnit{ID: "ou-1"}, nil).
 		Once()
-	store.On("IsOrganizationUnitExists", "ou-1").
+	store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 		Return(true, nil).
 		Once()
-	store.On(listMethod, "ou-1", limit, offset).
+	store.On(listMethod, mock.Anything, "ou-1", limit, offset).
 		Return(listReturn, nil).
 		Once()
-	store.On(countMethod, "ou-1").
+	store.On(countMethod, mock.Anything, "ou-1").
 		Return(countReturn, nil).
 		Once()
 }
@@ -213,7 +215,25 @@ func (suite *OrganizationUnitServiceTestSuite) newService(
 	store *organizationUnitStoreInterfaceMock,
 	authzService *sysauthzmock.SystemAuthorizationServiceInterfaceMock,
 ) *organizationUnitService {
-	return &organizationUnitService{ouStore: store, authzService: authzService}
+	mtx := new(mockTransactioner)
+	mtx.On("Transact", mock.Anything, mock.Anything).Return(nil).Maybe()
+	return &organizationUnitService{
+		ouStore:       store,
+		authzService:  authzService,
+		transactioner: mtx,
+	}
+}
+
+type mockTransactioner struct {
+	mock.Mock
+}
+
+func (m *mockTransactioner) Transact(ctx context.Context, fn func(context.Context) error) error {
+	args := m.Called(ctx, fn)
+	if args.Get(0) == nil {
+		return fn(ctx)
+	}
+	return args.Error(0)
 }
 
 func newAllowAllAuthz(t interface {
@@ -261,10 +281,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			limit:  2,
 			offset: 1,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount").
+				store.On("GetOrganizationUnitListCount", mock.Anything).
 					Return(3, nil).
 					Once()
-				store.On("GetOrganizationUnitList", 2, 1).
+				store.On("GetOrganizationUnitList", mock.Anything, 2, 1).
 					Return([]OrganizationUnitBasic{
 						{ID: "ou-1", Handle: "root", Name: "Root"},
 						{ID: "ou-2", Handle: "child", Name: "Child"},
@@ -295,7 +315,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			limit:  5,
 			offset: 0,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount").
+				store.On("GetOrganizationUnitListCount", mock.Anything).
 					Return(0, errors.New("count failed")).
 					Once()
 			},
@@ -306,10 +326,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			limit:  5,
 			offset: 0,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount").
+				store.On("GetOrganizationUnitListCount", mock.Anything).
 					Return(10, nil).
 					Once()
-				store.On("GetOrganizationUnitList", 5, 0).
+				store.On("GetOrganizationUnitList", mock.Anything, 5, 0).
 					Return(nil, errors.New("list failed")).
 					Once()
 			},
@@ -338,7 +358,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			}
 
 			if tc.wantErr == &ErrorInvalidLimit {
-				store.AssertNotCalled(suite.T(), "GetOrganizationUnitListCount")
+				store.AssertNumberOfCalls(suite.T(), "GetOrganizationUnitListCount", 0)
 			}
 			store.AssertExpectations(suite.T())
 		})
@@ -377,7 +397,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 				Parent: &parentID,
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", parentID).
+				store.On("IsOrganizationUnitExists", mock.Anything, parentID).
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -391,7 +411,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 				Parent: &parentID,
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", parentID).
+				store.On("IsOrganizationUnitExists", mock.Anything, parentID).
 					Return(false, nil).
 					Once()
 			},
@@ -401,7 +421,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 			name:    "name conflict error",
 			request: validRequest,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(true, nil).
 					Once()
 			},
@@ -411,7 +431,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 			name:    "name conflict check failure",
 			request: validRequest,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(false, errors.New("name check failed")).
 					Once()
 			},
@@ -421,10 +441,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 			name:    "handle conflict",
 			request: validRequest,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 					Return(true, nil).
 					Once()
 			},
@@ -434,10 +454,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 			name:    "handle conflict check failure",
 			request: validRequest,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 					Return(false, errors.New("handle check failed")).
 					Once()
 			},
@@ -447,13 +467,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 			name:    "create failure",
 			request: validRequest,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CreateOrganizationUnit", mock.AnythingOfType("ou.OrganizationUnit")).
+				store.On("CreateOrganizationUnit", mock.Anything, mock.AnythingOfType("ou.OrganizationUnit")).
 					Return(errors.New("insert failed")).
 					Once()
 			},
@@ -463,13 +483,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 			name:    "success",
 			request: validRequest,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CreateOrganizationUnit", mock.MatchedBy(func(ou OrganizationUnit) bool {
+				store.On("CreateOrganizationUnit", mock.Anything, mock.MatchedBy(func(ou OrganizationUnit) bool {
 					return ou.Name == "Finance" && ou.Handle == "finance"
 				})).
 					Return(nil).
@@ -486,13 +506,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 				LogoURL:  "https://example.com/logo.png",
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 					Return(false, nil).
 					Once()
-				store.On("CreateOrganizationUnit", mock.MatchedBy(func(ou OrganizationUnit) bool {
+				store.On("CreateOrganizationUnit", mock.Anything, mock.MatchedBy(func(ou OrganizationUnit) bool {
 					return ou.Name == "Finance" && ou.Handle == "finance" &&
 						ou.ThemeID == "theme-123" && ou.LayoutID == "layout-456" &&
 						ou.LogoURL == "https://example.com/logo.png"
@@ -525,7 +545,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationU
 			}
 
 			if tc.wantErr == &ErrorInvalidRequestFormat {
-				store.AssertNotCalled(suite.T(), "CheckOrganizationUnitNameConflict", mock.Anything, mock.Anything)
+				store.AssertNumberOfCalls(suite.T(), "CheckOrganizationUnitNameConflict", 0)
 			}
 			store.AssertExpectations(suite.T())
 		})
@@ -541,7 +561,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 		{
 			name: "success",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(OrganizationUnit{ID: "ou-1", Name: "Root"}, nil).
 					Once()
 			},
@@ -549,7 +569,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 		{
 			name: "not found",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 					Once()
 			},
@@ -558,7 +578,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 		{
 			name: "store error",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(OrganizationUnit{}, errors.New("boom")).
 					Once()
 			},
@@ -603,7 +623,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			path: "/root/child/",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				store.
-					On("GetOrganizationUnitByPath", []string{"root", "child"}).
+					On("GetOrganizationUnitByPath", mock.Anything, []string{"root", "child"}).
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 					Once()
 			},
@@ -613,7 +633,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name: "store error",
 			path: "root",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitByPath", []string{"root"}).
+				store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 					Return(OrganizationUnit{}, errors.New("boom")).
 					Once()
 			},
@@ -623,7 +643,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name: "success",
 			path: "root",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitByPath", []string{"root"}).
+				store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 					Return(OrganizationUnit{ID: "ou-1", Handle: "root"}, nil).
 					Once()
 			},
@@ -650,7 +670,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			}
 
 			if tc.wantErr == &ErrorInvalidHandlePath {
-				store.AssertNotCalled(suite.T(), "GetOrganizationUnitByPath", mock.Anything)
+				store.AssertNumberOfCalls(suite.T(), "GetOrganizationUnitByPath", 0)
 			}
 		})
 	}
@@ -666,7 +686,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsOrganizationUnitE
 		{
 			name: "success",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
 			},
@@ -675,7 +695,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsOrganizationUnitE
 		{
 			name: "store error",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -718,8 +738,8 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 
 	suite.Run("returns true for direct parent", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnit", childID).
-			Return(OrganizationUnit{ID: childID, Parent: new(parentID)}, nil).
+		store.On("GetOrganizationUnit", mock.Anything, childID).
+			Return(OrganizationUnit{ID: childID, Parent: &parentID}, nil).
 			Once()
 
 		service := suite.newService(store, newAllowAllAuthz(suite.T()))
@@ -732,11 +752,11 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 
 	suite.Run("returns true for ancestor", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnit", childID).
-			Return(OrganizationUnit{ID: childID, Parent: new("mid-1")}, nil).
+		store.On("GetOrganizationUnit", mock.Anything, childID).
+			Return(OrganizationUnit{ID: childID, Parent: &testMidID}, nil).
 			Once()
-		store.On("GetOrganizationUnit", "mid-1").
-			Return(OrganizationUnit{ID: "mid-1", Parent: new(parentID)}, nil).
+		store.On("GetOrganizationUnit", mock.Anything, "mid-1").
+			Return(OrganizationUnit{ID: "mid-1", Parent: &parentID}, nil).
 			Once()
 
 		service := suite.newService(store, newAllowAllAuthz(suite.T()))
@@ -749,10 +769,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 
 	suite.Run("returns false when parent not in hierarchy", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnit", childID).
-			Return(OrganizationUnit{ID: childID, Parent: new("mid-1")}, nil).
+		store.On("GetOrganizationUnit", mock.Anything, childID).
+			Return(OrganizationUnit{ID: childID, Parent: &testMidID}, nil).
 			Once()
-		store.On("GetOrganizationUnit", "mid-1").
+		store.On("GetOrganizationUnit", mock.Anything, "mid-1").
 			Return(OrganizationUnit{ID: "mid-1"}, nil).
 			Once()
 
@@ -766,7 +786,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 
 	suite.Run("returns error when child not found", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnit", childID).
+		store.On("GetOrganizationUnit", mock.Anything, childID).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
@@ -780,7 +800,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 
 	suite.Run("returns error on store failure", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnit", childID).
+		store.On("GetOrganizationUnit", mock.Anything, childID).
 			Return(OrganizationUnit{}, errors.New("boom")).
 			Once()
 
@@ -818,13 +838,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 					Name:        "Root",
 					Description: "old",
 				}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("UpdateOrganizationUnit", OrganizationUnit{
+				store.On("UpdateOrganizationUnit", mock.Anything, OrganizationUnit{
 					ID:          "ou-1",
 					Handle:      "root",
 					Name:        "Root",
@@ -857,13 +877,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 					LayoutID: "layout-old",
 					LogoURL:  "https://example.com/old-logo.png",
 				}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("UpdateOrganizationUnit", OrganizationUnit{
+				store.On("UpdateOrganizationUnit", mock.Anything, OrganizationUnit{
 					ID:       "ou-1",
 					Handle:   "root",
 					Name:     "Root",
@@ -888,7 +908,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 				Name:   "Root",
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnit", "missing").
+				store.On("GetOrganizationUnit", mock.Anything, "missing").
 					Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 					Once()
 			},
@@ -902,7 +922,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 				Name:   "Root",
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(OrganizationUnit{}, errors.New("boom")).
 					Once()
 			},
@@ -917,10 +937,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
 			},
@@ -936,13 +956,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("IsOrganizationUnitExists", parentID).
+				store.On("IsOrganizationUnitExists", mock.Anything, parentID).
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -958,13 +978,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("IsOrganizationUnitExists", parentID).
+				store.On("IsOrganizationUnitExists", mock.Anything, parentID).
 					Return(false, nil).
 					Once()
 			},
@@ -976,17 +996,17 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			request: OrganizationUnitRequest{
 				Handle: "root",
 				Name:   "Root",
-				Parent: new("ou-1"),
+				Parent: &testOUID,
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
 			},
@@ -1001,13 +1021,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(true, nil).
 					Once()
 			},
@@ -1022,13 +1042,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -1043,13 +1063,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 					Return(true, nil).
 					Once()
 			},
@@ -1064,13 +1084,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+				store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -1085,13 +1105,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("UpdateOrganizationUnit", mock.AnythingOfType("ou.OrganizationUnit")).
+				store.On("UpdateOrganizationUnit", mock.Anything, mock.AnythingOfType("ou.OrganizationUnit")).
 					Return(ErrOrganizationUnitNotFound).
 					Once()
 			},
@@ -1106,13 +1126,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			},
 			setup: func(store *organizationUnitStoreInterfaceMock) {
 				existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-				store.On("GetOrganizationUnit", "ou-1").
+				store.On("GetOrganizationUnit", mock.Anything, "ou-1").
 					Return(existing, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("UpdateOrganizationUnit", mock.AnythingOfType("ou.OrganizationUnit")).
+				store.On("UpdateOrganizationUnit", mock.Anything, mock.AnythingOfType("ou.OrganizationUnit")).
 					Return(errors.New("boom")).
 					Once()
 			},
@@ -1156,12 +1176,12 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 		_, err := service.UpdateOrganizationUnitByPath(context.Background(), "   ", request)
 
 		suite.Require().Equal(ErrorInvalidHandlePath, *err)
-		store.AssertNotCalled(suite.T(), "GetOrganizationUnitByPath", mock.Anything)
+		store.AssertNumberOfCalls(suite.T(), "GetOrganizationUnitByPath", 0)
 	})
 
 	suite.Run("not found", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
@@ -1173,7 +1193,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 
 	suite.Run("get by path error", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(OrganizationUnit{}, errors.New("boom")).
 			Once()
 
@@ -1186,13 +1206,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 	suite.Run("success", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
 		existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(existing, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", "ou-1").
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 			Return(false).
 			Twice() // Called in UpdateOrganizationUnitByPath and updateOUInternal
-		store.On("UpdateOrganizationUnit", mock.AnythingOfType("ou.OrganizationUnit")).
+		store.On("UpdateOrganizationUnit", mock.Anything, mock.AnythingOfType("ou.OrganizationUnit")).
 			Return(nil).
 			Once()
 
@@ -1206,10 +1226,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 	suite.Run("declarative resource cannot be updated", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
 		existing := OrganizationUnit{ID: "ou-1", Handle: "root", Name: "Root"}
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(existing, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", "ou-1").
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 			Return(true).
 			Once()
 
@@ -1217,7 +1237,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 		_, err := service.UpdateOrganizationUnitByPath(context.Background(), "root", request)
 
 		suite.Require().Equal(ErrorCannotModifyDeclarativeResource, *err)
-		store.AssertNotCalled(suite.T(), "UpdateOrganizationUnit", mock.Anything)
+		store.AssertNumberOfCalls(suite.T(), "UpdateOrganizationUnit", 0)
 	})
 }
 
@@ -1230,7 +1250,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		{
 			name: "existence check error",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -1239,7 +1259,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		{
 			name: "not found",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(false, nil).
 					Once()
 			},
@@ -1248,13 +1268,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		{
 			name: "has children",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitHasChildResources", "ou-1").
+				store.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
 			},
@@ -1263,13 +1283,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		{
 			name: "child check failure",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitHasChildResources", "ou-1").
+				store.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -1278,16 +1298,16 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		{
 			name: "delete failure",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitHasChildResources", "ou-1").
+				store.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 					Return(false, nil).
 					Once()
-				store.On("DeleteOrganizationUnit", "ou-1").
+				store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 					Return(errors.New("boom")).
 					Once()
 			},
@@ -1296,16 +1316,16 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		{
 			name: "delete not found",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitHasChildResources", "ou-1").
+				store.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 					Return(false, nil).
 					Once()
-				store.On("DeleteOrganizationUnit", "ou-1").
+				store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 					Return(ErrOrganizationUnitNotFound).
 					Once()
 			},
@@ -1314,16 +1334,16 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		{
 			name: "success",
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("IsOrganizationUnitDeclarative", "ou-1").
+				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).
 					Once()
-				store.On("CheckOrganizationUnitHasChildResources", "ou-1").
+				store.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 					Return(false, nil).
 					Once()
-				store.On("DeleteOrganizationUnit", "ou-1").
+				store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 					Return(nil).
 					Once()
 			},
@@ -1356,12 +1376,12 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		err := service.DeleteOrganizationUnitByPath(context.Background(), "  ")
 
 		suite.Require().Equal(ErrorInvalidHandlePath, *err)
-		store.AssertNotCalled(suite.T(), "GetOrganizationUnitByPath", mock.Anything)
+		store.AssertNumberOfCalls(suite.T(), "GetOrganizationUnitByPath", 0)
 	})
 
 	suite.Run("not found", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
@@ -1373,7 +1393,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 
 	suite.Run("get by path error", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(OrganizationUnit{}, errors.New("boom")).
 			Once()
 
@@ -1385,13 +1405,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 
 	suite.Run("cannot delete", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(OrganizationUnit{ID: "ou-1"}, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", "ou-1").
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 			Return(false).
 			Twice() // Called in DeleteOrganizationUnitByPath and deleteOUInternal
-		store.On("CheckOrganizationUnitHasChildResources", "ou-1").
+		store.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 			Return(true, nil).
 			Once()
 
@@ -1403,16 +1423,16 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 
 	suite.Run("success", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(OrganizationUnit{ID: "ou-1"}, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", "ou-1").
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 			Return(false).
 			Twice() // Called in DeleteOrganizationUnitByPath and deleteOUInternal
-		store.On("CheckOrganizationUnitHasChildResources", "ou-1").
+		store.On("CheckOrganizationUnitHasChildResources", mock.Anything, "ou-1").
 			Return(false, nil).
 			Once()
-		store.On("DeleteOrganizationUnit", "ou-1").
+		store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 			Return(nil).
 			Once()
 
@@ -1424,10 +1444,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 
 	suite.Run("declarative resource cannot be deleted", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
-		store.On("GetOrganizationUnitByPath", []string{"root"}).
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(OrganizationUnit{ID: "ou-1"}, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", "ou-1").
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 			Return(true).
 			Once()
 
@@ -1435,8 +1455,8 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 		err := service.DeleteOrganizationUnitByPath(context.Background(), "root")
 
 		suite.Require().Equal(ErrorCannotModifyDeclarativeResource, *err)
-		store.AssertNotCalled(suite.T(), "CheckOrganizationUnitHasChildResources", mock.Anything)
-		store.AssertNotCalled(suite.T(), "DeleteOrganizationUnit", mock.Anything)
+		store.AssertNumberOfCalls(suite.T(), "CheckOrganizationUnitHasChildResources", 0)
+		store.AssertNumberOfCalls(suite.T(), "DeleteOrganizationUnit", 0)
 	})
 }
 
@@ -1459,7 +1479,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "ou not found",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(false, nil).
 					Once()
 			},
@@ -1469,7 +1489,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "existence check error",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -1479,10 +1499,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "list failure",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenList", "ou-1", 5, 0).
+				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 5, 0).
 					Return(nil, errors.New("list fail")).
 					Once()
 			},
@@ -1492,13 +1512,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "count failure",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenList", "ou-1", 5, 0).
+				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 5, 0).
 					Return([]OrganizationUnitBasic{}, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenCount", "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
 					Return(0, errors.New("count fail")).
 					Once()
 			},
@@ -1508,15 +1528,15 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "success",
 			limit: 2,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenList", "ou-1", 2, 0).
+				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 2, 0).
 					Return([]OrganizationUnitBasic{
 						{ID: "child-1", Handle: "finance", Name: "Finance"},
 					}, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenCount", "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
 					Return(1, nil).
 					Once()
 			},
@@ -1551,7 +1571,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			}
 
 			if tc.wantErr == &ErrorInvalidLimit {
-				store.AssertNotCalled(suite.T(), "IsOrganizationUnitExists", mock.Anything)
+				store.AssertNumberOfCalls(suite.T(), "IsOrganizationUnitExists", 0)
 			}
 		})
 	}
@@ -1592,7 +1612,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "not found",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(false, nil).
 					Once()
 			},
@@ -1602,7 +1622,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "existence error",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(false, errors.New("boom")).
 					Once()
 			},
@@ -1612,10 +1632,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "list error",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitUsersList", "ou-1", 5, 0).
+				store.On("GetOrganizationUnitUsersList", mock.Anything, "ou-1", 5, 0).
 					Return(nil, errors.New("list")).
 					Once()
 			},
@@ -1625,13 +1645,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "count error",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitUsersList", "ou-1", 5, 0).
+				store.On("GetOrganizationUnitUsersList", mock.Anything, "ou-1", 5, 0).
 					Return([]User{{ID: "user-1"}}, nil).
 					Once()
-				store.On("GetOrganizationUnitUsersCount", "ou-1").
+				store.On("GetOrganizationUnitUsersCount", mock.Anything, "ou-1").
 					Return(0, errors.New("count")).
 					Once()
 			},
@@ -1641,13 +1661,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "success",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitUsersList", "ou-1", 5, 0).
+				store.On("GetOrganizationUnitUsersList", mock.Anything, "ou-1", 5, 0).
 					Return([]User{{ID: "user-1"}, {ID: "user-2"}}, nil).
 					Once()
-				store.On("GetOrganizationUnitUsersCount", "ou-1").
+				store.On("GetOrganizationUnitUsersCount", mock.Anything, "ou-1").
 					Return(2, nil).
 					Once()
 			},
@@ -1675,7 +1695,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			}
 
 			if tc.wantErr == &ErrorInvalidLimit {
-				store.AssertNotCalled(suite.T(), "IsOrganizationUnitExists", mock.Anything)
+				store.AssertNumberOfCalls(suite.T(), "IsOrganizationUnitExists", 0)
 			}
 		})
 	}
@@ -1716,10 +1736,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "list error",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitGroupsList", "ou-1", 5, 0).
+				store.On("GetOrganizationUnitGroupsList", mock.Anything, "ou-1", 5, 0).
 					Return(nil, errors.New("boom")).
 					Once()
 			},
@@ -1729,13 +1749,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			name:  "success",
 			limit: 5,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("IsOrganizationUnitExists", "ou-1").
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitGroupsList", "ou-1", 5, 0).
+				store.On("GetOrganizationUnitGroupsList", mock.Anything, "ou-1", 5, 0).
 					Return([]Group{{ID: "g1"}}, nil).
 					Once()
-				store.On("GetOrganizationUnitGroupsCount", "ou-1").
+				store.On("GetOrganizationUnitGroupsCount", mock.Anything, "ou-1").
 					Return(1, nil).
 					Once()
 			},
@@ -1760,7 +1780,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 				suite.Require().Nil(resp)
 				suite.Require().Equal(*tc.wantErr, *err)
 				if tc.wantErr == &ErrorInvalidLimit {
-					store.AssertNotCalled(suite.T(), "IsOrganizationUnitExists", mock.Anything)
+					store.AssertNumberOfCalls(suite.T(), "IsOrganizationUnitExists", 0)
 				}
 				return
 			}
@@ -1869,33 +1889,33 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_CheckCircularDepend
 	service := suite.newService(store, newAllowAllAuthz(suite.T()))
 	parentID := testParentID
 
-	store.On("GetOrganizationUnit", parentID).
-		Return(OrganizationUnit{ID: parentID, Parent: new("grand")}, nil).
+	store.On("GetOrganizationUnit", mock.Anything, parentID).
+		Return(OrganizationUnit{ID: parentID, Parent: &testGrandID}, nil).
 		Once()
-	store.On("GetOrganizationUnit", "grand").
-		Return(OrganizationUnit{ID: "grand", Parent: new("ou-1")}, nil).
+	store.On("GetOrganizationUnit", mock.Anything, "grand").
+		Return(OrganizationUnit{ID: "grand", Parent: &testOUID}, nil).
 		Once()
 
-	err := service.checkCircularDependency("ou-1", &parentID)
+	err := service.checkCircularDependency(context.Background(), "ou-1", &parentID)
 
 	suite.Require().Equal(&ErrorCircularDependency, err)
 
 	store2 := newOrganizationUnitStoreInterfaceMock(suite.T())
 	service2 := suite.newService(store2, newAllowAllAuthz(suite.T()))
-	store2.On("GetOrganizationUnit", parentID).
+	store2.On("GetOrganizationUnit", mock.Anything, parentID).
 		Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 		Once()
 
-	err = service2.checkCircularDependency("ou-1", &parentID)
+	err = service2.checkCircularDependency(context.Background(), "ou-1", &parentID)
 	suite.Require().Nil(err)
 
 	store3 := newOrganizationUnitStoreInterfaceMock(suite.T())
 	service3 := suite.newService(store3, newAllowAllAuthz(suite.T()))
-	store3.On("GetOrganizationUnit", parentID).
+	store3.On("GetOrganizationUnit", mock.Anything, parentID).
 		Return(OrganizationUnit{}, errors.New("boom")).
 		Once()
 
-	err = service3.checkCircularDependency("ou-1", &parentID)
+	err = service3.checkCircularDependency(context.Background(), "ou-1", &parentID)
 	suite.Require().Equal(&ErrorInternalServerError, err)
 }
 
@@ -1911,20 +1931,20 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			Description: "old",
 			Parent:      &parentID,
 		}
-		store.On("GetOrganizationUnit", testOUID).
+		store.On("GetOrganizationUnit", mock.Anything, testOUID).
 			Return(existing, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", testOUID).
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, testOUID).
 			Return(false).
 			Once()
-		store.On("IsOrganizationUnitExists", parentID).
+		store.On("IsOrganizationUnitExists", mock.Anything, parentID).
 			Return(true, nil).
 			Once()
 		// checkCircularDependency walks up from parent
-		store.On("GetOrganizationUnit", parentID).
+		store.On("GetOrganizationUnit", mock.Anything, parentID).
 			Return(OrganizationUnit{ID: parentID, Parent: nil}, nil).
 			Once()
-		store.On("UpdateOrganizationUnit", mock.MatchedBy(func(ou OrganizationUnit) bool {
+		store.On("UpdateOrganizationUnit", mock.Anything, mock.MatchedBy(func(ou OrganizationUnit) bool {
 			return ou.ID == testOUID && ou.Description == "updated" && *ou.Parent == parentID
 		})).
 			Return(nil).
@@ -1935,13 +1955,13 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			Handle:      "finance",
 			Name:        "Finance",
 			Description: "updated",
-			Parent:      new(parentID),
+			Parent:      &parentID,
 		})
 
 		suite.Require().Nil(err)
 		suite.Require().Equal("updated", result.Description)
-		store.AssertNotCalled(suite.T(), "CheckOrganizationUnitNameConflict", mock.Anything, mock.Anything)
-		store.AssertNotCalled(suite.T(), "CheckOrganizationUnitHandleConflict", mock.Anything, mock.Anything)
+		store.AssertNumberOfCalls(suite.T(), "CheckOrganizationUnitNameConflict", 0)
+		store.AssertNumberOfCalls(suite.T(), "CheckOrganizationUnitHandleConflict", 0)
 		store.AssertExpectations(suite.T())
 	})
 
@@ -1953,30 +1973,30 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			Name:   "Finance",
 			Parent: nil,
 		}
-		store.On("GetOrganizationUnit", testOUID).
+		store.On("GetOrganizationUnit", mock.Anything, testOUID).
 			Return(existing, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", testOUID).
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, testOUID).
 			Return(false).
 			Once()
-		store.On("IsOrganizationUnitExists", parentID).
+		store.On("IsOrganizationUnitExists", mock.Anything, parentID).
 			Return(true, nil).
 			Once()
 		// checkCircularDependency walks up from parent
-		store.On("GetOrganizationUnit", parentID).
+		store.On("GetOrganizationUnit", mock.Anything, parentID).
 			Return(OrganizationUnit{ID: parentID, Parent: nil}, nil).
 			Once()
-		store.On("CheckOrganizationUnitNameConflict", "Finance", mock.MatchedBy(func(p *string) bool {
+		store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", mock.MatchedBy(func(p *string) bool {
 			return p != nil && *p == parentID
 		})).
 			Return(false, nil).
 			Once()
-		store.On("CheckOrganizationUnitHandleConflict", "finance", mock.MatchedBy(func(p *string) bool {
+		store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", mock.MatchedBy(func(p *string) bool {
 			return p != nil && *p == parentID
 		})).
 			Return(false, nil).
 			Once()
-		store.On("UpdateOrganizationUnit", mock.MatchedBy(func(ou OrganizationUnit) bool {
+		store.On("UpdateOrganizationUnit", mock.Anything, mock.MatchedBy(func(ou OrganizationUnit) bool {
 			return ou.ID == testOUID && *ou.Parent == parentID
 		})).
 			Return(nil).
@@ -1986,7 +2006,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 		result, err := service.UpdateOrganizationUnit(context.Background(), testOUID, OrganizationUnitRequest{
 			Handle: "finance",
 			Name:   "Finance",
-			Parent: new(parentID),
+			Parent: &parentID,
 		})
 
 		suite.Require().Nil(err)
@@ -2002,19 +2022,19 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_UpdateOrganizationU
 			Name:   "Finance",
 			Parent: &parentID,
 		}
-		store.On("GetOrganizationUnit", testOUID).
+		store.On("GetOrganizationUnit", mock.Anything, testOUID).
 			Return(existing, nil).
 			Once()
-		store.On("IsOrganizationUnitDeclarative", testOUID).
+		store.On("IsOrganizationUnitDeclarative", mock.Anything, testOUID).
 			Return(false).
 			Once()
-		store.On("CheckOrganizationUnitNameConflict", "Finance", (*string)(nil)).
+		store.On("CheckOrganizationUnitNameConflict", mock.Anything, "Finance", (*string)(nil)).
 			Return(false, nil).
 			Once()
-		store.On("CheckOrganizationUnitHandleConflict", "finance", (*string)(nil)).
+		store.On("CheckOrganizationUnitHandleConflict", mock.Anything, "finance", (*string)(nil)).
 			Return(false, nil).
 			Once()
-		store.On("UpdateOrganizationUnit", mock.MatchedBy(func(ou OrganizationUnit) bool {
+		store.On("UpdateOrganizationUnit", mock.Anything, mock.MatchedBy(func(ou OrganizationUnit) bool {
 			return ou.ID == testOUID && ou.Parent == nil
 		})).
 			Return(nil).
@@ -2103,7 +2123,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 					Once()
 			},
 			setupStore: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitsByIDs", []string{"ou-1"}).
+				store.On("GetOrganizationUnitsByIDs", mock.Anything, []string{"ou-1"}).
 					Return([]OrganizationUnitBasic{{ID: "ou-1"}}, nil).
 					Once()
 			},
@@ -2119,8 +2139,8 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 					Once()
 			},
 			setupStore: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount").Return(0, nil).Once()
-				store.On("GetOrganizationUnitList", 10, 0).
+				store.On("GetOrganizationUnitListCount", mock.Anything).Return(0, nil).Once()
+				store.On("GetOrganizationUnitList", mock.Anything, 10, 0).
 					Return([]OrganizationUnitBasic{}, ErrResultLimitExceededInCompositeMode).
 					Once()
 			},
@@ -2191,7 +2211,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_listAccessibleOrgan
 			limit:  10,
 			offset: 0,
 			setupStore: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitsByIDs", []string{"ou-1"}).
+				store.On("GetOrganizationUnitsByIDs", mock.Anything, []string{"ou-1"}).
 					Return([]OrganizationUnitBasic{}, errors.New("boom")).
 					Once()
 			},
@@ -2203,7 +2223,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_listAccessibleOrgan
 			limit:  2,
 			offset: 1,
 			setupStore: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitsByIDs", []string{"ou-2", "ou-3"}).
+				store.On("GetOrganizationUnitsByIDs", mock.Anything, []string{"ou-2", "ou-3"}).
 					Return([]OrganizationUnitBasic{{ID: "ou-2"}, {ID: "ou-3"}}, nil).
 					Once()
 			},
@@ -2220,7 +2240,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_listAccessibleOrgan
 				tc.setupStore(store)
 			}
 			service := &organizationUnitService{ouStore: store}
-			resp, err := service.listAccessibleOrganizationUnits(tc.ids, tc.limit, tc.offset)
+			resp, err := service.listAccessibleOrganizationUnits(context.Background(), tc.ids, tc.limit, tc.offset)
 
 			if tc.wantErr != nil {
 				suite.Require().NotNil(err)
@@ -2238,10 +2258,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_listAccessibleOrgan
 
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsOrganizationUnitDeclarative() {
 	store := newOrganizationUnitStoreInterfaceMock(suite.T())
-	store.On("IsOrganizationUnitDeclarative", "ou-1").Return(true).Once()
+	store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").Return(true).Once()
 
 	service := &organizationUnitService{ouStore: store}
-	res := service.IsOrganizationUnitDeclarative("ou-1")
+	res := service.IsOrganizationUnitDeclarative(context.Background(), "ou-1")
 	suite.Require().True(res)
 	store.AssertExpectations(suite.T())
 }

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -19,6 +19,7 @@
 package ou
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,25 +33,25 @@ const storeLoggerComponentName = "OrganizationUnitStore"
 
 // organizationUnitStoreInterface defines the interface for organization unit store operations.
 type organizationUnitStoreInterface interface {
-	GetOrganizationUnitListCount() (int, error)
-	GetOrganizationUnitList(limit, offset int) ([]OrganizationUnitBasic, error)
-	GetOrganizationUnitsByIDs(ids []string) ([]OrganizationUnitBasic, error)
-	CreateOrganizationUnit(ou OrganizationUnit) error
-	GetOrganizationUnit(id string) (OrganizationUnit, error)
-	GetOrganizationUnitByPath(handles []string) (OrganizationUnit, error)
-	IsOrganizationUnitExists(id string) (bool, error)
-	IsOrganizationUnitDeclarative(id string) bool
-	CheckOrganizationUnitNameConflict(name string, parent *string) (bool, error)
-	CheckOrganizationUnitHandleConflict(handle string, parent *string) (bool, error)
-	UpdateOrganizationUnit(ou OrganizationUnit) error
-	DeleteOrganizationUnit(id string) error
-	CheckOrganizationUnitHasChildResources(id string) (bool, error)
-	GetOrganizationUnitChildrenCount(id string) (int, error)
-	GetOrganizationUnitChildrenList(id string, limit, offset int) ([]OrganizationUnitBasic, error)
-	GetOrganizationUnitUsersCount(id string) (int, error)
-	GetOrganizationUnitUsersList(id string, limit, offset int) ([]User, error)
-	GetOrganizationUnitGroupsCount(id string) (int, error)
-	GetOrganizationUnitGroupsList(id string, limit, offset int) ([]Group, error)
+	GetOrganizationUnitListCount(ctx context.Context) (int, error)
+	GetOrganizationUnitList(ctx context.Context, limit, offset int) ([]OrganizationUnitBasic, error)
+	GetOrganizationUnitsByIDs(ctx context.Context, ids []string) ([]OrganizationUnitBasic, error)
+	CreateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error
+	GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, error)
+	GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error)
+	IsOrganizationUnitExists(ctx context.Context, id string) (bool, error)
+	IsOrganizationUnitDeclarative(ctx context.Context, id string) bool
+	CheckOrganizationUnitNameConflict(ctx context.Context, name string, parent *string) (bool, error)
+	CheckOrganizationUnitHandleConflict(ctx context.Context, handle string, parent *string) (bool, error)
+	UpdateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error
+	DeleteOrganizationUnit(ctx context.Context, id string) error
+	CheckOrganizationUnitHasChildResources(ctx context.Context, id string) (bool, error)
+	GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error)
+	GetOrganizationUnitChildrenList(ctx context.Context, id string, limit, offset int) ([]OrganizationUnitBasic, error)
+	GetOrganizationUnitUsersCount(ctx context.Context, id string) (int, error)
+	GetOrganizationUnitUsersList(ctx context.Context, id string, limit, offset int) ([]User, error)
+	GetOrganizationUnitGroupsCount(ctx context.Context, id string) (int, error)
+	GetOrganizationUnitGroupsList(ctx context.Context, id string, limit, offset int) ([]Group, error)
 }
 
 // organizationUnitStore is the default implementation of organizationUnitStoreInterface.
@@ -68,13 +69,13 @@ func newOrganizationUnitStore() organizationUnitStoreInterface {
 }
 
 // GetOrganizationUnitListCount retrieves the total count of organization units.
-func (s *organizationUnitStore) GetOrganizationUnitListCount() (int, error) {
+func (s *organizationUnitStore) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetRootOrganizationUnitListCount, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetRootOrganizationUnitListCount, s.deploymentID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -92,13 +93,15 @@ func (s *organizationUnitStore) GetOrganizationUnitListCount() (int, error) {
 }
 
 // GetOrganizationUnitList retrieves organization units with pagination.
-func (s *organizationUnitStore) GetOrganizationUnitList(limit, offset int) ([]OrganizationUnitBasic, error) {
+func (s *organizationUnitStore) GetOrganizationUnitList(
+	ctx context.Context, limit, offset int,
+) ([]OrganizationUnitBasic, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetRootOrganizationUnitList, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetRootOrganizationUnitList, limit, offset, s.deploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -116,7 +119,9 @@ func (s *organizationUnitStore) GetOrganizationUnitList(limit, offset int) ([]Or
 }
 
 // GetOrganizationUnitsByIDs retrieves organization units matching the given IDs.
-func (s *organizationUnitStore) GetOrganizationUnitsByIDs(ids []string) ([]OrganizationUnitBasic, error) {
+func (s *organizationUnitStore) GetOrganizationUnitsByIDs(
+	ctx context.Context, ids []string,
+) ([]OrganizationUnitBasic, error) {
 	if len(ids) == 0 {
 		return []OrganizationUnitBasic{}, nil
 	}
@@ -133,7 +138,7 @@ func (s *organizationUnitStore) GetOrganizationUnitsByIDs(ids []string) ([]Organ
 	}
 	args = append(args, s.deploymentID)
 
-	results, err := dbClient.Query(query, args...)
+	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -151,7 +156,7 @@ func (s *organizationUnitStore) GetOrganizationUnitsByIDs(ids []string) ([]Organ
 }
 
 // CreateOrganizationUnit creates a new organization unit in the database.
-func (s *organizationUnitStore) CreateOrganizationUnit(ou OrganizationUnit) error {
+func (s *organizationUnitStore) CreateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
@@ -163,7 +168,7 @@ func (s *organizationUnitStore) CreateOrganizationUnit(ou OrganizationUnit) erro
 		return fmt.Errorf("failed to serialize OU Metadata: %w", err)
 	}
 
-	_, err = dbClient.Execute(
+	_, err = dbClient.ExecuteContext(ctx,
 		queryCreateOrganizationUnit,
 		ou.ID,
 		ou.Parent,
@@ -183,13 +188,13 @@ func (s *organizationUnitStore) CreateOrganizationUnit(ou OrganizationUnit) erro
 }
 
 // GetOrganizationUnit retrieves an organization unit by its id.
-func (s *organizationUnitStore) GetOrganizationUnit(id string) (OrganizationUnit, error) {
+func (s *organizationUnitStore) GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return OrganizationUnit{}, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetOrganizationUnitByID, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitByID, id, s.deploymentID)
 	if err != nil {
 		return OrganizationUnit{}, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -207,7 +212,9 @@ func (s *organizationUnitStore) GetOrganizationUnit(id string) (OrganizationUnit
 }
 
 // GetOrganizationUnitByPath retrieves an organization unit by its hierarchical handle path.
-func (s *organizationUnitStore) GetOrganizationUnitByPath(handlePath []string) (OrganizationUnit, error) {
+func (s *organizationUnitStore) GetOrganizationUnitByPath(
+	ctx context.Context, handlePath []string,
+) (OrganizationUnit, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, storeLoggerComponentName))
 
 	if len(handlePath) == 0 {
@@ -228,9 +235,11 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(handlePath []string) (
 		var results []map[string]interface{}
 
 		if parentID == nil {
-			results, err = dbClient.Query(queryGetRootOrganizationUnitByHandle, handle, s.deploymentID)
+			results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.deploymentID)
 		} else {
-			results, err = dbClient.Query(queryGetOrganizationUnitByHandle, handle, *parentID, s.deploymentID)
+			results, err = dbClient.QueryContext(
+				ctx, queryGetOrganizationUnitByHandle, handle, *parentID, s.deploymentID,
+			)
 		}
 
 		if err != nil {
@@ -257,13 +266,13 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(handlePath []string) (
 }
 
 // IsOrganizationUnitExists checks if an organization unit exists by ID.
-func (s *organizationUnitStore) IsOrganizationUnitExists(id string) (bool, error) {
+func (s *organizationUnitStore) IsOrganizationUnitExists(ctx context.Context, id string) (bool, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryCheckOrganizationUnitExists, id, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryCheckOrganizationUnitExists, id, s.deploymentID)
 	if err != nil {
 		return false, fmt.Errorf("failed to execute existence check query: %w", err)
 	}
@@ -283,12 +292,12 @@ func (s *organizationUnitStore) IsOrganizationUnitExists(id string) (bool, error
 
 // IsOrganizationUnitDeclarative checks if an organization unit is immutable.
 // Database store resources are always mutable, so this always returns false.
-func (s *organizationUnitStore) IsOrganizationUnitDeclarative(id string) bool {
+func (s *organizationUnitStore) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
 	return false
 }
 
 // UpdateOrganizationUnit updates an existing organization unit.
-func (s *organizationUnitStore) UpdateOrganizationUnit(ou OrganizationUnit) error {
+func (s *organizationUnitStore) UpdateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
@@ -300,7 +309,7 @@ func (s *organizationUnitStore) UpdateOrganizationUnit(ou OrganizationUnit) erro
 		return fmt.Errorf("failed to serialize OU Metadata: %w", err)
 	}
 
-	_, err = dbClient.Execute(
+	_, err = dbClient.ExecuteContext(ctx,
 		queryUpdateOrganizationUnit,
 		ou.ID,
 		ou.Parent,
@@ -320,13 +329,13 @@ func (s *organizationUnitStore) UpdateOrganizationUnit(ou OrganizationUnit) erro
 }
 
 // DeleteOrganizationUnit deletes an organization unit.
-func (s *organizationUnitStore) DeleteOrganizationUnit(id string) error {
+func (s *organizationUnitStore) DeleteOrganizationUnit(ctx context.Context, id string) error {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	_, err = dbClient.Execute(queryDeleteOrganizationUnit, id, s.deploymentID)
+	_, err = dbClient.ExecuteContext(ctx, queryDeleteOrganizationUnit, id, s.deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -335,13 +344,13 @@ func (s *organizationUnitStore) DeleteOrganizationUnit(id string) error {
 }
 
 // GetOrganizationUnitChildrenCount retrieves the total count of child organization units for a given parent ID.
-func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(parentID string) (int, error) {
+func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(ctx context.Context, parentID string) (int, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetOrganizationUnitChildrenCount, parentID, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitChildrenCount, parentID, s.deploymentID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -360,7 +369,7 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(parentID string
 }
 
 // GetOrganizationUnitChildrenList retrieves a paginated list of child organization units for a given parent ID.
-func (s *organizationUnitStore) GetOrganizationUnitChildrenList(
+func (s *organizationUnitStore) GetOrganizationUnitChildrenList(ctx context.Context,
 	parentID string, limit, offset int,
 ) ([]OrganizationUnitBasic, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
@@ -368,7 +377,9 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenList(
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetOrganizationUnitChildrenList, parentID, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(
+		ctx, queryGetOrganizationUnitChildrenList, parentID, limit, offset, s.deploymentID,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -386,13 +397,13 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenList(
 }
 
 // GetOrganizationUnitUsersCount retrieves the total count of users in a given organization unit.
-func (s *organizationUnitStore) GetOrganizationUnitUsersCount(ouID string) (int, error) {
+func (s *organizationUnitStore) GetOrganizationUnitUsersCount(ctx context.Context, ouID string) (int, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetOrganizationUnitUsersCount, ouID, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitUsersCount, ouID, s.deploymentID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -411,13 +422,15 @@ func (s *organizationUnitStore) GetOrganizationUnitUsersCount(ouID string) (int,
 }
 
 // GetOrganizationUnitUsersList retrieves a paginated list of users in a given organization unit.
-func (s *organizationUnitStore) GetOrganizationUnitUsersList(ouID string, limit, offset int) ([]User, error) {
+func (s *organizationUnitStore) GetOrganizationUnitUsersList(
+	ctx context.Context, ouID string, limit, offset int,
+) ([]User, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetOrganizationUnitUsersList, ouID, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitUsersList, ouID, limit, offset, s.deploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -437,13 +450,13 @@ func (s *organizationUnitStore) GetOrganizationUnitUsersList(ouID string, limit,
 }
 
 // GetOrganizationUnitGroupsCount retrieves the total count of groups in a given organization unit.
-func (s *organizationUnitStore) GetOrganizationUnitGroupsCount(ouID string) (int, error) {
+func (s *organizationUnitStore) GetOrganizationUnitGroupsCount(ctx context.Context, ouID string) (int, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetOrganizationUnitGroupsCount, ouID, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitGroupsCount, ouID, s.deploymentID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -462,13 +475,15 @@ func (s *organizationUnitStore) GetOrganizationUnitGroupsCount(ouID string) (int
 }
 
 // GetOrganizationUnitGroupsList retrieves a paginated list of groups in a given organization unit.
-func (s *organizationUnitStore) GetOrganizationUnitGroupsList(ouID string, limit, offset int) ([]Group, error) {
+func (s *organizationUnitStore) GetOrganizationUnitGroupsList(
+	ctx context.Context, ouID string, limit, offset int,
+) ([]Group, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryGetOrganizationUnitGroupsList, ouID, limit, offset, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitGroupsList, ouID, limit, offset, s.deploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -500,8 +515,10 @@ func (s *organizationUnitStore) GetOrganizationUnitGroupsList(ouID string, limit
 }
 
 // CheckOrganizationUnitNameConflict checks if an organization unit name conflicts under the same parent.
-func (s *organizationUnitStore) CheckOrganizationUnitNameConflict(name string, parentID *string) (bool, error) {
-	return s.checkConflict(
+func (s *organizationUnitStore) CheckOrganizationUnitNameConflict(
+	ctx context.Context, name string, parentID *string,
+) (bool, error) {
+	return s.checkConflict(ctx,
 		queryCheckOrganizationUnitNameConflict,
 		queryCheckOrganizationUnitNameConflictRoot,
 		name,
@@ -511,8 +528,10 @@ func (s *organizationUnitStore) CheckOrganizationUnitNameConflict(name string, p
 }
 
 // CheckOrganizationUnitHandleConflict checks if an organization unit handle conflicts under the same parent.
-func (s *organizationUnitStore) CheckOrganizationUnitHandleConflict(handle string, parentID *string) (bool, error) {
-	return s.checkConflict(
+func (s *organizationUnitStore) CheckOrganizationUnitHandleConflict(
+	ctx context.Context, handle string, parentID *string,
+) (bool, error) {
+	return s.checkConflict(ctx,
 		queryCheckOrganizationUnitHandleConflict,
 		queryCheckOrganizationUnitHandleConflictRoot,
 		handle,
@@ -522,13 +541,13 @@ func (s *organizationUnitStore) CheckOrganizationUnitHandleConflict(handle strin
 }
 
 // CheckOrganizationUnitHasChildResources checks if an organization unit has users groups or sub-ous.
-func (s *organizationUnitStore) CheckOrganizationUnitHasChildResources(ouID string) (bool, error) {
+func (s *organizationUnitStore) CheckOrganizationUnitHasChildResources(ctx context.Context, ouID string) (bool, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return false, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.Query(queryCheckOrganizationUnitHasUsersOrGroups, ouID, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryCheckOrganizationUnitHasUsersOrGroups, ouID, s.deploymentID)
 	if err != nil {
 		return false, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -657,7 +676,7 @@ func buildOrganizationUnitFromResultRow(
 }
 
 // checkConflict is a helper function to check for conflicts in organization unit attributes.
-func (s *organizationUnitStore) checkConflict(
+func (s *organizationUnitStore) checkConflict(ctx context.Context,
 	queryWithParent, queryWithoutParent dbmodel.DBQuery,
 	value string,
 	parentID *string,
@@ -672,10 +691,10 @@ func (s *organizationUnitStore) checkConflict(
 
 	if parentID != nil {
 		args := append([]interface{}{value, *parentID}, extraArgs...)
-		results, err = dbClient.Query(queryWithParent, args...)
+		results, err = dbClient.QueryContext(ctx, queryWithParent, args...)
 	} else {
 		args := append([]interface{}{value}, extraArgs...)
-		results, err = dbClient.Query(queryWithoutParent, args...)
+		results, err = dbClient.QueryContext(ctx, queryWithoutParent, args...)
 	}
 
 	if err != nil {

--- a/backend/internal/ou/store_test.go
+++ b/backend/internal/ou/store_test.go
@@ -19,6 +19,8 @@
 package ou
 
 import (
+	"context"
+
 	"errors"
 	"testing"
 
@@ -158,7 +160,8 @@ func (suite *OrganizationUnitStoreTestSuite) runConflictQueryScenario(
 				setup: func(parent *string) {
 					suite.expectDBClient()
 					suite.dbClientMock.
-						On("Query", withParentQueryID, value, *parent, testDeploymentID).
+						On(
+							"QueryContext", mock.Anything, withParentQueryID, value, *parent, testDeploymentID).
 						Return([]map[string]interface{}{{"count": withParentCount}}, nil).
 						Once()
 				},
@@ -169,7 +172,8 @@ func (suite *OrganizationUnitStoreTestSuite) runConflictQueryScenario(
 				setup: func(_ *string) {
 					suite.expectDBClient()
 					suite.dbClientMock.
-						On("Query", withoutParentQueryID, value, testDeploymentID).
+						On(
+							"QueryContext", mock.Anything, withoutParentQueryID, value, testDeploymentID).
 						Return([]map[string]interface{}{{"count": withoutParentCount}}, nil).
 						Once()
 				},
@@ -180,7 +184,8 @@ func (suite *OrganizationUnitStoreTestSuite) runConflictQueryScenario(
 				setup: func(_ *string) {
 					suite.expectDBClient()
 					suite.dbClientMock.
-						On("Query", withoutParentQueryID, value, testDeploymentID).
+						On(
+							"QueryContext", mock.Anything, withoutParentQueryID, value, testDeploymentID).
 						Return(nil, errors.New("query err")).
 						Once()
 				},
@@ -213,7 +218,8 @@ func (suite *OrganizationUnitStoreTestSuite) runCountQueryScenario(
 				setup: func() {
 					suite.expectDBClient()
 					suite.dbClientMock.
-						On("Query", queryID, arg, deploymentID).
+						On(
+							"QueryContext", mock.Anything, queryID, arg, deploymentID).
 						Return([]map[string]interface{}{{"total": int64(successCount)}}, nil).
 						Once()
 				},
@@ -224,7 +230,8 @@ func (suite *OrganizationUnitStoreTestSuite) runCountQueryScenario(
 				setup: func() {
 					suite.expectDBClient()
 					suite.dbClientMock.
-						On("Query", queryID, arg, deploymentID).
+						On(
+							"QueryContext", mock.Anything, queryID, arg, deploymentID).
 						Return([]map[string]interface{}{}, nil).
 						Once()
 				},
@@ -235,7 +242,8 @@ func (suite *OrganizationUnitStoreTestSuite) runCountQueryScenario(
 				setup: func() {
 					suite.expectDBClient()
 					suite.dbClientMock.
-						On("Query", queryID, arg, deploymentID).
+						On(
+							"QueryContext", mock.Anything, queryID, arg, deploymentID).
 						Return([]map[string]interface{}{{"total": "bad"}}, nil).
 						Once()
 				},
@@ -246,7 +254,8 @@ func (suite *OrganizationUnitStoreTestSuite) runCountQueryScenario(
 				setup: func() {
 					suite.expectDBClient()
 					suite.dbClientMock.
-						On("Query", queryID, arg, deploymentID).
+						On(
+							"QueryContext", mock.Anything, queryID, arg, deploymentID).
 						Return(nil, errors.New("query err")).
 						Once()
 				},
@@ -454,7 +463,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitHa
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitHasUsersOrGroups, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryCheckOrganizationUnitHasUsersOrGroups, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{{"count": int64(1)}}, nil).
 					Once()
 			},
@@ -465,7 +476,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitHa
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitHasUsersOrGroups, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryCheckOrganizationUnitHasUsersOrGroups, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{{"count": int64(0)}}, nil).
 					Once()
 			},
@@ -476,7 +489,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitHa
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitHasUsersOrGroups, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryCheckOrganizationUnitHasUsersOrGroups, "ou1", testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -500,7 +515,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitHa
 			suite.SetupTest()
 			tc.setup()
 
-			hasChildren, err := suite.store.CheckOrganizationUnitHasChildResources("ou1")
+			hasChildren, err := suite.store.CheckOrganizationUnitHasChildResources(context.Background(), "ou1")
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -522,7 +537,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitNa
 		1,
 		0,
 		func(parent *string) (bool, error) {
-			return suite.store.CheckOrganizationUnitNameConflict("Finance", parent)
+			return suite.store.CheckOrganizationUnitNameConflict(context.Background(), "Finance", parent)
 		},
 	)
 }
@@ -535,7 +550,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitHa
 		0,
 		2,
 		func(parent *string) (bool, error) {
-			return suite.store.CheckOrganizationUnitHandleConflict("finance", parent)
+			return suite.store.CheckOrganizationUnitHandleConflict(context.Background(), "finance", parent)
 		},
 	)
 }
@@ -552,7 +567,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{{"total": int64(2)}}, nil).
 					Once()
 			},
@@ -563,7 +579,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{}, nil).
 					Once()
 			},
@@ -574,7 +591,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{{"total": "bad"}}, nil).
 					Once()
 			},
@@ -585,7 +603,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitGroupsCount, "ou1", testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -609,7 +628,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			suite.SetupTest()
 			tc.setup()
 
-			count, err := suite.store.GetOrganizationUnitGroupsCount("ou1")
+			count, err := suite.store.GetOrganizationUnitGroupsCount(context.Background(), "ou1")
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -639,7 +658,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{
 						{"id": "grp1", "name": "Group 1"},
 						{"id": "grp2", "name": "Group 2"},
@@ -659,7 +680,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{
 						{"id": 123},
 					}, nil).
@@ -674,7 +697,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{
 						{"id": "grp1", "name": 5},
 					}, nil).
@@ -689,7 +714,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitGroupsList, "ou1", limit, offset, testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -715,7 +742,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitGrou
 			suite.SetupTest()
 			tc.setup(tc.limit, tc.offset)
 
-			groups, err := suite.store.GetOrganizationUnitGroupsList("ou1", tc.limit, tc.offset)
+			groups, err := suite.store.GetOrganizationUnitGroupsList(context.Background(), "ou1", tc.limit, tc.offset)
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -738,7 +765,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitUser
 		testDeploymentID,
 		4,
 		func() (int, error) {
-			return suite.store.GetOrganizationUnitUsersCount("ou1")
+			return suite.store.GetOrganizationUnitUsersCount(context.Background(), "ou1")
 		},
 	)
 }
@@ -759,7 +786,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitUser
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitUsersList, "ou1", limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitUsersList, "ou1", limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{
 						{"id": "user1"},
 						{"id": "user2"},
@@ -778,7 +807,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitUser
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitUsersList, "ou1", limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitUsersList, "ou1", limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{
 						{"id": 123},
 					}, nil).
@@ -793,7 +824,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitUser
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitUsersList, "ou1", limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitUsersList, "ou1", limit, offset, testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -819,7 +852,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitUser
 			suite.SetupTest()
 			tc.setup(tc.limit, tc.offset)
 
-			users, err := suite.store.GetOrganizationUnitUsersList("ou1", tc.limit, tc.offset)
+			users, err := suite.store.GetOrganizationUnitUsersList(context.Background(), "ou1", tc.limit, tc.offset)
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -842,7 +875,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 		testDeploymentID,
 		5,
 		func() (int, error) {
-			return suite.store.GetOrganizationUnitChildrenCount("root")
+			return suite.store.GetOrganizationUnitChildrenCount(context.Background(), "root")
 		},
 	)
 }
@@ -865,7 +898,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 			setup: func(parent string, limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{
 						makeOUResultRow("child1", "child1", "Child 1", "", &parent),
 						makeOUResultRow("child2", "child2", "Child 2", "desc", &parent),
@@ -885,7 +920,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 			setup: func(parent string, limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -899,7 +936,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 			setup: func(parent string, limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{{"ou_id": 1}}, nil).
 					Once()
 			},
@@ -926,7 +965,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 			suite.SetupTest()
 			tc.setup(tc.parent, tc.limit, tc.offset)
 
-			children, err := suite.store.GetOrganizationUnitChildrenList(tc.parent, tc.limit, tc.offset)
+			children, err := suite.store.GetOrganizationUnitChildrenList(
+				context.Background(), tc.parent, tc.limit, tc.offset,
+			)
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -965,7 +1006,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_UpdateOrganizationUnit(
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"Execute",
+						"ExecuteContext", mock.Anything,
 						queryUpdateOrganizationUnit,
 						ou.ID,
 						ou.Parent,
@@ -1000,7 +1041,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_UpdateOrganizationUnit(
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"Execute",
+						"ExecuteContext", mock.Anything,
 						queryUpdateOrganizationUnit,
 						ou.ID,
 						ou.Parent,
@@ -1024,7 +1065,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_UpdateOrganizationUnit(
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"Execute",
+						"ExecuteContext", mock.Anything,
 						queryUpdateOrganizationUnit,
 						ou.ID,
 						ou.Parent,
@@ -1060,7 +1101,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_UpdateOrganizationUnit(
 			suite.SetupTest()
 			tc.setup(tc.ou)
 
-			err := suite.store.UpdateOrganizationUnit(tc.ou)
+			err := suite.store.UpdateOrganizationUnit(context.Background(), tc.ou)
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -1084,7 +1125,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_DeleteOrganizationUnit(
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Execute", queryDeleteOrganizationUnit, "ou1", testDeploymentID).
+					On(
+						"ExecuteContext", mock.Anything, queryDeleteOrganizationUnit, "ou1", testDeploymentID).
 					Return(int64(1), nil).
 					Once()
 			},
@@ -1094,7 +1136,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_DeleteOrganizationUnit(
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Execute", queryDeleteOrganizationUnit, "ou1", testDeploymentID).
+					On(
+						"ExecuteContext", mock.Anything, queryDeleteOrganizationUnit, "ou1", testDeploymentID).
 					Return(int64(0), errors.New("delete failed")).
 					Once()
 			},
@@ -1118,7 +1161,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_DeleteOrganizationUnit(
 			suite.SetupTest()
 			tc.setup()
 
-			err := suite.store.DeleteOrganizationUnit("ou1")
+			err := suite.store.DeleteOrganizationUnit(context.Background(), "ou1")
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -1143,7 +1186,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitExist
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{{"count": int64(1)}}, nil).
 					Once()
 			},
@@ -1154,7 +1198,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitExist
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{}, nil).
 					Once()
 			},
@@ -1165,7 +1210,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitExist
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{{"count": int64(0)}}, nil).
 					Once()
 			},
@@ -1176,7 +1222,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitExist
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
 					Return([]map[string]interface{}{{"count": "bad"}}, nil).
 					Once()
 			},
@@ -1187,7 +1234,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitExist
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryCheckOrganizationUnitExists, "ou1", testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -1211,7 +1259,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitExist
 			suite.SetupTest()
 			tc.setup()
 
-			exists, err := suite.store.IsOrganizationUnitExists("ou1")
+			exists, err := suite.store.IsOrganizationUnitExists(context.Background(), "ou1")
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -1243,13 +1291,16 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 				childID := "child-id"
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
 					Return([]map[string]interface{}{
 						makeOUResultRow(rootID, "root", "Root", "desc", nil),
 					}, nil).
 					Once()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitByHandle, "child", rootID, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitByHandle, "child", rootID, testDeploymentID).
 					Return([]map[string]interface{}{
 						makeOUResultRow(childID, "child", "Child", "", &rootID),
 					}, nil).
@@ -1286,7 +1337,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 			setup: func(_ []string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
 					Return(nil, errors.New("query")).
 					Once()
 			},
@@ -1298,7 +1350,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 			setup: func(_ []string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
 					Return([]map[string]interface{}{}, nil).
 					Once()
 			},
@@ -1310,7 +1363,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 			setup: func(_ []string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
 					Return([]map[string]interface{}{{"ou_id": 1}}, nil).
 					Once()
 			},
@@ -1323,11 +1377,14 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 				rootID := "root"
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle, "root", testDeploymentID).
 					Return([]map[string]interface{}{makeOUResultRow(rootID, "root", "Root", "", nil)}, nil).
 					Once()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitByHandle, "child", rootID, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetOrganizationUnitByHandle, "child", rootID, testDeploymentID).
 					Return(nil, errors.New("child query failed")).
 					Once()
 			},
@@ -1343,7 +1400,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByPa
 				tc.setup(tc.path)
 			}
 
-			ou, err := suite.store.GetOrganizationUnitByPath(tc.path)
+			ou, err := suite.store.GetOrganizationUnitByPath(context.Background(), tc.path)
 
 			switch {
 			case tc.wantErr != nil:
@@ -1382,7 +1439,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnit() {
 				row := makeOUResultRow(id, "root", "Root", "desc", &parentID)
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitByID, id, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitByID, id, testDeploymentID).
 					Return([]map[string]interface{}{row}, nil).
 					Once()
 			},
@@ -1398,7 +1456,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnit() {
 			setup: func(id string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitByID, id, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitByID, id, testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -1410,7 +1469,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnit() {
 			setup: func(id string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitByID, id, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitByID, id, testDeploymentID).
 					Return([]map[string]interface{}{}, nil).
 					Once()
 			},
@@ -1422,7 +1482,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnit() {
 			setup: func(id string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetOrganizationUnitByID, id, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetOrganizationUnitByID, id, testDeploymentID).
 					Return([]map[string]interface{}{{"ou_id": 2}}, nil).
 					Once()
 			},
@@ -1447,7 +1508,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnit() {
 			suite.SetupTest()
 			tc.setup(tc.id)
 
-			ou, err := suite.store.GetOrganizationUnit(tc.id)
+			ou, err := suite.store.GetOrganizationUnit(context.Background(), tc.id)
 
 			switch {
 			case tc.wantErr != nil:
@@ -1484,7 +1545,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CreateOrganizationUnit(
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"Execute",
+						"ExecuteContext", mock.Anything,
 						queryCreateOrganizationUnit,
 						ou.ID,
 						ou.Parent,
@@ -1515,7 +1576,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CreateOrganizationUnit(
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"Execute",
+						"ExecuteContext", mock.Anything,
 						queryCreateOrganizationUnit,
 						ou.ID,
 						ou.Parent,
@@ -1544,7 +1605,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CreateOrganizationUnit(
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"Execute",
+						"ExecuteContext", mock.Anything,
 						queryCreateOrganizationUnit,
 						ou.ID,
 						ou.Parent,
@@ -1582,7 +1643,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CreateOrganizationUnit(
 				tc.setup(tc.ou)
 			}
 
-			err := suite.store.CreateOrganizationUnit(tc.ou)
+			err := suite.store.CreateOrganizationUnit(context.Background(), tc.ou)
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -1615,7 +1676,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 					makeOUResultRow("child", "child", "Child", "", nil),
 				}
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
 					Return(rows, nil).
 					Once()
 			},
@@ -1632,7 +1695,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
 					Return(nil, errors.New("query error")).
 					Once()
 			},
@@ -1645,7 +1710,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything,
+						queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{{"ou_id": 123}}, nil).
 					Once()
 			},
@@ -1671,7 +1738,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			suite.SetupTest()
 			tc.setup(tc.limit, tc.offset)
 
-			ous, err := suite.store.GetOrganizationUnitList(tc.limit, tc.offset)
+			ous, err := suite.store.GetOrganizationUnitList(context.Background(), tc.limit, tc.offset)
 
 			if tc.wantErrString != "" {
 				suite.Require().Error(err)
@@ -1700,7 +1767,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitListCount, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitListCount, testDeploymentID).
 					Return([]map[string]interface{}{{"total": int64(3)}}, nil).
 					Once()
 			},
@@ -1711,7 +1779,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitListCount, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitListCount, testDeploymentID).
 					Return(nil, errors.New("boom")).
 					Once()
 			},
@@ -1722,7 +1791,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			setup: func() {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", queryGetRootOrganizationUnitListCount, testDeploymentID).
+					On(
+						"QueryContext", mock.Anything, queryGetRootOrganizationUnitListCount, testDeploymentID).
 					Return([]map[string]interface{}{{"total": "3"}}, nil).
 					Once()
 			},
@@ -1746,7 +1816,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			suite.SetupTest()
 			tc.setup()
 
-			count, err := suite.store.GetOrganizationUnitListCount()
+			count, err := suite.store.GetOrganizationUnitListCount(context.Background())
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -1779,7 +1849,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitsByI
 					makeOUResultRow("ou2", "root2", "Root2", "desc2", nil),
 				}
 				suite.dbClientMock.
-					On("Query", mock.AnythingOfType("model.DBQuery"), mock.Anything, mock.Anything, mock.Anything).
+					On(
+						"QueryContext", mock.Anything,
+						mock.AnythingOfType("model.DBQuery"), mock.Anything, mock.Anything, mock.Anything).
 					Return(rows, nil).
 					Once()
 			},
@@ -1802,7 +1874,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitsByI
 			setup: func(ids []string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", mock.AnythingOfType("model.DBQuery"), mock.Anything, mock.Anything).
+					On(
+						"QueryContext", mock.Anything,
+						mock.AnythingOfType("model.DBQuery"), mock.Anything, mock.Anything).
 					Return(nil, errors.New("query error")).
 					Once()
 			},
@@ -1814,7 +1888,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitsByI
 			setup: func(ids []string) {
 				suite.expectDBClient()
 				suite.dbClientMock.
-					On("Query", mock.AnythingOfType("model.DBQuery"), mock.Anything, mock.Anything).
+					On(
+						"QueryContext", mock.Anything,
+						mock.AnythingOfType("model.DBQuery"), mock.Anything, mock.Anything).
 					Return([]map[string]interface{}{{"ou_id": 123}}, nil).
 					Once()
 			},
@@ -1841,7 +1917,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitsByI
 				tc.setup(tc.ids)
 			}
 
-			ous, err := suite.store.GetOrganizationUnitsByIDs(tc.ids)
+			ous, err := suite.store.GetOrganizationUnitsByIDs(context.Background(), tc.ids)
 
 			if tc.wantErrString != "" {
 				suite.Require().Error(err)
@@ -1861,7 +1937,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitsByI
 func (suite *OrganizationUnitStoreTestSuite) TestOUStore_IsOrganizationUnitDeclarative() {
 	suite.Run("returns false", func() {
 		suite.SetupTest()
-		res := suite.store.IsOrganizationUnitDeclarative("ou1")
+		res := suite.store.IsOrganizationUnitDeclarative(context.Background(), "ou1")
 		suite.Require().False(res)
 	})
 }

--- a/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
+++ b/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
@@ -930,16 +930,16 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitUsersByPath_Ca
 }
 
 // IsOrganizationUnitDeclarative provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
+func (_mock *OrganizationUnitServiceInterfaceMock) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsOrganizationUnitDeclarative")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -952,19 +952,25 @@ type OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call str
 }
 
 // IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) IsOrganizationUnitDeclarative(ctx interface{}, id interface{}) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", ctx, id)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(ctx context.Context, id string)) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -975,7 +981,7 @@ func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Cal
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *OrganizationUnitServiceInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
+++ b/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package oumock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/ou"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,8 +39,8 @@ func (_m *organizationUnitStoreInterfaceMock) EXPECT() *organizationUnitStoreInt
 }
 
 // CheckOrganizationUnitHandleConflict provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHandleConflict(handle string, parent *string) (bool, error) {
-	ret := _mock.Called(handle, parent)
+func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHandleConflict(ctx context.Context, handle string, parent *string) (bool, error) {
+	ret := _mock.Called(ctx, handle, parent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckOrganizationUnitHandleConflict")
@@ -46,16 +48,16 @@ func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHandleConf
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *string) (bool, error)); ok {
-		return returnFunc(handle, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (bool, error)); ok {
+		return returnFunc(ctx, handle, parent)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *string) bool); ok {
-		r0 = returnFunc(handle, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) bool); ok {
+		r0 = returnFunc(ctx, handle, parent)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *string) error); ok {
-		r1 = returnFunc(handle, parent)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) error); ok {
+		r1 = returnFunc(ctx, handle, parent)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -68,25 +70,31 @@ type organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call
 }
 
 // CheckOrganizationUnitHandleConflict is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handle string
 //   - parent *string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHandleConflict(handle interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
-	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call{Call: _e.mock.On("CheckOrganizationUnitHandleConflict", handle, parent)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHandleConflict(ctx interface{}, handle interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
+	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call{Call: _e.mock.On("CheckOrganizationUnitHandleConflict", ctx, handle, parent)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) Run(run func(handle string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) Run(run func(ctx context.Context, handle string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 *string
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*string)
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -97,14 +105,14 @@ func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) RunAndReturn(run func(handle string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call) RunAndReturn(run func(ctx context.Context, handle string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHandleConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CheckOrganizationUnitHasChildResources provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHasChildResources(id string) (bool, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHasChildResources(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckOrganizationUnitHasChildResources")
@@ -112,16 +120,16 @@ func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitHasChildRe
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -134,19 +142,25 @@ type organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_C
 }
 
 // CheckOrganizationUnitHasChildResources is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHasChildResources(id interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
-	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call{Call: _e.mock.On("CheckOrganizationUnitHasChildResources", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitHasChildResources(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
+	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call{Call: _e.mock.On("CheckOrganizationUnitHasChildResources", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -157,14 +171,14 @@ func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResour
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) RunAndReturn(run func(id string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitHasChildResources_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CheckOrganizationUnitNameConflict provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitNameConflict(name string, parent *string) (bool, error) {
-	ret := _mock.Called(name, parent)
+func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitNameConflict(ctx context.Context, name string, parent *string) (bool, error) {
+	ret := _mock.Called(ctx, name, parent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckOrganizationUnitNameConflict")
@@ -172,16 +186,16 @@ func (_mock *organizationUnitStoreInterfaceMock) CheckOrganizationUnitNameConfli
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *string) (bool, error)); ok {
-		return returnFunc(name, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (bool, error)); ok {
+		return returnFunc(ctx, name, parent)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *string) bool); ok {
-		r0 = returnFunc(name, parent)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) bool); ok {
+		r0 = returnFunc(ctx, name, parent)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *string) error); ok {
-		r1 = returnFunc(name, parent)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) error); ok {
+		r1 = returnFunc(ctx, name, parent)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -194,25 +208,31 @@ type organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call s
 }
 
 // CheckOrganizationUnitNameConflict is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
 //   - parent *string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitNameConflict(name interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
-	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call{Call: _e.mock.On("CheckOrganizationUnitNameConflict", name, parent)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CheckOrganizationUnitNameConflict(ctx interface{}, name interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
+	return &organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call{Call: _e.mock.On("CheckOrganizationUnitNameConflict", ctx, name, parent)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) Run(run func(name string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) Run(run func(ctx context.Context, name string, parent *string)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 *string
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*string)
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -223,22 +243,22 @@ func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_C
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) RunAndReturn(run func(name string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
+func (_c *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call) RunAndReturn(run func(ctx context.Context, name string, parent *string) (bool, error)) *organizationUnitStoreInterfaceMock_CheckOrganizationUnitNameConflict_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) CreateOrganizationUnit(ou1 ou.OrganizationUnit) error {
-	ret := _mock.Called(ou1)
+func (_mock *organizationUnitStoreInterfaceMock) CreateOrganizationUnit(ctx context.Context, ou1 ou.OrganizationUnit) error {
+	ret := _mock.Called(ctx, ou1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateOrganizationUnit")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(ou.OrganizationUnit) error); ok {
-		r0 = returnFunc(ou1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ou.OrganizationUnit) error); ok {
+		r0 = returnFunc(ctx, ou1)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -251,19 +271,25 @@ type organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call struct {
 }
 
 // CreateOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - ou1 ou.OrganizationUnit
-func (_e *organizationUnitStoreInterfaceMock_Expecter) CreateOrganizationUnit(ou1 interface{}) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call{Call: _e.mock.On("CreateOrganizationUnit", ou1)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) CreateOrganizationUnit(ctx interface{}, ou1 interface{}) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call{Call: _e.mock.On("CreateOrganizationUnit", ctx, ou1)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) Run(run func(ou1 ou.OrganizationUnit)) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) Run(run func(ctx context.Context, ou1 ou.OrganizationUnit)) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 ou.OrganizationUnit
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(ou.OrganizationUnit)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 ou.OrganizationUnit
+		if args[1] != nil {
+			arg1 = args[1].(ou.OrganizationUnit)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -274,22 +300,22 @@ func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) Return
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) RunAndReturn(run func(ou1 ou.OrganizationUnit) error) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, ou1 ou.OrganizationUnit) error) *organizationUnitStoreInterfaceMock_CreateOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) DeleteOrganizationUnit(id string) error {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) DeleteOrganizationUnit(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteOrganizationUnit")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -302,19 +328,25 @@ type organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call struct {
 }
 
 // DeleteOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) DeleteOrganizationUnit(id interface{}) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call{Call: _e.mock.On("DeleteOrganizationUnit", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) DeleteOrganizationUnit(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call{Call: _e.mock.On("DeleteOrganizationUnit", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -325,14 +357,14 @@ func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) Return
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) RunAndReturn(run func(id string) error) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, id string) error) *organizationUnitStoreInterfaceMock_DeleteOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnit(id string) (ou.OrganizationUnit, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnit(ctx context.Context, id string) (ou.OrganizationUnit, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnit")
@@ -340,16 +372,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnit(id string) 
 
 	var r0 ou.OrganizationUnit
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (ou.OrganizationUnit, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (ou.OrganizationUnit, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) ou.OrganizationUnit); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ou.OrganizationUnit); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(ou.OrganizationUnit)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -362,19 +394,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call struct {
 }
 
 // GetOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnit(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call{Call: _e.mock.On("GetOrganizationUnit", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnit(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call{Call: _e.mock.On("GetOrganizationUnit", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -385,14 +423,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) Return(or
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) RunAndReturn(run func(id string) (ou.OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, id string) (ou.OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitByPath provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(handles []string) (ou.OrganizationUnit, error) {
-	ret := _mock.Called(handles)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(ctx context.Context, handles []string) (ou.OrganizationUnit, error) {
+	ret := _mock.Called(ctx, handles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitByPath")
@@ -400,16 +438,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(handl
 
 	var r0 ou.OrganizationUnit
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) (ou.OrganizationUnit, error)); ok {
-		return returnFunc(handles)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (ou.OrganizationUnit, error)); ok {
+		return returnFunc(ctx, handles)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]string) ou.OrganizationUnit); ok {
-		r0 = returnFunc(handles)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ou.OrganizationUnit); ok {
+		r0 = returnFunc(ctx, handles)
 	} else {
 		r0 = ret.Get(0).(ou.OrganizationUnit)
 	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(handles)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, handles)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -422,19 +460,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call struct {
 }
 
 // GetOrganizationUnitByPath is a helper method to define mock.On call
+//   - ctx context.Context
 //   - handles []string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitByPath(handles interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call{Call: _e.mock.On("GetOrganizationUnitByPath", handles)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitByPath(ctx interface{}, handles interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call{Call: _e.mock.On("GetOrganizationUnitByPath", ctx, handles)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Run(run func(handles []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Run(run func(ctx context.Context, handles []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -445,14 +489,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Ret
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) RunAndReturn(run func(handles []string) (ou.OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) RunAndReturn(run func(ctx context.Context, handles []string) (ou.OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(id string) (int, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenCount")
@@ -460,16 +504,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCoun
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -482,19 +526,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call st
 }
 
 // GetOrganizationUnitChildrenCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -505,14 +555,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Ca
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(id string, limit int, offset int) ([]ou.OrganizationUnitBasic, error) {
-	ret := _mock.Called(id, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(ctx context.Context, id string, limit int, offset int) ([]ou.OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, id, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenList")
@@ -520,18 +570,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList
 
 	var r0 []ou.OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]ou.OrganizationUnitBasic, error)); ok {
-		return returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]ou.OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, id, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []ou.OrganizationUnitBasic); ok {
-		r0 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []ou.OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, id, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ou.OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -544,31 +594,37 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call str
 }
 
 // GetOrganizationUnitChildrenList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", id, limit, offset)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", ctx, id, limit, offset)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -579,14 +635,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Cal
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(id string, limit int, offset int) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitGroupsCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsCount(id string) (int, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsCount(ctx context.Context, id string) (int, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitGroupsCount")
@@ -594,16 +650,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsCount(
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -616,19 +672,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call stru
 }
 
 // GetOrganizationUnitGroupsCount is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsCount(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call{Call: _e.mock.On("GetOrganizationUnitGroupsCount", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call{Call: _e.mock.On("GetOrganizationUnitGroupsCount", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -639,14 +701,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) RunAndReturn(run func(id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitGroupsList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsList(id string, limit int, offset int) ([]ou.Group, error) {
-	ret := _mock.Called(id, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsList(ctx context.Context, id string, limit int, offset int) ([]ou.Group, error) {
+	ret := _mock.Called(ctx, id, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitGroupsList")
@@ -654,18 +716,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitGroupsList(i
 
 	var r0 []ou.Group
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]ou.Group, error)); ok {
-		return returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]ou.Group, error)); ok {
+		return returnFunc(ctx, id, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []ou.Group); ok {
-		r0 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []ou.Group); ok {
+		r0 = returnFunc(ctx, id, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ou.Group)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -678,31 +740,37 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call struc
 }
 
 // GetOrganizationUnitGroupsList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsList(id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call{Call: _e.mock.On("GetOrganizationUnitGroupsList", id, limit, offset)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitGroupsList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call{Call: _e.mock.On("GetOrganizationUnitGroupsList", ctx, id, limit, offset)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) Run(run func(id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
 		var arg2 int
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -713,14 +781,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call)
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) RunAndReturn(run func(id string, limit int, offset int) ([]ou.Group, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]ou.Group, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitGroupsList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(limit int, offset int) ([]ou.OrganizationUnitBasic, error) {
-	ret := _mock.Called(limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) ([]ou.OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -728,18 +796,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(limit i
 
 	var r0 []ou.OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]ou.OrganizationUnitBasic, error)); ok {
-		return returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]ou.OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []ou.OrganizationUnitBasic); ok {
-		r0 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []ou.OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ou.OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -752,199 +820,18 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call struct {
 }
 
 // GetOrganizationUnitList is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", limit, offset)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Return(organizationUnitBasics []ou.OrganizationUnitBasic, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	_c.Call.Return(organizationUnitBasics, err)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(limit int, offset int) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOrganizationUnitListCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOrganizationUnitListCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitListCount'
-type organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call struct {
-	*mock.Call
-}
-
-// GetOrganizationUnitListCount is a helper method to define mock.On call
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount() *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount")}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func()) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func() (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOrganizationUnitUsersCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersCount(id string) (int, error) {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOrganizationUnitUsersCount")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
-		return returnFunc(id)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersCount'
-type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call struct {
-	*mock.Call
-}
-
-// GetOrganizationUnitUsersCount is a helper method to define mock.On call
-//   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersCount(id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call{Call: _e.mock.On("GetOrganizationUnitUsersCount", id)}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) RunAndReturn(run func(id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOrganizationUnitUsersList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersList(id string, limit int, offset int) ([]ou.User, error) {
-	ret := _mock.Called(id, limit, offset)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOrganizationUnitUsersList")
-	}
-
-	var r0 []ou.User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]ou.User, error)); ok {
-		return returnFunc(id, limit, offset)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, int) []ou.User); ok {
-		r0 = returnFunc(id, limit, offset)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]ou.User)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, int) error); ok {
-		r1 = returnFunc(id, limit, offset)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersList'
-type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call struct {
-	*mock.Call
-}
-
-// GetOrganizationUnitUsersList is a helper method to define mock.On call
-//   - id string
-//   - limit int
-//   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersList(id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call{Call: _e.mock.On("GetOrganizationUnitUsersList", id, limit, offset)}
-}
-
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) Run(run func(id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
@@ -963,19 +850,225 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) 
 	return _c
 }
 
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Return(organizationUnitBasics []ou.OrganizationUnitBasic, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	_c.Call.Return(organizationUnitBasics, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOrganizationUnitListCount provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitListCount'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount(ctx interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount", ctx)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func(ctx context.Context)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOrganizationUnitUsersCount provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersCount(ctx context.Context, id string) (int, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitUsersCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersCount'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitUsersCount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call{Call: _e.mock.On("GetOrganizationUnitUsersCount", ctx, id)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) Return(n int, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOrganizationUnitUsersList provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitUsersList(ctx context.Context, id string, limit int, offset int) ([]ou.User, error) {
+	ret := _mock.Called(ctx, id, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitUsersList")
+	}
+
+	var r0 []ou.User
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]ou.User, error)); ok {
+		return returnFunc(ctx, id, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []ou.User); ok {
+		r0 = returnFunc(ctx, id, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ou.User)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitUsersList'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitUsersList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - limit int
+//   - offset int
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitUsersList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call{Call: _e.mock.On("GetOrganizationUnitUsersList", ctx, id, limit, offset)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
 func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) Return(users []ou.User, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
 	_c.Call.Return(users, err)
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) RunAndReturn(run func(id string, limit int, offset int) ([]ou.User, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]ou.User, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitUsersList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitsByIDs provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitsByIDs(ids []string) ([]ou.OrganizationUnitBasic, error) {
-	ret := _mock.Called(ids)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitsByIDs(ctx context.Context, ids []string) ([]ou.OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, ids)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitsByIDs")
@@ -983,18 +1076,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitsByIDs(ids [
 
 	var r0 []ou.OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]ou.OrganizationUnitBasic, error)); ok {
-		return returnFunc(ids)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]ou.OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, ids)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []ou.OrganizationUnitBasic); ok {
-		r0 = returnFunc(ids)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []ou.OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, ids)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ou.OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, ids)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1007,19 +1100,25 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call struct {
 }
 
 // GetOrganizationUnitsByIDs is a helper method to define mock.On call
+//   - ctx context.Context
 //   - ids []string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitsByIDs(ids interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call{Call: _e.mock.On("GetOrganizationUnitsByIDs", ids)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitsByIDs(ctx interface{}, ids interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call{Call: _e.mock.On("GetOrganizationUnitsByIDs", ctx, ids)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) Run(run func(ids []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) Run(run func(ctx context.Context, ids []string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1030,22 +1129,22 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) Ret
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) RunAndReturn(run func(ids []string) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call) RunAndReturn(run func(ctx context.Context, ids []string) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitsByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsOrganizationUnitDeclarative provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(id string) bool {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsOrganizationUnitDeclarative")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -1058,19 +1157,25 @@ type organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call struc
 }
 
 // IsOrganizationUnitDeclarative is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
-	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitDeclarative(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call{Call: _e.mock.On("IsOrganizationUnitDeclarative", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1081,14 +1186,14 @@ func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call)
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call) RunAndReturn(run func(ctx context.Context, id string) bool) *organizationUnitStoreInterfaceMock_IsOrganizationUnitDeclarative_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsOrganizationUnitExists provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(id string) (bool, error) {
-	ret := _mock.Called(id)
+func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(ctx context.Context, id string) (bool, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsOrganizationUnitExists")
@@ -1096,16 +1201,16 @@ func (_mock *organizationUnitStoreInterfaceMock) IsOrganizationUnitExists(id str
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1118,19 +1223,25 @@ type organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call struct {
 }
 
 // IsOrganizationUnitExists is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitExists(id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
-	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call{Call: _e.mock.On("IsOrganizationUnitExists", id)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) IsOrganizationUnitExists(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
+	return &organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call{Call: _e.mock.On("IsOrganizationUnitExists", ctx, id)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Run(run func(id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1141,22 +1252,22 @@ func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) Retu
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(id string) (bool, error)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
+func (_c *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call) RunAndReturn(run func(ctx context.Context, id string) (bool, error)) *organizationUnitStoreInterfaceMock_IsOrganizationUnitExists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateOrganizationUnit provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) UpdateOrganizationUnit(ou1 ou.OrganizationUnit) error {
-	ret := _mock.Called(ou1)
+func (_mock *organizationUnitStoreInterfaceMock) UpdateOrganizationUnit(ctx context.Context, ou1 ou.OrganizationUnit) error {
+	ret := _mock.Called(ctx, ou1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateOrganizationUnit")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(ou.OrganizationUnit) error); ok {
-		r0 = returnFunc(ou1)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ou.OrganizationUnit) error); ok {
+		r0 = returnFunc(ctx, ou1)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1169,19 +1280,25 @@ type organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call struct {
 }
 
 // UpdateOrganizationUnit is a helper method to define mock.On call
+//   - ctx context.Context
 //   - ou1 ou.OrganizationUnit
-func (_e *organizationUnitStoreInterfaceMock_Expecter) UpdateOrganizationUnit(ou1 interface{}) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
-	return &organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call{Call: _e.mock.On("UpdateOrganizationUnit", ou1)}
+func (_e *organizationUnitStoreInterfaceMock_Expecter) UpdateOrganizationUnit(ctx interface{}, ou1 interface{}) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
+	return &organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call{Call: _e.mock.On("UpdateOrganizationUnit", ctx, ou1)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) Run(run func(ou1 ou.OrganizationUnit)) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) Run(run func(ctx context.Context, ou1 ou.OrganizationUnit)) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 ou.OrganizationUnit
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(ou.OrganizationUnit)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 ou.OrganizationUnit
+		if args[1] != nil {
+			arg1 = args[1].(ou.OrganizationUnit)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1192,7 +1309,7 @@ func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) Return
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) RunAndReturn(run func(ou1 ou.OrganizationUnit) error) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
+func (_c *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call) RunAndReturn(run func(ctx context.Context, ou1 ou.OrganizationUnit) error) *organizationUnitStoreInterfaceMock_UpdateOrganizationUnit_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
As we have introduced the transection architecture, we are adapting our services to use transections. In this PR we have updated the OU service to use transactions.


Sub Issue : https://github.com/asgardeo/thunder/issues/1428
Parent issue : https://github.com/asgardeo/thunder/issues/282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Organization unit APIs and stores are now context-aware, propagating cancellation/timeouts across list, retrieve, create, update, delete, and helper flows.

* **New Features**
  * Transactional support added to organization unit service for safer create/update/delete operations.

* **Tests**
  * Test suite and mocks updated to the new context-aware signatures and revised mock types.

* **Bug Fix**
  * Composite listing/deduplication behavior preserved with existing limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->