### PR TITLE
Add core email sending capability with system config and SMTP client

### DIFF
--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -351,6 +351,22 @@ type RestSecurityConfig struct {
 	APIKey string `yaml:"api_key" json:"api_key"`
 }
 
+// EmailConfig holds the email configuration details.
+type EmailConfig struct {
+	SMTP SMTPEmailConfig `yaml:"smtp" json:"smtp"`
+}
+
+// SMTPEmailConfig holds the SMTP email configuration details.
+type SMTPEmailConfig struct {
+	Host                 string `yaml:"host" json:"host"`
+	Port                 int    `yaml:"port" json:"port"`
+	Username             string `yaml:"username" json:"username"`
+	Password             string `yaml:"password" json:"password"`
+	FromAddress          string `yaml:"from_address" json:"from_address"`
+	EnableStartTLS       *bool  `yaml:"enable_start_tls" json:"enable_start_tls"`
+	EnableAuthentication *bool  `yaml:"enable_authentication" json:"enable_authentication"`
+}
+
 // ConsentConfig holds the configuration for the consent service integration.
 type ConsentConfig struct {
 	Enabled    bool   `yaml:"enabled" json:"enabled"`
@@ -385,6 +401,7 @@ type Config struct {
 	Role                 RoleConfig             `yaml:"role" json:"role"`
 	Theme                ThemeConfig            `yaml:"theme" json:"theme"`
 	Layout               LayoutConfig           `yaml:"layout" json:"layout"`
+	Email                EmailConfig            `yaml:"email" json:"email"`
 	Consent              ConsentConfig          `yaml:"consent" json:"consent"`
 }
 

--- a/backend/internal/system/email/client.go
+++ b/backend/internal/system/email/client.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package email provides a reusable email sending capability for the Thunder platform.
+// It defines a common interface and implementations for sending emails via various transports.
+package email
+
+// EmailClientInterface defines the interface for sending emails.
+type EmailClientInterface interface {
+	// Send sends an email using the provided EmailData.
+	Send(emailData EmailData) error
+}

--- a/backend/internal/system/email/error_constants.go
+++ b/backend/internal/system/email/error_constants.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package email
+
+import "errors"
+
+// Client errors for email service
+var (
+	// ErrorInvalidRecipient is returned when the email has no valid recipients.
+	ErrorInvalidRecipient = errors.New("invalid recipient: the email must have at least one valid recipient address")
+	// ErrorInvalidSender is returned when the sender (From) address is empty.
+	ErrorInvalidSender = errors.New("invalid sender: the sender email address is invalid or empty")
+	// ErrorInvalidSubject is returned when the email subject contains invalid characters.
+	ErrorInvalidSubject = errors.New("invalid subject: the email subject contains invalid characters")
+	// ErrorInvalidHost is returned when the SMTP host is empty.
+	ErrorInvalidHost = errors.New("invalid host: the SMTP host cannot be empty")
+	// ErrorInvalidPort is returned when the SMTP port is zero or negative.
+	ErrorInvalidPort = errors.New("invalid port: the SMTP port must be greater than zero")
+	// ErrorInvalidCredentials is returned when the SMTP username or password is empty but authentication is enabled.
+	ErrorInvalidCredentials = errors.New("invalid credentials: username and password cannot be empty " +
+		"when authentication is enabled")
+)
+
+// Server errors for email service
+var (
+	// ErrorSMTPConnection is returned when the SMTP connection cannot be established.
+	ErrorSMTPConnection = errors.New("smtp connection failed")
+	// ErrorSMTPAuth is returned when SMTP authentication fails.
+	ErrorSMTPAuth = errors.New("smtp authentication failed")
+	// ErrorEmailSendFailed is returned when the email fails to send.
+	ErrorEmailSendFailed = errors.New("email sending failed")
+)

--- a/backend/internal/system/email/model.go
+++ b/backend/internal/system/email/model.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package email
+
+// EmailData represents the data structure for an email message.
+type EmailData struct {
+	To      []string `json:"to"`      // recipient email addresses
+	CC      []string `json:"cc"`      // CC email addresses (optional)
+	BCC     []string `json:"bcc"`     // BCC email addresses (optional)
+	Subject string   `json:"subject"` // email subject
+	Body    string   `json:"body"`    // email body content
+	IsHTML  bool     `json:"is_html"` // true for HTML content, false for plain text
+}
+
+type smtpConfig struct {
+	host                 string
+	port                 int
+	username             string
+	password             string
+	from                 string
+	useTLS               bool
+	enableAuthentication bool
+}
+
+type smtpClient struct {
+	config smtpConfig
+}

--- a/backend/internal/system/email/smtp_client.go
+++ b/backend/internal/system/email/smtp_client.go
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package email
+
+import (
+	"crypto/tls"
+	"fmt"
+	"mime"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"strings"
+	"time"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/log"
+)
+
+const (
+	smtpLoggerComponentName = "SMTPEmailClient"
+	smtpDialTimeout         = 30 * time.Second
+)
+
+// The newSMTPClient creates a new instance of smtpClient.
+// It validates the configuration at creation time to avoid runtime errors.
+func newSMTPClient(config smtpConfig) (EmailClientInterface, error) {
+	if config.from == "" {
+		return nil, ErrorInvalidSender
+	}
+	if _, error := mail.ParseAddress(config.from); error != nil {
+		return nil, ErrorInvalidSender
+	}
+	if strings.TrimSpace(config.host) == "" {
+		return nil, ErrorInvalidHost
+	}
+	if config.port <= 0 {
+		return nil, ErrorInvalidPort
+	}
+	if config.enableAuthentication {
+		if strings.TrimSpace(config.username) == "" || strings.TrimSpace(config.password) == "" {
+			return nil, ErrorInvalidCredentials
+		}
+	}
+	return &smtpClient{
+		config: config,
+	}, nil
+}
+
+// NewSMTPClientFromConfig creates a new smtpClient using the global Thunder configuration.
+// It reads the email.smtp section from the Thunder runtime config.
+// Returns an error if the configuration is invalid (e.g., missing sender address)
+// or if the runtime is not initialized.
+func NewSMTPClientFromConfig() (EmailClientInterface, error) {
+	emailConfig := config.GetThunderRuntime().Config.Email.SMTP
+
+	enableStartTLS := true
+	if emailConfig.EnableStartTLS != nil {
+		enableStartTLS = *emailConfig.EnableStartTLS
+	}
+
+	enableAuth := true
+	if emailConfig.EnableAuthentication != nil {
+		enableAuth = *emailConfig.EnableAuthentication
+	}
+
+	return newSMTPClient(smtpConfig{
+		host:                 emailConfig.Host,
+		port:                 emailConfig.Port,
+		username:             emailConfig.Username,
+		password:             emailConfig.Password,
+		from:                 emailConfig.FromAddress,
+		useTLS:               enableStartTLS,
+		enableAuthentication: enableAuth,
+	})
+}
+
+func (c *smtpClient) Send(emailData EmailData) error {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, smtpLoggerComponentName))
+
+	// 1. Validate, sanitize in place, and extract the flat envelope list
+	allRecipients, error := c.validateAndProcessRecipients(&emailData)
+	if error != nil {
+		return error
+	}
+
+	logger.Debug("Sending email via SMTP",
+		log.String("from", log.MaskString(c.config.from)),
+		log.Int("recipientCount", len(emailData.To)))
+
+	serverAddress := fmt.Sprintf("%s:%d", c.config.host, c.config.port)
+
+	// 2. Build the message headers (now using the trimmed emailData.To and emailData.CC arrays)
+	message := c.buildMessage(emailData)
+
+	// 3. Send via SMTP
+	if error := c.sendViaSMTP(serverAddress, allRecipients, message); error != nil {
+		return error
+	}
+
+	logger.Debug("Email sent successfully")
+	return nil
+}
+
+func (c *smtpClient) validateAndProcessRecipients(emailData *EmailData) ([]string, error) {
+	var allRecipients []string
+	hasRecipient := false
+
+	// Inline helper to validate and clean a specific group of addresses
+	processGroup := func(addresses []string) ([]string, error) {
+		var cleaned []string
+		for _, address := range addresses {
+			trimmed := strings.TrimSpace(address)
+			if trimmed == "" {
+				return nil, fmt.Errorf("%w: recipient address cannot be empty", ErrorInvalidRecipient)
+			}
+			if _, error := mail.ParseAddress(trimmed); error != nil {
+				return nil, fmt.Errorf("%w: invalid recipient address '%s': %w", ErrorInvalidRecipient, trimmed, error)
+			}
+			cleaned = append(cleaned, trimmed)
+			allRecipients = append(allRecipients, trimmed)
+			hasRecipient = true
+		}
+		return cleaned, nil
+	}
+
+	var error error
+	if emailData.To, error = processGroup(emailData.To); error != nil {
+		return nil, error
+	}
+	if emailData.CC, error = processGroup(emailData.CC); error != nil {
+		return nil, error
+	}
+	if emailData.BCC, error = processGroup(emailData.BCC); error != nil {
+		return nil, error
+	}
+
+	if !hasRecipient {
+		return nil, ErrorInvalidRecipient
+	}
+
+	// Reject CR/LF in Subject to prevent header injection.
+	if strings.ContainsAny(emailData.Subject, "\r\n") {
+		return nil, ErrorInvalidSubject
+	}
+
+	return allRecipients, nil
+}
+
+func (c *smtpClient) buildMessage(emailData EmailData) string {
+	var builder strings.Builder
+
+	builder.WriteString(fmt.Sprintf("From: %s\r\n", c.config.from))
+
+	if len(emailData.To) > 0 {
+		builder.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(emailData.To, ", ")))
+	} else {
+		builder.WriteString("To: undisclosed-recipients:;\r\n")
+	}
+
+	if len(emailData.CC) > 0 {
+		builder.WriteString(fmt.Sprintf("Cc: %s\r\n", strings.Join(emailData.CC, ", ")))
+	}
+
+	builder.WriteString(fmt.Sprintf("Subject: %s\r\n", mime.QEncoding.Encode("utf-8", emailData.Subject)))
+	builder.WriteString("MIME-Version: 1.0\r\n")
+
+	if emailData.IsHTML {
+		builder.WriteString("Content-Type: text/html; charset=\"utf-8\"\r\n")
+	} else {
+		builder.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
+	}
+
+	builder.WriteString("\r\n")
+	builder.WriteString(emailData.Body)
+
+	return builder.String()
+}
+
+func (c *smtpClient) sendViaSMTP(serverAddress string, recipients []string, message string) error {
+	conn, error := net.DialTimeout("tcp", serverAddress, smtpDialTimeout)
+	if error != nil {
+		return fmt.Errorf("%w: %w", ErrorSMTPConnection, error)
+	}
+
+	client, error := smtp.NewClient(conn, c.config.host)
+	if error != nil {
+		_ = conn.Close()
+		return fmt.Errorf("%w: %w", ErrorSMTPConnection, error)
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	if c.config.useTLS {
+		ok, _ := client.Extension("STARTTLS")
+		if !ok {
+			return fmt.Errorf("%w: STARTTLS not supported by server", ErrorSMTPConnection)
+		}
+		tlsConfig := &tls.Config{
+			ServerName: c.config.host,
+			MinVersion: tls.VersionTLS12,
+		}
+		if error := client.StartTLS(tlsConfig); error != nil {
+			return fmt.Errorf("%w: %w", ErrorSMTPConnection, error)
+		}
+	}
+
+	if c.config.enableAuthentication && c.config.username != "" && c.config.password != "" {
+		if error := client.Auth(smtp.PlainAuth("", c.config.username, c.config.password, c.config.host)); error != nil {
+			return fmt.Errorf("%w: %w", ErrorSMTPAuth, error)
+		}
+	}
+
+	if error := client.Mail(c.config.from); error != nil {
+		return fmt.Errorf("%w: %w", ErrorEmailSendFailed, error)
+	}
+
+	for _, recipient := range recipients {
+		if error := client.Rcpt(recipient); error != nil {
+			return fmt.Errorf("%w: %w", ErrorEmailSendFailed, error)
+		}
+	}
+
+	writer, error := client.Data()
+	if error != nil {
+		return fmt.Errorf("%w: %w", ErrorEmailSendFailed, error)
+	}
+	if _, error := writer.Write([]byte(message)); error != nil {
+		return fmt.Errorf("%w: %w", ErrorEmailSendFailed, error)
+	}
+	if error := writer.Close(); error != nil {
+		return fmt.Errorf("%w: %w", ErrorEmailSendFailed, error)
+	}
+
+	if error := client.Quit(); error != nil {
+		log.GetLogger().With(log.String(log.LoggerKeyComponentName, smtpLoggerComponentName)).
+			Error("Failed to gracefully close SMTP client", log.Error(error))
+	}
+
+	return nil
+}

--- a/backend/internal/system/email/smtp_client_test.go
+++ b/backend/internal/system/email/smtp_client_test.go
@@ -1,0 +1,1316 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package email
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/asgardeo/thunder/internal/system/config"
+)
+
+const (
+	cmdData = "DATA"
+	cmdQuit = "QUIT"
+)
+
+type SMTPClientTestSuite struct {
+	suite.Suite
+}
+
+func TestSMTPClientTestSuite(t *testing.T) {
+	suite.Run(t, new(SMTPClientTestSuite))
+}
+
+func (suite *SMTPClientTestSuite) SetupSuite() {
+	testConfig := &config.Config{}
+	error := config.InitializeThunderRuntime("", testConfig)
+	if error != nil {
+		suite.T().Fatalf("Failed to initialize ThunderRuntime: %v", error)
+	}
+}
+
+func (suite *SMTPClientTestSuite) getValidSMTPConfig(host string, port int) smtpConfig {
+	return smtpConfig{
+		host:                 host,
+		port:                 port,
+		username:             "testuser",
+		password:             "testpass",
+		from:                 "sender@example.com",
+		useTLS:               false,
+		enableAuthentication: true,
+	}
+}
+
+// waitForDone waits for the mock server to finish with a timeout to avoid deadlocks.
+func (suite *SMTPClientTestSuite) waitForDone(done <-chan bool) {
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		suite.T().Fatal("timed out waiting for mock SMTP server to finish")
+	}
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClient_Success() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	suite.NotNil(client)
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClient_EmptyFrom_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	config.from = ""
+
+	client, error := newSMTPClient(config)
+	suite.Error(error)
+	suite.Nil(client)
+	suite.True(errors.Is(error, ErrorInvalidSender))
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClient_InvalidFrom_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	config.from = "invalid-email"
+
+	client, error := newSMTPClient(config)
+	suite.Error(error)
+	suite.Nil(client)
+	suite.True(errors.Is(error, ErrorInvalidSender))
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClient_EmptyHost_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	config.host = "   "
+
+	client, error := newSMTPClient(config)
+	suite.Error(error)
+	suite.Nil(client)
+	suite.True(errors.Is(error, ErrorInvalidHost))
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClient_InvalidPort_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	config.port = 0
+
+	client, error := newSMTPClient(config)
+	suite.Error(error)
+	suite.Nil(client)
+	suite.True(errors.Is(error, ErrorInvalidPort))
+
+	config.port = -1
+	client, error = newSMTPClient(config)
+	suite.Error(error)
+	suite.Nil(client)
+	suite.True(errors.Is(error, ErrorInvalidPort))
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClient_EmptyCredentials_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	config.enableAuthentication = true
+	config.username = ""
+
+	client, error := newSMTPClient(config)
+	suite.Error(error)
+	suite.Nil(client)
+	suite.True(errors.Is(error, ErrorInvalidCredentials))
+
+	config.username = "user"
+	config.password = "  "
+	client, error = newSMTPClient(config)
+	suite.Error(error)
+	suite.Nil(client)
+	suite.True(errors.Is(error, ErrorInvalidCredentials))
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_PlainText_Success() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServer(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test Subject",
+		Body:    "Hello, this is a test email.",
+		IsHTML:  false,
+	}
+
+	error = client.Send(emailData)
+
+	suite.Require().NoError(error)
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_HTML_Success() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServer(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "HTML Test",
+		Body:    "<h1>Hello</h1><p>This is an HTML email.</p>",
+		IsHTML:  true,
+	}
+
+	error = client.Send(emailData)
+
+	suite.Require().NoError(error)
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_MultipleRecipients_Success() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServer(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"to1@example.com", "to2@example.com"},
+		CC:      []string{"cc@example.com"},
+		BCC:     []string{"bcc@example.com"},
+		Subject: "Multi-recipient Test",
+		Body:    "Hello everyone!",
+		IsHTML:  false,
+	}
+
+	error = client.Send(emailData)
+
+	suite.Require().NoError(error)
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_EmptyToWithCC_Success() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServer(listener, done)
+
+	emailData := EmailData{
+		To:      []string{},
+		CC:      []string{"cc@example.com"},
+		BCC:     []string{"bcc@example.com"},
+		Subject: "Undisclosed Recipients Test",
+		Body:    "Hello everyone!",
+		IsHTML:  false,
+	}
+
+	error = client.Send(emailData)
+
+	suite.Require().NoError(error)
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_EmptyRecipients_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	emailData := EmailData{
+		To:      []string{},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorInvalidRecipient))
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_EmptyRecipientString_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	emailData := EmailData{
+		To:      []string{"   "}, // empty after trim
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorInvalidRecipient))
+	suite.Contains(error.Error(), "recipient address cannot be empty")
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_ConnectionError() {
+	// Allocate an ephemeral port and close it immediately to ensure nothing is listening on it.
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	port := serverAddress.Port
+	error = listener.Close()
+	suite.Require().NoError(error)
+
+	config := suite.getValidSMTPConfig("127.0.0.1", port)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorSMTPConnection))
+}
+
+func (suite *SMTPClientTestSuite) TestSendEmail_CRLFInjection_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	// Test CR/LF in recipient address.
+	emailData := EmailData{
+		To:      []string{"recipient@example.com\r\nBcc: evil@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+	error = client.Send(emailData)
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorInvalidRecipient))
+
+	// Test CR/LF in subject.
+	emailData = EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test\r\nBcc: evil@example.com",
+		Body:    "Test body",
+	}
+	error = client.Send(emailData)
+	suite.Error(error)
+	suite.Contains(error.Error(), "invalid characters")
+	suite.True(errors.Is(error, ErrorInvalidSubject))
+}
+
+func (suite *SMTPClientTestSuite) TestBuildMessage_PlainText() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	ci, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+	client := ci.(*smtpClient)
+
+	emailData := EmailData{
+		To:      []string{"to@example.com"},
+		Subject: "Test Subject",
+		Body:    "Hello, world!",
+		IsHTML:  false,
+	}
+
+	message := client.buildMessage(emailData)
+
+	suite.Contains(message, "From: sender@example.com")
+	suite.Contains(message, "To: to@example.com")
+	suite.Contains(message, "Content-Type: text/plain; charset=\"utf-8\"")
+	suite.Contains(message, "MIME-Version: 1.0")
+	suite.Contains(message, "Hello, world!")
+}
+
+func (suite *SMTPClientTestSuite) TestBuildMessage_HTMLWithCC() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	ci, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+	client := ci.(*smtpClient)
+
+	emailData := EmailData{
+		To:      []string{"to@example.com"},
+		CC:      []string{"cc1@example.com", "cc2@example.com"},
+		Subject: "HTML Test",
+		Body:    "<h1>Hello</h1>",
+		IsHTML:  true,
+	}
+
+	message := client.buildMessage(emailData)
+
+	suite.Contains(message, "Content-Type: text/html; charset=\"utf-8\"")
+	suite.Contains(message, "Cc: cc1@example.com, cc2@example.com")
+	suite.Contains(message, "<h1>Hello</h1>")
+}
+
+func (suite *SMTPClientTestSuite) TestValidateAndProcessRecipients() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	ci, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+	client := ci.(*smtpClient)
+
+	emailData := EmailData{
+		To:      []string{" to@example.com "},
+		CC:      []string{"cc@example.com"},
+		BCC:     []string{" bcc@example.com "},
+		Subject: "Test Subject",
+	}
+
+	recipients, error := client.validateAndProcessRecipients(&emailData)
+	suite.Require().NoError(error)
+
+	suite.Equal(3, len(recipients))
+	suite.Contains(recipients, "to@example.com")
+	suite.Contains(recipients, "cc@example.com")
+	suite.Contains(recipients, "bcc@example.com")
+
+	// Verify in-place updates
+	suite.Equal("to@example.com", emailData.To[0])
+	suite.Equal("bcc@example.com", emailData.BCC[0])
+}
+
+func (suite *SMTPClientTestSuite) TestValidateAndProcessRecipients_InvalidSubject_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	ci, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+	client := ci.(*smtpClient)
+
+	emailData := EmailData{
+		To:      []string{"to@example.com"},
+		Subject: "Invalid\nSubject",
+	}
+
+	_, error = client.validateAndProcessRecipients(&emailData)
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorInvalidSubject))
+}
+
+func (suite *SMTPClientTestSuite) TestValidateAndProcessRecipients_InvalidCC_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	ci, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+	client := ci.(*smtpClient)
+
+	emailData := EmailData{
+		To: []string{"to@example.com"},
+		CC: []string{"invalid-cc"},
+	}
+
+	_, error = client.validateAndProcessRecipients(&emailData)
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorInvalidRecipient))
+}
+
+func (suite *SMTPClientTestSuite) TestValidateAndProcessRecipients_InvalidBCC_Error() {
+	config := suite.getValidSMTPConfig("localhost", 25)
+	ci, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+	client := ci.(*smtpClient)
+
+	emailData := EmailData{
+		To:  []string{"to@example.com"},
+		BCC: []string{"invalid-bcc"},
+	}
+
+	_, error = client.validateAndProcessRecipients(&emailData)
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorInvalidRecipient))
+}
+
+// --- sendViaSMTP error path tests ---
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_InvalidGreeting_Error() {
+	// A listener that sends an invalid SMTP greeting so smtp.NewClient fails.
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go func() {
+		defer func() { done <- true }()
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		// Send invalid greeting (not a 220).
+		_, _ = fmt.Fprintf(conn, "500 Go away\r\n")
+	}()
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorSMTPConnection))
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_TLSNotSupported_Error() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.useTLS = true // Enable STARTTLS
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	// Standard mock server does not advertise STARTTLS
+	go suite.runMockSMTPServer(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorSMTPConnection))
+	suite.Contains(error.Error(), "STARTTLS not supported by server")
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_TLSError() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.useTLS = true // Enable STARTTLS
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerRejectTLS(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorSMTPConnection))
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_AuthError() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = true
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerRejectAuth(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorSMTPAuth))
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_MailFromError() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = false
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerRejectMailFrom(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorEmailSendFailed))
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_RcptToError() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = false
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerRejectRcptTo(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorEmailSendFailed))
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_DataError() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = false
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerRejectData(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorEmailSendFailed))
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_WriteError() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = false
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerCloseOnData(listener, done)
+
+	// Use a large body (~1MB) to overflow TCP kernel buffers after the server closes
+	// the connection. A small body would be silently buffered and the error would only
+	// surface on writer.Close(), not writer.Write().
+	largeBody := strings.Repeat("X", 1024*1024)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    largeBody,
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	// On Windows, this is often reported as a connection failure (SYS-EMAIL-5001)
+	errStr := error.Error()
+	suite.True(errors.Is(error, ErrorEmailSendFailed) || errors.Is(error, ErrorSMTPConnection),
+		"Expected error to wrap ErrorEmailSendFailed or ErrorSMTPConnection, but got: %s", errStr)
+	suite.waitForDone(done)
+}
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_DataTerminationError() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = false
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerRejectDataTermination(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Test body",
+	}
+
+	error = client.Send(emailData)
+
+	suite.Error(error)
+	suite.True(errors.Is(error, ErrorEmailSendFailed))
+	suite.waitForDone(done)
+}
+
+// --- NewSMTPClientFromConfig tests ---
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClientFromConfig_Defaults() {
+	// Reset and set up config with nil boolean pointers (should default to true).
+	config.ResetThunderRuntime()
+	defer config.ResetThunderRuntime()
+
+	testConfig := &config.Config{
+		Email: config.EmailConfig{
+			SMTP: config.SMTPEmailConfig{
+				Host:                 "smtp.example.com",
+				Port:                 587,
+				Username:             "user@example.com",
+				Password:             "secret",
+				FromAddress:          "noreply@example.com",
+				EnableStartTLS:       nil, // should default to true
+				EnableAuthentication: nil, // should default to true
+			},
+		},
+	}
+	error := config.InitializeThunderRuntime("", testConfig)
+	suite.Require().NoError(error)
+
+	client, error := NewSMTPClientFromConfig()
+	suite.Require().NoError(error)
+
+	suite.NotNil(client)
+
+	// Verify the internal config defaults.
+	smtpCl, ok := client.(*smtpClient)
+	suite.Require().True(ok)
+	suite.True(smtpCl.config.useTLS, "useTLS should default to true when nil")
+	suite.True(smtpCl.config.enableAuthentication, "enableAuthentication should default to true when nil")
+	suite.Equal("smtp.example.com", smtpCl.config.host)
+	suite.Equal(587, smtpCl.config.port)
+	suite.Equal("user@example.com", smtpCl.config.username)
+	suite.Equal("secret", smtpCl.config.password)
+	suite.Equal("noreply@example.com", smtpCl.config.from)
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClientFromConfig_ExplicitFalse() {
+	config.ResetThunderRuntime()
+	defer config.ResetThunderRuntime()
+
+	falseVal := false
+	testConfig := &config.Config{
+		Email: config.EmailConfig{
+			SMTP: config.SMTPEmailConfig{
+				Host:                 "smtp.example.com",
+				Port:                 25,
+				Username:             "",
+				Password:             "",
+				FromAddress:          "noreply@example.com",
+				EnableStartTLS:       &falseVal,
+				EnableAuthentication: &falseVal,
+			},
+		},
+	}
+	error := config.InitializeThunderRuntime("", testConfig)
+	suite.Require().NoError(error)
+
+	client, error := NewSMTPClientFromConfig()
+	suite.Require().NoError(error)
+
+	suite.NotNil(client)
+	smtpCl, ok := client.(*smtpClient)
+	suite.Require().True(ok)
+	suite.False(smtpCl.config.useTLS, "useTLS should be false when explicitly set")
+	suite.False(smtpCl.config.enableAuthentication, "enableAuthentication should be false when explicitly set")
+}
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClientFromConfig_ExplicitTrue() {
+	config.ResetThunderRuntime()
+	defer config.ResetThunderRuntime()
+
+	trueVal := true
+	testConfig := &config.Config{
+		Email: config.EmailConfig{
+			SMTP: config.SMTPEmailConfig{
+				Host:                 "smtp.example.com",
+				Port:                 465,
+				Username:             "user",
+				Password:             "pass",
+				FromAddress:          "noreply@example.com",
+				EnableStartTLS:       &trueVal,
+				EnableAuthentication: &trueVal,
+			},
+		},
+	}
+	error := config.InitializeThunderRuntime("", testConfig)
+	suite.Require().NoError(error)
+
+	client, error := NewSMTPClientFromConfig()
+	suite.Require().NoError(error)
+
+	suite.NotNil(client)
+	smtpCl, ok := client.(*smtpClient)
+	suite.Require().True(ok)
+	suite.True(smtpCl.config.useTLS)
+	suite.True(smtpCl.config.enableAuthentication)
+}
+
+// --- Test sending without authentication ---
+
+func (suite *SMTPClientTestSuite) TestSendEmail_NoAuth_Success() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = false
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerNoAuth(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test Subject",
+		Body:    "Hello, this is a test email.",
+		IsHTML:  false,
+	}
+
+	error = client.Send(emailData)
+
+	suite.Require().NoError(error)
+	suite.waitForDone(done)
+}
+
+// --- Test QUIT error is ignored ---
+
+func (suite *SMTPClientTestSuite) TestSendViaSMTP_QuitError_Ignored() {
+	listener, error := net.Listen("tcp", "127.0.0.1:0")
+	suite.Require().NoError(error)
+	defer func() { _ = listener.Close() }()
+
+	serverAddress := listener.Addr().(*net.TCPAddr)
+	config := suite.getValidSMTPConfig("127.0.0.1", serverAddress.Port)
+	config.enableAuthentication = false
+	client, error := newSMTPClient(config)
+	suite.Require().NoError(error)
+
+	done := make(chan bool, 1)
+	go suite.runMockSMTPServerRejectQuit(listener, done)
+
+	emailData := EmailData{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test Subject",
+		Body:    "Hello!",
+		IsHTML:  false,
+	}
+
+	// QUIT errors should be ignored since the message was already accepted.
+	error = client.Send(emailData)
+	suite.NoError(error)
+	suite.waitForDone(done)
+}
+
+// =============================================================================
+// Mock SMTP Server Variants
+// =============================================================================
+
+// runMockSMTPServer runs a minimal mock SMTP server that accepts one connection.
+func (suite *SMTPClientTestSuite) runMockSMTPServer(listener net.Listener, done chan bool) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP Mock Server\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "250 AUTH PLAIN LOGIN\r\n")
+		case strings.HasPrefix(line, "AUTH"):
+			_, _ = fmt.Fprintf(conn, "235 Authentication successful\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case line == cmdData:
+			_, _ = fmt.Fprintf(conn, "354 Start mail input\r\n")
+			for {
+				dataLine, dataErr := reader.ReadString('\n')
+				if dataErr != nil {
+					return
+				}
+				if strings.TrimSpace(dataLine) == "." {
+					break
+				}
+			}
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "221 Bye\r\n")
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// runMockSMTPServerRejectTLS accepts EHLO but does not actually support STARTTLS,
+// causing the TLS handshake to fail.
+func (suite *SMTPClientTestSuite) runMockSMTPServerRejectTLS(listener net.Listener, done chan bool) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "250 STARTTLS\r\n")
+		case line == "STARTTLS":
+			_, _ = fmt.Fprintf(conn, "220 Ready to start TLS\r\n")
+			return
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "221 Bye\r\n")
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+func (suite *SMTPClientTestSuite) runMockSMTPServerWithReject(
+	listener net.Listener, done chan bool,
+	ehloExtra string, rejectCmdPrefix string, rejectResponse string,
+) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "%s\r\n", ehloExtra)
+		case strings.HasPrefix(line, rejectCmdPrefix):
+			_, _ = fmt.Fprintf(conn, "%s\r\n", rejectResponse)
+			return
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "221 Bye\r\n")
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// runMockSMTPServerRejectAuth accepts EHLO but rejects AUTH.
+func (suite *SMTPClientTestSuite) runMockSMTPServerRejectAuth(listener net.Listener, done chan bool) {
+	suite.runMockSMTPServerWithReject(listener, done, "250 AUTH PLAIN LOGIN", "AUTH", "535 Authentication failed")
+}
+
+// runMockSMTPServerRejectMailFrom accepts EHLO but rejects MAIL FROM.
+func (suite *SMTPClientTestSuite) runMockSMTPServerRejectMailFrom(listener net.Listener, done chan bool) {
+	suite.runMockSMTPServerWithReject(listener, done, "250 OK", "MAIL FROM:", "550 Sender rejected")
+}
+
+// runMockSMTPServerRejectRcptTo accepts MAIL FROM but rejects RCPT TO.
+func (suite *SMTPClientTestSuite) runMockSMTPServerRejectRcptTo(listener net.Listener, done chan bool) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, _ = fmt.Fprintf(conn, "550 Recipient rejected\r\n")
+			return
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "221 Bye\r\n")
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// runMockSMTPServerRejectData accepts RCPT TO but rejects DATA.
+func (suite *SMTPClientTestSuite) runMockSMTPServerRejectData(listener net.Listener, done chan bool) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case line == cmdData:
+			_, _ = fmt.Fprintf(conn, "554 Transaction failed\r\n")
+			return
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "221 Bye\r\n")
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// runMockSMTPServerCloseOnData accepts DATA but closes the connection immediately,
+// causing the client's writer.Write to fail.
+func (suite *SMTPClientTestSuite) runMockSMTPServerCloseOnData(listener net.Listener, done chan bool) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case line == cmdData:
+			_, _ = fmt.Fprintf(conn, "354 Start mail input\r\n")
+			_ = conn.Close()
+			return
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "221 Bye\r\n")
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// runMockSMTPServerRejectDataTermination accepts data content but responds with
+// an error when the data termination dot is sent, causing writer.Close to fail.
+func (suite *SMTPClientTestSuite) runMockSMTPServerRejectDataTermination(listener net.Listener, done chan bool) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case line == cmdData:
+			_, _ = fmt.Fprintf(conn, "354 Start mail input\r\n")
+			for {
+				dataLine, dataErr := reader.ReadString('\n')
+				if dataErr != nil {
+					return
+				}
+				if strings.TrimSpace(dataLine) == "." {
+					break
+				}
+			}
+			_, _ = fmt.Fprintf(conn, "554 Message rejected\r\n")
+			return
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "221 Bye\r\n")
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// runMockSMTPServerCustomQuit is like the standard mock but uses a custom QUIT response.
+func (suite *SMTPClientTestSuite) runMockSMTPServerCustomQuit(
+	listener net.Listener, done chan bool, quitResponse string,
+) {
+	defer func() { done <- true }()
+
+	conn, error := listener.Accept()
+	if error != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+	_, _ = fmt.Fprintf(conn, "220 localhost SMTP\r\n")
+
+	for {
+		line, error := reader.ReadString('\n')
+		if error != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO") || strings.HasPrefix(line, "HELO"):
+			_, _ = fmt.Fprintf(conn, "250-localhost\r\n")
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case line == cmdData:
+			_, _ = fmt.Fprintf(conn, "354 Start mail input\r\n")
+			for {
+				dataLine, dataErr := reader.ReadString('\n')
+				if dataErr != nil {
+					return
+				}
+				if strings.TrimSpace(dataLine) == "." {
+					break
+				}
+			}
+			_, _ = fmt.Fprintf(conn, "250 OK\r\n")
+		case line == cmdQuit:
+			_, _ = fmt.Fprintf(conn, "%s\r\n", quitResponse)
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "500 Unrecognized command\r\n")
+		}
+	}
+}
+
+// runMockSMTPServerNoAuth is like the standard mock but doesn't expect AUTH.
+func (suite *SMTPClientTestSuite) runMockSMTPServerNoAuth(listener net.Listener, done chan bool) {
+	suite.runMockSMTPServerCustomQuit(listener, done, "221 Bye")
+}
+
+// runMockSMTPServerRejectQuit is like the standard mock but returns an error for QUIT.
+func (suite *SMTPClientTestSuite) runMockSMTPServerRejectQuit(listener net.Listener, done chan bool) {
+	suite.runMockSMTPServerCustomQuit(listener, done, "500 QUIT error")
+}
+
+// --- Test runtime not initialized ---
+
+func (suite *SMTPClientTestSuite) TestNewSMTPClientFromConfig_RuntimeNotInitialized() {
+	// Reset the runtime to simulate an uninitialized state.
+	config.ResetThunderRuntime()
+	defer config.ResetThunderRuntime()
+
+	// Should panic if runtime is not initialized.
+	suite.PanicsWithValue("ThunderRuntime is not initialized", func() {
+		_, _ = NewSMTPClientFromConfig()
+	})
+
+	// Re-initialize the runtime for subsequent tests.
+	testConfig := &config.Config{}
+	initErr := config.InitializeThunderRuntime("", testConfig)
+	suite.Require().NoError(initErr)
+}
+
+// TestSendLiveEmail is a manual test utility to verify email delivery against real SMTP credentials.
+// It loads the configuration from backend/cmd/server/repository/conf/deployment.yaml and attempts to send
+// a test email to the specified address.
+//
+// By default, this test is skipped during normal test execution.
+// To run this test manually, use the following command from the `backend` directory:
+//
+//	go test ./internal/system/email -v -run TestSMTPClientTestSuite/TestSendLiveEmail
+func (suite *SMTPClientTestSuite) TestSendLiveEmail() {
+	suite.T().Skip("Skipping live email test. To run, comment this line and use: " +
+		"go test ./internal/system/email -v -run TestSMTPClientTestSuite/TestSendLiveEmail")
+
+	config.ResetThunderRuntime()
+
+	emailConfig, error := config.LoadConfig(
+		"../../../cmd/server/repository/conf/deployment.yaml",
+		"",
+		"../../../cmd/server",
+	)
+	suite.Require().NoError(error, "Failed to load config")
+
+	error = config.InitializeThunderRuntime("", emailConfig)
+	suite.Require().NoError(error, "Failed to initialize thunder runtime")
+	defer config.ResetThunderRuntime()
+
+	client, error := NewSMTPClientFromConfig()
+	suite.Require().NoError(error)
+
+	emailData := EmailData{
+		To:      []string{"test@example.com"},
+		Subject: "Thunder Email System Test",
+		Body: "<h1>Thunder Email System is Working!</h1>" +
+			"<p>This is a live test email sent using the new email capability.</p>",
+		IsHTML: true,
+	}
+	fmt.Printf("Sending test email to %s...\n", emailData.To[0])
+	error = client.Send(emailData)
+	suite.NoError(error, "Failed to send email")
+	fmt.Println("Email sent successfully!")
+}

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -236,6 +236,41 @@ Signing keys are configured as an array. Each key has the following properties:
   key_file: "repository/resources/security/signing.key"
 ```
 
+## Email Configuration
+
+Controls email sending capabilities (e.g., for magic link authentication, user invitations).
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `email.smtp.host` | `""` | SMTP server hostname |
+| `email.smtp.port` | `0` | SMTP server port (e.g., 587 for STARTTLS) |
+| `email.smtp.username` | `""` | SMTP authentication username |
+| `email.smtp.password` | `""` | SMTP authentication password |
+| `email.smtp.from_address` | `""` | Sender email address |
+| `email.smtp.enable_start_tls` | `true` | Enable STARTTLS encryption |
+| `email.smtp.enable_authentication` | `true` | Enable SMTP authentication |
+
+**Example:**
+```yaml
+email:
+  smtp:
+    host: "smtp.example.com"
+    port: 587
+    username: "yourUsername"
+    password: "yourPassword"
+    from_address: "yourEmail"
+    enable_start_tls: true
+    enable_authentication: true
+```
+
+:::note
+**Transport Mode:** Referencing keys `enable_start_tls` and `enable_authentication`, only explicit STARTTLS is supported (set `enable_start_tls: true`). Implicit SMTPS (port 465) is not supported by this transport.
+:::
+
+:::note
+The email configuration is optional. If not provided, features that depend on email (e.g., magic link, user invitations) will not be available.
+:::
+
 ## Authentication Provider Configuration
 
 External authentication provider settings.


### PR DESCRIPTION
### Purpose
Introduces a core email sending capability to the Thunder platform. This PR adds the `email` package under `backend/internal/system/email/`, including a transport-agnostic client interface, an SMTP implementation, an extensible middleware pipeline, structured error constants, and system-level configuration support.

### Approach

The implementation is built around a clean, extensible pipeline pattern with the following components:

**Core abstractions (`client.go`, `model.go`)**
- `EmailClientInterface` defines a minimal, transport-agnostic interface (`GetName()`, `SendEmail(EmailData)`) that any backend must satisfy.
- `EmailData` is the canonical message struct covering `To`, `CC`, `BCC`, `Subject`, `Body`, `IsHTML`, and an open-ended `Metadata map[string]interface{}` field. The `Metadata` field allows middleware to consume custom contextual data without requiring struct changes.

**SMTP implementation (`smtp_client.go`)**
- `SMTPClient` implements `EmailClientInterface` using Go's standard `net/smtp` library with no external runtime dependencies.
- Optional **STARTTLS** and optional **SMTP AUTH (PLAIN)** are each independently controlled by config flags, making the client usable against both authenticated relays (e.g., Gmail, SendGrid) and unauthenticated internal servers.
- `NewSMTPClient(name, SMTPConfig)` — direct construction with an explicit config struct.
- `NewSMTPClientFromConfig()` — factory that reads the `email.smtp` section from the Thunder runtime config, wiring configuration automatically.
- Message building conforms to RFC 2822, with RFC 2047 Q-encoding applied to the `Subject` header for non-ASCII support.
- SMTP connection lifecycle is carefully managed: `QUIT` is sent on success (which also closes the connection), with a deferred `Close()` as a fallback only if `QUIT` was never sent, to avoid double-close errors.

**Middleware pipeline (`middleware.go`)**
- `EmailMiddleware` is a function type (`func(next EmailClientInterface) EmailClientInterface`) that follows the standard decorator pattern for pluggable processing (e.g., template rendering, body injection).
- `NewEmailClientWithMiddleware(base, ...middlewares)` composes the pipeline: middlewares wrap the base client in declaration order so the first middleware in the list is outermost (executed first), keeping call sites intuitive.

**Error constants (`error_constants.go`)**
- Structured `ServiceError` definitions for all failure cases, categorised as client errors (invalid sender/recipient) and server errors (connection failure, auth failure, send failure), each with a stable error code (`SYS-EMAIL-1001` through `SYS-EMAIL-5003`).

**System configuration (`config/config.go`, `deployment.yaml`)**
- Extended the Thunder `Config` struct with an `Email EmailConfig` field holding an `SMTP SMTPEmailConfig` sub-struct (host, port, username, password, from address, STARTTLS flag, auth flag).
- Added a corresponding `email.smtp` block to `deployment.yaml` with placeholder values and a TODO comment flagging that credentials should be moved to environment variables or a secure vault.

**Tests (`smtp_client_test.go`, `middleware_test.go`)**
- SMTP unit tests spin up a real in-process mock SMTP server (`net.Listen` on a random port) to drive the full send path without external dependencies. Coverage includes: plain-text send, HTML send, multiple To/CC/BCC recipients, auth-disabled path, empty-recipient validation error, empty-sender validation error, connection failure, `buildMessage` output format (plain and HTML with CC), and `collectRecipients` correctness.
- `TestNewSMTPClientFromConfig` verifies that `NewSMTPClientFromConfig()` correctly reads all fields from the Thunder runtime config.
- `TestSendLiveEmail` is an opt-in integration test (skipped by default via `t.Skip`) that loads `deployment.yaml`, initialises the Thunder runtime, builds a middleware-wrapped client via `NewEmailClientWithMiddleware`, and sends a real HTML email. Can be run manually with: `go test ./internal/system/email -v -run TestSMTPClientTestSuite/TestSendLiveEmail`.
- Middleware tests verify: no-middleware passthrough, single middleware mutation, multi-middleware execution order, metadata passthrough through the chain, error short-circuit by middleware (base never called), and error propagation from the base client up through the chain.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1823

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email functionality is now available with SMTP support. Users can configure SMTP settings including host, port, credentials, sender address, and optional authentication and TLS encryption options.
  * Built-in validation for email addresses, subjects, and SMTP credentials ensures reliable message delivery.

* **Documentation**
  * Added Email Configuration guide with SMTP setup instructions, examples, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->