### PR TITLE
Add `prompt` parameter support in authorize request

### DIFF
--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -21,6 +21,8 @@ package authz
 import (
 	"fmt"
 	"net/url"
+	"slices"
+	"strings"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
@@ -60,6 +62,15 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 	if err := oauthApp.ValidateRedirectURI(redirectURI); err != nil {
 		logger.Error("Validation failed for redirect URI", log.Error(err))
 		return false, constants.ErrorInvalidRequest, "Invalid redirect URI"
+	}
+
+	// Validate the prompt parameter if present.
+	promptParam, promptExists := msg.RequestQueryParams[constants.RequestParamPrompt]
+	if promptExists {
+		sendToClient, errCode, errMsg := validatePromptParameter(promptParam)
+		if errCode != "" {
+			return sendToClient, errCode, errMsg
+		}
 	}
 
 	// Validate if the authorization code grant type is allowed for the app.
@@ -124,4 +135,44 @@ func validateResourceParameter(resource string) error {
 	}
 
 	return nil
+}
+
+// validatePromptParameter validates the OIDC prompt parameter.
+func validatePromptParameter(prompt string) (bool, string, string) {
+	if strings.TrimSpace(prompt) == "" {
+		return true, constants.ErrorInvalidRequest, "Invalid prompt parameter value"
+	}
+
+	values := strings.Fields(prompt)
+
+	for _, v := range values {
+		if !slices.Contains(constants.ValidPromptValues, v) {
+			return true, constants.ErrorInvalidRequest, "Invalid prompt parameter value"
+		}
+	}
+
+	if slices.Contains(values, constants.PromptNone) {
+		// "none" must not be combined with other values.
+		if len(values) > 1 {
+			return true, constants.ErrorInvalidRequest,
+				"prompt value 'none' must not be combined with other values"
+		}
+
+		// Thunder does not support server-side sessions as of now.
+		return true, constants.ErrorLoginRequired,
+			"User authentication is required"
+	}
+
+	// Thunder does not support consent or account selection prompts as of now.
+	if slices.Contains(values, constants.PromptConsent) {
+		return true, constants.ErrorConsentRequired,
+			"Consent is not supported"
+	}
+
+	if slices.Contains(values, constants.PromptSelectAccount) {
+		return true, constants.ErrorAccountSelectionRequired,
+			"Account selection is not supported"
+	}
+
+	return false, "", ""
 }

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -479,3 +479,149 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 	assert.Empty(suite.T(), errorCode)
 	assert.Empty(suite.T(), errorMessage)
 }
+
+// Prompt Parameter Validation Tests (OIDC Core §3.1.2.1)
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptNone_LoginRequired() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "none",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorLoginRequired, errorCode)
+	assert.Equal(suite.T(), "User authentication is required", errorMessage)
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_PromptLogin_Success() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "login",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.False(suite.T(), sendErrorToApp)
+	assert.Empty(suite.T(), errorCode)
+	assert.Empty(suite.T(), errorMessage)
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptConsent_ConsentRequired() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "consent",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorConsentRequired, errorCode)
+	assert.Equal(suite.T(), "Consent is not supported", errorMessage)
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptNoneCombined_InvalidRequest() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "none login",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
+	assert.Contains(suite.T(), errorMessage, "must not be combined")
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptInvalidValue_InvalidRequest() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "invalid_value",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
+	assert.Contains(suite.T(), errorMessage, "Invalid prompt parameter value")
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptSelectAccount() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "select_account",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorAccountSelectionRequired, errorCode)
+	assert.Equal(suite.T(), "Account selection is not supported", errorMessage)
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptLoginConsent_ConsentRequired() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "login consent",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorConsentRequired, errorCode)
+	assert.Equal(suite.T(), "Consent is not supported", errorMessage)
+}
+
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptEmpty_InvalidRequest() {
+	msg := &OAuthMessage{
+		RequestQueryParams: map[string]string{
+			constants.RequestParamClientID:     "test-client-id",
+			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
+			constants.RequestParamResponseType: string(constants.ResponseTypeCode),
+			constants.RequestParamPrompt:       "",
+		},
+	}
+
+	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(
+		msg, suite.oauthApp)
+
+	assert.True(suite.T(), sendErrorToApp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
+	assert.Contains(suite.T(), errorMessage, "Invalid prompt parameter value")
+}

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -55,7 +55,21 @@ const (
 	RequestParamClaims              string = "claims"
 	RequestParamClaimsLocales       string = "claims_locales"
 	RequestParamNonce               string = "nonce"
+	RequestParamPrompt              string = "prompt"
 )
+
+// OIDC prompt parameter values.
+const (
+	PromptNone          string = "none"
+	PromptLogin         string = "login"
+	PromptConsent       string = "consent"
+	PromptSelectAccount string = "select_account"
+)
+
+// ValidPromptValues contains all valid OIDC prompt parameter values.
+var ValidPromptValues = []string{
+	PromptNone, PromptLogin, PromptConsent, PromptSelectAccount,
+}
 
 // OAuth2 request parameter validation limits.
 const (
@@ -218,16 +232,19 @@ func (tti TokenTypeIdentifier) IsValid() bool {
 
 // OAuth2 error codes.
 const (
-	ErrorInvalidRequest          string = "invalid_request"
-	ErrorInvalidClient           string = "invalid_client"
-	ErrorInvalidGrant            string = "invalid_grant"
-	ErrorUnauthorizedClient      string = "unauthorized_client"
-	ErrorUnsupportedGrantType    string = "unsupported_grant_type"
-	ErrorInvalidScope            string = "invalid_scope"
-	ErrorInvalidTarget           string = "invalid_target"
-	ErrorServerError             string = "server_error"
-	ErrorUnsupportedResponseType string = "unsupported_response_type"
-	ErrorAccessDenied            string = "access_denied"
+	ErrorInvalidRequest           string = "invalid_request"
+	ErrorInvalidClient            string = "invalid_client"
+	ErrorInvalidGrant             string = "invalid_grant"
+	ErrorUnauthorizedClient       string = "unauthorized_client"
+	ErrorUnsupportedGrantType     string = "unsupported_grant_type"
+	ErrorInvalidScope             string = "invalid_scope"
+	ErrorInvalidTarget            string = "invalid_target"
+	ErrorServerError              string = "server_error"
+	ErrorUnsupportedResponseType  string = "unsupported_response_type"
+	ErrorAccessDenied             string = "access_denied"
+	ErrorLoginRequired            string = "login_required"
+	ErrorConsentRequired          string = "consent_required"
+	ErrorAccountSelectionRequired string = "account_selection_required"
 )
 
 // UnSupportedGrantTypeError is returned when an unsupported grant type is requested.


### PR DESCRIPTION
This pull request adds support for validating the OpenID Connect (OIDC) `prompt` parameter in the OAuth2 authorization request validator. It introduces a dedicated validation function for the `prompt` parameter, updates the constants to include valid prompt values and related error codes, and adds comprehensive unit tests to cover various scenarios for prompt validation.

**OIDC Prompt Parameter Validation:**

* Added a new function `validatePromptParameter` in `validator.go` to validate the OIDC `prompt` parameter, ensuring only supported values are accepted and handling special cases such as `"none"` not being combinable with other values. The function also returns appropriate error codes and messages for unsupported prompt values or combinations.
* Updated the `validateInitialAuthorizationRequest` method to invoke the new `prompt` parameter validation logic, returning errors to the client if validation fails.

**Constants and Error Codes:**

* Added new constants in `constants.go` for the `prompt` request parameter, valid prompt values (`none`, `login`, `consent`, `select_account`), and corresponding error codes (`login_required`, `consent_required`, `account_selection_required`, etc.). [[1]](diffhunk://#diff-68fc6075f5e8a7ea5d0a73f85fecdccdcba3269b653f5a7a9f032d6a70b3915eR58-R73) [[2]](diffhunk://#diff-68fc6075f5e8a7ea5d0a73f85fecdccdcba3269b653f5a7a9f032d6a70b3915eR245-R248)

**Unit Tests:**

* Added a suite of unit tests in `validator_test.go` to verify correct handling of the `prompt` parameter, including scenarios for valid prompts, invalid values, unsupported prompts, and invalid combinations (e.g., `"none login"`).

**Imports:**

* Added imports for the standard library packages `slices` and `strings` to support the new validation logic.

Related issue;

Fix 12 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OIDC "prompt" parameter in authorization flows, enforcing allowed values (none, login, consent, select_account) and returning appropriate error or redirect responses, including new error responses like login_required, consent_required, and account_selection_required.

* **Tests**
  * Added tests covering prompt semantics: none, login, consent, select_account, invalid values, and disallowed combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->