### PR TITLE
Update `aud` in introspect to support array

### DIFF
--- a/backend/internal/oauth/oauth2/introspect/model.go
+++ b/backend/internal/oauth/oauth2/introspect/model.go
@@ -35,7 +35,7 @@ type IntrospectResponse struct {
 	Iat       int64  `json:"iat,omitempty"`
 	Nbf       int64  `json:"nbf,omitempty"`
 	Sub       string `json:"sub,omitempty"`
-	Aud       string `json:"aud,omitempty"`
+	Aud       any    `json:"aud,omitempty"`
 	Iss       string `json:"iss,omitempty"`
 	Jti       string `json:"jti,omitempty"`
 }

--- a/backend/internal/oauth/oauth2/introspect/service.go
+++ b/backend/internal/oauth/oauth2/introspect/service.go
@@ -113,8 +113,19 @@ func (s *tokenIntrospectionService) prepareValidResponse(payload map[string]inte
 	if sub, ok := payload[constants.ClaimSub].(string); ok {
 		response.Sub = sub
 	}
-	if aud, ok := payload[constants.ClaimAud].(string); ok {
+	switch aud := payload[constants.ClaimAud].(type) {
+	case string:
 		response.Aud = aud
+	case []interface{}:
+		audSlice := make([]string, 0, len(aud))
+		for _, v := range aud {
+			if s, ok := v.(string); ok {
+				audSlice = append(audSlice, s)
+			}
+		}
+		if len(audSlice) > 0 {
+			response.Aud = audSlice
+		}
 	}
 	if iss, ok := payload[constants.ClaimIss].(string); ok {
 		response.Iss = iss

--- a/backend/internal/oauth/oauth2/introspect/service_test.go
+++ b/backend/internal/oauth/oauth2/introspect/service_test.go
@@ -190,6 +190,15 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 			},
 		},
 		{
+			name:        "ValidTokenWithArrayAud",
+			tokenFn:     func(s *TokenIntrospectionServiceTestSuite) string { return s.createArrayAudToken() },
+			expectError: false,
+			active:      true,
+			expectedFields: map[string]interface{}{
+				"Aud": []string{"api.example.com", "api2.example.com"},
+			},
+		},
+		{
 			name: "TokenWithMissingExpClaim",
 			tokenFn: func(s *TokenIntrospectionServiceTestSuite) string {
 				claims := map[string]interface{}{
@@ -224,7 +233,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 				"ClientID":  "",
 				"Username":  "",
 				"Sub":       "",
-				"Aud":       "",
+				"Aud":       nil,
 				"Iss":       "",
 				"Jti":       "",
 			},
@@ -409,6 +418,17 @@ func (s *TokenIntrospectionServiceTestSuite) createMissingClaimsToken() string {
 	claims := map[string]interface{}{
 		"exp": float64(time.Now().Add(time.Hour).Unix()),
 		"nbf": float64(time.Now().Add(-time.Minute).Unix()),
+	}
+
+	return s.createToken(claims)
+}
+
+func (s *TokenIntrospectionServiceTestSuite) createArrayAudToken() string {
+	claims := map[string]interface{}{
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+		"nbf": float64(time.Now().Add(-time.Minute).Unix()),
+		"iat": float64(time.Now().Unix()),
+		"aud": []string{"api.example.com", "api2.example.com"},
 	}
 
 	return s.createToken(claims)


### PR DESCRIPTION
This pull request updates the handling of the `aud` (audience) claim in OAuth2 token introspection responses to support both string and array formats, improving compatibility with different token issuers. It also adds tests to ensure correct behavior for tokens with array audiences.

**Support for multiple audience formats:**

* The `Aud` field in the `IntrospectResponse` struct was changed from `string` to `any` to allow for both string and array types, aligning with the OAuth2 specification.
* The introspection service now detects if the `aud` claim is a string or an array and sets the response accordingly, converting arrays of interfaces to slices of strings as needed.

**Testing improvements:**

* Added a test case for tokens with an array-valued `aud` claim, verifying that the introspection response correctly returns a string slice for the `Aud` field. [[1]](diffhunk://#diff-0a9d1f19d172764d752ed14600449dcff81afa5c9f85e8eca3907c1923f0295eR192-R200) [[2]](diffhunk://#diff-0a9d1f19d172764d752ed14600449dcff81afa5c9f85e8eca3907c1923f0295eR425-R435)
* Updated test expectations for tokens with missing `aud` claims to expect `nil` instead of an empty string, reflecting the new `any` type.

Address 13 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth2 token introspection now accepts audience ("aud") as either a string or an array, improving compatibility with varied token formats.

* **Tests**
  * Added tests covering array-formatted audience claims and adjusted expectations for missing optional audience claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->