### PR TITLE
Remove CORS from authz request

### DIFF
--- a/backend/internal/oauth/oauth2/authz/init.go
+++ b/backend/internal/oauth/oauth2/authz/init.go
@@ -44,24 +44,15 @@ func Initialize(
 
 // registerRoutes registers the routes for OAuth2 authorization operations.
 func registerRoutes(mux *http.ServeMux, authzHandler AuthorizeHandlerInterface) {
-	authorizeOpts := middleware.CORSOptions{
-		AllowedMethods:   "GET",
-		AllowedHeaders:   "Content-Type, Authorization",
-		AllowCredentials: true,
-	}
+	// CORS MUST NOT be enabled on the authorization endpoint.
+	// The client redirects the user agent to it; it is not accessed directly via XHR/fetch.
+	mux.HandleFunc("GET /oauth2/authorize", authzHandler.HandleAuthorizeGetRequest)
 
 	callbackOpts := middleware.CORSOptions{
 		AllowedMethods:   "POST",
 		AllowedHeaders:   "Content-Type, Authorization",
 		AllowCredentials: true,
 	}
-
-	mux.HandleFunc(middleware.WithCORS("GET /oauth2/authorize",
-		authzHandler.HandleAuthorizeGetRequest, authorizeOpts))
-	mux.HandleFunc(middleware.WithCORS("OPTIONS /oauth2/authorize",
-		func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNoContent)
-		}, authorizeOpts))
 
 	mux.HandleFunc(middleware.WithCORS("POST /oauth2/auth/callback",
 		authzHandler.HandleAuthCallbackPostRequest, callbackOpts))

--- a/backend/internal/oauth/oauth2/authz/init_test.go
+++ b/backend/internal/oauth/oauth2/authz/init_test.go
@@ -91,9 +91,6 @@ func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	_, pattern = mux.Handler(&http.Request{Method: "POST", URL: &url.URL{Path: "/oauth2/auth/callback"}})
 	assert.Contains(suite.T(), pattern, "/oauth2/auth/callback")
 
-	_, pattern = mux.Handler(&http.Request{Method: "OPTIONS", URL: &url.URL{Path: "/oauth2/authorize"}})
-	assert.Contains(suite.T(), pattern, "/oauth2/authorize")
-
 	_, pattern = mux.Handler(&http.Request{Method: "OPTIONS", URL: &url.URL{Path: "/oauth2/auth/callback"}})
 	assert.Contains(suite.T(), pattern, "/oauth2/auth/callback")
 }
@@ -119,12 +116,6 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSConfiguration() {
 			name:          "POST /oauth2/auth/callback allowed",
 			method:        "POST",
 			path:          "/oauth2/auth/callback",
-			expectAllowed: true,
-		},
-		{
-			name:          "OPTIONS /oauth2/authorize returns no content",
-			method:        "OPTIONS",
-			path:          "/oauth2/authorize",
 			expectAllowed: true,
 		},
 		{
@@ -164,15 +155,6 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSHeaders() {
 		expectedAllowMethods string
 		expectedAllowHeaders string
 	}{
-		{
-			name:                 "OPTIONS /oauth2/authorize returns GET method",
-			method:               "OPTIONS",
-			path:                 "/oauth2/authorize",
-			origin:               "https://example.com",
-			expectedStatus:       http.StatusNoContent,
-			expectedAllowMethods: "GET",
-			expectedAllowHeaders: "Content-Type, Authorization",
-		},
 		{
 			name:                 "OPTIONS /oauth2/auth/callback returns POST method",
 			method:               "OPTIONS",


### PR DESCRIPTION
This pull request removes CORS handling from the OAuth2 authorization endpoint to comply with best practices, since the endpoint is only accessed via browser redirects and not directly via XHR or fetch. The associated tests for CORS on this endpoint have also been removed to reflect this change. CORS handling remains in place for the callback endpoint.

**OAuth2 Authorization Endpoint CORS Handling:**

* Removed CORS middleware from the `GET /oauth2/authorize` route in `init.go`, ensuring CORS is not enabled for the authorization endpoint.
* Deleted related CORS test cases for the authorization endpoint in `init_test.go`, including checks for `OPTIONS /oauth2/authorize` and expected CORS headers. [[1]](diffhunk://#diff-f551a250f681b2d907a8a1e1f9ca3fb92df87e9ab0845b03a3b01d7434dd32a4L94-L96) [[2]](diffhunk://#diff-f551a250f681b2d907a8a1e1f9ca3fb92df87e9ab0845b03a3b01d7434dd32a4L124-L129) [[3]](diffhunk://#diff-f551a250f681b2d907a8a1e1f9ca3fb92df87e9ab0845b03a3b01d7434dd32a4L167-L175)

Related issue:

Address 18 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified OAuth2 authorization endpoint configuration, removing CORS-enabled handler wrappers and consolidating to direct GET route handling. Callback endpoint CORS configuration remains unaffected by this change.

* **Tests**
  * Removed test cases that verified CORS OPTIONS request handling behavior for the OAuth2 authorization endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->