### PR TITLE
Add `WWW-Authenticate` for client auth errors

### DIFF
--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -290,8 +290,6 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidAuthorizationHeader() 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
 	assert.Equal(suite.T(), errInvalidAuthorizationHeader, authErr)
-	assert.NotNil(suite.T(), authErr.ResponseHeaders)
-	assert.Equal(suite.T(), "Basic", authErr.ResponseHeaders["WWW-Authenticate"])
 }
 
 func (suite *ClientAuthTestSuite) TestAuthenticate_BothHeaderAndBody() {

--- a/backend/internal/oauth/oauth2/clientauth/error.go
+++ b/backend/internal/oauth/oauth2/clientauth/error.go
@@ -29,7 +29,6 @@ type authError struct {
 	ErrorCode        string
 	ErrorDescription string
 	StatusCode       int
-	ResponseHeaders  map[string]string
 }
 
 // newAuthError creates a new authentication error.
@@ -41,23 +40,12 @@ func newAuthError(errorCode, errorDescription string, statusCode int) *authError
 	}
 }
 
-// newAuthErrorWithHeaders creates a new authentication error with response headers.
-func newAuthErrorWithHeaders(errorCode, errorDescription string, statusCode int, headers map[string]string) *authError {
-	return &authError{
-		ErrorCode:        errorCode,
-		ErrorDescription: errorDescription,
-		StatusCode:       statusCode,
-		ResponseHeaders:  headers,
-	}
-}
-
 // Common authentication errors
 var (
-	errInvalidAuthorizationHeader = newAuthErrorWithHeaders(
+	errInvalidAuthorizationHeader = newAuthError(
 		constants.ErrorInvalidClient,
 		"Invalid client credentials",
 		http.StatusUnauthorized,
-		map[string]string{"WWW-Authenticate": "Basic"},
 	)
 	errInvalidClientCredentials = newAuthError(
 		constants.ErrorInvalidClient,

--- a/backend/internal/oauth/oauth2/clientauth/middleware.go
+++ b/backend/internal/oauth/oauth2/clientauth/middleware.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/discovery"
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/utils"
 )
@@ -35,10 +36,14 @@ func ClientAuthMiddleware(appService application.ApplicationServiceInterface, jw
 			// Authenticate client
 			clientInfo, authErr := authenticate(r, appService, jwtService, discoveryService)
 			if authErr != nil {
-				// Convert headers to the format expected by WriteJSONError
+				// If the client attempted to authenticate via the Authorization
+				// header, include WWW-Authenticate in 401 responses.
 				var respHeaders []map[string]string
-				if len(authErr.ResponseHeaders) > 0 {
-					respHeaders = []map[string]string{authErr.ResponseHeaders}
+				if authErr.StatusCode == http.StatusUnauthorized &&
+					r.Header.Get(serverconst.AuthorizationHeaderName) != "" {
+					respHeaders = []map[string]string{
+						{serverconst.WWWAuthenticateHeaderName: "Basic"},
+					}
 				}
 				// Write error response
 				utils.WriteJSONError(

--- a/backend/internal/oauth/oauth2/clientauth/middleware_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/middleware_test.go
@@ -315,3 +315,94 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_ContextProp
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
 	assert.NotNil(suite.T(), clientInfo)
 }
+
+// Tests for RFC 6749 §5.2: WWW-Authenticate header on 401 responses when client used Authorization header.
+
+func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_BasicAuth_401_IncludesWWWAuthenticate() {
+	// Client not found with Basic auth should include WWW-Authenticate: Basic
+	suite.mockAppService.On("GetOAuthApplication", testClientID).
+		Return(nil, nil).Once()
+
+	middleware := ClientAuthMiddleware(suite.mockAppService, suite.mockJwtService, suite.mockDiscoveryService)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.SetBasicAuth(testClientID, testClientSecret)
+	w := httptest.NewRecorder()
+
+	middleware(handler).ServeHTTP(w, req)
+
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	assert.Equal(suite.T(), "Basic", w.Header().Get("WWW-Authenticate"))
+}
+
+func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_BasicAuth_InvalidCreds_IncludesWWWAuth() {
+	clientSecret := testClientSecret
+	hashedSecret := hash.GenerateThumbprintFromString(clientSecret)
+	mockApp := &appmodel.OAuthAppConfigProcessedDTO{
+		ClientID:                testClientID,
+		HashedClientSecret:      hashedSecret,
+		TokenEndpointAuthMethod: constants.TokenEndpointAuthMethodClientSecretBasic,
+		GrantTypes:              []constants.GrantType{constants.GrantTypeAuthorizationCode},
+	}
+
+	suite.mockAppService.On("GetOAuthApplication", testClientID).
+		Return(mockApp, nil).Once()
+
+	middleware := ClientAuthMiddleware(suite.mockAppService, suite.mockJwtService, suite.mockDiscoveryService)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.SetBasicAuth(testClientID, "wrong-secret")
+	w := httptest.NewRecorder()
+
+	middleware(handler).ServeHTTP(w, req)
+
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	assert.Equal(suite.T(), "Basic", w.Header().Get("WWW-Authenticate"))
+}
+
+func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_PostAuth_401_NoWWWAuthenticate() {
+	// Client not found with POST body auth should not include WWW-Authenticate
+	suite.mockAppService.On("GetOAuthApplication", "non-existent").
+		Return(nil, nil).Once()
+
+	middleware := ClientAuthMiddleware(suite.mockAppService, suite.mockJwtService, suite.mockDiscoveryService)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	formData := url.Values{}
+	formData.Set("client_id", "non-existent")
+	formData.Set("client_secret", testClientSecret)
+
+	req := httptest.NewRequest("POST", "/test", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	middleware(handler).ServeHTTP(w, req)
+
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	assert.Empty(suite.T(), w.Header().Get("WWW-Authenticate"))
+}
+
+func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_InvalidBasicAuth_IncludesWWWAuthenticate() {
+	// Invalid Basic auth header format should include WWW-Authenticate: Basic
+	middleware := ClientAuthMiddleware(suite.mockAppService, suite.mockJwtService, suite.mockDiscoveryService)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	w := httptest.NewRecorder()
+
+	middleware(handler).ServeHTTP(w, req)
+
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	assert.Equal(suite.T(), "Basic", w.Header().Get("WWW-Authenticate"))
+}

--- a/backend/internal/oauth/oauth2/userinfo/handler.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler.go
@@ -19,6 +19,7 @@
 package userinfo
 
 import (
+	"fmt"
 	"net/http"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
@@ -51,8 +52,12 @@ func (h *userInfoHandler) HandleUserInfo(w http.ResponseWriter, r *http.Request)
 	authHeader := r.Header.Get(serverconst.AuthorizationHeaderName)
 	accessToken, err := utils.ExtractBearerToken(authHeader)
 	if err != nil {
-		utils.WriteJSONError(w, constants.ErrorInvalidRequest,
-			err.Error(), http.StatusUnauthorized, nil)
+		if authHeader == "" || !utils.IsBearerAuth(authHeader) {
+			w.Header().Set(serverconst.WWWAuthenticateHeaderName, serverconst.TokenTypeBearer)
+			w.WriteHeader(http.StatusUnauthorized)
+		} else {
+			writeBearerError(w, constants.ErrorInvalidRequest, err.Error(), http.StatusBadRequest)
+		}
 		return
 	}
 
@@ -93,5 +98,16 @@ func (h *userInfoHandler) writeServiceErrorResponse(w http.ResponseWriter, svcEr
 		statusCode = http.StatusUnauthorized
 	}
 
-	utils.WriteJSONError(w, svcErr.Code, svcErr.ErrorDescription, statusCode, nil)
+	if statusCode == http.StatusInternalServerError {
+		utils.WriteJSONError(w, constants.ErrorServerError, serviceerror.InternalServerError.Error, statusCode, nil)
+	} else {
+		writeBearerError(w, svcErr.Code, svcErr.ErrorDescription, statusCode)
+	}
+}
+
+// writeBearerError writes a JSON error response with a WWW-Authenticate: Bearer header.
+func writeBearerError(w http.ResponseWriter, errorCode, errorDescription string, statusCode int) {
+	wwwAuth := fmt.Sprintf("Bearer error=%q, error_description=%q", errorCode, errorDescription)
+	utils.WriteJSONError(w, errorCode, errorDescription, statusCode,
+		[]map[string]string{{serverconst.WWWAuthenticateHeaderName: wwwAuth}})
 }

--- a/backend/internal/oauth/oauth2/userinfo/handler_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler_test.go
@@ -46,7 +46,7 @@ func (s *UserInfoHandlerTestSuite) SetupTest() {
 	s.handler = newUserInfoHandler(s.mockService)
 }
 
-// TestHandleUserInfo_MissingAuthorizationHeader tests missing Authorization header
+// TestHandleUserInfo_MissingAuthorizationHeader tests missing Authorization header.
 func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_MissingAuthorizationHeader() {
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
 	rr := httptest.NewRecorder()
@@ -54,11 +54,11 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_MissingAuthorizationHeader
 	s.handler.HandleUserInfo(rr, req)
 
 	assert.Equal(s.T(), http.StatusUnauthorized, rr.Code)
-	assert.Contains(s.T(), rr.Body.String(), constants.ErrorInvalidRequest)
-	assert.Contains(s.T(), rr.Body.String(), "missing Authorization header")
+	assert.Equal(s.T(), "Bearer", rr.Header().Get("WWW-Authenticate"))
+	assert.Empty(s.T(), rr.Body.String())
 }
 
-// TestHandleUserInfo_InvalidAuthorizationHeaderFormat tests invalid Authorization header format
+// TestHandleUserInfo_InvalidAuthorizationHeaderFormat tests invalid Authorization header format.
 func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_InvalidAuthorizationHeaderFormat() {
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
 	req.Header.Set("Authorization", "InvalidFormat token123")
@@ -67,11 +67,12 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_InvalidAuthorizationHeader
 	s.handler.HandleUserInfo(rr, req)
 
 	assert.Equal(s.T(), http.StatusUnauthorized, rr.Code)
-	assert.Contains(s.T(), rr.Body.String(), constants.ErrorInvalidRequest)
-	assert.Contains(s.T(), rr.Body.String(), "invalid Authorization header format")
+	assert.Equal(s.T(), "Bearer", rr.Header().Get("WWW-Authenticate"))
+	assert.Empty(s.T(), rr.Body.String())
 }
 
-// TestHandleUserInfo_MissingBearerToken tests missing Bearer token
+// TestHandleUserInfo_MissingBearerToken tests missing Bearer token.
+// RFC 6750 §3.1: Malformed Bearer request should return 400 with invalid_request.
 func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_MissingBearerToken() {
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
 	req.Header.Set("Authorization", "Bearer ")
@@ -79,41 +80,24 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_MissingBearerToken() {
 
 	s.handler.HandleUserInfo(rr, req)
 
-	assert.Equal(s.T(), http.StatusUnauthorized, rr.Code)
+	assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
 	assert.Contains(s.T(), rr.Body.String(), constants.ErrorInvalidRequest)
 	assert.Contains(s.T(), rr.Body.String(), "missing access token")
+	wwwAuth := rr.Header().Get("WWW-Authenticate")
+	assert.Contains(s.T(), wwwAuth, "Bearer")
+	assert.Contains(s.T(), wwwAuth, constants.ErrorInvalidRequest)
 }
 
 // TestHandleUserInfo_InvalidToken tests invalid token error
 func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_InvalidToken() {
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
-	req.Header.Set("Authorization", "Bearer invalid-token")
-	rr := httptest.NewRecorder()
-
-	s.mockService.On("GetUserInfo", mock.Anything, "invalid-token").Return(nil, &errorInvalidAccessToken)
-
-	s.handler.HandleUserInfo(rr, req)
-
-	assert.Equal(s.T(), http.StatusUnauthorized, rr.Code)
-	assert.Contains(s.T(), rr.Body.String(), errorInvalidAccessToken.Code)
-	assert.Contains(s.T(), rr.Body.String(), errorInvalidAccessToken.ErrorDescription)
-	s.mockService.AssertExpectations(s.T())
+	s.assertServiceErrorResponse("invalid-token", &errorInvalidAccessToken,
+		http.StatusUnauthorized, "invalid_token")
 }
 
 // TestHandleUserInfo_MissingSubClaim tests missing sub claim error
 func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_MissingSubClaim() {
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
-	req.Header.Set("Authorization", "Bearer token123")
-	rr := httptest.NewRecorder()
-
-	s.mockService.On("GetUserInfo", mock.Anything, "token123").Return(nil, &errorMissingSubClaim)
-
-	s.handler.HandleUserInfo(rr, req)
-
-	assert.Equal(s.T(), http.StatusUnauthorized, rr.Code)
-	assert.Contains(s.T(), rr.Body.String(), errorMissingSubClaim.Code)
-	assert.Contains(s.T(), rr.Body.String(), errorMissingSubClaim.ErrorDescription)
-	s.mockService.AssertExpectations(s.T())
+	s.assertServiceErrorResponse("token123", &errorMissingSubClaim,
+		http.StatusUnauthorized, "invalid_token")
 }
 
 // TestHandleUserInfo_ServerError tests server error
@@ -129,9 +113,18 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_ServerError() {
 	s.handler.HandleUserInfo(rr, req)
 
 	assert.Equal(s.T(), http.StatusInternalServerError, rr.Code)
-	assert.Contains(s.T(), rr.Body.String(), expectedError.Code)
-	assert.Contains(s.T(), rr.Body.String(), expectedError.ErrorDescription)
+	assert.Contains(s.T(), rr.Body.String(), "server_error")
+	assert.Contains(s.T(), rr.Body.String(), serviceerror.InternalServerError.Error)
+	assert.NotContains(s.T(), rr.Body.String(), expectedError.ErrorDescription)
+	// Server errors should not include WWW-Authenticate
+	assert.Empty(s.T(), rr.Header().Get("WWW-Authenticate"))
 	s.mockService.AssertExpectations(s.T())
+}
+
+// TestHandleUserInfo_InsufficientScope tests insufficient scope error returns 403 with WWW-Authenticate
+func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_InsufficientScope() {
+	s.assertServiceErrorResponse("token123", &errorInsufficientScope,
+		http.StatusForbidden, "insufficient_scope")
 }
 
 // TestHandleUserInfo_Success tests successful response
@@ -257,7 +250,8 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_EmptyResponse() {
 	s.mockService.AssertExpectations(s.T())
 }
 
-// TestHandleUserInfo_InvalidAuthorizationHeaderSinglePart tests invalid Authorization header with only one part
+// TestHandleUserInfo_InvalidAuthorizationHeaderSinglePart tests "Bearer" without a token.
+// RFC 6750 §3.1: Malformed Bearer request should return 400 with invalid_request.
 func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_InvalidAuthorizationHeaderSinglePart() {
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
 	req.Header.Set("Authorization", "Bearer")
@@ -265,7 +259,7 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_InvalidAuthorizationHeader
 
 	s.handler.HandleUserInfo(rr, req)
 
-	assert.Equal(s.T(), http.StatusUnauthorized, rr.Code)
+	assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
 	assert.Contains(s.T(), rr.Body.String(), constants.ErrorInvalidRequest)
 	assert.Contains(s.T(), rr.Body.String(), "invalid Authorization header format")
 }
@@ -314,6 +308,32 @@ func (s *UserInfoHandlerTestSuite) TestWriteServiceErrorResponse_DefaultCase() {
 	assert.Equal(s.T(), http.StatusUnauthorized, rr.Code)
 	assert.Contains(s.T(), rr.Body.String(), "unknown_error")
 	assert.Contains(s.T(), rr.Body.String(), "An unknown error occurred")
+	// RFC 6750 §3: WWW-Authenticate header must be present on 401 responses
+	wwwAuth := rr.Header().Get("WWW-Authenticate")
+	assert.Contains(s.T(), wwwAuth, "Bearer")
+	assert.Contains(s.T(), wwwAuth, "unknown_error")
+	s.mockService.AssertExpectations(s.T())
+}
+
+// assertServiceErrorResponse is a helper to test service error responses with WWW-Authenticate headers.
+func (s *UserInfoHandlerTestSuite) assertServiceErrorResponse(
+	token string, svcErr *serviceerror.ServiceError, expectedStatus int, expectedWWWAuthError string,
+) {
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	s.mockService.On("GetUserInfo", mock.Anything, token).Return(nil, svcErr)
+
+	s.handler.HandleUserInfo(rr, req)
+
+	assert.Equal(s.T(), expectedStatus, rr.Code)
+	assert.Contains(s.T(), rr.Body.String(), svcErr.Code)
+	assert.Contains(s.T(), rr.Body.String(), svcErr.ErrorDescription)
+	// RFC 6750 §3: WWW-Authenticate header must be present on error responses
+	wwwAuth := rr.Header().Get("WWW-Authenticate")
+	assert.Contains(s.T(), wwwAuth, "Bearer")
+	assert.Contains(s.T(), wwwAuth, expectedWWWAuthError)
 	s.mockService.AssertExpectations(s.T())
 }
 

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -53,6 +53,9 @@ const ContentTypeJWT = "application/jwt"
 // ContentTypeFormURLEncoded is the content type for form-urlencoded data.
 const ContentTypeFormURLEncoded = "application/x-www-form-urlencoded"
 
+// WWWAuthenticateHeaderName is the name of the WWW-Authenticate header used in HTTP responses.
+const WWWAuthenticateHeaderName = "WWW-Authenticate"
+
 // CacheControlHeaderName is the name of the cache-control header used in HTTP responses.
 const CacheControlHeaderName = "Cache-Control"
 

--- a/backend/internal/system/security/middleware.go
+++ b/backend/internal/system/security/middleware.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net/http"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
@@ -59,7 +60,7 @@ func writeSecurityError(w http.ResponseWriter, err error) {
 		description = "Authentication is required to access this resource"
 		statusCode = http.StatusUnauthorized
 		// Set WWW-Authenticate header for 401 responses
-		w.Header().Set("WWW-Authenticate", "Bearer")
+		w.Header().Set(serverconst.WWWAuthenticateHeaderName, serverconst.TokenTypeBearer)
 	} else if errors.Is(err, errForbidden) || errors.Is(err, errInsufficientPermissions) {
 		code = "forbidden"
 		description = "You do not have sufficient permissions to access this resource"
@@ -68,7 +69,7 @@ func writeSecurityError(w http.ResponseWriter, err error) {
 		code = "unauthorized"
 		description = "Authentication failed"
 		statusCode = http.StatusUnauthorized
-		w.Header().Set("WWW-Authenticate", "Bearer")
+		w.Header().Set(serverconst.WWWAuthenticateHeaderName, serverconst.TokenTypeBearer)
 	}
 
 	// Use the existing WriteJSONError utility

--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -162,6 +162,12 @@ func SanitizeStringMap(inputs map[string]string) map[string]string {
 	return sanitized
 }
 
+// IsBearerAuth checks if the Authorization header uses the Bearer scheme (case-insensitive).
+func IsBearerAuth(authHeader string) bool {
+	parts := strings.SplitN(authHeader, " ", 2)
+	return len(parts) >= 1 && strings.EqualFold(parts[0], constants.TokenTypeBearer)
+}
+
 // ExtractBearerToken extracts the Bearer token from the Authorization header value.
 // It validates that the header is not empty, starts with "Bearer" (case-insensitive),
 // and contains a non-empty token. Returns the token and an error if validation fails.

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -49,7 +49,7 @@ var (
 				"type": "string",
 			},
 			"password": map[string]interface{}{
-				"type": "string",
+				"type":       "string",
 				"credential": true,
 			},
 			"email": map[string]interface{}{
@@ -736,16 +736,12 @@ func (ts *UserInfoTestSuite) TestUserInfo_MissingToken() {
 	ts.Require().NoError(err, "Failed to call UserInfo endpoint")
 	defer resp.Body.Close()
 
-	// Should return 401 Unauthorized (OAuth2 spec: missing authentication returns 401)
+	// Should return 401 Unauthorized (RFC 6750 §3.1: missing authentication returns 401)
 	assert.Equal(ts.T(), http.StatusUnauthorized, resp.StatusCode, "Should return 401 for missing token")
 
-	// Parse error response
-	var errorResp map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&errorResp)
-	ts.Require().NoError(err, "Failed to parse error response")
-
-	// Verify error details
-	assert.Equal(ts.T(), "invalid_request", errorResp["error"], "Error should be invalid_request")
+	// RFC 6750 §3.1: bare WWW-Authenticate: Bearer challenge for missing auth
+	assert.Equal(ts.T(), "Bearer", resp.Header.Get("WWW-Authenticate"),
+		"Should include bare WWW-Authenticate: Bearer challenge")
 }
 
 func (ts *UserInfoTestSuite) TestUserInfo_SeparateAttributesConfiguration() {


### PR DESCRIPTION
This pull request improves standards compliance for OAuth2 and OpenID Connect error responses by ensuring that the `WWW-Authenticate` header is set correctly on relevant HTTP 401 and 403 responses, in line with RFC 6749 and RFC 6750. It also refactors how error headers are handled, adds comprehensive tests for these behaviors, and introduces utility constants for header names.

Key changes include:

**OAuth2 Client Authentication error handling:**

- Refactored the `authError` struct by removing the `ResponseHeaders` field and the `newAuthErrorWithHeaders` constructor, centralizing header logic in the middleware layer instead of error objects. [[1]](diffhunk://#diff-da3f4eb1e15438abb380580887d65e99b418b93cc86fe020902c2c255dfacf7dL32) [[2]](diffhunk://#diff-da3f4eb1e15438abb380580887d65e99b418b93cc86fe020902c2c255dfacf7dL44-L60)
- Updated the client authentication middleware to add `WWW-Authenticate: Basic` headers on 401 responses only when the client used the Authorization header, as required by RFC 6749 §5.2.

**OAuth2 UserInfo endpoint compliance:**

- Implemented a new `writeBearerError` helper to ensure all 401 and 403 responses from the UserInfo endpoint include a properly formatted `WWW-Authenticate: Bearer ...` header, as specified by RFC 6750 §3. [[1]](diffhunk://#diff-b5018a9d7de5b1412a365185e06629945fe856e3e39b3aba0441e6375bbe1c5eL54-R55) [[2]](diffhunk://#diff-b5018a9d7de5b1412a365185e06629945fe856e3e39b3aba0441e6375bbe1c5eR96-R107)
- Updated error handling in the UserInfo handler to use this helper, and expanded tests to verify the presence and correctness of the `WWW-Authenticate` header on all relevant error cases, including insufficient scope. [[1]](diffhunk://#diff-767de77648dd6cf3e517623688da70692890d216abb78994e57b05821b575a15R59-R62) [[2]](diffhunk://#diff-767de77648dd6cf3e517623688da70692890d216abb78994e57b05821b575a15R76-R79) [[3]](diffhunk://#diff-767de77648dd6cf3e517623688da70692890d216abb78994e57b05821b575a15R93-R96) [[4]](diffhunk://#diff-767de77648dd6cf3e517623688da70692890d216abb78994e57b05821b575a15R112-R115) [[5]](diffhunk://#diff-767de77648dd6cf3e517623688da70692890d216abb78994e57b05821b575a15R132-R135) [[6]](diffhunk://#diff-767de77648dd6cf3e517623688da70692890d216abb78994e57b05821b575a15R154-R175) [[7]](diffhunk://#diff-767de77648dd6cf3e517623688da70692890d216abb78994e57b05821b575a15R359-R362)

**Security middleware improvements:**

- Updated the security middleware to use a new constant for the `WWW-Authenticate` header name and value, improving maintainability and consistency. [[1]](diffhunk://#diff-8cddeaae8fee14e62f453efaa5979168e63ba472dc7cd97dc0804d04aab90734R25) [[2]](diffhunk://#diff-8cddeaae8fee14e62f453efaa5979168e63ba472dc7cd97dc0804d04aab90734L62-R63) [[3]](diffhunk://#diff-8cddeaae8fee14e62f453efaa5979168e63ba472dc7cd97dc0804d04aab90734L71-R72) [[4]](diffhunk://#diff-8b88d469a2fd29721fad307de14583016648bffae3c09be19ac462f0aaa81576R53-R55)

**Testing and standards coverage:**

- Added comprehensive tests for client authentication middleware to verify correct inclusion or omission of the `WWW-Authenticate` header based on authentication method and error type.

These changes collectively ensure that the API's error responses are standards-compliant and provide clear, actionable information to OAuth2 clients.

Related issue:
Address 4, 15 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth 2.0 compliance: 401/403 error responses now include RFC 6749 §5.2-compliant WWW-Authenticate headers for Basic and Bearer flows; 500 errors no longer include WWW-Authenticate.
  * Missing or malformed token responses consistently return Bearer challenges where appropriate.

* **Tests**
  * Expanded test coverage for 401/403 WWW-Authenticate behavior across Basic, POST form, invalid headers, and token/scope error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->