### PR TITLE
Fix i18n extractor for multiline string concatenations

### DIFF
--- a/tools/i18n-extractor/extractor.go
+++ b/tools/i18n-extractor/extractor.go
@@ -160,8 +160,8 @@ func (e *Extractor) extractMessageFromLiteral(lit *ast.CompositeLit, fset *token
 		}
 
 		// Extract the string value
-		strValue := e.extractStringValue(kv.Value)
-		if strValue == "" {
+		strValue, ok := e.extractStringValue(kv.Value)
+		if !ok {
 			continue
 		}
 
@@ -188,21 +188,40 @@ func (e *Extractor) extractMessageFromLiteral(lit *ast.CompositeLit, fset *token
 }
 
 // extractStringValue extracts the string value from an AST expression.
-func (e *Extractor) extractStringValue(expr ast.Expr) string {
-	basicLit, ok := expr.(*ast.BasicLit)
-	if !ok {
-		return ""
+// It handles single string literals, concatenated strings (e.g., "str1" + "str2"),
+// and parenthesized expressions (e.g., ("str1" + "str2")).
+// The bool return value disambiguates success (true) from failure (false),
+// allowing empty strings to be valid results.
+func (e *Extractor) extractStringValue(expr ast.Expr) (string, bool) {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return "", false
+		}
+		// Unquote the string literal
+		value, err := strconv.Unquote(v.Value)
+		if err != nil {
+			return "", false
+		}
+		return value, true
+	case *ast.BinaryExpr:
+		// Handle string concatenation: "str1" + "str2"
+		if v.Op != token.ADD {
+			return "", false
+		}
+		left, ok := e.extractStringValue(v.X)
+		if !ok {
+			return "", false
+		}
+		right, ok := e.extractStringValue(v.Y)
+		if !ok {
+			return "", false
+		}
+		return left + right, true
+	case *ast.ParenExpr:
+		// Handle parenthesized expressions: ("str1" + "str2")
+		return e.extractStringValue(v.X)
+	default:
+		return "", false
 	}
-
-	if basicLit.Kind != token.STRING {
-		return ""
-	}
-
-	// Unquote the string literal
-	value, err := strconv.Unquote(basicLit.Value)
-	if err != nil {
-		return ""
-	}
-
-	return value
 }

--- a/tools/i18n-extractor/extractor_test.go
+++ b/tools/i18n-extractor/extractor_test.go
@@ -127,3 +127,131 @@ var testMsg = core.I18nMessage{Key: "ignored", DefaultValue: "Ignored"}
 		t.Errorf("Not all keys found. Found: %v", foundKeys)
 	}
 }
+
+func TestExtractParenthesizedStringExpression(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir := t.TempDir()
+
+	// content with parenthesized string expressions
+	fileContent := `
+package main
+
+import "github.com/wso2/thunder/backend/internal/system/i18n/core"
+
+var msg1 = core.I18nMessage{
+    Key: ("paren.key"),
+    DefaultValue: ("Parenthesized value"),
+}
+
+var msg2 = core.I18nMessage{
+    Key: "paren.concat",
+    DefaultValue: ("first part " + "second part"),
+}
+`
+
+	// Create file
+	if err := os.WriteFile(filepath.Join(tempDir, "paren.go"), []byte(fileContent), 0644); err != nil {
+		t.Fatalf("Failed to create file: %v", err)
+	}
+
+	// Run extractor
+	extractor := NewExtractor(false)
+	messages, err := extractor.ExtractFromDirectory(tempDir)
+	if err != nil {
+		t.Fatalf("ExtractFromDirectory failed: %v", err)
+	}
+
+	if len(messages) != 2 {
+		t.Errorf("Expected 2 messages, got %d", len(messages))
+	}
+
+	expectedKeys := map[string]string{
+		"paren.key":    "Parenthesized value",
+		"paren.concat": "first part second part",
+	}
+
+	foundKeys := make(map[string]bool)
+	for _, msg := range messages {
+		if expectedVal, ok := expectedKeys[msg.Key]; ok {
+			if msg.DefaultValue != expectedVal {
+				t.Errorf("Mismatch value for key %s:\nexpected: %q\ngot: %q", msg.Key, expectedVal, msg.DefaultValue)
+			}
+			foundKeys[msg.Key] = true
+		} else {
+			t.Errorf("Unexpected key found: %s with value: %q", msg.Key, msg.DefaultValue)
+		}
+	}
+
+	if len(foundKeys) != 2 {
+		t.Errorf("Not all keys found. Found: %v", foundKeys)
+	}
+}
+
+func TestExtractMultilineStringConcatenation(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir := t.TempDir()
+
+	// content with multiline string concatenation
+	fileContent := `
+package main
+
+import "github.com/wso2/thunder/backend/internal/system/i18n/core"
+
+var msg1 = core.I18nMessage{
+    Key: "multiline.key",
+    DefaultValue: "This is a long string that spans " +
+        "multiple lines using concatenation",
+}
+
+var msg2 = core.I18nMessage{
+    Key: "single.line",
+    DefaultValue: "Single line value",
+}
+
+var msg3 = core.I18nMessage{
+    Key: "triple.concat",
+    DefaultValue: "First part " +
+        "second part " +
+        "third part",
+}
+`
+
+	// Create file
+	if err := os.WriteFile(filepath.Join(tempDir, "multiline.go"), []byte(fileContent), 0644); err != nil {
+		t.Fatalf("Failed to create file: %v", err)
+	}
+
+	// Run extractor
+	extractor := NewExtractor(false)
+	messages, err := extractor.ExtractFromDirectory(tempDir)
+	if err != nil {
+		t.Fatalf("ExtractFromDirectory failed: %v", err)
+	}
+
+	// Verify results
+	if len(messages) != 3 {
+		t.Errorf("Expected 3 messages, got %d", len(messages))
+	}
+
+	expectedKeys := map[string]string{
+		"multiline.key": "This is a long string that spans multiple lines using concatenation",
+		"single.line":   "Single line value",
+		"triple.concat": "First part second part third part",
+	}
+
+	foundKeys := make(map[string]bool)
+	for _, msg := range messages {
+		if expectedVal, ok := expectedKeys[msg.Key]; ok {
+			if msg.DefaultValue != expectedVal {
+				t.Errorf("Mismatch value for key %s:\nexpected: %q\ngot: %q", msg.Key, expectedVal, msg.DefaultValue)
+			}
+			foundKeys[msg.Key] = true
+		} else {
+			t.Errorf("Unexpected key found: %s with value: %q", msg.Key, msg.DefaultValue)
+		}
+	}
+
+	if len(foundKeys) != 3 {
+		t.Errorf("Not all keys found. Found: %v", foundKeys)
+	}
+}


### PR DESCRIPTION
### Purpose
This pull request enhances the i18n extractor tool by improving its ability to handle string concatenations in Go source files, ensuring that messages with multi-line or concatenated default values are correctly extracted. It also adds comprehensive tests to verify this new functionality.

### Approach
**Extractor logic improvements:**

* Updated the `extractStringValue` method in `extractor.go` to support extraction of string values from both single string literals and concatenated strings (e.g., `"str1" + "str2"`), including multi-line concatenations.

**Testing enhancements:**

* Added the `TestExtractMultilineStringConcatenation` test in `extractor_test.go` to validate that the extractor correctly parses and combines multi-line and multiple concatenated string literals in i18n message definitions.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved internationalization extraction to support concatenated and parenthesized string expressions.

* **Behavior Changes**
  * Extraction now fails explicitly when parts cannot be resolved, preventing partial/incorrect values.

* **Tests**
  * Added tests covering parenthesized expressions and multiline/concatenated string extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->