### PR TITLE
Add Client Secret regeneration functionality and related components

### DIFF
--- a/frontend/apps/thunder-develop/src/features/applications/api/useRegenerateClientSecret.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/api/useRegenerateClientSecret.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
+import {useConfig} from '@thunder/shared-contexts';
+import {useAsgardeo} from '@asgardeo/react';
+import type {Application} from '../models/application';
+import type {InboundAuthConfig} from '../models/inbound-auth';
+import ApplicationQueryKeys from '../constants/application-query-keys';
+
+/**
+ * Variables for the {@link useRegenerateClientSecret} mutation.
+ *
+ * @public
+ */
+export interface RegenerateSecretVariables {
+  /**
+   * The unique identifier of the application whose client secret will be regenerated
+   */
+  applicationId: string;
+}
+
+/**
+ * Result of the {@link useRegenerateClientSecret} mutation.
+ *
+ * @public
+ */
+export interface RegenerateSecretResult {
+  /**
+   * The updated application after client secret regeneration
+   */
+  application: Application;
+  /**
+   * The new client secret generated during regeneration
+   * This is only available immediately after regeneration and should be saved by the user
+   */
+  clientSecret: string;
+}
+
+/**
+ * Generates a cryptographically secure OAuth 2.0 client secret.
+ *
+ * @remarks
+ * Matches the backend implementation in `GenerateOAuth2ClientSecret()`:
+ * - 32 random bytes (256 bits of entropy) via the Web Crypto API
+ * - Encoded as base64url (URL-safe, no padding) using the same scheme as
+ *   Go's `base64.RawURLEncoding`
+ *
+ * The Web Crypto API (`crypto.getRandomValues`) is a CSPRNG available in all
+ * modern browsers and Node.js ≥ 15, making it the correct choice for
+ * security-sensitive values such as OAuth client secrets.
+ *
+ * @returns A base64url-encoded 32-byte (256-bit) client secret string
+ */
+function generateClientSecret(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+
+  // Convert to base64url without padding, matching Go's base64.RawURLEncoding
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+/**
+ * Custom React hook to regenerate an application's client secret.
+ *
+ * This hook handles the client secret regeneration process by:
+ * 1. Fetching the current application details
+ * 2. Generating a new client secret
+ * 3. Updating the application with the new client secret via the update API
+ *
+ * Upon successful regeneration, the cache is invalidated to ensure the UI
+ * reflects the latest changes.
+ *
+ * @remarks
+ * Currently, there is no dedicated API endpoint to regenerate a client secret.
+ * This hook uses the update application endpoint to regenerate the client secret.
+ * When a dedicated regenerate endpoint is implemented in the backend, this hook
+ * can be updated to use that endpoint without changing the UI components.
+ *
+ * @returns TanStack Query mutation object for regenerating client secrets with mutate function, loading state, and error information
+ *
+ * @example
+ * ```tsx
+ * function RegenerateButton({ applicationId }: { applicationId: string }) {
+ *   const regenerateSecret = useRegenerateClientSecret();
+ *
+ *   const handleRegenerate = () => {
+ *     regenerateSecret.mutate(
+ *       { applicationId },
+ *       {
+ *         onSuccess: ({ application, clientSecret }) => {
+ *           // Only log the non-sensitive identifier, never log the secret itself
+ *           console.log('Client secret regenerated for:', application.id);
+ *           // Display the new client secret to the user via a secure UI flow
+ *           // e.g.: showSecretModal(application.id, clientSecret);
+ *           void clientSecret; // Secret must be handled by the UI, not logged
+ *         },
+ *         onError: (error) => {
+ *           console.error('Failed to regenerate client secret:', error);
+ *         }
+ *       }
+ *     );
+ *   };
+ *
+ *   return (
+ *     <button onClick={handleRegenerate} disabled={regenerateSecret.isPending}>
+ *       {regenerateSecret.isPending ? 'Regenerating...' : 'Regenerate Client Secret'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @public
+ */
+export default function useRegenerateClientSecret(): UseMutationResult<
+  RegenerateSecretResult,
+  Error,
+  RegenerateSecretVariables
+> {
+  const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation<RegenerateSecretResult, Error, RegenerateSecretVariables>({
+    mutationFn: async ({applicationId}: RegenerateSecretVariables): Promise<RegenerateSecretResult> => {
+      const serverUrl: string = getServerUrl();
+
+      // Step 1: Fetch the current application details
+      const getResponse: {data: Application} = await http.request({
+        url: `${serverUrl}/applications/${applicationId}`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      const currentApplication = getResponse.data;
+
+      // Step 2: Generate a new client secret
+      const newClientSecret = generateClientSecret();
+
+      // Step 3: Prepare the update request with the new client secret
+      // Destructure to remove server-generated fields
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const {id, created_at: createdAt, updated_at: updatedAt, ...updateRequest} = currentApplication;
+
+      // Update the OAuth2 config with the new client secret
+      const inboundAuthConfig = updateRequest.inbound_auth_config;
+      const oauth2Config = Array.isArray(inboundAuthConfig)
+        ? inboundAuthConfig.find((config: InboundAuthConfig) => config.type === 'oauth2')
+        : undefined;
+
+      if (!oauth2Config) {
+        throw new Error('Application does not have an OAuth2 configuration. Cannot regenerate client secret.');
+      }
+
+      oauth2Config.config.client_secret = newClientSecret;
+
+      // Step 4: Update the application with the new client secret
+      const updateResponse: {data: Application} = await http.request({
+        url: `${serverUrl}/applications/${applicationId}`,
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify(updateRequest),
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return {
+        application: updateResponse.data,
+        clientSecret: newClientSecret,
+      };
+    },
+    onSuccess: (_data, variables) => {
+      // Invalidate and refetch the specific application
+      queryClient
+        .invalidateQueries({queryKey: [ApplicationQueryKeys.APPLICATION, variables.applicationId]})
+        .catch(() => {
+          // Ignore invalidation errors
+        });
+      // Invalidate and refetch applications list
+      queryClient.invalidateQueries({queryKey: [ApplicationQueryKeys.APPLICATIONS]}).catch(() => {
+        // Ignore invalidation errors
+      });
+    },
+  });
+}

--- a/frontend/apps/thunder-develop/src/features/applications/components/ClientSecretSuccessDialog.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/ClientSecretSuccessDialog.tsx
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useState, useRef, useEffect, type JSX} from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogActions,
+  Button,
+  Alert,
+  Box,
+  Typography,
+  TextField,
+  IconButton,
+  InputAdornment,
+  Stack,
+} from '@wso2/oxygen-ui';
+import {Copy, Eye, EyeOff, AlertTriangle} from '@wso2/oxygen-ui-icons-react';
+import {useTranslation} from 'react-i18next';
+
+/**
+ * Props for the {@link ClientSecretSuccessDialog} component.
+ */
+export interface ClientSecretSuccessDialogProps {
+  /**
+   * Whether the dialog is open
+   */
+  open: boolean;
+  /**
+   * The new client secret to display
+   */
+  clientSecret: string;
+  /**
+   * Callback when the dialog should be closed
+   */
+  onClose: () => void;
+}
+
+/**
+ * Dialog component for displaying the new client secret after successful regeneration.
+ *
+ * This dialog shows the new client secret with a copy button and warns users
+ * that the secret will not be shown again after closing the dialog.
+ *
+ * @param props - Component props
+ * @returns The client secret success dialog
+ */
+export default function ClientSecretSuccessDialog({
+  open,
+  clientSecret,
+  onClose,
+}: ClientSecretSuccessDialogProps): JSX.Element {
+  const {t} = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const [showSecret, setShowSecret] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Clear the copy timeout on unmount to prevent state updates after unmount
+  useEffect(() => () => clearTimeout(copyTimeoutRef.current), []);
+
+  const handleCopy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(clientSecret);
+      setCopied(true);
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Failed to copy - user can manually select and copy
+    }
+  };
+
+  const handleToggleVisibility = (): void => {
+    setShowSecret(!showSecret);
+  };
+
+  const handleClose = (): void => {
+    clearTimeout(copyTimeoutRef.current);
+    setCopied(false);
+    setShowSecret(false);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogContent>
+        <Stack direction="column" spacing={3} sx={{width: '100%', pt: 2}}>
+          {/* Warning Icon */}
+          <Box
+            sx={{
+              width: 64,
+              height: 64,
+              borderRadius: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              alignSelf: 'center',
+            }}
+          >
+            <AlertTriangle size={64} color="var(--mui-palette-warning-main)" />
+          </Box>
+
+          {/* Header */}
+          <Stack direction="column" spacing={1} sx={{textAlign: 'center'}}>
+            <Typography variant="h5" component="h2">
+              {t('applications:regenerateSecret.success.title')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t('applications:regenerateSecret.success.subtitle')}
+            </Typography>
+          </Stack>
+
+          {/* Client Secret Card */}
+          <Box
+            sx={{
+              p: 3,
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1,
+            }}
+          >
+            <Box>
+              <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 1}}>
+                {t('applications:regenerateSecret.success.secretLabel')}
+              </Typography>
+              <TextField
+                fullWidth
+                type={showSecret ? 'text' : 'password'}
+                value={clientSecret}
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={handleToggleVisibility}
+                          edge="end"
+                          size="small"
+                          aria-label={t('applications:regenerateSecret.success.toggleVisibility')}
+                        >
+                          {showSecret ? <EyeOff size={16} /> : <Eye size={16} />}
+                        </IconButton>
+                        <IconButton
+                          onClick={() => {
+                            handleCopy().catch(() => {
+                              // Error is handled silently
+                            });
+                          }}
+                          edge="end"
+                          size="small"
+                          sx={{ml: 0.5}}
+                          aria-label={t('applications:regenerateSecret.success.copyButton')}
+                        >
+                          <Copy size={16} />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                    sx: {
+                      fontFamily: 'monospace',
+                      fontSize: '0.875rem',
+                    },
+                  },
+                }}
+              />
+            </Box>
+          </Box>
+
+          {/* Security Reminder Alert */}
+          <Alert severity="warning" icon={<AlertTriangle size={20} />}>
+            <Typography variant="body2" sx={{fontWeight: 'medium', mb: 1}}>
+              {t('applications:regenerateSecret.success.securityReminder.title')}
+            </Typography>
+            <Typography variant="body2">
+              {t('applications:regenerateSecret.success.securityReminder.description')}
+            </Typography>
+          </Alert>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{px: 3, pb: 3, pt: 1}}>
+        <Stack direction="row" spacing={2} sx={{width: '100%'}}>
+          <Button
+            variant="contained"
+            fullWidth
+            startIcon={<Copy size={16} />}
+            onClick={() => {
+              handleCopy().catch(() => {
+                // Error is handled silently
+              });
+            }}
+            disabled={copied}
+          >
+            {copied
+              ? t('applications:regenerateSecret.success.copied')
+              : t('applications:regenerateSecret.success.copySecret')}
+          </Button>
+          <Button variant="outlined" fullWidth onClick={handleClose}>
+            {t('common:actions.done')}
+          </Button>
+        </Stack>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/apps/thunder-develop/src/features/applications/components/RegenerateSecretDialog.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/RegenerateSecretDialog.tsx
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useState, useEffect, type JSX} from 'react';
+import {Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Alert} from '@wso2/oxygen-ui';
+import {useTranslation} from 'react-i18next';
+import {useLogger} from '@thunder/logger';
+import useRegenerateClientSecret from '../api/useRegenerateClientSecret';
+
+/**
+ * Props for the {@link RegenerateSecretDialog} component.
+ */
+export interface RegenerateSecretDialogProps {
+  /**
+   * Whether the dialog is open
+   */
+  open: boolean;
+  /**
+   * The ID of the application whose client secret will be regenerated
+   */
+  applicationId: string | null;
+  /**
+   * Callback when the dialog should be closed
+   */
+  onClose: () => void;
+  /**
+   * Callback when the client secret is successfully regenerated with the new client secret
+   */
+  onSuccess?: (newClientSecret: string) => void;
+  /**
+   * Callback when the regeneration fails
+   */
+  onError?: (message: string) => void;
+}
+
+/**
+ * Dialog component for confirming client secret regeneration.
+ *
+ * This dialog warns users about the consequences of regenerating an application's
+ * client secret before proceeding with the action.
+ *
+ * @param props - Component props
+ * @returns The regenerate client secret confirmation dialog
+ */
+export default function RegenerateSecretDialog({
+  open,
+  applicationId,
+  onClose,
+  onSuccess = undefined,
+  onError = undefined,
+}: RegenerateSecretDialogProps): JSX.Element {
+  const {t} = useTranslation();
+  const logger = useLogger('RegenerateSecretDialog');
+  const [error, setError] = useState<string | null>(null);
+  const regenerateClientSecret = useRegenerateClientSecret();
+
+  // Reset error state when dialog is opened
+  useEffect(() => {
+    if (open) {
+      setError(null);
+    }
+  }, [open]);
+
+  const handleCancel = (): void => {
+    setError(null);
+    onClose();
+  };
+
+  const handleConfirm = (): void => {
+    if (!applicationId) {
+      setError(t('applications:regenerateSecret.dialog.error'));
+      return;
+    }
+
+    setError(null);
+    logger.info('Regenerating application client secret', {applicationId});
+
+    regenerateClientSecret.mutate(
+      {applicationId},
+      {
+        onSuccess: ({clientSecret}) => {
+          logger.info('Application client secret regenerated successfully. New client secret generated.', {
+            applicationId,
+          });
+          onClose();
+          onSuccess?.(clientSecret);
+        },
+        onError: (err) => {
+          const errorMessage = err instanceof Error ? err.message : t('applications:regenerateSecret.dialog.error');
+          logger.error('Failed to regenerate client secret', {
+            applicationId,
+            errorMessage,
+            errorName: err instanceof Error ? err.name : 'UnknownError',
+          });
+          setError(errorMessage);
+          onError?.(errorMessage);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('applications:regenerateSecret.dialog.title')}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{mb: 2}}>{t('applications:regenerateSecret.dialog.message')}</DialogContentText>
+        <Alert severity="warning" sx={{mb: 2}}>
+          {t('applications:regenerateSecret.dialog.disclaimer')}
+        </Alert>
+        {error && (
+          <Alert severity="error" sx={{mt: 2}}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} disabled={regenerateClientSecret.isPending}>
+          {t('common:actions.cancel')}
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          color="error"
+          variant="contained"
+          disabled={regenerateClientSecret.isPending || !applicationId}
+        >
+          {regenerateClientSecret.isPending
+            ? t('applications:regenerateSecret.dialog.regenerating')
+            : t('applications:regenerateSecret.dialog.confirmButton')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/apps/thunder-develop/src/features/applications/components/__tests__/ClientSecretSuccessDialog.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/__tests__/ClientSecretSuccessDialog.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, waitFor} from '@thunder/test-utils';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import userEvent from '@testing-library/user-event';
+import ClientSecretSuccessDialog from '../ClientSecretSuccessDialog';
+
+// Mock translations
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'applications:regenerateSecret.success.title': 'Save Your New Client Secret',
+        'applications:regenerateSecret.success.subtitle':
+          "This is the only time you'll see this secret. Store it somewhere safe.",
+        'applications:regenerateSecret.success.secretLabel': 'New Client Secret',
+        'applications:regenerateSecret.success.copyButton': 'Copy to clipboard',
+        'applications:regenerateSecret.success.toggleVisibility': 'Toggle secret visibility',
+        'applications:regenerateSecret.success.copySecret': 'Copy Secret',
+        'applications:regenerateSecret.success.copied': 'Copied to clipboard',
+        'applications:regenerateSecret.success.securityReminder.title': 'Security Reminder',
+        'applications:regenerateSecret.success.securityReminder.description':
+          'Never share your client secret publicly or store it in version control.',
+        'common:actions.done': 'Done',
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe('ClientSecretSuccessDialog', () => {
+  const mockOnClose = vi.fn();
+  const testClientSecret = 'test-client-secret-abc123xyz789';
+  // Stored at describe scope so assertions can reference it even after userEvent.setup()
+  // replaces navigator.clipboard with its own stub.
+  const mockWriteText = vi.fn().mockResolvedValue(undefined);
+
+  const defaultProps = {
+    open: true,
+    clientSecret: testClientSecret,
+    onClose: mockOnClose,
+  };
+
+  const renderDialog = (props = defaultProps) => render(<ClientSecretSuccessDialog {...props} />);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock clipboard API using defineProperty since navigator.clipboard is a getter-only property.
+    // Re-apply each time because userEvent.setup() may replace navigator.clipboard with its own stub.
+    mockWriteText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render the dialog when open is true', () => {
+      renderDialog();
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Save Your New Client Secret')).toBeInTheDocument();
+    });
+
+    it('should display the subtitle message', () => {
+      renderDialog();
+
+      expect(
+        screen.getByText("This is the only time you'll see this secret. Store it somewhere safe."),
+      ).toBeInTheDocument();
+    });
+
+    it('should display the client secret label', () => {
+      renderDialog();
+
+      expect(screen.getByText('New Client Secret')).toBeInTheDocument();
+    });
+
+    it('should have the client secret as a masked password field by default', () => {
+      renderDialog();
+
+      const textField = document.querySelector('input[type="password"]');
+      expect(textField).toBeInTheDocument();
+      expect(textField).toHaveValue(testClientSecret);
+    });
+
+    it('should display the security reminder', () => {
+      renderDialog();
+
+      expect(screen.getByText('Security Reminder')).toBeInTheDocument();
+      expect(
+        screen.getByText('Never share your client secret publicly or store it in version control.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should not render dialog content when open is false', () => {
+      renderDialog({...defaultProps, open: false});
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should render Done and Copy Secret buttons', () => {
+      renderDialog();
+
+      expect(screen.getByRole('button', {name: 'Done'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Copy Secret'})).toBeInTheDocument();
+    });
+
+    it('should render the warning icon', () => {
+      renderDialog();
+
+      // AlertTriangle icon should be present
+      const svgIcons = document.querySelectorAll('svg');
+      expect(svgIcons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('should call onClose when Done button is clicked', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      const doneButton = screen.getByRole('button', {name: 'Done'});
+      await user.click(doneButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when Escape key is pressed', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.keyboard('{Escape}');
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should copy client secret to clipboard when Copy Secret button is clicked', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      // Spy after userEvent.setup() so we intercept the clipboard stub it installs
+      const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+
+      const copyButton = screen.getByRole('button', {name: 'Copy Secret'});
+      await user.click(copyButton);
+
+      expect(writeTextSpy).toHaveBeenCalledWith(testClientSecret);
+    });
+
+    it('should copy client secret when inline copy icon is clicked', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      // Spy after userEvent.setup() so we intercept the clipboard stub it installs
+      const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+
+      const copyButton = screen.getByRole('button', {name: 'Copy to clipboard'});
+      await user.click(copyButton);
+
+      expect(writeTextSpy).toHaveBeenCalledWith(testClientSecret);
+    });
+
+    it('should show "Copied to clipboard" text after successful copy', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true});
+      const user = userEvent.setup({advanceTimers: vi.advanceTimersByTime});
+      renderDialog();
+
+      const copyButton = screen.getByRole('button', {name: 'Copy Secret'});
+      await user.click(copyButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Copied to clipboard')).toBeInTheDocument();
+      });
+
+      vi.useRealTimers();
+    });
+
+    it('should toggle secret visibility when visibility button is clicked', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      // Initially should be password type (masked)
+      const passwordField = document.querySelector('input[type="password"]');
+      expect(passwordField).toBeInTheDocument();
+
+      // Click toggle visibility button
+      const toggleButton = screen.getByRole('button', {name: 'Toggle secret visibility'});
+      await user.click(toggleButton);
+
+      // Should now be text type (visible)
+      const textField = document.querySelector('input[type="text"]');
+      expect(textField).toBeInTheDocument();
+      expect(textField).toHaveValue(testClientSecret);
+    });
+  });
+
+  describe('Text Field Properties', () => {
+    it('should have a readonly text field', () => {
+      renderDialog();
+
+      const textField = document.querySelector('input');
+      expect(textField).toHaveAttribute('readonly');
+    });
+
+    it('should display the full client secret when visible', async () => {
+      const user = userEvent.setup();
+      const longSecret = 'a'.repeat(64);
+      renderDialog({...defaultProps, clientSecret: longSecret});
+
+      // Toggle visibility to see the full secret
+      const toggleButton = screen.getByRole('button', {name: 'Toggle secret visibility'});
+      await user.click(toggleButton);
+
+      const textField = document.querySelector('input[type="text"]');
+      expect(textField).toHaveValue(longSecret);
+    });
+
+    it('should reset visibility state when dialog is closed and reopened', async () => {
+      const user = userEvent.setup();
+      const {rerender} = renderDialog();
+
+      // Toggle visibility
+      const toggleButton = screen.getByRole('button', {name: 'Toggle secret visibility'});
+      await user.click(toggleButton);
+
+      // Should be visible
+      expect(document.querySelector('input[type="text"]')).toBeInTheDocument();
+
+      // Click Done to close
+      const doneButton = screen.getByRole('button', {name: 'Done'});
+      await user.click(doneButton);
+
+      // Rerender with open: false then open: true
+      rerender(<ClientSecretSuccessDialog {...defaultProps} open={false} />);
+      rerender(<ClientSecretSuccessDialog {...defaultProps} open />);
+
+      // Should be masked again
+      expect(document.querySelector('input[type="password"]')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/apps/thunder-develop/src/features/applications/components/__tests__/RegenerateSecretDialog.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/__tests__/RegenerateSecretDialog.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, waitFor} from '@thunder/test-utils';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import userEvent from '@testing-library/user-event';
+import type {MutateOptions, MutationFunctionContext} from '@tanstack/react-query';
+import RegenerateSecretDialog from '../RegenerateSecretDialog';
+import type {RegenerateSecretDialogProps} from '../RegenerateSecretDialog';
+import type {RegenerateSecretVariables, RegenerateSecretResult} from '../../api/useRegenerateClientSecret';
+
+// Mock the logger
+vi.mock('@thunder/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunder/logger')>();
+  return {
+    ...actual,
+    useLogger: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  };
+});
+
+// Create a mock mutate function
+const mockMutate = vi.fn();
+const mockRegenerateClientSecret = {
+  mutate: mockMutate,
+  isPending: false,
+};
+
+// Mock useRegenerateClientSecret hook
+vi.mock('../../api/useRegenerateClientSecret', () => ({
+  default: () => mockRegenerateClientSecret,
+}));
+
+// Mock translations
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'applications:regenerateSecret.dialog.title': 'Regenerate Client Secret',
+        'applications:regenerateSecret.dialog.message':
+          'Are you sure you want to regenerate the client secret for this application? This will regenerate the client secret.',
+        'applications:regenerateSecret.dialog.disclaimer':
+          'This action will regenerate the client secret. All existing access tokens will be invalidated and the application will stop working until the new client secret is updated in your application configuration.',
+        'applications:regenerateSecret.dialog.confirmButton': 'Regenerate',
+        'applications:regenerateSecret.dialog.regenerating': 'Regenerating...',
+        'applications:regenerateSecret.dialog.error': 'Failed to regenerate client secret. Please try again.',
+        'common:actions.cancel': 'Cancel',
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe('RegenerateSecretDialog', () => {
+  const mockOnClose = vi.fn();
+  const mockOnSuccess = vi.fn();
+  const mockOnError = vi.fn();
+
+  const defaultProps: RegenerateSecretDialogProps = {
+    open: true,
+    applicationId: 'test-app-id',
+    onClose: mockOnClose,
+    onSuccess: mockOnSuccess,
+    onError: mockOnError,
+  };
+
+  const renderDialog = (props: RegenerateSecretDialogProps = defaultProps) =>
+    render(<RegenerateSecretDialog {...props} />);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegenerateClientSecret.isPending = false;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render the dialog when open is true', () => {
+      renderDialog();
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Regenerate Client Secret')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Are you sure you want to regenerate the client secret for this application? This will regenerate the client secret.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should show warning disclaimer', () => {
+      renderDialog();
+
+      expect(
+        screen.getByText(
+          'This action will regenerate the client secret. All existing access tokens will be invalidated and the application will stop working until the new client secret is updated in your application configuration.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should not render dialog content when open is false', () => {
+      renderDialog({...defaultProps, open: false});
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should render Cancel and Regenerate buttons', () => {
+      renderDialog();
+
+      expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Regenerate'})).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('should call onClose when Cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      const cancelButton = screen.getByRole('button', {name: 'Cancel'});
+      await user.click(cancelButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when Escape key is pressed', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.keyboard('{Escape}');
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call mutate when Regenerate button is clicked', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      const regenerateButton = screen.getByRole('button', {name: 'Regenerate'});
+      await user.click(regenerateButton);
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        {applicationId: 'test-app-id'},
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          onSuccess: expect.any(Function),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          onError: expect.any(Function),
+        }),
+      );
+    });
+
+    it('should not initiate regeneration when applicationId is null', async () => {
+      renderDialog({...defaultProps, applicationId: null});
+
+      const regenerateButton = screen.getByRole('button', {name: 'Regenerate'});
+
+      expect(regenerateButton).toBeDisabled();
+    });
+  });
+
+  describe('Success Flow', () => {
+    it('should call onSuccess with new client secret after successful regeneration', async () => {
+      // Mock mutate to immediately call onSuccess
+      mockMutate.mockImplementation(
+        (vars: RegenerateSecretVariables, options?: MutateOptions<RegenerateSecretResult, Error, RegenerateSecretVariables>) => {
+          const mockContext = {} as MutationFunctionContext;
+          options?.onSuccess?.({clientSecret: 'new-test-secret-123'} as RegenerateSecretResult, vars, undefined, mockContext);
+        },
+      );
+
+      const user = userEvent.setup();
+      renderDialog();
+
+      const regenerateButton = screen.getByRole('button', {name: 'Regenerate'});
+      await user.click(regenerateButton);
+
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled();
+        expect(mockOnSuccess).toHaveBeenCalledWith('new-test-secret-123');
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should display error message when regeneration fails', async () => {
+      // Mock mutate to immediately call onError
+      mockMutate.mockImplementation(
+        (vars: RegenerateSecretVariables, options?: MutateOptions<RegenerateSecretResult, Error, RegenerateSecretVariables>) => {
+          const mockContext = {} as MutationFunctionContext;
+          options?.onError?.(new Error('Failed to regenerate client secret. Please try again.'), vars, undefined, mockContext);
+        },
+      );
+
+      const user = userEvent.setup();
+      renderDialog();
+
+      const regenerateButton = screen.getByRole('button', {name: 'Regenerate'});
+      await user.click(regenerateButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to regenerate client secret. Please try again.')).toBeInTheDocument();
+      });
+    });
+
+    it('should call onError callback when regeneration fails', async () => {
+      // Mock mutate to immediately call onError
+      mockMutate.mockImplementation(
+        (vars: RegenerateSecretVariables, options?: MutateOptions<RegenerateSecretResult, Error, RegenerateSecretVariables>) => {
+          const mockContext = {} as MutationFunctionContext;
+          options?.onError?.(new Error('Failed to regenerate client secret. Please try again.'), vars, undefined, mockContext);
+        },
+      );
+
+      const user = userEvent.setup();
+      renderDialog();
+
+      const regenerateButton = screen.getByRole('button', {name: 'Regenerate'});
+      await user.click(regenerateButton);
+
+      await waitFor(() => {
+        expect(mockOnError).toHaveBeenCalledWith('Failed to regenerate client secret. Please try again.');
+      });
+    });
+  });
+});

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/DangerZoneSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/DangerZoneSection.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {JSX} from 'react';
+import {Typography, Button} from '@wso2/oxygen-ui';
+import {useTranslation} from 'react-i18next';
+import SettingsCard from '@/components/SettingsCard';
+
+/**
+ * Props for the {@link DangerZoneSection} component.
+ */
+interface DangerZoneSectionProps {
+  /**
+   * Callback function to open the regenerate client secret confirmation dialog
+   */
+  onRegenerateClick: () => void;
+}
+
+/**
+ * Section component displaying the danger zone with destructive actions.
+ *
+ * Displays a regenerate client secret button for rotating the application's client secret.
+ * This action will invalidate the current client secret and all existing tokens.
+ *
+ * @param props - Component props
+ * @returns Danger zone UI within a SettingsCard
+ */
+export default function DangerZoneSection({onRegenerateClick}: DangerZoneSectionProps): JSX.Element {
+  const {t} = useTranslation();
+
+  return (
+    <SettingsCard
+      title={t('applications:edit.general.sections.dangerZone.title')}
+      description={t('applications:edit.general.sections.dangerZone.description')}
+    >
+      <Typography variant="h6" gutterBottom color="error">
+        {t('applications:edit.general.sections.dangerZone.regenerateSecret.title')}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+        {t('applications:edit.general.sections.dangerZone.regenerateSecret.description')}
+      </Typography>
+      <Button variant="contained" color="error" onClick={onRegenerateClick}>
+        {t('applications:edit.general.sections.dangerZone.regenerateSecret.button')}
+      </Button>
+    </SettingsCard>
+  );
+}

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
@@ -16,11 +16,16 @@
  * under the License.
  */
 
+import {useState, useCallback} from 'react';
+import type {JSX} from 'react';
 import {Stack} from '@wso2/oxygen-ui';
 import type {Application} from '../../../models/application';
 import type {OAuth2Config} from '../../../models/oauth';
 import QuickCopySection from './QuickCopySection';
 import AccessSection from './AccessSection';
+import DangerZoneSection from './DangerZoneSection';
+import ClientSecretSuccessDialog from '../../ClientSecretSuccessDialog';
+import RegenerateSecretDialog from '../../RegenerateSecretDialog';
 
 /**
  * Props for the {@link EditGeneralSettings} component.
@@ -62,6 +67,7 @@ interface EditGeneralSettingsProps {
  * Displays sections for:
  * - Quick copy of application credentials (ID, Client ID)
  * - Access configuration (URL, redirect URIs, allowed user types)
+ * - Danger zone (regenerate client secret)
  *
  * @param props - Component props
  * @returns General settings sections wrapped in a Stack
@@ -73,21 +79,57 @@ export default function EditGeneralSettings({
   oauth2Config = undefined,
   copiedField,
   onCopyToClipboard,
-}: EditGeneralSettingsProps) {
+}: EditGeneralSettingsProps): JSX.Element {
+  const [regenerateDialogOpen, setRegenerateDialogOpen] = useState(false);
+  const [secretDialogOpen, setSecretDialogOpen] = useState(false);
+  const [newClientSecret, setNewClientSecret] = useState<string>('');
+
+  const handleRegenerateClick = useCallback((): void => {
+    setRegenerateDialogOpen(true);
+  }, []);
+
+  const handleRegenerateSuccess = useCallback((clientSecret: string): void => {
+    setNewClientSecret(clientSecret);
+    setSecretDialogOpen(true);
+  }, []);
+
+  const handleSecretDialogClose = useCallback((): void => {
+    setSecretDialogOpen(false);
+    setNewClientSecret('');
+  }, []);
+
   return (
-    <Stack spacing={3}>
-      <QuickCopySection
-        application={application}
-        oauth2Config={oauth2Config}
-        copiedField={copiedField}
-        onCopyToClipboard={onCopyToClipboard}
+    <>
+      <Stack spacing={3}>
+        <QuickCopySection
+          application={application}
+          oauth2Config={oauth2Config}
+          copiedField={copiedField}
+          onCopyToClipboard={onCopyToClipboard}
+        />
+        <AccessSection
+          application={application}
+          editedApp={editedApp}
+          oauth2Config={oauth2Config}
+          onFieldChange={onFieldChange}
+        />
+        <DangerZoneSection onRegenerateClick={handleRegenerateClick} />
+      </Stack>
+
+      {/* Regenerate Client Secret Confirmation Dialog */}
+      <RegenerateSecretDialog
+        open={regenerateDialogOpen}
+        applicationId={application.id}
+        onClose={() => setRegenerateDialogOpen(false)}
+        onSuccess={handleRegenerateSuccess}
       />
-      <AccessSection
-        application={application}
-        editedApp={editedApp}
-        oauth2Config={oauth2Config}
-        onFieldChange={onFieldChange}
+
+      {/* New Client Secret Success Dialog */}
+      <ClientSecretSuccessDialog
+        open={secretDialogOpen}
+        clientSecret={newClientSecret}
+        onClose={handleSecretDialogClose}
       />
-    </Stack>
+    </>
   );
 }

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/DangerZoneSection.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/DangerZoneSection.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {screen, fireEvent, renderWithProviders} from '@thunder/test-utils';
+import DangerZoneSection from '../DangerZoneSection';
+
+// Mock translations
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'applications:edit.general.sections.dangerZone.title': 'Danger Zone',
+        'applications:edit.general.sections.dangerZone.description':
+          'Irreversible and destructive actions for this application',
+        'applications:edit.general.sections.dangerZone.regenerateSecret.title': 'Regenerate Client Secret',
+        'applications:edit.general.sections.dangerZone.regenerateSecret.description':
+          'Regenerating the client secret will immediately invalidate the current client secret and generate a new one. All active access tokens will be revoked and the application will stop working until the new client secret is updated in your application configuration.',
+        'applications:edit.general.sections.dangerZone.regenerateSecret.button': 'Regenerate Client Secret',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('DangerZoneSection', () => {
+  const mockOnRegenerateClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the danger zone section', () => {
+    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+
+    expect(screen.getByText('Danger Zone')).toBeInTheDocument();
+    expect(screen.getByText('Irreversible and destructive actions for this application')).toBeInTheDocument();
+  });
+
+  it('should render revoke application title', () => {
+    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+
+    const heading = screen.getByRole('heading', {name: 'Regenerate Client Secret', level: 6});
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('should render warning description', () => {
+    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+
+    expect(
+      screen.getByText(
+        'Regenerating the client secret will immediately invalidate the current client secret and generate a new one. All active access tokens will be revoked and the application will stop working until the new client secret is updated in your application configuration.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render revoke button', () => {
+    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+
+    const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
+    expect(regenerateButton).toBeInTheDocument();
+  });
+
+  it('should call onRegenerateClick when revoke button is clicked', () => {
+    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+
+    const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
+    fireEvent.click(regenerateButton);
+
+    expect(mockOnRegenerateClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onRegenerateClick multiple times when clicked multiple times', () => {
+    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+
+    const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
+    fireEvent.click(regenerateButton);
+    fireEvent.click(regenerateButton);
+    fireEvent.click(regenerateButton);
+
+    expect(mockOnRegenerateClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('should render revoke button with error color', () => {
+    renderWithProviders(<DangerZoneSection onRegenerateClick={mockOnRegenerateClick} />);
+
+    const regenerateButton = screen.getByRole('button', {name: 'Regenerate Client Secret'});
+    expect(regenerateButton).toHaveClass('MuiButton-colorError');
+  });
+});

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/EditGeneralSettings.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/EditGeneralSettings.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import EditGeneralSettings from '../EditGeneralSettings';
 import type {Application} from '../../../../models/application';
 import type {OAuth2Config} from '../../../../models/oauth';
@@ -55,6 +55,51 @@ vi.mock('../AccessSection', () => ({
       {oauth2Config?.client_id ?? 'None'}
     </div>
   ),
+}));
+
+vi.mock('../DangerZoneSection', () => ({
+  default: ({onRegenerateClick}: {onRegenerateClick: () => void}) => (
+    <div data-testid="danger-zone-section">
+      <button type="button" onClick={onRegenerateClick} data-testid="regenerate-button">
+        Regenerate Client Secret
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../../../RegenerateSecretDialog', () => ({
+  default: ({
+    open,
+    applicationId,
+    onClose,
+    onSuccess,
+  }: {
+    open: boolean;
+    applicationId: string | null;
+    onClose: () => void;
+    onSuccess?: (clientSecret: string) => void;
+  }) =>
+    open ? (
+      <div data-testid="regenerate-dialog" data-application-id={applicationId}>
+        <button type="button" onClick={onClose} data-testid="dialog-close">
+          Close
+        </button>
+        <button type="button" onClick={() => onSuccess?.('new-test-secret')} data-testid="dialog-success">
+          Trigger Success
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../../ClientSecretSuccessDialog', () => ({
+  default: ({open, clientSecret, onClose}: {open: boolean; clientSecret: string; onClose: () => void}) =>
+    open ? (
+      <div data-testid="secret-dialog" data-client-secret={clientSecret}>
+        <button type="button" onClick={onClose} data-testid="secret-dialog-close">
+          Close Secret Dialog
+        </button>
+      </div>
+    ) : null,
 }));
 
 describe('EditGeneralSettings', () => {
@@ -245,6 +290,127 @@ describe('EditGeneralSettings', () => {
       const sections = container.querySelectorAll('[data-testid]');
       expect(sections[0]).toHaveAttribute('data-testid', 'quick-copy-section');
       expect(sections[1]).toHaveAttribute('data-testid', 'access-section');
+      expect(sections[2]).toHaveAttribute('data-testid', 'danger-zone-section');
+    });
+
+    it('should render DangerZoneSection', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      expect(screen.getByTestId('danger-zone-section')).toBeInTheDocument();
+    });
+  });
+
+  describe('Regenerate Secret Flow', () => {
+    it('should open regenerate dialog when regenerate button is clicked', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      const regenerateButton = screen.getByTestId('regenerate-button');
+      fireEvent.click(regenerateButton);
+
+      expect(screen.getByTestId('regenerate-dialog')).toBeInTheDocument();
+    });
+
+    it('should pass application id to regenerate dialog', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      const regenerateButton = screen.getByTestId('regenerate-button');
+      fireEvent.click(regenerateButton);
+
+      expect(screen.getByTestId('regenerate-dialog')).toHaveAttribute('data-application-id', 'app-123');
+    });
+
+    it('should close regenerate dialog when close is triggered', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      const regenerateButton = screen.getByTestId('regenerate-button');
+      fireEvent.click(regenerateButton);
+
+      expect(screen.getByTestId('regenerate-dialog')).toBeInTheDocument();
+
+      const closeButton = screen.getByTestId('dialog-close');
+      fireEvent.click(closeButton);
+
+      expect(screen.queryByTestId('regenerate-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should open secret dialog when regeneration is successful', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      const regenerateButton = screen.getByTestId('regenerate-button');
+      fireEvent.click(regenerateButton);
+
+      const successButton = screen.getByTestId('dialog-success');
+      fireEvent.click(successButton);
+
+      expect(screen.getByTestId('secret-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('secret-dialog')).toHaveAttribute('data-client-secret', 'new-test-secret');
+    });
+
+    it('should close secret dialog when close is triggered', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      // Open regenerate dialog and trigger success
+      const regenerateButton = screen.getByTestId('regenerate-button');
+      fireEvent.click(regenerateButton);
+
+      const successButton = screen.getByTestId('dialog-success');
+      fireEvent.click(successButton);
+
+      expect(screen.getByTestId('secret-dialog')).toBeInTheDocument();
+
+      // Close secret dialog
+      const closeSecretButton = screen.getByTestId('secret-dialog-close');
+      fireEvent.click(closeSecretButton);
+
+      expect(screen.queryByTestId('secret-dialog')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -797,6 +797,24 @@ const translations = {
     'delete.title': 'Delete Application',
     'delete.message': 'Are you sure you want to delete this application? This action cannot be undone.',
     'delete.disclaimer': 'Warning: All associated data, configurations, and access tokens will be permanently removed.',
+    'regenerateSecret.dialog.title': 'Regenerate Client Secret',
+    'regenerateSecret.dialog.message':
+      'Are you sure you want to regenerate the client secret for this application? This will immediately invalidate the current client secret and generate a new one.',
+    'regenerateSecret.dialog.disclaimer':
+      'Warning: Regenerating the client secret will invalidate the current secret and the application may stop working until the new client secret is updated in its configuration.',
+    'regenerateSecret.dialog.confirmButton': 'Regenerate',
+    'regenerateSecret.dialog.regenerating': 'Regenerating...',
+    'regenerateSecret.dialog.error': 'Failed to regenerate client secret. Please try again.',
+    'regenerateSecret.success.title': 'Save Your New Client Secret',
+    'regenerateSecret.success.subtitle': "This is the only time you'll see this secret. Store it somewhere safe.",
+    'regenerateSecret.success.secretLabel': 'New Client Secret',
+    'regenerateSecret.success.copyButton': 'Copy to clipboard',
+    'regenerateSecret.success.toggleVisibility': 'Toggle secret visibility',
+    'regenerateSecret.success.copySecret': 'Copy Secret',
+    'regenerateSecret.success.copied': 'Copied to clipboard',
+    'regenerateSecret.success.securityReminder.title': 'Security Reminder',
+    'regenerateSecret.success.securityReminder.description':
+      'Never share your client secret publicly or store it in version control. If you believe your secret has been compromised, regenerate it immediately.',
     'onboarding.preview.title': 'Preview',
     'onboarding.preview.signin': 'Sign In',
     'onboarding.preview.username': 'Username',
@@ -1120,6 +1138,12 @@ const translations = {
     'edit.general.allowedUserTypes.placeholder': 'Select user types',
     'edit.general.allowedUserTypes.hint': 'Users of these types can authenticate with this application',
     'edit.general.applicationUrl.hint': 'The homepage URL of your application',
+    'edit.general.sections.dangerZone.title': 'Danger Zone',
+    'edit.general.sections.dangerZone.description': 'Actions in this section are irreversible. Proceed with caution.',
+    'edit.general.sections.dangerZone.regenerateSecret.title': 'Regenerate Client Secret',
+    'edit.general.sections.dangerZone.regenerateSecret.description':
+      'Regenerating the client secret will immediately invalidate the current client secret and cannot be undone.',
+    'edit.general.sections.dangerZone.regenerateSecret.button': 'Regenerate Client Secret',
 
     // Flows section
     'edit.flows.labels.authFlow': 'Authentication Flow',


### PR DESCRIPTION
### Purpose
This pull request introduces a workflow for securely regenerating OAuth 2.0 client secrets for applications in the Thunder Develop frontend. 

Previously, this feature was missing, but these changes improve both the security and user experience of managing application client secrets by adding a secure regeneration flow, complete with warning and success dialogs.

#### `DangerZoneSection`
<img width="1176" height="241" alt="Screenshot 2026-03-05 134315" src="https://github.com/user-attachments/assets/06504be5-3a0f-4d65-b10d-b9adfbc09399" />

#### `RegenerateSecretDialog`
<img width="568" height="278" alt="Screenshot 2026-03-05 134328" src="https://github.com/user-attachments/assets/7c057ad5-831e-4359-88da-3f1e92a00196" />

#### `ClientSecretSuccessDialog`
<img width="558" height="482" alt="Screenshot 2026-03-05 134347" src="https://github.com/user-attachments/assets/99535c57-6af4-4e01-a436-a127c877bf03" />



<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
The implementation focuses on separating the business logic from the UI components for better maintainability:

* **Custom Hook (`useRegenerateClientSecret`)**: Handles the core logic. It utilizes a cryptographically secure random generator to create the new secret (matching backend encoding), pushes the update to the application via the API, and invalidates related queries to ensure the UI data refreshes automatically.
* **Confirmation Dialog (`RegenerateSecretDialog`)**: Introduced to act as a guardrail. It explicitly warns users about the consequences of regenerating a client secret before they proceed, and gracefully handles the mutation process with error and success callbacks.
* **Success Dialog (`ClientSecretSuccessDialog`)**: Presented upon successful regeneration. It displays the new client secret, provides visibility toggle and copy-to-clipboard features, and explicitly reminds the user that the secret will not be shown again once the dialog is closed.


### Related Issues
- Fixes #1461 

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regenerate application OAuth2 client secrets via a secure confirmation flow that produces a cryptographically strong 256-bit secret.
  * Display newly generated secret in a success dialog with copy-to-clipboard, visibility toggle, and security reminder.
  * Danger Zone section in application settings to trigger secret regeneration.

* **Tests**
  * Added comprehensive unit tests for dialogs, danger-zone UI, copy/visibility behavior, and success/error flows.

* **Documentation**
  * Added user-facing translation strings for dialogs, alerts, progress, and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->