### PR TITLE
Integrate system authz for group package

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -338,6 +338,8 @@ Write-Host ""
 #           └── Action handle "view"       → permission "system:ou:view"
 #       └── Resource handle "user"         → permission "system:user"
 #           └── Action handle "view"       → permission "system:user:view"
+#       └── Resource handle "group"        → permission "system:group"
+#           └── Action handle "view"       → permission "system:group:view"
 #       └── Resource handle "userschema"   → permission "system:userschema"
 #           └── Action handle "view"       → permission "system:userschema:view"
 # ============================================================================
@@ -627,6 +629,86 @@ elseif ($response.StatusCode -eq 409) {
 }
 else {
     Log-Error "Failed to create user schema view action (HTTP $($response.StatusCode))"
+    Log-Error "Response: $($response.Body)"
+    exit 1
+}
+
+Write-Host ""
+
+Log-Info "Creating 'group' sub-resource under the 'system' resource..."
+
+if (-not $SYSTEM_RESOURCE_ID) {
+    Log-Error "System resource ID is not available. Cannot create group resource."
+    exit 1
+}
+
+$groupResourceData = @{
+    name        = "Group"
+    description = "Group resource"
+    handle      = "group"
+    parent      = $SYSTEM_RESOURCE_ID
+} | ConvertTo-Json -Depth 10
+
+$response = Invoke-ThunderApi -Method POST -Endpoint "/resource-servers/$SYSTEM_RS_ID/resources" -Data $groupResourceData
+
+if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
+    Log-Success "Group resource created successfully (permission: system:group)"
+    $body = $response.Body | ConvertFrom-Json
+    $GROUP_RESOURCE_ID = $body.id
+    if ($GROUP_RESOURCE_ID) {
+        Log-Info "Group resource ID: $GROUP_RESOURCE_ID"
+    }
+    else {
+        Log-Error "Could not extract group resource ID from response"
+        exit 1
+    }
+}
+elseif ($response.StatusCode -eq 409) {
+    Log-Warning "Group resource already exists, retrieving ID..."
+    $response = Invoke-ThunderApi -Method GET -Endpoint "/resource-servers/$SYSTEM_RS_ID/resources?parentId=$SYSTEM_RESOURCE_ID"
+
+    if ($response.StatusCode -eq 200) {
+        $body = $response.Body | ConvertFrom-Json
+        $groupResource = $body.resources | Where-Object { $_.handle -eq "group" } | Select-Object -First 1
+
+        if ($groupResource) {
+            $GROUP_RESOURCE_ID = $groupResource.id
+            Log-Success "Found group resource ID: $GROUP_RESOURCE_ID"
+        }
+        else {
+            Log-Error "Could not find group resource in response"
+            exit 1
+        }
+    }
+    else {
+        Log-Error "Failed to fetch resources (HTTP $($response.StatusCode))"
+        exit 1
+    }
+}
+else {
+    Log-Error "Failed to create group resource (HTTP $($response.StatusCode))"
+    Log-Error "Response: $($response.Body)"
+    exit 1
+}
+
+Log-Info "Creating 'view' action under the 'group' resource..."
+
+$groupViewActionData = @{
+    name        = "View"
+    description = "Read-only access to groups"
+    handle      = "view"
+} | ConvertTo-Json -Depth 10
+
+$response = Invoke-ThunderApi -Method POST -Endpoint "/resource-servers/$SYSTEM_RS_ID/resources/$GROUP_RESOURCE_ID/actions" -Data $groupViewActionData
+
+if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
+    Log-Success "Group view action created successfully (permission: system:group:view)"
+}
+elseif ($response.StatusCode -eq 409) {
+    Log-Warning "Group view action already exists, skipping"
+}
+else {
+    Log-Error "Failed to create group view action (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
     exit 1
 }

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -327,6 +327,8 @@ echo ""
 #           └── Action handle "view"       → permission "system:ou:view"
 #       └── Resource handle "user"         → permission "system:user"
 #           └── Action handle "view"       → permission "system:user:view"
+#       └── Resource handle "group"        → permission "system:group"
+#           └── Action handle "view"       → permission "system:group:view"
 #       └── Resource handle "userschema"   → permission "system:userschema"
 #           └── Action handle "view"       → permission "system:userschema:view"
 # ============================================================================
@@ -574,6 +576,74 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "User schema view action already exists, skipping"
 else
     log_error "Failed to create user schema view action (HTTP $HTTP_CODE)"
+    echo "Response: $BODY"
+    exit 1
+fi
+
+echo ""
+
+log_info "Creating 'group' sub-resource under the 'system' resource..."
+
+RESPONSE=$(thunder_api_call POST "/resource-servers/${SYSTEM_RS_ID}/resources" "{
+  \"name\": \"Group\",
+  \"description\": \"Group resource\",
+  \"handle\": \"group\",
+  \"parent\": \"${SYSTEM_RESOURCE_ID}\"
+}")
+
+HTTP_CODE="${RESPONSE: -3}"
+BODY="${RESPONSE%???}"
+
+if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
+    log_success "Group resource created successfully (permission: system:group)"
+    GROUP_RESOURCE_ID=$(echo "$BODY" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+    if [[ -n "$GROUP_RESOURCE_ID" ]]; then
+        log_info "Group resource ID: $GROUP_RESOURCE_ID"
+    else
+        log_error "Could not extract group resource ID from response"
+        exit 1
+    fi
+elif [[ "$HTTP_CODE" == "409" ]]; then
+    log_warning "Group resource already exists, retrieving ID..."
+    RESPONSE=$(thunder_api_call GET "/resource-servers/${SYSTEM_RS_ID}/resources?parentId=${SYSTEM_RESOURCE_ID}")
+    HTTP_CODE="${RESPONSE: -3}"
+    BODY="${RESPONSE%???}"
+
+    if [[ "$HTTP_CODE" == "200" ]]; then
+        GROUP_RESOURCE_ID=$(echo "$BODY" | sed 's/},{/}\n{/g' | grep '"handle":"group"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+        if [[ -n "$GROUP_RESOURCE_ID" ]]; then
+            log_success "Found group resource ID: $GROUP_RESOURCE_ID"
+        else
+            log_error "Could not find group resource in response"
+            exit 1
+        fi
+    else
+        log_error "Failed to fetch resources (HTTP $HTTP_CODE)"
+        exit 1
+    fi
+else
+    log_error "Failed to create group resource (HTTP $HTTP_CODE)"
+    echo "Response: $BODY"
+    exit 1
+fi
+
+log_info "Creating 'view' action under the 'group' resource..."
+
+RESPONSE=$(thunder_api_call POST "/resource-servers/${SYSTEM_RS_ID}/resources/${GROUP_RESOURCE_ID}/actions" '{
+  "name": "View",
+  "description": "Read-only access to groups",
+  "handle": "view"
+}')
+
+HTTP_CODE="${RESPONSE: -3}"
+BODY="${RESPONSE%???}"
+
+if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
+    log_success "Group view action created successfully (permission: system:group:view)"
+elif [[ "$HTTP_CODE" == "409" ]]; then
+    log_warning "Group view action already exists, skipping"
+else
+    log_error "Failed to create group view action (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
     exit 1
 fi

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -126,7 +126,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	}
 	exporters = append(exporters, userExporter)
 
-	groupService, err := group.Initialize(mux, ouService, userService)
+	groupService, err := group.Initialize(mux, ouService, userService, ouAuthzService)
 	if err != nil {
 		logger.Fatal("Failed to initialize GroupService", log.Error(err))
 	}

--- a/backend/internal/group/groupStoreInterface_mock_test.go
+++ b/backend/internal/group/groupStoreInterface_mock_test.go
@@ -486,6 +486,86 @@ func (_c *groupStoreInterfaceMock_GetGroupList_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetGroupListByOUIDs provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetGroupListByOUIDs(ctx context.Context, ouIDs []string, limit int, offset int) ([]GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, ouIDs, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupListByOUIDs")
+	}
+
+	var r0 []GroupBasicDAO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, int, int) ([]GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, ouIDs, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, int, int) []GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, ouIDs, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]GroupBasicDAO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string, int, int) error); ok {
+		r1 = returnFunc(ctx, ouIDs, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetGroupListByOUIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupListByOUIDs'
+type groupStoreInterfaceMock_GetGroupListByOUIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupListByOUIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ouIDs []string
+//   - limit int
+//   - offset int
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupListByOUIDs(ctx interface{}, ouIDs interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	return &groupStoreInterfaceMock_GetGroupListByOUIDs_Call{Call: _e.mock.On("GetGroupListByOUIDs", ctx, ouIDs, limit, offset)}
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListByOUIDs_Call) Run(run func(ctx context.Context, ouIDs []string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListByOUIDs_Call) Return(groupBasicDAOs []GroupBasicDAO, err error) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	_c.Call.Return(groupBasicDAOs, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListByOUIDs_Call) RunAndReturn(run func(ctx context.Context, ouIDs []string, limit int, offset int) ([]GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroupListCount provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroupListCount(ctx context.Context) (int, error) {
 	ret := _mock.Called(ctx)
@@ -542,6 +622,72 @@ func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Return(n int, err erro
 }
 
 func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *groupStoreInterfaceMock_GetGroupListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetGroupListCountByOUIDs provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetGroupListCountByOUIDs(ctx context.Context, ouIDs []string) (int, error) {
+	ret := _mock.Called(ctx, ouIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupListCountByOUIDs")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (int, error)); ok {
+		return returnFunc(ctx, ouIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) int); ok {
+		r0 = returnFunc(ctx, ouIDs)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, ouIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupListCountByOUIDs'
+type groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupListCountByOUIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ouIDs []string
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupListCountByOUIDs(ctx interface{}, ouIDs interface{}) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
+	return &groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call{Call: _e.mock.On("GetGroupListCountByOUIDs", ctx, ouIDs)}
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call) Run(run func(ctx context.Context, ouIDs []string)) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call) Return(n int, err error) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call) RunAndReturn(run func(ctx context.Context, ouIDs []string) (int, error)) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/group/handler.go
+++ b/backend/internal/group/handler.go
@@ -369,6 +369,8 @@ func (gh *groupHandler) handleError(w http.ResponseWriter, logger *log.Logger,
 			ErrorEmptyMembers.Code, ErrorInvalidUserMemberID.Code,
 			ErrorInvalidGroupMemberID.Code:
 			statusCode = http.StatusBadRequest
+		case serviceerror.ErrorUnauthorized.Code:
+			statusCode = http.StatusForbidden
 		default:
 			statusCode = http.StatusBadRequest
 		}

--- a/backend/internal/group/init.go
+++ b/backend/internal/group/init.go
@@ -25,6 +25,7 @@ import (
 	oupkg "github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/middleware"
+	"github.com/asgardeo/thunder/internal/system/sysauthz"
 	"github.com/asgardeo/thunder/internal/user"
 )
 
@@ -33,6 +34,7 @@ func Initialize(
 	mux *http.ServeMux,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	userService user.UserServiceInterface,
+	authzService sysauthz.SystemAuthorizationServiceInterface,
 ) (GroupServiceInterface, error) {
 	// Get transactioner from DB provider
 	transactioner, err := provider.GetDBProvider().GetUserDBTransactioner()
@@ -40,7 +42,7 @@ func Initialize(
 		return nil, err
 	}
 
-	groupService := newGroupService(ouService, userService, transactioner)
+	groupService := newGroupService(ouService, userService, authzService, transactioner)
 	groupHandler := newGroupHandler(groupService)
 	registerRoutes(mux, groupHandler)
 	return groupService, nil

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -30,6 +30,8 @@ import (
 	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/security"
+	"github.com/asgardeo/thunder/internal/system/sysauthz"
 	"github.com/asgardeo/thunder/internal/system/utils"
 	"github.com/asgardeo/thunder/internal/user"
 )
@@ -60,18 +62,21 @@ type groupService struct {
 	ouService     oupkg.OrganizationUnitServiceInterface
 	userService   user.UserServiceInterface
 	transactioner transaction.Transactioner
+	authzService  sysauthz.SystemAuthorizationServiceInterface
 }
 
 // newGroupService creates a new instance of GroupService with injected dependencies.
 func newGroupService(
 	ouService oupkg.OrganizationUnitServiceInterface,
 	userService user.UserServiceInterface,
+	authzService sysauthz.SystemAuthorizationServiceInterface,
 	transactioner transaction.Transactioner,
 ) GroupServiceInterface {
 	return &groupService{
 		groupStore:    newGroupStore(),
 		ouService:     ouService,
 		userService:   userService,
+		authzService:  authzService,
 		transactioner: transactioner,
 	}
 }
@@ -80,12 +85,25 @@ func newGroupService(
 // integer
 func (gs *groupService) GetGroupList(ctx context.Context, limit, offset int) (
 	*GroupListResponse, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-
 	if err := validatePaginationParams(limit, offset); err != nil {
 		return nil, err
 	}
 
+	accessibleOUs, svcErr := gs.getAccessibleOUs(ctx, security.ActionListGroups)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	if accessibleOUs.AllAllowed {
+		return gs.listAllGroups(ctx, limit, offset)
+	}
+
+	return gs.listGroupsByOUIDs(ctx, accessibleOUs.IDs, limit, offset)
+}
+
+func (gs *groupService) listAllGroups(ctx context.Context, limit, offset int) (
+	*GroupListResponse, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	totalCount, err := gs.groupStore.GetGroupListCount(ctx)
 	if err != nil {
 		logger.Error("Failed to get group count", log.Error(err))
@@ -95,6 +113,58 @@ func (gs *groupService) GetGroupList(ctx context.Context, limit, offset int) (
 	groups, err := gs.groupStore.GetGroupList(ctx, limit, offset)
 	if err != nil {
 		logger.Error("Failed to list groups", log.Error(err))
+		return nil, &ErrorInternalServerError
+	}
+
+	groupBasics := make([]GroupBasic, 0, len(groups))
+	for _, groupDAO := range groups {
+		groupBasics = append(groupBasics, buildGroupBasic(groupDAO))
+	}
+
+	response := &GroupListResponse{
+		TotalResults: totalCount,
+		Groups:       groupBasics,
+		StartIndex:   offset + 1,
+		Count:        len(groupBasics),
+		Links:        buildPaginationLinks("/groups", limit, offset, totalCount),
+	}
+
+	return response, nil
+}
+
+func (gs *groupService) listGroupsByOUIDs(ctx context.Context, ouIDs []string, limit, offset int) (
+	*GroupListResponse, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if len(ouIDs) == 0 {
+		return &GroupListResponse{
+			TotalResults: 0,
+			Groups:       []GroupBasic{},
+			StartIndex:   offset + 1,
+			Count:        0,
+			Links:        []Link{},
+		}, nil
+	}
+
+	totalCount, err := gs.groupStore.GetGroupListCountByOUIDs(ctx, ouIDs)
+	if err != nil {
+		logger.Error("Failed to get group count by OU IDs", log.Error(err))
+		return nil, &ErrorInternalServerError
+	}
+
+	if totalCount == 0 {
+		return &GroupListResponse{
+			TotalResults: 0,
+			Groups:       []GroupBasic{},
+			StartIndex:   offset + 1,
+			Count:        0,
+			Links:        []Link{},
+		}, nil
+	}
+
+	groups, err := gs.groupStore.GetGroupListByOUIDs(ctx, ouIDs, limit, offset)
+	if err != nil {
+		logger.Error("Failed to list groups by OU IDs", log.Error(err))
 		return nil, &ErrorInternalServerError
 	}
 
@@ -136,6 +206,10 @@ func (gs *groupService) GetGroupsByPath(
 	organizationUnitID := ou.ID
 
 	if err := validatePaginationParams(limit, offset); err != nil {
+		return nil, err
+	}
+
+	if err := gs.checkGroupAccess(ctx, security.ActionListGroups, organizationUnitID, ""); err != nil {
 		return nil, err
 	}
 
@@ -181,6 +255,10 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 		return nil, err
 	}
 
+	if err := gs.checkGroupAccess(ctx, security.ActionCreateGroup, request.OrganizationUnitID, ""); err != nil {
+		return nil, err
+	}
+
 	var userIDs []string
 	var groupIDs []string
 	for _, member := range request.Members {
@@ -192,7 +270,7 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 		}
 	}
 
-	if err := gs.validateUserIDs(ctx, userIDs); err != nil {
+	if err := gs.validateUserIDsWithAccess(ctx, userIDs); err != nil {
 		return nil, err
 	}
 
@@ -304,6 +382,10 @@ func (gs *groupService) GetGroup(ctx context.Context, groupID string) (*Group, *
 		return nil, &ErrorInternalServerError
 	}
 
+	if err := gs.checkGroupAccess(ctx, security.ActionReadGroup, groupDAO.OrganizationUnitID, groupID); err != nil {
+		return nil, err
+	}
+
 	group := convertGroupDAOToGroup(groupDAO)
 	logger.Debug("Successfully retrieved group", log.String("id", group.ID), log.String("name", group.Name))
 	return &group, nil
@@ -348,6 +430,28 @@ func (gs *groupService) UpdateGroup(
 				return errors.New("rollback for invalid OU")
 			}
 			updateOrganizationUnitID = request.OrganizationUnitID
+		}
+
+		if err := gs.checkGroupAccess(
+			txCtx,
+			security.ActionUpdateGroup,
+			existingGroupDAO.OrganizationUnitID,
+			groupID,
+		); err != nil {
+			capturedSvcErr = err
+			return errors.New("rollback for unauthorized access")
+		}
+
+		if updateOrganizationUnitID != existingGroupDAO.OrganizationUnitID {
+			if err := gs.checkGroupAccess(
+				txCtx,
+				security.ActionUpdateGroup,
+				updateOrganizationUnitID,
+				groupID,
+			); err != nil {
+				capturedSvcErr = err
+				return errors.New("rollback for unauthorized access to target OU")
+			}
 		}
 
 		if existingGroup.Name != request.Name || existingGroup.OrganizationUnitID != request.OrganizationUnitID {
@@ -407,7 +511,7 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *servic
 	var capturedSvcErr *serviceerror.ServiceError
 
 	err := gs.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		_, err := gs.groupStore.GetGroup(txCtx, groupID)
+		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
 				logger.Debug("Group not found", log.String("id", groupID))
@@ -417,6 +521,16 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *servic
 			logger.Error("Failed to retrieve group", log.String("id", groupID), log.Error(err))
 			capturedSvcErr = &ErrorInternalServerError
 			return err
+		}
+
+		if err := gs.checkGroupAccess(
+			txCtx,
+			security.ActionDeleteGroup,
+			existingGroupDAO.OrganizationUnitID,
+			groupID,
+		); err != nil {
+			capturedSvcErr = err
+			return errors.New("rollback for unauthorized access")
 		}
 
 		if err := gs.groupStore.DeleteGroup(txCtx, groupID); err != nil {
@@ -452,7 +566,7 @@ func (gs *groupService) GetGroupMembers(ctx context.Context, groupID string, lim
 		return nil, &ErrorMissingGroupID
 	}
 
-	_, err := gs.groupStore.GetGroup(ctx, groupID)
+	existingGroupDAO, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, ErrGroupNotFound) {
 			logger.Debug("Group not found", log.String("id", groupID))
@@ -460,6 +574,15 @@ func (gs *groupService) GetGroupMembers(ctx context.Context, groupID string, lim
 		}
 		logger.Error("Failed to retrieve group", log.String("id", groupID), log.Error(err))
 		return nil, &ErrorInternalServerError
+	}
+
+	if err := gs.checkGroupAccess(
+		ctx,
+		security.ActionReadGroup,
+		existingGroupDAO.OrganizationUnitID,
+		groupID,
+	); err != nil {
+		return nil, err
 	}
 
 	totalCount, err := gs.groupStore.GetGroupMemberCount(ctx, groupID)
@@ -510,7 +633,7 @@ func (gs *groupService) AddGroupMembers(
 	var updatedGroupDAO GroupDAO
 
 	err := gs.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		_, err := gs.groupStore.GetGroup(txCtx, groupID)
+		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
 				logger.Debug("Group not found", log.String("id", groupID))
@@ -520,6 +643,16 @@ func (gs *groupService) AddGroupMembers(
 			logger.Error("Failed to check group existence", log.String("id", groupID), log.Error(err))
 			capturedSvcErr = &ErrorInternalServerError
 			return err
+		}
+
+		if err := gs.checkGroupAccess(
+			txCtx,
+			security.ActionUpdateGroup,
+			existingGroupDAO.OrganizationUnitID,
+			groupID,
+		); err != nil {
+			capturedSvcErr = err
+			return errors.New("rollback for unauthorized access")
 		}
 
 		var userIDs []string
@@ -533,7 +666,7 @@ func (gs *groupService) AddGroupMembers(
 			}
 		}
 
-		if svcErr := gs.validateUserIDs(txCtx, userIDs); svcErr != nil {
+		if svcErr := gs.validateUserIDsWithAccess(txCtx, userIDs); svcErr != nil {
 			capturedSvcErr = svcErr
 			return errors.New("rollback for invalid user IDs")
 		}
@@ -594,7 +727,7 @@ func (gs *groupService) RemoveGroupMembers(
 	var updatedGroupDAO GroupDAO
 
 	err := gs.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		_, err := gs.groupStore.GetGroup(txCtx, groupID)
+		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
 				logger.Debug("Group not found", log.String("id", groupID))
@@ -604,6 +737,16 @@ func (gs *groupService) RemoveGroupMembers(
 			logger.Error("Failed to check group existence", log.String("id", groupID), log.Error(err))
 			capturedSvcErr = &ErrorInternalServerError
 			return err
+		}
+
+		if err := gs.checkGroupAccess(
+			txCtx,
+			security.ActionUpdateGroup,
+			existingGroupDAO.OrganizationUnitID,
+			groupID,
+		); err != nil {
+			capturedSvcErr = err
+			return errors.New("rollback for unauthorized access")
 		}
 
 		if err := gs.groupStore.RemoveGroupMembers(txCtx, groupID, members); err != nil {
@@ -692,14 +835,14 @@ func (gs *groupService) isOrganizationUnitChanged(existingGroup Group, request U
 func (gs *groupService) validateOU(ctx context.Context, ouID string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
-	_, err := gs.ouService.GetOrganizationUnit(ctx, ouID)
+	isExists, err := gs.ouService.IsOrganizationUnitExists(ctx, ouID)
 	if err != nil {
-		if err.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
-			return &ErrorInvalidOUID
-		} else {
-			logger.Error("Failed to get organization unit", log.Any("error: ", err))
-			return &ErrorInternalServerError
-		}
+		logger.Error("Failed to check organization unit existence", log.Any("error: ", err))
+		return &ErrorInternalServerError
+	}
+
+	if !isExists {
+		return &ErrorInvalidOUID
 	}
 
 	return nil
@@ -718,6 +861,48 @@ func (gs *groupService) validateUserIDs(ctx context.Context, userIDs []string) *
 	if len(invalidUserIDs) > 0 {
 		logger.Debug("Invalid user IDs found", log.Any("invalidUserIDs", invalidUserIDs))
 		return &ErrorInvalidUserMemberID
+	}
+
+	return nil
+}
+
+// validateUserIDsWithAccess validates user IDs in two steps:
+//  1. Existence check — returns ErrorInvalidUserMemberID for any unknown user ID.
+//  2. OU-scope check — returns ErrorUnauthorized for any user ID outside the caller's accessible OUs
+//     (OUs where the caller holds group-update permission).
+//
+// When the caller is a full admin (AllAllowed), only step 1 is performed.
+func (gs *groupService) validateUserIDsWithAccess(
+	ctx context.Context, userIDs []string,
+) *serviceerror.ServiceError {
+	if len(userIDs) == 0 {
+		return nil
+	}
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if err := gs.validateUserIDs(ctx, userIDs); err != nil {
+		return err
+	}
+
+	accessibleOUs, svcErr := gs.getAccessibleOUs(ctx, security.ActionUpdateGroup)
+	if svcErr != nil {
+		return svcErr
+	}
+
+	if accessibleOUs.AllAllowed {
+		// Full admin — no scope restriction.
+		return nil
+	}
+
+	outOfScopeIDs, svcErr := gs.userService.ValidateUserIDsInOUs(ctx, userIDs, accessibleOUs.IDs)
+	if svcErr != nil {
+		logger.Error("Failed to validate user IDs in OUs", log.String("error", svcErr.Error))
+		return &ErrorInternalServerError
+	}
+
+	if len(outOfScopeIDs) > 0 {
+		logger.Debug("User IDs outside accessible OUs", log.Any("outOfScopeIDs", outOfScopeIDs))
+		return &serviceerror.ErrorUnauthorized
 	}
 
 	return nil
@@ -799,6 +984,38 @@ func buildPaginationLinks(base string, limit, offset, totalCount int) []Link {
 	}
 
 	return links
+}
+
+// checkGroupAccess performs an authorization check on the group resource against the current caller.
+func (gs *groupService) checkGroupAccess(
+	ctx context.Context, action security.Action, ouID string, groupID string) *serviceerror.ServiceError {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	actionCtx := sysauthz.ActionContext{
+		ResourceType: security.ResourceTypeGroup,
+		OuID:         ouID,
+		ResourceID:   groupID,
+	}
+
+	hasAccess, err := gs.authzService.IsActionAllowed(ctx, action, &actionCtx)
+	if err != nil {
+		logger.Error("Failed to check authorization", log.String("err", err.Error))
+		return &ErrorInternalServerError
+	}
+	if !hasAccess {
+		return &serviceerror.ErrorUnauthorized
+	}
+	return nil
+}
+
+// getAccessibleOUs retrieves the accessible resources for the group.
+func (gs *groupService) getAccessibleOUs(
+	ctx context.Context, action security.Action) (*sysauthz.AccessibleResources, *serviceerror.ServiceError) {
+	accessibleResources, err := gs.authzService.GetAccessibleResources(ctx, action, security.ResourceTypeOU)
+	if err != nil {
+		return nil, err
+	}
+	return accessibleResources, nil
 }
 
 // validateAndProcessHandlePath validates and processes the handle path.

--- a/backend/internal/group/service_test.go
+++ b/backend/internal/group/service_test.go
@@ -29,7 +29,10 @@ import (
 
 	oupkg "github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/security"
+	"github.com/asgardeo/thunder/internal/system/sysauthz"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
+	"github.com/asgardeo/thunder/tests/mocks/sysauthzmock"
 	"github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
@@ -39,6 +42,31 @@ type stubTransactioner struct{}
 
 func (s *stubTransactioner) Transact(ctx context.Context, txFunc func(context.Context) error) error {
 	return txFunc(ctx)
+}
+
+const (
+	testOUID1 = "ou-123"
+	testOUID2 = "ou-456"
+)
+
+// newAllowAllAuthz returns a mock AuthzService that grants full access.
+func newAllowAllAuthz(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+	mockAuthz := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+	mockAuthz.On("IsActionAllowed", mock.Anything, mock.Anything, mock.Anything).
+		Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
+	mockAuthz.On("GetAccessibleResources", mock.Anything, mock.Anything, security.ResourceTypeOU).
+		Return(&sysauthz.AccessibleResources{AllAllowed: true}, (*serviceerror.ServiceError)(nil)).Maybe()
+	return mockAuthz
+}
+
+// newAuthzError returns a mock that simulates an internal authorization error.
+func newAuthzError(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+	mockAuthz := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+	mockAuthz.On("IsActionAllowed", mock.Anything, mock.Anything, mock.Anything).
+		Return(false, &ErrorInternalServerError).Maybe()
+	mockAuthz.On("GetAccessibleResources", mock.Anything, mock.Anything, security.ResourceTypeOU).
+		Return((*sysauthz.AccessibleResources)(nil), &ErrorInternalServerError).Maybe()
+	return mockAuthz
 }
 
 type GroupServiceTestSuite struct {
@@ -108,6 +136,7 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupList() {
 		limit      int
 		offset     int
 		setup      func(*groupStoreInterfaceMock)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
 		wantErr    *serviceerror.ServiceError
 		wantResult *groupListExpectations
 	}{
@@ -167,6 +196,71 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupList() {
 			},
 			wantErr: &ErrorInternalServerError,
 		},
+		{
+			name:   "filtered by OUIDs",
+			limit:  5,
+			offset: 0,
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"GetAccessibleResources",
+					mock.Anything,
+					security.ActionListGroups,
+					security.ResourceTypeOU,
+				).Return(
+					&sysauthz.AccessibleResources{AllAllowed: false, IDs: []string{testOUID1, testOUID2}},
+					(*serviceerror.ServiceError)(nil),
+				)
+				return authzMock
+			},
+			setup: func(storeMock *groupStoreInterfaceMock) {
+				ouIDs := []string{testOUID1, testOUID2}
+				storeMock.On("GetGroupListCountByOUIDs", mock.Anything, ouIDs).Return(1, nil).Once()
+				storeMock.On("GetGroupListByOUIDs", mock.Anything, ouIDs, 5, 0).
+					Return([]GroupBasicDAO{{ID: "id1", Name: "name1", OrganizationUnitID: testOUID1}}, nil).Once()
+			},
+			wantResult: &groupListExpectations{
+				totalResults: 1,
+				count:        1,
+				startIndex:   1,
+				groupNames:   []string{"name1"},
+				linkRels:     []string{},
+				linkHrefs:    []string{},
+			},
+		},
+		{
+			name:   "empty OUIDs returns empty list",
+			limit:  5,
+			offset: 0,
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"GetAccessibleResources",
+					mock.Anything,
+					security.ActionListGroups,
+					security.ResourceTypeOU,
+				).Return(
+					&sysauthz.AccessibleResources{AllAllowed: false, IDs: []string{}},
+					(*serviceerror.ServiceError)(nil),
+				)
+				return authzMock
+			},
+			wantResult: &groupListExpectations{
+				totalResults: 0,
+				count:        0,
+				startIndex:   1,
+				groupNames:   []string{},
+				linkRels:     []string{},
+				linkHrefs:    []string{},
+			},
+		},
+		{
+			name:       "authz error",
+			limit:      5,
+			offset:     0,
+			authzSetup: newAuthzError,
+			wantErr:    &ErrorInternalServerError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -178,8 +272,15 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupList() {
 				tc.setup(storeMock)
 			}
 
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
 			service := &groupService{
-				groupStore: storeMock,
+				authzService: authzSvc,
+				groupStore:   storeMock,
 			}
 
 			response, err := service.GetGroupList(context.Background(), tc.limit, tc.offset)
@@ -210,6 +311,7 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupsByPath() {
 			*groupStoreInterfaceMock,
 			*oumock.OrganizationUnitServiceInterfaceMock,
 		) *serviceerror.ServiceError
+		authzSetup          func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
 		wantErr             *serviceerror.ServiceError
 		wantErrFromSetup    bool
 		wantResult          *groupListExpectations
@@ -367,6 +469,28 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupsByPath() {
 			},
 			wantErr: &ErrorInternalServerError,
 		},
+		{
+			name:   "access denied",
+			path:   "/org",
+			limit:  5,
+			offset: 0,
+			setup: func(
+				_ *groupStoreInterfaceMock,
+				ouMock *oumock.OrganizationUnitServiceInterfaceMock,
+			) *serviceerror.ServiceError {
+				ouMock.On("GetOrganizationUnitByPath", mock.Anything, "/org").
+					Return(oupkg.OrganizationUnit{ID: testOUID1}, (*serviceerror.ServiceError)(nil)).Once()
+				return nil
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On("IsActionAllowed", mock.Anything, security.ActionListGroups,
+					&sysauthz.ActionContext{OuID: testOUID1, ResourceType: security.ResourceTypeGroup}).
+					Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			wantErr: &serviceerror.ErrorUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -380,9 +504,16 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupsByPath() {
 				expectedErr = tc.setup(storeMock, ouServiceMock)
 			}
 
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
 			service := &groupService{
-				groupStore: storeMock,
-				ouService:  ouServiceMock,
+				authzService: authzSvc,
+				groupStore:   storeMock,
+				ouService:    ouServiceMock,
 			}
 
 			response, err := service.GetGroupsByPath(context.Background(), tc.path, tc.limit, tc.offset)
@@ -421,11 +552,12 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 	}
 
 	testCases := []struct {
-		name      string
-		request   CreateGroupRequest
-		setup     func(*setupArgs)
-		expectErr *serviceerror.ServiceError
-		expectRes bool
+		name       string
+		request    CreateGroupRequest
+		setup      func(*setupArgs)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
+		expectErr  *serviceerror.ServiceError
+		expectRes  bool
 	}{
 		{
 			name: "success",
@@ -453,8 +585,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 					Return(nil).
 					Once()
 
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-001").
-					Return(oupkg.OrganizationUnit{ID: "ou-001"}, nil).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-001").
+					Return(true, nil).
 					Once()
 
 				args.user.On("ValidateUserIDs", mock.Anything, []string{"usr-001"}).
@@ -470,8 +602,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 				OrganizationUnitID: "ou-unknown",
 			},
 			setup: func(args *setupArgs) {
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-unknown").
-					Return(oupkg.OrganizationUnit{}, &oupkg.ErrorOrganizationUnitNotFound).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-unknown").
+					Return(false, nil).
 					Once()
 				args.user.On("ValidateUserIDs", mock.Anything, []string{}).
 					Return([]string{}, nil).
@@ -490,8 +622,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 				args.store.On("CheckGroupNameConflictForCreate", mock.Anything, "engineering", "ou-001").
 					Return(nil).
 					Maybe()
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-001").
-					Return(oupkg.OrganizationUnit{ID: "ou-001"}, nil).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-001").
+					Return(true, nil).
 					Once()
 				args.user.On("ValidateUserIDs", mock.Anything, []string{"usr-invalid"}).
 					Return([]string{"usr-invalid"}, nil).
@@ -509,11 +641,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 				args.store.On("CheckGroupNameConflictForCreate", mock.Anything, "engineering", "ou-001").
 					Return(ErrGroupNameConflict).
 					Once()
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-001").
-					Return(oupkg.OrganizationUnit{ID: "ou-001"}, nil).
-					Once()
-				args.user.On("ValidateUserIDs", mock.Anything, mock.Anything).
-					Return([]string{}, nil).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-001").
+					Return(true, nil).
 					Once()
 				args.store.On("ValidateGroupIDs", mock.Anything, mock.Anything).
 					Return([]string{}, nil).
@@ -531,11 +660,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 				args.store.On("CheckGroupNameConflictForCreate", mock.Anything, "engineering", "ou-001").
 					Return(errors.New("db failure")).
 					Once()
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-001").
-					Return(oupkg.OrganizationUnit{ID: "ou-001"}, nil).
-					Once()
-				args.user.On("ValidateUserIDs", mock.Anything, mock.Anything).
-					Return([]string{}, nil).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-001").
+					Return(true, nil).
 					Once()
 				args.store.On("ValidateGroupIDs", mock.Anything, mock.Anything).
 					Return([]string{}, nil).
@@ -559,11 +685,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 				args.store.On("CreateGroup", mock.Anything, mock.Anything).
 					Return(errors.New("create fail")).
 					Once()
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-001").
-					Return(oupkg.OrganizationUnit{ID: "ou-001"}, nil).
-					Once()
-				args.user.On("ValidateUserIDs", mock.Anything, mock.Anything).
-					Return([]string{}, nil).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-001").
+					Return(true, nil).
 					Once()
 			},
 			expectErr: &ErrorInternalServerError,
@@ -575,12 +698,31 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 				OrganizationUnitID: "ou-001",
 			},
 			setup: func(args *setupArgs) {
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-001").
-					Return(oupkg.OrganizationUnit{},
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-001").
+					Return(false,
 						&serviceerror.ServiceError{Code: "OU-5000", Type: serviceerror.ServerErrorType}).
 					Once()
 			},
 			expectErr: &ErrorInternalServerError,
+		},
+		{
+			name: "access denied",
+			request: CreateGroupRequest{
+				Name:               "developers",
+				OrganizationUnitID: testOUID1,
+			},
+			setup: func(args *setupArgs) {
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, testOUID1).
+					Return(true, (*serviceerror.ServiceError)(nil)).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On("IsActionAllowed", mock.Anything, security.ActionCreateGroup,
+					&sysauthz.ActionContext{OuID: testOUID1, ResourceType: security.ResourceTypeGroup}).
+					Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			expectErr: &serviceerror.ErrorUnauthorized,
 		},
 	}
 
@@ -598,7 +740,14 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroup() {
 				tc.setup(&setupArgs{store: storeMock, ou: ouServiceMock, user: userServiceMock})
 			}
 
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
 			service := &groupService{
+				authzService:  authzSvc,
 				groupStore:    storeMock,
 				ouService:     ouServiceMock,
 				userService:   userServiceMock,
@@ -694,6 +843,7 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroupByPath() {
 			}
 
 			service := &groupService{
+				authzService:  newAllowAllAuthz(suite.T()),
 				groupStore:    storeMock,
 				ouService:     ouServiceMock,
 				userService:   userServiceMock,
@@ -727,10 +877,11 @@ func (suite *GroupServiceTestSuite) TestGroupService_CreateGroupByPath() {
 
 func (suite *GroupServiceTestSuite) TestGroupService_GetGroup() {
 	testCases := []struct {
-		name    string
-		id      string
-		setup   func(*groupStoreInterfaceMock)
-		wantErr *serviceerror.ServiceError
+		name       string
+		id         string
+		setup      func(*groupStoreInterfaceMock)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
+		wantErr    *serviceerror.ServiceError
 	}{
 		{
 			name:    "missing id",
@@ -757,6 +908,39 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroup() {
 			},
 			wantErr: &ErrorGroupNotFound,
 		},
+		{
+			name: "success",
+			id:   "grp-001",
+			setup: func(storeMock *groupStoreInterfaceMock) {
+				storeMock.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", Name: "test", OrganizationUnitID: testOUID1}, nil).
+					Once()
+			},
+		},
+		{
+			name: "access denied",
+			id:   "grp-001",
+			setup: func(storeMock *groupStoreInterfaceMock) {
+				storeMock.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", OrganizationUnitID: testOUID1}, nil).
+					Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionReadGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID1,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			wantErr: &serviceerror.ErrorUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -769,7 +953,16 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroup() {
 				tc.setup(storeMock)
 			}
 
-			service := &groupService{groupStore: storeMock}
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
+			service := &groupService{
+				authzService: authzSvc,
+				groupStore:   storeMock,
+			}
 
 			group, err := service.GetGroup(context.Background(), tc.id)
 
@@ -801,6 +994,7 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 		groupID     string
 		request     UpdateGroupRequest
 		setup       func(*setupArgs)
+		authzSetup  func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
 		expectErr   *serviceerror.ServiceError
 		expectGroup bool
 	}{
@@ -836,8 +1030,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 				})).
 					Return(nil).
 					Once()
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-new").
-					Return(oupkg.OrganizationUnit{ID: "ou-new"}, nil).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-new").
+					Return(true, nil).
 					Once()
 			},
 			expectGroup: true,
@@ -856,8 +1050,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 				args.store.On("CheckGroupNameConflictForUpdate", mock.Anything, "new-name", "ou-new", "grp-001").
 					Return(ErrGroupNameConflict).
 					Once()
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-new").
-					Return(oupkg.OrganizationUnit{ID: "ou-new"}, nil).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-new").
+					Return(true, nil).
 					Once()
 			},
 			expectErr: &ErrorGroupNameConflict,
@@ -901,8 +1095,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 				args.store.On("GetGroup", mock.Anything, "grp-001").
 					Return(GroupDAO{ID: "grp-001", Name: "name", OrganizationUnitID: "ou-old"}, nil).
 					Once()
-				args.ou.On("GetOrganizationUnit", mock.Anything, "ou-new").
-					Return(oupkg.OrganizationUnit{}, &oupkg.ErrorOrganizationUnitNotFound).
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, "ou-new").
+					Return(false, nil).
 					Once()
 			},
 			expectErr: &ErrorInvalidOUID,
@@ -944,6 +1138,72 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 			},
 			expectErr: &ErrorInternalServerError,
 		},
+		{
+			name:    "access denied on source OU",
+			groupID: "grp-001",
+			request: UpdateGroupRequest{
+				Name:               "new-name",
+				OrganizationUnitID: testOUID1,
+			},
+			setup: func(args *setupArgs) {
+				args.store.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", OrganizationUnitID: testOUID1}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionUpdateGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID1,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			expectErr: &serviceerror.ErrorUnauthorized,
+		},
+		{
+			name:    "access denied on target OU",
+			groupID: "grp-001",
+			request: UpdateGroupRequest{
+				Name:               "new-name",
+				OrganizationUnitID: testOUID2,
+			},
+			setup: func(args *setupArgs) {
+				args.store.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", OrganizationUnitID: testOUID1}, nil).Once()
+				args.ou.On("IsOrganizationUnitExists", mock.Anything, testOUID2).
+					Return(true, (*serviceerror.ServiceError)(nil)).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionUpdateGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID1,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(true, (*serviceerror.ServiceError)(nil))
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionUpdateGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID2,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			expectErr: &serviceerror.ErrorUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -960,7 +1220,14 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 				tc.setup(&setupArgs{store: storeMock, ou: ouServiceMock, user: userServiceMock})
 			}
 
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
 			service := &groupService{
+				authzService:  authzSvc,
 				groupStore:    storeMock,
 				ouService:     ouServiceMock,
 				userService:   userServiceMock,
@@ -995,10 +1262,11 @@ func (suite *GroupServiceTestSuite) TestGroupService_UpdateGroup() {
 
 func (suite *GroupServiceTestSuite) TestGroupService_DeleteGroup() {
 	testCases := []struct {
-		name      string
-		id        string
-		setup     func(*groupStoreInterfaceMock)
-		expectErr *serviceerror.ServiceError
+		name       string
+		id         string
+		setup      func(*groupStoreInterfaceMock)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
+		expectErr  *serviceerror.ServiceError
 	}{
 		{
 			name: "success",
@@ -1050,6 +1318,29 @@ func (suite *GroupServiceTestSuite) TestGroupService_DeleteGroup() {
 			},
 			expectErr: &ErrorGroupNotFound,
 		},
+		{
+			name: "access denied",
+			id:   "grp-001",
+			setup: func(storeMock *groupStoreInterfaceMock) {
+				storeMock.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", OrganizationUnitID: testOUID1}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionDeleteGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID1,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			expectErr: &serviceerror.ErrorUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1061,7 +1352,17 @@ func (suite *GroupServiceTestSuite) TestGroupService_DeleteGroup() {
 				tc.setup(storeMock)
 			}
 
-			service := &groupService{groupStore: storeMock, transactioner: &stubTransactioner{}}
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
+			service := &groupService{
+				authzService:  authzSvc,
+				groupStore:    storeMock,
+				transactioner: &stubTransactioner{},
+			}
 
 			err := service.DeleteGroup(context.Background(), tc.id)
 
@@ -1081,13 +1382,14 @@ func (suite *GroupServiceTestSuite) TestGroupService_DeleteGroup() {
 
 func (suite *GroupServiceTestSuite) TestGroupService_GetGroupMembers() {
 	testCases := []struct {
-		name      string
-		id        string
-		limit     int
-		offset    int
-		setup     func(*groupStoreInterfaceMock)
-		expectErr *serviceerror.ServiceError
-		expectRes bool
+		name       string
+		id         string
+		limit      int
+		offset     int
+		setup      func(*groupStoreInterfaceMock)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
+		expectErr  *serviceerror.ServiceError
+		expectRes  bool
 	}{
 		{
 			name:   "success",
@@ -1181,6 +1483,31 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupMembers() {
 			},
 			expectErr: &ErrorInternalServerError,
 		},
+		{
+			name:   "access denied",
+			id:     "grp-001",
+			limit:  5,
+			offset: 0,
+			setup: func(storeMock *groupStoreInterfaceMock) {
+				storeMock.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", OrganizationUnitID: testOUID1}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionReadGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID1,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			expectErr: &serviceerror.ErrorUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1192,7 +1519,16 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupMembers() {
 				tc.setup(storeMock)
 			}
 
-			service := &groupService{groupStore: storeMock}
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
+			service := &groupService{
+				authzService: authzSvc,
+				groupStore:   storeMock,
+			}
 
 			response, err := service.GetGroupMembers(context.Background(), tc.id, tc.limit, tc.offset)
 
@@ -1219,7 +1555,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_GetGroupMembers() {
 }
 
 func (suite *GroupServiceTestSuite) TestGroupService_ValidateCreateGroupRequest() {
-	service := &groupService{}
+	service := &groupService{
+		authzService: newAllowAllAuthz(suite.T())}
 
 	testCases := []groupRequestValidationTestCase[CreateGroupRequest]{
 		{
@@ -1265,7 +1602,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_ValidateCreateGroupRequest(
 }
 
 func (suite *GroupServiceTestSuite) TestGroupService_ValidateUpdateGroupRequest() {
-	service := &groupService{}
+	service := &groupService{
+		authzService: newAllowAllAuthz(suite.T())}
 
 	testCases := []groupRequestValidationTestCase[UpdateGroupRequest]{
 		{
@@ -1294,15 +1632,16 @@ func (suite *GroupServiceTestSuite) TestGroupService_ValidateUpdateGroupRequest(
 func (suite *GroupServiceTestSuite) TestGroupService_ValidateOUHandlesInternalError() {
 	t := suite.T()
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
-	ouServiceMock.On("GetOrganizationUnit", mock.Anything, "ou-1").
-		Return(oupkg.OrganizationUnit{}, &serviceerror.ServiceError{
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
+		Return(false, &serviceerror.ServiceError{
 			Code: "OU-5000",
 			Type: serviceerror.ServerErrorType,
 		}).
 		Once()
 
 	service := &groupService{
-		ouService: ouServiceMock,
+		authzService: newAllowAllAuthz(suite.T()),
+		ouService:    ouServiceMock,
 	}
 
 	err := service.validateOU(context.Background(), "ou-1")
@@ -1313,7 +1652,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_ValidateOUHandlesInternalEr
 
 func (suite *GroupServiceTestSuite) TestGroupService_ValidateAndProcessHandlePath() {
 	t := suite.T()
-	service := &groupService{}
+	service := &groupService{
+		authzService: newAllowAllAuthz(suite.T())}
 
 	testCases := []struct {
 		name        string
@@ -1382,13 +1722,184 @@ func (suite *GroupServiceTestSuite) TestGroupService_ValidateUserIDsHandlesServi
 		Once()
 
 	service := &groupService{
-		userService: userServiceMock,
+		authzService: newAllowAllAuthz(suite.T()),
+		userService:  userServiceMock,
 	}
 
 	err := service.validateUserIDs(context.Background(), []string{"usr-001"})
 
 	require.NotNil(t, err)
 	require.Equal(t, ErrorInternalServerError, *err)
+}
+
+func (suite *GroupServiceTestSuite) TestGroupService_ValidateUserIDsWithAccess() {
+	testCases := []struct {
+		name       string
+		userIDs    []string
+		setup      func(*usermock.UserServiceInterfaceMock)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
+		wantErr    *serviceerror.ServiceError
+	}{
+		{
+			name:    "empty user IDs returns nil immediately",
+			userIDs: []string{},
+			wantErr: nil,
+		},
+		{
+			name:    "invalid user IDs returns 400",
+			userIDs: []string{"usr-invalid"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-invalid"}).
+					Return([]string{"usr-invalid"}, nil).Once()
+			},
+			wantErr: &ErrorInvalidUserMemberID,
+		},
+		{
+			name:    "user service error on validate IDs returns 500",
+			userIDs: []string{"usr-001"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-001"}).
+					Return(nil, &serviceerror.ServiceError{Code: "USR-5000", Type: serviceerror.ServerErrorType}).
+					Once()
+			},
+			wantErr: &ErrorInternalServerError,
+		},
+		{
+			name:    "full admin skips OU scope check",
+			userIDs: []string{"usr-001"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-001"}).
+					Return([]string{}, nil).Once()
+				// ValidateUserIDsInOUs must NOT be called when AllAllowed is true.
+			},
+			// authzSetup nil → newAllowAllAuthz → AllAllowed: true
+			wantErr: nil,
+		},
+		{
+			name:    "user in accessible OU returns nil",
+			userIDs: []string{"usr-001"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-001"}).
+					Return([]string{}, nil).Once()
+				userMock.On("ValidateUserIDsInOUs", mock.Anything, []string{"usr-001"}, []string{testOUID1}).
+					Return([]string{}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				m := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				m.On("GetAccessibleResources", mock.Anything,
+					security.ActionUpdateGroup, security.ResourceTypeOU).
+					Return(&sysauthz.AccessibleResources{
+						AllAllowed: false, IDs: []string{testOUID1},
+					}, (*serviceerror.ServiceError)(nil))
+				return m
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "user outside accessible OU returns 403",
+			userIDs: []string{"usr-002"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-002"}).
+					Return([]string{}, nil).Once()
+				userMock.On("ValidateUserIDsInOUs", mock.Anything, []string{"usr-002"}, []string{testOUID1}).
+					Return([]string{"usr-002"}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				m := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				m.On("GetAccessibleResources", mock.Anything,
+					security.ActionUpdateGroup, security.ResourceTypeOU).
+					Return(&sysauthz.AccessibleResources{
+						AllAllowed: false, IDs: []string{testOUID1},
+					}, (*serviceerror.ServiceError)(nil))
+				return m
+			},
+			wantErr: &serviceerror.ErrorUnauthorized,
+		},
+		{
+			name:    "no accessible OUs makes all users out of scope",
+			userIDs: []string{"usr-001"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-001"}).
+					Return([]string{}, nil).Once()
+				userMock.On("ValidateUserIDsInOUs", mock.Anything, []string{"usr-001"}, []string{}).
+					Return([]string{"usr-001"}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				m := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				m.On("GetAccessibleResources", mock.Anything,
+					security.ActionUpdateGroup, security.ResourceTypeOU).
+					Return(&sysauthz.AccessibleResources{
+						AllAllowed: false, IDs: []string{},
+					}, (*serviceerror.ServiceError)(nil))
+				return m
+			},
+			wantErr: &serviceerror.ErrorUnauthorized,
+		},
+		{
+			name:    "authz service error propagates",
+			userIDs: []string{"usr-001"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-001"}).
+					Return([]string{}, nil).Once()
+			},
+			authzSetup: newAuthzError,
+			wantErr:    &ErrorInternalServerError,
+		},
+		{
+			name:    "validate in OUs store error returns 500",
+			userIDs: []string{"usr-001"},
+			setup: func(userMock *usermock.UserServiceInterfaceMock) {
+				userMock.On("ValidateUserIDs", mock.Anything, []string{"usr-001"}).
+					Return([]string{}, nil).Once()
+				userMock.On("ValidateUserIDsInOUs", mock.Anything, []string{"usr-001"}, []string{testOUID1}).
+					Return(nil, &serviceerror.ServiceError{Code: "USR-5000", Type: serviceerror.ServerErrorType}).
+					Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				m := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				m.On("GetAccessibleResources", mock.Anything,
+					security.ActionUpdateGroup, security.ResourceTypeOU).
+					Return(&sysauthz.AccessibleResources{
+						AllAllowed: false, IDs: []string{testOUID1},
+					}, (*serviceerror.ServiceError)(nil))
+				return m
+			},
+			wantErr: &ErrorInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			userServiceMock := usermock.NewUserServiceInterfaceMock(suite.T())
+			if tc.setup != nil {
+				tc.setup(userServiceMock)
+			}
+
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
+
+			service := &groupService{
+				authzService: authzSvc,
+				userService:  userServiceMock,
+			}
+
+			err := service.validateUserIDsWithAccess(context.Background(), tc.userIDs)
+
+			if tc.wantErr != nil {
+				suite.Require().NotNil(err)
+				suite.Require().Equal(*tc.wantErr, *err)
+			} else {
+				suite.Require().Nil(err)
+			}
+
+			userServiceMock.AssertExpectations(suite.T())
+		})
+	}
 }
 
 func (suite *GroupServiceTestSuite) TestGroupService_ValidateGroupIDs() {
@@ -1421,7 +1932,8 @@ func (suite *GroupServiceTestSuite) TestGroupService_ValidateGroupIDs() {
 		tc := tc
 		suite.Run(tc.name, func() {
 			storeMock := newGroupStoreInterfaceMock(suite.T())
-			service := &groupService{groupStore: storeMock}
+			service := &groupService{
+				authzService: newAllowAllAuthz(suite.T()), groupStore: storeMock}
 			tc.setup(storeMock)
 
 			err := service.ValidateGroupIDs(context.Background(), []string{"grp-001"})
@@ -1436,11 +1948,12 @@ func (suite *GroupServiceTestSuite) TestGroupService_ValidateGroupIDs() {
 
 func (suite *GroupServiceTestSuite) TestGroupService_AddGroupMembers() {
 	testCases := []struct {
-		name    string
-		groupID string
-		members []Member
-		setup   func(*groupStoreInterfaceMock, *usermock.UserServiceInterfaceMock)
-		wantErr *serviceerror.ServiceError
+		name       string
+		groupID    string
+		members    []Member
+		setup      func(*groupStoreInterfaceMock, *usermock.UserServiceInterfaceMock)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
+		wantErr    *serviceerror.ServiceError
 	}{
 		{
 			name:    "missing group id",
@@ -1521,6 +2034,30 @@ func (suite *GroupServiceTestSuite) TestGroupService_AddGroupMembers() {
 			},
 			wantErr: nil,
 		},
+		{
+			name:    "access denied",
+			groupID: "grp-001",
+			members: []Member{{ID: "usr-001", Type: MemberTypeUser}},
+			setup: func(storeMock *groupStoreInterfaceMock, _ *usermock.UserServiceInterfaceMock) {
+				storeMock.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", OrganizationUnitID: testOUID1}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionUpdateGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID1,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			wantErr: &serviceerror.ErrorUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1533,7 +2070,14 @@ func (suite *GroupServiceTestSuite) TestGroupService_AddGroupMembers() {
 				tc.setup(storeMock, userServiceMock)
 			}
 
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
 			service := &groupService{
+				authzService:  authzSvc,
 				groupStore:    storeMock,
 				userService:   userServiceMock,
 				transactioner: &stubTransactioner{},
@@ -1558,11 +2102,12 @@ func (suite *GroupServiceTestSuite) TestGroupService_AddGroupMembers() {
 
 func (suite *GroupServiceTestSuite) TestGroupService_RemoveGroupMembers() {
 	testCases := []struct {
-		name    string
-		groupID string
-		members []Member
-		setup   func(*groupStoreInterfaceMock)
-		wantErr *serviceerror.ServiceError
+		name       string
+		groupID    string
+		members    []Member
+		setup      func(*groupStoreInterfaceMock)
+		authzSetup func(*testing.T) sysauthz.SystemAuthorizationServiceInterface
+		wantErr    *serviceerror.ServiceError
 	}{
 		{
 			name:    "missing group id",
@@ -1623,6 +2168,30 @@ func (suite *GroupServiceTestSuite) TestGroupService_RemoveGroupMembers() {
 			},
 			wantErr: nil,
 		},
+		{
+			name:    "access denied",
+			groupID: "grp-001",
+			members: []Member{{ID: "usr-001", Type: MemberTypeUser}},
+			setup: func(storeMock *groupStoreInterfaceMock) {
+				storeMock.On("GetGroup", mock.Anything, "grp-001").
+					Return(GroupDAO{ID: "grp-001", OrganizationUnitID: testOUID1}, nil).Once()
+			},
+			authzSetup: func(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+				authzMock.On(
+					"IsActionAllowed",
+					mock.Anything,
+					security.ActionUpdateGroup,
+					&sysauthz.ActionContext{
+						OuID:         testOUID1,
+						ResourceType: security.ResourceTypeGroup,
+						ResourceID:   "grp-001",
+					},
+				).Return(false, (*serviceerror.ServiceError)(nil))
+				return authzMock
+			},
+			wantErr: &serviceerror.ErrorUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1634,7 +2203,14 @@ func (suite *GroupServiceTestSuite) TestGroupService_RemoveGroupMembers() {
 				tc.setup(storeMock)
 			}
 
+			var authzSvc sysauthz.SystemAuthorizationServiceInterface
+			if tc.authzSetup != nil {
+				authzSvc = tc.authzSetup(suite.T())
+			} else {
+				authzSvc = newAllowAllAuthz(suite.T())
+			}
 			service := &groupService{
+				authzService:  authzSvc,
 				groupStore:    storeMock,
 				transactioner: &stubTransactioner{},
 			}

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -35,6 +35,8 @@ var buildBulkGroupExistsQueryFunc = buildBulkGroupExistsQuery
 type groupStoreInterface interface {
 	GetGroupListCount(ctx context.Context) (int, error)
 	GetGroupList(ctx context.Context, limit, offset int) ([]GroupBasicDAO, error)
+	GetGroupListCountByOUIDs(ctx context.Context, ouIDs []string) (int, error)
+	GetGroupListByOUIDs(ctx context.Context, ouIDs []string, limit, offset int) ([]GroupBasicDAO, error)
 	CreateGroup(ctx context.Context, group GroupDAO) error
 	GetGroup(ctx context.Context, id string) (GroupDAO, error)
 	GetGroupMembers(ctx context.Context, groupID string, limit, offset int) ([]Member, error)
@@ -74,7 +76,7 @@ func (s *groupStore) GetGroupListCount(ctx context.Context) (int, error) {
 
 	countResults, err := dbClient.QueryContext(ctx, QueryGetGroupListCount, s.deploymentID)
 	if err != nil {
-		return 0, fmt.Errorf("failed to execute count query: %w", err)
+		return 0, fmt.Errorf("failed to execute group list count query: %w", err)
 	}
 
 	var totalCount int
@@ -93,7 +95,6 @@ func (s *groupStore) GetGroupList(ctx context.Context, limit, offset int) ([]Gro
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
-
 	results, err := dbClient.QueryContext(ctx, QueryGetGroupList, limit, offset, s.deploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute group list query: %w", err)
@@ -119,7 +120,75 @@ func (s *groupStore) GetGroupList(ctx context.Context, limit, offset int) ([]Gro
 	return groups, nil
 }
 
-// CreateGroup creates a new group in the database.
+// GetGroupListCountByOUIDs retrieves the total count of groups belonging to a set of OUs.
+func (s *groupStore) GetGroupListCountByOUIDs(ctx context.Context, ouIDs []string) (int, error) {
+	if len(ouIDs) == 0 {
+		return 0, nil
+	}
+
+	dbClient, err := s.dbProvider.GetUserDBClient()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get database client for counter query: %w", err)
+	}
+
+	query, args := buildGetGroupsCountByOUIDsQuery(ouIDs, s.deploymentID)
+
+	var count int
+	countResults, err := dbClient.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(countResults) > 0 {
+		if countVal, ok := countResults[0]["total"].(int64); ok {
+			count = int(countVal)
+		} else if countVal, ok := countResults[0]["total"].(float64); ok { // sqlite count result type
+			count = int(countVal)
+		}
+	}
+
+	return count, nil
+}
+
+// GetGroupListByOUIDs retrieves groups belonging to a set of OUs with pagination.
+func (s *groupStore) GetGroupListByOUIDs(
+	ctx context.Context, ouIDs []string, limit, offset int) ([]GroupBasicDAO, error) {
+	if len(ouIDs) == 0 {
+		return []GroupBasicDAO{}, nil
+	}
+
+	dbClient, err := s.dbProvider.GetUserDBClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database client for query: %w", err)
+	}
+	query, args := buildGetGroupsByOUIDsQuery(ouIDs, limit, offset, s.deploymentID)
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	groups := make([]GroupBasicDAO, 0, len(results))
+	for _, row := range results {
+		group, err := buildGroupFromResultRow(row)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build group from result row: %w", err)
+		}
+
+		groupBasic := GroupBasicDAO{
+			ID:                 group.ID,
+			Name:               group.Name,
+			Description:        group.Description,
+			OrganizationUnitID: group.OrganizationUnitID,
+		}
+
+		groups = append(groups, groupBasic)
+	}
+
+	return groups, nil
+}
+
+// CreateGroup adds a new group record to the database.
 func (s *groupStore) CreateGroup(ctx context.Context, group GroupDAO) error {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {

--- a/backend/internal/group/store_constants.go
+++ b/backend/internal/group/store_constants.go
@@ -38,86 +38,178 @@ var (
 		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" ` +
 			`WHERE DEPLOYMENT_ID = $3 ORDER BY NAME LIMIT $1 OFFSET $2`,
 	}
+)
 
+// buildGetGroupsCountByOUIDsQuery returns the query and args to count groups
+// belonging to the specified list of organization unit IDs.
+func buildGetGroupsCountByOUIDsQuery(
+	ouIDs []string, deploymentID string,
+) (dbmodel.DBQuery, []interface{}) {
+	if len(ouIDs) == 0 {
+		return dbmodel.DBQuery{
+			ID:            "GRQ-GROUP_MGT-03",
+			Query:         "SELECT 0 WHERE 1=0",
+			PostgresQuery: "SELECT 0 WHERE 1=0",
+			SQLiteQuery:   "SELECT 0 WHERE 1=0",
+		}, []interface{}{}
+	}
+
+	postgresPlaceholders := make([]string, len(ouIDs))
+	sqlitePlaceholders := make([]string, len(ouIDs))
+	for i := range ouIDs {
+		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+1)
+		sqlitePlaceholders[i] = "?"
+	}
+	deploymentIDIdx := len(ouIDs) + 1
+
+	postgresQuery := fmt.Sprintf(
+		`SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID IN (%s) AND DEPLOYMENT_ID = $%d`,
+		strings.Join(postgresPlaceholders, ","), deploymentIDIdx)
+	sqliteQuery := fmt.Sprintf(
+		`SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID IN (%s) AND DEPLOYMENT_ID = ?`,
+		strings.Join(sqlitePlaceholders, ","))
+
+	args := make([]interface{}, 0, len(ouIDs)+1)
+	for _, id := range ouIDs {
+		args = append(args, id)
+	}
+	args = append(args, deploymentID)
+
+	return dbmodel.DBQuery{
+		ID:            "GRQ-GROUP_MGT-03",
+		Query:         postgresQuery,
+		PostgresQuery: postgresQuery,
+		SQLiteQuery:   sqliteQuery,
+	}, args
+}
+
+// buildGetGroupsByOUIDsQuery returns the query and args to retrieve paginated groups
+// filtered by the specified list of organization unit IDs.
+func buildGetGroupsByOUIDsQuery(
+	ouIDs []string, limit, offset int, deploymentID string,
+) (dbmodel.DBQuery, []interface{}) {
+	if len(ouIDs) == 0 {
+		return dbmodel.DBQuery{
+			ID:            "GRQ-GROUP_MGT-04",
+			Query:         `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
+			PostgresQuery: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
+			SQLiteQuery:   `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
+		}, []interface{}{}
+	}
+
+	postgresPlaceholders := make([]string, len(ouIDs))
+	sqlitePlaceholders := make([]string, len(ouIDs))
+	for i := range ouIDs {
+		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+1)
+		sqlitePlaceholders[i] = "?"
+	}
+	deploymentIDIdx := len(ouIDs) + 1
+	limitIdx := len(ouIDs) + 2
+	offsetIdx := len(ouIDs) + 3
+
+	postgresQuery := fmt.Sprintf(
+		`SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" `+
+			`WHERE OU_ID IN (%s) AND DEPLOYMENT_ID = $%d ORDER BY NAME LIMIT $%d OFFSET $%d`,
+		strings.Join(postgresPlaceholders, ","), deploymentIDIdx, limitIdx, offsetIdx)
+	sqliteQuery := fmt.Sprintf(
+		`SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" `+
+			`WHERE OU_ID IN (%s) AND DEPLOYMENT_ID = ? ORDER BY NAME LIMIT ? OFFSET ?`,
+		strings.Join(sqlitePlaceholders, ","))
+
+	args := make([]interface{}, 0, len(ouIDs)+3)
+	for _, id := range ouIDs {
+		args = append(args, id)
+	}
+	args = append(args, deploymentID, limit, offset)
+
+	return dbmodel.DBQuery{
+		ID:            "GRQ-GROUP_MGT-04",
+		Query:         postgresQuery,
+		PostgresQuery: postgresQuery,
+		SQLiteQuery:   sqliteQuery,
+	}, args
+}
+
+var (
 	// QueryCreateGroup is the query to create a new group.
 	QueryCreateGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-03",
+		ID:    "GRQ-GROUP_MGT-05",
 		Query: `INSERT INTO "GROUP" (ID, OU_ID, NAME, DESCRIPTION, DEPLOYMENT_ID) VALUES ($1, $2, $3, $4, $5)`,
 	}
 
 	// QueryGetGroupByID is the query to get a group by id.
 	QueryGetGroupByID = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-04",
+		ID:    "GRQ-GROUP_MGT-06",
 		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
 	// QueryGetGroupMembers is the query to get members assigned to a group.
 	QueryGetGroupMembers = dbmodel.DBQuery{
-		ID: "GRQ-GROUP_MGT-05",
+		ID: "GRQ-GROUP_MGT-07",
 		Query: `SELECT MEMBER_ID, MEMBER_TYPE FROM GROUP_MEMBER_REFERENCE WHERE GROUP_ID = $1 AND DEPLOYMENT_ID = $4 ` +
 			`ORDER BY MEMBER_TYPE, MEMBER_ID LIMIT $2 OFFSET $3`,
 	}
 
 	// QueryGetGroupMemberCount is the query to get total count of members in a group.
 	QueryGetGroupMemberCount = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-06",
+		ID:    "GRQ-GROUP_MGT-08",
 		Query: `SELECT COUNT(*) as total FROM GROUP_MEMBER_REFERENCE WHERE GROUP_ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
 	// QueryUpdateGroup is the query to update a group.
 	QueryUpdateGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-07",
+		ID:    "GRQ-GROUP_MGT-09",
 		Query: `UPDATE "GROUP" SET OU_ID = $2, NAME = $3, DESCRIPTION = $4 WHERE ID = $1 AND DEPLOYMENT_ID = $5`,
 	}
 
 	// QueryDeleteGroup is the query to delete a group.
 	QueryDeleteGroup = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-08",
+		ID:    "GRQ-GROUP_MGT-10",
 		Query: `DELETE FROM "GROUP" WHERE ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
 	// QueryDeleteGroupMembers is the query to delete all members assigned to a group.
 	QueryDeleteGroupMembers = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-09",
+		ID:    "GRQ-GROUP_MGT-11",
 		Query: `DELETE FROM GROUP_MEMBER_REFERENCE WHERE GROUP_ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
 	// QueryAddMemberToGroup is the query to assign member to a group.
 	QueryAddMemberToGroup = dbmodel.DBQuery{
-		ID: "GRQ-GROUP_MGT-10",
+		ID: "GRQ-GROUP_MGT-12",
 		Query: `INSERT INTO GROUP_MEMBER_REFERENCE (GROUP_ID, MEMBER_TYPE, MEMBER_ID, DEPLOYMENT_ID) ` +
 			`VALUES ($1, $2, $3, $4) ON CONFLICT (GROUP_ID, MEMBER_TYPE, MEMBER_ID, DEPLOYMENT_ID) DO NOTHING`,
 	}
 
 	// QueryCheckGroupNameConflict is the query to check if a group name conflicts within the same organization unit.
 	QueryCheckGroupNameConflict = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-11",
+		ID:    "GRQ-GROUP_MGT-13",
 		Query: `SELECT COUNT(*) as count FROM "GROUP" WHERE NAME = $1 AND OU_ID = $2 AND DEPLOYMENT_ID = $3`,
 	}
 
 	// QueryCheckGroupNameConflictForUpdate is the query to check name conflict during update.
 	QueryCheckGroupNameConflictForUpdate = dbmodel.DBQuery{
-		ID: "GRQ-GROUP_MGT-12",
+		ID: "GRQ-GROUP_MGT-14",
 		Query: `SELECT COUNT(*) as count FROM "GROUP" ` +
 			`WHERE NAME = $1 AND OU_ID = $2 AND ID != $3 AND DEPLOYMENT_ID = $4`,
 	}
 
 	// QueryGetGroupsByOrganizationUnitCount is the query to get total count of groups by organization unit.
 	QueryGetGroupsByOrganizationUnitCount = dbmodel.DBQuery{
-		ID:    "GRQ-GROUP_MGT-13",
+		ID:    "GRQ-GROUP_MGT-15",
 		Query: `SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
 	// QueryGetGroupsByOrganizationUnit is the query to get groups by organization unit with pagination.
 	QueryGetGroupsByOrganizationUnit = dbmodel.DBQuery{
-		ID: "GRQ-GROUP_MGT-14",
+		ID: "GRQ-GROUP_MGT-16",
 		Query: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" ` +
 			`WHERE OU_ID = $1 AND DEPLOYMENT_ID = $4 ORDER BY NAME LIMIT $2 OFFSET $3`,
 	}
 
 	// QueryDeleteGroupMember is the query to delete a specific member from a group.
 	QueryDeleteGroupMember = dbmodel.DBQuery{
-		ID: "GRQ-GROUP_MGT-16",
+		ID: "GRQ-GROUP_MGT-17",
 		Query: `DELETE FROM GROUP_MEMBER_REFERENCE ` +
 			`WHERE GROUP_ID = $1 AND MEMBER_TYPE = $2 AND MEMBER_ID = $3 AND DEPLOYMENT_ID = $4`,
 	}
@@ -145,7 +237,7 @@ func buildBulkGroupExistsQuery(groupIDs []string, deploymentID string) (dbmodel.
 	sqliteQuery := fmt.Sprintf(baseQuery, "?", strings.Join(sqlitePlaceholders, ","))
 
 	query := dbmodel.DBQuery{
-		ID:            "GRQ-GROUP_MGT-15",
+		ID:            "GRQ-GROUP_MGT-18",
 		Query:         postgresQuery,
 		PostgresQuery: postgresQuery,
 		SQLiteQuery:   sqliteQuery,

--- a/backend/internal/group/store_constants_test.go
+++ b/backend/internal/group/store_constants_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package group
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildGetGroupListCountByOUIDsQuery(t *testing.T) {
+	deploymentID := "dep1"
+	testCases := []struct {
+		name           string
+		ouIDs          []string
+		expectedPG     string
+		expectedSQLite string
+		expectedArgs   []interface{}
+	}{
+		{
+			name:           "Empty list",
+			ouIDs:          []string{},
+			expectedPG:     "SELECT 0 WHERE 1=0",
+			expectedSQLite: "SELECT 0 WHERE 1=0",
+			expectedArgs:   []interface{}{},
+		},
+		{
+			name:           "Single item",
+			ouIDs:          []string{"ou1"},
+			expectedPG:     `SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID IN ($1) AND DEPLOYMENT_ID = $2`,
+			expectedSQLite: `SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID IN (?) AND DEPLOYMENT_ID = ?`,
+			expectedArgs:   []interface{}{"ou1", deploymentID},
+		},
+		{
+			name:           "Multiple items",
+			ouIDs:          []string{"ou1", "ou2", "ou3"},
+			expectedPG:     `SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID IN ($1,$2,$3) AND DEPLOYMENT_ID = $4`,
+			expectedSQLite: `SELECT COUNT(*) as total FROM "GROUP" WHERE OU_ID IN (?,?,?) AND DEPLOYMENT_ID = ?`,
+			expectedArgs:   []interface{}{"ou1", "ou2", "ou3", deploymentID},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, args := buildGetGroupsCountByOUIDsQuery(tc.ouIDs, deploymentID)
+			require.Equal(t, tc.expectedPG, result.PostgresQuery)
+			require.Equal(t, tc.expectedSQLite, result.SQLiteQuery)
+			require.Equal(t, tc.expectedArgs, args)
+		})
+	}
+}
+
+func TestBuildGetGroupListByOUIDsQuery(t *testing.T) {
+	limit, offset, deploymentID := 10, 5, "dep1"
+	testCases := []struct {
+		name           string
+		ouIDs          []string
+		expectedPG     string
+		expectedSQLite string
+		expectedArgs   []interface{}
+	}{
+		{
+			name:           "Empty list",
+			ouIDs:          []string{},
+			expectedPG:     `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
+			expectedSQLite: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
+			expectedArgs:   []interface{}{},
+		},
+		{
+			name:  "Single item",
+			ouIDs: []string{"ou1"},
+			expectedPG: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" ` +
+				`WHERE OU_ID IN ($1) AND DEPLOYMENT_ID = $2 ORDER BY NAME LIMIT $3 OFFSET $4`,
+			expectedSQLite: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" ` +
+				`WHERE OU_ID IN (?) AND DEPLOYMENT_ID = ? ORDER BY NAME LIMIT ? OFFSET ?`,
+			expectedArgs: []interface{}{"ou1", deploymentID, limit, offset},
+		},
+		{
+			name:  "Multiple items",
+			ouIDs: []string{"ou1", "ou2", "ou3"},
+			expectedPG: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" ` +
+				`WHERE OU_ID IN ($1,$2,$3) AND DEPLOYMENT_ID = $4 ORDER BY NAME LIMIT $5 OFFSET $6`,
+			expectedSQLite: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" ` +
+				`WHERE OU_ID IN (?,?,?) AND DEPLOYMENT_ID = ? ORDER BY NAME LIMIT ? OFFSET ?`,
+			expectedArgs: []interface{}{"ou1", "ou2", "ou3", deploymentID, limit, offset},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, args := buildGetGroupsByOUIDsQuery(tc.ouIDs, limit, offset, deploymentID)
+			require.Equal(t, tc.expectedPG, result.PostgresQuery)
+			require.Equal(t, tc.expectedSQLite, result.SQLiteQuery)
+			require.Equal(t, tc.expectedArgs, args)
+		})
+	}
+}

--- a/backend/internal/group/store_test.go
+++ b/backend/internal/group/store_test.go
@@ -40,7 +40,7 @@ func TestGroupStoreTestSuite(t *testing.T) {
 	suite.Run(t, new(GroupStoreTestSuite))
 }
 
-const queryGroupExistsID = "GRQ-GROUP_MGT-15"
+const queryGroupExistsID = "GRQ-GROUP_MGT-18"
 const testDeploymentID = "test-deployment-id"
 
 type validateGroupIDsSetupFn func(
@@ -175,7 +175,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupListCount() {
 					Return(nil, errors.New("boom")).
 					Once()
 			},
-			wantErr:   "failed to execute count query",
+			wantErr:   "boom",
 			wantCount: 0,
 		},
 	}

--- a/backend/internal/system/security/permissions.go
+++ b/backend/internal/system/security/permissions.go
@@ -221,6 +221,7 @@ var apiPermissionEntries = []apiPermissionEntry{
 	{"GET /groups", PermissionGroupView},
 	{"POST /groups", PermissionGroup},
 	{"GET /groups/**", PermissionGroupView},
+	{"POST /groups/**", PermissionGroup},
 	{"PUT /groups/**", PermissionGroup},
 	{"DELETE /groups/**", PermissionGroup},
 

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -1143,6 +1143,82 @@ func (_c *UserServiceInterfaceMock_ValidateUserIDs_Call) RunAndReturn(run func(c
 	return _c
 }
 
+// ValidateUserIDsInOUs provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) ValidateUserIDsInOUs(ctx context.Context, userIDs []string, ouIDs []string) ([]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userIDs, ouIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateUserIDsInOUs")
+	}
+
+	var r0 []string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) ([]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userIDs, ouIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) []string); ok {
+		r0 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_ValidateUserIDsInOUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateUserIDsInOUs'
+type UserServiceInterfaceMock_ValidateUserIDsInOUs_Call struct {
+	*mock.Call
+}
+
+// ValidateUserIDsInOUs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+//   - ouIDs []string
+func (_e *UserServiceInterfaceMock_Expecter) ValidateUserIDsInOUs(ctx interface{}, userIDs interface{}, ouIDs interface{}) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	return &UserServiceInterfaceMock_ValidateUserIDsInOUs_Call{Call: _e.mock.On("ValidateUserIDsInOUs", ctx, userIDs, ouIDs)}
+}
+
+func (_c *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call) Run(run func(ctx context.Context, userIDs []string, ouIDs []string)) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call) Return(strings []string, serviceError *serviceerror.ServiceError) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(strings, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string, ouIDs []string) ([]string, *serviceerror.ServiceError)) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // VerifyUser provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) VerifyUser(ctx context.Context, userID string, credentials map[string]interface{}) (*User, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, userID, credentials)

--- a/backend/internal/user/composite_store.go
+++ b/backend/internal/user/composite_store.go
@@ -271,6 +271,42 @@ func (c *compositeUserStore) ValidateUserIDs(ctx context.Context, userIDs []stri
 	return invalidIDs, nil
 }
 
+// ValidateUserIDsInOUs checks which of the provided user IDs belong to the given OU scope
+// across both the database and file-based stores.
+// Returns user IDs that do not belong to any of the provided OUs in either store.
+func (c *compositeUserStore) ValidateUserIDsInOUs(
+	ctx context.Context, userIDs []string, ouIDs []string,
+) ([]string, error) {
+	if len(userIDs) == 0 {
+		return []string{}, nil
+	}
+	if len(ouIDs) == 0 {
+		return append([]string{}, userIDs...), nil
+	}
+
+	ouSet := make(map[string]bool, len(ouIDs))
+	for _, ou := range ouIDs {
+		ouSet[ou] = true
+	}
+
+	outOfScope := make([]string, 0)
+	for _, id := range userIDs {
+		user, err := c.GetUser(ctx, id)
+		if err != nil {
+			if errors.Is(err, ErrUserNotFound) {
+				// Not found in any store — treat as out of scope.
+				outOfScope = append(outOfScope, id)
+				continue
+			}
+			return nil, err
+		}
+		if !ouSet[user.OrganizationUnit] {
+			outOfScope = append(outOfScope, id)
+		}
+	}
+	return outOfScope, nil
+}
+
 // mergeAndDeduplicateUsers merges and deduplicates users from two lists.
 // Database users take precedence over file-based users when IDs conflict.
 func mergeAndDeduplicateUsers(dbUsers, fileUsers []User) []User {

--- a/backend/internal/user/composite_store_test.go
+++ b/backend/internal/user/composite_store_test.go
@@ -400,6 +400,122 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ValidateUserIDs_StoreEr
 	suite.Nil(result)
 }
 
+// TestCompositeStore_ValidateUserIDsInOUs_EmptyUserIDs verifies short-circuit on empty user IDs.
+func (suite *CompositeStoreTestSuite) TestCompositeStore_ValidateUserIDsInOUs_EmptyUserIDs() {
+	out, err := suite.compositeStore.ValidateUserIDsInOUs(context.Background(), []string{}, []string{"ou-1"})
+	suite.NoError(err)
+	suite.Empty(out)
+}
+
+// TestCompositeStore_ValidateUserIDsInOUs_EmptyOUIDs verifies all IDs are out-of-scope when no OUs provided.
+func (suite *CompositeStoreTestSuite) TestCompositeStore_ValidateUserIDsInOUs_EmptyOUIDs() {
+	userIDs := []string{"usr-001", "usr-002"}
+	out, err := suite.compositeStore.ValidateUserIDsInOUs(context.Background(), userIDs, []string{})
+	suite.NoError(err)
+	suite.Equal(userIDs, out)
+}
+
+// TestCompositeStore_ValidateUserIDsInOUs covers OU-scope checking across both underlying stores.
+func (suite *CompositeStoreTestSuite) TestCompositeStore_ValidateUserIDsInOUs() {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name           string
+		userIDs        []string
+		ouIDs          []string
+		dbGetUser      func()
+		wantOutOfScope []string
+		wantError      bool
+	}{
+		{
+			name:    "user in scope found in db store",
+			userIDs: []string{"usr-001"},
+			ouIDs:   []string{"ou-1"},
+			dbGetUser: func() {
+				suite.mockDBStore.On("GetUser", ctx, "usr-001").
+					Return(User{ID: "usr-001", OrganizationUnit: "ou-1"}, nil).Once()
+			},
+			wantOutOfScope: []string{},
+		},
+		{
+			name:    "user out of scope",
+			userIDs: []string{"usr-001"},
+			ouIDs:   []string{"ou-2"},
+			dbGetUser: func() {
+				suite.mockDBStore.On("GetUser", ctx, "usr-001").
+					Return(User{ID: "usr-001", OrganizationUnit: "ou-1"}, nil).Once()
+			},
+			wantOutOfScope: []string{"usr-001"},
+		},
+		{
+			name:    "user not found in either store treated as out of scope",
+			userIDs: []string{"usr-missing"},
+			ouIDs:   []string{"ou-1"},
+			dbGetUser: func() {
+				suite.mockDBStore.On("GetUser", ctx, "usr-missing").
+					Return(User{}, ErrUserNotFound).Once()
+				suite.mockFileStore.On("GetUser", ctx, "usr-missing").
+					Return(User{}, ErrUserNotFound).Once()
+			},
+			wantOutOfScope: []string{"usr-missing"},
+		},
+		{
+			name:    "user found in file store when not in db store",
+			userIDs: []string{"usr-file"},
+			ouIDs:   []string{"ou-1"},
+			dbGetUser: func() {
+				suite.mockDBStore.On("GetUser", ctx, "usr-file").
+					Return(User{}, ErrUserNotFound).Once()
+				suite.mockFileStore.On("GetUser", ctx, "usr-file").
+					Return(User{ID: "usr-file", OrganizationUnit: "ou-1"}, nil).Once()
+			},
+			wantOutOfScope: []string{},
+		},
+		{
+			name:    "mixed in scope and out of scope",
+			userIDs: []string{"usr-001", "usr-002"},
+			ouIDs:   []string{"ou-1"},
+			dbGetUser: func() {
+				suite.mockDBStore.On("GetUser", ctx, "usr-001").
+					Return(User{ID: "usr-001", OrganizationUnit: "ou-1"}, nil).Once()
+				suite.mockDBStore.On("GetUser", ctx, "usr-002").
+					Return(User{ID: "usr-002", OrganizationUnit: "ou-2"}, nil).Once()
+			},
+			wantOutOfScope: []string{"usr-002"},
+		},
+		{
+			name:    "non-not-found error from GetUser propagates",
+			userIDs: []string{"usr-001"},
+			ouIDs:   []string{"ou-1"},
+			dbGetUser: func() {
+				suite.mockDBStore.On("GetUser", ctx, "usr-001").
+					Return(User{}, errors.New("connection refused")).Once()
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			if tc.dbGetUser != nil {
+				tc.dbGetUser()
+			}
+
+			out, err := suite.compositeStore.ValidateUserIDsInOUs(ctx, tc.userIDs, tc.ouIDs)
+			if tc.wantError {
+				suite.Error(err)
+			} else {
+				suite.NoError(err)
+				suite.Equal(tc.wantOutOfScope, out)
+			}
+
+			suite.mockDBStore.AssertExpectations(suite.T())
+			suite.mockFileStore.AssertExpectations(suite.T())
+		})
+	}
+}
+
 // TestCompositeStoreTestSuite runs the test suite.
 func TestCompositeStoreTestSuite(t *testing.T) {
 	suite.Run(t, new(CompositeStoreTestSuite))

--- a/backend/internal/user/file_based_store.go
+++ b/backend/internal/user/file_based_store.go
@@ -254,6 +254,41 @@ func (f *userFileBasedStore) ValidateUserIDs(ctx context.Context, userIDs []stri
 	return invalid, nil
 }
 
+// ValidateUserIDsInOUs checks which of the provided user IDs belong to the given OU scope.
+// Returns user IDs that do not belong to any of the provided OUs.
+func (f *userFileBasedStore) ValidateUserIDsInOUs(
+	ctx context.Context, userIDs []string, ouIDs []string,
+) ([]string, error) {
+	if len(userIDs) == 0 {
+		return []string{}, nil
+	}
+	if len(ouIDs) == 0 {
+		return append([]string{}, userIDs...), nil
+	}
+
+	ouSet := make(map[string]bool, len(ouIDs))
+	for _, ou := range ouIDs {
+		ouSet[ou] = true
+	}
+
+	outOfScope := make([]string, 0)
+	for _, id := range userIDs {
+		u, err := f.GetUser(ctx, id)
+		if err != nil {
+			if errors.Is(err, ErrUserNotFound) {
+				// Not found in file store — treat as out of scope for this store.
+				outOfScope = append(outOfScope, id)
+				continue
+			}
+			return nil, err
+		}
+		if !ouSet[u.OrganizationUnit] {
+			outOfScope = append(outOfScope, id)
+		}
+	}
+	return outOfScope, nil
+}
+
 // IsUserDeclarative checks if a user is immutable (exists in file store).
 func (f *userFileBasedStore) IsUserDeclarative(ctx context.Context, id string) (bool, error) {
 	_, err := f.GetUser(ctx, id)

--- a/backend/internal/user/file_based_store_test.go
+++ b/backend/internal/user/file_based_store_test.go
@@ -277,3 +277,76 @@ func (suite *FileBasedStoreTestSuite) TestGroupMethods() {
 	suite.NoError(err)
 	suite.Len(groups, 0)
 }
+
+// TestValidateUserIDsInOUs_EmptyUserIDs verifies short-circuit when no user IDs provided.
+func (suite *FileBasedStoreTestSuite) TestValidateUserIDsInOUs_EmptyUserIDs() {
+	out, err := suite.store.ValidateUserIDsInOUs(context.Background(), []string{}, []string{"ou-1"})
+	suite.NoError(err)
+	suite.Empty(out)
+}
+
+// TestValidateUserIDsInOUs_EmptyOUIDs verifies that all user IDs are out-of-scope when no OUs given.
+func (suite *FileBasedStoreTestSuite) TestValidateUserIDsInOUs_EmptyOUIDs() {
+	userIDs := []string{"usr-001", "usr-002"}
+	out, err := suite.store.ValidateUserIDsInOUs(context.Background(), userIDs, []string{})
+	suite.NoError(err)
+	suite.Equal(userIDs, out)
+}
+
+// TestValidateUserIDsInOUs covers the core OU-scope logic using real in-memory users.
+func (suite *FileBasedStoreTestSuite) TestValidateUserIDsInOUs() {
+	ctx := context.Background()
+
+	// Seed two users in different OUs.
+	user1 := suite.buildUser("usr-001", "ou-1", map[string]interface{}{"username": "alice"})
+	user2 := suite.buildUser("usr-002", "ou-2", map[string]interface{}{"username": "bob"})
+	suite.NoError(suite.store.CreateUser(ctx, user1, nil))
+	suite.NoError(suite.store.CreateUser(ctx, user2, nil))
+
+	testCases := []struct {
+		name           string
+		userIDs        []string
+		ouIDs          []string
+		wantOutOfScope []string
+	}{
+		{
+			name:           "user in scope",
+			userIDs:        []string{"usr-001"},
+			ouIDs:          []string{"ou-1"},
+			wantOutOfScope: []string{},
+		},
+		{
+			name:           "user out of scope",
+			userIDs:        []string{"usr-001"},
+			ouIDs:          []string{"ou-2"},
+			wantOutOfScope: []string{"usr-001"},
+		},
+		{
+			name:           "user not found treated as out of scope",
+			userIDs:        []string{"usr-missing"},
+			ouIDs:          []string{"ou-1"},
+			wantOutOfScope: []string{"usr-missing"},
+		},
+		{
+			name:           "mixed in scope and out of scope",
+			userIDs:        []string{"usr-001", "usr-002"},
+			ouIDs:          []string{"ou-1"},
+			wantOutOfScope: []string{"usr-002"},
+		},
+		{
+			name:           "all users in scope across multiple OUs",
+			userIDs:        []string{"usr-001", "usr-002"},
+			ouIDs:          []string{"ou-1", "ou-2"},
+			wantOutOfScope: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			out, err := suite.store.ValidateUserIDsInOUs(ctx, tc.userIDs, tc.ouIDs)
+			suite.NoError(err)
+			suite.Equal(tc.wantOutOfScope, out)
+		})
+	}
+}

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -66,6 +66,8 @@ type UserServiceInterface interface {
 		identifiers map[string]interface{},
 		credentials map[string]interface{}) (*AuthenticateUserResponse, *serviceerror.ServiceError)
 	ValidateUserIDs(ctx context.Context, userIDs []string) ([]string, *serviceerror.ServiceError)
+	ValidateUserIDsInOUs(ctx context.Context, userIDs []string,
+		ouIDs []string) ([]string, *serviceerror.ServiceError)
 	GetUserCredentialsByType(ctx context.Context, userID string,
 		credentialType string) ([]Credential, *serviceerror.ServiceError)
 	IsUserDeclarative(ctx context.Context, userID string) (bool, *serviceerror.ServiceError)
@@ -1216,6 +1218,28 @@ func (us *userService) ValidateUserIDs(ctx context.Context, userIDs []string) ([
 	}
 
 	return invalidUserIDs, nil
+}
+
+// ValidateUserIDsInOUs validates that all provided user IDs belong to one of the given OUs.
+// Returns IDs that are outside the allowed OU scope.
+func (us *userService) ValidateUserIDsInOUs(
+	ctx context.Context, userIDs []string, ouIDs []string,
+) ([]string, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if len(userIDs) == 0 {
+		return []string{}, nil
+	}
+	if len(ouIDs) == 0 {
+		// No accessible OUs — all IDs are out of scope.
+		return append([]string{}, userIDs...), nil
+	}
+
+	outOfScopeIDs, err := us.userStore.ValidateUserIDsInOUs(ctx, userIDs, ouIDs)
+	if err != nil {
+		return nil, logErrorAndReturnServerError(logger, "Failed to validate user IDs in OUs", err)
+	}
+	return outOfScopeIDs, nil
 }
 
 // GetUserCredentialsByType retrieves credentials of a specific type for a user.

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -2730,6 +2730,98 @@ func TestUserService_ValidateUserIDs(t *testing.T) {
 	require.Len(t, invalidIDs, 0)
 }
 
+func TestUserService_ValidateUserIDsInOUs(t *testing.T) {
+	testCases := []struct {
+		name           string
+		userIDs        []string
+		ouIDs          []string
+		setup          func(*userStoreInterfaceMock)
+		wantOutOfScope []string
+		wantErr        bool
+	}{
+		{
+			name:           "empty user IDs returns empty slice immediately",
+			userIDs:        []string{},
+			ouIDs:          []string{"ou-1"},
+			wantOutOfScope: []string{},
+		},
+		{
+			name:           "empty OU IDs returns all user IDs as out of scope",
+			userIDs:        []string{"usr-001", "usr-002"},
+			ouIDs:          []string{},
+			wantOutOfScope: []string{"usr-001", "usr-002"},
+		},
+		{
+			name:    "all users in scope returns empty out-of-scope list",
+			userIDs: []string{"usr-001", "usr-002"},
+			ouIDs:   []string{"ou-1"},
+			setup: func(storeMock *userStoreInterfaceMock) {
+				storeMock.On("ValidateUserIDsInOUs",
+					mock.Anything, []string{"usr-001", "usr-002"}, []string{"ou-1"}).
+					Return([]string{}, nil).Once()
+			},
+			wantOutOfScope: []string{},
+		},
+		{
+			name:    "partial out-of-scope IDs returned",
+			userIDs: []string{"usr-001", "usr-002"},
+			ouIDs:   []string{"ou-1"},
+			setup: func(storeMock *userStoreInterfaceMock) {
+				storeMock.On("ValidateUserIDsInOUs",
+					mock.Anything, []string{"usr-001", "usr-002"}, []string{"ou-1"}).
+					Return([]string{"usr-002"}, nil).Once()
+			},
+			wantOutOfScope: []string{"usr-002"},
+		},
+		{
+			name:    "all users out of scope",
+			userIDs: []string{"usr-001"},
+			ouIDs:   []string{"ou-1"},
+			setup: func(storeMock *userStoreInterfaceMock) {
+				storeMock.On("ValidateUserIDsInOUs",
+					mock.Anything, []string{"usr-001"}, []string{"ou-1"}).
+					Return([]string{"usr-001"}, nil).Once()
+			},
+			wantOutOfScope: []string{"usr-001"},
+		},
+		{
+			name:    "store error returns service error",
+			userIDs: []string{"usr-001"},
+			ouIDs:   []string{"ou-1"},
+			setup: func(storeMock *userStoreInterfaceMock) {
+				storeMock.On("ValidateUserIDsInOUs",
+					mock.Anything, []string{"usr-001"}, []string{"ou-1"}).
+					Return(nil, errors.New("db failure")).Once()
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			storeMock := newUserStoreInterfaceMock(t)
+			if tc.setup != nil {
+				tc.setup(storeMock)
+			}
+
+			service := &userService{userStore: storeMock}
+
+			outOfScope, err := service.ValidateUserIDsInOUs(context.Background(), tc.userIDs, tc.ouIDs)
+
+			if tc.wantErr {
+				require.NotNil(t, err)
+				require.Nil(t, outOfScope)
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, tc.wantOutOfScope, outOfScope)
+			}
+
+			storeMock.AssertExpectations(t)
+		})
+	}
+}
+
 func TestUserService_GetUserGroups_ErrorCases(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
 	service := &userService{

--- a/backend/internal/user/store.go
+++ b/backend/internal/user/store.go
@@ -48,6 +48,7 @@ type userStoreInterface interface {
 	IdentifyUser(ctx context.Context, filters map[string]interface{}) (*string, error)
 	GetCredentials(ctx context.Context, id string) (User, Credentials, error)
 	ValidateUserIDs(ctx context.Context, userIDs []string) ([]string, error)
+	ValidateUserIDsInOUs(ctx context.Context, userIDs []string, ouIDs []string) ([]string, error)
 	IsUserDeclarative(ctx context.Context, id string) (bool, error)
 }
 
@@ -533,6 +534,50 @@ func (us *userStore) ValidateUserIDs(ctx context.Context, userIDs []string) ([]s
 	}
 
 	return invalidUserIDs, nil
+}
+
+// ValidateUserIDsInOUs checks which of the provided user IDs belong to the given OU scope.
+// It returns user IDs that exist but are not in any of the provided OUs.
+func (us *userStore) ValidateUserIDsInOUs(
+	ctx context.Context, userIDs []string, ouIDs []string,
+) ([]string, error) {
+	if len(userIDs) == 0 {
+		return []string{}, nil
+	}
+	if len(ouIDs) == 0 {
+		// No accessible OUs — all provided IDs are out of scope.
+		return append([]string{}, userIDs...), nil
+	}
+
+	dbClient, err := us.dbProvider.GetUserDBClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	query, args, err := buildBulkUserExistsQueryInOUs(userIDs, ouIDs, us.deploymentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	inScopeIDs := make(map[string]bool, len(results))
+	for _, row := range results {
+		if id, ok := row["id"].(string); ok {
+			inScopeIDs[id] = true
+		}
+	}
+
+	outOfScopeIDs := make([]string, 0)
+	for _, userID := range userIDs {
+		if !inScopeIDs[userID] {
+			outOfScopeIDs = append(outOfScopeIDs, userID)
+		}
+	}
+	return outOfScopeIDs, nil
 }
 
 // GetGroupCountForUser retrieves the total count of groups a user belongs to.

--- a/backend/internal/user/store_constants.go
+++ b/backend/internal/user/store_constants.go
@@ -274,6 +274,55 @@ func buildBulkUserExistsQuery(userIDs []string, deploymentID string) (model.DBQu
 	return query, args, nil
 }
 
+// buildBulkUserExistsQueryInOUs constructs a query that returns which of the provided user IDs
+// exist AND belong to one of the given organization unit IDs.
+func buildBulkUserExistsQueryInOUs(
+	userIDs []string, ouIDs []string, deploymentID string,
+) (model.DBQuery, []interface{}, error) {
+	if len(userIDs) == 0 {
+		return model.DBQuery{}, nil, fmt.Errorf("userIDs list cannot be empty")
+	}
+	if len(ouIDs) == 0 {
+		return model.DBQuery{}, nil, fmt.Errorf("ouIDs list cannot be empty")
+	}
+
+	// Layout: [$1=deploymentID, $2...$N=ouIDs, $N+1...=userIDs]
+	args := make([]interface{}, 0, 1+len(ouIDs)+len(userIDs))
+	args = append(args, deploymentID)
+
+	postgresOUPlaceholders := make([]string, len(ouIDs))
+	sqliteOUPlaceholders := make([]string, len(ouIDs))
+	for i, ouID := range ouIDs {
+		postgresOUPlaceholders[i] = fmt.Sprintf("$%d", i+2)
+		sqliteOUPlaceholders[i] = "?"
+		args = append(args, ouID)
+	}
+
+	idBase := 2 + len(ouIDs)
+	postgresIDPlaceholders := make([]string, len(userIDs))
+	sqliteIDPlaceholders := make([]string, len(userIDs))
+	for i, userID := range userIDs {
+		postgresIDPlaceholders[i] = fmt.Sprintf("$%d", idBase+i)
+		sqliteIDPlaceholders[i] = "?"
+		args = append(args, userID)
+	}
+
+	baseQueryTpl := "SELECT ID FROM \"USER\" WHERE DEPLOYMENT_ID = %s AND OU_ID IN (%s) AND ID IN (%s)"
+	postgresQuery := fmt.Sprintf(baseQueryTpl, "$1",
+		strings.Join(postgresOUPlaceholders, ","), strings.Join(postgresIDPlaceholders, ","))
+	sqliteQuery := fmt.Sprintf(baseQueryTpl, "?",
+		strings.Join(sqliteOUPlaceholders, ","), strings.Join(sqliteIDPlaceholders, ","))
+
+	query := model.DBQuery{
+		ID:            "ASQ-USER_MGT-21",
+		Query:         postgresQuery,
+		PostgresQuery: postgresQuery,
+		SQLiteQuery:   sqliteQuery,
+	}
+
+	return query, args, nil
+}
+
 // buildUserListQuery constructs a query to get users with optional filtering.
 func buildUserListQuery(
 	filters map[string]interface{}, limit, offset int, deploymentID string,

--- a/backend/internal/user/store_constants_test.go
+++ b/backend/internal/user/store_constants_test.go
@@ -485,3 +485,131 @@ func (suite *StoreConstantsTestSuite) TestBuildUserListQueryByOUIDs_WithFilters(
 	suite.Equal(10, args[len(args)-2])
 	suite.Equal(0, args[len(args)-1])
 }
+
+// Test buildBulkUserExistsQueryInOUs
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_EmptyUserIDs() {
+	_, _, err := buildBulkUserExistsQueryInOUs([]string{}, []string{"ou-1"}, testDeploymentIDForConstants)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "userIDs list cannot be empty")
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_EmptyOUIDs() {
+	_, _, err := buildBulkUserExistsQueryInOUs([]string{"usr-001"}, []string{}, testDeploymentIDForConstants)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "ouIDs list cannot be empty")
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_QueryID() {
+	query, _, err := buildBulkUserExistsQueryInOUs(
+		[]string{"usr-001"}, []string{"ou-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	suite.Equal("ASQ-USER_MGT-21", query.ID)
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_SingleUserSingleOU() {
+	query, args, err := buildBulkUserExistsQueryInOUs(
+		[]string{"usr-001"}, []string{"ou-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	// Postgres: SELECT ID FROM "USER" WHERE DEPLOYMENT_ID = $1 AND OU_ID IN ($2) AND ID IN ($3)
+	suite.Contains(query.PostgresQuery, `SELECT ID FROM "USER"`)
+	suite.Contains(query.PostgresQuery, "DEPLOYMENT_ID = $1")
+	suite.Contains(query.PostgresQuery, "OU_ID IN ($2)")
+	suite.Contains(query.PostgresQuery, "ID IN ($3)")
+	// SQLite: all positional params are ?
+	suite.Contains(query.SQLiteQuery, "DEPLOYMENT_ID = ?")
+	suite.Contains(query.SQLiteQuery, "OU_ID IN (?)")
+	suite.Contains(query.SQLiteQuery, "ID IN (?)")
+	// Args layout: [deploymentID, ouIDs..., userIDs...]
+	suite.Len(args, 3)
+	suite.Equal(testDeploymentIDForConstants, args[0])
+	suite.Equal("ou-1", args[1])
+	suite.Equal("usr-001", args[2])
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_MultipleUsersMultipleOUs() {
+	userIDs := []string{"usr-001", "usr-002", "usr-003"}
+	ouIDs := []string{"ou-1", "ou-2"}
+
+	query, args, err := buildBulkUserExistsQueryInOUs(userIDs, ouIDs, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	// Postgres placeholders: $1=deployment, $2,$3=ouIDs, $4,$5,$6=userIDs
+	suite.Contains(query.PostgresQuery, "DEPLOYMENT_ID = $1")
+	suite.Contains(query.PostgresQuery, "OU_ID IN ($2,$3)")
+	suite.Contains(query.PostgresQuery, "ID IN ($4,$5,$6)")
+	// SQLite has the right number of ? placeholders
+	suite.Contains(query.SQLiteQuery, "OU_ID IN (?,?)")
+	suite.Contains(query.SQLiteQuery, "ID IN (?,?,?)")
+	// Args layout: [deploymentID, ou-1, ou-2, usr-001, usr-002, usr-003]
+	suite.Len(args, 6)
+	suite.Equal(testDeploymentIDForConstants, args[0])
+	suite.Equal("ou-1", args[1])
+	suite.Equal("ou-2", args[2])
+	suite.Equal("usr-001", args[3])
+	suite.Equal("usr-002", args[4])
+	suite.Equal("usr-003", args[5])
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_PostgresAndSQLiteAreSeparate() {
+	query, _, err := buildBulkUserExistsQueryInOUs(
+		[]string{"usr-001"}, []string{"ou-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	suite.NotEmpty(query.PostgresQuery)
+	suite.NotEmpty(query.SQLiteQuery)
+	suite.NotEqual(query.PostgresQuery, query.SQLiteQuery)
+	// Postgres uses $N placeholders
+	suite.Contains(query.PostgresQuery, "$1")
+	// SQLite uses ? placeholders
+	suite.NotContains(query.SQLiteQuery, "$")
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_ArgsOrderIsDeploymentFirstThenOUsThenUsers() {
+	query, args, err := buildBulkUserExistsQueryInOUs(
+		[]string{"usr-A", "usr-B"},
+		[]string{"ou-X"},
+		"deploy-123",
+	)
+
+	suite.NoError(err)
+	_ = query
+	// First arg must be the deploymentID
+	suite.Equal("deploy-123", args[0])
+	// Next come the OU IDs
+	suite.Equal("ou-X", args[1])
+	// Then the user IDs
+	suite.Equal("usr-A", args[2])
+	suite.Equal("usr-B", args[3])
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_QueryMatchesModel() {
+	query, _, err := buildBulkUserExistsQueryInOUs(
+		[]string{"usr-001"}, []string{"ou-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	// The default Query field should match PostgresQuery (primary dialect)
+	suite.Equal(query.PostgresQuery, query.Query)
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_SelectsIDColumn() {
+	query, _, err := buildBulkUserExistsQueryInOUs(
+		[]string{"usr-001"}, []string{"ou-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	suite.Contains(query.PostgresQuery, "SELECT ID FROM")
+}
+
+// Verify the returned DBQuery implements model.DBQuery structure expectations.
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQueryInOUs_ReturnsDBQuery() {
+	query, args, err := buildBulkUserExistsQueryInOUs(
+		[]string{"usr-001"}, []string{"ou-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	suite.IsType(model.DBQuery{}, query)
+	suite.NotNil(args)
+}

--- a/backend/internal/user/store_test.go
+++ b/backend/internal/user/store_test.go
@@ -124,6 +124,28 @@ func (m *MockDBProvider) GetRuntimeDBTransactioner() (transaction.Transactioner,
 	return nil, nil
 }
 
+// errorUserDBProvider is a provider that returns an error for GetUserDBClient calls.
+type errorUserDBProvider struct{}
+
+func (e *errorUserDBProvider) GetConfigDBClient() (provider.DBClientInterface, error) {
+	return nil, nil
+}
+func (e *errorUserDBProvider) GetRuntimeDBClient() (provider.DBClientInterface, error) {
+	return nil, nil
+}
+func (e *errorUserDBProvider) GetUserDBClient() (provider.DBClientInterface, error) {
+	return nil, errors.New("user db client unavailable")
+}
+func (e *errorUserDBProvider) GetConfigDBTransactioner() (transaction.Transactioner, error) {
+	return nil, nil
+}
+func (e *errorUserDBProvider) GetUserDBTransactioner() (transaction.Transactioner, error) {
+	return nil, nil
+}
+func (e *errorUserDBProvider) GetRuntimeDBTransactioner() (transaction.Transactioner, error) {
+	return nil, nil
+}
+
 // UserStoreTestSuite is the test suite for userStore.
 type UserStoreTestSuite struct {
 	suite.Suite
@@ -544,6 +566,116 @@ func (suite *UserStoreTestSuite) TestValidateUserIDs() {
 	invalid, err := suite.store.ValidateUserIDs(context.Background(), userIDs)
 	suite.NoError(err)
 	suite.Empty(invalid)
+}
+
+func (suite *UserStoreTestSuite) TestValidateUserIDsInOUs_EmptyUserIDs() {
+	outOfScope, err := suite.store.ValidateUserIDsInOUs(context.Background(), []string{}, []string{"ou-1"})
+	suite.NoError(err)
+	suite.Empty(outOfScope)
+	suite.mockDB.AssertNotCalled(suite.T(), "QueryContext")
+}
+
+func (suite *UserStoreTestSuite) TestValidateUserIDsInOUs_EmptyOUIDs() {
+	userIDs := []string{"usr-001", "usr-002"}
+	outOfScope, err := suite.store.ValidateUserIDsInOUs(context.Background(), userIDs, []string{})
+	suite.NoError(err)
+	suite.Equal(userIDs, outOfScope)
+	suite.mockDB.AssertNotCalled(suite.T(), "QueryContext")
+}
+
+func (suite *UserStoreTestSuite) TestValidateUserIDsInOUs() {
+	testCases := []struct {
+		name           string
+		userIDs        []string
+		ouIDs          []string
+		dbRows         []map[string]interface{}
+		dbErr          error
+		wantOutOfScope []string
+		wantErr        bool
+	}{
+		{
+			name:    "user in scope",
+			userIDs: []string{"usr-001"},
+			ouIDs:   []string{"ou-1"},
+			dbRows: []map[string]interface{}{
+				{"id": "usr-001"},
+			},
+			wantOutOfScope: []string{},
+		},
+		{
+			name:           "user out of scope",
+			userIDs:        []string{"usr-001"},
+			ouIDs:          []string{"ou-1"},
+			dbRows:         []map[string]interface{}{},
+			wantOutOfScope: []string{"usr-001"},
+		},
+		{
+			name:    "query execution error",
+			userIDs: []string{"usr-001"},
+			ouIDs:   []string{"ou-1"},
+			dbErr:   errors.New("db failure"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			// For 1 user + 1 OU: args = [deploymentID, ouID, userID] → 5 total (ctx, query, +3)
+			suite.mockDB.On("QueryContext",
+				mock.Anything,
+				mock.MatchedBy(func(query dbmodel.DBQuery) bool {
+					return query.ID == "ASQ-USER_MGT-21"
+				}),
+				mock.Anything, mock.Anything, mock.Anything).
+				Return(tc.dbRows, tc.dbErr).Once()
+
+			outOfScope, err := suite.store.ValidateUserIDsInOUs(
+				context.Background(), tc.userIDs, tc.ouIDs)
+
+			if tc.wantErr {
+				suite.Error(err)
+			} else {
+				suite.NoError(err)
+				suite.Equal(tc.wantOutOfScope, outOfScope)
+			}
+
+			suite.mockDB.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *UserStoreTestSuite) TestValidateUserIDsInOUs_PartialOutOfScope() {
+	// 2 users, 1 OU → args = [deploymentID, ou-1, usr-001, usr-002] → 6 total (ctx, query, +4)
+	suite.mockDB.On("QueryContext",
+		mock.Anything,
+		mock.MatchedBy(func(query dbmodel.DBQuery) bool {
+			return query.ID == "ASQ-USER_MGT-21"
+		}),
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]map[string]interface{}{{"id": "usr-001"}}, nil).Once()
+
+	outOfScope, err := suite.store.ValidateUserIDsInOUs(
+		context.Background(), []string{"usr-001", "usr-002"}, []string{"ou-1"})
+
+	suite.NoError(err)
+	suite.Equal([]string{"usr-002"}, outOfScope)
+	suite.mockDB.AssertExpectations(suite.T())
+}
+
+func (suite *UserStoreTestSuite) TestValidateUserIDsInOUs_DBClientError() {
+	// Use a store wired to a provider that fails on GetUserDBClient.
+	errProvider := &errorUserDBProvider{}
+	store := &userStore{
+		deploymentID: testDeploymentID,
+		dbProvider:   errProvider,
+	}
+
+	_, err := store.ValidateUserIDsInOUs(
+		context.Background(), []string{"usr-001"}, []string{"ou-1"})
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to get database client")
 }
 
 func (suite *UserStoreTestSuite) TestIdentifyUser_NoIndexedFilters() {

--- a/backend/internal/user/userStoreInterface_mock_test.go
+++ b/backend/internal/user/userStoreInterface_mock_test.go
@@ -1068,3 +1068,77 @@ func (_c *userStoreInterfaceMock_ValidateUserIDs_Call) RunAndReturn(run func(ctx
 	_c.Call.Return(run)
 	return _c
 }
+
+// ValidateUserIDsInOUs provides a mock function for the type userStoreInterfaceMock
+func (_mock *userStoreInterfaceMock) ValidateUserIDsInOUs(ctx context.Context, userIDs []string, ouIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, userIDs, ouIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateUserIDsInOUs")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) ([]string, error)); ok {
+		return returnFunc(ctx, userIDs, ouIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) []string); ok {
+		r0 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string, []string) error); ok {
+		r1 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userStoreInterfaceMock_ValidateUserIDsInOUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateUserIDsInOUs'
+type userStoreInterfaceMock_ValidateUserIDsInOUs_Call struct {
+	*mock.Call
+}
+
+// ValidateUserIDsInOUs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+//   - ouIDs []string
+func (_e *userStoreInterfaceMock_Expecter) ValidateUserIDsInOUs(ctx interface{}, userIDs interface{}, ouIDs interface{}) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	return &userStoreInterfaceMock_ValidateUserIDsInOUs_Call{Call: _e.mock.On("ValidateUserIDsInOUs", ctx, userIDs, ouIDs)}
+}
+
+func (_c *userStoreInterfaceMock_ValidateUserIDsInOUs_Call) Run(run func(ctx context.Context, userIDs []string, ouIDs []string)) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_ValidateUserIDsInOUs_Call) Return(strings []string, err error) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_ValidateUserIDsInOUs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string, ouIDs []string) ([]string, error)) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
+++ b/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
@@ -487,6 +487,86 @@ func (_c *groupStoreInterfaceMock_GetGroupList_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetGroupListByOUIDs provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetGroupListByOUIDs(ctx context.Context, ouIDs []string, limit int, offset int) ([]group.GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, ouIDs, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupListByOUIDs")
+	}
+
+	var r0 []group.GroupBasicDAO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, int, int) ([]group.GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, ouIDs, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, int, int) []group.GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, ouIDs, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]group.GroupBasicDAO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string, int, int) error); ok {
+		r1 = returnFunc(ctx, ouIDs, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetGroupListByOUIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupListByOUIDs'
+type groupStoreInterfaceMock_GetGroupListByOUIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupListByOUIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ouIDs []string
+//   - limit int
+//   - offset int
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupListByOUIDs(ctx interface{}, ouIDs interface{}, limit interface{}, offset interface{}) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	return &groupStoreInterfaceMock_GetGroupListByOUIDs_Call{Call: _e.mock.On("GetGroupListByOUIDs", ctx, ouIDs, limit, offset)}
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListByOUIDs_Call) Run(run func(ctx context.Context, ouIDs []string, limit int, offset int)) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListByOUIDs_Call) Return(groupBasicDAOs []group.GroupBasicDAO, err error) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	_c.Call.Return(groupBasicDAOs, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListByOUIDs_Call) RunAndReturn(run func(ctx context.Context, ouIDs []string, limit int, offset int) ([]group.GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupListByOUIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroupListCount provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroupListCount(ctx context.Context) (int, error) {
 	ret := _mock.Called(ctx)
@@ -543,6 +623,72 @@ func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) Return(n int, err erro
 }
 
 func (_c *groupStoreInterfaceMock_GetGroupListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *groupStoreInterfaceMock_GetGroupListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetGroupListCountByOUIDs provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetGroupListCountByOUIDs(ctx context.Context, ouIDs []string) (int, error) {
+	ret := _mock.Called(ctx, ouIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupListCountByOUIDs")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (int, error)); ok {
+		return returnFunc(ctx, ouIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) int); ok {
+		r0 = returnFunc(ctx, ouIDs)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, ouIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupListCountByOUIDs'
+type groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupListCountByOUIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ouIDs []string
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupListCountByOUIDs(ctx interface{}, ouIDs interface{}) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
+	return &groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call{Call: _e.mock.On("GetGroupListCountByOUIDs", ctx, ouIDs)}
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call) Run(run func(ctx context.Context, ouIDs []string)) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call) Return(n int, err error) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call) RunAndReturn(run func(ctx context.Context, ouIDs []string) (int, error)) *groupStoreInterfaceMock_GetGroupListCountByOUIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -1144,6 +1144,82 @@ func (_c *UserServiceInterfaceMock_ValidateUserIDs_Call) RunAndReturn(run func(c
 	return _c
 }
 
+// ValidateUserIDsInOUs provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) ValidateUserIDsInOUs(ctx context.Context, userIDs []string, ouIDs []string) ([]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userIDs, ouIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateUserIDsInOUs")
+	}
+
+	var r0 []string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) ([]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userIDs, ouIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) []string); ok {
+		r0 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_ValidateUserIDsInOUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateUserIDsInOUs'
+type UserServiceInterfaceMock_ValidateUserIDsInOUs_Call struct {
+	*mock.Call
+}
+
+// ValidateUserIDsInOUs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+//   - ouIDs []string
+func (_e *UserServiceInterfaceMock_Expecter) ValidateUserIDsInOUs(ctx interface{}, userIDs interface{}, ouIDs interface{}) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	return &UserServiceInterfaceMock_ValidateUserIDsInOUs_Call{Call: _e.mock.On("ValidateUserIDsInOUs", ctx, userIDs, ouIDs)}
+}
+
+func (_c *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call) Run(run func(ctx context.Context, userIDs []string, ouIDs []string)) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call) Return(strings []string, serviceError *serviceerror.ServiceError) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(strings, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string, ouIDs []string) ([]string, *serviceerror.ServiceError)) *UserServiceInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // VerifyUser provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) VerifyUser(ctx context.Context, userID string, credentials map[string]interface{}) (*user.User, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, userID, credentials)

--- a/backend/tests/mocks/usermock/userStoreInterface_mock.go
+++ b/backend/tests/mocks/usermock/userStoreInterface_mock.go
@@ -1069,3 +1069,77 @@ func (_c *userStoreInterfaceMock_ValidateUserIDs_Call) RunAndReturn(run func(ctx
 	_c.Call.Return(run)
 	return _c
 }
+
+// ValidateUserIDsInOUs provides a mock function for the type userStoreInterfaceMock
+func (_mock *userStoreInterfaceMock) ValidateUserIDsInOUs(ctx context.Context, userIDs []string, ouIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, userIDs, ouIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateUserIDsInOUs")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) ([]string, error)); ok {
+		return returnFunc(ctx, userIDs, ouIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, []string) []string); ok {
+		r0 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string, []string) error); ok {
+		r1 = returnFunc(ctx, userIDs, ouIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userStoreInterfaceMock_ValidateUserIDsInOUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateUserIDsInOUs'
+type userStoreInterfaceMock_ValidateUserIDsInOUs_Call struct {
+	*mock.Call
+}
+
+// ValidateUserIDsInOUs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+//   - ouIDs []string
+func (_e *userStoreInterfaceMock_Expecter) ValidateUserIDsInOUs(ctx interface{}, userIDs interface{}, ouIDs interface{}) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	return &userStoreInterfaceMock_ValidateUserIDsInOUs_Call{Call: _e.mock.On("ValidateUserIDsInOUs", ctx, userIDs, ouIDs)}
+}
+
+func (_c *userStoreInterfaceMock_ValidateUserIDsInOUs_Call) Run(run func(ctx context.Context, userIDs []string, ouIDs []string)) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_ValidateUserIDsInOUs_Call) Return(strings []string, err error) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_ValidateUserIDsInOUs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string, ouIDs []string) ([]string, error)) *userStoreInterfaceMock_ValidateUserIDsInOUs_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/tests/integration/group/group_authz_test.go
+++ b/tests/integration/group/group_authz_test.go
@@ -1,0 +1,523 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package group
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+// GroupAuthzTestSuite validates that group CRUD operations respect OU-scoped authz.
+//
+// Permission model:
+//
+//	system:group      → create, update, delete groups
+//	system:group:view → list, get groups (implied by system:group)
+//
+// A user-manager living in OU1 holds the system:group permission. The suite
+// verifies that:
+//
+//   - Read operations on groups in OU1 are allowed (200)
+//   - Read operations on groups in OU2 (sibling) are denied (403)
+//   - Write operations on groups in OU1 are allowed (201/200/204)
+//   - Write operations on groups in OU2 are denied (403)
+//   - Listing groups only returns groups from the accessible OU
+//
+// Fixture topology:
+//
+//	OU1 (handle: authz-group-ou1) ← group-manager and target groups belong here
+//	OU2 (handle: authz-group-ou2) ← sibling OU with its own target group
+type GroupAuthzTestSuite struct {
+	suite.Suite
+
+	// Admin-created OUs
+	groupOU1ID string
+	groupOU2ID string
+
+	// User schemas (one for the user-manager in OU1)
+	userSchemaOU1ID string
+
+	// Test role and manager
+	groupMgrRoleID      string
+	groupMgrUserID      string
+	targetGroupOU1ID    string
+	deletableGroupOU1ID string
+	targetGroupOU2ID    string
+
+	// Member users created in each OU to test membership authz
+	memberUserOU1ID   string
+	memberUserOU2ID   string
+	memberSchemaOU2ID string
+
+	// HTTP client carrying the user-manager's system:group scoped token
+	groupAdminClient *http.Client
+}
+
+const (
+	groupAuthzServerURL = "https://localhost:8095"
+
+	groupAuthzOU1Handle = "authz-group-ou1"
+	groupAuthzOU2Handle = "authz-group-ou2"
+
+	groupMgrUsername  = "authz-group-manager"
+	groupMgrPassword  = "GroupMgr@123"
+	groupMgrRoleName  = "Group Admin (group-authz-test)"
+	userSchemaOU1Name = "authz-mgr-schema-ou1"
+
+	groupAuthzDevelopClientID    = "DEVELOP"
+	groupAuthzDevelopRedirectURI = "https://localhost:8095/develop"
+
+	memberSchemaOU2Name = "authz-member-schema-ou2"
+
+	memberOU1Username = "authz-member-ou1"
+	memberOU1Password = "MemberOU1@123"
+	memberOU2Username = "authz-member-ou2"
+	memberOU2Password = "MemberOU2@123"
+)
+
+func TestGroupAuthzTestSuite(t *testing.T) {
+	suite.Run(t, new(GroupAuthzTestSuite))
+}
+
+// ---------------------------------------------------------------------------
+// Suite setup
+// ---------------------------------------------------------------------------
+
+func (ts *GroupAuthzTestSuite) SetupSuite() {
+	// ---- 1. Create the two OUs ----
+	ou1ID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      groupAuthzOU1Handle,
+		Name:        "Group Authz Test OU1",
+		Description: "Primary OU for group authz integration test",
+	})
+	ts.Require().NoError(err, "create group-authz OU1")
+	ts.groupOU1ID = ou1ID
+
+	ou2ID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      groupAuthzOU2Handle,
+		Name:        "Group Authz Test OU2",
+		Description: "Sibling OU for group authz integration test",
+	})
+	ts.Require().NoError(err, "create group-authz OU2")
+	ts.groupOU2ID = ou2ID
+
+	// ---- 2. Create user schema for user-manager in OU1 ----
+	schemaOU1ID, err := testutils.CreateUserType(testutils.UserSchema{
+		Name:               userSchemaOU1Name,
+		OrganizationUnitId: ts.groupOU1ID,
+		Schema: map[string]interface{}{
+			"username":     map[string]interface{}{"type": "string"},
+			"password":     map[string]interface{}{"type": "string", "credential": true},
+			"display_name": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "create user schema for OU1")
+	ts.userSchemaOU1ID = schemaOU1ID
+
+	// ---- 3. Create the user-manager in OU1 ----
+	userMgrID, err := testutils.CreateUser(testutils.User{
+		Type:             userSchemaOU1Name,
+		OrganizationUnit: ts.groupOU1ID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "display_name": "Group Manager"}`,
+			groupMgrUsername, groupMgrPassword,
+		)),
+	})
+	ts.Require().NoError(err, "create group-manager user")
+	ts.groupMgrUserID = userMgrID
+
+	// ---- 3b. Create a plain member user in OU1 (used in membership authz tests) ----
+	memberOU1ID, err := testutils.CreateUser(testutils.User{
+		Type:             userSchemaOU1Name,
+		OrganizationUnit: ts.groupOU1ID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "display_name": "Member OU1"}`,
+			memberOU1Username, memberOU1Password,
+		)),
+	})
+	ts.Require().NoError(err, "create member user in OU1")
+	ts.memberUserOU1ID = memberOU1ID
+
+	// ---- 3c. Create a user schema for OU2 ----
+	schemaOU2ID, err := testutils.CreateUserType(testutils.UserSchema{
+		Name:               memberSchemaOU2Name,
+		OrganizationUnitId: ts.groupOU2ID,
+		Schema: map[string]interface{}{
+			"username":     map[string]interface{}{"type": "string"},
+			"password":     map[string]interface{}{"type": "string", "credential": true},
+			"display_name": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "create user schema for OU2")
+	ts.memberSchemaOU2ID = schemaOU2ID
+
+	// ---- 3d. Create a plain member user in OU2 (used in membership authz tests) ----
+	memberOU2ID, err := testutils.CreateUser(testutils.User{
+		Type:             memberSchemaOU2Name,
+		OrganizationUnit: ts.groupOU2ID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "display_name": "Member OU2"}`,
+			memberOU2Username, memberOU2Password,
+		)),
+	})
+	ts.Require().NoError(err, "create member user in OU2")
+	ts.memberUserOU2ID = memberOU2ID
+
+	// ---- 4. Create target groups ----
+	targetOU1ID, err := testutils.CreateGroup(testutils.Group{
+		Name:               "authz-target-ou1",
+		Description:        "Target Group OU1",
+		OrganizationUnitId: ts.groupOU1ID,
+	})
+	ts.Require().NoError(err, "create target group in OU1")
+	ts.targetGroupOU1ID = targetOU1ID
+
+	deletableID, err := testutils.CreateGroup(testutils.Group{
+		Name:               "authz-deletable-ou1",
+		Description:        "Deletable Group OU1",
+		OrganizationUnitId: ts.groupOU1ID,
+	})
+	ts.Require().NoError(err, "create deletable group in OU1")
+	ts.deletableGroupOU1ID = deletableID
+
+	targetOU2ID, err := testutils.CreateGroup(testutils.Group{
+		Name:               "authz-target-ou2",
+		Description:        "Target Group OU2",
+		OrganizationUnitId: ts.groupOU2ID,
+	})
+	ts.Require().NoError(err, "create target group in OU2")
+	ts.targetGroupOU2ID = targetOU2ID
+
+	// ---- 5. Look up the system resource server seeded by bootstrap ----
+	systemRSID, err := testutils.GetResourceServerByIdentifier("system")
+	ts.Require().NoError(err, "look up system resource server")
+
+	// ---- 6. Create a role with system:group permission and assign to the user-manager ----
+	roleID, err := testutils.CreateRole(testutils.Role{
+		Name:               groupMgrRoleName,
+		OrganizationUnitID: ts.groupOU1ID,
+		Permissions: []testutils.ResourcePermissions{
+			{
+				ResourceServerID: systemRSID,
+				Permissions:      []string{"system:ou:view", "system:group", "system:group:view"},
+			},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.groupMgrUserID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "create group-manager role")
+	ts.groupMgrRoleID = roleID
+
+	// ---- 7. Obtain a scoped access token for the user-manager ----
+	tokenResp, err := testutils.ObtainAccessTokenWithPassword(
+		groupAuthzDevelopClientID,
+		groupAuthzDevelopRedirectURI,
+		"system:ou:view system:group system:group:view",
+		groupMgrUsername,
+		groupMgrPassword,
+		true,
+	)
+	ts.Require().NoError(err, "obtain group-manager token")
+	ts.Require().NotEmpty(tokenResp.AccessToken, "group-manager token must be non-empty")
+
+	ts.groupAdminClient = testutils.GetHTTPClientWithToken(tokenResp.AccessToken)
+}
+
+// ---------------------------------------------------------------------------
+// Suite teardown
+// ---------------------------------------------------------------------------
+
+func (ts *GroupAuthzTestSuite) TearDownSuite() {
+	if ts.groupMgrRoleID != "" {
+		if err := testutils.DeleteRole(ts.groupMgrRoleID); err != nil {
+			ts.T().Logf("teardown: delete group-manager role: %v", err)
+		}
+	}
+	for _, id := range []string{ts.targetGroupOU1ID, ts.deletableGroupOU1ID} {
+		if id != "" {
+			if err := testutils.DeleteGroup(id); err != nil {
+				ts.T().Logf("teardown: delete group %s: %v", id, err)
+			}
+		}
+	}
+	if ts.groupMgrUserID != "" {
+		if err := testutils.DeleteUser(ts.groupMgrUserID); err != nil {
+			ts.T().Logf("teardown: delete user manager: %v", err)
+		}
+	}
+	if ts.memberUserOU1ID != "" {
+		if err := testutils.DeleteUser(ts.memberUserOU1ID); err != nil {
+			ts.T().Logf("teardown: delete member user OU1: %v", err)
+		}
+	}
+	if ts.memberUserOU2ID != "" {
+		if err := testutils.DeleteUser(ts.memberUserOU2ID); err != nil {
+			ts.T().Logf("teardown: delete member user OU2: %v", err)
+		}
+	}
+	if ts.targetGroupOU2ID != "" {
+		if err := testutils.DeleteGroup(ts.targetGroupOU2ID); err != nil {
+			ts.T().Logf("teardown: delete target group in OU2: %v", err)
+		}
+	}
+	if ts.memberSchemaOU2ID != "" {
+		if err := testutils.DeleteUserType(ts.memberSchemaOU2ID); err != nil {
+			ts.T().Logf("teardown: delete member schema OU2: %v", err)
+		}
+	}
+	if ts.userSchemaOU1ID != "" {
+		if err := testutils.DeleteUserType(ts.userSchemaOU1ID); err != nil {
+			ts.T().Logf("teardown: delete user schema OU1: %v", err)
+		}
+	}
+	if ts.groupOU2ID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.groupOU2ID); err != nil {
+			ts.T().Logf("teardown: delete group-authz OU2: %v", err)
+		}
+	}
+	if ts.groupOU1ID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.groupOU1ID); err != nil {
+			ts.T().Logf("teardown: delete group-authz OU1: %v", err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helper — issue a request via the user-manager's admin client
+// ---------------------------------------------------------------------------
+
+func (ts *GroupAuthzTestSuite) doGroup(method, path string, body []byte) *http.Response {
+	ts.T().Helper()
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, groupAuthzServerURL+path, bodyReader)
+	ts.Require().NoError(err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := ts.groupAdminClient.Do(req)
+	ts.Require().NoError(err)
+	return resp
+}
+
+// ---------------------------------------------------------------------------
+// Tests — READ operations (system:group:view implied by system:group)
+// ---------------------------------------------------------------------------
+
+// TestListGroups verifies the list contains groups from the accessible OU only.
+func (ts *GroupAuthzTestSuite) TestListGroups() {
+	resp := ts.doGroup(http.MethodGet, "/groups", nil)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode, "list groups should succeed")
+
+	var listResp GroupListResponse
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResp))
+
+	ids := make([]string, 0, len(listResp.Groups))
+	for _, g := range listResp.Groups {
+		ids = append(ids, g.Id) // Id (uppercase I lowercase d) based on the testutils structure.
+	}
+
+	ts.Containsf(ids, ts.targetGroupOU1ID,
+		"list must include target group in OU1, got IDs: %v", ids)
+	ts.NotContainsf(ids, ts.targetGroupOU2ID,
+		"list must NOT include target group in OU2 (sibling), got IDs: %v", ids)
+}
+
+// TestGetGroupInOwnOU verifies the group-manager can read a group in their own OU.
+func (ts *GroupAuthzTestSuite) TestGetGroupInOwnOU() {
+	resp := ts.doGroup(http.MethodGet, "/groups/"+ts.targetGroupOU1ID, nil)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode,
+		"group-manager should be able to read a group in their own OU")
+}
+
+// TestGetGroupInOtherOU verifies the group-manager is denied reading a group in OU2.
+func (ts *GroupAuthzTestSuite) TestGetGroupInOtherOU() {
+	resp := ts.doGroup(http.MethodGet, "/groups/"+ts.targetGroupOU2ID, nil)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must be denied access to a group in a different OU")
+}
+
+// ---------------------------------------------------------------------------
+// Tests — WRITE operations (system:group)
+// ---------------------------------------------------------------------------
+
+// TestCreateGroupInOwnOU verifies the group-manager can create a group in their own OU.
+func (ts *GroupAuthzTestSuite) TestCreateGroupInOwnOU() {
+	payload, err := json.Marshal(map[string]interface{}{
+		"organizationUnitId": ts.groupOU1ID,
+		"name":               "authz-created-group",
+		"description":        "Created Group",
+	})
+	ts.Require().NoError(err)
+
+	resp := ts.doGroup(http.MethodPost, "/groups", payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusCreated, resp.StatusCode,
+		"group-manager should be able to create a group in their own OU")
+
+	// Parse the created group ID and clean it up via the admin client.
+	var created testutils.Group
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&created); decodeErr == nil && created.ID != "" {
+		if delErr := testutils.DeleteGroup(created.ID); delErr != nil {
+			ts.T().Logf("cleanup: failed to delete created group %s: %v", created.ID, delErr)
+		}
+	}
+}
+
+// TestCreateGroupInOtherOU verifies the group-manager is denied creating a group in OU2.
+func (ts *GroupAuthzTestSuite) TestCreateGroupInOtherOU() {
+	payload, err := json.Marshal(map[string]interface{}{
+		"organizationUnitId": ts.groupOU2ID,
+		"name":               "authz-denied-group",
+		"description":        "Denied Group",
+	})
+	ts.Require().NoError(err)
+
+	resp := ts.doGroup(http.MethodPost, "/groups", payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not create a group in a different OU")
+}
+
+// TestUpdateGroupInOwnOU verifies the group-manager can update a group in their own OU.
+func (ts *GroupAuthzTestSuite) TestUpdateGroupInOwnOU() {
+	payload, err := json.Marshal(map[string]interface{}{
+		"organizationUnitId": ts.groupOU1ID,
+		"name":               "authz-target-ou1",
+		"description":        "Updated Description",
+	})
+	ts.Require().NoError(err)
+
+	resp := ts.doGroup(http.MethodPut, "/groups/"+ts.targetGroupOU1ID, payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode,
+		"group-manager should be able to update a group in their own OU")
+}
+
+// TestUpdateGroupInOtherOU verifies the group-manager is denied updating a group in OU2.
+func (ts *GroupAuthzTestSuite) TestUpdateGroupInOtherOU() {
+	payload, err := json.Marshal(map[string]interface{}{
+		"organizationUnitId": ts.groupOU2ID,
+		"name":               "Should Not Update",
+	})
+	ts.Require().NoError(err)
+
+	resp := ts.doGroup(http.MethodPut, "/groups/"+ts.targetGroupOU2ID, payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not update a group in a different OU")
+}
+
+// TestDeleteGroupInOwnOU verifies the group-manager can delete a group in their own OU.
+func (ts *GroupAuthzTestSuite) TestDeleteGroupInOwnOU() {
+	resp := ts.doGroup(http.MethodDelete, "/groups/"+ts.deletableGroupOU1ID, nil)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusNoContent, resp.StatusCode,
+		"group-manager should be able to delete a group in their own OU")
+
+	// Clear so TearDownSuite does not attempt a double-delete.
+	ts.deletableGroupOU1ID = ""
+}
+
+// TestDeleteGroupInOtherOU verifies the group-manager is denied deleting a group in OU2.
+func (ts *GroupAuthzTestSuite) TestDeleteGroupInOtherOU() {
+	resp := ts.doGroup(http.MethodDelete, "/groups/"+ts.targetGroupOU2ID, nil)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not delete a group in a different OU")
+}
+
+// ---------------------------------------------------------------------------
+// Tests — MEMBER operations (system:group)
+// ---------------------------------------------------------------------------
+
+// TestAddMemberFromOtherOU verifies the group-manager is denied adding a user from OU2 to a group in OU1.
+// Run before TestAddMemberFromOwnOU / TestRemoveMemberFromGroupInOwnOU (alphabetical order).
+func (ts *GroupAuthzTestSuite) TestAddMemberFromOtherOU() {
+	payload, err := json.Marshal(MembersRequest{
+		Members: []Member{
+			{Id: ts.memberUserOU2ID, Type: MemberTypeUser},
+		},
+	})
+	ts.Require().NoError(err)
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.targetGroupOU1ID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not add a user from OU2 to a group in OU1")
+}
+
+// TestAddMemberFromOwnOU verifies the group-manager can add a user from OU1 to a group in OU1.
+func (ts *GroupAuthzTestSuite) TestAddMemberFromOwnOU() {
+	payload, err := json.Marshal(MembersRequest{
+		Members: []Member{
+			{Id: ts.memberUserOU1ID, Type: MemberTypeUser},
+		},
+	})
+	ts.Require().NoError(err)
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.targetGroupOU1ID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode,
+		"group-manager should be able to add a user from their own OU to a group in their own OU")
+}
+
+// TestRemoveMemberFromGroupInOwnOU verifies the group-manager can remove a user from a group in OU1.
+// Depends on TestAddMemberFromOwnOU having already added memberUserOU1 to targetGroupOU1.
+func (ts *GroupAuthzTestSuite) TestRemoveMemberFromGroupInOwnOU() {
+	payload, err := json.Marshal(MembersRequest{
+		Members: []Member{
+			{Id: ts.memberUserOU1ID, Type: MemberTypeUser},
+		},
+	})
+	ts.Require().NoError(err)
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.targetGroupOU1ID+"/members/remove", payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode,
+		"group-manager should be able to remove a user from a group in their own OU")
+}


### PR DESCRIPTION
### Purpose
This pull request introduces organization unit (OU)-aware authorization for group resource APIs, ensuring that group-related operations are protected by fine-grained access controls based on the user's permissions for specific OUs. It also updates the system bootstrap scripts to register the new `group` resource and its `view` action in both PowerShell and Bash scripts. Additionally, new mock methods are added for testing group listing and counting by OU IDs.

Fixes https://github.com/asgardeo/thunder/issues/1694

The most important changes are:

**Authorization and Service Logic:**
- The `groupService` now requires a `SystemAuthorizationServiceInterface` and checks OU-level permissions for all major group operations (listing, creating, retrieving, etc.), enforcing access control based on the user's allowed OUs and actions. This includes new logic to select between listing all groups or only those in accessible OUs, and explicit permission checks in each handler. [[1]](diffhunk://#diff-03fb6ff18e90a9a1deda3ea9e281fe937bfdb95c1382c50df367fcbdb3e4c6aeR33-R34) [[2]](diffhunk://#diff-03fb6ff18e90a9a1deda3ea9e281fe937bfdb95c1382c50df367fcbdb3e4c6aeR65-R79) [[3]](diffhunk://#diff-03fb6ff18e90a9a1deda3ea9e281fe937bfdb95c1382c50df367fcbdb3e4c6aeL83-R106) [[4]](diffhunk://#diff-03fb6ff18e90a9a1deda3ea9e281fe937bfdb95c1382c50df367fcbdb3e4c6aeR135-R186) [[5]](diffhunk://#diff-03fb6ff18e90a9a1deda3ea9e281fe937bfdb95c1382c50df367fcbdb3e4c6aeR212-R215) [[6]](diffhunk://#diff-03fb6ff18e90a9a1deda3ea9e281fe937bfdb95c1382c50df367fcbdb3e4c6aeR258-R261) [[7]](diffhunk://#diff-03fb6ff18e90a9a1deda3ea9e281fe937bfdb95c1382c50df367fcbdb3e4c6aeR385-R388) [[8]](diffhunk://#diff-9dc7a7a474826c304713eec4405603bde8a54bbd75a55b533ab75944f7726e27R28) [[9]](diffhunk://#diff-9dc7a7a474826c304713eec4405603bde8a54bbd75a55b533ab75944f7726e27R37-R45) [[10]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L129-R129)

**System Bootstrap Enhancements:**
- The bootstrap scripts (`01-default-resources.sh` and `.ps1`) now create the `group` sub-resource under the `system` resource, along with a `view` action, ensuring these permissions exist for use in the authorization layer. [[1]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aR330-R331) [[2]](diffhunk://#diff-251727c4cd4b985ce306b3bceda1a46916f4559e9aa429037689e8271628e3ceR341-R342) [[3]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aR585-R652) [[4]](diffhunk://#diff-251727c4cd4b985ce306b3bceda1a46916f4559e9aa429037689e8271628e3ceR638-R717)

**Testing Improvements:**
- New mock methods are added to `groupStoreInterface_mock_test.go` for `GetGroupListByOUIDs` and `GetGroupListCountByOUIDs`, enabling tests to simulate and verify OU-scoped group queries and counts. [[1]](diffhunk://#diff-ee9d50cfb607e1658e5b2458750d2b67fbe1cfc0c7cf2137141c38fce07eae77R489-R568) [[2]](diffhunk://#diff-ee9d50cfb607e1658e5b2458750d2b67fbe1cfc0c7cf2137141c38fce07eae77R629-R694)

**Error Handling:**
- The group handler now returns HTTP 403 Forbidden when authorization fails, providing clearer feedback for unauthorized access attempts.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization enforced across group operations and OU-scoped group listing so users only see/manage permitted groups.
  * Startup creates the default group resource and its view permission.
  * New OU-aware user validation to verify user membership scope.

* **Bug Fixes**
  * Unauthorized group access now returns 403 Forbidden where appropriate.

* **Tests**
  * Expanded unit and integration tests for authorization, OU scoping, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->