### PR TITLE
Add HTTP headers to prevent frame embedding authz requests

### DIFF
--- a/backend/internal/oauth/oauth2/authz/init.go
+++ b/backend/internal/oauth/oauth2/authz/init.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
+	"github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
@@ -46,7 +47,8 @@ func Initialize(
 func registerRoutes(mux *http.ServeMux, authzHandler AuthorizeHandlerInterface) {
 	// CORS MUST NOT be enabled on the authorization endpoint.
 	// The client redirects the user agent to it; it is not accessed directly via XHR/fetch.
-	mux.HandleFunc("GET /oauth2/authorize", authzHandler.HandleAuthorizeGetRequest)
+	mux.HandleFunc("GET /oauth2/authorize",
+		withFrameProtection(authzHandler.HandleAuthorizeGetRequest))
 
 	callbackOpts := middleware.CORSOptions{
 		AllowedMethods:   "POST",
@@ -60,4 +62,13 @@ func registerRoutes(mux *http.ServeMux, authzHandler AuthorizeHandlerInterface) 
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		}, callbackOpts))
+}
+
+// withFrameProtection wraps an HTTP handler to prevent the page from being embedded in frames.
+func withFrameProtection(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(constants.XFrameOptionsHeaderName, constants.XFrameOptionsDeny)
+		w.Header().Set(constants.ContentSecurityPolicyHeaderName, constants.ContentSecurityPolicyFrameAncestorsNone)
+		handler(w, r)
+	}
 }

--- a/backend/internal/oauth/oauth2/authz/init_test.go
+++ b/backend/internal/oauth/oauth2/authz/init_test.go
@@ -181,3 +181,19 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSHeaders() {
 		})
 	}
 }
+
+func (suite *InitTestSuite) TestWithFrameProtection() {
+	// RFC 9700 §4.16: Authorization servers MUST prevent clickjacking attacks.
+	handler := withFrameProtection(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/oauth2/authorize", nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	assert.Equal(suite.T(), http.StatusOK, rec.Code)
+	assert.Equal(suite.T(), "DENY", rec.Header().Get("X-Frame-Options"))
+	assert.Equal(suite.T(), "frame-ancestors 'none'", rec.Header().Get("Content-Security-Policy"))
+}

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -56,6 +56,18 @@ const ContentTypeFormURLEncoded = "application/x-www-form-urlencoded"
 // WWWAuthenticateHeaderName is the name of the WWW-Authenticate header used in HTTP responses.
 const WWWAuthenticateHeaderName = "WWW-Authenticate"
 
+// XFrameOptionsHeaderName is the name of the X-Frame-Options header used in HTTP responses.
+const XFrameOptionsHeaderName = "X-Frame-Options"
+
+// XFrameOptionsDeny is the X-Frame-Options value that prevents any framing of the page.
+const XFrameOptionsDeny = "DENY"
+
+// ContentSecurityPolicyHeaderName is the name of the Content-Security-Policy header used in HTTP responses.
+const ContentSecurityPolicyHeaderName = "Content-Security-Policy"
+
+// ContentSecurityPolicyFrameAncestorsNone is the CSP directive that prevents the page from being embedded in frames.
+const ContentSecurityPolicyFrameAncestorsNone = "frame-ancestors 'none'"
+
 // CacheControlHeaderName is the name of the cache-control header used in HTTP responses.
 const CacheControlHeaderName = "Cache-Control"
 


### PR DESCRIPTION
This pull request improves the security of the OAuth2 authorization endpoint by adding protections against clickjacking attacks. It introduces a middleware to set appropriate HTTP headers and includes corresponding unit tests to ensure the new protections are correctly applied.

Security enhancements:

* Added a `withFrameProtection` middleware that sets the `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` headers to prevent the authorization page from being embedded in frames, mitigating clickjacking risks (`backend/internal/oauth/oauth2/authz/init.go`).
* Updated the `/oauth2/authorize` route to use the new `withFrameProtection` middleware (`backend/internal/oauth/oauth2/authz/init.go`).

Testing:

* Added a unit test `TestWithFrameProtection` to verify that the frame protection headers are correctly set on the authorization endpoint (`backend/internal/oauth/oauth2/authz/init_test.go`).

Related issue:
Addresses 19 of https://github.com/asgardeo/thunder/issues/1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced the OAuth2 authorization endpoint with clickjacking protection. Frame protection headers now prevent the authorization page from being displayed within iframes, protecting user sessions from potential attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->