### PR TITLE
Add authentication for token introspect endpoint

### DIFF
--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -59,7 +59,7 @@ func Initialize(
 	discoveryService := discovery.Initialize(mux)
 	token.Initialize(mux, jwtService, applicationService, grantHandlerProvider,
 		scopeValidator, observabilitySvc, discoveryService)
-	introspect.Initialize(mux, jwtService)
+	introspect.Initialize(mux, jwtService, applicationService, discoveryService)
 	userinfo.Initialize(mux, jwtService, tokenValidator, applicationService, userService, ouService)
 	dcr.Initialize(mux, applicationService)
 }

--- a/backend/internal/oauth/oauth2/introspect/init.go
+++ b/backend/internal/oauth/oauth2/introspect/init.go
@@ -21,28 +21,49 @@ package introspect
 import (
 	"net/http"
 
+	"github.com/asgardeo/thunder/internal/application"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/clientauth"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/discovery"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
 
 // Initialize initializes the token introspection handler and registers its routes.
-func Initialize(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) TokenIntrospectionServiceInterface {
+func Initialize(
+	mux *http.ServeMux,
+	jwtService jwt.JWTServiceInterface,
+	appService application.ApplicationServiceInterface,
+	discoveryService discovery.DiscoveryServiceInterface,
+) TokenIntrospectionServiceInterface {
 	introspectionService := newTokenIntrospectionService(jwtService)
 	introspectHandler := newTokenIntrospectionHandler(introspectionService)
-	registerRoutes(mux, introspectHandler)
+	registerRoutes(mux, introspectHandler, appService, jwtService, discoveryService)
 	return introspectionService
 }
 
 // registerRoutes registers the routes for the IntrospectionAPIService.
-func registerRoutes(mux *http.ServeMux, introspectHandler *tokenIntrospectionHandler) {
+func registerRoutes(
+	mux *http.ServeMux,
+	introspectHandler *tokenIntrospectionHandler,
+	appService application.ApplicationServiceInterface,
+	jwtService jwt.JWTServiceInterface,
+	discoveryService discovery.DiscoveryServiceInterface,
+) {
 	opts := middleware.CORSOptions{
 		AllowedMethods:   "POST, OPTIONS",
 		AllowedHeaders:   "Content-Type, Authorization",
 		AllowCredentials: true,
 	}
 
-	mux.HandleFunc(middleware.WithCORS("POST /oauth2/introspect",
-		introspectHandler.HandleIntrospect, opts))
+	clientAuthMiddleware := clientauth.ClientAuthMiddleware(appService, jwtService, discoveryService)
+	handler := clientAuthMiddleware(http.HandlerFunc(introspectHandler.HandleIntrospect))
+
+	pattern, wrappedHandler := middleware.WithCORS(
+		"POST /oauth2/introspect",
+		handler.ServeHTTP,
+		opts,
+	)
+	mux.HandleFunc(pattern, wrappedHandler)
 	mux.HandleFunc(middleware.WithCORS("OPTIONS /oauth2/introspect",
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/oauth/oauth2/introspect/init_test.go
+++ b/backend/internal/oauth/oauth2/introspect/init_test.go
@@ -45,7 +45,7 @@ func (suite *InitTestSuite) SetupTest() {
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
 
-	service := Initialize(mux, suite.mockJWTService)
+	service := Initialize(mux, suite.mockJWTService, nil, nil)
 
 	assert.NotNil(suite.T(), service)
 	assert.Implements(suite.T(), (*TokenIntrospectionServiceInterface)(nil), service)
@@ -54,7 +54,7 @@ func (suite *InitTestSuite) TestInitialize() {
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
 
-	_ = Initialize(mux, suite.mockJWTService)
+	_ = Initialize(mux, suite.mockJWTService, nil, nil)
 
 	// Verify that the routes are registered by attempting to get a handler for them.
 	// The pattern includes the method because of CORS middleware wrapping.


### PR DESCRIPTION
This pull request enhances the security of the OAuth2 token introspection endpoint by introducing client authentication middleware. The main changes involve updating the introspection route initialization to require client authentication using the application service, ensuring only authorized clients can introspect tokens.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
The `/oauth2/introspect` endpoint now requires client authentication (client credentials via `client_secret_post` or `client_secret_basic`), matching the `/oauth2/token` endpoint behavior per RFC 7662 §2.1.

#### 💥 Impact
Existing callers that invoke the introspect endpoint without providing client credentials will receive a `401 Unauthorized` response.

#### 🔄 Migration Guide
Include client credentials when calling `/oauth2/introspect`. For example:

```bash
curl -X POST https://localhost:8090/oauth2/introspect \
  -d "token=<access_token>&client_id=<client_id>&client_secret=<client_secret>"
```

**Security improvements:**

* Added `clientauth.ClientAuthMiddleware` to the `POST /oauth2/introspect` endpoint to enforce client authentication, using the `application.ApplicationServiceInterface` for validation.
* Modified the `Initialize` function in `introspect` to accept the application service as a new dependency, ensuring the middleware has access to application data for authentication. [[1]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4L60-R60) [[2]](diffhunk://#diff-bc27c95c189ee77b3651781297a18e6700eedc2dae2c619e9f0a025d28567383R24-R62)

**Code structure changes:**

* Updated the `registerRoutes` function to wrap the introspection handler with the new client authentication middleware and properly handle CORS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OAuth introspection endpoint with improved client authentication and cross-origin request handling for better security and platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related issue:
1 of https://github.com/asgardeo/thunder/issues/1625