### PR TITLE
Disable React Query retries for 4xx client errors

### DIFF
--- a/frontend/apps/thunder-develop/src/AppWithConfig.tsx
+++ b/frontend/apps/thunder-develop/src/AppWithConfig.tsx
@@ -25,7 +25,18 @@ import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 import I18nProvider from './i18n/I18nProvider';
 import App from './App';
 
-const queryClient: QueryClient = new QueryClient();
+const queryClient: QueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) => {
+        const status = (error as {response?: {status?: number}})?.response?.status;
+        if (status && status >= 400 && status < 500) return false;
+
+        return failureCount < 3;
+      },
+    },
+  },
+});
 
 export default function AppWithConfig(): JSX.Element {
   const {getClientId, getServerUrl, getClientUrl, getScopes} = useConfig();

--- a/frontend/apps/thunder-gate/src/main.tsx
+++ b/frontend/apps/thunder-gate/src/main.tsx
@@ -42,7 +42,18 @@ await i18n.use(initReactI18next).init({
   debug: import.meta.env.DEV,
 });
 
-const queryClient: QueryClient = new QueryClient();
+const queryClient: QueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) => {
+        const status = (error as {response?: {status?: number}})?.response?.status;
+        if (status && status >= 400 && status < 500) return false;
+
+        return failureCount < 3;
+      },
+    },
+  },
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- Configure `QueryClient` in both `thunder-develop` and `thunder-gate` apps to skip retries for 4xx HTTP status codes
- Client errors (400-499) are deterministic — retrying them wastes time and network resources
- Server errors (5xx) and network failures continue to retry up to 3 times (default behavior)

## Changes
| File | Change |
|------|--------|
| `frontend/apps/thunder-develop/src/AppWithConfig.tsx` | Add custom `retry` function to `QueryClient` config |
| `frontend/apps/thunder-gate/src/main.tsx` | Add custom `retry` function to `QueryClient` config |

## Test plan
- [ ] Verify 4xx errors (e.g. 401, 403, 404, 409) are not retried
- [ ] Verify 5xx errors still retry up to 3 times
- [ ] Verify network errors still retry up to 3 times
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced API error resilience with intelligent retry logic. Client-side errors (4xx status codes) now terminate immediately without additional retries, improving response times. Network and server errors are automatically retried up to 3 times, providing better handling of transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->