### PR TITLE
Update auth code context clearing order

### DIFF
--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -356,6 +356,9 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 		authRequestCtx.OAuthParameters.PermissionScopes = []string{}
 	}
 
+	// All validation passed. Clear the authorization request context from the store to prevent replay.
+	as.authReqStore.ClearRequest(authID)
+
 	// Generate the authorization code.
 	authzCode, err := createAuthorizationCode(authRequestCtx, &claims, authTime)
 	if err != nil {
@@ -404,8 +407,6 @@ func (as *authorizeService) loadAuthRequestContext(authID string) (*authRequestC
 		return nil, errors.New("authorization request context not found for auth ID: " + authID)
 	}
 
-	// Remove the authorization request context after retrieval.
-	as.authReqStore.ClearRequest(authID)
 	return &authRequestCtx, nil
 }
 

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -358,7 +358,6 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_MissingA
 		},
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
 
 	svc := suite.newService()
 	redirectURI, authErr := svc.HandleAuthorizationCallback(testAuthID, "")
@@ -378,7 +377,6 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidA
 		},
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
 	suite.mockJWTService.EXPECT().VerifyJWT("invalid-assertion", "", "").Return(&jwt.ErrorInvalidTokenSignature)
 
 	svc := suite.newService()
@@ -390,6 +388,39 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidA
 	assert.Equal(suite.T(), "test-state", authErr.State)
 }
 
+// TestHandleAuthorizationCallback_ContextPreservedAfterInvalidAssertion verifies the core security
+// property of the fix: a failed callback attempt (e.g. invalid assertion) does NOT consume the
+// authorization request context, so the legitimate flow can still complete on a subsequent call.
+func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_ContextPreservedAfterInvalidAssertion() {
+	authCtx := authRequestContext{
+		OAuthParameters: oauth2model.OAuthParameters{
+			ClientID:    "test-client",
+			RedirectURI: "https://client.example.com/callback",
+			State:       "test-state",
+		},
+	}
+
+	// First call: invalid assertion — context must NOT be cleared.
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT("invalid-assertion", "", "").Return(&jwt.ErrorInvalidTokenSignature).Once()
+
+	svc := suite.newService()
+	_, authErr := svc.HandleAuthorizationCallback(testAuthID, "invalid-assertion")
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorInvalidRequest, authErr.Code)
+
+	// Second call: valid assertion — context is still available and flow completes successfully.
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx).Once()
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil).Once()
+	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything).Return(nil).Once()
+
+	redirectURI, authErr := svc.HandleAuthorizationCallback(testAuthID, svcJWTWithIat)
+	assert.Nil(suite.T(), authErr)
+	assert.Contains(suite.T(), redirectURI, "https://client.example.com/callback")
+	assert.Contains(suite.T(), redirectURI, "code=")
+}
+
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_FailedToDecodeAssertion() {
 	authCtx := authRequestContext{
 		OAuthParameters: oauth2model.OAuthParameters{
@@ -399,7 +430,6 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_FailedTo
 		},
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
 	// VerifyJWT succeeds but "not.valid.jwt" cannot be decoded as a valid JWT payload.
 	suite.mockJWTService.EXPECT().VerifyJWT("not.valid.jwt", "", "").Return(nil)
 


### PR DESCRIPTION
This pull request addresses a security issue in the OAuth2 authorization flow by ensuring that the authorization request context is only cleared from the store after all validation has passed. This prevents the context from being prematurely consumed if the callback is called with invalid or missing assertions, thereby mitigating replay and denial-of-service risks. The tests have also been updated and expanded to verify this behavior.

**Security Fixes:**

* The authorization request context is now cleared from the store only after all validation passes in `HandleAuthorizationCallback`, preventing loss of context on invalid or missing assertions and ensuring the flow can be retried safely. [[1]](diffhunk://#diff-a19169f208c81ae739b01ba45fef130d1026b848dbede951786de661df44d32eR359-R361) [[2]](diffhunk://#diff-a19169f208c81ae739b01ba45fef130d1026b848dbede951786de661df44d32eL407-L408)

**Testing Improvements:**

* Updated existing tests to remove expectations that the context is always cleared, reflecting the new logic where it is only cleared after successful validation. [[1]](diffhunk://#diff-6a0f13f852440ff875d92ddccc88c9929bdffff43c0ab29214b851ba91d892a2L361) [[2]](diffhunk://#diff-6a0f13f852440ff875d92ddccc88c9929bdffff43c0ab29214b851ba91d892a2L381) [[3]](diffhunk://#diff-6a0f13f852440ff875d92ddccc88c9929bdffff43c0ab29214b851ba91d892a2L402)
* Added a new test, `TestHandleAuthorizationCallback_ContextPreservedAfterInvalidAssertion`, to verify that the context is preserved after an invalid assertion and only cleared after a successful callback, ensuring the core security property of the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 authorization callback processing to prevent replay attacks by clearing authorization request context at the appropriate time.
  * Enhanced handling of invalid assertion errors during authorization flow, allowing retry attempts while maintaining security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->