### PR TITLE
Add batch fetch support for users and groups and fix display attribute resolution

### DIFF
--- a/api/role.yaml
+++ b/api/role.yaml
@@ -460,7 +460,7 @@ paths:
               - display
           description: |
             Optional parameter to include additional information.
-            - `display` - Include display names for users and groups
+            - `display` - Include display names for users and groups. For users, the display value is resolved from the schema-configured display attribute (`systemAttributes.display`). Falls back to the user ID if no display attribute is configured. For groups, the group name is used.
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
       responses:
@@ -733,7 +733,7 @@ components:
           description: "Type of entity being assigned (user or group)"
         display:
           type: string
-          description: "Display name of the user or group (only included when include=display query parameter is used)"
+          description: "Display name of the user or group (only included when include=display query parameter is used). For users, resolved from the schema-configured display attribute. For groups, the group name is used."
 
     AssignmentInput:
       type: object

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -136,7 +136,9 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 		logger.Fatal("Failed to initialize Resource Service", log.Error(err))
 	}
 	exporters = append(exporters, resourceExporter)
-	roleService, roleExporter, err := role.Initialize(mux, userService, groupService, ouService, resourceService)
+	roleService, roleExporter, err := role.Initialize(
+		mux, userService, groupService, ouService, resourceService, userSchemaService,
+	)
 	if err != nil {
 		logger.Fatal("Failed to initialize RoleService", log.Error(err))
 	}

--- a/backend/internal/group/GroupServiceInterface_mock_test.go
+++ b/backend/internal/group/GroupServiceInterface_mock_test.go
@@ -547,6 +547,76 @@ func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetGroupsByIDs provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) GetGroupsByIDs(ctx context.Context, groupIDs []string) (map[string]*Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupsByIDs")
+	}
+
+	var r0 map[string]*Group
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (map[string]*Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) map[string]*Group); ok {
+		r0 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*Group)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_GetGroupsByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupsByIDs'
+type GroupServiceInterfaceMock_GetGroupsByIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupsByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupIDs []string
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupsByIDs(ctx interface{}, groupIDs interface{}) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	return &GroupServiceInterfaceMock_GetGroupsByIDs_Call{Call: _e.mock.On("GetGroupsByIDs", ctx, groupIDs)}
+}
+
+func (_c *GroupServiceInterfaceMock_GetGroupsByIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetGroupsByIDs_Call) Return(stringToGroup map[string]*Group, serviceError *serviceerror.ServiceError) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(stringToGroup, serviceError)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetGroupsByIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) (map[string]*Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroupsByPath provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(ctx context.Context, handlePath string, limit int, offset int) (*GroupListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, handlePath, limit, offset)

--- a/backend/internal/group/groupStoreInterface_mock_test.go
+++ b/backend/internal/group/groupStoreInterface_mock_test.go
@@ -838,6 +838,74 @@ func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// GetGroupsByIDs provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupsByIDs")
+	}
+
+	var r0 []GroupBasicDAO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]GroupBasicDAO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetGroupsByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupsByIDs'
+type groupStoreInterfaceMock_GetGroupsByIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupsByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupIDs []string
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByIDs(ctx interface{}, groupIDs interface{}) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	return &groupStoreInterfaceMock_GetGroupsByIDs_Call{Call: _e.mock.On("GetGroupsByIDs", ctx, groupIDs)}
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupsByIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupsByIDs_Call) Return(groupBasicDAOs []GroupBasicDAO, err error) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(groupBasicDAOs, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupsByIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroupsByOrganizationUnit provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(ctx context.Context, organizationUnitID string, limit int, offset int) ([]GroupBasicDAO, error) {
 	ret := _mock.Called(ctx, organizationUnitID, limit, offset)

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -52,6 +52,7 @@ type GroupServiceInterface interface {
 	GetGroupMembers(ctx context.Context, groupID string, limit, offset int) (
 		*MemberListResponse, *serviceerror.ServiceError)
 	ValidateGroupIDs(ctx context.Context, groupIDs []string) *serviceerror.ServiceError
+	GetGroupsByIDs(ctx context.Context, groupIDs []string) (map[string]*Group, *serviceerror.ServiceError)
 	AddGroupMembers(ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError)
 	RemoveGroupMembers(ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError)
 }
@@ -924,6 +925,46 @@ func (gs *groupService) ValidateGroupIDs(ctx context.Context, groupIDs []string)
 	}
 
 	return nil
+}
+
+// GetGroupsByIDs retrieves groups by a list of IDs.
+func (gs *groupService) GetGroupsByIDs(
+	ctx context.Context, groupIDs []string,
+) (map[string]*Group, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if len(groupIDs) == 0 {
+		return map[string]*Group{}, nil
+	}
+
+	// Deduplicate IDs before passing to store.
+	seen := make(map[string]struct{}, len(groupIDs))
+	uniqueIDs := make([]string, 0, len(groupIDs))
+	for _, id := range groupIDs {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			uniqueIDs = append(uniqueIDs, id)
+		}
+	}
+
+	groupDAOs, err := gs.groupStore.GetGroupsByIDs(ctx, uniqueIDs)
+	if err != nil {
+		logger.Error("Failed to get groups by IDs", log.Error(err))
+		return nil, &ErrorInternalServerError
+	}
+
+	result := make(map[string]*Group, len(groupDAOs))
+	for _, dao := range groupDAOs {
+		group := convertGroupDAOToGroup(GroupDAO{
+			ID:                 dao.ID,
+			Name:               dao.Name,
+			Description:        dao.Description,
+			OrganizationUnitID: dao.OrganizationUnitID,
+		})
+		result[dao.ID] = &group
+	}
+
+	return result, nil
 }
 
 // convertGroupDAOToGroup constructs a Group from a GroupDAO.

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -51,6 +51,7 @@ type groupStoreInterface interface {
 		ctx context.Context, organizationUnitID string, limit, offset int) ([]GroupBasicDAO, error)
 	AddGroupMembers(ctx context.Context, groupID string, members []Member) error
 	RemoveGroupMembers(ctx context.Context, groupID string, members []Member) error
+	GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error)
 }
 
 // groupStore is the default implementation of groupStoreInterface.
@@ -495,6 +496,55 @@ func (s *groupStore) RemoveGroupMembers(ctx context.Context, groupID string, mem
 	}
 
 	return nil
+}
+
+// GetGroupsByIDs retrieves groups by a list of IDs.
+func (s *groupStore) GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error) {
+	const batchSize = 100
+
+	if len(groupIDs) == 0 {
+		return []GroupBasicDAO{}, nil
+	}
+
+	dbClient, err := s.dbProvider.GetUserDBClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	groups := make([]GroupBasicDAO, 0, len(groupIDs))
+
+	for start := 0; start < len(groupIDs); start += batchSize {
+		end := start + batchSize
+		if end > len(groupIDs) {
+			end = len(groupIDs)
+		}
+		chunk := groupIDs[start:end]
+
+		query, args, err := buildGetGroupsByIDsQuery(chunk, s.deploymentID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build get groups by IDs query: %w", err)
+		}
+
+		results, err := dbClient.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute query: %w", err)
+		}
+
+		for _, row := range results {
+			group, err := buildGroupFromResultRow(row)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build group from result row: %w", err)
+			}
+			groups = append(groups, GroupBasicDAO{
+				ID:                 group.ID,
+				Name:               group.Name,
+				Description:        group.Description,
+				OrganizationUnitID: group.OrganizationUnitID,
+			})
+		}
+	}
+
+	return groups, nil
 }
 
 // buildGroupFromResultRow constructs a GroupDAO from a database result row.

--- a/backend/internal/group/store_constants.go
+++ b/backend/internal/group/store_constants.go
@@ -215,33 +215,54 @@ var (
 	}
 )
 
-// buildBulkGroupExistsQuery constructs a query to check which group IDs exist from a list.
-func buildBulkGroupExistsQuery(groupIDs []string, deploymentID string) (dbmodel.DBQuery, []interface{}, error) {
+// buildGroupINClauseQuery constructs a query with an IN clause for group IDs.
+func buildGroupINClauseQuery(
+	queryID, baseQuery string, groupIDs []string, deploymentID string,
+) (dbmodel.DBQuery, []interface{}, error) {
 	if len(groupIDs) == 0 {
 		return dbmodel.DBQuery{}, nil, fmt.Errorf("groupIDs list cannot be empty")
 	}
+
 	args := make([]interface{}, len(groupIDs)+1)
-	args[0] = deploymentID
 
 	postgresPlaceholders := make([]string, len(groupIDs))
 	sqlitePlaceholders := make([]string, len(groupIDs))
 
 	for i, groupID := range groupIDs {
-		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+2)
+		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+1)
 		sqlitePlaceholders[i] = "?"
-		args[i+1] = groupID
+		args[i] = groupID
 	}
+	args[len(groupIDs)] = deploymentID
 
-	baseQuery := "SELECT ID FROM \"GROUP\" WHERE DEPLOYMENT_ID = %s AND ID IN (%s)"
-	postgresQuery := fmt.Sprintf(baseQuery, "$1", strings.Join(postgresPlaceholders, ","))
-	sqliteQuery := fmt.Sprintf(baseQuery, "?", strings.Join(sqlitePlaceholders, ","))
+	deploymentPlaceholder := fmt.Sprintf("$%d", len(groupIDs)+1)
+	postgresQuery := fmt.Sprintf(baseQuery, strings.Join(postgresPlaceholders, ","), deploymentPlaceholder)
+	sqliteQuery := fmt.Sprintf(baseQuery, strings.Join(sqlitePlaceholders, ","), "?")
 
 	query := dbmodel.DBQuery{
-		ID:            "GRQ-GROUP_MGT-18",
+		ID:            queryID,
 		Query:         postgresQuery,
 		PostgresQuery: postgresQuery,
 		SQLiteQuery:   sqliteQuery,
 	}
 
 	return query, args, nil
+}
+
+// buildBulkGroupExistsQuery constructs a query to check which group IDs exist from a list.
+func buildBulkGroupExistsQuery(groupIDs []string, deploymentID string) (dbmodel.DBQuery, []interface{}, error) {
+	return buildGroupINClauseQuery(
+		"GRQ-GROUP_MGT-18",
+		"SELECT ID FROM \"GROUP\" WHERE ID IN (%s) AND DEPLOYMENT_ID = %s",
+		groupIDs, deploymentID,
+	)
+}
+
+// buildGetGroupsByIDsQuery constructs a query to fetch groups by a list of IDs.
+func buildGetGroupsByIDsQuery(groupIDs []string, deploymentID string) (dbmodel.DBQuery, []interface{}, error) {
+	return buildGroupINClauseQuery(
+		"GRQ-GROUP_MGT-19",
+		"SELECT ID, OU_ID, NAME, DESCRIPTION FROM \"GROUP\" WHERE ID IN (%s) AND DEPLOYMENT_ID = %s",
+		groupIDs, deploymentID,
+	)
 }

--- a/backend/internal/group/store_constants_test.go
+++ b/backend/internal/group/store_constants_test.go
@@ -22,7 +22,120 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+// StoreConstantsTestSuite is the test suite for store_constants.go functions.
+type StoreConstantsTestSuite struct {
+	suite.Suite
+}
+
+// TestStoreConstantsTestSuite runs the test suite.
+func TestStoreConstantsTestSuite(t *testing.T) {
+	suite.Run(t, new(StoreConstantsTestSuite))
+}
+
+// Test buildGetGroupsByIDsQuery
+
+func (suite *StoreConstantsTestSuite) TestBuildGetGroupsByIDsQuery_EmptyIDs() {
+	query, args, err := buildGetGroupsByIDsQuery([]string{}, testDeploymentID)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "groupIDs list cannot be empty")
+	suite.Nil(args)
+	suite.Empty(query.Query)
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildGetGroupsByIDsQuery_SingleID() {
+	query, args, err := buildGetGroupsByIDsQuery([]string{"group-1"}, testDeploymentID)
+
+	suite.NoError(err)
+	suite.Equal("GRQ-GROUP_MGT-19", query.ID)
+	suite.Equal(
+		`SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE ID IN ($1) AND DEPLOYMENT_ID = $2`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE ID IN (?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 2)
+	suite.Equal("group-1", args[0])
+	suite.Equal(testDeploymentID, args[1])
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildGetGroupsByIDsQuery_MultipleIDs() {
+	query, args, err := buildGetGroupsByIDsQuery(
+		[]string{"group-1", "group-2", "group-3"}, testDeploymentID,
+	)
+
+	suite.NoError(err)
+	suite.Equal("GRQ-GROUP_MGT-19", query.ID)
+	suite.Equal(
+		`SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE ID IN ($1,$2,$3) AND DEPLOYMENT_ID = $4`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE ID IN (?,?,?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 4)
+	suite.Equal("group-1", args[0])
+	suite.Equal("group-2", args[1])
+	suite.Equal("group-3", args[2])
+	suite.Equal(testDeploymentID, args[3])
+}
+
+// Test buildBulkGroupExistsQuery
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkGroupExistsQuery_EmptyIDs() {
+	query, args, err := buildBulkGroupExistsQuery([]string{}, testDeploymentID)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "groupIDs list cannot be empty")
+	suite.Nil(args)
+	suite.Empty(query.Query)
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkGroupExistsQuery_SingleID() {
+	query, args, err := buildBulkGroupExistsQuery([]string{"group-1"}, testDeploymentID)
+
+	suite.NoError(err)
+	suite.Equal("GRQ-GROUP_MGT-18", query.ID)
+	suite.Equal(
+		`SELECT ID FROM "GROUP" WHERE ID IN ($1) AND DEPLOYMENT_ID = $2`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID FROM "GROUP" WHERE ID IN (?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 2)
+	suite.Equal("group-1", args[0])
+	suite.Equal(testDeploymentID, args[1])
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkGroupExistsQuery_MultipleIDs() {
+	query, args, err := buildBulkGroupExistsQuery(
+		[]string{"group-1", "group-2", "group-3"}, testDeploymentID,
+	)
+
+	suite.NoError(err)
+	suite.Equal("GRQ-GROUP_MGT-18", query.ID)
+	suite.Equal(
+		`SELECT ID FROM "GROUP" WHERE ID IN ($1,$2,$3) AND DEPLOYMENT_ID = $4`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID FROM "GROUP" WHERE ID IN (?,?,?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 4)
+	suite.Equal("group-1", args[0])
+	suite.Equal("group-2", args[1])
+	suite.Equal("group-3", args[2])
+	suite.Equal(testDeploymentID, args[3])
+}
 
 func TestBuildGetGroupListCountByOUIDsQuery(t *testing.T) {
 	deploymentID := "dep1"

--- a/backend/internal/group/store_test.go
+++ b/backend/internal/group/store_test.go
@@ -1073,7 +1073,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 					Once()
 
 				dbClientMock.
-					On("QueryContext", mock.Anything, queryMatcher(), testDeploymentID, "grp-1", "grp-2").
+					On("QueryContext", mock.Anything, queryMatcher(), "grp-1", "grp-2", testDeploymentID).
 					Return([]map[string]interface{}{{"id": "grp-1"}}, nil).
 					Once()
 			},
@@ -1092,7 +1092,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 					Once()
 
 				dbClientMock.
-					On("QueryContext", mock.Anything, queryMatcher(), testDeploymentID, "grp-miss", "", "grp-hit").
+					On("QueryContext", mock.Anything, queryMatcher(), "grp-miss", "", "grp-hit", testDeploymentID).
 					Return([]map[string]interface{}{{"id": "grp-hit"}}, nil).
 					Once()
 			},
@@ -1111,7 +1111,7 @@ func (suite *GroupStoreTestSuite) TestGroupStore_ValidateGroupIDs() {
 					Once()
 
 				dbClientMock.
-					On("QueryContext", mock.Anything, queryMatcher(), testDeploymentID, "grp-1").
+					On("QueryContext", mock.Anything, queryMatcher(), "grp-1", testDeploymentID).
 					Return(nil, errors.New("query fail")).
 					Once()
 			},
@@ -1693,6 +1693,113 @@ func (suite *GroupStoreTestSuite) TestGroupStore_BuildBulkGroupExistsQueryEmpty(
 	_, _, err := buildBulkGroupExistsQuery([]string{}, testDeploymentID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "groupIDs list cannot be empty")
+}
+
+func (suite *GroupStoreTestSuite) TestGroupStore_GetGroupsByIDs() {
+	t := suite.T()
+
+	queryMatcher := func() interface{} {
+		return mock.MatchedBy(func(q dbmodel.DBQuery) bool { return q.ID == "GRQ-GROUP_MGT-19" })
+	}
+
+	type testCase struct {
+		name      string
+		groupIDs  []string
+		setup     func(*providermock.DBProviderInterfaceMock, *providermock.DBClientInterfaceMock)
+		wantCount int
+		wantErr   string
+	}
+
+	testCases := []testCase{
+		{
+			name:      "empty input returns empty slice",
+			groupIDs:  []string{},
+			wantCount: 0,
+		},
+		{
+			name:     "success with multiple groups",
+			groupIDs: []string{"grp-1", "grp-2"},
+			setup: func(
+				providerMock *providermock.DBProviderInterfaceMock,
+				dbClientMock *providermock.DBClientInterfaceMock,
+			) {
+				providerMock.On("GetUserDBClient").Return(dbClientMock, nil).Once()
+				dbClientMock.On("QueryContext", mock.Anything, queryMatcher(), "grp-1", "grp-2", testDeploymentID).
+					Return([]map[string]interface{}{
+						{"id": "grp-1", "ou_id": "ou-1", "name": "Group One", "description": "First group"},
+						{"id": "grp-2", "ou_id": "ou-1", "name": "Group Two", "description": "Second group"},
+					}, nil).Once()
+			},
+			wantCount: 2,
+		},
+		{
+			name:     "partial results - some IDs not found",
+			groupIDs: []string{"grp-1", "grp-missing"},
+			setup: func(
+				providerMock *providermock.DBProviderInterfaceMock,
+				dbClientMock *providermock.DBClientInterfaceMock,
+			) {
+				providerMock.On("GetUserDBClient").Return(dbClientMock, nil).Once()
+				dbClientMock.On(
+					"QueryContext", mock.Anything, queryMatcher(), "grp-1", "grp-missing", testDeploymentID,
+				).
+					Return([]map[string]interface{}{
+						{"id": "grp-1", "ou_id": "ou-1", "name": "Group One", "description": "First group"},
+					}, nil).Once()
+			},
+			wantCount: 1,
+		},
+		{
+			name:     "query error",
+			groupIDs: []string{"grp-1"},
+			setup: func(
+				providerMock *providermock.DBProviderInterfaceMock,
+				dbClientMock *providermock.DBClientInterfaceMock,
+			) {
+				providerMock.On("GetUserDBClient").Return(dbClientMock, nil).Once()
+				dbClientMock.On("QueryContext", mock.Anything, queryMatcher(), "grp-1", testDeploymentID).
+					Return(nil, errors.New("query fail")).Once()
+			},
+			wantErr: "failed to execute query",
+		},
+		{
+			name:     "db client error",
+			groupIDs: []string{"grp-1"},
+			setup: func(
+				providerMock *providermock.DBProviderInterfaceMock,
+				_ *providermock.DBClientInterfaceMock,
+			) {
+				providerMock.On("GetUserDBClient").Return(nil, errors.New("client fail")).Once()
+			},
+			wantErr: "failed to get database client",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			providerMock := providermock.NewDBProviderInterfaceMock(t)
+			dbClientMock := providermock.NewDBClientInterfaceMock(t)
+
+			if tc.setup != nil {
+				tc.setup(providerMock, dbClientMock)
+			}
+
+			store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+			groups, err := store.GetGroupsByIDs(context.Background(), tc.groupIDs)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				require.Nil(t, groups)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, groups, tc.wantCount)
+			}
+
+			providerMock.AssertExpectations(t)
+			dbClientMock.AssertExpectations(t)
+		})
+	}
 }
 
 func (suite *GroupStoreTestSuite) TestGroupStore_AddMembersToGroupReturnsError() {

--- a/backend/internal/role/init.go
+++ b/backend/internal/role/init.go
@@ -30,6 +30,7 @@ import (
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 var getDBProvider = provider.GetDBProvider
@@ -41,6 +42,7 @@ func Initialize(
 	groupService group.GroupServiceInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	resourceService resourcepkg.ResourceServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 ) (RoleServiceInterface, declarativeresource.ResourceExporter, error) {
 	// Step 1: Initialize store based on configuration
 	roleStore, err := initializeStore()
@@ -60,7 +62,9 @@ func Initialize(
 	}
 
 	// Step 2: Create service with store
-	roleService := newRoleService(roleStore, userService, groupService, ouService, resourceService, transactioner)
+	roleService := newRoleService(
+		roleStore, userService, groupService, ouService, resourceService, userSchemaService, transactioner,
+	)
 	roleHandler := newRoleHandler(roleService)
 	registerRoutes(mux, roleHandler)
 	exporter := newRoleExporter(roleService)

--- a/backend/internal/role/init_test.go
+++ b/backend/internal/role/init_test.go
@@ -625,7 +625,7 @@ func (suite *InitTestSuite) TestInitialize_DBClientError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, err := Initialize(mux, nil, nil, nil, nil)
+	_, _, err := Initialize(mux, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	suite.Equal("mock db client error", err.Error())
@@ -649,7 +649,7 @@ func (suite *InitTestSuite) TestInitialize_TransactionerError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, err := Initialize(mux, nil, nil, nil, nil)
+	_, _, err := Initialize(mux, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	suite.Equal("mock transactioner error", err.Error())
@@ -680,7 +680,7 @@ func (suite *InitTestSuite) TestInitialize_Success() {
 	}()
 
 	mux := http.NewServeMux()
-	svc, exporter, err := Initialize(mux, nil, nil, nil, nil)
+	svc, exporter, err := Initialize(mux, nil, nil, nil, nil, nil)
 
 	suite.NoError(err)
 	suite.NotNil(svc)
@@ -716,7 +716,7 @@ func (suite *InitTestSuite) TestInitialize_StoreInitError() {
 	}()
 
 	mux := http.NewServeMux()
-	svc, exporter, err := Initialize(mux, nil, nil, nil, nil)
+	svc, exporter, err := Initialize(mux, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	if err != nil {

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -21,8 +21,10 @@ package role
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/asgardeo/thunder/internal/group"
 	oupkg "github.com/asgardeo/thunder/internal/ou"
@@ -33,6 +35,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
 	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/userschema"
 )
 
 const loggerComponentName = "RoleMgtService"
@@ -58,12 +61,13 @@ type RoleServiceInterface interface {
 
 // roleService is the default implementation of the RoleServiceInterface.
 type roleService struct {
-	roleStore       roleStoreInterface
-	userService     user.UserServiceInterface
-	groupService    group.GroupServiceInterface
-	ouService       oupkg.OrganizationUnitServiceInterface
-	resourceService resourcepkg.ResourceServiceInterface
-	transactioner   transaction.Transactioner
+	roleStore         roleStoreInterface
+	userService       user.UserServiceInterface
+	groupService      group.GroupServiceInterface
+	ouService         oupkg.OrganizationUnitServiceInterface
+	resourceService   resourcepkg.ResourceServiceInterface
+	userSchemaService userschema.UserSchemaServiceInterface
+	transactioner     transaction.Transactioner
 }
 
 // newRoleService creates a new instance of RoleService with injected dependencies.
@@ -73,15 +77,17 @@ func newRoleService(
 	groupService group.GroupServiceInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	resourceService resourcepkg.ResourceServiceInterface,
+	userSchemaService userschema.UserSchemaServiceInterface,
 	transactioner transaction.Transactioner,
 ) RoleServiceInterface {
 	return &roleService{
-		roleStore:       roleStore,
-		userService:     userService,
-		groupService:    groupService,
-		ouService:       ouService,
-		resourceService: resourceService,
-		transactioner:   transactioner,
+		roleStore:         roleStore,
+		userService:       userService,
+		groupService:      groupService,
+		ouService:         ouService,
+		resourceService:   resourceService,
+		userSchemaService: userSchemaService,
+		transactioner:     transactioner,
 	}
 }
 
@@ -385,23 +391,13 @@ func (rs *roleService) GetRoleAssignments(ctx context.Context, id string, limit,
 	// Convert to service layer assignments
 	serviceAssignments := make([]RoleAssignmentWithDisplay, len(assignments))
 
-	for i := range assignments {
-		// Populate display names if requested
-		displayName := ""
-		if includeDisplay {
-			displayName, err = rs.getDisplayNameForAssignment(ctx, &assignments[i])
-			if err != nil {
-				logger.Warn("Failed to get display name for assignment",
-					log.String("assignmentID", assignments[i].ID),
-					log.String("assignmentType", string(assignments[i].Type)),
-					log.Error(err))
-				// Continue with empty display name rather than failing the entire request
-				displayName = ""
-			}
+	if includeDisplay {
+		rs.populateDisplayNames(ctx, assignments, serviceAssignments)
+	} else {
+		for i := range assignments {
+			serviceAssignments[i].ID = assignments[i].ID
+			serviceAssignments[i].Type = assignments[i].Type
 		}
-		serviceAssignments[i].ID = assignments[i].ID
-		serviceAssignments[i].Type = assignments[i].Type
-		serviceAssignments[i].Display = displayName
 	}
 	baseURL := fmt.Sprintf("/roles/%s/assignments", id)
 	links := buildPaginationLinks(baseURL, limit, offset, totalCount)
@@ -711,27 +707,145 @@ func buildPaginationLinks(base string, limit, offset, totalCount int) []Link {
 	return links
 }
 
-// getDisplayNameForAssignment retrieves the display name for a user or group assignment.
-func (rs *roleService) getDisplayNameForAssignment(ctx context.Context, assignment *RoleAssignment) (string, error) {
-	switch assignment.Type {
-	case AssigneeTypeUser:
-		userResp, svcErr := rs.userService.GetUser(ctx, assignment.ID)
-		if svcErr != nil {
-			return "", fmt.Errorf("failed to get user: %w", errors.New(svcErr.Error))
+// populateDisplayNames batch-fetches display names for all assignments using GetUsersByIDs/GetGroupsByIDs.
+func (rs *roleService) populateDisplayNames(
+	ctx context.Context, assignments []RoleAssignment,
+	serviceAssignments []RoleAssignmentWithDisplay,
+) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	// Collect IDs by type
+	var userIDs, groupIDs []string
+	for _, a := range assignments {
+		switch a.Type {
+		case AssigneeTypeUser:
+			userIDs = append(userIDs, a.ID)
+		case AssigneeTypeGroup:
+			groupIDs = append(groupIDs, a.ID)
 		}
-		// Return user ID as display name (since User doesn't have a username field)
-		return userResp.ID, nil
+	}
 
-	case AssigneeTypeGroup:
-		groupResp, svcErr := rs.groupService.GetGroup(ctx, assignment.ID)
+	// Batch fetch users and groups
+	var usersMap map[string]*user.User
+	var groupsMap map[string]*group.Group
+
+	if len(userIDs) > 0 {
+		var svcErr *serviceerror.ServiceError
+		usersMap, svcErr = rs.userService.GetUsersByIDs(ctx, userIDs)
 		if svcErr != nil {
-			return "", fmt.Errorf("failed to get group: %w", errors.New(svcErr.Error))
+			logger.Warn("Failed to batch fetch users for display names", log.Any("error", svcErr))
 		}
-		// Return group name as display name
-		return groupResp.Name, nil
+	}
 
+	if len(groupIDs) > 0 {
+		var svcErr *serviceerror.ServiceError
+		groupsMap, svcErr = rs.groupService.GetGroupsByIDs(ctx, groupIDs)
+		if svcErr != nil {
+			logger.Warn("Failed to batch fetch groups for display names", log.Any("error", svcErr))
+		}
+	}
+
+	// Resolve display attribute paths for user types
+	displayAttrPaths := rs.resolveDisplayAttributePaths(ctx, usersMap)
+
+	for i := range assignments {
+		serviceAssignments[i].ID = assignments[i].ID
+		serviceAssignments[i].Type = assignments[i].Type
+		serviceAssignments[i].Display = assignments[i].ID // Fallback to ID if lookup fails
+
+		switch assignments[i].Type {
+		case AssigneeTypeUser:
+			if usersMap != nil {
+				if u, ok := usersMap[assignments[i].ID]; ok {
+					serviceAssignments[i].Display = resolveUserDisplay(u, displayAttrPaths)
+				}
+			}
+		case AssigneeTypeGroup:
+			if groupsMap != nil {
+				if g, ok := groupsMap[assignments[i].ID]; ok {
+					serviceAssignments[i].Display = g.Name
+				}
+			}
+		}
+	}
+}
+
+// resolveDisplayAttributePaths fetches display attribute paths for all unique user types in the map.
+func (rs *roleService) resolveDisplayAttributePaths(
+	ctx context.Context, usersMap map[string]*user.User,
+) map[string]string {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	if rs.userSchemaService == nil || len(usersMap) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var typeNames []string
+	for _, u := range usersMap {
+		if u.Type != "" {
+			if _, ok := seen[u.Type]; !ok {
+				seen[u.Type] = struct{}{}
+				typeNames = append(typeNames, u.Type)
+			}
+		}
+	}
+
+	if len(typeNames) == 0 {
+		return nil
+	}
+
+	displayPaths, svcErr := rs.userSchemaService.GetDisplayAttributesByNames(ctx, typeNames)
+	if svcErr != nil {
+		logger.Warn("Failed to get display attribute paths", log.Any("error", svcErr))
+		return nil
+	}
+
+	return displayPaths
+}
+
+// resolveUserDisplay extracts the display value from user attributes using the schema-configured path.
+// Falls back to user ID if no display attribute is configured or extraction fails.
+func resolveUserDisplay(u *user.User, displayAttrPaths map[string]string) string {
+	if displayAttrPaths != nil && u.Type != "" {
+		if path, ok := displayAttrPaths[u.Type]; ok && path != "" {
+			if val := extractDisplayValue(u.Attributes, path); val != "" {
+				return val
+			}
+		}
+	}
+
+	return u.ID
+}
+
+// extractDisplayValue extracts a string value from JSON attributes using a dot-notation path.
+func extractDisplayValue(attributes json.RawMessage, path string) string {
+	if len(attributes) == 0 || path == "" {
+		return ""
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(attributes, &data); err != nil {
+		return ""
+	}
+
+	parts := strings.Split(path, ".")
+	var current interface{} = data
+
+	for _, part := range parts {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = m[part]
+		if current == nil {
+			return ""
+		}
+	}
+
+	switch current.(type) {
+	case string, float64:
+		return utils.ConvertInterfaceValueToString(current)
 	default:
-		return "", fmt.Errorf("unknown assignment type: %s", assignment.Type)
+		return ""
 	}
 }
 

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -20,6 +20,7 @@ package role
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
 	"github.com/asgardeo/thunder/tests/mocks/resourcemock"
 	"github.com/asgardeo/thunder/tests/mocks/usermock"
+	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
 const (
@@ -59,13 +61,14 @@ func (f *fakeTransactioner) Transact(ctx context.Context, txFunc func(context.Co
 // Test Suite
 type RoleServiceTestSuite struct {
 	suite.Suite
-	mockStore           *roleStoreInterfaceMock
-	mockUserService     *usermock.UserServiceInterfaceMock
-	mockGroupService    *groupmock.GroupServiceInterfaceMock
-	mockOUService       *oumock.OrganizationUnitServiceInterfaceMock
-	mockResourceService *resourcemock.ResourceServiceInterfaceMock
-	transactioner       *fakeTransactioner
-	service             RoleServiceInterface
+	mockStore             *roleStoreInterfaceMock
+	mockUserService       *usermock.UserServiceInterfaceMock
+	mockGroupService      *groupmock.GroupServiceInterfaceMock
+	mockOUService         *oumock.OrganizationUnitServiceInterfaceMock
+	mockResourceService   *resourcemock.ResourceServiceInterfaceMock
+	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
+	transactioner         *fakeTransactioner
+	service               RoleServiceInterface
 }
 
 func TestRoleServiceTestSuite(t *testing.T) {
@@ -90,6 +93,7 @@ func (suite *RoleServiceTestSuite) SetupTest() {
 	suite.mockGroupService = groupmock.NewGroupServiceInterfaceMock(suite.T())
 	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
 	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	suite.mockUserSchemaService = userschemamock.NewUserSchemaServiceInterfaceMock(suite.T())
 	suite.transactioner = &fakeTransactioner{}
 	suite.service = newRoleService(
 		suite.mockStore,
@@ -97,6 +101,7 @@ func (suite *RoleServiceTestSuite) SetupTest() {
 		suite.mockGroupService,
 		suite.mockOUService,
 		suite.mockResourceService,
+		suite.mockUserSchemaService,
 		suite.transactioner,
 	)
 }
@@ -1227,10 +1232,22 @@ func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_Success() 
 		"role1").Return(2, nil)
 	suite.mockStore.On("GetRoleAssignments", mock.Anything,
 		"role1", 10, 0).Return(expectedAssignments, nil)
-	suite.mockUserService.On("GetUser", mock.Anything,
-		testUserID1).Return(&user.User{ID: testUserID1}, nil).Once()
-	suite.mockGroupService.On("GetGroup", mock.Anything,
-		"group1").Return(&group.Group{Name: "Test Group"}, nil).Once()
+	suite.mockUserService.On("GetUsersByIDs", mock.Anything,
+		[]string{testUserID1}).Return(map[string]*user.User{
+		testUserID1: {
+			ID:         testUserID1,
+			Type:       "employee",
+			Attributes: json.RawMessage(`{"email":"alice@example.com"}`),
+		},
+	}, (*serviceerror.ServiceError)(nil)).Once()
+	suite.mockGroupService.On("GetGroupsByIDs", mock.Anything,
+		[]string{"group1"}).Return(map[string]*group.Group{
+		"group1": {Name: "Test Group"},
+	}, (*serviceerror.ServiceError)(nil)).Once()
+	suite.mockUserSchemaService.On("GetDisplayAttributesByNames", mock.Anything,
+		[]string{"employee"}).Return(map[string]string{
+		"employee": "email",
+	}, (*serviceerror.ServiceError)(nil)).Once()
 
 	result, err := suite.service.GetRoleAssignments(context.Background(), "role1", 10, 0, true)
 
@@ -1238,8 +1255,31 @@ func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_Success() 
 	suite.NotNil(result)
 	suite.Equal(2, result.TotalResults)
 	suite.Equal(2, result.Count)
-	suite.Equal(testUserID1, result.Assignments[0].Display)
+	suite.Equal("alice@example.com", result.Assignments[0].Display)
 	suite.Equal("Test Group", result.Assignments[1].Display)
+}
+
+func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_FallbackToID() {
+	expectedAssignments := []RoleAssignment{
+		{ID: testUserID1, Type: AssigneeTypeUser},
+	}
+
+	suite.mockStore.On("IsRoleExist", mock.Anything,
+		"role1").Return(true, nil)
+	suite.mockStore.On("GetRoleAssignmentsCount", mock.Anything,
+		"role1").Return(1, nil)
+	suite.mockStore.On("GetRoleAssignments", mock.Anything,
+		"role1", 10, 0).Return(expectedAssignments, nil)
+	suite.mockUserService.On("GetUsersByIDs", mock.Anything,
+		[]string{testUserID1}).Return(map[string]*user.User{
+		testUserID1: {ID: testUserID1},
+	}, (*serviceerror.ServiceError)(nil)).Once()
+
+	result, err := suite.service.GetRoleAssignments(context.Background(), "role1", 10, 0, true)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(testUserID1, result.Assignments[0].Display)
 }
 
 func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_FetchErrors() {
@@ -1253,21 +1293,21 @@ func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_FetchError
 			name:       "User fetch error",
 			assignment: RoleAssignment{ID: testUserID1, Type: AssigneeTypeUser},
 			setupMock: func() {
-				suite.mockUserService.On("GetUser", mock.Anything,
-					testUserID1).
-					Return(nil, &serviceerror.ServiceError{Code: "USER_NOT_FOUND"}).Once()
+				suite.mockUserService.On("GetUsersByIDs", mock.Anything,
+					[]string{testUserID1}).
+					Return((map[string]*user.User)(nil), &serviceerror.ServiceError{Code: "INTERNAL_ERROR"}).Once()
 			},
-			expectedDisplay: "",
+			expectedDisplay: testUserID1,
 		},
 		{
 			name:       "Group fetch error",
 			assignment: RoleAssignment{ID: "group1", Type: AssigneeTypeGroup},
 			setupMock: func() {
-				suite.mockGroupService.On("GetGroup", mock.Anything,
-					"group1").
-					Return(nil, &serviceerror.ServiceError{Code: "GROUP_NOT_FOUND"}).Once()
+				suite.mockGroupService.On("GetGroupsByIDs", mock.Anything,
+					[]string{"group1"}).
+					Return((map[string]*group.Group)(nil), &serviceerror.ServiceError{Code: "INTERNAL_ERROR"}).Once()
 			},
-			expectedDisplay: "",
+			expectedDisplay: "group1",
 		},
 	}
 
@@ -1286,7 +1326,7 @@ func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_FetchError
 
 			result, err := suite.service.GetRoleAssignments(context.Background(), "role1", 10, 0, true)
 
-			// Should succeed but with empty display name on error
+			// Should succeed with fallback to assignment ID on error
 			suite.Nil(err)
 			suite.NotNil(result)
 			suite.Equal(1, result.TotalResults)
@@ -1294,6 +1334,187 @@ func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_FetchError
 			suite.Equal(tc.expectedDisplay, result.Assignments[0].Display)
 		})
 	}
+}
+
+func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_PartialResults() {
+	expectedAssignments := []RoleAssignment{
+		{ID: testUserID1, Type: AssigneeTypeUser},
+		{ID: "group1", Type: AssigneeTypeGroup},
+	}
+
+	suite.mockStore.On("IsRoleExist", mock.Anything,
+		"role1").Return(true, nil)
+	suite.mockStore.On("GetRoleAssignmentsCount", mock.Anything,
+		"role1").Return(2, nil)
+	suite.mockStore.On("GetRoleAssignments", mock.Anything,
+		"role1", 10, 0).Return(expectedAssignments, nil)
+	// Empty user/group maps — no users or groups found
+	suite.mockUserService.On("GetUsersByIDs", mock.Anything,
+		[]string{testUserID1}).Return(map[string]*user.User{}, (*serviceerror.ServiceError)(nil)).Once()
+	suite.mockGroupService.On("GetGroupsByIDs", mock.Anything,
+		[]string{"group1"}).Return(map[string]*group.Group{}, (*serviceerror.ServiceError)(nil)).Once()
+
+	result, err := suite.service.GetRoleAssignments(context.Background(), "role1", 10, 0, true)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(2, result.TotalResults)
+	suite.Equal(2, result.Count)
+	suite.Equal(testUserID1, result.Assignments[0].Display)
+	suite.Equal("group1", result.Assignments[1].Display)
+}
+
+func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_NestedDisplayAttribute() {
+	expectedAssignments := []RoleAssignment{
+		{ID: testUserID1, Type: AssigneeTypeUser},
+	}
+
+	suite.mockStore.On("IsRoleExist", mock.Anything,
+		"role1").Return(true, nil)
+	suite.mockStore.On("GetRoleAssignmentsCount", mock.Anything,
+		"role1").Return(1, nil)
+	suite.mockStore.On("GetRoleAssignments", mock.Anything,
+		"role1", 10, 0).Return(expectedAssignments, nil)
+	suite.mockUserService.On("GetUsersByIDs", mock.Anything,
+		[]string{testUserID1}).Return(map[string]*user.User{
+		testUserID1: {
+			ID:         testUserID1,
+			Type:       "employee",
+			Attributes: json.RawMessage(`{"profile":{"fullName":"Alice Smith"}}`),
+		},
+	}, (*serviceerror.ServiceError)(nil)).Once()
+	suite.mockUserSchemaService.On("GetDisplayAttributesByNames", mock.Anything,
+		[]string{"employee"}).Return(map[string]string{
+		"employee": "profile.fullName",
+	}, (*serviceerror.ServiceError)(nil)).Once()
+
+	result, err := suite.service.GetRoleAssignments(context.Background(), "role1", 10, 0, true)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal("Alice Smith", result.Assignments[0].Display)
+}
+
+func (suite *RoleServiceTestSuite) TestGetRoleAssignments_WithDisplay_SchemaServiceError() {
+	expectedAssignments := []RoleAssignment{
+		{ID: testUserID1, Type: AssigneeTypeUser},
+	}
+
+	suite.mockStore.On("IsRoleExist", mock.Anything,
+		"role1").Return(true, nil)
+	suite.mockStore.On("GetRoleAssignmentsCount", mock.Anything,
+		"role1").Return(1, nil)
+	suite.mockStore.On("GetRoleAssignments", mock.Anything,
+		"role1", 10, 0).Return(expectedAssignments, nil)
+	suite.mockUserService.On("GetUsersByIDs", mock.Anything,
+		[]string{testUserID1}).Return(map[string]*user.User{
+		testUserID1: {
+			ID:         testUserID1,
+			Type:       "employee",
+			Attributes: json.RawMessage(`{"email":"alice@example.com"}`),
+		},
+	}, (*serviceerror.ServiceError)(nil)).Once()
+	// Schema service fails — should fall back to user ID
+	suite.mockUserSchemaService.On("GetDisplayAttributesByNames", mock.Anything,
+		[]string{"employee"}).Return(
+		(map[string]string)(nil), &serviceerror.ServiceError{Code: "INTERNAL_ERROR"},
+	).Once()
+
+	result, err := suite.service.GetRoleAssignments(context.Background(), "role1", 10, 0, true)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(testUserID1, result.Assignments[0].Display)
+}
+
+// extractDisplayValue Tests
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_TopLevel() {
+	attrs := json.RawMessage(`{"email":"alice@example.com"}`)
+	suite.Equal("alice@example.com", extractDisplayValue(attrs, "email"))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_Nested() {
+	attrs := json.RawMessage(`{"profile":{"fullName":"Alice Smith"}}`)
+	suite.Equal("Alice Smith", extractDisplayValue(attrs, "profile.fullName"))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_NonExistentPath() {
+	attrs := json.RawMessage(`{"email":"alice@example.com"}`)
+	suite.Equal("", extractDisplayValue(attrs, "missing.field"))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_EmptyAttributes() {
+	suite.Equal("", extractDisplayValue(json.RawMessage(`{}`), "email"))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_NilAttributes() {
+	suite.Equal("", extractDisplayValue(nil, "email"))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_InvalidJSON() {
+	suite.Equal("", extractDisplayValue(json.RawMessage(`invalid`), "email"))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_EmptyPath() {
+	attrs := json.RawMessage(`{"email":"alice@example.com"}`)
+	suite.Equal("", extractDisplayValue(attrs, ""))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_NumericValue() {
+	attrs := json.RawMessage(`{"age":30}`)
+	suite.Equal("30", extractDisplayValue(attrs, "age"))
+}
+
+func (suite *RoleServiceTestSuite) TestExtractDisplayValue_BooleanValue() {
+	attrs := json.RawMessage(`{"active":true}`)
+	suite.Equal("", extractDisplayValue(attrs, "active"))
+}
+
+// resolveUserDisplay Tests
+
+func (suite *RoleServiceTestSuite) TestResolveUserDisplay_WithDisplayAttr() {
+	u := &user.User{
+		ID:         "user-1",
+		Type:       "employee",
+		Attributes: json.RawMessage(`{"email":"alice@example.com"}`),
+	}
+	paths := map[string]string{"employee": "email"}
+	suite.Equal("alice@example.com", resolveUserDisplay(u, paths))
+}
+
+func (suite *RoleServiceTestSuite) TestResolveUserDisplay_FallbackToID_NilPaths() {
+	u := &user.User{ID: "user-1", Type: "employee"}
+	suite.Equal("user-1", resolveUserDisplay(u, nil))
+}
+
+func (suite *RoleServiceTestSuite) TestResolveUserDisplay_FallbackToID_EmptyType() {
+	u := &user.User{
+		ID:         "user-1",
+		Attributes: json.RawMessage(`{"email":"alice@example.com"}`),
+	}
+	paths := map[string]string{"employee": "email"}
+	suite.Equal("user-1", resolveUserDisplay(u, paths))
+}
+
+func (suite *RoleServiceTestSuite) TestResolveUserDisplay_FallbackToID_EmptyDisplayPath() {
+	u := &user.User{
+		ID:         "user-1",
+		Type:       "employee",
+		Attributes: json.RawMessage(`{"email":"alice@example.com"}`),
+	}
+	paths := map[string]string{"employee": ""}
+	suite.Equal("user-1", resolveUserDisplay(u, paths))
+}
+
+func (suite *RoleServiceTestSuite) TestResolveUserDisplay_FallbackToID_MissingAttribute() {
+	u := &user.User{
+		ID:         "user-1",
+		Type:       "employee",
+		Attributes: json.RawMessage(`{"name":"Alice"}`),
+	}
+	paths := map[string]string{"employee": "email"}
+	suite.Equal("user-1", resolveUserDisplay(u, paths))
 }
 
 // AddAssignments Tests

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -630,6 +630,76 @@ func (_c *UserServiceInterfaceMock_GetUserList_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetUsersByIDs provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) GetUsersByIDs(ctx context.Context, userIDs []string) (map[string]*User, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersByIDs")
+	}
+
+	var r0 map[string]*User
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (map[string]*User, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) map[string]*User); ok {
+		r0 = returnFunc(ctx, userIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*User)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_GetUsersByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsersByIDs'
+type UserServiceInterfaceMock_GetUsersByIDs_Call struct {
+	*mock.Call
+}
+
+// GetUsersByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+func (_e *UserServiceInterfaceMock_Expecter) GetUsersByIDs(ctx interface{}, userIDs interface{}) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	return &UserServiceInterfaceMock_GetUsersByIDs_Call{Call: _e.mock.On("GetUsersByIDs", ctx, userIDs)}
+}
+
+func (_c *UserServiceInterfaceMock_GetUsersByIDs_Call) Run(run func(ctx context.Context, userIDs []string)) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUsersByIDs_Call) Return(stringToUser map[string]*User, serviceError *serviceerror.ServiceError) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(stringToUser, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUsersByIDs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string) (map[string]*User, *serviceerror.ServiceError)) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUsersByPath provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) GetUsersByPath(ctx context.Context, handlePath string, limit int, offset int, filters map[string]interface{}) (*UserListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, handlePath, limit, offset, filters)

--- a/backend/internal/user/composite_store.go
+++ b/backend/internal/user/composite_store.go
@@ -271,6 +271,26 @@ func (c *compositeUserStore) ValidateUserIDs(ctx context.Context, userIDs []stri
 	return invalidIDs, nil
 }
 
+// GetUsersByIDs retrieves users by a list of IDs from both stores.
+// Database users take precedence over file-based users for duplicate IDs.
+func (c *compositeUserStore) GetUsersByIDs(ctx context.Context, userIDs []string) ([]User, error) {
+	if len(userIDs) == 0 {
+		return []User{}, nil
+	}
+
+	dbUsers, err := c.dbStore.GetUsersByIDs(ctx, userIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	fileUsers, err := c.fileStore.GetUsersByIDs(ctx, userIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeAndDeduplicateUsers(dbUsers, fileUsers), nil
+}
+
 // ValidateUserIDsInOUs checks which of the provided user IDs belong to the given OU scope
 // across both the database and file-based stores.
 // Returns user IDs that do not belong to any of the provided OUs in either store.

--- a/backend/internal/user/file_based_store.go
+++ b/backend/internal/user/file_based_store.go
@@ -254,6 +254,27 @@ func (f *userFileBasedStore) ValidateUserIDs(ctx context.Context, userIDs []stri
 	return invalid, nil
 }
 
+// GetUsersByIDs retrieves users by a list of IDs from the file store.
+func (f *userFileBasedStore) GetUsersByIDs(ctx context.Context, userIDs []string) ([]User, error) {
+	if len(userIDs) == 0 {
+		return []User{}, nil
+	}
+
+	users := make([]User, 0, len(userIDs))
+	for _, id := range userIDs {
+		user, err := f.GetUser(ctx, id)
+		if err != nil {
+			if errors.Is(err, ErrUserNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		users = append(users, user)
+	}
+
+	return users, nil
+}
+
 // ValidateUserIDsInOUs checks which of the provided user IDs belong to the given OU scope.
 // Returns user IDs that do not belong to any of the provided OUs.
 func (f *userFileBasedStore) ValidateUserIDsInOUs(

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -66,6 +66,7 @@ type UserServiceInterface interface {
 		identifiers map[string]interface{},
 		credentials map[string]interface{}) (*AuthenticateUserResponse, *serviceerror.ServiceError)
 	ValidateUserIDs(ctx context.Context, userIDs []string) ([]string, *serviceerror.ServiceError)
+	GetUsersByIDs(ctx context.Context, userIDs []string) (map[string]*User, *serviceerror.ServiceError)
 	ValidateUserIDsInOUs(ctx context.Context, userIDs []string,
 		ouIDs []string) ([]string, *serviceerror.ServiceError)
 	GetUserCredentialsByType(ctx context.Context, userID string,
@@ -1218,6 +1219,39 @@ func (us *userService) ValidateUserIDs(ctx context.Context, userIDs []string) ([
 	}
 
 	return invalidUserIDs, nil
+}
+
+// GetUsersByIDs retrieves users by a list of IDs.
+func (us *userService) GetUsersByIDs(
+	ctx context.Context, userIDs []string,
+) (map[string]*User, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if len(userIDs) == 0 {
+		return map[string]*User{}, nil
+	}
+
+	// Deduplicate IDs before passing to store.
+	seen := make(map[string]struct{}, len(userIDs))
+	uniqueIDs := make([]string, 0, len(userIDs))
+	for _, id := range userIDs {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			uniqueIDs = append(uniqueIDs, id)
+		}
+	}
+
+	users, err := us.userStore.GetUsersByIDs(ctx, uniqueIDs)
+	if err != nil {
+		return nil, logErrorAndReturnServerError(logger, "Failed to get users by IDs", err)
+	}
+
+	result := make(map[string]*User, len(users))
+	for i := range users {
+		result[users[i].ID] = &users[i]
+	}
+
+	return result, nil
 }
 
 // ValidateUserIDsInOUs validates that all provided user IDs belong to one of the given OUs.

--- a/backend/internal/user/store.go
+++ b/backend/internal/user/store.go
@@ -48,6 +48,7 @@ type userStoreInterface interface {
 	IdentifyUser(ctx context.Context, filters map[string]interface{}) (*string, error)
 	GetCredentials(ctx context.Context, id string) (User, Credentials, error)
 	ValidateUserIDs(ctx context.Context, userIDs []string) ([]string, error)
+	GetUsersByIDs(ctx context.Context, userIDs []string) ([]User, error)
 	ValidateUserIDsInOUs(ctx context.Context, userIDs []string, ouIDs []string) ([]string, error)
 	IsUserDeclarative(ctx context.Context, id string) (bool, error)
 }
@@ -534,6 +535,50 @@ func (us *userStore) ValidateUserIDs(ctx context.Context, userIDs []string) ([]s
 	}
 
 	return invalidUserIDs, nil
+}
+
+// GetUsersByIDs retrieves users by a list of IDs.
+func (us *userStore) GetUsersByIDs(ctx context.Context, userIDs []string) ([]User, error) {
+	const batchSize = 100
+
+	if len(userIDs) == 0 {
+		return []User{}, nil
+	}
+
+	dbClient, err := us.dbProvider.GetUserDBClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	users := make([]User, 0, len(userIDs))
+
+	for start := 0; start < len(userIDs); start += batchSize {
+		end := start + batchSize
+		if end > len(userIDs) {
+			end = len(userIDs)
+		}
+		chunk := userIDs[start:end]
+
+		query, args, err := buildGetUsersByIDsQuery(chunk, us.deploymentID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build get users by IDs query: %w", err)
+		}
+
+		results, err := dbClient.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute query: %w", err)
+		}
+
+		for _, row := range results {
+			user, err := buildUserFromResultRow(row)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build user from result row: %w", err)
+			}
+			users = append(users, user)
+		}
+	}
+
+	return users, nil
 }
 
 // ValidateUserIDsInOUs checks which of the provided user IDs belong to the given OU scope.

--- a/backend/internal/user/store_constants.go
+++ b/backend/internal/user/store_constants.go
@@ -242,36 +242,47 @@ func buildIdentifyQuery(filters map[string]interface{}, deploymentID string) (mo
 	return filterQuery, args, nil
 }
 
-// buildBulkUserExistsQuery constructs a query to check which user IDs exist from a list.
-func buildBulkUserExistsQuery(userIDs []string, deploymentID string) (model.DBQuery, []interface{}, error) {
+// buildUserINClauseQuery constructs a query with an IN clause for user IDs.
+func buildUserINClauseQuery(
+	queryID, baseQuery string, userIDs []string, deploymentID string,
+) (model.DBQuery, []interface{}, error) {
 	if len(userIDs) == 0 {
 		return model.DBQuery{}, nil, fmt.Errorf("userIDs list cannot be empty")
 	}
-	// Build placeholders for IN clause
+
 	args := make([]interface{}, len(userIDs)+1)
-	args[0] = deploymentID // DEPLOYMENT_ID will be filled by caller
 
 	postgresPlaceholders := make([]string, len(userIDs))
 	sqlitePlaceholders := make([]string, len(userIDs))
 
 	for i, userID := range userIDs {
-		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+2)
+		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+1)
 		sqlitePlaceholders[i] = "?"
-		args[i+1] = userID
+		args[i] = userID
 	}
+	args[len(userIDs)] = deploymentID
 
-	baseQuery := "SELECT ID FROM \"USER\" WHERE DEPLOYMENT_ID = %s AND ID IN (%s)"
-	postgresQuery := fmt.Sprintf(baseQuery, "$1", strings.Join(postgresPlaceholders, ","))
-	sqliteQuery := fmt.Sprintf(baseQuery, "?", strings.Join(sqlitePlaceholders, ","))
+	deploymentPlaceholder := fmt.Sprintf("$%d", len(userIDs)+1)
+	postgresQuery := fmt.Sprintf(baseQuery, strings.Join(postgresPlaceholders, ","), deploymentPlaceholder)
+	sqliteQuery := fmt.Sprintf(baseQuery, strings.Join(sqlitePlaceholders, ","), "?")
 
 	query := model.DBQuery{
-		ID:            "ASQ-USER_MGT-09",
+		ID:            queryID,
 		Query:         postgresQuery,
 		PostgresQuery: postgresQuery,
 		SQLiteQuery:   sqliteQuery,
 	}
 
 	return query, args, nil
+}
+
+// buildBulkUserExistsQuery constructs a query to check which user IDs exist from a list.
+func buildBulkUserExistsQuery(userIDs []string, deploymentID string) (model.DBQuery, []interface{}, error) {
+	return buildUserINClauseQuery(
+		"ASQ-USER_MGT-09",
+		"SELECT ID FROM \"USER\" WHERE ID IN (%s) AND DEPLOYMENT_ID = %s",
+		userIDs, deploymentID,
+	)
 }
 
 // buildBulkUserExistsQueryInOUs constructs a query that returns which of the provided user IDs
@@ -544,4 +555,13 @@ func buildIdentifyQueryHybrid(
 	}
 
 	return query, args, nil
+}
+
+// buildGetUsersByIDsQuery constructs a query to fetch users by a list of IDs.
+func buildGetUsersByIDsQuery(userIDs []string, deploymentID string) (model.DBQuery, []interface{}, error) {
+	return buildUserINClauseQuery(
+		"ASQ-USER_MGT-22",
+		"SELECT ID, OU_ID, TYPE, ATTRIBUTES FROM \"USER\" WHERE ID IN (%s) AND DEPLOYMENT_ID = %s",
+		userIDs, deploymentID,
+	)
 }

--- a/backend/internal/user/store_constants_test.go
+++ b/backend/internal/user/store_constants_test.go
@@ -470,6 +470,112 @@ func (suite *StoreConstantsTestSuite) TestBuildUserListQueryByOUIDs_MultipleOUID
 	suite.Equal(10, args[5])
 }
 
+// ---------------------------------------------------------------------------
+// buildGetUsersByIDsQuery
+// ---------------------------------------------------------------------------
+
+func (suite *StoreConstantsTestSuite) TestBuildGetUsersByIDsQuery_EmptyIDs() {
+	query, args, err := buildGetUsersByIDsQuery([]string{}, testDeploymentIDForConstants)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "userIDs list cannot be empty")
+	suite.Nil(args)
+	suite.Empty(query.Query)
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildGetUsersByIDsQuery_SingleID() {
+	query, args, err := buildGetUsersByIDsQuery([]string{"user-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	suite.Equal("ASQ-USER_MGT-22", query.ID)
+	suite.Equal(
+		`SELECT ID, OU_ID, TYPE, ATTRIBUTES FROM "USER" WHERE ID IN ($1) AND DEPLOYMENT_ID = $2`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID, OU_ID, TYPE, ATTRIBUTES FROM "USER" WHERE ID IN (?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 2)
+	suite.Equal("user-1", args[0])
+	suite.Equal(testDeploymentIDForConstants, args[1])
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildGetUsersByIDsQuery_MultipleIDs() {
+	query, args, err := buildGetUsersByIDsQuery(
+		[]string{"user-1", "user-2", "user-3"}, testDeploymentIDForConstants,
+	)
+
+	suite.NoError(err)
+	suite.Equal("ASQ-USER_MGT-22", query.ID)
+	suite.Equal(
+		`SELECT ID, OU_ID, TYPE, ATTRIBUTES FROM "USER" WHERE ID IN ($1,$2,$3) AND DEPLOYMENT_ID = $4`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID, OU_ID, TYPE, ATTRIBUTES FROM "USER" WHERE ID IN (?,?,?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 4)
+	suite.Equal("user-1", args[0])
+	suite.Equal("user-2", args[1])
+	suite.Equal("user-3", args[2])
+	suite.Equal(testDeploymentIDForConstants, args[3])
+}
+
+// ---------------------------------------------------------------------------
+// buildBulkUserExistsQuery
+// ---------------------------------------------------------------------------
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQuery_EmptyIDs() {
+	query, args, err := buildBulkUserExistsQuery([]string{}, testDeploymentIDForConstants)
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "userIDs list cannot be empty")
+	suite.Nil(args)
+	suite.Empty(query.Query)
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQuery_SingleID() {
+	query, args, err := buildBulkUserExistsQuery([]string{"user-1"}, testDeploymentIDForConstants)
+
+	suite.NoError(err)
+	suite.Equal("ASQ-USER_MGT-09", query.ID)
+	suite.Equal(
+		`SELECT ID FROM "USER" WHERE ID IN ($1) AND DEPLOYMENT_ID = $2`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID FROM "USER" WHERE ID IN (?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 2)
+	suite.Equal("user-1", args[0])
+	suite.Equal(testDeploymentIDForConstants, args[1])
+}
+
+func (suite *StoreConstantsTestSuite) TestBuildBulkUserExistsQuery_MultipleIDs() {
+	query, args, err := buildBulkUserExistsQuery(
+		[]string{"user-1", "user-2", "user-3"}, testDeploymentIDForConstants,
+	)
+
+	suite.NoError(err)
+	suite.Equal("ASQ-USER_MGT-09", query.ID)
+	suite.Equal(
+		`SELECT ID FROM "USER" WHERE ID IN ($1,$2,$3) AND DEPLOYMENT_ID = $4`,
+		query.PostgresQuery,
+	)
+	suite.Equal(
+		`SELECT ID FROM "USER" WHERE ID IN (?,?,?) AND DEPLOYMENT_ID = ?`,
+		query.SQLiteQuery,
+	)
+	suite.Len(args, 4)
+	suite.Equal("user-1", args[0])
+	suite.Equal("user-2", args[1])
+	suite.Equal("user-3", args[2])
+	suite.Equal(testDeploymentIDForConstants, args[3])
+}
+
 func (suite *StoreConstantsTestSuite) TestBuildUserListQueryByOUIDs_WithFilters() {
 	ouIDs := []string{"ou-1"}
 	filters := map[string]interface{}{"username": "alice"}

--- a/backend/internal/user/store_test.go
+++ b/backend/internal/user/store_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 const testDeploymentID = "test-deployment-id"
+const getUsersByIDsQueryID = "ASQ-USER_MGT-22"
 
 // MockDBClient is a mock implementation of provider.DBClientInterface
 type MockDBClient struct {
@@ -805,4 +806,72 @@ func (suite *UserStoreTestSuite) TestUpdateUser_DBError() {
 
 	err := suite.store.UpdateUser(context.Background(), &User{ID: "u1"})
 	suite.Error(err)
+}
+
+func (suite *UserStoreTestSuite) TestGetUsersByIDs_EmptyInput() {
+	users, err := suite.store.GetUsersByIDs(context.Background(), []string{})
+	suite.NoError(err)
+	suite.Empty(users)
+	suite.mockDB.AssertNotCalled(suite.T(), "QueryContext")
+}
+
+func (suite *UserStoreTestSuite) TestGetUsersByIDs_Success() {
+	rows := []map[string]interface{}{
+		{"id": "user-1", "ou_id": "ou-1", "type": "person", "attributes": `{"username":"alice"}`},
+		{"id": "user-2", "ou_id": "ou-1", "type": "person", "attributes": `{"username":"bob"}`},
+	}
+
+	queryID := getUsersByIDsQueryID
+	suite.mockDB.On("QueryContext", mock.Anything, mock.MatchedBy(func(q dbmodel.DBQuery) bool {
+		return q.ID == queryID
+	}), mock.Anything, mock.Anything, mock.Anything).
+		Return(rows, nil)
+
+	users, err := suite.store.GetUsersByIDs(context.Background(), []string{"user-1", "user-2"})
+	suite.NoError(err)
+	suite.Len(users, 2)
+	suite.Equal("user-1", users[0].ID)
+	suite.Equal("user-2", users[1].ID)
+}
+
+func (suite *UserStoreTestSuite) TestGetUsersByIDs_PartialResults() {
+	rows := []map[string]interface{}{
+		{"id": "user-1", "ou_id": "ou-1", "type": "person", "attributes": `{"username":"alice"}`},
+	}
+
+	queryID := getUsersByIDsQueryID
+	suite.mockDB.On("QueryContext", mock.Anything, mock.MatchedBy(func(q dbmodel.DBQuery) bool {
+		return q.ID == queryID
+	}), mock.Anything, mock.Anything, mock.Anything).
+		Return(rows, nil)
+
+	users, err := suite.store.GetUsersByIDs(context.Background(), []string{"user-1", "user-missing"})
+	suite.NoError(err)
+	suite.Len(users, 1)
+	suite.Equal("user-1", users[0].ID)
+}
+
+func (suite *UserStoreTestSuite) TestGetUsersByIDs_QueryError() {
+	queryID := getUsersByIDsQueryID
+	suite.mockDB.On("QueryContext", mock.Anything, mock.MatchedBy(func(q dbmodel.DBQuery) bool {
+		return q.ID == queryID
+	}), mock.Anything, mock.Anything).
+		Return(nil, errors.New("query failed"))
+
+	users, err := suite.store.GetUsersByIDs(context.Background(), []string{"user-1"})
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to execute query")
+	suite.Nil(users)
+}
+
+func (suite *UserStoreTestSuite) TestGetUsersByIDs_DBClientError() {
+	store := &userStore{
+		deploymentID: testDeploymentID,
+		dbProvider:   &errorUserDBProvider{},
+	}
+
+	users, err := store.GetUsersByIDs(context.Background(), []string{"user-1"})
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to get database client")
+	suite.Nil(users)
 }

--- a/backend/internal/user/userStoreInterface_mock_test.go
+++ b/backend/internal/user/userStoreInterface_mock_test.go
@@ -747,6 +747,74 @@ func (_c *userStoreInterfaceMock_GetUserListCountByOUIDs_Call) RunAndReturn(run 
 	return _c
 }
 
+// GetUsersByIDs provides a mock function for the type userStoreInterfaceMock
+func (_mock *userStoreInterfaceMock) GetUsersByIDs(ctx context.Context, userIDs []string) ([]User, error) {
+	ret := _mock.Called(ctx, userIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersByIDs")
+	}
+
+	var r0 []User
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]User, error)); ok {
+		return returnFunc(ctx, userIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []User); ok {
+		r0 = returnFunc(ctx, userIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]User)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, userIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userStoreInterfaceMock_GetUsersByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsersByIDs'
+type userStoreInterfaceMock_GetUsersByIDs_Call struct {
+	*mock.Call
+}
+
+// GetUsersByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+func (_e *userStoreInterfaceMock_Expecter) GetUsersByIDs(ctx interface{}, userIDs interface{}) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	return &userStoreInterfaceMock_GetUsersByIDs_Call{Call: _e.mock.On("GetUsersByIDs", ctx, userIDs)}
+}
+
+func (_c *userStoreInterfaceMock_GetUsersByIDs_Call) Run(run func(ctx context.Context, userIDs []string)) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetUsersByIDs_Call) Return(users []User, err error) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(users, err)
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetUsersByIDs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string) ([]User, error)) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IdentifyUser provides a mock function for the type userStoreInterfaceMock
 func (_mock *userStoreInterfaceMock) IdentifyUser(ctx context.Context, filters map[string]interface{}) (*string, error) {
 	ret := _mock.Called(ctx, filters)

--- a/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
+++ b/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
@@ -548,6 +548,76 @@ func (_c *GroupServiceInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetGroupsByIDs provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) GetGroupsByIDs(ctx context.Context, groupIDs []string) (map[string]*group.Group, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupsByIDs")
+	}
+
+	var r0 map[string]*group.Group
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (map[string]*group.Group, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) map[string]*group.Group); ok {
+		r0 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*group.Group)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_GetGroupsByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupsByIDs'
+type GroupServiceInterfaceMock_GetGroupsByIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupsByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupIDs []string
+func (_e *GroupServiceInterfaceMock_Expecter) GetGroupsByIDs(ctx interface{}, groupIDs interface{}) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	return &GroupServiceInterfaceMock_GetGroupsByIDs_Call{Call: _e.mock.On("GetGroupsByIDs", ctx, groupIDs)}
+}
+
+func (_c *GroupServiceInterfaceMock_GetGroupsByIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetGroupsByIDs_Call) Return(stringToGroup map[string]*group.Group, serviceError *serviceerror.ServiceError) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(stringToGroup, serviceError)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetGroupsByIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) (map[string]*group.Group, *serviceerror.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroupsByPath provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) GetGroupsByPath(ctx context.Context, handlePath string, limit int, offset int) (*group.GroupListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, handlePath, limit, offset)

--- a/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
+++ b/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
@@ -839,6 +839,74 @@ func (_c *groupStoreInterfaceMock_GetGroupMembers_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// GetGroupsByIDs provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]group.GroupBasicDAO, error) {
+	ret := _mock.Called(ctx, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupsByIDs")
+	}
+
+	var r0 []group.GroupBasicDAO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]group.GroupBasicDAO, error)); ok {
+		return returnFunc(ctx, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []group.GroupBasicDAO); ok {
+		r0 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]group.GroupBasicDAO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetGroupsByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupsByIDs'
+type groupStoreInterfaceMock_GetGroupsByIDs_Call struct {
+	*mock.Call
+}
+
+// GetGroupsByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupIDs []string
+func (_e *groupStoreInterfaceMock_Expecter) GetGroupsByIDs(ctx interface{}, groupIDs interface{}) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	return &groupStoreInterfaceMock_GetGroupsByIDs_Call{Call: _e.mock.On("GetGroupsByIDs", ctx, groupIDs)}
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupsByIDs_Call) Run(run func(ctx context.Context, groupIDs []string)) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupsByIDs_Call) Return(groupBasicDAOs []group.GroupBasicDAO, err error) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(groupBasicDAOs, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetGroupsByIDs_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) ([]group.GroupBasicDAO, error)) *groupStoreInterfaceMock_GetGroupsByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroupsByOrganizationUnit provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroupsByOrganizationUnit(ctx context.Context, organizationUnitID string, limit int, offset int) ([]group.GroupBasicDAO, error) {
 	ret := _mock.Called(ctx, organizationUnitID, limit, offset)

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -631,6 +631,76 @@ func (_c *UserServiceInterfaceMock_GetUserList_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetUsersByIDs provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) GetUsersByIDs(ctx context.Context, userIDs []string) (map[string]*user.User, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersByIDs")
+	}
+
+	var r0 map[string]*user.User
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (map[string]*user.User, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) map[string]*user.User); ok {
+		r0 = returnFunc(ctx, userIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*user.User)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_GetUsersByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsersByIDs'
+type UserServiceInterfaceMock_GetUsersByIDs_Call struct {
+	*mock.Call
+}
+
+// GetUsersByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+func (_e *UserServiceInterfaceMock_Expecter) GetUsersByIDs(ctx interface{}, userIDs interface{}) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	return &UserServiceInterfaceMock_GetUsersByIDs_Call{Call: _e.mock.On("GetUsersByIDs", ctx, userIDs)}
+}
+
+func (_c *UserServiceInterfaceMock_GetUsersByIDs_Call) Run(run func(ctx context.Context, userIDs []string)) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUsersByIDs_Call) Return(stringToUser map[string]*user.User, serviceError *serviceerror.ServiceError) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(stringToUser, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUsersByIDs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string) (map[string]*user.User, *serviceerror.ServiceError)) *UserServiceInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUsersByPath provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) GetUsersByPath(ctx context.Context, handlePath string, limit int, offset int, filters map[string]interface{}) (*user.UserListResponse, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, handlePath, limit, offset, filters)

--- a/backend/tests/mocks/usermock/userStoreInterface_mock.go
+++ b/backend/tests/mocks/usermock/userStoreInterface_mock.go
@@ -748,6 +748,74 @@ func (_c *userStoreInterfaceMock_GetUserListCountByOUIDs_Call) RunAndReturn(run 
 	return _c
 }
 
+// GetUsersByIDs provides a mock function for the type userStoreInterfaceMock
+func (_mock *userStoreInterfaceMock) GetUsersByIDs(ctx context.Context, userIDs []string) ([]user.User, error) {
+	ret := _mock.Called(ctx, userIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersByIDs")
+	}
+
+	var r0 []user.User
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]user.User, error)); ok {
+		return returnFunc(ctx, userIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []user.User); ok {
+		r0 = returnFunc(ctx, userIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]user.User)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, userIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// userStoreInterfaceMock_GetUsersByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsersByIDs'
+type userStoreInterfaceMock_GetUsersByIDs_Call struct {
+	*mock.Call
+}
+
+// GetUsersByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userIDs []string
+func (_e *userStoreInterfaceMock_Expecter) GetUsersByIDs(ctx interface{}, userIDs interface{}) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	return &userStoreInterfaceMock_GetUsersByIDs_Call{Call: _e.mock.On("GetUsersByIDs", ctx, userIDs)}
+}
+
+func (_c *userStoreInterfaceMock_GetUsersByIDs_Call) Run(run func(ctx context.Context, userIDs []string)) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetUsersByIDs_Call) Return(users []user.User, err error) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(users, err)
+	return _c
+}
+
+func (_c *userStoreInterfaceMock_GetUsersByIDs_Call) RunAndReturn(run func(ctx context.Context, userIDs []string) ([]user.User, error)) *userStoreInterfaceMock_GetUsersByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IdentifyUser provides a mock function for the type userStoreInterfaceMock
 func (_mock *userStoreInterfaceMock) IdentifyUser(ctx context.Context, filters map[string]interface{}) (*string, error) {
 	ret := _mock.Called(ctx, filters)


### PR DESCRIPTION
## Summary

- Adds `GetUsersByIDs` and `GetGroupsByIDs` methods to both store and service layers for batch retrieval of users/groups by ID lists
- Refactors role service `GetRoleAssignments` to use batch fetch for display name resolution, eliminating N+1 queries (50 assignments = 2 queries instead of 50)
- Resolves user display names using schema-configured display attribute (via `systemAttributes.display`) instead of returning the user ID
- Extracts shared `buildUserINClauseQuery` / `buildGroupINClauseQuery` helpers to reduce duplication in query builders

Closes #1524
Closes #1518

## Changes

| File | Change |
|------|--------|
| `internal/user/store_constants.go` | Add `buildUserINClauseQuery` helper, `buildGetUsersByIDsQuery` (ASQ-USER_MGT-21) |
| `internal/user/store.go` | Add `GetUsersByIDs` to `userStoreInterface` + DB implementation |
| `internal/user/file_based_store.go` | Add `GetUsersByIDs` file-based store implementation |
| `internal/user/composite_store.go` | Add `GetUsersByIDs` composite store implementation |
| `internal/user/service.go` | Add `GetUsersByIDs` to `UserServiceInterface` + implementation (returns `map[string]*User`) |
| `internal/group/store_constants.go` | Add `buildGroupINClauseQuery` helper, `buildGetGroupsByIDsQuery` (GRQ-GROUP_MGT-17) |
| `internal/group/store.go` | Add `GetGroupsByIDs` to `groupStoreInterface` + DB implementation |
| `internal/group/service.go` | Add `GetGroupsByIDs` to `GroupServiceInterface` + implementation (returns `map[string]*Group`) |
| `internal/role/service.go` | Replace N+1 `getDisplayNameForAssignment` with batch `populateDisplayNames`; resolve user display via schema display attribute path |
| `internal/role/service_test.go` | Update display name tests to use batch mock expectations |
| `internal/user/store_constants_test.go` | Add tests for `buildGetUsersByIDsQuery` |
| `internal/group/store_constants_test.go` | **New** — tests for `buildGetGroupsByIDsQuery` |
| Mock files (6) | Add `GetUsersByIDs` / `GetGroupsByIDs` mock methods |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: Verify role assignments endpoint returns correct display names with batch fetch
- [x] Manual: Verify with mixed user/group assignments (>10 assignments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch retrieval for users and groups by IDs; role APIs expose bulk lookup capability.
  * Role service can resolve display names via schema-driven attribute paths.

* **Performance Improvements**
  * Role display-name population now uses bulk lookups for faster resolution.

* **Bug Fixes**
  * Batch operations tolerate partial failures (log and continue).

* **Tests**
  * Expanded unit tests for query builders, batch retrievals, display-extraction, stores, and mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->