### PR TITLE
Update Issue Chat notification to skip issues created by team members

### DIFF
--- a/.github/workflows/issue-chat-notification.yml
+++ b/.github/workflows/issue-chat-notification.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   notify-google-chat:
+    if: |
+      !contains(format(',{0},', vars.PROJECT_MAINTAINERS), format(',{0},', github.actor))
     runs-on: ubuntu-latest
     steps:
       - name: Send Notification to Google Chat


### PR DESCRIPTION
### Purpose
This pull request adds a conditional check to the `notify-google-chat` job in the `.github/workflows/issue-chat-notification.yml` workflow. The job will now only run if the actor is not a member of the Thunder team.

Workflow logic improvement:

* Added an `if` condition to the `notify-google-chat` job so it only executes when the GitHub actor is not in `vars.THUNDER_TEAM_MEMBERS`. (`.github/workflows/issue-chat-notification.yml`)
---

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Notification workflow updated to skip Google Chat alerts for configured maintainers.
  * Notifications are now suppressed when actions originate from listed maintainers.
  * Reduces noise for maintainers and improves signal-to-noise for important alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->