### PR TITLE
Remove credentials columns from user list table

### DIFF
--- a/frontend/apps/thunder-develop/src/features/users/components/UsersList.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/components/UsersList.tsx
@@ -186,6 +186,11 @@ export default function UsersList(props: UsersListProps) {
         return;
       }
 
+      // Skip credential fields as they are not returned in the user list response
+      if ('credential' in fieldDef && fieldDef.credential) {
+        return;
+      }
+
       // Special handling for isActive/status fields with Chip
       if (fieldName === 'isActive' || fieldName === 'active' || fieldName === 'status') {
         schemaColumns.push({


### PR DESCRIPTION
### Purpose
This pull request makes a targeted improvement to the `UsersList` component by ensuring credential fields are not displayed in the user list. This helps protect sensitive information and keeps the user interface clean.

Sensitive data handling:

* Updated `UsersList.tsx` to skip any fields marked as credentials when constructing the list columns, preventing credential fields from being shown in the user list.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
