### PR TITLE
Improve OAuth package error handling

### DIFF
--- a/backend/internal/oauth/jwks/handler.go
+++ b/backend/internal/oauth/jwks/handler.go
@@ -45,7 +45,7 @@ func (h *jwksHandler) HandleJWKSRequest(w http.ResponseWriter, r *http.Request) 
 
 	jwksResponse, svcErr := h.jwksService.GetJWKS()
 	if svcErr != nil {
-		h.handleError(w, svcErr)
+		h.logAndWriteError(w, logger, svcErr)
 		return
 	}
 
@@ -53,18 +53,19 @@ func (h *jwksHandler) HandleJWKSRequest(w http.ResponseWriter, r *http.Request) 
 	logger.Debug("JWKS response successfully sent")
 }
 
-// handleError handles errors by writing an appropriate error response to the HTTP response writer.
-func (h *jwksHandler) handleError(w http.ResponseWriter,
+// logAndWriteError logs server errors and writes an appropriate error response to the HTTP response writer.
+func (h *jwksHandler) logAndWriteError(w http.ResponseWriter, logger *log.Logger,
 	svcErr *serviceerror.ServiceError) {
+	statusCode := http.StatusBadRequest
+	if svcErr.Type == serviceerror.ServerErrorType {
+		statusCode = http.StatusInternalServerError
+		logger.Error("Failed to retrieve JWKS", log.String("error_code", svcErr.Code))
+	}
+
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
-	}
-
-	statusCode := http.StatusInternalServerError
-	if svcErr.Type == serviceerror.ClientErrorType {
-		statusCode = http.StatusBadRequest
 	}
 
 	sysutils.WriteErrorResponse(w, statusCode, errResp)

--- a/backend/internal/oauth/jwks/handler_test.go
+++ b/backend/internal/oauth/jwks/handler_test.go
@@ -82,21 +82,6 @@ func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_Success() {
 	s.mockService.AssertExpectations(s.T())
 }
 
-func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_ServiceError() {
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/jwks", nil)
-	rr := httptest.NewRecorder()
-
-	svcErr := serviceerror.CustomServiceError(serviceerror.InternalServerError, "Failed to get JWKS")
-	s.mockService.On("GetJWKS").Return(nil, svcErr)
-
-	s.handler.HandleJWKSRequest(rr, req)
-
-	assert.Equal(s.T(), http.StatusInternalServerError, rr.Code)
-	assert.Equal(s.T(), "application/json", rr.Header().Get("Content-Type"))
-	assert.Contains(s.T(), rr.Body.String(), svcErr.Code)
-	s.mockService.AssertExpectations(s.T())
-}
-
 func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_ClientError() {
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/jwks", nil)
 	rr := httptest.NewRecorder()
@@ -113,5 +98,20 @@ func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_ClientError() {
 
 	assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
 	assert.Equal(s.T(), "application/json", rr.Header().Get("Content-Type"))
+	s.mockService.AssertExpectations(s.T())
+}
+
+func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_ServiceError() {
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/jwks", nil)
+	rr := httptest.NewRecorder()
+
+	svcErr := serviceerror.CustomServiceError(serviceerror.InternalServerError, "Failed to get JWKS")
+	s.mockService.On("GetJWKS").Return(nil, svcErr)
+
+	s.handler.HandleJWKSRequest(rr, req)
+
+	assert.Equal(s.T(), http.StatusInternalServerError, rr.Code)
+	assert.Equal(s.T(), "application/json", rr.Header().Get("Content-Type"))
+	assert.Contains(s.T(), rr.Body.String(), svcErr.Code)
 	s.mockService.AssertExpectations(s.T())
 }

--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -63,7 +63,7 @@ func (s *jwksService) GetJWKS() (*JWKSResponse, *serviceerror.ServiceError) {
 	}
 
 	if len(allCerts) == 0 {
-		return nil, ErrorNoCertificateFound
+		return nil, &serviceerror.InternalServerError
 	}
 
 	var jwksKeys []JWKS
@@ -98,7 +98,7 @@ func (s *jwksService) GetJWKS() (*JWKSResponse, *serviceerror.ServiceError) {
 	}
 
 	if len(jwksKeys) == 0 {
-		return nil, ErrorNoCertificateFound
+		return nil, &serviceerror.InternalServerError
 	}
 
 	return &JWKSResponse{

--- a/backend/internal/oauth/jwks/service_test.go
+++ b/backend/internal/oauth/jwks/service_test.go
@@ -144,7 +144,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_NoCertificatesFound() {
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
-	assert.Equal(suite.T(), ErrorNoCertificateFound.Code, svcErr.Code)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_UnsupportedPublicKeyType() {
@@ -257,7 +257,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_OnlyUnsupportedKeys() {
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
-	assert.Equal(suite.T(), ErrorNoCertificateFound.Code, svcErr.Code)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_ZeroExponent() {

--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -121,7 +121,7 @@ func (acs *authorizationCodeStore) GetAuthorizationCode(clientID, authCode strin
 		return nil, fmt.Errorf("error while retrieving authorization code: %w", err)
 	}
 	if len(results) == 0 {
-		return nil, ErrAuthorizationCodeNotFound
+		return nil, errAuthorizationCodeNotFound
 	}
 	row := results[0]
 
@@ -165,7 +165,7 @@ func buildAuthorizationCodeFromResultRow(row map[string]interface{}) (*Authoriza
 		return nil, errors.New("code ID is of unexpected type")
 	}
 	if codeID == "" {
-		return nil, ErrAuthorizationCodeNotFound
+		return nil, errAuthorizationCodeNotFound
 	}
 
 	authorizationCode, ok := row[columnNameAuthorizationCode].(string)

--- a/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
@@ -222,7 +222,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_NoResults
 
 	result, err := suite.store.GetAuthorizationCode("test-client-id", "test-code")
 	assert.Error(suite.T(), err)
-	assert.Equal(suite.T(), ErrAuthorizationCodeNotFound, err)
+	assert.Equal(suite.T(), errAuthorizationCodeNotFound, err)
 	assert.Nil(suite.T(), result)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -242,7 +242,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_EmptyCode
 
 	result, err := suite.store.GetAuthorizationCode("test-client-id", "test-code")
 	assert.Error(suite.T(), err)
-	assert.Equal(suite.T(), ErrAuthorizationCodeNotFound, err)
+	assert.Equal(suite.T(), errAuthorizationCodeNotFound, err)
 	assert.Nil(suite.T(), result)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())

--- a/backend/internal/oauth/oauth2/authz/auth_req_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_req_store.go
@@ -28,7 +28,6 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
-	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
 )
 
@@ -39,9 +38,9 @@ type authRequestContext struct {
 
 // authorizationRequestStoreInterface defines the interface for authorization request storage.
 type authorizationRequestStoreInterface interface {
-	AddRequest(value authRequestContext) string
-	GetRequest(key string) (bool, authRequestContext)
-	ClearRequest(key string)
+	AddRequest(value authRequestContext) (string, error)
+	GetRequest(key string) (bool, authRequestContext, error)
+	ClearRequest(key string) error
 }
 
 // authorizationRequestStore provides the authorization request store functionality using database.
@@ -49,7 +48,6 @@ type authorizationRequestStore struct {
 	dbProvider     provider.DBProviderInterface
 	validityPeriod time.Duration
 	deploymentID   string
-	logger         *log.Logger
 }
 
 // newAuthorizationRequestStore creates a new instance of authorizationRequestStore with injected dependencies.
@@ -58,22 +56,19 @@ func newAuthorizationRequestStore() authorizationRequestStoreInterface {
 		dbProvider:     provider.GetDBProvider(),
 		validityPeriod: 10 * time.Minute,
 		deploymentID:   config.GetThunderRuntime().Config.Server.Identifier,
-		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthorizationRequestStore")),
 	}
 }
 
 // AddRequest adds an authorization request context entry to the store.
-func (authzRS *authorizationRequestStore) AddRequest(value authRequestContext) string {
+func (authzRS *authorizationRequestStore) AddRequest(value authRequestContext) (string, error) {
 	dbClient, err := authzRS.dbProvider.GetRuntimeDBClient()
 	if err != nil {
-		authzRS.logger.Error("Failed to get database client", log.Error(err))
-		return ""
+		return "", fmt.Errorf("failed to get database client: %w", err)
 	}
 
 	key, err := utils.GenerateUUIDv7()
 	if err != nil {
-		authzRS.logger.Error("Failed to generate UUID", log.Error(err))
-		return ""
+		return "", fmt.Errorf("failed to generate UUID: %w", err)
 	}
 	// Calculate expiry based on current time
 	requestInitiatedTime := time.Now()
@@ -82,69 +77,65 @@ func (authzRS *authorizationRequestStore) AddRequest(value authRequestContext) s
 	// Serialize authRequestContext to JSON
 	jsonDataBytes, err := authzRS.getJSONDataBytes(value)
 	if err != nil {
-		authzRS.logger.Error("Failed to marshal request context to JSON", log.Error(err))
-		return ""
+		return "", fmt.Errorf("failed to marshal request context to JSON: %w", err)
 	}
 
 	_, err = dbClient.Execute(queryInsertAuthRequest, key, jsonDataBytes, expiryTime, authzRS.deploymentID)
 	if err != nil {
-		authzRS.logger.Error("Failed to insert authorization request", log.Error(err))
-		return ""
+		return "", fmt.Errorf("failed to insert authorization request: %w", err)
 	}
 
-	return key
+	return key, nil
 }
 
 // GetRequest retrieves an authorization request context entry from the store.
-func (authzRS *authorizationRequestStore) GetRequest(key string) (bool, authRequestContext) {
+func (authzRS *authorizationRequestStore) GetRequest(key string) (bool, authRequestContext, error) {
 	if key == "" {
-		return false, authRequestContext{}
+		return false, authRequestContext{}, nil
 	}
 
 	dbClient, err := authzRS.dbProvider.GetRuntimeDBClient()
 	if err != nil {
-		authzRS.logger.Error("Failed to get database client", log.Error(err))
-		return false, authRequestContext{}
+		return false, authRequestContext{}, fmt.Errorf("failed to get database client: %w", err)
 	}
 
 	// Check expiry by comparing with current time
 	now := time.Now()
 	results, err := dbClient.Query(queryGetAuthRequest, key, now, authzRS.deploymentID)
 	if err != nil {
-		authzRS.logger.Error("Failed to query authorization request", log.Error(err))
-		return false, authRequestContext{}
+		return false, authRequestContext{}, fmt.Errorf("failed to query authorization request: %w", err)
 	}
 
 	if len(results) == 0 {
-		return false, authRequestContext{}
+		return false, authRequestContext{}, nil
 	}
 
 	row := results[0]
 	authRequestCtx, err := authzRS.buildAuthRequestContextFromResultRow(row)
 	if err != nil {
-		authzRS.logger.Error("Failed to build authorization request context from result", log.Error(err))
-		return false, authRequestContext{}
+		return false, authRequestContext{}, fmt.Errorf("failed to build authorization request context: %w", err)
 	}
 
-	return true, authRequestCtx
+	return true, authRequestCtx, nil
 }
 
 // ClearRequest removes a specific authorization request context entry from the store.
-func (authzRS *authorizationRequestStore) ClearRequest(key string) {
+func (authzRS *authorizationRequestStore) ClearRequest(key string) error {
 	if key == "" {
-		return
+		return nil
 	}
 
 	dbClient, err := authzRS.dbProvider.GetRuntimeDBClient()
 	if err != nil {
-		authzRS.logger.Error("Failed to get database client", log.Error(err))
-		return
+		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
 	_, err = dbClient.Execute(queryDeleteAuthRequest, key, authzRS.deploymentID)
 	if err != nil {
-		authzRS.logger.Error("Failed to delete authorization request", log.Error(err))
+		return fmt.Errorf("failed to delete authorization request: %w", err)
 	}
+
+	return nil
 }
 
 // getJSONDataBytes prepares the JSON data bytes for the authorization request context.

--- a/backend/internal/oauth/oauth2/authz/auth_req_store_test.go
+++ b/backend/internal/oauth/oauth2/authz/auth_req_store_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/asgardeo/thunder/internal/system/log"
-
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/system/config"
 
@@ -70,7 +68,6 @@ func (suite *AuthorizationRequestStoreTestSuite) SetupTest() {
 		dbProvider:     suite.mockdbProvider,
 		validityPeriod: 10 * time.Minute,
 		deploymentID:   testDeploymentID,
-		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthorizationRequestStore")),
 	}
 
 	suite.testAuthRequestContext = authRequestContext{
@@ -113,7 +110,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestAddRequest_Success() {
 		testDeploymentID).
 		Return(int64(1), nil)
 
-	identifier := suite.store.AddRequest(suite.testAuthRequestContext)
+	identifier, err := suite.store.AddRequest(suite.testAuthRequestContext)
+	assert.NoError(suite.T(), err)
 	assert.NotEmpty(suite.T(), identifier)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -123,7 +121,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestAddRequest_Success() {
 func (suite *AuthorizationRequestStoreTestSuite) TestAddRequest_DBClientError() {
 	suite.mockdbProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db client error"))
 
-	identifier := suite.store.AddRequest(suite.testAuthRequestContext)
+	identifier, err := suite.store.AddRequest(suite.testAuthRequestContext)
+	assert.Error(suite.T(), err)
 	assert.Empty(suite.T(), identifier)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -136,7 +135,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestAddRequest_ExecuteError() {
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(int64(0), errors.New("execute error"))
 
-	identifier := suite.store.AddRequest(suite.testAuthRequestContext)
+	identifier, err := suite.store.AddRequest(suite.testAuthRequestContext)
+	assert.Error(suite.T(), err)
 	assert.Empty(suite.T(), identifier)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -161,7 +161,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestAddRequest_JSONMarshalingEr
 		testDeploymentID).
 		Return(int64(1), nil)
 
-	identifier := suite.store.AddRequest(suite.testAuthRequestContext)
+	identifier, err := suite.store.AddRequest(suite.testAuthRequestContext)
+	assert.NoError(suite.T(), err)
 	assert.NotEmpty(suite.T(), identifier)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -195,7 +196,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_Success() {
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), "test-state", result.OAuthParameters.State)
 	assert.Equal(suite.T(), "test-client-id", result.OAuthParameters.ClientID)
@@ -212,14 +214,16 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_Success() {
 }
 
 func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_EmptyKey() {
-	ok, _ := suite.store.GetRequest("")
+	ok, _, err := suite.store.GetRequest("")
+	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), ok)
 }
 
 func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_DBClientError() {
 	suite.mockdbProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db client error"))
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.Error(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -231,7 +235,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_QueryError() {
 	suite.mockDBClient.On("Query", queryGetAuthRequest, "test-request-id", mock.Anything, testDeploymentID).
 		Return(nil, errors.New("query error"))
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.Error(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -244,7 +249,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_NoResults() {
 	suite.mockDBClient.On("Query", queryGetAuthRequest, "test-request-id", mock.Anything, testDeploymentID).
 		Return([]map[string]interface{}{}, nil)
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -258,7 +264,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_Expired() {
 	suite.mockDBClient.On("Query", queryGetAuthRequest, "test-request-id", mock.Anything, testDeploymentID).
 		Return([]map[string]interface{}{}, nil)
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -277,7 +284,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_MissingRequestDa
 			},
 		}, nil)
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.Error(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -296,7 +304,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_EmptyRequestData
 			},
 		}, nil)
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.Error(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -324,7 +333,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_RequestDataAsByt
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), "test-state", result.OAuthParameters.State)
 	assert.Equal(suite.T(), "test-client-id", result.OAuthParameters.ClientID)
@@ -345,7 +355,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_InvalidRequestDa
 			},
 		}, nil)
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.Error(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -374,7 +385,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_EmptyScopes() {
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), []string{}, result.OAuthParameters.StandardScopes)
 	assert.Equal(suite.T(), []string{}, result.OAuthParameters.PermissionScopes)
@@ -406,7 +418,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_NilScopes() {
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), []string{}, result.OAuthParameters.StandardScopes)
 	assert.Equal(suite.T(), []string{}, result.OAuthParameters.PermissionScopes)
@@ -437,7 +450,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_StringScopes() {
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), []string{"openid", "profile"}, result.OAuthParameters.StandardScopes)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.OAuthParameters.PermissionScopes)
@@ -452,7 +466,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestClearRequest_Success() {
 	suite.mockDBClient.On("Execute", queryDeleteAuthRequest, "test-request-id", testDeploymentID).
 		Return(int64(1), nil)
 
-	suite.store.ClearRequest("test-request-id")
+	err := suite.store.ClearRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
 	suite.mockDBClient.AssertExpectations(suite.T())
@@ -460,7 +475,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestClearRequest_Success() {
 
 func (suite *AuthorizationRequestStoreTestSuite) TestClearRequest_EmptyKey() {
 	// Should return early without calling DB
-	suite.store.ClearRequest("")
+	err := suite.store.ClearRequest("")
+	assert.NoError(suite.T(), err)
 
 	// No expectations set, so this should pass
 }
@@ -468,7 +484,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestClearRequest_EmptyKey() {
 func (suite *AuthorizationRequestStoreTestSuite) TestClearRequest_DBClientError() {
 	suite.mockdbProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db client error"))
 
-	suite.store.ClearRequest("test-request-id")
+	err := suite.store.ClearRequest("test-request-id")
+	assert.Error(suite.T(), err)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
 }
@@ -479,7 +496,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestClearRequest_ExecuteError()
 	suite.mockDBClient.On("Execute", queryDeleteAuthRequest, "test-request-id", testDeploymentID).
 		Return(int64(0), errors.New("execute error"))
 
-	suite.store.ClearRequest("test-request-id")
+	err := suite.store.ClearRequest("test-request-id")
+	assert.Error(suite.T(), err)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
 	suite.mockDBClient.AssertExpectations(suite.T())
@@ -578,7 +596,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_EmptyByteArray()
 			},
 		}, nil)
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.Error(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -597,7 +616,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_RequestDataAsUne
 			},
 		}, nil)
 
-	ok, _ := suite.store.GetRequest("test-request-id")
+	ok, _, err := suite.store.GetRequest("test-request-id")
+	assert.Error(suite.T(), err)
 	assert.False(suite.T(), ok)
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
@@ -645,7 +665,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_AllOptionalField
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), "test-state", result.OAuthParameters.State)
 	assert.Empty(suite.T(), result.OAuthParameters.ClientID)
@@ -680,7 +701,8 @@ func (suite *AuthorizationRequestStoreTestSuite) TestGetRequest_NonStringScopes(
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), "test-state", result.OAuthParameters.State)
 	assert.Equal(suite.T(), []string{}, result.OAuthParameters.StandardScopes)   // Should default to empty
@@ -732,7 +754,8 @@ func (suite *AuthorizationRequestStoreTestSuite) testGetRequestWithInvalidScopes
 			},
 		}, nil)
 
-	ok, result := suite.store.GetRequest("test-request-id")
+	ok, result, err := suite.store.GetRequest("test-request-id")
+	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), ok)
 	assertFn(result)
 

--- a/backend/internal/oauth/oauth2/authz/authorizationRequestStoreInterface_mock_test.go
+++ b/backend/internal/oauth/oauth2/authz/authorizationRequestStoreInterface_mock_test.go
@@ -36,7 +36,7 @@ func (_m *authorizationRequestStoreInterfaceMock) EXPECT() *authorizationRequest
 }
 
 // AddRequest provides a mock function for the type authorizationRequestStoreInterfaceMock
-func (_mock *authorizationRequestStoreInterfaceMock) AddRequest(value authRequestContext) string {
+func (_mock *authorizationRequestStoreInterfaceMock) AddRequest(value authRequestContext) (string, error) {
 	ret := _mock.Called(value)
 
 	if len(ret) == 0 {
@@ -44,12 +44,21 @@ func (_mock *authorizationRequestStoreInterfaceMock) AddRequest(value authReques
 	}
 
 	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(authRequestContext) (string, error)); ok {
+		return returnFunc(value)
+	}
 	if returnFunc, ok := ret.Get(0).(func(authRequestContext) string); ok {
 		r0 = returnFunc(value)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(authRequestContext) error); ok {
+		r1 = returnFunc(value)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // authorizationRequestStoreInterfaceMock_AddRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddRequest'
@@ -76,20 +85,31 @@ func (_c *authorizationRequestStoreInterfaceMock_AddRequest_Call) Run(run func(v
 	return _c
 }
 
-func (_c *authorizationRequestStoreInterfaceMock_AddRequest_Call) Return(s string) *authorizationRequestStoreInterfaceMock_AddRequest_Call {
-	_c.Call.Return(s)
+func (_c *authorizationRequestStoreInterfaceMock_AddRequest_Call) Return(s string, err error) *authorizationRequestStoreInterfaceMock_AddRequest_Call {
+	_c.Call.Return(s, err)
 	return _c
 }
 
-func (_c *authorizationRequestStoreInterfaceMock_AddRequest_Call) RunAndReturn(run func(value authRequestContext) string) *authorizationRequestStoreInterfaceMock_AddRequest_Call {
+func (_c *authorizationRequestStoreInterfaceMock_AddRequest_Call) RunAndReturn(run func(value authRequestContext) (string, error)) *authorizationRequestStoreInterfaceMock_AddRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ClearRequest provides a mock function for the type authorizationRequestStoreInterfaceMock
-func (_mock *authorizationRequestStoreInterfaceMock) ClearRequest(key string) {
-	_mock.Called(key)
-	return
+func (_mock *authorizationRequestStoreInterfaceMock) ClearRequest(key string) error {
+	ret := _mock.Called(key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClearRequest")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }
 
 // authorizationRequestStoreInterfaceMock_ClearRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClearRequest'
@@ -116,18 +136,18 @@ func (_c *authorizationRequestStoreInterfaceMock_ClearRequest_Call) Run(run func
 	return _c
 }
 
-func (_c *authorizationRequestStoreInterfaceMock_ClearRequest_Call) Return() *authorizationRequestStoreInterfaceMock_ClearRequest_Call {
-	_c.Call.Return()
+func (_c *authorizationRequestStoreInterfaceMock_ClearRequest_Call) Return(err error) *authorizationRequestStoreInterfaceMock_ClearRequest_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *authorizationRequestStoreInterfaceMock_ClearRequest_Call) RunAndReturn(run func(key string)) *authorizationRequestStoreInterfaceMock_ClearRequest_Call {
-	_c.Run(run)
+func (_c *authorizationRequestStoreInterfaceMock_ClearRequest_Call) RunAndReturn(run func(key string) error) *authorizationRequestStoreInterfaceMock_ClearRequest_Call {
+	_c.Call.Return(run)
 	return _c
 }
 
 // GetRequest provides a mock function for the type authorizationRequestStoreInterfaceMock
-func (_mock *authorizationRequestStoreInterfaceMock) GetRequest(key string) (bool, authRequestContext) {
+func (_mock *authorizationRequestStoreInterfaceMock) GetRequest(key string) (bool, authRequestContext, error) {
 	ret := _mock.Called(key)
 
 	if len(ret) == 0 {
@@ -136,7 +156,8 @@ func (_mock *authorizationRequestStoreInterfaceMock) GetRequest(key string) (boo
 
 	var r0 bool
 	var r1 authRequestContext
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, authRequestContext)); ok {
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(string) (bool, authRequestContext, error)); ok {
 		return returnFunc(key)
 	}
 	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
@@ -149,7 +170,12 @@ func (_mock *authorizationRequestStoreInterfaceMock) GetRequest(key string) (boo
 	} else {
 		r1 = ret.Get(1).(authRequestContext)
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(string) error); ok {
+		r2 = returnFunc(key)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
 }
 
 // authorizationRequestStoreInterfaceMock_GetRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRequest'
@@ -176,12 +202,12 @@ func (_c *authorizationRequestStoreInterfaceMock_GetRequest_Call) Run(run func(k
 	return _c
 }
 
-func (_c *authorizationRequestStoreInterfaceMock_GetRequest_Call) Return(b bool, authRequestContextMoqParam authRequestContext) *authorizationRequestStoreInterfaceMock_GetRequest_Call {
-	_c.Call.Return(b, authRequestContextMoqParam)
+func (_c *authorizationRequestStoreInterfaceMock_GetRequest_Call) Return(b bool, authRequestContextMoqParam authRequestContext, err error) *authorizationRequestStoreInterfaceMock_GetRequest_Call {
+	_c.Call.Return(b, authRequestContextMoqParam, err)
 	return _c
 }
 
-func (_c *authorizationRequestStoreInterfaceMock_GetRequest_Call) RunAndReturn(run func(key string) (bool, authRequestContext)) *authorizationRequestStoreInterfaceMock_GetRequest_Call {
+func (_c *authorizationRequestStoreInterfaceMock_GetRequest_Call) RunAndReturn(run func(key string) (bool, authRequestContext, error)) *authorizationRequestStoreInterfaceMock_GetRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/oauth/oauth2/authz/constants.go
+++ b/backend/internal/oauth/oauth2/authz/constants.go
@@ -18,8 +18,6 @@
 
 package authz
 
-import "errors"
-
 // Authorization code states.
 const (
 	AuthCodeStateActive   = "ACTIVE"
@@ -27,6 +25,3 @@ const (
 	AuthCodeStateExpired  = "EXPIRED"
 	AuthCodeStateRevoked  = "REVOKED"
 )
-
-// ErrAuthorizationCodeNotFound is returned when an authorization code is not found in the database.
-var ErrAuthorizationCodeNotFound = errors.New("authorization code not found")

--- a/backend/internal/oauth/oauth2/authz/error_constants.go
+++ b/backend/internal/oauth/oauth2/authz/error_constants.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,14 +16,12 @@
  * under the License.
  */
 
-package jwks
+package authz
 
-import "github.com/asgardeo/thunder/internal/system/error/serviceerror"
+import "errors"
 
-// ErrorNoCertificateFound is returned when no certificate is found to generate JWKS.
-var ErrorNoCertificateFound = &serviceerror.ServiceError{
-	Code:             "JWKS-5001",
-	Type:             serviceerror.ServerErrorType,
-	Error:            "No certificate found.",
-	ErrorDescription: "No certificate found to generate JWKS.",
-}
+// errAuthorizationCodeNotFound is returned when an authorization code is not found in the database.
+var errAuthorizationCodeNotFound = errors.New("authorization code not found")
+
+// errAuthRequestNotFound is returned when an authorization request context is not found in the store.
+var errAuthRequestNotFound = errors.New("authorization request context not found")

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -70,7 +70,8 @@ func (ah *authorizeHandler) HandleAuthorizeGetRequest(w http.ResponseWriter, r *
 			}
 			redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
 			if err != nil {
-				ah.redirectToErrorPage(w, r, oauth2const.ErrorServerError, "Failed to redirect to login page")
+				ah.logger.Error("Failed to construct client redirect URI", log.Error(err))
+				ah.redirectToErrorPage(w, r, oauth2const.ErrorServerError, "Failed to process authorization request")
 				return
 			}
 			http.Redirect(w, r, redirectURI, http.StatusFound)
@@ -98,6 +99,10 @@ func (ah *authorizeHandler) HandleAuthCallbackPostRequest(w http.ResponseWriter,
 
 		redirectURI, authErr := ah.authZService.HandleAuthorizationCallback(authID, assertion)
 		if authErr != nil {
+			if authErr.SendErrorToClient {
+				ah.writeAuthZResponseToClientRedirect(w, authErr)
+				return
+			}
 			ah.writeAuthZResponseToErrorPage(w, authErr.Code, authErr.Message, authErr.State)
 			return
 		}
@@ -145,7 +150,7 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 // getOAuthMessageForGetRequest extracts the OAuth message from an authorization GET request.
 func (ah *authorizeHandler) getOAuthMessageForGetRequest(r *http.Request) (*OAuthMessage, error) {
 	if err := r.ParseForm(); err != nil {
-		return nil, errors.New("failed to parse form data: " + err.Error())
+		return nil, fmt.Errorf("failed to parse form data: %w", err)
 	}
 
 	queryParams := make(map[string]string)
@@ -208,10 +213,11 @@ func (ah *authorizeHandler) redirectToLoginPage(w http.ResponseWriter, r *http.R
 
 	redirectURI, err := getLoginPageRedirectURI(queryParams)
 	if err != nil {
-		logger.Error("Failed to construct login page URL: " + err.Error())
+		logger.Error("Failed to construct login page URL", log.Error(err))
+		ah.redirectToErrorPage(w, r, oauth2const.ErrorServerError, "Failed to process authorization request")
 		return
 	}
-	logger.Debug("Redirecting to login page: " + redirectURI)
+	logger.Debug("Redirecting to login page")
 
 	http.Redirect(w, r, redirectURI, http.StatusFound)
 }
@@ -244,11 +250,11 @@ func (ah *authorizeHandler) redirectToErrorPage(w http.ResponseWriter, r *http.R
 
 	redirectURL, err := getErrorPageRedirectURL(code, msg)
 	if err != nil {
-		logger.Error("Failed to construct error page URL: " + err.Error())
+		logger.Error("Failed to construct error page URL", log.Error(err))
 		http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
 		return
 	}
-	logger.Debug("Redirecting to error page: " + redirectURL)
+	logger.Debug("Redirecting to error page")
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
@@ -279,6 +285,28 @@ func (ah *authorizeHandler) writeAuthZResponseToErrorPage(w http.ResponseWriter,
 			http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
 			return
 		}
+	}
+
+	ah.writeAuthZResponse(w, redirectURI)
+}
+
+// writeAuthZResponseToClientRedirect writes the authorization error response redirecting to the
+// client's registered redirect URI.
+func (ah *authorizeHandler) writeAuthZResponseToClientRedirect(w http.ResponseWriter, authErr *AuthorizationError) {
+	queryParams := map[string]string{
+		oauth2const.RequestParamError:            authErr.Code,
+		oauth2const.RequestParamErrorDescription: authErr.Message,
+	}
+	if authErr.State != "" {
+		queryParams[oauth2const.RequestParamState] = authErr.State
+	}
+
+	redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
+	if err != nil {
+		ah.logger.Error("Failed to construct client redirect URI", log.Error(err))
+		ah.writeAuthZResponseToErrorPage(w, oauth2const.ErrorServerError,
+			"Failed to process authorization request", authErr.State)
+		return
 	}
 
 	ah.writeAuthZResponse(w, redirectURI)

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -312,6 +312,37 @@ func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_Servic
 	assert.Contains(suite.T(), resp.RedirectURI, "state=test-state")
 }
 
+func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_ServiceErrorRedirectToClient() {
+	authErr := &AuthorizationError{
+		Code:              oauth2const.ErrorServerError,
+		Message:           "Failed to process authorization request",
+		State:             "test-state",
+		SendErrorToClient: true,
+		ClientRedirectURI: "https://client.example.com/callback",
+	}
+	suite.mockAuthzService.EXPECT().HandleAuthorizationCallback(testAuthID, "test-assertion").Return("", authErr)
+
+	postData := AuthZPostRequest{
+		AuthID:    testAuthID,
+		Assertion: "test-assertion",
+	}
+	jsonData, _ := json.Marshal(postData)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", bytes.NewReader(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	suite.handler.HandleAuthCallbackPostRequest(rr, req)
+
+	assert.Equal(suite.T(), http.StatusOK, rr.Code)
+	var resp AuthZPostResponse
+	err := json.NewDecoder(rr.Body).Decode(&resp)
+	assert.NoError(suite.T(), err)
+	assert.Contains(suite.T(), resp.RedirectURI, "https://client.example.com/callback")
+	assert.Contains(suite.T(), resp.RedirectURI, "error=server_error")
+	assert.Contains(suite.T(), resp.RedirectURI, "state=test-state")
+}
+
 func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_InvalidRequestType() {
 	// nil body causes JSON decode to fail → getOAuthMessage returns nil → 400
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", nil)
@@ -598,7 +629,7 @@ func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_Decode
 	_, _, err := decodeAttributesFromAssertion(invalidJWT)
 
 	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "Failed to decode the JWT token")
+	assert.Contains(suite.T(), err.Error(), "failed to decode the JWT token")
 }
 
 func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_InvalidSubClaim() {

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -22,6 +22,7 @@ package authz
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -87,7 +88,7 @@ func (as *authorizeService) GetAuthorizationCodeDetails(clientID string, code st
 
 	authCode, err := as.authCodeStore.GetAuthorizationCode(clientID, code)
 	if err != nil {
-		if errors.Is(err, ErrAuthorizationCodeNotFound) {
+		if errors.Is(err, errAuthorizationCodeNotFound) {
 			return nil, errors.New("invalid authorization code")
 		}
 		as.logger.Error("error retrieving authorization code", log.Error(err))
@@ -143,20 +144,21 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(msg *OAuthMessage)
 	app, svcErr := as.appService.GetOAuthApplication(context.TODO(), clientID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			as.logger.Error("Failed to retrieve OAuth application", log.String("error", svcErr.Error))
+			as.logger.Error("Failed to retrieve OAuth application",
+				log.String("error_code", svcErr.Code))
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorServerError,
 				Message: "Failed to process authorization request",
 			}
 		}
 		return nil, &AuthorizationError{
-			Code:    oauth2const.ErrorInvalidClient,
+			Code:    oauth2const.ErrorInvalidRequest,
 			Message: "Invalid client_id",
 		}
 	}
 	if app == nil {
 		return nil, &AuthorizationError{
-			Code:    oauth2const.ErrorInvalidClient,
+			Code:    oauth2const.ErrorInvalidRequest,
 			Message: "Invalid client_id",
 		}
 	}
@@ -170,7 +172,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(msg *OAuthMessage)
 			as.logger.Debug("Failed to parse claims parameter", log.Error(err))
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorInvalidRequest,
-				Message: "Invalid claims parameter",
+				Message: "The claims request parameter is malformed or contains invalid values",
 			}
 		}
 	}
@@ -238,10 +240,14 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(msg *OAuthMessage)
 
 	flowID, flowErr := as.flowExecService.InitiateFlow(flowInitCtx)
 	if flowErr != nil {
-		as.logger.Error("Failed to initiate authentication flow", log.String("error", flowErr.Error))
+		as.logger.Error("Failed to initiate authentication flow",
+			log.String("error_code", flowErr.Code))
 		return nil, &AuthorizationError{
-			Code:    oauth2const.ErrorServerError,
-			Message: "Failed to initiate authentication flow",
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Failed to process authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: oauthParams.RedirectURI,
+			State:             state,
 		}
 	}
 
@@ -250,12 +256,15 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(msg *OAuthMessage)
 	}
 
 	// Store authorization request context in the store.
-	identifier := as.authReqStore.AddRequest(authRequestCtx)
-	if identifier == "" {
-		as.logger.Error("Failed to store authorization request context")
+	identifier, storeErr := as.authReqStore.AddRequest(authRequestCtx)
+	if storeErr != nil {
+		as.logger.Error("Failed to store authorization request context", log.Error(storeErr))
 		return nil, &AuthorizationError{
-			Code:    oauth2const.ErrorServerError,
-			Message: "Failed to store authorization request",
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Failed to process authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: oauthParams.RedirectURI,
+			State:             state,
 		}
 	}
 
@@ -271,8 +280,11 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(msg *OAuthMessage)
 	if err != nil {
 		as.logger.Error("Failed to parse redirect URI", log.Error(err))
 		return nil, &AuthorizationError{
-			Code:    oauth2const.ErrorServerError,
-			Message: "Failed to redirect to login page",
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Failed to process authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: oauthParams.RedirectURI,
+			State:             state,
 		}
 	}
 	if parsedRedirectURI.Scheme == "http" {
@@ -289,26 +301,37 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 	// Load the authorization request context.
 	authRequestCtx, err := as.loadAuthRequestContext(authID)
 	if err != nil {
+		if errors.Is(err, errAuthRequestNotFound) {
+			return "", &AuthorizationError{
+				Code:    oauth2const.ErrorInvalidRequest,
+				Message: "Invalid authorization request",
+			}
+		}
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorInvalidRequest,
-			Message: "Invalid authorization request",
+			Code:    oauth2const.ErrorServerError,
+			Message: "Failed to process authorization request",
 		}
 	}
 
 	if assertion == "" {
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorInvalidRequest,
-			Message: "Invalid authorization request",
-			State:   authRequestCtx.OAuthParameters.State,
+			Code:              oauth2const.ErrorInvalidRequest,
+			Message:           "Invalid authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+			State:             authRequestCtx.OAuthParameters.State,
 		}
 	}
 
 	// Verify the assertion.
 	if err := as.verifyAssertion(assertion); err != nil {
+		as.logger.Debug("Assertion verification failed", log.Error(err))
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorInvalidRequest,
-			Message: err.Error(),
-			State:   authRequestCtx.OAuthParameters.State,
+			Code:              oauth2const.ErrorInvalidRequest,
+			Message:           "Authorization request failed",
+			SendErrorToClient: true,
+			ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+			State:             authRequestCtx.OAuthParameters.State,
 		}
 	}
 
@@ -317,18 +340,22 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 	if err != nil {
 		as.logger.Error("Failed to decode user attributes from assertion", log.Error(err))
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorInvalidRequest,
-			Message: "Something went wrong",
-			State:   authRequestCtx.OAuthParameters.State,
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Failed to process authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+			State:             authRequestCtx.OAuthParameters.State,
 		}
 	}
 
 	if claims.userID == "" {
 		as.logger.Error("User ID is empty after decoding assertion")
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorInvalidRequest,
-			Message: "Invalid user ID",
-			State:   authRequestCtx.OAuthParameters.State,
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Authorization request failed",
+			SendErrorToClient: true,
+			ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+			State:             authRequestCtx.OAuthParameters.State,
 		}
 	}
 
@@ -339,9 +366,11 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 		if err := validateSubClaimConstraint(authRequestCtx.OAuthParameters.ClaimsRequest, claims.userID); err != nil {
 			as.logger.Debug("Sub claim validation failed", log.Error(err))
 			return "", &AuthorizationError{
-				Code:    oauth2const.ErrorAccessDenied,
-				Message: "Subject identifier mismatch",
-				State:   authRequestCtx.OAuthParameters.State,
+				Code:              oauth2const.ErrorAccessDenied,
+				Message:           "Authorization request failed",
+				SendErrorToClient: true,
+				ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+				State:             authRequestCtx.OAuthParameters.State,
 			}
 		}
 	}
@@ -361,9 +390,11 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 	if err != nil {
 		as.logger.Error("Failed to generate authorization code", log.Error(err))
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorServerError,
-			Message: "Failed to generate authorization code",
-			State:   authRequestCtx.OAuthParameters.State,
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Failed to process authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+			State:             authRequestCtx.OAuthParameters.State,
 		}
 	}
 
@@ -371,9 +402,11 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 	if persistErr := as.authCodeStore.InsertAuthorizationCode(authzCode); persistErr != nil {
 		as.logger.Error("Failed to persist authorization code", log.Error(persistErr))
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorServerError,
-			Message: "Failed to persist authorization code",
-			State:   authRequestCtx.OAuthParameters.State,
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Failed to process authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+			State:             authRequestCtx.OAuthParameters.State,
 		}
 	}
 
@@ -388,9 +421,11 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 	if err != nil {
 		as.logger.Error("Failed to construct redirect URI", log.Error(err))
 		return "", &AuthorizationError{
-			Code:    oauth2const.ErrorServerError,
-			Message: "Failed to redirect to client",
-			State:   authRequestCtx.OAuthParameters.State,
+			Code:              oauth2const.ErrorServerError,
+			Message:           "Failed to process authorization request",
+			SendErrorToClient: true,
+			ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+			State:             authRequestCtx.OAuthParameters.State,
 		}
 	}
 
@@ -399,13 +434,20 @@ func (as *authorizeService) HandleAuthorizationCallback(authID string, assertion
 
 // loadAuthRequestContext loads the authorization request context from the store using the auth ID.
 func (as *authorizeService) loadAuthRequestContext(authID string) (*authRequestContext, error) {
-	ok, authRequestCtx := as.authReqStore.GetRequest(authID)
+	ok, authRequestCtx, err := as.authReqStore.GetRequest(authID)
+	if err != nil {
+		as.logger.Error("Failed to retrieve authorization request context", log.Error(err))
+		return nil, errors.New("failed to retrieve authorization request context")
+	}
 	if !ok {
-		return nil, errors.New("authorization request context not found for auth ID: " + authID)
+		as.logger.Debug("Authorization request context not found", log.String("auth_id", authID))
+		return nil, errAuthRequestNotFound
 	}
 
 	// Remove the authorization request context after retrieval.
-	as.authReqStore.ClearRequest(authID)
+	if clearErr := as.authReqStore.ClearRequest(authID); clearErr != nil {
+		as.logger.Error("Failed to clear authorization request context", log.Error(clearErr))
+	}
 	return &authRequestCtx, nil
 }
 
@@ -426,7 +468,7 @@ func decodeAttributesFromAssertion(assertion string) (assertionClaims, time.Time
 
 	_, jwtPayload, err := jwt.DecodeJWT(assertion)
 	if err != nil {
-		return claims, time.Time{}, errors.New("Failed to decode the JWT token: " + err.Error())
+		return claims, time.Time{}, fmt.Errorf("failed to decode the JWT token: %w", err)
 	}
 
 	// Extract authentication time from iat claim.

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -165,7 +165,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_In
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), authErr)
-	assert.Equal(suite.T(), oauth2const.ErrorInvalidClient, authErr.Code)
+	assert.Equal(suite.T(), oauth2const.ErrorInvalidRequest, authErr.Code)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_InvalidClaimsParameter() {
@@ -241,6 +241,9 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Fl
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), authErr)
 	assert.Equal(suite.T(), oauth2const.ErrorServerError, authErr.Code)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
+	assert.Equal(suite.T(), "test-state", authErr.State)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Success() {
@@ -249,7 +252,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Su
 	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
 		Return(false, "", "")
 	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything).Return("test-flow-id", nil)
-	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID, nil)
 
 	svc := suite.newService()
 	result, authErr := svc.HandleInitialAuthorizationRequest(suite.testMsg())
@@ -268,7 +271,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_In
 	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
 		Return(false, "", "")
 	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything).Return("test-flow-id", nil)
-	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID, nil)
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
@@ -294,7 +297,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Em
 	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
 		Return(false, "", "")
 	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything).Return("test-flow-id", nil)
-	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID, nil)
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
@@ -319,7 +322,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Wi
 	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
 		Return(false, "", "")
 	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything).Return("test-flow-id", nil)
-	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything).Return(testAuthID, nil)
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
@@ -340,7 +343,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Wi
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidAuthID() {
-	suite.mockAuthReqStore.EXPECT().GetRequest("invalid-key").Return(false, authRequestContext{})
+	suite.mockAuthReqStore.EXPECT().GetRequest("invalid-key").Return(false, authRequestContext{}, nil)
 
 	svc := suite.newService()
 	redirectURI, authErr := svc.HandleAuthorizationCallback("invalid-key", "test-assertion")
@@ -348,6 +351,18 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidA
 	assert.Empty(suite.T(), redirectURI)
 	assert.NotNil(suite.T(), authErr)
 	assert.Equal(suite.T(), oauth2const.ErrorInvalidRequest, authErr.Code)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_StoreError() {
+	suite.mockAuthReqStore.EXPECT().GetRequest("db-fail-key").
+		Return(false, authRequestContext{}, errors.New("db connection error"))
+
+	svc := suite.newService()
+	redirectURI, authErr := svc.HandleAuthorizationCallback("db-fail-key", "test-assertion")
+
+	assert.Empty(suite.T(), redirectURI)
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorServerError, authErr.Code)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_MissingAssertion() {
@@ -358,8 +373,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_MissingA
 			State:       "test-state",
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 
 	svc := suite.newService()
 	redirectURI, authErr := svc.HandleAuthorizationCallback(testAuthID, "")
@@ -368,6 +383,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_MissingA
 	assert.NotNil(suite.T(), authErr)
 	assert.Equal(suite.T(), oauth2const.ErrorInvalidRequest, authErr.Code)
 	assert.Equal(suite.T(), "test-state", authErr.State)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidAssertionSignature() {
@@ -378,8 +395,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidA
 			State:       "test-state",
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 	suite.mockJWTService.EXPECT().VerifyJWT("invalid-assertion", "", "").Return(&jwt.ErrorInvalidTokenSignature)
 
 	svc := suite.newService()
@@ -389,6 +406,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidA
 	assert.NotNil(suite.T(), authErr)
 	assert.Equal(suite.T(), oauth2const.ErrorInvalidRequest, authErr.Code)
 	assert.Equal(suite.T(), "test-state", authErr.State)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_FailedToDecodeAssertion() {
@@ -399,8 +418,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_FailedTo
 			State:       "test-state",
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 	// VerifyJWT succeeds but "not.valid.jwt" cannot be decoded as a valid JWT payload.
 	suite.mockJWTService.EXPECT().VerifyJWT("not.valid.jwt", "", "").Return(nil)
 
@@ -409,7 +428,11 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_FailedTo
 
 	assert.Empty(suite.T(), redirectURI)
 	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorServerError, authErr.Code)
+	assert.Equal(suite.T(), "Failed to process authorization request", authErr.Message)
 	assert.Equal(suite.T(), "test-state", authErr.State)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_PersistAuthCodeError() {
@@ -420,8 +443,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_PersistA
 			State:       "test-state",
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything).Return(errors.New("db error"))
 
@@ -432,6 +455,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_PersistA
 	assert.NotNil(suite.T(), authErr)
 	assert.Equal(suite.T(), oauth2const.ErrorServerError, authErr.Code)
 	assert.Equal(suite.T(), "test-state", authErr.State)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_Success() {
@@ -441,8 +466,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_Success(
 			RedirectURI: "https://client.example.com/callback",
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything).Return(nil)
 
@@ -462,8 +487,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_WithStat
 			State:       "test-state-123",
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything).Return(nil)
 
@@ -485,8 +510,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_EmptyAut
 			PermissionScopes: []string{"read", "write"},
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything).Return(nil)
 
@@ -505,8 +530,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_CreateAu
 			RedirectURI: "https://client.example.com/callback",
 		},
 	}
-	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx)
-	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID)
+	suite.mockAuthReqStore.EXPECT().GetRequest(testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(testAuthID).Return(nil)
 	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTMinimal, "", "").Return(nil)
 
 	svc := suite.newService()
@@ -533,7 +558,7 @@ func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_NotFound
 	suite.mockAuthzCodeStore.EXPECT().ConsumeAuthorizationCode("client-id", "invalid-code").
 		Return(false, nil)
 	suite.mockAuthzCodeStore.EXPECT().GetAuthorizationCode("client-id", "invalid-code").
-		Return(nil, ErrAuthorizationCodeNotFound)
+		Return(nil, errAuthorizationCodeNotFound)
 
 	svc := suite.newService()
 	result, err := svc.GetAuthorizationCodeDetails("client-id", "invalid-code")

--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -60,7 +60,7 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 
 	// Validate the redirect URI against the registered application.
 	if err := oauthApp.ValidateRedirectURI(redirectURI); err != nil {
-		logger.Error("Validation failed for redirect URI", log.Error(err))
+		logger.Debug("Validation failed for redirect URI", log.Error(err))
 		return false, constants.ErrorInvalidRequest, "Invalid redirect URI"
 	}
 
@@ -99,7 +99,7 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 		// Validate code challenge format and method if PKCE parameters are present
 		if codeChallenge != "" {
 			if err := pkce.ValidateCodeChallenge(codeChallenge, codeChallengeMethod); err != nil {
-				return true, constants.ErrorInvalidRequest, "Invalid PKCE parameters"
+				return true, constants.ErrorInvalidRequest, "Invalid code_challenge or code_challenge_method parameter"
 			}
 		}
 	}
@@ -113,7 +113,7 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(msg *OAuth
 	resource := msg.RequestQueryParams[constants.RequestParamResource]
 	if resource != "" {
 		if err := validateResourceParameter(resource); err != nil {
-			return true, constants.ErrorInvalidTarget, err.Error()
+			return true, constants.ErrorInvalidTarget, "Invalid resource parameter"
 		}
 	}
 
@@ -142,14 +142,14 @@ func validateResourceParameter(resource string) error {
 // validatePromptParameter validates the OIDC prompt parameter.
 func validatePromptParameter(prompt string) (bool, string, string) {
 	if strings.TrimSpace(prompt) == "" {
-		return true, constants.ErrorInvalidRequest, "Invalid prompt parameter value"
+		return true, constants.ErrorInvalidRequest, "The prompt parameter cannot be empty"
 	}
 
 	values := strings.Fields(prompt)
 
 	for _, v := range values {
 		if !slices.Contains(constants.ValidPromptValues, v) {
-			return true, constants.ErrorInvalidRequest, "Invalid prompt parameter value"
+			return true, constants.ErrorInvalidRequest, "Unsupported prompt parameter value"
 		}
 	}
 

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -284,7 +284,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "absolute URI with a scheme")
+	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceWithFragment() {
@@ -302,7 +302,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "fragment component")
+	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceRelativeURI() {
@@ -320,7 +320,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "absolute URI with a scheme")
+	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceInvalidURI() {
@@ -338,7 +338,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errorCode)
-	assert.Contains(suite.T(), errorMessage, "absolute URI")
+	assert.Contains(suite.T(), errorMessage, "Invalid resource parameter")
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceParameterWithQuery() {
@@ -416,7 +416,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCERequired_
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
-	assert.Equal(suite.T(), "Invalid PKCE parameters", errorMessage)
+	assert.Equal(suite.T(), "Invalid code_challenge or code_challenge_method parameter", errorMessage)
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_PKCERequired_ValidPKCE() {
@@ -478,7 +478,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCERequired_
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
-	assert.Equal(suite.T(), "Invalid PKCE parameters", errorMessage)
+	assert.Equal(suite.T(), "Invalid code_challenge or code_challenge_method parameter", errorMessage)
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_PKCENotRequired() {
@@ -537,7 +537,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCENotRequir
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
-	assert.Equal(suite.T(), "Invalid PKCE parameters", errorMessage)
+	assert.Equal(suite.T(), "Invalid code_challenge or code_challenge_method parameter", errorMessage)
 }
 
 // Prompt Parameter Validation Tests (OIDC Core §3.1.2.1)
@@ -629,7 +629,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
-	assert.Contains(suite.T(), errorMessage, "Invalid prompt parameter value")
+	assert.Equal(suite.T(), "Unsupported prompt parameter value", errorMessage)
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptSelectAccount() {
@@ -683,5 +683,5 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 	assert.True(suite.T(), sendErrorToApp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errorCode)
-	assert.Contains(suite.T(), errorMessage, "Invalid prompt parameter value")
+	assert.Equal(suite.T(), "The prompt parameter cannot be empty", errorMessage)
 }

--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -223,7 +223,7 @@ func validateClientAssertion(
 	discoveryService discovery.DiscoveryServiceInterface,
 	clientID, clientAssertion string) error {
 	if oauthApp.Certificate == nil || oauthApp.Certificate.Type == cert.CertificateTypeNone {
-		return fmt.Errorf("No certificate configured for client assertion validation")
+		return fmt.Errorf("no certificate configured for client assertion validation")
 	}
 
 	// Get token endpoint from discovery service for aud validation
@@ -232,7 +232,7 @@ func validateClientAssertion(
 	if oauthApp.Certificate.Type == cert.CertificateTypeJWKSURI {
 		if err := jwtService.VerifyJWTWithJWKS(clientAssertion, oauthApp.Certificate.Value, tokenEndpoint,
 			clientID); err != nil {
-			return fmt.Errorf("Client assertion verification with JWKS URI failed: %v", err.Error)
+			return fmt.Errorf("client assertion verification with JWKS URI failed: %v", err.Error)
 		}
 		return nil
 	}
@@ -241,12 +241,12 @@ func validateClientAssertion(
 		Keys []map[string]any `json:"keys"`
 	}
 	if err := json.Unmarshal([]byte(oauthApp.Certificate.Value), &jwks); err != nil {
-		return fmt.Errorf("Invalid jwks certificate format: %v", err.Error())
+		return fmt.Errorf("invalid JWKS certificate format: %w", err)
 	}
 
 	var kid string
 	if header, err := jwt.DecodeJWTHeader(clientAssertion); err != nil {
-		return fmt.Errorf("Failed to decode header: %v", err.Error())
+		return fmt.Errorf("failed to decode header: %w", err)
 	} else if k, ok := header["kid"].(string); !ok || k == "" {
 		return fmt.Errorf("JWT header missing 'kid' claim or 'kid' is not a string")
 	} else {
@@ -261,16 +261,16 @@ func validateClientAssertion(
 		}
 	}
 	if jwk == nil {
-		return fmt.Errorf("No matching key found in JWKS for kid: %v", kid)
+		return fmt.Errorf("no matching key found in JWKS for kid: %v", kid)
 	}
 
 	pubKey, err := jws.JWKToPublicKey(jwk)
 	if err != nil {
-		return fmt.Errorf("Failed to convert JWK to public key: %v", err.Error())
+		return fmt.Errorf("failed to convert JWK to public key: %w", err)
 	}
 
 	if err := jwtService.VerifyJWTWithPublicKey(clientAssertion, pubKey, tokenEndpoint, clientID); err != nil {
-		return fmt.Errorf("Client assertion verification failed: %v", err.Error)
+		return fmt.Errorf("client assertion verification failed: %v", err.Error)
 	}
 
 	return nil

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -978,7 +978,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NilCertificate() {
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client",
 		"some.jwt.token")
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "No certificate configured")
+	assert.Contains(suite.T(), err.Error(), "no certificate configured")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_CertificateTypeNone() {
@@ -993,7 +993,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_CertificateTypeNon
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client",
 		"some.jwt.token")
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "No certificate configured")
+	assert.Contains(suite.T(), err.Error(), "no certificate configured")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_JWKSURI_Success() {
@@ -1044,7 +1044,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_JWKSURI_Verificati
 
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", assertion)
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "Client assertion verification with JWKS URI failed")
+	assert.Contains(suite.T(), err.Error(), "client assertion verification with JWKS URI failed")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKSJSON() {
@@ -1065,7 +1065,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKSJSON() 
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService,
 		"test-client", "some.jwt.token")
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "Invalid jwks certificate format")
+	assert.Contains(suite.T(), err.Error(), "invalid JWKS certificate format")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWTFormat() {
@@ -1087,7 +1087,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWTFormat()
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService,
 		"test-client", "invalid-jwt")
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "Failed to decode header")
+	assert.Contains(suite.T(), err.Error(), "failed to decode header")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_MissingKidInHeader() {
@@ -1182,7 +1182,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NoMatchingKidInJWK
 
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "No matching key found in JWKS")
+	assert.Contains(suite.T(), err.Error(), "no matching key found in JWKS")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKCannotConvertToPublicKey() {
@@ -1212,7 +1212,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKCannotCo
 
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "Failed to convert JWK to public key")
+	assert.Contains(suite.T(), err.Error(), "failed to convert JWK to public key")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_VerificationFails() {
@@ -1243,7 +1243,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_VerificationFails(
 
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "Client assertion verification failed")
+	assert.Contains(suite.T(), err.Error(), "client assertion verification failed")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_Success() {
@@ -1295,7 +1295,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_EmptyJWKSKeys() {
 
 	err := validateClientAssertion(oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "No matching key found in JWKS")
+	assert.Contains(suite.T(), err.Error(), "no matching key found in JWKS")
 }
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_MultipleKeysMatchesCorrectKid() {

--- a/backend/internal/oauth/oauth2/dcr/error_constants.go
+++ b/backend/internal/oauth/oauth2/dcr/error_constants.go
@@ -27,7 +27,7 @@ var (
 		Type:             serviceerror.ClientErrorType,
 		Code:             "invalid_client_metadata",
 		Error:            "Invalid request format",
-		ErrorDescription: "The request format is invalid",
+		ErrorDescription: "The request body is missing or has an invalid format",
 	}
 
 	// ErrorInvalidRedirectURI is the standard error for redirect URI issues

--- a/backend/internal/oauth/oauth2/dcr/service.go
+++ b/backend/internal/oauth/oauth2/dcr/service.go
@@ -71,7 +71,13 @@ func (ds *dcrService) RegisterClient(request *DCRRegistrationRequest) (
 
 	createdApp, err := ds.appService.CreateApplication(context.TODO(), appDTO)
 	if err != nil {
-		logger.Error("Failed to create application via Application service", log.String("error", err.Error))
+		if err.Type == serviceerror.ServerErrorType {
+			logger.Error("Failed to create application via Application service",
+				log.String("error_code", err.Code))
+			return nil, &ErrorServerError
+		}
+		logger.Debug("Failed to create application via Application service",
+			log.String("error_code", err.Code))
 		return nil, ds.mapApplicationErrorToDCRError(err)
 	}
 

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -60,7 +60,7 @@ func (h *authorizationCodeGrantHandler) ValidateGrant(tokenRequest *model.TokenR
 	if tokenRequest.GrantType == "" {
 		return &model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,
-			ErrorDescription: "Missing grant type",
+			ErrorDescription: "Missing grant_type parameter",
 		}
 	}
 	if constants.GrantType(tokenRequest.GrantType) != constants.GrantTypeAuthorizationCode {
@@ -78,7 +78,7 @@ func (h *authorizationCodeGrantHandler) ValidateGrant(tokenRequest *model.TokenR
 	if tokenRequest.ClientID == "" {
 		return &model.ErrorResponse{
 			Error:            constants.ErrorInvalidClient,
-			ErrorDescription: "Client Id is required",
+			ErrorDescription: "client_id is required",
 		}
 	}
 
@@ -174,7 +174,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(tokenRequest *model.TokenReq
 			logger.Error("Failed to generate ID token", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
-				ErrorDescription: "Failed to generate ID token",
+				ErrorDescription: "Failed to generate token",
 			}
 		}
 		tokenResponse.IDToken = *idToken

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -164,7 +164,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_MissingGr
 	err := suite.handler.ValidateGrant(tokenReq, suite.oauthApp)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, err.Error)
-	assert.Equal(suite.T(), "Missing grant type", err.ErrorDescription)
+	assert.Equal(suite.T(), "Missing grant_type parameter", err.ErrorDescription)
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_UnsupportedGrantType() {
@@ -203,7 +203,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_MissingCl
 	err := suite.handler.ValidateGrant(tokenReq, suite.oauthApp)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorInvalidClient, err.Error)
-	assert.Equal(suite.T(), "Client Id is required", err.ErrorDescription)
+	assert.Equal(suite.T(), "client_id is required", err.ErrorDescription)
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestValidateGrant_MissingRedirectURI() {
@@ -913,7 +913,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_IDTokenGene
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
-	assert.Equal(suite.T(), "Failed to generate ID token", err.ErrorDescription)
+	assert.Equal(suite.T(), "Failed to generate token", err.ErrorDescription)
 
 	suite.mockAuthzService.AssertExpectations(suite.T())
 	suite.mockUserService.AssertExpectations(suite.T())

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -88,7 +88,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 	// Validate refresh token using token validator
 	refreshTokenClaims, err := h.tokenValidator.ValidateRefreshToken(tokenRequest.RefreshToken, tokenRequest.ClientID)
 	if err != nil {
-		logger.Error("Failed to validate refresh token", log.Error(err))
+		logger.Debug("Failed to validate refresh token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorInvalidGrant,
 			ErrorDescription: "Invalid refresh token",
@@ -138,7 +138,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 			logger.Error("Failed to generate ID token", log.Error(idErr))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
-				ErrorDescription: "Failed to generate ID token",
+				ErrorDescription: "Failed to generate token",
 			}
 		}
 		tokenResponse.IDToken = *idToken
@@ -155,7 +155,6 @@ func (h *refreshTokenGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 			refreshTokenClaims.GrantType, newTokenScopes, refreshTokenClaims.ClaimsRequest,
 			refreshTokenClaims.ClaimsLocales)
 		if errResp != nil && errResp.Error != "" {
-			errResp.ErrorDescription = "Error while issuing refresh token: " + errResp.ErrorDescription
 			logger.Error("Failed to issue refresh token", log.String("error", errResp.Error))
 			return nil, errResp
 		}

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -420,7 +420,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IssueRefreshToke
 	assert.Nil(suite.T(), response)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
-	assert.Contains(suite.T(), err.ErrorDescription, "Error while issuing refresh token")
+	assert.Equal(suite.T(), "Failed to generate refresh token", err.ErrorDescription)
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ExtractIatClaimError() {
@@ -607,7 +607,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGeneratio
 	assert.Nil(suite.T(), response)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
-	assert.Equal(suite.T(), "Failed to generate ID token", err.ErrorDescription)
+	assert.Equal(suite.T(), "Failed to generate token", err.ErrorDescription)
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenewOnGrant() {

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -19,7 +19,6 @@
 package granthandlers
 
 import (
-	"fmt"
 	"net/url"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
@@ -74,7 +73,7 @@ func (h *tokenExchangeGrantHandler) ValidateGrant(tokenRequest *model.TokenReque
 	if !constants.TokenTypeIdentifier(tokenRequest.SubjectTokenType).IsValid() {
 		return &model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,
-			ErrorDescription: fmt.Sprintf("Unsupported subject_token_type: %s", tokenRequest.SubjectTokenType),
+			ErrorDescription: "Unsupported subject_token_type",
 		}
 	}
 
@@ -111,7 +110,7 @@ func (h *tokenExchangeGrantHandler) ValidateGrant(tokenRequest *model.TokenReque
 		if !constants.TokenTypeIdentifier(tokenRequest.ActorTokenType).IsValid() {
 			return &model.ErrorResponse{
 				Error:            constants.ErrorInvalidRequest,
-				ErrorDescription: fmt.Sprintf("Unsupported actor_token_type: %s", tokenRequest.ActorTokenType),
+				ErrorDescription: "Unsupported actor_token_type",
 			}
 		}
 	}
@@ -122,18 +121,15 @@ func (h *tokenExchangeGrantHandler) ValidateGrant(tokenRequest *model.TokenReque
 		if !requestedType.IsValid() {
 			return &model.ErrorResponse{
 				Error:            constants.ErrorInvalidRequest,
-				ErrorDescription: fmt.Sprintf("Unsupported requested_token_type: %s", tokenRequest.RequestedTokenType),
+				ErrorDescription: "Unsupported requested_token_type",
 			}
 		}
 		// TODO: Add support for other token types if needed
 		if requestedType != constants.TokenTypeIdentifierAccessToken &&
 			requestedType != constants.TokenTypeIdentifierJWT {
 			return &model.ErrorResponse{
-				Error: constants.ErrorInvalidRequest,
-				ErrorDescription: fmt.Sprintf(
-					"Requested token type '%s' is not supported. Only access tokens and JWT tokens are supported.",
-					tokenRequest.RequestedTokenType,
-				),
+				Error:            constants.ErrorInvalidRequest,
+				ErrorDescription: "Unsupported requested_token_type. Only access tokens and JWT tokens are supported",
 			}
 		}
 	}
@@ -150,7 +146,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(tokenRequest *model.TokenRequest
 	// Validate and extract subject token claims
 	subjectClaims, err := h.tokenValidator.ValidateSubjectToken(tokenRequest.SubjectToken, oauthApp)
 	if err != nil {
-		logger.Error("Failed to validate subject token", log.Error(err))
+		logger.Debug("Failed to validate subject token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,
 			ErrorDescription: "Invalid subject_token",
@@ -162,7 +158,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(tokenRequest *model.TokenRequest
 	if tokenRequest.ActorToken != "" {
 		actorClaims, err = h.tokenValidator.ValidateSubjectToken(tokenRequest.ActorToken, oauthApp)
 		if err != nil {
-			logger.Error("Failed to validate actor token", log.Error(err))
+			logger.Debug("Failed to validate actor token", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorInvalidRequest,
 				ErrorDescription: "Invalid actor_token",

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -1085,8 +1085,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedID
 	errResp := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
 	assert.NotNil(suite.T(), errResp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "not supported")
-	assert.Contains(suite.T(), errResp.ErrorDescription, string(constants.TokenTypeIdentifierIDToken))
+	assert.Contains(suite.T(), errResp.ErrorDescription, "Unsupported requested_token_type")
+	assert.Contains(suite.T(), errResp.ErrorDescription, "Only access tokens and JWT tokens are supported")
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedRefreshTokenType() {
@@ -1102,8 +1102,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedRe
 	errResp := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
 	assert.NotNil(suite.T(), errResp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
-	assert.Contains(suite.T(), errResp.ErrorDescription, "not supported")
-	assert.Contains(suite.T(), errResp.ErrorDescription, string(constants.TokenTypeIdentifierRefreshToken))
+	assert.Contains(suite.T(), errResp.ErrorDescription, "Unsupported requested_token_type")
+	assert.Contains(suite.T(), errResp.ErrorDescription, "Only access tokens and JWT tokens are supported")
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchangeFlow() {

--- a/backend/internal/oauth/oauth2/introspect/handler.go
+++ b/backend/internal/oauth/oauth2/introspect/handler.go
@@ -19,12 +19,9 @@
 package introspect
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
-	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
-	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/log"
 	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
@@ -32,46 +29,30 @@ import (
 // tokenIntrospectionHandler handles OAuth 2.0 token introspection requests.
 type tokenIntrospectionHandler struct {
 	service TokenIntrospectionServiceInterface
+	logger  *log.Logger
 }
 
 // newTokenIntrospectionHandler creates a new token introspection handler (internal use).
 func newTokenIntrospectionHandler(introspectionService TokenIntrospectionServiceInterface) *tokenIntrospectionHandler {
 	return &tokenIntrospectionHandler{
 		service: introspectionService,
+		logger:  log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenIntrospectionHandler")),
 	}
 }
 
 // HandleIntrospect handles token introspection requests
 func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *http.Request) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenIntrospectionHandler"))
-
 	if err := r.ParseForm(); err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-		errResp := model.ErrorResponse{
-			Error:            constants.ErrorInvalidRequest,
-			ErrorDescription: "Failed to decode request body",
-		}
-		if err := json.NewEncoder(w).Encode(errResp); err != nil {
-			logger.Error("Error encoding error response", log.Error(err))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteJSONError(w, constants.ErrorInvalidRequest, "Failed to decode request body",
+			http.StatusBadRequest, nil)
 		return
 	}
 
 	// Extract request parameters
 	token := r.FormValue(constants.RequestParamToken)
 	if token == "" {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusBadRequest)
-		errResp := model.ErrorResponse{
-			Error:            constants.ErrorInvalidRequest,
-			ErrorDescription: "Token parameter is required",
-		}
-		if err := json.NewEncoder(w).Encode(errResp); err != nil {
-			logger.Error("Error encoding error response", log.Error(err))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		sysutils.WriteJSONError(w, constants.ErrorInvalidRequest, "Token parameter is required",
+			http.StatusBadRequest, nil)
 		return
 	}
 	// token_type_hint parameter is not supported due to non persistent tokens in the server
@@ -79,16 +60,10 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 
 	response, err := h.service.IntrospectToken(token, tokenTypeHint)
 	if err != nil {
-		w.Header().Set(serverconst.ContentTypeHeaderName, serverconst.ContentTypeJSON)
-		w.WriteHeader(http.StatusInternalServerError)
-		errResp := model.ErrorResponse{
-			Error:            constants.ErrorServerError,
-			ErrorDescription: "Server error while introspecting token",
-		}
-		if err := json.NewEncoder(w).Encode(errResp); err != nil {
-			logger.Error("Error encoding error response", log.Error(err))
-			http.Error(w, "Failed to encode error response", http.StatusInternalServerError)
-		}
+		h.logger.Error("Failed to introspect token", log.Error(err))
+		sysutils.WriteJSONError(w, constants.ErrorServerError,
+			"An unexpected error occurred while processing the request",
+			http.StatusInternalServerError, nil)
 		return
 	}
 

--- a/backend/internal/oauth/oauth2/introspect/handler_test.go
+++ b/backend/internal/oauth/oauth2/introspect/handler_test.go
@@ -89,10 +89,10 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_ParseFormError
 	// Execute the handler - should attempt to write error response despite encoding failure
 	s.handler.HandleIntrospect(bw, req)
 
-	// Verify that the handler attempted to set headers (Content-Type will be text/plain after http.Error fallback)
+	// Verify that the handler attempted to set headers
 	assert.NotNil(s.T(), bw.Header())
-	// After encoding fails, http.Error() is called which sets Content-Type to text/plain
-	assert.Contains(s.T(), bw.Header().Get("Content-Type"), "text/plain")
+	// WriteJSONError sets Content-Type to application/json before attempting to encode
+	assert.Contains(s.T(), bw.Header().Get("Content-Type"), "application/json")
 }
 
 func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_MissingToken() {
@@ -118,10 +118,10 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_MissingToken_E
 	// Execute the handler - should attempt to write error response despite encoding failure
 	s.handler.HandleIntrospect(bw, req)
 
-	// Verify that the handler attempted to set headers (Content-Type will be text/plain after http.Error fallback)
+	// Verify that the handler attempted to set headers
 	assert.NotNil(s.T(), bw.Header())
-	// After encoding fails, http.Error() is called which sets Content-Type to text/plain
-	assert.Contains(s.T(), bw.Header().Get("Content-Type"), "text/plain")
+	// WriteJSONError sets Content-Type to application/json before attempting to encode
+	assert.Contains(s.T(), bw.Header().Get("Content-Type"), "application/json")
 }
 
 func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_IntrospectionError() {
@@ -138,7 +138,7 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_IntrospectionE
 	s.handler.HandleIntrospect(rr, req)
 	assert.Equal(s.T(), http.StatusInternalServerError, rr.Code)
 	assert.Contains(s.T(), rr.Body.String(), constants.ErrorServerError)
-	assert.Contains(s.T(), rr.Body.String(), "Server error while introspecting token")
+	assert.Contains(s.T(), rr.Body.String(), "An unexpected error occurred while processing the request")
 	s.introspectionServiceMock.AssertExpectations(s.T())
 }
 

--- a/backend/internal/oauth/oauth2/token/handler.go
+++ b/backend/internal/oauth/oauth2/token/handler.go
@@ -107,8 +107,6 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 			switch tokenError.Error {
 			case constants.ErrorServerError:
 				statusCode = http.StatusInternalServerError
-			case constants.ErrorUnauthorizedClient:
-				statusCode = http.StatusUnauthorized
 			default:
 				statusCode = http.StatusBadRequest
 			}

--- a/backend/internal/oauth/oauth2/token/handler_test.go
+++ b/backend/internal/oauth/oauth2/token/handler_test.go
@@ -138,7 +138,7 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_ServiceErrors() {
 			grantType:     "client_credentials",
 			errCode:       constants.ErrorUnauthorizedClient,
 			errDesc:       "The client is not authorized to use this grant type",
-			expectedCode:  http.StatusUnauthorized,
+			expectedCode:  http.StatusBadRequest,
 			expectedError: "unauthorized_client",
 		},
 	}

--- a/backend/internal/oauth/oauth2/token/service.go
+++ b/backend/internal/oauth/oauth2/token/service.go
@@ -118,7 +118,7 @@ func (ts *tokenService) ProcessTokenRequest(
 			500, "Failed to get grant handler", startTime)
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
-			ErrorDescription: "Something went wrong",
+			ErrorDescription: "Failed to process token request",
 		}
 	}
 
@@ -161,6 +161,9 @@ func (ts *tokenService) ProcessTokenRequest(
 			}
 			publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 				code, tokenError.ErrorDescription, startTime)
+			if tokenError.Error == constants.ErrorServerError {
+				tokenError.ErrorDescription = "Failed to process token request"
+			}
 		}
 		return nil, tokenError
 	}
@@ -169,7 +172,7 @@ func (ts *tokenService) ProcessTokenRequest(
 			500, "Grant handler returned empty response", startTime)
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
-			ErrorDescription: "Something went wrong",
+			ErrorDescription: "Failed to process token request",
 		}
 	}
 
@@ -186,7 +189,7 @@ func (ts *tokenService) ProcessTokenRequest(
 				500, "Failed to get refresh grant handler", startTime)
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
-				ErrorDescription: "Something went wrong",
+				ErrorDescription: "Failed to process token request",
 			}
 		}
 		refreshGrantHandlerTyped, ok := refreshGrantHandler.(granthandlers.RefreshTokenGrantHandlerInterface)
@@ -197,7 +200,7 @@ func (ts *tokenService) ProcessTokenRequest(
 				500, "Internal Server Error", startTime)
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
-				ErrorDescription: "Something went wrong",
+				ErrorDescription: "Failed to process token request",
 			}
 		}
 
@@ -210,6 +213,9 @@ func (ts *tokenService) ProcessTokenRequest(
 		if refreshTokenError != nil && refreshTokenError.Error != "" {
 			publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 				500, refreshTokenError.ErrorDescription, startTime)
+			if refreshTokenError.Error == constants.ErrorServerError {
+				refreshTokenError.ErrorDescription = "Failed to process token request"
+			}
 			return nil, refreshTokenError
 		}
 	}

--- a/backend/internal/oauth/oauth2/token/service_test.go
+++ b/backend/internal/oauth/oauth2/token/service_test.go
@@ -252,6 +252,37 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_HandleGrantError() {
 	assert.Equal(suite.T(), "invalid_grant", errResp.Error)
 }
 
+func (suite *TokenServiceTestSuite) TestProcessTokenRequest_HandleGrantServerError_NormalizesDescription() {
+	req := &model.TokenRequest{
+		ClientID:  "test-client-id",
+		GrantType: string(constants.GrantTypeAuthorizationCode),
+		Code:      "test-code",
+		Scope:     "openid",
+	}
+	app := suite.defaultApp()
+
+	suite.mockGrantProvider.ExpectedCalls = nil
+	suite.mockGrantProvider.
+		On("GetGrantHandler", constants.GrantTypeAuthorizationCode).
+		Return(suite.mockGrantHandler, nil)
+
+	suite.mockGrantHandler.On("ValidateGrant", mock.Anything, app).Return(nil)
+	suite.mockScopeValidator.On("ValidateScopes", "openid", "test-client-id").Return("openid", nil)
+	suite.mockGrantHandler.
+		On("HandleGrant", mock.Anything, app).
+		Return(nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to generate token",
+		})
+
+	svc := suite.newService()
+	_, errResp := svc.ProcessTokenRequest(context.Background(), req, app)
+
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
+	assert.Equal(suite.T(), "Failed to process token request", errResp.ErrorDescription)
+}
+
 func (suite *TokenServiceTestSuite) TestProcessTokenRequest_Success() {
 	req := &model.TokenRequest{
 		ClientID:  "test-client-id",
@@ -404,6 +435,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_RefreshTokenIssuance
 
 	assert.NotNil(suite.T(), errResp)
 	assert.Equal(suite.T(), "server_error", errResp.Error)
+	assert.Equal(suite.T(), "Failed to process token request", errResp.ErrorDescription)
 }
 
 func (suite *TokenServiceTestSuite) TestProcessTokenRequest_RefreshTokenHandlerNotFound() {

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -82,7 +82,7 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 		jwt.TokenTypeAccessToken,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate access token: %v", err)
+		return nil, fmt.Errorf("failed to generate access token: %v", err.Error)
 	}
 
 	// Assign generated token and issued at time
@@ -221,7 +221,7 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth
 		jwt.TokenTypeJWT,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate refresh token: %v", err)
+		return nil, fmt.Errorf("failed to generate refresh token: %v", err.Error)
 	}
 
 	// Assign generated token and issued at time
@@ -297,7 +297,7 @@ func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.Tok
 		jwt.TokenTypeJWT,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate ID token: %v", err)
+		return nil, fmt.Errorf("failed to generate ID token: %v", err.Error)
 	}
 
 	// Assign generated token and issued at time

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -53,7 +53,7 @@ func (tv *tokenValidator) ValidateAccessToken(token string) (*AccessTokenClaims,
 	// Verify signature and standard claims.
 	expectedIss := config.GetThunderRuntime().Config.JWT.Issuer
 	if err := tv.jwtService.VerifyJWT(token, "", expectedIss); err != nil {
-		return nil, fmt.Errorf("access token verification failed: %v", err)
+		return nil, fmt.Errorf("access token verification failed: %v", err.Error)
 	}
 
 	// Validate the typ header.
@@ -109,7 +109,7 @@ func (tv *tokenValidator) ValidateAccessToken(token string) (*AccessTokenClaims,
 // ValidateRefreshToken validates a refresh token and extracts the claims.
 func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*RefreshTokenClaims, error) {
 	if err := tv.jwtService.VerifyJWT(token, "", ""); err != nil {
-		return nil, fmt.Errorf("invalid refresh token: %v", err)
+		return nil, fmt.Errorf("invalid refresh token: %v", err.Error)
 	}
 
 	claims, err := jwt.DecodeJWTPayload(token)
@@ -248,7 +248,7 @@ func (tv *tokenValidator) verifyTokenSignatureByIssuer(
 	if issuers[issuer] {
 		svcErr := tv.jwtService.VerifyJWTSignature(token)
 		if svcErr != nil {
-			return fmt.Errorf("failed to verify token signature: %v", svcErr)
+			return fmt.Errorf("failed to verify token signature: %v", svcErr.Error)
 		}
 		return nil
 	}

--- a/backend/internal/oauth/oauth2/userinfo/handler.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler.go
@@ -56,7 +56,8 @@ func (h *userInfoHandler) HandleUserInfo(w http.ResponseWriter, r *http.Request)
 			w.Header().Set(serverconst.WWWAuthenticateHeaderName, serverconst.TokenTypeBearer)
 			w.WriteHeader(http.StatusUnauthorized)
 		} else {
-			writeBearerError(w, constants.ErrorInvalidRequest, err.Error(), http.StatusBadRequest)
+			writeBearerError(w, constants.ErrorInvalidRequest,
+				"Invalid or malformed Bearer token", http.StatusBadRequest)
 		}
 		return
 	}
@@ -87,7 +88,7 @@ func (h *userInfoHandler) writeServiceErrorResponse(w http.ResponseWriter, svcEr
 
 	switch svcErr.Type {
 	case serviceerror.ClientErrorType:
-		if svcErr == &errorInsufficientScope {
+		if svcErr.Code == errorInsufficientScope.Code {
 			statusCode = http.StatusForbidden
 		} else {
 			statusCode = http.StatusUnauthorized

--- a/backend/internal/oauth/oauth2/userinfo/handler_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler_test.go
@@ -82,7 +82,7 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_MissingBearerToken() {
 
 	assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
 	assert.Contains(s.T(), rr.Body.String(), constants.ErrorInvalidRequest)
-	assert.Contains(s.T(), rr.Body.String(), "missing access token")
+	assert.Contains(s.T(), rr.Body.String(), "Invalid or malformed Bearer token")
 	wwwAuth := rr.Header().Get("WWW-Authenticate")
 	assert.Contains(s.T(), wwwAuth, "Bearer")
 	assert.Contains(s.T(), wwwAuth, constants.ErrorInvalidRequest)
@@ -261,7 +261,7 @@ func (s *UserInfoHandlerTestSuite) TestHandleUserInfo_InvalidAuthorizationHeader
 
 	assert.Equal(s.T(), http.StatusBadRequest, rr.Code)
 	assert.Contains(s.T(), rr.Body.String(), constants.ErrorInvalidRequest)
-	assert.Contains(s.T(), rr.Body.String(), "invalid Authorization header format")
+	assert.Contains(s.T(), rr.Body.String(), "Invalid or malformed Bearer token")
 }
 
 // TestHandleUserInfo_EncodingError tests encoding error handling

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -328,7 +328,7 @@ func (ts *AuthzTestSuite) TestBasicAuthorizationRequest() {
 			Scope:          "openid",
 			State:          "test_state_456",
 			ExpectedStatus: http.StatusFound,
-			ExpectedError:  "invalid_client",
+			ExpectedError:  "invalid_request",
 		},
 		{
 			Name:           "Invalid Response Type",

--- a/tests/integration/oauth/token/tokenexchange_test.go
+++ b/tests/integration/oauth/token/tokenexchange_test.go
@@ -61,7 +61,7 @@ var (
 				"type": "string",
 			},
 			"password": map[string]interface{}{
-				"type": "string",
+				"type":       "string",
 				"credential": true,
 			},
 			"email": map[string]interface{}{
@@ -555,7 +555,7 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_ApplicationNotRegisteredForG
 
 		tokenResp, statusCode, err := ts.exchangeToken(formData.Encode(), authHeader)
 		ts.Require().NoError(err)
-		ts.Equal(http.StatusUnauthorized, statusCode)
+		ts.Equal(http.StatusBadRequest, statusCode)
 		ts.Equal("unauthorized_client", tokenResp.Error)
 		ts.Contains(tokenResp.ErrorDescription, "not authorized")
 	}


### PR DESCRIPTION
This pull request focuses on improving error handling and consistency in the OAuth module, particularly in the authorization code and authorization request stores, as well as the JWKS service. The changes enhance error reporting, standardize error types, and update the interfaces and tests to better propagate and assert errors.

**Error handling and consistency improvements:**

* Standardized the error returned when no certificates are found in the `jwksService.GetJWKS` method to always use `serviceerror.InternalServerError` instead of a custom error. Updated related tests to assert the new error type. [[1]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L66-R66) [[2]](diffhunk://#diff-177eca09c049c969f398969b09595e0c715dea12908cf4a26d1de968cffe1b34L101-R101) [[3]](diffhunk://#diff-164d709332aaaba7253d0f2ac1a3bb3f21d007a12d7254e7a4d9ad251e77936cL147-R147) [[4]](diffhunk://#diff-164d709332aaaba7253d0f2ac1a3bb3f21d007a12d7254e7a4d9ad251e77936cL260-R260)
* Updated the `jwksHandler.HandleJWKSRequest` to log errors with an error code when a server error occurs, improving observability.
* Renamed `ErrAuthorizationCodeNotFound` to `errAuthorizationCodeNotFound` for consistency and updated all usages in the authorization code store and tests. [[1]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL124-R124) [[2]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL168-R168) [[3]](diffhunk://#diff-4505abf3272b6504ef692bf20b049aeb554ecbdb84a5b966bb587577e5d69772L225-R225) [[4]](diffhunk://#diff-4505abf3272b6504ef692bf20b049aeb554ecbdb84a5b966bb587577e5d69772L245-R245)

**Authorization request store interface and implementation changes:**

* Modified the `authorizationRequestStoreInterface` and its implementation so that `AddRequest`, `GetRequest`, and `ClearRequest` now return errors instead of logging internally, improving error propagation and testability. Removed the logger from the store. [[1]](diffhunk://#diff-a5ab79126bea86bd09fc0efe55e92b8949d09ef3cfb19b15ddc10ff8ea8ecfccL42-L52) [[2]](diffhunk://#diff-a5ab79126bea86bd09fc0efe55e92b8949d09ef3cfb19b15ddc10ff8ea8ecfccL61-R71) [[3]](diffhunk://#diff-a5ab79126bea86bd09fc0efe55e92b8949d09ef3cfb19b15ddc10ff8ea8ecfccL85-R138)
* Updated all related tests in `auth_req_store_test.go` to handle and assert errors returned by the new method signatures. [[1]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L116-R114) [[2]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L126-R125) [[3]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L139-R139) [[4]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L164-R165) [[5]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L198-R200) [[6]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L215-R226) [[7]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L234-R239) [[8]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L247-R253) [[9]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L261-R268) [[10]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L280-R288) [[11]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L299-R308) [[12]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L327-R337) [[13]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L348-R359)

**Code cleanup:**

* Removed unused logger imports and logger fields from the authorization request store and its tests. [[1]](diffhunk://#diff-a5ab79126bea86bd09fc0efe55e92b8949d09ef3cfb19b15ddc10ff8ea8ecfccL31) [[2]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L31-L32) [[3]](diffhunk://#diff-02057e3b5940f97e72309e9462e530a000d47426308f270f18150db3be552b86L73)