### PR TITLE
Refactor invite executor to support send/verify modes

### DIFF
--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -128,13 +128,22 @@
                     ],
                     "action": {
                         "ref": "action_submit_email",
-                        "nextNode": "invite"
+                        "nextNode": "invite_generate"
                     }
                 }
             ]
         },
         {
-            "id": "invite",
+            "id": "invite_generate",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "InviteExecutor",
+                "mode": "generate"
+            },
+            "onSuccess": "invite_verify"
+        },
+        {
+            "id": "invite_verify",
             "type": "TASK_EXECUTION",
             "inputs": [
                 {
@@ -145,7 +154,8 @@
                 }
             ],
             "executor": {
-                "name": "InviteExecutor"
+                "name": "InviteExecutor",
+                "mode": "verify"
             },
             "onSuccess": "prompt_user_details"
         },

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -131,6 +131,8 @@ const (
 	DataConsentPrompt = "consentPrompt"
 	// DataConsentExpiresAt is the key used for the consent expiry timestamp in the flow response.
 	DataConsentExpiresAt = "consentExpiresAt"
+	// DataInviteLink is the key used for the invite link in the flow response additional data.
+	DataInviteLink = "inviteLink"
 )
 
 // DefaultHTTPTimeout defines the default timeout duration for HTTP requests.
@@ -164,6 +166,8 @@ const (
 	RuntimeKeyConsentedAttributes = "consented_attributes"
 	// RuntimeKeyConsentSessionToken holds the signed JWT session token for consent validation.
 	RuntimeKeyConsentSessionToken = "consent_session_token"
+	// RuntimeKeyStoredInviteToken holds the generated invite token stored during the invite send phase.
+	RuntimeKeyStoredInviteToken = "storedInviteToken"
 )
 
 // TODO: Define a go type for InputType when formalizing input types

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -46,8 +46,9 @@ const (
 
 // Executor mode constants
 const (
-	ExecutorModeSend   = "send"
-	ExecutorModeVerify = "verify"
+	ExecutorModeSend     = "send"
+	ExecutorModeGenerate = "generate"
+	ExecutorModeVerify   = "verify"
 )
 
 // User attribute and input constants
@@ -92,12 +93,10 @@ var nonUserAttributes = []string{"userID", "code", "nonce", "state", "flowID",
 	"authorized_permissions", "requested_permissions", "required_attributes", "required_locales",
 	userTypeKey, ouIDKey, defaultOUIDKey, userInputOuName, userInputOuHandle, userInputOuDesc, userInputInviteToken,
 	common.RuntimeKeyUserEligibleForProvisioning, common.RuntimeKeySkipProvisioning,
-	common.RuntimeKeyUserAutoProvisioned, runtimeKeyStoredInviteToken,
+	common.RuntimeKeyUserAutoProvisioned, common.RuntimeKeyStoredInviteToken,
 	common.RuntimeKeyConsentID, common.RuntimeKeyConsentExpiresAt, userInputConsentDecisions,
 	common.RuntimeKeyConsentedAttributes, common.RuntimeKeyConsentSessionToken,
 	"applicationId", "idpId", "senderId"}
-
-const runtimeKeyStoredInviteToken = "storedInviteToken"
 
 // Failure reason constants
 const (

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -56,39 +56,62 @@ func newInviteExecutor(flowFactory core.FlowFactoryInterface) *inviteExecutor {
 	}
 }
 
-// Execute generates the invite link and returns it in AdditionalData.
+// Execute delegates to the appropriate mode handler based on the executor mode.
 func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
+	switch ctx.ExecutorMode {
+	case ExecutorModeGenerate:
+		return e.executeGenerate(ctx)
+	case ExecutorModeVerify:
+		return e.executeVerify(ctx)
+	default:
+		return nil, fmt.Errorf("invalid executor mode for InviteExecutor: %s", ctx.ExecutorMode)
+	}
+}
+
+// executeGenerate generates the invite token and link.
+func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
-	logger.Debug("Executing invite executor")
+	logger.Debug("Executing invite executor in generate mode")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
 		RuntimeData:    make(map[string]string),
 	}
 
-	// Check if inviteToken is provided by the user
+	inviteToken, err := e.getOrGenerateToken(ctx)
+	if err != nil {
+		logger.Debug("Failed to get or generate invite token", log.Error(err))
+		execResp.Status = common.ExecFailure
+		return execResp, nil
+	}
+
+	inviteLink := e.generateInviteLink(ctx, inviteToken)
+
+	execResp.RuntimeData[common.RuntimeKeyStoredInviteToken] = inviteToken
+	execResp.AdditionalData[common.DataInviteLink] = inviteLink
+	execResp.Status = common.ExecComplete
+	return execResp, nil
+}
+
+// executeVerify validates the user-provided invite token against the stored token.
+func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger.Debug("Executing invite executor in verify mode")
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// If the user has not yet provided the invite token, request it
 	if !e.HasRequiredInputs(ctx, execResp) {
-		inviteToken, err := e.getOrGenerateToken(ctx)
-		if err != nil {
-			logger.Debug("Failed to get or generate invite token", log.Error(err))
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = "Failed to generate invite token"
-			return execResp, nil
-		}
-
-		inviteLink := e.generateInviteLink(ctx, inviteToken)
-
-		// Store the token for validation and return the link
-		execResp.RuntimeData[runtimeKeyStoredInviteToken] = inviteToken
-		execResp.AdditionalData["inviteLink"] = inviteLink
-
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
 
 	// User has provided the invite token, validate it against stored token
 	inviteTokenInput := ctx.UserInputs[userInputInviteToken]
-	storedToken, hasStoredToken := ctx.RuntimeData[runtimeKeyStoredInviteToken]
+	storedToken, hasStoredToken := ctx.RuntimeData[common.RuntimeKeyStoredInviteToken]
 
 	if !hasStoredToken {
 		logger.Debug("No invite token found in runtime data")
@@ -111,7 +134,7 @@ func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespons
 
 // getOrGenerateToken retrieves the existing invite token from runtime data or generates a new one.
 func (e *inviteExecutor) getOrGenerateToken(ctx *core.NodeContext) (string, error) {
-	if storedToken, exists := ctx.RuntimeData[runtimeKeyStoredInviteToken]; exists && storedToken != "" {
+	if storedToken, exists := ctx.RuntimeData[common.RuntimeKeyStoredInviteToken]; exists && storedToken != "" {
 		return storedToken, nil
 	}
 

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -72,32 +72,51 @@ func (suite *InviteExecutorTestSuite) TearDownTest() {
 	config.ResetThunderRuntime()
 }
 
-func (suite *InviteExecutorTestSuite) TestExecute_GenerateToken_AdminPhase() {
+func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_GenerateToken() {
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow-id",
-		UserInputs:  make(map[string]string),
-		RuntimeData: make(map[string]string),
+		FlowID:         "test-flow-id",
+		ExecutorMode:   ExecutorModeGenerate,
+		UserInputs:     make(map[string]string),
+		RuntimeData:    make(map[string]string),
+		NodeProperties: make(map[string]interface{}),
 	}
-
-	mockExecutor := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
-	mockExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(false)
 
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
-	assert.NotEmpty(suite.T(), resp.RuntimeData[runtimeKeyStoredInviteToken])
-	assert.Contains(suite.T(), resp.AdditionalData["inviteLink"], "inviteToken=")
-	assert.Contains(suite.T(), resp.AdditionalData["inviteLink"], "flowId=test-flow-id")
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyStoredInviteToken])
+	assert.Contains(suite.T(), resp.AdditionalData[common.DataInviteLink], "inviteToken=")
+	assert.Contains(suite.T(), resp.AdditionalData[common.DataInviteLink], "flowId=test-flow-id")
 }
 
-func (suite *InviteExecutorTestSuite) TestExecute_Idempotency_AdminRetry() {
+func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_Idempotency() {
 	existingToken := "existing-token-123"
 	ctx := &core.NodeContext{
-		FlowID:     "test-flow-id",
-		UserInputs: make(map[string]string),
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeGenerate,
+		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
-			runtimeKeyStoredInviteToken: existingToken,
+			common.RuntimeKeyStoredInviteToken: existingToken,
+		},
+		NodeProperties: make(map[string]interface{}),
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), existingToken, resp.RuntimeData[common.RuntimeKeyStoredInviteToken])
+	assert.Contains(suite.T(), resp.AdditionalData[common.DataInviteLink], existingToken)
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_NoTokenProvided() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeVerify,
+		UserInputs:   make(map[string]string),
+		RuntimeData: map[string]string{
+			common.RuntimeKeyStoredInviteToken: "stored-token",
 		},
 	}
 
@@ -108,19 +127,18 @@ func (suite *InviteExecutorTestSuite) TestExecute_Idempotency_AdminRetry() {
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
-	assert.Equal(suite.T(), existingToken, resp.RuntimeData[runtimeKeyStoredInviteToken])
-	assert.Contains(suite.T(), resp.AdditionalData["inviteLink"], existingToken)
 }
 
-func (suite *InviteExecutorTestSuite) TestExecute_ValidationSuccess_UserPhase() {
+func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationSuccess() {
 	token := "valid-token"
 	ctx := &core.NodeContext{
-		FlowID: "test-flow-id",
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeVerify,
 		UserInputs: map[string]string{
 			userInputInviteToken: token,
 		},
 		RuntimeData: map[string]string{
-			runtimeKeyStoredInviteToken: token,
+			common.RuntimeKeyStoredInviteToken: token,
 		},
 	}
 
@@ -133,14 +151,15 @@ func (suite *InviteExecutorTestSuite) TestExecute_ValidationSuccess_UserPhase() 
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
 }
 
-func (suite *InviteExecutorTestSuite) TestExecute_ValidationFailure_Mismatch() {
+func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationFailure_Mismatch() {
 	ctx := &core.NodeContext{
-		FlowID: "test-flow-id",
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeVerify,
 		UserInputs: map[string]string{
 			userInputInviteToken: "wrong-token",
 		},
 		RuntimeData: map[string]string{
-			runtimeKeyStoredInviteToken: "correct-token",
+			common.RuntimeKeyStoredInviteToken: "correct-token",
 		},
 	}
 
@@ -154,9 +173,10 @@ func (suite *InviteExecutorTestSuite) TestExecute_ValidationFailure_Mismatch() {
 	assert.Equal(suite.T(), "Invalid invite token", resp.FailureReason)
 }
 
-func (suite *InviteExecutorTestSuite) TestExecute_ValidationFailure_NoStoredToken() {
+func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationFailure_NoStoredToken() {
 	ctx := &core.NodeContext{
-		FlowID: "test-flow-id",
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeVerify,
 		UserInputs: map[string]string{
 			userInputInviteToken: "some-token",
 		},
@@ -171,6 +191,21 @@ func (suite *InviteExecutorTestSuite) TestExecute_ValidationFailure_NoStoredToke
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
 	assert.Equal(suite.T(), "Invalid invite token", resp.FailureReason)
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_InvalidMode() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		ExecutorMode: "invalid",
+		UserInputs:   make(map[string]string),
+		RuntimeData:  make(map[string]string),
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), resp)
+	assert.Contains(suite.T(), err.Error(), "invalid executor mode for InviteExecutor")
 }
 
 func TestInviteExecutorSuite(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the invite step of the user onboarding flow to introduce explicit "send" and "verify" phases, improving clarity and separation of responsibilities. The `InviteExecutor` now operates in two modes (`send` and `verify`), and the related constants, runtime data, and tests have been updated to match this new structure.

**User Onboarding Flow Refactor:**
- Split the invite step into two distinct nodes: `invite_send` (send phase) and `invite_verify` (verify phase) in `user_onboarding_flow.json`. Each uses `InviteExecutor` with the appropriate mode, clarifying the flow and responsibilities. [[1]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL131-R146) [[2]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL148-R158)

**Invite Executor Enhancements:**
- Refactored `InviteExecutor` to delegate execution based on `ExecutorMode`, introducing `executeSend` for generating and storing invite tokens and links, and `executeVerify` for validating user-provided tokens. This improves code organization and maintainability. [[1]](diffhunk://#diff-dccaf85100a16c4bdaed19f643df139636c702ce9658b627c9276a816bf32306L59-L70) [[2]](diffhunk://#diff-dccaf85100a16c4bdaed19f643df139636c702ce9658b627c9276a816bf32306L81-R115)
- Added new runtime and additional data keys (`RuntimeKeyStoredInviteToken`, `additionalDataInviteLink`) for clearer data handling and naming consistency. [[1]](diffhunk://#diff-9efdd475ef67a1c9e9acb315486fdf7b3fdd9de00897898495ea69c599cbf79dR167-R168) [[2]](diffhunk://#diff-82a5330129814e06de3d54d982ddd0ee9e70262be578aa6dcfbe0babfa628d4fR86-R90) [[3]](diffhunk://#diff-82a5330129814e06de3d54d982ddd0ee9e70262be578aa6dcfbe0babfa628d4fL95-L101)

**Testing Improvements:**
- Updated and expanded unit tests to cover both send and verify modes, including idempotency, validation success/failure, and invalid mode handling, ensuring robust coverage of the new logic. [[1]](diffhunk://#diff-f5f71f7599ac36afe94b15aec541de18a478a996c76e46f1024e3342d553773eL75-R119) [[2]](diffhunk://#diff-f5f71f7599ac36afe94b15aec541de18a478a996c76e46f1024e3342d553773eL111-R141) [[3]](diffhunk://#diff-f5f71f7599ac36afe94b15aec541de18a478a996c76e46f1024e3342d553773eL136-R162) [[4]](diffhunk://#diff-f5f71f7599ac36afe94b15aec541de18a478a996c76e46f1024e3342d553773eL157-R179) [[5]](diffhunk://#diff-f5f71f7599ac36afe94b15aec541de18a478a996c76e46f1024e3342d553773eR196-R210)

Related Issue:
- https://github.com/asgardeo/thunder/issues/1718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured user onboarding flow with a two-step invitation process: token generation now occurs in a dedicated initial step, followed by a separate verification step before users provide additional details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->