### PR TITLE
Fix declarative resource validations

### DIFF
--- a/backend/internal/flow/mgt/init.go
+++ b/backend/internal/flow/mgt/init.go
@@ -142,6 +142,11 @@ func isCompositeModeEnabled() bool {
 	return getFlowStoreMode() == serverconst.StoreModeComposite
 }
 
+// isDeclarativeModeEnabled checks if immutable-only store mode is enabled for flows.
+func isDeclarativeModeEnabled() bool {
+	return getFlowStoreMode() == serverconst.StoreModeDeclarative
+}
+
 // registerRoutes registers the HTTP routes for flow management.
 func registerRoutes(mux *http.ServeMux, handler *flowMgtHandler) {
 	opts1 := middleware.CORSOptions{

--- a/backend/internal/flow/mgt/service.go
+++ b/backend/internal/flow/mgt/service.go
@@ -28,7 +28,6 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/core"
 	"github.com/asgardeo/thunder/internal/flow/executor"
 	"github.com/asgardeo/thunder/internal/system/config"
-	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
@@ -124,8 +123,8 @@ func (s *flowMgtService) ListFlows(limit, offset int, flowType common.FlowType) 
 // CreateFlow creates a new flow definition with version 1.
 func (s *flowMgtService) CreateFlow(flowDef *FlowDefinition) (
 	*CompleteFlowDefinition, *serviceerror.ServiceError) {
-	if err := declarativeresource.CheckDeclarativeCreate(); err != nil {
-		return nil, err
+	if isDeclarativeModeEnabled() {
+		return nil, &ErrorFlowDeclarativeReadOnly
 	}
 
 	if err := validateFlowDefinition(flowDef); err != nil {
@@ -206,8 +205,8 @@ func (s *flowMgtService) GetFlowByHandle(handle string, flowType common.FlowType
 // Old versions are retained up to the configured max_version_history limit.
 func (s *flowMgtService) UpdateFlow(flowID string, flowDef *FlowDefinition) (
 	*CompleteFlowDefinition, *serviceerror.ServiceError) {
-	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
-		return nil, err
+	if isDeclarativeModeEnabled() {
+		return nil, &ErrorFlowDeclarativeReadOnly
 	}
 
 	if flowID == "" {
@@ -260,8 +259,8 @@ func (s *flowMgtService) UpdateFlow(flowID string, flowDef *FlowDefinition) (
 
 // DeleteFlow deletes a flow definition and all its version history.
 func (s *flowMgtService) DeleteFlow(flowID string) *serviceerror.ServiceError {
-	if err := declarativeresource.CheckDeclarativeDelete(); err != nil {
-		return err
+	if isDeclarativeModeEnabled() {
+		return &ErrorFlowDeclarativeReadOnly
 	}
 
 	if flowID == "" {
@@ -363,6 +362,10 @@ func (s *flowMgtService) GetFlowVersion(flowID string, version int) (
 // Creates a new version by copying the configuration from the specified version.
 func (s *flowMgtService) RestoreFlowVersion(flowID string, version int) (
 	*CompleteFlowDefinition, *serviceerror.ServiceError) {
+	if isDeclarativeModeEnabled() {
+		return nil, &ErrorFlowDeclarativeReadOnly
+	}
+
 	if flowID == "" {
 		return nil, &ErrorMissingFlowID
 	}

--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -27,7 +27,6 @@ import (
 
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/database/transaction"
-	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/security"
@@ -424,11 +423,6 @@ func (ous *organizationUnitService) UpdateOrganizationUnit(
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	logger.Debug("Updating organization unit", log.String("ouID", id))
 
-	// Fail if store is in declarative mode
-	if isDeclarativeModeEnabled() {
-		return OrganizationUnit{}, &ErrorCannotModifyDeclarativeResource
-	}
-
 	if svcErr := ous.checkOUAccess(ctx, security.ActionUpdateOU, id); svcErr != nil {
 		return OrganizationUnit{}, svcErr
 	}
@@ -474,10 +468,6 @@ func (ous *organizationUnitService) UpdateOrganizationUnitByPath(
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	logger.Debug("Updating organization unit by path", log.String("path", handlePath))
-
-	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
-		return OrganizationUnit{}, err
-	}
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -624,11 +614,6 @@ func (ous *organizationUnitService) DeleteOrganizationUnit(ctx context.Context, 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	logger.Debug("Deleting organization unit", log.String("ouID", id))
 
-	// Fail if store is in declarative mode
-	if isDeclarativeModeEnabled() {
-		return &ErrorCannotModifyDeclarativeResource
-	}
-
 	if svcErr := ous.checkOUAccess(ctx, security.ActionDeleteOU, id); svcErr != nil {
 		return svcErr
 	}
@@ -673,10 +658,6 @@ func (ous *organizationUnitService) DeleteOrganizationUnitByPath(
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	logger.Debug("Deleting organization unit by path", log.String("path", handlePath))
-
-	if err := declarativeresource.CheckDeclarativeDelete(); err != nil {
-		return err
-	}
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {

--- a/backend/internal/ou/service_declarative_mode_test.go
+++ b/backend/internal/ou/service_declarative_mode_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/config"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -32,6 +33,7 @@ import (
 type DeclarativeModeServiceTestSuite struct {
 	suite.Suite
 	service OrganizationUnitServiceInterface
+	store   *organizationUnitStoreInterfaceMock
 }
 
 func (suite *DeclarativeModeServiceTestSuite) SetupTest() {
@@ -45,9 +47,15 @@ func (suite *DeclarativeModeServiceTestSuite) SetupTest() {
 	err := config.InitializeThunderRuntime("/tmp/test", testConfig)
 	suite.Require().NoError(err)
 
-	// Create service with mock store (store won't be called in declarative mode)
-	mockStore := new(organizationUnitStoreInterfaceMock)
-	suite.service = newOrganizationUnitService(nil, mockStore, nil)
+	// Create service with mock store and dependencies
+	suite.store = newOrganizationUnitStoreInterfaceMock(suite.T())
+	mtx := new(mockTransactioner)
+	mtx.On("Transact", mock.Anything, mock.Anything).Return(nil).Maybe()
+	suite.service = &organizationUnitService{
+		ouStore:       suite.store,
+		authzService:  newAllowAllAuthz(suite.T()),
+		transactioner: mtx,
+	}
 }
 
 func (suite *DeclarativeModeServiceTestSuite) TearDownTest() {
@@ -70,6 +78,14 @@ func (suite *DeclarativeModeServiceTestSuite) TestCreateOrganizationUnit_FailsIn
 }
 
 func (suite *DeclarativeModeServiceTestSuite) TestUpdateOrganizationUnit_FailsInDeclarativeMode() {
+	suite.store.On("GetOrganizationUnit", mock.Anything, "ou-1").Return(OrganizationUnit{
+		ID:          "ou-1",
+		Name:        "Existing OU",
+		Handle:      "existing-ou",
+		Description: "Existing Description",
+	}, nil).Once()
+	suite.store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").Return(true).Once()
+
 	request := OrganizationUnitRequest{
 		Name:        "Updated OU",
 		Handle:      "updated-ou",
@@ -85,6 +101,14 @@ func (suite *DeclarativeModeServiceTestSuite) TestUpdateOrganizationUnit_FailsIn
 }
 
 func (suite *DeclarativeModeServiceTestSuite) TestUpdateOrganizationUnitByPath_FailsInDeclarativeMode() {
+	suite.store.On("GetOrganizationUnitByPath", mock.Anything, []string{"path", "to", "ou"}).Return(OrganizationUnit{
+		ID:          "ou-1",
+		Name:        "Existing OU",
+		Handle:      "existing-ou",
+		Description: "Existing Description",
+	}, nil).Once()
+	suite.store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").Return(true).Once()
+
 	request := OrganizationUnitRequest{
 		Name:        "Updated OU",
 		Handle:      "updated-ou",
@@ -93,13 +117,15 @@ func (suite *DeclarativeModeServiceTestSuite) TestUpdateOrganizationUnitByPath_F
 
 	ou, err := suite.service.UpdateOrganizationUnitByPath(context.Background(), "/path/to/ou", request)
 
-	// Should fail because even getting the OU to update will check declarative mode
-	// Or fail during update operation
 	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorCannotModifyDeclarativeResource.Code, err.Code)
 	assert.Equal(suite.T(), OrganizationUnit{}, ou)
 }
 
 func (suite *DeclarativeModeServiceTestSuite) TestDeleteOrganizationUnit_FailsInDeclarativeMode() {
+	suite.store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").Return(true, nil).Once()
+	suite.store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").Return(true).Once()
+
 	err := suite.service.DeleteOrganizationUnit(context.Background(), "ou-1")
 
 	// Should fail with immutable resource error
@@ -108,11 +134,15 @@ func (suite *DeclarativeModeServiceTestSuite) TestDeleteOrganizationUnit_FailsIn
 }
 
 func (suite *DeclarativeModeServiceTestSuite) TestDeleteOrganizationUnitByPath_FailsInDeclarativeMode() {
+	suite.store.On("GetOrganizationUnitByPath", mock.Anything, []string{"path", "to", "ou"}).Return(OrganizationUnit{
+		ID: "ou-1",
+	}, nil).Once()
+	suite.store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").Return(true).Once()
+
 	err := suite.service.DeleteOrganizationUnitByPath(context.Background(), "/path/to/ou")
 
-	// Should fail because even getting the OU to delete will check declarative mode
-	// Or fail during delete operation
 	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorCannotModifyDeclarativeResource.Code, err.Code)
 }
 
 func TestDeclarativeModeServiceTestSuite(t *testing.T) {

--- a/backend/internal/user/composite_store_test.go
+++ b/backend/internal/user/composite_store_test.go
@@ -314,7 +314,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetUserGroups() {
 func (suite *CompositeStoreTestSuite) TestCompositeStore_IdentifyUser() {
 	ctx := context.Background()
 	filters := map[string]interface{}{"username": "alice"}
-	userID := "user-1"
+	userID := svcTestUserID1
 
 	suite.mockDBStore.On("IdentifyUser", ctx, filters).Return(&userID, nil)
 

--- a/backend/internal/user/error_constants.go
+++ b/backend/internal/user/error_constants.go
@@ -166,6 +166,13 @@ var (
 		Error:            "Invalid request format",
 		ErrorDescription: "Invalid credential fields in request",
 	}
+	// ErrorCannotModifyDeclarativeResource is the error returned when trying to modify a declarative user.
+	ErrorCannotModifyDeclarativeResource = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "USR-1025",
+		Error:            "Cannot modify declarative resource",
+		ErrorDescription: "The user is declarative and cannot be modified or deleted",
+	}
 )
 
 // Server errors for user management operations.

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -537,6 +537,11 @@ func (us *userService) UpdateUser(ctx context.Context, userID string, user *User
 		}
 	}
 
+	// Check if user is declarative (immutable)
+	if svcErr := us.checkUserDeclarative(ctx, userID, logger); svcErr != nil {
+		return nil, svcErr
+	}
+
 	// Ensure the user object has the correct ID
 	user.ID = userID
 
@@ -663,6 +668,11 @@ func (us *userService) UpdateUserAttributes(
 		return nil, svcErr
 	}
 
+	// Check if user is declarative (immutable)
+	if svcErr := us.checkUserDeclarative(ctx, userID, logger); svcErr != nil {
+		return nil, svcErr
+	}
+
 	var updatedUser User
 	var capturedSvcErr *serviceerror.ServiceError
 
@@ -785,6 +795,11 @@ func (us *userService) batchUpdateUserCredentials(
 	// Check authz outside the transaction so a denial is returned directly without a rollback.
 	if svcErr := us.checkUserAccess(
 		ctx, security.ActionUpdateUser, existingUser.OrganizationUnit, userID); svcErr != nil {
+		return svcErr
+	}
+
+	// Check if user is declarative (immutable)
+	if svcErr := us.checkUserDeclarative(ctx, userID, logger); svcErr != nil {
 		return svcErr
 	}
 
@@ -1041,6 +1056,11 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceer
 	// Check authz using the user's OU ID.
 	if svcErr := us.checkUserAccess(
 		ctx, security.ActionDeleteUser, existingUser.OrganizationUnit, userID); svcErr != nil {
+		return svcErr
+	}
+
+	// Check if user is declarative (immutable)
+	if svcErr := us.checkUserDeclarative(ctx, userID, logger); svcErr != nil {
 		return svcErr
 	}
 
@@ -1517,6 +1537,25 @@ func mapOUServiceError(
 	logFields = append(logFields, log.Any("error", svcErr))
 	logger.Error(fmt.Sprintf("Organization unit service error while %s", context), logFields...)
 	return &ErrorInternalServerError
+}
+
+// checkUserDeclarative checks if a user is declarative and returns an error if it is.
+func (us *userService) checkUserDeclarative(
+	ctx context.Context, userID string, logger *log.Logger,
+) *serviceerror.ServiceError {
+	isDeclarative, err := us.userStore.IsUserDeclarative(ctx, userID)
+	if err != nil {
+		if errors.Is(err, ErrUserNotFound) {
+			return &ErrorUserNotFound
+		}
+		logger.Error("Failed to check if user is declarative",
+			log.String("userID", userID), log.Error(err))
+		return &ErrorInternalServerError
+	}
+	if isDeclarative {
+		return &ErrorCannotModifyDeclarativeResource
+	}
+	return nil
 }
 
 // checkUserAccess validates that the caller is authorized to perform the given action on a user.

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -46,9 +46,10 @@ import (
 )
 
 const (
-	svcTestUserID1   = "user-1"
-	svcTestUserID123 = "user-123"
-	testUserType     = "employee"
+	svcTestUserID1            = "user-1"
+	svcTestUserID123          = "user-123"
+	svcTestDeclarativeUserID1 = "declarative-user-1"
+	testUserType              = "employee"
 )
 const testOrgID = "11111111-1111-1111-1111-111111111111"
 
@@ -230,6 +231,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 				existingUserID := svcTestUserID123
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userStoreMock := newUserStoreInterfaceMock(t)
+				userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				userStoreMock.
 					On("IdentifyUser", mock.Anything, mock.AnythingOfType("map[string]interface {}")).
 					Return(&existingUserID, nil).
@@ -270,6 +272,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userStoreMock := newUserStoreInterfaceMock(t)
+				userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				userStoreMock.
 					On("IdentifyUser", mock.Anything, mock.AnythingOfType("map[string]interface {}")).
 					Return((*string)(nil), nil).
@@ -308,6 +311,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userStoreMock := newUserStoreInterfaceMock(t)
+				userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				userStoreMock.
 					On("IdentifyUser", mock.Anything, mock.AnythingOfType("map[string]interface {}")).
 					Return((*string)(nil), errors.New("store failure")).
@@ -353,6 +357,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 				existingUserID := svcTestUserID123
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				userStoreMock := newUserStoreInterfaceMock(t)
+				userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				userStoreMock.
 					On("IdentifyUser", mock.Anything, mock.AnythingOfType("map[string]interface {}")).
 					Return(&existingUserID, nil).
@@ -757,6 +762,7 @@ func TestUserService_CreateUser_UsesTransactionAndStore(t *testing.T) {
 		Once()
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	var capturedCtx context.Context
 	storeMock.
 		On("CreateUser", mock.Anything, mock.MatchedBy(func(u User) bool {
@@ -817,6 +823,7 @@ func TestUserService_CreateUser_PropagatesStoreError(t *testing.T) {
 		Once()
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.
 		On("CreateUser", mock.Anything, mock.Anything, mock.Anything).
 		Return(storeErr).
@@ -867,6 +874,7 @@ func TestUserService_CreateUser_TransactionerError(t *testing.T) {
 		Once()
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything, mock.Anything)
 
 	txMock := &fakeTransactioner{err: errors.New("tx failed")}
@@ -1076,6 +1084,7 @@ func TestUserService_UpdateUserCredentials_Validation(t *testing.T) {
 
 	t.Run("ReturnsInvalidCredentialForUnsupportedType", func(t *testing.T) {
 		userStoreMock := newUserStoreInterfaceMock(t)
+		userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 		userStoreMock.
 			On("GetUser", mock.Anything, svcTestUserID1).
 			Return(User{ID: svcTestUserID1}, nil).
@@ -1116,6 +1125,7 @@ func TestUserService_UpdateUserCredentials_Validation(t *testing.T) {
 
 func TestUserService_UpdateUserCredentials_UserNotFound(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	userStoreMock.
 		On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{}, ErrUserNotFound).
@@ -1135,6 +1145,7 @@ func TestUserService_UpdateUserCredentials_UserNotFound(t *testing.T) {
 
 func TestUserService_UpdateUserCredentials_Succeeds(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	existingCredentials := Credentials{
 		CredentialType("password"): {
 			{
@@ -1240,6 +1251,7 @@ func TestUserService_UpdateUserCredentials_Succeeds(t *testing.T) {
 
 func TestUserService_UpdateUserCredentials_MultiplePasskeys(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	existingCredentials := Credentials{}
 
 	userStoreMock.
@@ -1308,6 +1320,7 @@ func TestUserService_UpdateUserCredentials_MultiplePasskeys(t *testing.T) {
 
 func TestUserService_UpdateUserCredentials_RejectsMultiplePasswords(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	existingCredentials := Credentials{}
 
 	userStoreMock.
@@ -1376,6 +1389,7 @@ func TestUserService_GetUserCredentialsByType_Validation(t *testing.T) {
 
 func TestUserService_GetUserCredentialsByType_UserNotFound(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	userStoreMock.
 		On("GetCredentials", mock.Anything, svcTestUserID1).
 		Return(User{}, Credentials{}, ErrUserNotFound).
@@ -1393,6 +1407,7 @@ func TestUserService_GetUserCredentialsByType_UserNotFound(t *testing.T) {
 
 func TestUserService_GetUserCredentialsByType_StoreError(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	userStoreMock.
 		On("GetCredentials", mock.Anything, svcTestUserID1).
 		Return(User{}, Credentials{}, errors.New("database error")).
@@ -1410,6 +1425,7 @@ func TestUserService_GetUserCredentialsByType_StoreError(t *testing.T) {
 
 func TestUserService_GetUserCredentialsByType_CredentialTypeNotFound(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	existingCredentials := Credentials{
 		"pin": {
 			{
@@ -1436,6 +1452,7 @@ func TestUserService_GetUserCredentialsByType_CredentialTypeNotFound(t *testing.
 
 func TestUserService_GetUserCredentialsByType_EmptyCredentialArray(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	existingCredentials := Credentials{
 		"password": {}, // Empty array
 		"pin": {
@@ -1463,6 +1480,7 @@ func TestUserService_GetUserCredentialsByType_EmptyCredentialArray(t *testing.T)
 
 func TestUserService_GetUserCredentialsByType_Succeeds(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	existingCredentials := Credentials{
 		"password": {
 			{
@@ -1509,6 +1527,7 @@ func TestUserService_GetUserCredentialsByType_Succeeds(t *testing.T) {
 
 func TestUserService_GetUserCredentialsByType_MultipleCredentials(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	existingCredentials := Credentials{
 		"passkey": {
 			{Value: "public-key-1"},
@@ -1551,6 +1570,7 @@ func TestUserService_UpdateUserAttributes_Validation(t *testing.T) {
 
 func TestUserService_UpdateUserAttributes_RejectsCredentialAttributes(t *testing.T) {
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, Type: "Person"}, nil).
 		Once()
@@ -1574,6 +1594,7 @@ func TestUserService_UpdateUserAttributes_RejectsCredentialAttributes(t *testing
 
 func TestUserService_UpdateUserAttributes_UserNotFound(t *testing.T) {
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, svcTestUserID1).Return(User{}, ErrUserNotFound).Once()
 
 	service := &userService{
@@ -1590,6 +1611,7 @@ func TestUserService_UpdateUserAttributes_UserNotFound(t *testing.T) {
 
 func TestUserService_UpdateUserAttributes_SchemaValidationFails(t *testing.T) {
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.
 		On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, Type: testUserType, Attributes: json.RawMessage(`{"email":"old"}`)}, nil)
@@ -1620,6 +1642,7 @@ func TestUserService_UpdateUserAttributes_SchemaValidationFails(t *testing.T) {
 
 func TestUserService_UpdateUserAttributes_Succeeds(t *testing.T) {
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.
 		On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, Type: testUserType,
@@ -1673,6 +1696,7 @@ func TestUserService_GetUser_ReturnsUser(t *testing.T) {
 	expectedUser := User{ID: userID, OrganizationUnit: testOrgID}
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, userID).Return(expectedUser, nil).Once()
 
 	service := &userService{
@@ -1689,6 +1713,7 @@ func TestUserService_DeleteUser(t *testing.T) {
 	userID := svcTestUserID1
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, userID).
 		Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 	storeMock.On("DeleteUser", mock.Anything, userID).Return(nil).Once()
@@ -1712,6 +1737,7 @@ func TestUserService_UpdateUser(t *testing.T) {
 		Attributes: json.RawMessage(`{"updated":"true"}`)}
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 
 	// Mock GetUser pre-fetch for authz check
 	storeMock.On("GetUser", mock.Anything, userID).
@@ -1766,6 +1792,7 @@ func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
 	}
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	hashMock := hashmock.NewHashServiceInterfaceMock(t)
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
@@ -2083,6 +2110,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 			}
 
 			storeMock := newUserStoreInterfaceMock(t)
+			storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 			hashMock := hashmock.NewHashServiceInterfaceMock(t)
 			ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 			userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
@@ -2314,6 +2342,7 @@ func TestUserService_UpdateUser_AuthzBranches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			storeMock := newUserStoreInterfaceMock(t)
+			storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 			ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 			userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 			hashMock := hashmock.NewHashServiceInterfaceMock(t)
@@ -2428,6 +2457,7 @@ func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
 
 	// Setup mocks
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 	hashMock := hashmock.NewHashServiceInterfaceMock(t)
@@ -2557,6 +2587,7 @@ func TestUserService_GetUserList(t *testing.T) {
 	filters := map[string]interface{}{}
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUserListCount", mock.Anything, filters).Return(5, nil).Once()
 	storeMock.On("GetUserList", mock.Anything, limit, offset, filters).
 		Return([]User{{ID: svcTestUserID1}}, nil).
@@ -2581,6 +2612,7 @@ func TestUserService_GetUserList_ScopedByOUIDs(t *testing.T) {
 	ouIDs := []string{testOrgID}
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUserListCountByOUIDs", mock.Anything, ouIDs, filters).Return(3, nil).Once()
 	storeMock.On("GetUserListByOUIDs", mock.Anything, ouIDs, limit, offset, filters).
 		Return([]User{{ID: svcTestUserID1, OrganizationUnit: testOrgID}}, nil).
@@ -2625,6 +2657,7 @@ func TestUserService_GetUserList_EmptyOUIDs(t *testing.T) {
 
 func TestUserService_GetUserGroups(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	userID := svcTestUserID123
 	limit, offset := 10, 0
 
@@ -2648,6 +2681,7 @@ func TestUserService_GetUserGroups(t *testing.T) {
 
 func TestUserService_VerifyUser(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	mockHash := hashmock.NewHashServiceInterfaceMock(t)
 	userID := svcTestUserID123
 	creds := map[string]interface{}{"password": "password123"}
@@ -2680,6 +2714,7 @@ func TestUserService_VerifyUser(t *testing.T) {
 
 func TestUserService_AuthenticateUser(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	mockHash := hashmock.NewHashServiceInterfaceMock(t)
 
 	identifiers := map[string]interface{}{
@@ -2719,6 +2754,7 @@ func TestUserService_AuthenticateUser(t *testing.T) {
 
 func TestUserService_ValidateUserIDs(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	userIDs := []string{"u1", "u2"}
 
 	mockStore.On("ValidateUserIDs", mock.Anything, userIDs).Return([]string{}, nil)
@@ -2801,6 +2837,7 @@ func TestUserService_ValidateUserIDsInOUs(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			storeMock := newUserStoreInterfaceMock(t)
+			storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 			if tc.setup != nil {
 				tc.setup(storeMock)
 			}
@@ -2824,6 +2861,7 @@ func TestUserService_ValidateUserIDsInOUs(t *testing.T) {
 
 func TestUserService_GetUserGroups_ErrorCases(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	service := &userService{
 		userStore:    mockStore,
 		authzService: newAllowAllAuthz(t),
@@ -2868,6 +2906,7 @@ func TestUserService_GetUserGroups_ErrorCases(t *testing.T) {
 
 func TestUserService_VerifyUser_ErrorCases(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	mockHash := hashmock.NewHashServiceInterfaceMock(t)
 	service := &userService{userStore: mockStore, hashService: mockHash}
 	ctx := context.Background()
@@ -2924,6 +2963,7 @@ func TestUserService_VerifyUser_ErrorCases(t *testing.T) {
 
 func TestUserService_AuthenticateUser_ErrorCases(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	service := &userService{userStore: mockStore}
 	ctx := context.Background()
 
@@ -2972,6 +3012,7 @@ func TestBuildPaginationLinks(t *testing.T) {
 
 func TestUserService_CRUD_ErrorCases(t *testing.T) {
 	mockStore := newUserStoreInterfaceMock(t)
+	mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	service := &userService{
 		userStore:     mockStore,
 		transactioner: &fakeTransactioner{},
@@ -3156,6 +3197,7 @@ func TestUserService_IdentifyVerify_EdgeCases(t *testing.T) {
 
 	t.Run("VerifyUser_InvalidCredentialType", func(t *testing.T) {
 		mockStore := newUserStoreInterfaceMock(t)
+		mockStore.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 		mockStore.On("GetCredentials", mock.Anything, "u1").
 			Return(User{ID: "u1"}, Credentials{CredentialType("password"): []Credential{{Value: "h"}}}, nil).Once()
 		service := &userService{userStore: mockStore}
@@ -3167,6 +3209,7 @@ func TestUserService_IdentifyVerify_EdgeCases(t *testing.T) {
 
 func TestUserService_MoreErrorCases(t *testing.T) {
 	storeMock := &userStoreInterfaceMock{}
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 	txMock := &fakeTransactioner{}
@@ -3601,6 +3644,7 @@ func TestUserService_CreateUser_GetCredentialAttributesInternalError(t *testing.
 
 func TestUserService_UpdateUser_NilSchemaService(t *testing.T) {
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, OrganizationUnit: testOrgID, Type: testUserType}, nil).Once()
 
@@ -3629,6 +3673,7 @@ func TestUserService_UpdateUser_SchemaNotFound(t *testing.T) {
 		Return(nil, &userschema.ErrorUserSchemaNotFound).Once()
 
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, OrganizationUnit: testOrgID, Type: testUserType}, nil).Once()
 
@@ -3654,6 +3699,7 @@ func TestUserService_UpdateUser_SchemaNotFound(t *testing.T) {
 
 func TestUserService_UpdateUserAttributes_NilSchemaService(t *testing.T) {
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, Type: testUserType}, nil).Once()
 
@@ -3671,6 +3717,7 @@ func TestUserService_UpdateUserAttributes_NilSchemaService(t *testing.T) {
 
 func TestUserService_UpdateUserAttributes_SchemaNotFound(t *testing.T) {
 	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	storeMock.On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, Type: testUserType}, nil).Once()
 
@@ -3693,6 +3740,7 @@ func TestUserService_UpdateUserAttributes_SchemaNotFound(t *testing.T) {
 
 func TestUserService_UpdateUserCredentials_NilSchemaService(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	userStoreMock.On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, OrganizationUnit: testOrgID, Type: testUserType}, nil).Once()
 	userStoreMock.On("GetCredentials", mock.Anything, svcTestUserID1).
@@ -3712,6 +3760,7 @@ func TestUserService_UpdateUserCredentials_NilSchemaService(t *testing.T) {
 
 func TestUserService_UpdateUserCredentials_SchemaNotFound(t *testing.T) {
 	userStoreMock := newUserStoreInterfaceMock(t)
+	userStoreMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	userStoreMock.On("GetUser", mock.Anything, svcTestUserID1).
 		Return(User{ID: svcTestUserID1, OrganizationUnit: testOrgID, Type: testUserType}, nil).Once()
 	userStoreMock.On("GetCredentials", mock.Anything, svcTestUserID1).
@@ -3819,6 +3868,7 @@ func TestUserService_GetUserList_ErrorCases(t *testing.T) {
 			name: "AllAllowed_GetUserListCount_Error_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUserListCount", mock.Anything, filters).Return(0, storeErr).Once()
 				return &userService{
 					userStore:    storeMock,
@@ -3831,6 +3881,7 @@ func TestUserService_GetUserList_ErrorCases(t *testing.T) {
 			name: "AllAllowed_GetUserList_Error_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUserListCount", mock.Anything, filters).Return(5, nil).Once()
 				storeMock.On("GetUserList", mock.Anything, limit, offset, filters).
 					Return(nil, storeErr).Once()
@@ -3845,6 +3896,7 @@ func TestUserService_GetUserList_ErrorCases(t *testing.T) {
 			name: "ScopedOUIDs_GetUserListCountByOUIDs_Error_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUserListCountByOUIDs", mock.Anything, ouIDs, filters).
 					Return(0, storeErr).Once()
 				authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
@@ -3861,6 +3913,7 @@ func TestUserService_GetUserList_ErrorCases(t *testing.T) {
 			name: "ScopedOUIDs_GetUserListByOUIDs_Error_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUserListCountByOUIDs", mock.Anything, ouIDs, filters).Return(3, nil).Once()
 				storeMock.On("GetUserListByOUIDs", mock.Anything, ouIDs, limit, offset, filters).
 					Return(nil, storeErr).Once()
@@ -4024,6 +4077,7 @@ func TestUserService_GetUser_ErrorCases(t *testing.T) {
 			name: "StoreError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).Return(User{}, storeErr).Once()
 				return &userService{
 					userStore:    storeMock,
@@ -4036,6 +4090,7 @@ func TestUserService_GetUser_ErrorCases(t *testing.T) {
 			name: "AuthzDenied_ReturnsUnauthorized",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4054,6 +4109,7 @@ func TestUserService_GetUser_ErrorCases(t *testing.T) {
 			name: "AuthzServiceError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4102,6 +4158,7 @@ func TestUserService_GetUserGroups_AuthzChecks(t *testing.T) {
 			name: "AuthzDenied_ReturnsUnauthorized",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4120,6 +4177,7 @@ func TestUserService_GetUserGroups_AuthzChecks(t *testing.T) {
 			name: "AuthzServiceError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4167,6 +4225,7 @@ func TestUserService_UpdateUser_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "GetUser_NotFound_ReturnsUserNotFound",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).Return(User{}, ErrUserNotFound).Once()
 				return &userService{
 					userStore:    storeMock,
@@ -4179,6 +4238,7 @@ func TestUserService_UpdateUser_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "GetUser_StoreError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).Return(User{}, storeErr).Once()
 				return &userService{
 					userStore:    storeMock,
@@ -4191,6 +4251,7 @@ func TestUserService_UpdateUser_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "AuthzDenied_ReturnsUnauthorized",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4209,6 +4270,7 @@ func TestUserService_UpdateUser_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "AuthzServiceError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4256,6 +4318,7 @@ func TestUserService_UpdateUserAttributes_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "GetUser_StoreError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).Return(User{}, storeErr).Once()
 				return &userService{
 					userStore:    storeMock,
@@ -4270,6 +4333,7 @@ func TestUserService_UpdateUserAttributes_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "AuthzDenied_ReturnsUnauthorized",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				// Single pre-fetch: used for both schema lookup and authz check.
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, Type: testUserType, OrganizationUnit: testOrgID}, nil).Once()
@@ -4295,6 +4359,7 @@ func TestUserService_UpdateUserAttributes_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "AuthzServiceError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				// Single pre-fetch: used for both schema lookup and authz check.
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, Type: testUserType, OrganizationUnit: testOrgID}, nil).Once()
@@ -4347,6 +4412,7 @@ func TestUserService_UpdateUserCredentials_PreFetchAndAuthzChecks(t *testing.T) 
 			name: "GetUser_StoreError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).Return(User{}, storeErr).Once()
 				return &userService{
 					userStore:    storeMock,
@@ -4359,6 +4425,7 @@ func TestUserService_UpdateUserCredentials_PreFetchAndAuthzChecks(t *testing.T) 
 			name: "AuthzDenied_ReturnsUnauthorized",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4377,6 +4444,7 @@ func TestUserService_UpdateUserCredentials_PreFetchAndAuthzChecks(t *testing.T) 
 			name: "AuthzServiceError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4421,6 +4489,7 @@ func TestUserService_DeleteUser_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "GetUser_StoreError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).Return(User{}, storeErr).Once()
 				return &userService{
 					userStore:     storeMock,
@@ -4434,6 +4503,7 @@ func TestUserService_DeleteUser_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "AuthzDenied_ReturnsUnauthorized",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4453,6 +4523,7 @@ func TestUserService_DeleteUser_PreFetchAndAuthzChecks(t *testing.T) {
 			name: "AuthzServiceError_ReturnsInternalServerError",
 			setup: func(t *testing.T) *userService {
 				storeMock := newUserStoreInterfaceMock(t)
+				storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OrganizationUnit: testOrgID}, nil).Once()
 
@@ -4564,4 +4635,260 @@ func (suite *ServiceIsUserDeclarativeTestSuite) TestIsUserDeclarative_Whitespace
 // TestServiceIsUserDeclarativeTestSuite runs the test suite.
 func TestServiceIsUserDeclarativeTestSuite(t *testing.T) {
 	suite.Run(t, new(ServiceIsUserDeclarativeTestSuite))
+}
+
+// TestUpdateUser_DeclarativeResource tests that UpdateUser returns ErrorCannotModifyDeclarativeResource
+// when the user is declarative.
+func TestUpdateUser_DeclarativeResource(t *testing.T) {
+	userID := svcTestDeclarativeUserID1
+	updatedUser := User{
+		ID:               userID,
+		OrganizationUnit: "ou1",
+		Type:             "employee",
+		Attributes:       json.RawMessage(`{"name":"test"}`),
+	}
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return true
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(true, nil).Once()
+
+	service := &userService{
+		userStore:     storeMock,
+		transactioner: &fakeTransactioner{},
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	_, err := service.UpdateUser(context.Background(), userID, &updatedUser)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorCannotModifyDeclarativeResource.Code, err.Code)
+}
+
+// TestUpdateUser_DeclarativeCheckError tests that UpdateUser surfaces errors from IsUserDeclarative.
+func TestUpdateUser_DeclarativeCheckError(t *testing.T) {
+	userID := svcTestUserID1
+	updatedUser := User{
+		ID:               userID,
+		OrganizationUnit: "ou1",
+		Type:             "employee",
+		Attributes:       json.RawMessage(`{"name":"test"}`),
+	}
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return an error
+	storeErr := errors.New("database connection failed")
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(false, storeErr).Once()
+
+	service := &userService{
+		userStore:     storeMock,
+		transactioner: &fakeTransactioner{},
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	_, err := service.UpdateUser(context.Background(), userID, &updatedUser)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInternalServerError.Code, err.Code)
+}
+
+// TestUpdateUser_DeclarativeCheckUserNotFound tests that UpdateUser returns ErrorUserNotFound
+// when IsUserDeclarative encounters ErrUserNotFound.
+func TestUpdateUser_DeclarativeCheckUserNotFound(t *testing.T) {
+	userID := "non-existent-user"
+	updatedUser := User{
+		ID:               userID,
+		OrganizationUnit: "ou1",
+		Type:             "employee",
+		Attributes:       json.RawMessage(`{"name":"test"}`),
+	}
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return ErrUserNotFound
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(false, ErrUserNotFound).Once()
+
+	service := &userService{
+		userStore:     storeMock,
+		transactioner: &fakeTransactioner{},
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	_, err := service.UpdateUser(context.Background(), userID, &updatedUser)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorUserNotFound.Code, err.Code)
+}
+
+// TestUpdateUserAttributes_DeclarativeResource tests that UpdateUserAttributes returns
+// ErrorCannotModifyDeclarativeResource when the user is declarative.
+func TestUpdateUserAttributes_DeclarativeResource(t *testing.T) {
+	userID := svcTestDeclarativeUserID1
+	attributes := json.RawMessage(`{"name":"updated"}`)
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return true
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(true, nil).Once()
+
+	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+	userSchemaMock.On("GetCredentialAttributes", mock.Anything, "employee").
+		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).Once()
+
+	service := &userService{
+		userStore:         storeMock,
+		userSchemaService: userSchemaMock,
+		transactioner:     &fakeTransactioner{},
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	_, err := service.UpdateUserAttributes(context.Background(), userID, attributes)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorCannotModifyDeclarativeResource.Code, err.Code)
+}
+
+// TestUpdateUserAttributes_DeclarativeCheckError tests that UpdateUserAttributes surfaces errors
+// from IsUserDeclarative.
+func TestUpdateUserAttributes_DeclarativeCheckError(t *testing.T) {
+	userID := svcTestUserID1
+	attributes := json.RawMessage(`{"name":"updated"}`)
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return an error
+	storeErr := errors.New("database connection failed")
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(false, storeErr).Once()
+
+	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+	userSchemaMock.On("GetCredentialAttributes", mock.Anything, "employee").
+		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).Once()
+
+	service := &userService{
+		userStore:         storeMock,
+		userSchemaService: userSchemaMock,
+		transactioner:     &fakeTransactioner{},
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	_, err := service.UpdateUserAttributes(context.Background(), userID, attributes)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInternalServerError.Code, err.Code)
+}
+
+// TestUpdateUserCredentials_DeclarativeResource tests that UpdateUserCredentials returns
+// ErrorCannotModifyDeclarativeResource when the user is declarative.
+func TestUpdateUserCredentials_DeclarativeResource(t *testing.T) {
+	userID := svcTestDeclarativeUserID1
+	credentials := json.RawMessage(`{"password":"newpass123"}`)
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return true
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(true, nil).Once()
+
+	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+
+	service := &userService{
+		userStore:         storeMock,
+		userSchemaService: userSchemaMock,
+		transactioner:     &fakeTransactioner{},
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	err := service.UpdateUserCredentials(context.Background(), userID, credentials)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorCannotModifyDeclarativeResource.Code, err.Code)
+}
+
+// TestUpdateUserCredentials_DeclarativeCheckError tests that UpdateUserCredentials surfaces errors
+// from IsUserDeclarative.
+func TestUpdateUserCredentials_DeclarativeCheckError(t *testing.T) {
+	userID := svcTestUserID1
+	credentials := json.RawMessage(`{"password":"newpass123"}`)
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return an error
+	storeErr := errors.New("database connection failed")
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(false, storeErr).Once()
+
+	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+
+	service := &userService{
+		userStore:         storeMock,
+		userSchemaService: userSchemaMock,
+		transactioner:     &fakeTransactioner{},
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	err := service.UpdateUserCredentials(context.Background(), userID, credentials)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInternalServerError.Code, err.Code)
+}
+
+// TestDeleteUser_DeclarativeResource tests that DeleteUser returns ErrorCannotModifyDeclarativeResource
+// when the user is declarative.
+func TestDeleteUser_DeclarativeResource(t *testing.T) {
+	userID := svcTestDeclarativeUserID1
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return true
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(true, nil).Once()
+
+	service := &userService{
+		userStore:     storeMock,
+		transactioner: &fakeTransactioner{},
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorCannotModifyDeclarativeResource.Code, err.Code)
+}
+
+// TestDeleteUser_DeclarativeCheckError tests that DeleteUser surfaces errors from IsUserDeclarative.
+func TestDeleteUser_DeclarativeCheckError(t *testing.T) {
+	userID := svcTestUserID1
+
+	storeMock := newUserStoreInterfaceMock(t)
+	// Mock GetUser for pre-fetch
+	storeMock.On("GetUser", mock.Anything, userID).
+		Return(User{ID: userID, OrganizationUnit: "ou1", Type: "employee"}, nil).Once()
+
+	// Mock IsUserDeclarative to return an error
+	storeErr := errors.New("database connection failed")
+	storeMock.On("IsUserDeclarative", mock.Anything, userID).Return(false, storeErr).Once()
+
+	service := &userService{
+		userStore:     storeMock,
+		transactioner: &fakeTransactioner{},
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInternalServerError.Code, err.Code)
 }

--- a/backend/internal/userschema/config.go
+++ b/backend/internal/userschema/config.go
@@ -62,3 +62,8 @@ func getUserSchemaStoreMode() serverconst.StoreMode {
 
 	return serverconst.StoreModeMutable
 }
+
+// isDeclarativeModeEnabled checks if immutable-only store mode is enabled for user schemas.
+func isDeclarativeModeEnabled() bool {
+	return getUserSchemaStoreMode() == serverconst.StoreModeDeclarative
+}

--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -29,7 +29,6 @@ import (
 	oupkg "github.com/asgardeo/thunder/internal/ou"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/database/transaction"
-	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/security"
@@ -183,8 +182,8 @@ func (us *userSchemaService) CreateUserSchema(
 ) (*UserSchema, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaLoggerComponentName))
 
-	if err := declarativeresource.CheckDeclarativeCreate(); err != nil {
-		return nil, err
+	if isDeclarativeModeEnabled() {
+		return nil, &ErrorCannotModifyDeclarativeResource
 	}
 
 	// Validate the schema definition
@@ -317,10 +316,6 @@ func (us *userSchemaService) UpdateUserSchema(ctx context.Context, schemaID stri
 	*UserSchema, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaLoggerComponentName))
 
-	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
-		return nil, err
-	}
-
 	if schemaID == "" {
 		return nil, invalidSchemaRequestError("schema id must not be empty")
 	}
@@ -417,10 +412,6 @@ func (us *userSchemaService) UpdateUserSchema(ctx context.Context, schemaID stri
 // DeleteUserSchema deletes a user schema by its ID.
 func (us *userSchemaService) DeleteUserSchema(ctx context.Context, schemaID string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaLoggerComponentName))
-
-	if err := declarativeresource.CheckDeclarativeDelete(); err != nil {
-		return err
-	}
 
 	if schemaID == "" {
 		return invalidSchemaRequestError("schema id must not be empty")


### PR DESCRIPTION
### Purpose
Fix declarative resource validations

### Approach
This pull request refactors the handling of declarative (immutable) resource modes across flow, organization unit, user, and user schema management services. The main goal is to centralize and simplify the logic for checking whether modifications are allowed in declarative mode, replacing scattered checks and imports with consistent, service-specific functions. Additionally, it introduces explicit error handling for attempts to modify declarative resources.

Declarative mode enforcement and error handling:

* Introduced `isDeclarativeModeEnabled()` functions in `flow/mgt/init.go` and `userschema/config.go` to consistently check for declarative mode in flow and user schema services, replacing previous checks that relied on the `declarative_resource` package. [[1]](diffhunk://#diff-aea83b50006fa9ceaa98f33b204c6b92baa6ceec597e9832f26e8385228a1163R145-R149) [[2]](diffhunk://#diff-f73825b52089d9c3386eaf1dfda5927ae3d6d8a9b5c91a84662f1c41cf557dcbR65-R69)
* Removed imports and usage of `declarativeresource.CheckDeclarativeCreate`, `CheckDeclarativeUpdate`, and `CheckDeclarativeDelete` in flow, organization unit, and user schema services, replacing them with local declarative mode checks and early returns with appropriate errors. [[1]](diffhunk://#diff-b60161cd9b99de01c053622fa43c38076c15ead31b99661728a499e33f59b7dcL31) [[2]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510L30) [[3]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaL32)

Service-specific error handling for immutable resources:

* Added explicit error constants such as `ErrorCannotModifyDeclarativeResource` in `user/error_constants.go`, and used these errors when modification attempts are made in declarative mode.
* Implemented the `checkUserDeclarative` method in `user/service.go`, which is used in update, attribute update, credential batch update, and delete operations to prevent modifications to declarative users. [[1]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR540-R544) [[2]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR671-R675) [[3]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR801-R805) [[4]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR1062-R1066) [[5]](diffhunk://#diff-445a73f157e02dcd0f3f72d27f80664cbcc4de25fd0a6db25089a092f3c87f6aR1542-R1557)

Organization unit and user schema service updates:

* Updated organization unit and user schema services to use the new declarative mode checks, ensuring that update and delete operations fail early if the resource is immutable, and removed redundant checks and imports. [[1]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510L427-L431) [[2]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510L478-L481) [[3]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510L627-L631) [[4]](diffhunk://#diff-3182e56acf2b9cccc52c6c066f60106472bc9d1ba69738c1c639621615bcf510L677-L680) [[5]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaL186-R186) [[6]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaL320-L323) [[7]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaL421-L424)

These changes make declarative mode enforcement more robust and maintainable by consolidating checks and error handling, and by removing dependency on the `declarative_resource` package in favor of local logic.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only enforcement for declarative resources across flows, users, user schemas, and organization units with a consistent "cannot modify" error.

* **Bug Fixes**
  * Users attempting to modify or delete declarative resources now receive clear, specific error messages preventing changes.

* **Tests**
  * Expanded and adjusted tests to cover declarative-resource behavior and error paths, improving coverage for create/update/delete/restore scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->