### PR TITLE
Fix GitHub edit URL in documentation

### DIFF
--- a/docs/docusaurus.thunder.config.ts
+++ b/docs/docusaurus.thunder.config.ts
@@ -66,7 +66,7 @@ const docusaurusThunderConfig = {
         releasesUrl: 'https://github.com/asgardeo/thunder/releases',
         editUrls: {
           blog: 'https://github.com/asgardeo/thunder/tree/main/blog/',
-          content: 'https://github.com/asgardeo/thunder/tree/main/content/',
+          content: 'https://github.com/asgardeo/thunder/tree/main/docs/',
         },
         owner: {
           name: 'asgardeo',


### PR DESCRIPTION
### Purpose
This pull request makes a small configuration update to the documentation site. The main change is updating the edit URL for content to point to the correct directory in the repository.

- Changed the `content` edit URL in the `docusaurusThunderConfig` object to reference the `docs` directory instead of `content` in `docs/docusaurus.thunder.config.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted documentation configuration so edit links now point to the docs/ location instead of the previous content/ path. This ensures in-app edit links direct contributors to the correct docs location; no other behavior was changed. No public APIs or exported signatures were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->