### PR TITLE
Minor improvements in composite stores

### DIFF
--- a/backend/internal/flow/mgt/composite_store_test.go
+++ b/backend/internal/flow/mgt/composite_store_test.go
@@ -284,9 +284,8 @@ func (s *CompositeStoreTestSuite) TestGetFlowByID_DBErrorAndFileError() {
 
 	result, err := s.compositeStore.GetFlowByID(context.Background(), flowID)
 
-	// When both stores fail, CompositeGetHelper returns errFlowNotFound
 	assert.Error(s.T(), err)
-	assert.Equal(s.T(), errFlowNotFound, err)
+	assert.Equal(s.T(), fileError, err)
 	assert.Nil(s.T(), result)
 }
 
@@ -346,9 +345,8 @@ func (s *CompositeStoreTestSuite) TestGetFlowByHandle_DBAndFileError() {
 
 	result, err := s.compositeStore.GetFlowByHandle(context.Background(), handle, flowType)
 
-	// When both stores fail, CompositeGetHelper returns the not found error
 	s.Error(err)
-	s.Equal(errFlowNotFound, err)
+	s.Equal(fileError, err)
 	s.Nil(result)
 }
 

--- a/backend/internal/idp/composite_store.go
+++ b/backend/internal/idp/composite_store.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 )
 
@@ -55,17 +56,50 @@ func (c *compositeIDPStore) CreateIdentityProvider(ctx context.Context, idp IDPD
 // GetIdentityProviderList retrieves identity providers from both stores and merges the results.
 // Database IDPs are marked as mutable (IsReadOnly=false), file-based IDPs as immutable (IsReadOnly=true).
 func (c *compositeIDPStore) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, error) {
-	dbIDPs, err := c.dbStore.GetIdentityProviderList(ctx)
+	dbCount, err := c.dbStore.GetIdentityProviderListCount(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	fileIDPs, err := c.fileStore.GetIdentityProviderList(ctx)
+	fileCount, err := c.fileStore.GetIdentityProviderListCount(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return mergeAndDeduplicateIDPs(dbIDPs, fileIDPs), nil
+	totalCount := dbCount + fileCount
+	idps, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
+		func() (int, error) { return dbCount, nil },
+		func() (int, error) { return fileCount, nil },
+		func(count int) ([]BasicIDPDTO, error) { return c.dbStore.GetIdentityProviderList(ctx) },
+		func(count int) ([]BasicIDPDTO, error) { return c.fileStore.GetIdentityProviderList(ctx) },
+		mergeAndDeduplicateIDPs,
+		totalCount,
+		0,
+		serverconst.MaxCompositeStoreRecords,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if limitExceeded {
+		return nil, ErrResultLimitExceededInCompositeMode
+	}
+
+	return idps, nil
+}
+
+// GetIdentityProviderListCount retrieves the count of identity providers across both stores.
+func (c *compositeIDPStore) GetIdentityProviderListCount(ctx context.Context) (int, error) {
+	dbCount, err := c.dbStore.GetIdentityProviderListCount(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	fileCount, err := c.fileStore.GetIdentityProviderListCount(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return dbCount + fileCount, nil
 }
 
 // GetIdentityProvider retrieves an identity provider by ID from either store.

--- a/backend/internal/idp/composite_store_test.go
+++ b/backend/internal/idp/composite_store_test.go
@@ -168,6 +168,8 @@ func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_MergesAndDedupl
 		{ID: "file-2", Name: "File IDP 2", Type: IDPTypeOIDC},
 	}
 
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(len(dbIDPs), nil)
+	s.fileStore.On("GetIdentityProviderListCount", context.Background()).Return(len(fileIDPs), nil)
 	s.dbStore.On("GetIdentityProviderList", context.Background()).Return(dbIDPs, nil)
 	s.fileStore.On("GetIdentityProviderList", context.Background()).Return(fileIDPs, nil)
 
@@ -210,6 +212,8 @@ func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_DeduplicatesOnI
 		{ID: "file-2", Name: "File IDP 2", Type: IDPTypeOIDC},
 	}
 
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(len(dbIDPs), nil)
+	s.fileStore.On("GetIdentityProviderListCount", context.Background()).Return(len(fileIDPs), nil)
 	s.dbStore.On("GetIdentityProviderList", context.Background()).Return(dbIDPs, nil)
 	s.fileStore.On("GetIdentityProviderList", context.Background()).Return(fileIDPs, nil)
 
@@ -245,18 +249,20 @@ func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_DeduplicatesOnI
 
 // TestGetIdentityProviderList_HandlesEmptyStores verifies empty results are handled
 func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_HandlesEmptyStores() {
-	s.dbStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, nil)
-	s.fileStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, nil)
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(0, nil)
+	s.fileStore.On("GetIdentityProviderListCount", context.Background()).Return(0, nil)
 
 	result, err := s.compositeStore.GetIdentityProviderList(context.Background())
 
 	s.NoError(err)
 	s.Len(result, 0)
+	s.dbStore.AssertNotCalled(s.T(), "GetIdentityProviderList", context.Background())
+	s.fileStore.AssertNotCalled(s.T(), "GetIdentityProviderList", context.Background())
 }
 
 // TestGetIdentityProviderList_HandlesDBStoreError verifies error handling
 func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_HandlesDBStoreError() {
-	s.dbStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, errors.New("DB error"))
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(0, errors.New("DB error"))
 
 	result, err := s.compositeStore.GetIdentityProviderList(context.Background())
 
@@ -269,6 +275,8 @@ func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderList_HandlesFileStor
 	dbIDPs := []BasicIDPDTO{
 		{ID: "db-1", Name: "DB IDP 1", Type: IDPTypeOIDC},
 	}
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(len(dbIDPs), nil)
+	s.fileStore.On("GetIdentityProviderListCount", context.Background()).Return(1, nil)
 	s.dbStore.On("GetIdentityProviderList", context.Background()).Return(dbIDPs, nil)
 	s.fileStore.On("GetIdentityProviderList", context.Background()).Return([]BasicIDPDTO{}, errors.New("File error"))
 

--- a/backend/internal/idp/error_constants.go
+++ b/backend/internal/idp/error_constants.go
@@ -27,6 +27,9 @@ import (
 // ErrIDPNotFound is returned when the IdP is not found in the system.
 var ErrIDPNotFound = errors.New("IdP not found")
 
+// ErrResultLimitExceededInCompositeMode is the internal sentinel error for composite mode limit exceeded.
+var ErrResultLimitExceededInCompositeMode = errors.New("result limit exceeded in composite mode")
+
 // Client errors for identity provider operations.
 var (
 	// ErrorIDPNotFound is the error returned when an identity provider is not found.
@@ -98,5 +101,12 @@ var (
 		Code:             "IDP-1010",
 		Error:            "Identity provider is immutable",
 		ErrorDescription: "The requested identity provider is declarative and cannot be modified or deleted",
+	}
+	// ErrorResultLimitExceededInCompositeMode is the error returned when the total number of records exceeds
+	ErrorResultLimitExceededInCompositeMode = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "IDP-1011",
+		Error:            "Result limit exceeded in composite mode",
+		ErrorDescription: "The total number of records exceeds the maximum limit in composite mode",
 	}
 )

--- a/backend/internal/idp/file_based_store.go
+++ b/backend/internal/idp/file_based_store.go
@@ -93,6 +93,11 @@ func (f *idpFileBasedStore) GetIdentityProviderList(ctx context.Context) ([]Basi
 	return idpList, nil
 }
 
+// GetIdentityProviderListCount retrieves the total count of identity providers.
+func (f *idpFileBasedStore) GetIdentityProviderListCount(ctx context.Context) (int, error) {
+	return f.GenericFileBasedStore.Count()
+}
+
 // UpdateIdentityProvider implements idpStoreInterface.
 func (f *idpFileBasedStore) UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error {
 	return errors.New("UpdateIdentityProvider is not supported in file-based store")

--- a/backend/internal/idp/idpStoreInterface_mock_test.go
+++ b/backend/internal/idp/idpStoreInterface_mock_test.go
@@ -349,6 +349,66 @@ func (_c *idpStoreInterfaceMock_GetIdentityProviderList_Call) RunAndReturn(run f
 	return _c
 }
 
+// GetIdentityProviderListCount provides a mock function for the type idpStoreInterfaceMock
+func (_mock *idpStoreInterfaceMock) GetIdentityProviderListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProviderListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// idpStoreInterfaceMock_GetIdentityProviderListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderListCount'
+type idpStoreInterfaceMock_GetIdentityProviderListCount_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProviderListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProviderListCount(ctx interface{}) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	return &idpStoreInterfaceMock_GetIdentityProviderListCount_Call{Call: _e.mock.On("GetIdentityProviderListCount", ctx)}
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) Run(run func(ctx context.Context)) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) Return(n int, err error) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateIdentityProvider provides a mock function for the type idpStoreInterfaceMock
 func (_mock *idpStoreInterfaceMock) UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error {
 	ret := _mock.Called(ctx, idp)

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -111,6 +111,9 @@ func (is *idpService) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDT
 	logger := is.logger
 	idps, err := is.idpStore.GetIdentityProviderList(ctx)
 	if err != nil {
+		if errors.Is(err, ErrResultLimitExceededInCompositeMode) {
+			return nil, &ErrorResultLimitExceededInCompositeMode
+		}
 		logger.Error("Failed to get identity provider list", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -33,6 +33,7 @@ import (
 type idpStoreInterface interface {
 	CreateIdentityProvider(ctx context.Context, idp IDPDTO) error
 	GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, error)
+	GetIdentityProviderListCount(ctx context.Context) (int, error)
 	GetIdentityProvider(ctx context.Context, idpID string) (*IDPDTO, error)
 	GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error)
 	UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error
@@ -100,6 +101,39 @@ func (s *idpStore) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, 
 	}
 
 	return idpList, nil
+}
+
+// GetIdentityProviderListCount retrieves the total count of identity providers.
+func (s *idpStore) GetIdentityProviderListCount(ctx context.Context) (int, error) {
+	dbClient, err := s.dbProvider.GetConfigDBClient()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	results, err := dbClient.QueryContext(ctx, queryGetIdentityProviderListCount, s.deploymentID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	if len(results) == 0 || len(results[0]) == 0 {
+		return 0, nil
+	}
+
+	countVal, ok := results[0]["count"]
+	if !ok {
+		return 0, fmt.Errorf("count field not found in result")
+	}
+
+	switch v := countVal.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	default:
+		return 0, fmt.Errorf("unexpected count type: %T", countVal)
+	}
 }
 
 // GetIdentityProvider retrieves a specific idp by its ID from the database.

--- a/backend/internal/idp/store_constants.go
+++ b/backend/internal/idp/store_constants.go
@@ -53,4 +53,9 @@ var (
 		ID:    "IPQ-IDP_MGT-06",
 		Query: "SELECT ID, NAME, DESCRIPTION, TYPE, PROPERTIES FROM IDP WHERE NAME = $1 AND DEPLOYMENT_ID = $2",
 	}
+	// queryGetIdentityProviderListCount is the query to get a count of IdPs.
+	queryGetIdentityProviderListCount = model.DBQuery{
+		ID:    "IPQ-IDP_MGT-07",
+		Query: "SELECT COUNT(*) AS count FROM IDP WHERE DEPLOYMENT_ID = $1",
+	}
 )

--- a/backend/internal/ou/composite_store.go
+++ b/backend/internal/ou/composite_store.go
@@ -117,13 +117,47 @@ func (c *compositeOUStore) GetOrganizationUnit(ctx context.Context, id string) (
 	)
 }
 
-// GetOrganizationUnitByPath retrieves an organization unit by hierarchical path from either store.
-func (c *compositeOUStore) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
+// GetOrganizationUnitByHandle retrieves an organization unit by handle and parent from either store.
+// Checks database store first, then falls back to file store.
+func (c *compositeOUStore) GetOrganizationUnitByHandle(
+	ctx context.Context, handle string, parent *string,
+) (OrganizationUnit, error) {
 	return declarativeresource.CompositeGetHelper(
-		func() (OrganizationUnit, error) { return c.dbStore.GetOrganizationUnitByPath(ctx, handles) },
-		func() (OrganizationUnit, error) { return c.fileStore.GetOrganizationUnitByPath(ctx, handles) },
+		func() (OrganizationUnit, error) { return c.dbStore.GetOrganizationUnitByHandle(ctx, handle, parent) },
+		func() (OrganizationUnit, error) { return c.fileStore.GetOrganizationUnitByHandle(ctx, handle, parent) },
 		ErrOrganizationUnitNotFound,
 	)
+}
+
+// GetOrganizationUnitByPath retrieves an organization unit by hierarchical path from either store.
+func (c *compositeOUStore) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
+	if len(handles) == 0 {
+		return OrganizationUnit{}, ErrOrganizationUnitNotFound
+	}
+
+	current, err := c.findRootByHandle(ctx, handles[0])
+	if err != nil {
+		return OrganizationUnit{}, err
+	}
+
+	for i := 1; i < len(handles); i++ {
+		current, err = c.findChildByHandle(ctx, current.ID, handles[i])
+		if err != nil {
+			return OrganizationUnit{}, err
+		}
+	}
+
+	return current, nil
+}
+
+func (c *compositeOUStore) findRootByHandle(ctx context.Context, handle string) (OrganizationUnit, error) {
+	return c.GetOrganizationUnitByHandle(ctx, handle, nil)
+}
+
+func (c *compositeOUStore) findChildByHandle(
+	ctx context.Context, parentID, handle string,
+) (OrganizationUnit, error) {
+	return c.GetOrganizationUnitByHandle(ctx, handle, &parentID)
 }
 
 // IsOrganizationUnitExists checks if an organization unit exists in either store.

--- a/backend/internal/ou/composite_store_test.go
+++ b/backend/internal/ou/composite_store_test.go
@@ -487,7 +487,11 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 			Name:   "Level 2 OU",
 		}
 
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handles).
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "level1", (*string)(nil)).
+			Return(OrganizationUnit{ID: "db-root", Handle: "level1", Name: "Root"}, nil).
+			Once()
+		parentID := "db-root"
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "level2", &parentID).
 			Return(expectedOU, nil).
 			Once()
 
@@ -497,6 +501,8 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 	})
 
 	suite.Run("falls back to file store when not in DB", func() {
+		suite.SetupTest() // Fresh setup
+
 		// Create parent and child in file store
 		parentID := "file-parent"
 		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
@@ -514,7 +520,10 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handles).
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "level1", (*string)(nil)).
+			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
+			Once()
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "level2", &parentID).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
@@ -524,11 +533,40 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		suite.Equal("level2", result.Handle)
 	})
 
+	suite.Run("resolves mixed ancestry file parent and DB child", func() {
+		suite.SetupTest() // Fresh setup
+
+		// Root in file store
+		rootID := "file-root"
+		err := suite.fileStore.CreateOrganizationUnit(context.Background(), OrganizationUnit{
+			ID:     rootID,
+			Handle: "default",
+			Name:   "Default",
+		})
+		suite.NoError(err)
+
+		// Child in DB store under file root
+		dbChild := OrganizationUnit{ID: "db-child", Handle: "thin-ends-make", Name: "Thin Ends Make", Parent: &rootID}
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "default", (*string)(nil)).
+			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
+			Once()
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "thin-ends-make", &rootID).
+			Return(dbChild, nil).
+			Once()
+
+		result, err := suite.compositeStore.GetOrganizationUnitByPath(
+			context.Background(), []string{"default", "thin-ends-make"},
+		)
+		suite.NoError(err)
+		suite.Equal("db-child", result.ID)
+		suite.Equal("thin-ends-make", result.Handle)
+	})
+
 	suite.Run("returns not found when in neither store", func() {
 		suite.SetupTest() // Fresh setup
 		handlesTest := []string{"nonexistent1", "nonexistent2"}
 
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handlesTest).
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "nonexistent1", (*string)(nil)).
 			Return(OrganizationUnit{}, ErrOrganizationUnitNotFound).
 			Once()
 
@@ -540,7 +578,7 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 
 	suite.Run("propagates DB errors other than not found", func() {
 		dbErr := errors.New("database connection error")
-		suite.dbStoreMock.On("GetOrganizationUnitByPath", mock.Anything, handles).
+		suite.dbStoreMock.On("GetOrganizationUnitByHandle", mock.Anything, "level1", (*string)(nil)).
 			Return(OrganizationUnit{}, dbErr).
 			Once()
 

--- a/backend/internal/ou/file_based_store.go
+++ b/backend/internal/ou/file_based_store.go
@@ -68,36 +68,44 @@ func (f *fileBasedStore) GetOrganizationUnit(ctx context.Context, id string) (Or
 	return *ou, nil
 }
 
-// GetOrganizationUnitByPath implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
+// GetOrganizationUnitByHandle implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitByHandle(
+	ctx context.Context, handle string, parent *string,
+) (OrganizationUnit, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return OrganizationUnit{}, err
 	}
 
-	// Build the path by traversing the hierarchy
+	for _, item := range list {
+		ou, ok := item.Data.(*OrganizationUnit)
+		if !ok {
+			continue
+		}
+
+		parentMatch := (parent == nil && ou.Parent == nil) ||
+			(parent != nil && ou.Parent != nil && *parent == *ou.Parent)
+		if ou.Handle == handle && parentMatch {
+			return *ou, nil
+		}
+	}
+
+	return OrganizationUnit{}, ErrOrganizationUnitNotFound
+}
+
+// GetOrganizationUnitByPath implements organizationUnitStoreInterface.
+func (f *fileBasedStore) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
 	var currentOU *OrganizationUnit
 	var currentParent *string
 
 	for _, handle := range handles {
-		found := false
-		for _, item := range list {
-			if ou, ok := item.Data.(*OrganizationUnit); ok {
-				// Check if this OU has the right handle and parent
-				parentMatch := (currentParent == nil && ou.Parent == nil) ||
-					(currentParent != nil && ou.Parent != nil && *currentParent == *ou.Parent)
-
-				if ou.Handle == handle && parentMatch {
-					currentOU = ou
-					currentParent = &ou.ID
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
+		ou, err := f.GetOrganizationUnitByHandle(ctx, handle, currentParent)
+		if err != nil {
 			return OrganizationUnit{}, ErrOrganizationUnitNotFound
 		}
+
+		currentOU = &ou
+		currentParent = &ou.ID
 	}
 
 	if currentOU == nil {

--- a/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
+++ b/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
@@ -361,6 +361,78 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) RunAndRet
 	return _c
 }
 
+// GetOrganizationUnitByHandle provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByHandle(ctx context.Context, handle string, parent *string) (OrganizationUnit, error) {
+	ret := _mock.Called(ctx, handle, parent)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitByHandle")
+	}
+
+	var r0 OrganizationUnit
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (OrganizationUnit, error)); ok {
+		return returnFunc(ctx, handle, parent)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) OrganizationUnit); ok {
+		r0 = returnFunc(ctx, handle, parent)
+	} else {
+		r0 = ret.Get(0).(OrganizationUnit)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) error); ok {
+		r1 = returnFunc(ctx, handle, parent)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitByHandle'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitByHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - parent *string
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitByHandle(ctx interface{}, handle interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call{Call: _e.mock.On("GetOrganizationUnitByHandle", ctx, handle, parent)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call) Run(run func(ctx context.Context, handle string, parent *string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call) Return(organizationUnit OrganizationUnit, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	_c.Call.Return(organizationUnit, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call) RunAndReturn(run func(ctx context.Context, handle string, parent *string) (OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOrganizationUnitByPath provides a mock function for the type organizationUnitStoreInterfaceMock
 func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error) {
 	ret := _mock.Called(ctx, handles)

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -21,6 +21,7 @@ package ou
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/asgardeo/thunder/internal/system/config"
@@ -38,6 +39,7 @@ type organizationUnitStoreInterface interface {
 	GetOrganizationUnitsByIDs(ctx context.Context, ids []string) ([]OrganizationUnitBasic, error)
 	CreateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error
 	GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, error)
+	GetOrganizationUnitByHandle(ctx context.Context, handle string, parent *string) (OrganizationUnit, error)
 	GetOrganizationUnitByPath(ctx context.Context, handles []string) (OrganizationUnit, error)
 	IsOrganizationUnitExists(ctx context.Context, id string) (bool, error)
 	IsOrganizationUnitDeclarative(ctx context.Context, id string) bool
@@ -206,6 +208,38 @@ func (s *organizationUnitStore) GetOrganizationUnit(ctx context.Context, id stri
 	return ou, nil
 }
 
+// GetOrganizationUnitByHandle retrieves an organization unit by handle and parent.
+// When parent is nil, only root organization units are considered.
+func (s *organizationUnitStore) GetOrganizationUnitByHandle(
+	ctx context.Context, handle string, parent *string,
+) (OrganizationUnit, error) {
+	dbClient, err := s.dbProvider.GetUserDBClient()
+	if err != nil {
+		return OrganizationUnit{}, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	var results []map[string]interface{}
+	if parent == nil {
+		results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.deploymentID)
+	} else {
+		results, err = dbClient.QueryContext(ctx, queryGetOrganizationUnitByHandle, handle, *parent, s.deploymentID)
+	}
+	if err != nil {
+		return OrganizationUnit{}, fmt.Errorf("failed to execute query for handle %s: %w", handle, err)
+	}
+
+	if len(results) == 0 {
+		return OrganizationUnit{}, ErrOrganizationUnitNotFound
+	}
+
+	ou, err := buildOrganizationUnitFromResultRow(results[0])
+	if err != nil {
+		return OrganizationUnit{}, fmt.Errorf("failed to build organization unit for handle %s: %w", handle, err)
+	}
+
+	return ou, nil
+}
+
 // GetOrganizationUnitByPath retrieves an organization unit by its hierarchical handle path.
 func (s *organizationUnitStore) GetOrganizationUnitByPath(
 	ctx context.Context, handlePath []string,
@@ -227,21 +261,11 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(
 
 	for i, handle := range handlePath {
 		fullPath = fullPath + "/" + handle
-		var results []map[string]interface{}
-
-		if parentID == nil {
-			results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.deploymentID)
-		} else {
-			results, err = dbClient.QueryContext(
-				ctx, queryGetOrganizationUnitByHandle, handle, *parentID, s.deploymentID,
-			)
-		}
-
+		currentOU, err = s.getOrganizationUnitByHandleWithClient(ctx, dbClient, handle, parentID)
 		if err != nil {
-			return OrganizationUnit{}, fmt.Errorf("failed to execute query for handle %s: %w", handle, err)
-		}
-
-		if len(results) == 0 {
+			if !errors.Is(err, ErrOrganizationUnitNotFound) {
+				return OrganizationUnit{}, err
+			}
 			logger.Debug("Organization unit not found in path",
 				log.String("handle", handle),
 				log.Int("pathIndex", i),
@@ -249,15 +273,37 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(
 			return OrganizationUnit{}, ErrOrganizationUnitNotFound
 		}
 
-		currentOU, err = buildOrganizationUnitFromResultRow(results[0])
-		if err != nil {
-			return OrganizationUnit{}, fmt.Errorf("failed to build organization unit for handle %s: %w", handle, err)
-		}
-
 		parentID = &currentOU.ID
 	}
 
 	return currentOU, nil
+}
+
+func (s *organizationUnitStore) getOrganizationUnitByHandleWithClient(
+	ctx context.Context, dbClient provider.DBClientInterface, handle string, parent *string,
+) (OrganizationUnit, error) {
+	var results []map[string]interface{}
+	var err error
+
+	if parent == nil {
+		results, err = dbClient.QueryContext(ctx, queryGetRootOrganizationUnitByHandle, handle, s.deploymentID)
+	} else {
+		results, err = dbClient.QueryContext(ctx, queryGetOrganizationUnitByHandle, handle, *parent, s.deploymentID)
+	}
+	if err != nil {
+		return OrganizationUnit{}, fmt.Errorf("failed to execute query for handle %s: %w", handle, err)
+	}
+
+	if len(results) == 0 {
+		return OrganizationUnit{}, ErrOrganizationUnitNotFound
+	}
+
+	ou, err := buildOrganizationUnitFromResultRow(results[0])
+	if err != nil {
+		return OrganizationUnit{}, fmt.Errorf("failed to build organization unit for handle %s: %w", handle, err)
+	}
+
+	return ou, nil
 }
 
 // IsOrganizationUnitExists checks if an organization unit exists by ID.

--- a/backend/internal/resource/composite_store.go
+++ b/backend/internal/resource/composite_store.go
@@ -20,9 +20,8 @@ package resource
 
 import (
 	"context"
-	"errors"
-	"math"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 )
 
@@ -51,69 +50,102 @@ func (c *compositeResourceStore) CreateResourceServer(ctx context.Context, id st
 }
 
 func (c *compositeResourceStore) GetResourceServer(ctx context.Context, id string) (ResourceServer, error) {
-	// Try DB store first
-	server, err := c.dbStore.GetResourceServer(ctx, id)
-	if err == nil {
-		server.IsReadOnly = false
-		return server, nil
-	}
-
-	// If not found in DB, try file store
-	if errors.Is(err, errResourceServerNotFound) {
-		server, err := c.fileStore.GetResourceServer(ctx, id)
-		if err == nil {
-			server.IsReadOnly = true
-			return server, nil
-		}
-		return ResourceServer{}, err
-	}
-
-	return ResourceServer{}, err
+	server, err := declarativeresource.CompositeGetHelper(
+		func() (ResourceServer, error) {
+			s, err := c.dbStore.GetResourceServer(ctx, id)
+			if err == nil {
+				s.IsReadOnly = false
+			}
+			return s, err
+		},
+		func() (ResourceServer, error) {
+			s, err := c.fileStore.GetResourceServer(ctx, id)
+			if err == nil {
+				s.IsReadOnly = true
+			}
+			return s, err
+		},
+		errResourceServerNotFound,
+	)
+	return server, err
 }
 
 func (c *compositeResourceStore) GetResourceServerList(
 	ctx context.Context, limit, offset int) ([]ResourceServer, error) {
-	// Fetch all servers from both stores using math.MaxInt to ensure no LIMIT 0 issue
-	dbServers, err := c.dbStore.GetResourceServerList(ctx, math.MaxInt, 0)
+	dbCount, err := c.dbStore.GetResourceServerListCount(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	fileServers, err := c.fileStore.GetResourceServerList(ctx, math.MaxInt, 0)
+	fileCount, err := c.fileStore.GetResourceServerListCount(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Merge and deduplicate
-	merged := mergeAndDeduplicateResourceServers(dbServers, fileServers)
-
-	// Apply pagination
-	start := offset
-	end := offset + limit
-	if start > len(merged) {
+	if dbCount == 0 && fileCount == 0 {
 		return []ResourceServer{}, nil
 	}
-	if end > len(merged) {
-		end = len(merged)
+
+	// Fetch all from both stores, then deduplicate before applying the cap.
+	// This avoids spurious limit errors when IDs overlap across the two stores.
+	dbServers, err := c.dbStore.GetResourceServerList(ctx, dbCount, 0)
+	if err != nil {
+		return nil, err
 	}
 
-	return merged[start:end], nil
+	fileServers, err := c.fileStore.GetResourceServerList(ctx, fileCount, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceServers := mergeAndDeduplicateResourceServers(dbServers, fileServers)
+	if len(resourceServers) > serverconst.MaxCompositeStoreRecords {
+		return nil, errResultLimitExceededInCompositeMode
+	}
+
+	// Apply pagination on the deduplicated slice.
+	start := offset
+	if start > len(resourceServers) {
+		return []ResourceServer{}, nil
+	}
+	end := start + limit
+	if end > len(resourceServers) {
+		end = len(resourceServers)
+	}
+	return resourceServers[start:end], nil
 }
 
 func (c *compositeResourceStore) GetResourceServerListCount(ctx context.Context) (int, error) {
-	// Fetch all servers from both stores using math.MaxInt to avoid LIMIT issues
-	dbServers, err := c.dbStore.GetResourceServerList(ctx, math.MaxInt, 0)
+	dbCount, err := c.dbStore.GetResourceServerListCount(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	fileServers, err := c.fileStore.GetResourceServerList(ctx, math.MaxInt, 0)
+	fileCount, err := c.fileStore.GetResourceServerListCount(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	// Merge and deduplicate, then return count
+	if dbCount == 0 && fileCount == 0 {
+		return 0, nil
+	}
+
+	// Fetch all from both stores, deduplicate, then apply the cap.
+	// Checking the raw sum before dedup would cause spurious errors when IDs overlap.
+	dbServers, err := c.dbStore.GetResourceServerList(ctx, dbCount, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	fileServers, err := c.fileStore.GetResourceServerList(ctx, fileCount, 0)
+	if err != nil {
+		return 0, err
+	}
+
 	merged := mergeAndDeduplicateResourceServers(dbServers, fileServers)
+	if len(merged) > serverconst.MaxCompositeStoreRecords {
+		return 0, errResultLimitExceededInCompositeMode
+	}
 	return len(merged), nil
 }
 
@@ -174,35 +206,20 @@ func (c *compositeResourceStore) CreateResource(
 
 func (c *compositeResourceStore) GetResource(
 	ctx context.Context, id string, resServerID string) (Resource, error) {
-	// Try DB store first
-	resource, err := c.dbStore.GetResource(ctx, id, resServerID)
-	if err == nil {
-		return resource, nil
-	}
-
-	// If not found in DB, try file store
-	if errors.Is(err, errResourceNotFound) {
-		return c.fileStore.GetResource(ctx, id, resServerID)
-	}
-
-	return Resource{}, err
+	resource, err := declarativeresource.CompositeGetHelper(
+		func() (Resource, error) { return c.dbStore.GetResource(ctx, id, resServerID) },
+		func() (Resource, error) { return c.fileStore.GetResource(ctx, id, resServerID) },
+		errResourceNotFound,
+	)
+	return resource, err
 }
 
 func (c *compositeResourceStore) GetResourceList(
 	ctx context.Context, resServerID string, limit, offset int) ([]Resource, error) {
-	// Fetch all resources from both stores using math.MaxInt to ensure no LIMIT 0 issue
-	dbResources, err := c.dbStore.GetResourceList(ctx, resServerID, math.MaxInt, 0)
+	merged, err := c.getMergedResources(ctx, resServerID)
 	if err != nil {
 		return nil, err
 	}
-
-	fileResources, err := c.fileStore.GetResourceList(ctx, resServerID, math.MaxInt, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge and deduplicate
-	merged := mergeAndDeduplicateResources(dbResources, fileResources)
 
 	// Apply pagination
 	start := offset
@@ -220,20 +237,10 @@ func (c *compositeResourceStore) GetResourceList(
 func (c *compositeResourceStore) GetResourceListByParent(
 	ctx context.Context, resServerID string, parentID *string, limit, offset int,
 ) ([]Resource, error) {
-	// Fetch all resources from both stores using math.MaxInt to ensure no LIMIT 0 issue
-	dbResources, err := c.dbStore.GetResourceListByParent(ctx, resServerID, parentID, math.MaxInt, 0)
+	merged, err := c.getMergedResourcesByParent(ctx, resServerID, parentID)
 	if err != nil {
 		return nil, err
 	}
-
-	fileResources, err := c.fileStore.GetResourceListByParent(
-		ctx, resServerID, parentID, math.MaxInt, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge and deduplicate
-	merged := mergeAndDeduplicateResources(dbResources, fileResources)
 
 	// Apply pagination
 	start := offset
@@ -249,38 +256,19 @@ func (c *compositeResourceStore) GetResourceListByParent(
 }
 
 func (c *compositeResourceStore) GetResourceListCount(ctx context.Context, resServerID string) (int, error) {
-	// Fetch all resources from both stores using math.MaxInt to avoid LIMIT issues
-	dbResources, err := c.dbStore.GetResourceList(ctx, resServerID, math.MaxInt, 0)
+	merged, err := c.getMergedResources(ctx, resServerID)
 	if err != nil {
 		return 0, err
 	}
-
-	fileResources, err := c.fileStore.GetResourceList(ctx, resServerID, math.MaxInt, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	// Merge and deduplicate, then return count
-	merged := mergeAndDeduplicateResources(dbResources, fileResources)
 	return len(merged), nil
 }
 
 func (c *compositeResourceStore) GetResourceListCountByParent(
 	ctx context.Context, resServerID string, parentID *string) (int, error) {
-	// Fetch all resources from both stores using math.MaxInt to avoid LIMIT issues
-	dbResources, err := c.dbStore.GetResourceListByParent(ctx, resServerID, parentID, math.MaxInt, 0)
+	merged, err := c.getMergedResourcesByParent(ctx, resServerID, parentID)
 	if err != nil {
 		return 0, err
 	}
-
-	fileResources, err := c.fileStore.GetResourceListByParent(
-		ctx, resServerID, parentID, math.MaxInt, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	// Merge and deduplicate, then return count
-	merged := mergeAndDeduplicateResources(dbResources, fileResources)
 	return len(merged), nil
 }
 
@@ -335,19 +323,10 @@ func (c *compositeResourceStore) GetAction(
 
 func (c *compositeResourceStore) GetActionList(
 	ctx context.Context, resServerID string, resID *string, limit, offset int) ([]Action, error) {
-	// Fetch all actions from both stores using math.MaxInt to ensure no LIMIT 0 issue
-	dbActions, err := c.dbStore.GetActionList(ctx, resServerID, resID, math.MaxInt, 0)
+	merged, err := c.getMergedActions(ctx, resServerID, resID)
 	if err != nil {
 		return nil, err
 	}
-
-	fileActions, err := c.fileStore.GetActionList(ctx, resServerID, resID, math.MaxInt, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge and deduplicate
-	merged := mergeAndDeduplicateActions(dbActions, fileActions)
 
 	// Apply pagination
 	start := offset
@@ -364,20 +343,121 @@ func (c *compositeResourceStore) GetActionList(
 
 func (c *compositeResourceStore) GetActionListCount(
 	ctx context.Context, resServerID string, resID *string) (int, error) {
-	// Fetch all actions from both stores using math.MaxInt to avoid LIMIT issues
-	dbActions, err := c.dbStore.GetActionList(ctx, resServerID, resID, math.MaxInt, 0)
+	merged, err := c.getMergedActions(ctx, resServerID, resID)
 	if err != nil {
 		return 0, err
 	}
-
-	fileActions, err := c.fileStore.GetActionList(ctx, resServerID, resID, math.MaxInt, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	// Merge and deduplicate, then return count
-	merged := mergeAndDeduplicateActions(dbActions, fileActions)
 	return len(merged), nil
+}
+
+func (c *compositeResourceStore) getMergedResources(ctx context.Context, resServerID string) ([]Resource, error) {
+	dbCount, err := c.dbStore.GetResourceListCount(ctx, resServerID)
+	if err != nil {
+		return nil, err
+	}
+
+	fileCount, err := c.fileStore.GetResourceListCount(ctx, resServerID)
+	if err != nil {
+		return nil, err
+	}
+
+	resources, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
+		func() (int, error) { return dbCount, nil },
+		func() (int, error) { return fileCount, nil },
+		func(count int) ([]Resource, error) { return c.dbStore.GetResourceList(ctx, resServerID, count, 0) },
+		func(count int) ([]Resource, error) { return c.fileStore.GetResourceList(ctx, resServerID, count, 0) },
+		mergeAndDeduplicateResources,
+		dbCount+fileCount,
+		0,
+		serverconst.MaxCompositeStoreRecords,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if limitExceeded {
+		return nil, errResultLimitExceededInCompositeMode
+	}
+
+	return resources, nil
+}
+
+func (c *compositeResourceStore) getMergedResourcesByParent(
+	ctx context.Context,
+	resServerID string,
+	parentID *string,
+) ([]Resource, error) {
+	dbCount, err := c.dbStore.GetResourceListCountByParent(ctx, resServerID, parentID)
+	if err != nil {
+		return nil, err
+	}
+
+	fileCount, err := c.fileStore.GetResourceListCountByParent(ctx, resServerID, parentID)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeCompositeListWithLimit(
+		dbCount,
+		fileCount,
+		func(count int) ([]Resource, error) {
+			return c.dbStore.GetResourceListByParent(ctx, resServerID, parentID, count, 0)
+		},
+		func(count int) ([]Resource, error) {
+			return c.fileStore.GetResourceListByParent(ctx, resServerID, parentID, count, 0)
+		},
+		mergeAndDeduplicateResources,
+	)
+}
+
+func (c *compositeResourceStore) getMergedActions(
+	ctx context.Context,
+	resServerID string,
+	resID *string,
+) ([]Action, error) {
+	dbCount, err := c.dbStore.GetActionListCount(ctx, resServerID, resID)
+	if err != nil {
+		return nil, err
+	}
+
+	fileCount, err := c.fileStore.GetActionListCount(ctx, resServerID, resID)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeCompositeListWithLimit(
+		dbCount,
+		fileCount,
+		func(count int) ([]Action, error) { return c.dbStore.GetActionList(ctx, resServerID, resID, count, 0) },
+		func(count int) ([]Action, error) { return c.fileStore.GetActionList(ctx, resServerID, resID, count, 0) },
+		mergeAndDeduplicateActions,
+	)
+}
+
+func mergeCompositeListWithLimit[T any](
+	dbCount int,
+	fileCount int,
+	dbListFn func(count int) ([]T, error),
+	fileListFn func(count int) ([]T, error),
+	mergeFn func(dbList []T, fileList []T) []T,
+) ([]T, error) {
+	merged, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
+		func() (int, error) { return dbCount, nil },
+		func() (int, error) { return fileCount, nil },
+		dbListFn,
+		fileListFn,
+		mergeFn,
+		dbCount+fileCount,
+		0,
+		serverconst.MaxCompositeStoreRecords,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if limitExceeded {
+		return nil, errResultLimitExceededInCompositeMode
+	}
+
+	return merged, nil
 }
 
 func (c *compositeResourceStore) UpdateAction(

--- a/backend/internal/resource/composite_store_test.go
+++ b/backend/internal/resource/composite_store_test.go
@@ -21,7 +21,6 @@ package resource
 import (
 	"context"
 	"errors"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,8 +140,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_MergesBothSt
 		{ID: "rs-file1", Name: "File Server 1"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(dbServers, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(fileServers, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(dbServers), nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(fileServers), nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(dbServers, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(fileServers, nil)
 
 	result, err := s.compositeStore.GetResourceServerList(s.ctx, 10, 0)
 
@@ -161,8 +162,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_WithPaginati
 		{ID: "rs3", Name: "Server 3"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(dbServers, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(fileServers, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(dbServers), nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(fileServers), nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(dbServers, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(fileServers, nil)
 
 	// Get first page
 	result, err := s.compositeStore.GetResourceServerList(s.ctx, 2, 0)
@@ -185,8 +188,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_Deduplicates
 		{ID: "rs3", Name: "Server 3"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(dbServers, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(fileServers, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(dbServers), nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(fileServers), nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(dbServers, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(fileServers, nil)
 
 	result, err := s.compositeStore.GetResourceServerList(s.ctx, 10, 0)
 
@@ -211,8 +216,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_VerifiesIsRe
 		{ID: "rs-file1", Name: "File Server 1"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(dbServers, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(fileServers, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(dbServers), nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(fileServers), nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(dbServers, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(fileServers, nil)
 
 	result, err := s.compositeStore.GetResourceServerList(s.ctx, 10, 0)
 
@@ -242,8 +249,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_Deduplicates
 		{ID: "rs3", Name: "Server 3"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(dbServers, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(fileServers, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(dbServers), nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(fileServers), nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(dbServers, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(fileServers, nil)
 
 	result, err := s.compositeStore.GetResourceServerList(s.ctx, 10, 0)
 
@@ -266,13 +275,15 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_Deduplicates
 
 func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_HandlesEmptyStoresAndSetsIsReadOnly() {
 	// Both stores empty
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return([]ResourceServer{}, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return([]ResourceServer{}, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(0, nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(0, nil)
 
 	result, err := s.compositeStore.GetResourceServerList(s.ctx, 10, 0)
 
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), result)
+	s.dbStoreMock.AssertNotCalled(s.T(), "GetResourceServerList", s.ctx, mock.Anything, 0)
+	s.fileStoreMock.AssertNotCalled(s.T(), "GetResourceServerList", s.ctx, mock.Anything, 0)
 
 	// DB store has servers, file store is empty
 	s.dbStoreMock.ExpectedCalls = nil
@@ -282,8 +293,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_HandlesEmpty
 		{ID: "rs-db1", Name: "DB Server 1"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(dbServers, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return([]ResourceServer{}, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(dbServers), nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(0, nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(dbServers, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return([]ResourceServer{}, nil)
 
 	result, err = s.compositeStore.GetResourceServerList(s.ctx, 10, 0)
 
@@ -299,8 +312,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerList_HandlesEmpty
 		{ID: "rs-file1", Name: "File Server 1"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return([]ResourceServer{}, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(fileServers, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(0, nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(fileServers), nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return([]ResourceServer{}, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(fileServers, nil)
 
 	result, err = s.compositeStore.GetResourceServerList(s.ctx, 10, 0)
 
@@ -319,8 +334,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceServerListCount_SumsBot
 		{ID: "rs3", Name: "Server 3"},
 	}
 
-	s.dbStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(dbServers, nil)
-	s.fileStoreMock.On("GetResourceServerList", s.ctx, math.MaxInt, 0).Return(fileServers, nil)
+	s.dbStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(dbServers), nil)
+	s.fileStoreMock.On("GetResourceServerListCount", s.ctx).Return(len(fileServers), nil)
+	s.dbStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(dbServers, nil)
+	s.fileStoreMock.On("GetResourceServerList", s.ctx, mock.Anything, 0).Return(fileServers, nil)
 
 	count, err := s.compositeStore.GetResourceServerListCount(s.ctx)
 
@@ -516,8 +533,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceList_MergesBothStores()
 		{ID: "res-file1", Name: "File Resource 1"},
 	}
 
-	s.dbStoreMock.On("GetResourceList", s.ctx, "rs1", math.MaxInt, 0).Return(dbResources, nil)
-	s.fileStoreMock.On("GetResourceList", s.ctx, "rs1", math.MaxInt, 0).Return(fileResources, nil)
+	s.dbStoreMock.On("GetResourceListCount", s.ctx, "rs1").Return(len(dbResources), nil)
+	s.fileStoreMock.On("GetResourceListCount", s.ctx, "rs1").Return(len(fileResources), nil)
+	s.dbStoreMock.On("GetResourceList", s.ctx, "rs1", mock.Anything, 0).Return(dbResources, nil)
+	s.fileStoreMock.On("GetResourceList", s.ctx, "rs1", mock.Anything, 0).Return(fileResources, nil)
 
 	result, err := s.compositeStore.GetResourceList(s.ctx, "rs1", 10, 0)
 
@@ -536,11 +555,13 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListByParent_MergesBoth
 		{ID: "res-file1", Name: "File Resource 1"},
 	}
 
+	s.dbStoreMock.On("GetResourceListCountByParent", s.ctx, "rs1", &parentID).Return(len(dbResources), nil)
+	s.fileStoreMock.On("GetResourceListCountByParent", s.ctx, "rs1", &parentID).Return(len(fileResources), nil)
 	s.dbStoreMock.On(
-		"GetResourceListByParent", s.ctx, "rs1", &parentID, math.MaxInt, 0,
+		"GetResourceListByParent", s.ctx, "rs1", &parentID, mock.Anything, 0,
 	).Return(dbResources, nil)
 	s.fileStoreMock.On(
-		"GetResourceListByParent", s.ctx, "rs1", &parentID, math.MaxInt, 0,
+		"GetResourceListByParent", s.ctx, "rs1", &parentID, mock.Anything, 0,
 	).Return(fileResources, nil)
 
 	result, err := s.compositeStore.GetResourceListByParent(s.ctx, "rs1", &parentID, 10, 0)
@@ -555,9 +576,7 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListByParent_DBError() 
 	parentID := testParentID
 	dbErr := errors.New("db error")
 
-	s.dbStoreMock.On(
-		"GetResourceListByParent", s.ctx, "rs1", &parentID, math.MaxInt, 0,
-	).Return(nil, dbErr)
+	s.dbStoreMock.On("GetResourceListCountByParent", s.ctx, "rs1", &parentID).Return(0, dbErr)
 
 	result, err := s.compositeStore.GetResourceListByParent(s.ctx, "rs1", &parentID, 10, 0)
 
@@ -571,12 +590,8 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListByParent_FileError(
 	parentID := testParentID
 	fileErr := errors.New("file error")
 
-	s.dbStoreMock.On(
-		"GetResourceListByParent", s.ctx, "rs1", &parentID, math.MaxInt, 0,
-	).Return([]Resource{}, nil)
-	s.fileStoreMock.On(
-		"GetResourceListByParent", s.ctx, "rs1", &parentID, math.MaxInt, 0,
-	).Return(nil, fileErr)
+	s.dbStoreMock.On("GetResourceListCountByParent", s.ctx, "rs1", &parentID).Return(0, nil)
+	s.fileStoreMock.On("GetResourceListCountByParent", s.ctx, "rs1", &parentID).Return(0, fileErr)
 
 	result, err := s.compositeStore.GetResourceListByParent(s.ctx, "rs1", &parentID, 10, 0)
 
@@ -584,6 +599,8 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListByParent_FileError(
 	assert.Nil(s.T(), result)
 	s.dbStoreMock.AssertExpectations(s.T())
 	s.fileStoreMock.AssertExpectations(s.T())
+	s.dbStoreMock.AssertNotCalled(s.T(), "GetResourceListByParent")
+	s.fileStoreMock.AssertNotCalled(s.T(), "GetResourceListByParent")
 }
 
 func (s *CompositeResourceStoreTestSuite) TestGetResourceListCount_SumsBothStores() {
@@ -596,8 +613,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListCount_SumsBothStore
 		{ID: "res3", Name: "Resource 3"},
 	}
 
-	s.dbStoreMock.On("GetResourceList", s.ctx, "rs1", math.MaxInt, 0).Return(dbResources, nil)
-	s.fileStoreMock.On("GetResourceList", s.ctx, "rs1", math.MaxInt, 0).Return(fileResources, nil)
+	s.dbStoreMock.On("GetResourceListCount", s.ctx, "rs1").Return(len(dbResources), nil)
+	s.fileStoreMock.On("GetResourceListCount", s.ctx, "rs1").Return(len(fileResources), nil)
+	s.dbStoreMock.On("GetResourceList", s.ctx, "rs1", mock.Anything, 0).Return(dbResources, nil)
+	s.fileStoreMock.On("GetResourceList", s.ctx, "rs1", mock.Anything, 0).Return(fileResources, nil)
 
 	count, err := s.compositeStore.GetResourceListCount(s.ctx, "rs1")
 
@@ -610,7 +629,7 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListCount_SumsBothStore
 
 func (s *CompositeResourceStoreTestSuite) TestGetResourceListCount_DBError() {
 	dbErr := errors.New("db error")
-	s.dbStoreMock.On("GetResourceList", s.ctx, "rs1", math.MaxInt, 0).Return(nil, dbErr)
+	s.dbStoreMock.On("GetResourceListCount", s.ctx, "rs1").Return(0, dbErr)
 
 	count, err := s.compositeStore.GetResourceListCount(s.ctx, "rs1")
 
@@ -622,8 +641,8 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListCount_DBError() {
 
 func (s *CompositeResourceStoreTestSuite) TestGetResourceListCount_FileError() {
 	fileErr := errors.New("file error")
-	s.dbStoreMock.On("GetResourceList", s.ctx, "rs1", math.MaxInt, 0).Return([]Resource{}, nil)
-	s.fileStoreMock.On("GetResourceList", s.ctx, "rs1", math.MaxInt, 0).Return(nil, fileErr)
+	s.dbStoreMock.On("GetResourceListCount", s.ctx, "rs1").Return(0, nil)
+	s.fileStoreMock.On("GetResourceListCount", s.ctx, "rs1").Return(0, fileErr)
 
 	count, err := s.compositeStore.GetResourceListCount(s.ctx, "rs1")
 
@@ -631,6 +650,8 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListCount_FileError() {
 	assert.Equal(s.T(), 0, count)
 	s.dbStoreMock.AssertExpectations(s.T())
 	s.fileStoreMock.AssertExpectations(s.T())
+	s.dbStoreMock.AssertNotCalled(s.T(), "GetResourceList")
+	s.fileStoreMock.AssertNotCalled(s.T(), "GetResourceList")
 }
 
 func (s *CompositeResourceStoreTestSuite) TestGetResourceListCountByParent_SumsBothStores() {
@@ -644,11 +665,13 @@ func (s *CompositeResourceStoreTestSuite) TestGetResourceListCountByParent_SumsB
 		{ID: "res3", Name: "Resource 3"},
 	}
 
+	s.dbStoreMock.On("GetResourceListCountByParent", s.ctx, "rs1", &parentID).Return(len(dbResources), nil)
+	s.fileStoreMock.On("GetResourceListCountByParent", s.ctx, "rs1", &parentID).Return(len(fileResources), nil)
 	s.dbStoreMock.On(
-		"GetResourceListByParent", s.ctx, "rs1", &parentID, math.MaxInt, 0,
+		"GetResourceListByParent", s.ctx, "rs1", &parentID, mock.Anything, 0,
 	).Return(dbResources, nil)
 	s.fileStoreMock.On(
-		"GetResourceListByParent", s.ctx, "rs1", &parentID, math.MaxInt, 0,
+		"GetResourceListByParent", s.ctx, "rs1", &parentID, mock.Anything, 0,
 	).Return(fileResources, nil)
 
 	count, err := s.compositeStore.GetResourceListCountByParent(s.ctx, "rs1", &parentID)
@@ -812,8 +835,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetActionList_MergesBothStores() {
 		{ID: "act-file1", Name: "File Action 1"},
 	}
 
-	s.dbStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0).Return(dbActions, nil)
-	s.fileStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0).Return(fileActions, nil)
+	s.dbStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(len(dbActions), nil)
+	s.fileStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(len(fileActions), nil)
+	s.dbStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), mock.Anything, 0).Return(dbActions, nil)
+	s.fileStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), mock.Anything, 0).Return(fileActions, nil)
 
 	result, err := s.compositeStore.GetActionList(s.ctx, "rs1", nil, 10, 0)
 
@@ -825,9 +850,9 @@ func (s *CompositeResourceStoreTestSuite) TestGetActionList_MergesBothStores() {
 
 func (s *CompositeResourceStoreTestSuite) TestGetActionList_DBError() {
 	dbErr := errors.New("db error")
-	s.dbStoreMock.On(
-		"GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0,
-	).Return(nil, dbErr)
+	s.dbStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(1, nil)
+	s.fileStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(0, nil)
+	s.dbStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), mock.Anything, 0).Return(nil, dbErr)
 
 	result, err := s.compositeStore.GetActionList(s.ctx, "rs1", nil, 10, 0)
 
@@ -839,12 +864,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetActionList_DBError() {
 
 func (s *CompositeResourceStoreTestSuite) TestGetActionList_FileError() {
 	fileErr := errors.New("file error")
-	s.dbStoreMock.On(
-		"GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0,
-	).Return([]Action{}, nil)
-	s.fileStoreMock.On(
-		"GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0,
-	).Return(nil, fileErr)
+	s.dbStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(0, nil)
+	s.fileStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(1, nil)
+	s.dbStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), mock.Anything, 0).Return([]Action{}, nil)
+	s.fileStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), mock.Anything, 0).Return(nil, fileErr)
 
 	result, err := s.compositeStore.GetActionList(s.ctx, "rs1", nil, 10, 0)
 
@@ -864,8 +887,10 @@ func (s *CompositeResourceStoreTestSuite) TestGetActionListCount_SumsBothStores(
 		{ID: "act3", Name: "Action 3"},
 	}
 
-	s.dbStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0).Return(dbActions, nil)
-	s.fileStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0).Return(fileActions, nil)
+	s.dbStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(len(dbActions), nil)
+	s.fileStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(len(fileActions), nil)
+	s.dbStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), mock.Anything, 0).Return(dbActions, nil)
+	s.fileStoreMock.On("GetActionList", s.ctx, "rs1", (*string)(nil), mock.Anything, 0).Return(fileActions, nil)
 
 	count, err := s.compositeStore.GetActionListCount(s.ctx, "rs1", nil)
 
@@ -878,9 +903,7 @@ func (s *CompositeResourceStoreTestSuite) TestGetActionListCount_SumsBothStores(
 
 func (s *CompositeResourceStoreTestSuite) TestGetActionListCount_DBError() {
 	dbErr := errors.New("db error")
-	s.dbStoreMock.On(
-		"GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0,
-	).Return(nil, dbErr)
+	s.dbStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(0, dbErr)
 
 	count, err := s.compositeStore.GetActionListCount(s.ctx, "rs1", nil)
 
@@ -892,12 +915,8 @@ func (s *CompositeResourceStoreTestSuite) TestGetActionListCount_DBError() {
 
 func (s *CompositeResourceStoreTestSuite) TestGetActionListCount_FileError() {
 	fileErr := errors.New("file error")
-	s.dbStoreMock.On(
-		"GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0,
-	).Return([]Action{}, nil)
-	s.fileStoreMock.On(
-		"GetActionList", s.ctx, "rs1", (*string)(nil), math.MaxInt, 0,
-	).Return(nil, fileErr)
+	s.dbStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(0, nil)
+	s.fileStoreMock.On("GetActionListCount", s.ctx, "rs1", (*string)(nil)).Return(0, fileErr)
 
 	count, err := s.compositeStore.GetActionListCount(s.ctx, "rs1", nil)
 
@@ -905,6 +924,8 @@ func (s *CompositeResourceStoreTestSuite) TestGetActionListCount_FileError() {
 	assert.Equal(s.T(), 0, count)
 	s.dbStoreMock.AssertExpectations(s.T())
 	s.fileStoreMock.AssertExpectations(s.T())
+	s.dbStoreMock.AssertNotCalled(s.T(), "GetActionList")
+	s.fileStoreMock.AssertNotCalled(s.T(), "GetActionList")
 }
 
 func (s *CompositeResourceStoreTestSuite) TestUpdateAction_DelegatesToDB() {

--- a/backend/internal/resource/declarative_resource.go
+++ b/backend/internal/resource/declarative_resource.go
@@ -309,7 +309,7 @@ func processResourceServer(rs *ResourceServer) error {
 
 	// Process resources and compute permissions
 	for i := range rs.Resources {
-		if err := processResource(&rs.Resources[i], resourceHandleMap, rs.Identifier, delimiter); err != nil {
+		if err := processResource(&rs.Resources[i], resourceHandleMap, delimiter); err != nil {
 			return err
 		}
 	}
@@ -321,11 +321,10 @@ func processResourceServer(rs *ResourceServer) error {
 func processResource(
 	res *Resource,
 	resourceHandleMap map[string]*Resource,
-	serverIdentifier string,
 	delimiter string,
 ) error {
 	// Build permission string from parent chain
-	permission, err := buildPermissionString(res, resourceHandleMap, serverIdentifier, delimiter)
+	permission, err := buildPermissionString(res, resourceHandleMap, delimiter)
 	if err != nil {
 		return err
 	}
@@ -345,15 +344,9 @@ func processResource(
 func buildPermissionString(
 	res *Resource,
 	resourceHandleMap map[string]*Resource,
-	serverIdentifier string,
 	delimiter string,
 ) (string, error) {
 	var parts []string
-
-	// Add server identifier if present
-	if serverIdentifier != "" {
-		parts = append(parts, serverIdentifier)
-	}
 
 	// Build parent chain
 	parentChain := []string{}

--- a/backend/internal/resource/declarative_resource_test.go
+++ b/backend/internal/resource/declarative_resource_test.go
@@ -326,7 +326,7 @@ func TestBuildPermissionString(t *testing.T) {
 			},
 			serverIdentifier: "api",
 			delimiter:        ":",
-			expected:         "api:users",
+			expected:         "users",
 		},
 		{
 			name: "nested resource with identifier",
@@ -337,7 +337,7 @@ func TestBuildPermissionString(t *testing.T) {
 			},
 			serverIdentifier: "api",
 			delimiter:        ":",
-			expected:         "api:users:profile",
+			expected:         "users:profile",
 		},
 		{
 			name: "root resource without identifier",
@@ -354,7 +354,7 @@ func TestBuildPermissionString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := buildPermissionString(tt.resource, resourceHandleMap, tt.serverIdentifier, tt.delimiter)
+			result, err := buildPermissionString(tt.resource, resourceHandleMap, tt.delimiter)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -387,9 +387,9 @@ func TestProcessResourceServer_SetsPermissionsAndDelimiter(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, ":", rs.Delimiter)
-	assert.Equal(t, "api:users", rs.Resources[0].Permission)
-	assert.Equal(t, "api:users:read", rs.Resources[0].Actions[0].Permission)
-	assert.Equal(t, "api:users:profile", rs.Resources[1].Permission)
+	assert.Equal(t, "users", rs.Resources[0].Permission)
+	assert.Equal(t, "users:read", rs.Resources[0].Actions[0].Permission)
+	assert.Equal(t, "users:profile", rs.Resources[1].Permission)
 }
 
 func TestProcessResourceServer_DuplicateHandle(t *testing.T) {
@@ -423,18 +423,18 @@ func TestProcessResource_SetsPermissions(t *testing.T) {
 		"child": resource,
 	}
 
-	err := processResource(resource, resourceHandleMap, "api", ":")
+	err := processResource(resource, resourceHandleMap, ":")
 
 	assert.NoError(t, err)
-	assert.Equal(t, "api:root:child", resource.Permission)
-	assert.Equal(t, "api:root:child:read", resource.Actions[0].Permission)
+	assert.Equal(t, "root:child", resource.Permission)
+	assert.Equal(t, "root:child:read", resource.Actions[0].Permission)
 }
 
 func TestProcessResource_MissingParent(t *testing.T) {
 	resource := &Resource{Handle: "child", ParentHandle: "missing"}
 	resourceHandleMap := map[string]*Resource{}
 
-	err := processResource(resource, resourceHandleMap, "api", ":")
+	err := processResource(resource, resourceHandleMap, ":")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "parent resource handle")
@@ -463,9 +463,9 @@ resources:
 	assert.NoError(t, err)
 	rs, ok := result.(*ResourceServer)
 	assert.True(t, ok)
-	assert.Equal(t, "api:users", rs.Resources[0].Permission)
-	assert.Equal(t, "api:users:read", rs.Resources[0].Actions[0].Permission)
-	assert.Equal(t, "api:users:profile", rs.Resources[1].Permission)
+	assert.Equal(t, "users", rs.Resources[0].Permission)
+	assert.Equal(t, "users:read", rs.Resources[0].Actions[0].Permission)
+	assert.Equal(t, "users:profile", rs.Resources[1].Permission)
 }
 
 func TestParseAndValidateResourceServerWrapper_InvalidYAML(t *testing.T) {

--- a/backend/internal/resource/error_constants.go
+++ b/backend/internal/resource/error_constants.go
@@ -167,6 +167,13 @@ var (
 		Error:            "Cannot modify declarative action",
 		ErrorDescription: "Action %s is defined in declarative configuration and cannot be modified",
 	}
+	// ErrResultLimitExceededInCompositeMode is the error returned when the total number of records exceeds
+	ErrResultLimitExceededInCompositeMode = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "RES-1021",
+		Error:            "Result limit exceeded in composite mode",
+		ErrorDescription: "The total number of records exceeds the maximum limit in composite mode",
+	}
 )
 
 // Internal error constants.
@@ -179,4 +186,7 @@ var (
 
 	// errActionNotFound is returned when the action is not found.
 	errActionNotFound = errors.New("action not found")
+
+	// errResultLimitExceededInCompositeMode is the internal sentinel error for composite mode limit exceeded.
+	errResultLimitExceededInCompositeMode = errors.New("result limit exceeded in composite mode")
 )

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -234,12 +234,18 @@ func (rs *resourceService) GetResourceServerList(
 
 	totalCount, err := rs.resourceStore.GetResourceServerListCount(ctx)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ErrResultLimitExceededInCompositeMode
+		}
 		rs.logger.Error("Failed to get resource server count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	resourceServers, err := rs.resourceStore.GetResourceServerList(ctx, limit, offset)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ErrResultLimitExceededInCompositeMode
+		}
 		rs.logger.Error("Failed to list resource servers", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -542,12 +548,18 @@ func (rs *resourceService) GetResourceList(
 
 	totalCount, err := rs.resourceStore.GetResourceListCountByParent(ctx, resourceServerID, parentID)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ErrResultLimitExceededInCompositeMode
+		}
 		rs.logger.Error("Failed to get top-level resource count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	resources, err = rs.resourceStore.GetResourceListByParent(ctx, resourceServerID, parentID, limit, offset)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ErrResultLimitExceededInCompositeMode
+		}
 		rs.logger.Error("Failed to list resources", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -853,12 +865,18 @@ func (rs *resourceService) GetActionList(
 
 	totalCount, err := rs.resourceStore.GetActionListCount(ctx, resourceServerID, resID)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ErrResultLimitExceededInCompositeMode
+		}
 		rs.logger.Error("Failed to get action count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	actions, err := rs.resourceStore.GetActionList(ctx, resourceServerID, resID, limit, offset)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ErrResultLimitExceededInCompositeMode
+		}
 		rs.logger.Error("Failed to list actions", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -21,6 +21,7 @@ package role
 import (
 	"context"
 
+	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 )
 
@@ -42,67 +43,65 @@ func newCompositeRoleStore(fileStore, dbStore roleStoreInterface) roleStoreInter
 	}
 }
 
-// GetRoleListCount retrieves the total count of roles from both stores.
+// GetRoleListCount retrieves the total count of unique roles across both stores.
 func (c *compositeRoleStore) GetRoleListCount(ctx context.Context) (int, error) {
-	dbCount, err := c.dbStore.GetRoleListCount(ctx)
+	capCount := func(fn func(context.Context) (int, error)) func() (int, error) {
+		return func() (int, error) {
+			count, err := fn(ctx)
+			if err != nil {
+				return 0, err
+			}
+			return min(count, serverconst.MaxCompositeStoreRecords), nil
+		}
+	}
+	roles, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
+		capCount(c.dbStore.GetRoleListCount),
+		capCount(c.fileStore.GetRoleListCount),
+		func(count int) ([]Role, error) { return c.dbStore.GetRoleList(ctx, count, 0) },
+		func(count int) ([]Role, error) { return c.fileStore.GetRoleList(ctx, count, 0) },
+		mergeRoles,
+		serverconst.MaxCompositeStoreRecords+1,
+		0,
+		serverconst.MaxCompositeStoreRecords,
+	)
 	if err != nil {
 		return 0, err
 	}
-
-	fileCount, err := c.fileStore.GetRoleListCount(ctx)
-	if err != nil {
-		return 0, err
+	if limitExceeded {
+		return 0, errResultLimitExceededInCompositeMode
 	}
 
-	dbRoles, err := c.dbStore.GetRoleList(ctx, dbCount, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	fileRoles, err := c.fileStore.GetRoleList(ctx, fileCount, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	mergedRoles := mergeRoles(dbRoles, fileRoles)
-	return len(mergedRoles), nil
+	return len(roles), nil
 }
 
 // GetRoleList retrieves roles from both stores and merges them.
 func (c *compositeRoleStore) GetRoleList(ctx context.Context, limit, offset int) ([]Role, error) {
-	dbCount, err := c.dbStore.GetRoleListCount(ctx)
+	capCount := func(fn func(context.Context) (int, error)) func() (int, error) {
+		return func() (int, error) {
+			count, err := fn(ctx)
+			if err != nil {
+				return 0, err
+			}
+			return min(count, serverconst.MaxCompositeStoreRecords), nil
+		}
+	}
+	roles, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
+		capCount(c.dbStore.GetRoleListCount),
+		capCount(c.fileStore.GetRoleListCount),
+		func(count int) ([]Role, error) { return c.dbStore.GetRoleList(ctx, count, 0) },
+		func(count int) ([]Role, error) { return c.fileStore.GetRoleList(ctx, count, 0) },
+		mergeRoles,
+		limit,
+		offset,
+		serverconst.MaxCompositeStoreRecords,
+	)
 	if err != nil {
 		return nil, err
 	}
-
-	fileCount, err := c.fileStore.GetRoleListCount(ctx)
-	if err != nil {
-		return nil, err
+	if limitExceeded {
+		return nil, errResultLimitExceededInCompositeMode
 	}
-
-	dbRoles, err := c.dbStore.GetRoleList(ctx, dbCount, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	fileRoles, err := c.fileStore.GetRoleList(ctx, fileCount, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge roles from both stores
-	mergedRoles := mergeRoles(dbRoles, fileRoles)
-
-	start := offset
-	if start > len(mergedRoles) {
-		start = len(mergedRoles)
-	}
-	end := start + limit
-	if end > len(mergedRoles) {
-		end = len(mergedRoles)
-	}
-
-	return mergedRoles[start:end], nil
+	return roles, nil
 }
 
 // CreateRole creates a new role in the database store only.
@@ -144,65 +143,63 @@ func (c *compositeRoleStore) GetRoleAssignments(
 	id string,
 	limit, offset int,
 ) ([]RoleAssignment, error) {
-	dbCount, err := c.dbStore.GetRoleAssignmentsCount(ctx, id)
+	capCount := func(fn func(context.Context, string) (int, error)) func() (int, error) {
+		return func() (int, error) {
+			count, err := fn(ctx, id)
+			if err != nil {
+				return 0, err
+			}
+			return min(count, serverconst.MaxCompositeStoreRecords), nil
+		}
+	}
+	assignments, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
+		capCount(c.dbStore.GetRoleAssignmentsCount),
+		capCount(c.fileStore.GetRoleAssignmentsCount),
+		func(count int) ([]RoleAssignment, error) { return c.dbStore.GetRoleAssignments(ctx, id, count, 0) },
+		func(count int) ([]RoleAssignment, error) { return c.fileStore.GetRoleAssignments(ctx, id, count, 0) },
+		mergeAssignments,
+		limit,
+		offset,
+		serverconst.MaxCompositeStoreRecords,
+	)
 	if err != nil {
 		return nil, err
 	}
-
-	fileCount, err := c.fileStore.GetRoleAssignmentsCount(ctx, id)
-	if err != nil {
-		return nil, err
+	if limitExceeded {
+		return nil, errResultLimitExceededInCompositeMode
 	}
-
-	dbAssignments, err := c.dbStore.GetRoleAssignments(ctx, id, dbCount, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	fileAssignments, err := c.fileStore.GetRoleAssignments(ctx, id, fileCount, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge assignments from both stores
-	mergedAssignments := mergeAssignments(dbAssignments, fileAssignments)
-
-	start := offset
-	if start > len(mergedAssignments) {
-		start = len(mergedAssignments)
-	}
-	end := start + limit
-	if end > len(mergedAssignments) {
-		end = len(mergedAssignments)
-	}
-
-	return mergedAssignments[start:end], nil
+	return assignments, nil
 }
 
-// GetRoleAssignmentsCount retrieves the count of role assignments from both stores.
+// GetRoleAssignmentsCount retrieves the count of unique role assignments across both stores.
 func (c *compositeRoleStore) GetRoleAssignmentsCount(ctx context.Context, id string) (int, error) {
-	dbCount, err := c.dbStore.GetRoleAssignmentsCount(ctx, id)
+	capCount := func(fn func(context.Context, string) (int, error)) func() (int, error) {
+		return func() (int, error) {
+			count, err := fn(ctx, id)
+			if err != nil {
+				return 0, err
+			}
+			return min(count, serverconst.MaxCompositeStoreRecords), nil
+		}
+	}
+	assignments, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
+		capCount(c.dbStore.GetRoleAssignmentsCount),
+		capCount(c.fileStore.GetRoleAssignmentsCount),
+		func(count int) ([]RoleAssignment, error) { return c.dbStore.GetRoleAssignments(ctx, id, count, 0) },
+		func(count int) ([]RoleAssignment, error) { return c.fileStore.GetRoleAssignments(ctx, id, count, 0) },
+		mergeAssignments,
+		serverconst.MaxCompositeStoreRecords+1,
+		0,
+		serverconst.MaxCompositeStoreRecords,
+	)
 	if err != nil {
 		return 0, err
 	}
-
-	fileCount, err := c.fileStore.GetRoleAssignmentsCount(ctx, id)
-	if err != nil {
-		return 0, err
+	if limitExceeded {
+		return 0, errResultLimitExceededInCompositeMode
 	}
 
-	dbAssignments, err := c.dbStore.GetRoleAssignments(ctx, id, dbCount, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	fileAssignments, err := c.fileStore.GetRoleAssignments(ctx, id, fileCount, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	mergedAssignments := mergeAssignments(dbAssignments, fileAssignments)
-	return len(mergedAssignments), nil
+	return len(assignments), nil
 }
 
 // UpdateRole updates a role in the database store only.

--- a/backend/internal/role/composite_store_edge_cases_test.go
+++ b/backend/internal/role/composite_store_edge_cases_test.go
@@ -316,20 +316,17 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetRoleList_MergesAndPagin
 
 // Test GetRoleList returns empty when offset exceeds results
 func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetRoleList_OffsetBeyondResults() {
-	dbRoles := []Role{
-		{ID: "role1", Name: "Admin"},
-	}
-	fileRoles := []Role{}
-
 	suite.mockDBStore.On("GetRoleListCount", suite.ctx).Return(1, nil)
 	suite.mockFileStore.On("GetRoleListCount", suite.ctx).Return(0, nil)
-	suite.mockDBStore.On("GetRoleList", suite.ctx, 1, 0).Return(dbRoles, nil)
-	suite.mockFileStore.On("GetRoleList", suite.ctx, 0, 0).Return(fileRoles, nil)
+	// When offset (100) exceeds effectiveTotal (1), the implementation short-circuits
+	// and does not call GetRoleList on either store.
 
 	result, err := suite.store.GetRoleList(suite.ctx, 10, 100)
 
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), result, 0)
+	suite.mockDBStore.AssertNotCalled(suite.T(), "GetRoleList", mock.Anything, mock.Anything, mock.Anything)
+	suite.mockFileStore.AssertNotCalled(suite.T(), "GetRoleList", mock.Anything, mock.Anything, mock.Anything)
 }
 
 // Test GetRoleAssignmentsCount merges and deduplicates

--- a/backend/internal/role/error_constants.go
+++ b/backend/internal/role/error_constants.go
@@ -144,12 +144,23 @@ var (
 		Error:            "Internal server error",
 		ErrorDescription: "An unexpected error occurred while processing the request",
 	}
+	// ResultLimitExceededInCompositeMode is the error returned when the total number of records exceeds
+	// the maximum limit in composite mode (combining database and declarative resources).
+	ResultLimitExceededInCompositeMode = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "ROL-1016",
+		Error:            "Result limit exceeded in composite mode",
+		ErrorDescription: "The total number of records exceeds the maximum limit in composite mode",
+	}
 )
 
 // Internal error constants for role management operations.
 var (
 	// ErrRoleNotFound is returned when the role is not found in the system.
 	ErrRoleNotFound = errors.New("role not found")
+
+	// errResultLimitExceededInCompositeMode is the internal sentinel error for composite mode limit exceeded.
+	errResultLimitExceededInCompositeMode = errors.New("result limit exceeded in composite mode")
 
 	// ErrRoleHasAssignments is returned when attempting to delete a role that has active assignments.
 	ErrRoleHasAssignments = errors.New("role has active assignments")

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -99,12 +99,18 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 
 	totalCount, err := rs.roleStore.GetRoleListCount(ctx)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ResultLimitExceededInCompositeMode
+		}
 		logger.Error("Failed to get role count", log.Error(err))
 		return nil, &ErrorInternalServerError
 	}
 
 	roles, err := rs.roleStore.GetRoleList(ctx, limit, offset)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ResultLimitExceededInCompositeMode
+		}
 		logger.Error("Failed to list roles", log.Error(err))
 		return nil, &ErrorInternalServerError
 	}
@@ -332,6 +338,9 @@ func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.
 	// Check if role has any assignments before deleting
 	assignmentCount, err := rs.roleStore.GetRoleAssignmentsCount(ctx, id)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return &ResultLimitExceededInCompositeMode
+		}
 		logger.Error("Failed to get role assignments count", log.String("id", id), log.Error(err))
 		return &ErrorInternalServerError
 	}
@@ -376,12 +385,18 @@ func (rs *roleService) GetRoleAssignments(ctx context.Context, id string, limit,
 
 	totalCount, err := rs.roleStore.GetRoleAssignmentsCount(ctx, id)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ResultLimitExceededInCompositeMode
+		}
 		logger.Error("Failed to get role assignments count", log.String("id", id), log.Error(err))
 		return nil, &ErrorInternalServerError
 	}
 
 	assignments, err := rs.roleStore.GetRoleAssignments(ctx, id, limit, offset)
 	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ResultLimitExceededInCompositeMode
+		}
 		logger.Error("Failed to get role assignments", log.String("id", id), log.Error(err))
 		return nil, &ErrorInternalServerError
 	}

--- a/backend/internal/system/declarative_resource/composite_helpers.go
+++ b/backend/internal/system/declarative_resource/composite_helpers.go
@@ -67,6 +67,9 @@ func CompositeGetHelper[T any](
 		if fileErr == nil {
 			return entity, nil
 		}
+		if !errors.Is(fileErr, notFoundError) {
+			return zero, fileErr
+		}
 		// Not found in either store
 		return zero, notFoundError
 	}

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -1439,7 +1439,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 		return &ErrorUserSchemaNotFound
 	}
 
-	if strings.TrimSpace(oUID) == "" || !utils.IsValidUUID(oUID) {
+	if strings.TrimSpace(oUID) == "" {
 		return &ErrorInvalidOUID
 	}
 

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -458,13 +458,13 @@ func TestOUStore_ValidateOrganizationUnitForUserType(t *testing.T) {
 			expectedErr: &ErrorInvalidOUID,
 		},
 		{
-			name:     "ReturnsErrorWhenIDInvalid",
+			name:     "ReturnsInternalErrorWhenOUServiceMissing",
 			userType: testUserType,
 			ouID:     "invalid-id",
 			setup: func(t *testing.T) (*userService, testMocks) {
 				return &userService{}, testMocks{}
 			},
-			expectedErr: &ErrorInvalidOUID,
+			expectedErr: &ErrorInternalServerError,
 		},
 		{
 			name:     "ReturnsErrorWhenOrganizationUnitMissing",
@@ -3188,15 +3188,16 @@ func TestNewFunctions(t *testing.T) {
 
 func TestUserService_Validation_EdgeCases(t *testing.T) {
 	service := &userService{}
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
 
 	t.Run("ValidateOU_InvalidUUID", func(t *testing.T) {
-		err := service.validateOrganizationUnitForUserType(context.Background(), "customer", "invalid-uuid", nil)
+		err := service.validateOrganizationUnitForUserType(context.Background(), "customer", "invalid-uuid", logger)
 		require.NotNil(t, err)
-		require.Equal(t, ErrorInvalidOUID.Code, err.Code)
+		require.Equal(t, ErrorInternalServerError.Code, err.Code)
 	})
 
 	t.Run("ValidateOU_EmptyOU", func(t *testing.T) {
-		err := service.validateOrganizationUnitForUserType(context.Background(), "customer", "", nil)
+		err := service.validateOrganizationUnitForUserType(context.Background(), "customer", "", logger)
 		require.NotNil(t, err)
 		require.Equal(t, ErrorInvalidOUID.Code, err.Code)
 	})

--- a/backend/tests/mocks/idp/idpmock/idpStoreInterface_mock.go
+++ b/backend/tests/mocks/idp/idpmock/idpStoreInterface_mock.go
@@ -350,6 +350,66 @@ func (_c *idpStoreInterfaceMock_GetIdentityProviderList_Call) RunAndReturn(run f
 	return _c
 }
 
+// GetIdentityProviderListCount provides a mock function for the type idpStoreInterfaceMock
+func (_mock *idpStoreInterfaceMock) GetIdentityProviderListCount(ctx context.Context) (int, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProviderListCount")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// idpStoreInterfaceMock_GetIdentityProviderListCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderListCount'
+type idpStoreInterfaceMock_GetIdentityProviderListCount_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProviderListCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProviderListCount(ctx interface{}) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	return &idpStoreInterfaceMock_GetIdentityProviderListCount_Call{Call: _e.mock.On("GetIdentityProviderListCount", ctx)}
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) Run(run func(ctx context.Context)) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) Return(n int, err error) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateIdentityProvider provides a mock function for the type idpStoreInterfaceMock
 func (_mock *idpStoreInterfaceMock) UpdateIdentityProvider(ctx context.Context, idp1 *idp.IDPDTO) error {
 	ret := _mock.Called(ctx, idp1)

--- a/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
+++ b/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
@@ -362,6 +362,78 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnit_Call) RunAndRet
 	return _c
 }
 
+// GetOrganizationUnitByHandle provides a mock function for the type organizationUnitStoreInterfaceMock
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByHandle(ctx context.Context, handle string, parent *string) (ou.OrganizationUnit, error) {
+	ret := _mock.Called(ctx, handle, parent)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitByHandle")
+	}
+
+	var r0 ou.OrganizationUnit
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (ou.OrganizationUnit, error)); ok {
+		return returnFunc(ctx, handle, parent)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) ou.OrganizationUnit); ok {
+		r0 = returnFunc(ctx, handle, parent)
+	} else {
+		r0 = ret.Get(0).(ou.OrganizationUnit)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) error); ok {
+		r1 = returnFunc(ctx, handle, parent)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitByHandle'
+type organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitByHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - parent *string
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitByHandle(ctx interface{}, handle interface{}, parent interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call{Call: _e.mock.On("GetOrganizationUnitByHandle", ctx, handle, parent)}
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call) Run(run func(ctx context.Context, handle string, parent *string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call) Return(organizationUnit ou.OrganizationUnit, err error) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	_c.Call.Return(organizationUnit, err)
+	return _c
+}
+
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call) RunAndReturn(run func(ctx context.Context, handle string, parent *string) (ou.OrganizationUnit, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitByHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOrganizationUnitByPath provides a mock function for the type organizationUnitStoreInterfaceMock
 func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitByPath(ctx context.Context, handles []string) (ou.OrganizationUnit, error) {
 	ret := _mock.Called(ctx, handles)


### PR DESCRIPTION
### Purpose
Minor improvements in composite stores

### Approach
This pull request introduces record limits for composite stores across identity provider, resource, and role modules to prevent memory exhaustion when aggregating results from multiple sources. It also adds new error constants to signal when these limits are exceeded, and refactors list and count retrieval methods to use shared helper functions for merging and limiting results.

**Composite Store Record Limiting**

* Applied a 1000-record limit (`serverconst.MaxCompositeStoreRecords`) to composite store list and count operations for identity providers, resources, roles, and role assignments. If the limit is exceeded, the operation returns a new error indicating the result limit was exceeded in composite mode. [[1]](diffhunk://#diff-447b3c90fba6bbdc0671ad8f19eea2df18487ef0780d0d1734cab52f707ae586L68-R78) [[2]](diffhunk://#diff-39d5d1b5926361dad95fdb36df3385941a87fd75e6625a0667efdce80f4e8554R90-R94) [[3]](diffhunk://#diff-39d5d1b5926361dad95fdb36df3385941a87fd75e6625a0667efdce80f4e8554R122-R127) [[4]](diffhunk://#diff-c59b5410cc89d068dd3d08818644443065d3a8d5beb4579f2f0b3afb9ec18bfeL47-R74) [[5]](diffhunk://#diff-c59b5410cc89d068dd3d08818644443065d3a8d5beb4579f2f0b3afb9ec18bfeR111-R142)

**Error Handling Improvements**

* Added new error constants (`ErrResultLimitExceededInCompositeMode`, `errResultLimitExceededInCompositeMode`) in `error_constants.go` for identity provider, resource, and role modules to signal when composite mode record limits are exceeded. [[1]](diffhunk://#diff-64dde28f2dccfc1fd3daafd3a3b136a80ba934880c16e7d788622b0d85fecad4R30-R33) [[2]](diffhunk://#diff-5f0a12f1a3273f4071f15bff6f51803f86734329ee87178aa1deced812ece3d8R182-R185) [[3]](diffhunk://#diff-a01423277f338d3352f03cc2c157ee577e54cf66f435f705c1f20649e2ecb5b2R154-R157)

**Code Refactoring and Helper Usage**

* Refactored list and count retrieval methods in `composite_store.go` for roles and role assignments to use shared helpers (`CompositeMergeCountHelper`, `CompositeMergeListHelperWithLimit`) from `declarativeresource`, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-c59b5410cc89d068dd3d08818644443065d3a8d5beb4579f2f0b3afb9ec18bfeL47-R74) [[2]](diffhunk://#diff-c59b5410cc89d068dd3d08818644443065d3a8d5beb4579f2f0b3afb9ec18bfeR111-R142)

**Resource Store Improvements**

* Refactored resource and resource server retrieval in `composite_store.go` to use `CompositeGetHelper`, streamlining logic for fetching from multiple sources and marking mutability. [[1]](diffhunk://#diff-39d5d1b5926361dad95fdb36df3385941a87fd75e6625a0667efdce80f4e8554L54-R71) [[2]](diffhunk://#diff-39d5d1b5926361dad95fdb36df3385941a87fd75e6625a0667efdce80f4e8554L177-R193)

**Documentation and Imports**

* Updated comments to clarify the purpose of the record limit in composite mode and added necessary imports for `serverconst` and `declarativeresource` in relevant files. [[1]](diffhunk://#diff-447b3c90fba6bbdc0671ad8f19eea2df18487ef0780d0d1734cab52f707ae586R58-R59) [[2]](diffhunk://#diff-447b3c90fba6bbdc0671ad8f19eea2df18487ef0780d0d1734cab52f707ae586R25) [[3]](diffhunk://#diff-39d5d1b5926361dad95fdb36df3385941a87fd75e6625a0667efdce80f4e8554L23-R25) [[4]](diffhunk://#diff-c59b5410cc89d068dd3d08818644443065d3a8d5beb4579f2f0b3afb9ec18bfeR24)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced composite-mode record limit across list operations; exceeding queries now return a specific "result limit exceeded in composite mode" error surfaced to services.
* **Improvements**
  * Centralized cross-store merge/deduplication with consistent not-found and DB-first semantics for IDPs, resources, roles, actions, and OUs.
  * OU path resolution improved to handle mixed DB/file ancestry.
* **New Features**
  * Added count endpoints and service-level error mappings to support count-first, limit-aware listing.
* **Tests**
  * Updated tests and mocks to follow the new count-first, limit-aware list flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->