### PR TITLE
Add i18n for `AcceptInvite` component

### DIFF
--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -1313,6 +1313,32 @@ const translations = {
     'errors.passkey.failed': 'Failed to create passkey. Please try again.',
   },
 
+  // This should be resolved from backend in future efforts
+  // ISSUE: https://github.com/asgardeo/thunder/issues/1724
+  // ============================================================================
+  // Onboarding namespace - User onboarding flow translation
+  // ============================================================================
+  onboarding: {
+    'forms.email.title': 'User Email',
+    'forms.email.fields.email.label': 'Email',
+    'forms.email.fields.email.placeholder': 'Enter email',
+    'forms.email.actions.next.label': 'Next',
+    'forms.user_details.title': 'User Details',
+    'forms.user_details.fields.username.label': 'Username',
+    'forms.user_details.fields.username.placeholder': 'Enter username',
+    'forms.user_details.fields.first_name.label': 'First Name',
+    'forms.user_details.fields.first_name.placeholder': 'Enter first name',
+    'forms.user_details.fields.last_name.label': 'Last Name',
+    'forms.user_details.fields.last_name.placeholder': 'Enter last name',
+    'forms.user_details.fields.phone_number.label': 'Phone Number',
+    'forms.user_details.fields.phone_number.placeholder': 'Enter phone number',
+    'forms.user_details.actions.next.label': 'Next',
+    'forms.credential.title': 'Set Password',
+    'forms.credential.fields.password.label': 'Password',
+    'forms.credential.fields.password.placeholder': 'Enter password',
+    'forms.credential.actions.submit.label': 'Set Password',
+  },
+
   // ============================================================================
   // Invite namespace - Invite acceptance feature translations (for Thunder Gate)
   // ============================================================================


### PR DESCRIPTION
This pull request adds new English translations for the user onboarding flow to the `en-US.ts` file. These translations cover form labels, placeholders, and button texts for email, user details, and password setup steps. The translations are currently hardcoded but are intended to be resolved from the backend in future updates.

**Onboarding translations:**

* Added an `onboarding` namespace with keys and values for user onboarding forms, including email, user details (username, first name, last name, phone number), and password setup fields and actions.

Related Issue:
- https://github.com/asgardeo/thunder/issues/1724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added English language translations for the onboarding flow, including form labels and text for email entry, user details, and credential setup (onboarding forms, validation messages, and helper copy). These translations are now available to display the complete onboarding UI in English.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->