### PR TITLE
Add UI for showing display attribute of users

### DIFF
--- a/frontend/apps/thunder-develop/src/features/groups/api/__tests__/useGetGroupMembers.test.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/api/__tests__/useGetGroupMembers.test.ts
@@ -69,7 +69,7 @@ describe('useGetGroupMembers', () => {
 
     expect(mockHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://localhost:8090/groups/g1/members?limit=30&offset=0',
+        url: 'https://localhost:8090/groups/g1/members?limit=30&offset=0&include=display',
         method: 'GET',
       }),
     );
@@ -82,7 +82,7 @@ describe('useGetGroupMembers', () => {
     await waitFor(() => {
       expect(mockHttpRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://localhost:8090/groups/g1/members?limit=10&offset=5',
+          url: 'https://localhost:8090/groups/g1/members?limit=10&offset=5&include=display',
         }),
       );
     });

--- a/frontend/apps/thunder-develop/src/features/groups/api/useGetGroupMembers.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/api/useGetGroupMembers.ts
@@ -45,6 +45,7 @@ export default function useGetGroupMembers(
       const queryParams: URLSearchParams = new URLSearchParams({
         limit: limit.toString(),
         offset: offset.toString(),
+        include: 'display',
       });
 
       const response: {

--- a/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/AddMemberDialog.tsx
+++ b/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/AddMemberDialog.tsx
@@ -101,10 +101,11 @@ export default function AddMemberDialog({open, onClose, onAdd}: AddMemberDialogP
         ),
       },
       {
-        field: 'id',
+        field: 'display',
         headerName: t('groups:addMember.columns.userId'),
         flex: 1,
         minWidth: 250,
+        valueGetter: (_value: unknown, row: ApiUser) => row.display ?? row.id,
       },
     ],
     [theme, t],

--- a/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/ManageMembersSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/ManageMembersSection.tsx
@@ -84,10 +84,11 @@ export default function ManageMembersSection({groupId, onRemoveMember, headerAct
         ),
       },
       {
-        field: 'id',
+        field: 'display',
         headerName: t('groups:edit.members.sections.manage.listing.columns.id'),
         flex: 1,
         minWidth: 250,
+        valueGetter: (_value: unknown, row: Member) => row.display ?? row.id,
       },
       {
         field: 'type',

--- a/frontend/apps/thunder-develop/src/features/groups/models/group.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/models/group.ts
@@ -24,6 +24,8 @@ export interface Member {
   id: string;
   /** Type of the member */
   type: 'user' | 'group';
+  /** Display name of the member */
+  display?: string;
 }
 
 /**

--- a/frontend/apps/thunder-develop/src/features/organization-units/api/useGetOrganizationUnitUsers.ts
+++ b/frontend/apps/thunder-develop/src/features/organization-units/api/useGetOrganizationUnitUsers.ts
@@ -67,6 +67,7 @@ export default function useGetOrganizationUnitUsers(
       const queryParams: URLSearchParams = new URLSearchParams({
         limit: limit.toString(),
         offset: offset.toString(),
+        include: 'display',
       });
 
       const response: {

--- a/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
@@ -88,10 +88,11 @@ export default function ManageUsersSection({organizationUnitId}: ManageUsersSect
         ),
       },
       {
-        field: 'id',
+        field: 'display',
         headerName: t('organizationUnits:edit.users.sections.manage.listing.columns.id'),
         flex: 1,
         minWidth: 200,
+        valueGetter: (_value: unknown, row: ApiUser) => row.display ?? row.id,
       },
       {
         field: 'type',

--- a/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
@@ -36,7 +36,7 @@ import {
 } from '@wso2/oxygen-ui';
 import {Plus, Trash2, Info} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
-import {useEffect, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {SchemaPropertyInput, UIPropertyType} from '../../types/user-types';
 
@@ -50,6 +50,8 @@ export interface ConfigurePropertiesProps {
   onPropertiesChange: (properties: SchemaPropertyInput[]) => void;
   enumInput: Record<string, string>;
   onEnumInputChange: (enumInput: Record<string, string>) => void;
+  displayAttribute: string;
+  onDisplayAttributeChange: (displayAttribute: string) => void;
   onReadyChange?: (isReady: boolean) => void;
 }
 
@@ -63,10 +65,46 @@ export default function ConfigureProperties({
   onPropertiesChange,
   enumInput,
   onEnumInputChange,
+  displayAttribute,
+  onDisplayAttributeChange,
   onReadyChange = undefined,
 }: ConfigurePropertiesProps): JSX.Element {
   const {t} = useTranslation();
   const nextId = useRef(properties.length + 1);
+
+  // Eligible properties for display attribute: string/enum type, non-credential, with a name
+  const eligibleDisplayProperties = useMemo(
+    () =>
+      properties.filter(
+        (p) => (p.type === 'string' || p.type === 'enum') && !p.credential && p.name.trim().length > 0,
+      ),
+    [properties],
+  );
+
+  // Track whether user has explicitly cleared the display attribute.
+  const userClearedRef = useRef(false);
+
+  const handleDisplayAttributeChange = useCallback(
+    (value: string): void => {
+      if (!value) {
+        userClearedRef.current = true;
+      } else {
+        userClearedRef.current = false;
+      }
+      onDisplayAttributeChange(value);
+    },
+    [onDisplayAttributeChange],
+  );
+
+  // Auto-select when exactly one eligible property (unless user explicitly cleared), clear if selected becomes ineligible
+  useEffect((): void => {
+    const eligibleNames = eligibleDisplayProperties.map((p) => p.name.trim());
+    if (eligibleNames.length === 1 && !displayAttribute && !userClearedRef.current) {
+      onDisplayAttributeChange(eligibleNames[0]);
+    } else if (displayAttribute && !eligibleNames.includes(displayAttribute)) {
+      onDisplayAttributeChange('');
+    }
+  }, [eligibleDisplayProperties, displayAttribute, onDisplayAttributeChange]);
 
   // Broadcast readiness - ready when at least one property has a name
   useEffect((): void => {
@@ -354,6 +392,46 @@ export default function ConfigureProperties({
       >
         {t('userTypes:addProperty')}
       </Button>
+
+      {/* Display Attribute selection */}
+      {eligibleDisplayProperties.length > 0 && (
+        <Paper variant="outlined" sx={{px: 3, py: 3, borderRadius: 2}}>
+          <FormControl fullWidth>
+            <FormLabel>{t('userTypes:displayAttribute', 'Display Attribute')}</FormLabel>
+            <Typography variant="body2" color="text.secondary" sx={{mb: 1}}>
+              {t('userTypes:displayAttributeHint', 'The property used to display user names in listings and references')}
+            </Typography>
+            <Select
+              value={displayAttribute}
+              onChange={(e) => handleDisplayAttributeChange(e.target.value)}
+              size="small"
+              displayEmpty
+              renderValue={(selected) => {
+                const value = typeof selected === 'string' ? selected : '';
+                if (!value) {
+                  return (
+                    <Typography variant="body2" color="text.secondary">
+                      {t('userTypes:selectDisplayAttribute', 'Select a display attribute')}
+                    </Typography>
+                  );
+                }
+                return value;
+              }}
+            >
+              <MenuItem value="">
+                <Typography variant="body2" color="text.secondary">
+                  {t('common:none', 'None')}
+                </Typography>
+              </MenuItem>
+              {eligibleDisplayProperties.map((prop) => (
+                <MenuItem key={prop.id} value={prop.name.trim()}>
+                  {prop.name.trim()}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Paper>
+      )}
     </Stack>
   );
 }

--- a/frontend/apps/thunder-develop/src/features/user-types/contexts/UserTypeCreate/UserTypeCreateContext.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/contexts/UserTypeCreate/UserTypeCreateContext.tsx
@@ -47,6 +47,9 @@ export interface UserTypeCreateContextType {
   enumInput: Record<string, string>;
   setEnumInput: (enumInput: Record<string, string>) => void;
 
+  displayAttribute: string;
+  setDisplayAttribute: (displayAttribute: string) => void;
+
   error: string | null;
   setError: (error: string | null) => void;
 

--- a/frontend/apps/thunder-develop/src/features/user-types/contexts/UserTypeCreate/UserTypeCreateProvider.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/contexts/UserTypeCreate/UserTypeCreateProvider.tsx
@@ -45,6 +45,7 @@ const INITIAL_STATE = {
     },
   ] satisfies SchemaPropertyInput[],
   enumInput: {} as Record<string, string>,
+  displayAttribute: '',
   error: null as string | null,
 };
 
@@ -61,6 +62,7 @@ export default function UserTypeCreateProvider({children}: PropsWithChildren) {
   const [allowSelfRegistration, setAllowSelfRegistration] = useState<boolean>(INITIAL_STATE.allowSelfRegistration);
   const [properties, setProperties] = useState<SchemaPropertyInput[]>(INITIAL_STATE.properties);
   const [enumInput, setEnumInput] = useState<Record<string, string>>(INITIAL_STATE.enumInput);
+  const [displayAttribute, setDisplayAttribute] = useState<string>(INITIAL_STATE.displayAttribute);
   const [error, setError] = useState<string | null>(INITIAL_STATE.error);
 
   const reset = useCallback((): void => {
@@ -70,6 +72,7 @@ export default function UserTypeCreateProvider({children}: PropsWithChildren) {
     setAllowSelfRegistration(INITIAL_STATE.allowSelfRegistration);
     setProperties(INITIAL_STATE.properties);
     setEnumInput(INITIAL_STATE.enumInput);
+    setDisplayAttribute(INITIAL_STATE.displayAttribute);
     setError(INITIAL_STATE.error);
   }, []);
 
@@ -87,11 +90,13 @@ export default function UserTypeCreateProvider({children}: PropsWithChildren) {
       setProperties,
       enumInput,
       setEnumInput,
+      displayAttribute,
+      setDisplayAttribute,
       error,
       setError,
       reset,
     }),
-    [currentStep, name, ouId, allowSelfRegistration, properties, enumInput, error, reset],
+    [currentStep, name, ouId, allowSelfRegistration, properties, enumInput, displayAttribute, error, reset],
   );
 
   return <UserTypeCreateContext.Provider value={contextValue}>{children}</UserTypeCreateContext.Provider>;

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/CreateUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/CreateUserTypePage.tsx
@@ -60,6 +60,8 @@ export default function CreateUserTypePage(): JSX.Element {
     setProperties,
     enumInput,
     setEnumInput,
+    displayAttribute,
+    setDisplayAttribute,
     error,
     setError,
   } = useUserTypeCreate();
@@ -199,6 +201,10 @@ export default function CreateUserTypePage(): JSX.Element {
       requestBody.allowSelfRegistration = true;
     }
 
+    if (displayAttribute) {
+      requestBody.systemAttributes = {display: displayAttribute};
+    }
+
     try {
       await createUserTypeMutation.mutateAsync(requestBody);
       await navigate('/user-types');
@@ -259,6 +265,8 @@ export default function CreateUserTypePage(): JSX.Element {
             onPropertiesChange={setProperties}
             enumInput={enumInput}
             onEnumInputChange={setEnumInput}
+            displayAttribute={displayAttribute}
+            onDisplayAttributeChange={setDisplayAttribute}
             onReadyChange={handlePropertiesStepReadyChange}
           />
         );

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
@@ -81,6 +81,7 @@ export default function ViewUserTypePage() {
   const [ouId, setOuId] = useState('');
   const [allowSelfRegistration, setAllowSelfRegistration] = useState(false);
   const [properties, setProperties] = useState<SchemaPropertyInput[]>([]);
+  const [displayAttribute, setDisplayAttribute] = useState('');
   const [enumInput, setEnumInput] = useState<Record<string, string>>({});
   const [validationError, setValidationError] = useState<string | null>(null);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -91,6 +92,13 @@ export default function ViewUserTypePage() {
   const selectedOrganizationUnit = useMemo(
     () => organizationUnits.find((unit) => unit.id === ouId),
     [organizationUnits, ouId],
+  );
+  const eligibleDisplayProperties = useMemo(
+    () =>
+      properties.filter(
+        (p) => (p.type === 'string' || p.type === 'enum') && !p.credential && p.name.trim().length > 0,
+      ),
+    [properties],
   );
 
   const convertSchemaToProperties = (schema: UserSchemaDefinition) => {
@@ -112,6 +120,7 @@ export default function ViewUserTypePage() {
       setName(userType.name);
       setOuId(userType.ouId);
       setAllowSelfRegistration(userType.allowSelfRegistration ?? false);
+      setDisplayAttribute(userType.systemAttributes?.display ?? '');
       convertSchemaToProperties(userType.schema);
     }
   }, [userType]);
@@ -127,6 +136,7 @@ export default function ViewUserTypePage() {
       setName(userType.name);
       setOuId(userType.ouId);
       setAllowSelfRegistration(userType.allowSelfRegistration ?? false);
+      setDisplayAttribute(userType.systemAttributes?.display ?? '');
       convertSchemaToProperties(userType.schema);
     }
     setValidationError(null);
@@ -241,6 +251,7 @@ export default function ViewUserTypePage() {
           name: name.trim(),
           ouId: trimmedOuId,
           allowSelfRegistration,
+          ...(displayAttribute ? {systemAttributes: {display: displayAttribute}} : {}),
           schema,
         },
       });
@@ -459,6 +470,46 @@ export default function ViewUserTypePage() {
                   }
                   label={t('userTypes:allowSelfRegistration')}
                 />
+              )}
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 0.5}}>
+                {t('userTypes:displayAttribute', 'Display Attribute')}
+              </Typography>
+              {!isEditMode ? (
+                <Typography variant="body1" sx={{fontWeight: 500}}>
+                  {userType.systemAttributes?.display ?? t('userTypes:noDisplayAttribute', 'Not configured')}
+                </Typography>
+              ) : (
+                <Select
+                  value={displayAttribute}
+                  onChange={(event) => setDisplayAttribute(event.target.value)}
+                  size="small"
+                  fullWidth
+                  displayEmpty
+                  renderValue={(selected) => {
+                    const value = typeof selected === 'string' ? selected : '';
+                    if (!value) {
+                      return (
+                        <Typography variant="body2" color="text.secondary">
+                          {t('userTypes:selectDisplayAttribute', 'Select a display attribute')}
+                        </Typography>
+                      );
+                    }
+                    return value;
+                  }}
+                >
+                  <MenuItem value="">
+                    <Typography variant="body2" color="text.secondary">
+                      {t('common:none', 'None')}
+                    </Typography>
+                  </MenuItem>
+                  {eligibleDisplayProperties.map((prop) => (
+                    <MenuItem key={prop.id} value={prop.name.trim()}>
+                      {prop.name.trim()}
+                    </MenuItem>
+                  ))}
+                </Select>
               )}
             </Box>
           </Stack>

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/CreateUserTypePage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/CreateUserTypePage.test.tsx
@@ -586,6 +586,7 @@ describe('CreateUserTypePage', () => {
             required: true,
           },
         },
+        systemAttributes: {display: 'email'},
       });
     });
 
@@ -632,6 +633,7 @@ describe('CreateUserTypePage', () => {
             required: false,
           },
         },
+        systemAttributes: {display: 'email'},
       });
     });
   });
@@ -765,6 +767,7 @@ describe('CreateUserTypePage', () => {
             enum: ['ACTIVE', 'INACTIVE'],
           },
         },
+        systemAttributes: {display: 'status'},
       });
     });
   });
@@ -801,6 +804,7 @@ describe('CreateUserTypePage', () => {
             regex: '^[A-Z]{3}$',
           },
         },
+        systemAttributes: {display: 'code'},
       });
     });
   });

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
@@ -75,8 +75,8 @@ vi.mock('../../../organization-units/api/useGetOrganizationUnits', () => ({
 }));
 
 const getOrganizationUnitSelect = () => screen.getAllByRole('combobox')[0];
-const getPropertyTypeSelect = (index = 0) => screen.getAllByRole('combobox')[index + 1];
-const getPropertyTypeSelects = () => screen.getAllByRole('combobox').slice(1);
+const getPropertyTypeSelect = (index = 0) => screen.getAllByRole('combobox')[index + 2];
+const getPropertyTypeSelects = () => screen.getAllByRole('combobox').slice(2);
 
 describe('ViewUserTypePage', () => {
   const mockUserType: ApiUserSchema = {

--- a/frontend/apps/thunder-develop/src/features/user-types/types/user-types.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/types/user-types.ts
@@ -99,6 +99,13 @@ export type PropertyDefinition =
 export type UserSchemaDefinition = Record<string, PropertyDefinition>;
 
 /**
+ * System-level metadata for a user schema.
+ */
+export interface SystemAttributes {
+  display?: string;
+}
+
+/**
  * Complete User Schema object as returned by API
  */
 export interface ApiUserSchema {
@@ -106,6 +113,7 @@ export interface ApiUserSchema {
   name: string;
   ouId: string;
   allowSelfRegistration: boolean;
+  systemAttributes?: SystemAttributes;
   schema: UserSchemaDefinition;
 }
 
@@ -117,6 +125,7 @@ export interface UserSchemaListItem {
   name: string;
   ouId: string;
   allowSelfRegistration: boolean;
+  systemAttributes?: SystemAttributes;
 }
 
 /**
@@ -145,6 +154,7 @@ export interface CreateUserSchemaRequest {
   name: string;
   ouId: string;
   allowSelfRegistration?: boolean;
+  systemAttributes?: SystemAttributes;
   schema: UserSchemaDefinition;
 }
 
@@ -155,6 +165,7 @@ export interface UpdateUserSchemaRequest {
   name: string;
   ouId: string;
   allowSelfRegistration?: boolean;
+  systemAttributes?: SystemAttributes;
   schema: UserSchemaDefinition;
 }
 

--- a/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUsers.test.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/__tests__/useGetUsers.test.ts
@@ -112,7 +112,7 @@ describe('useGetUsers', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const callArgs = mockHttpRequest.mock.calls[0][0];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(callArgs.url).toBe('https://api.test.com/users');
+    expect(callArgs.url).toBe('https://api.test.com/users?include=display');
   });
 
   it('should use custom pagination parameters', async () => {

--- a/frontend/apps/thunder-develop/src/features/users/api/useGetUsers.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useGetUsers.ts
@@ -48,6 +48,7 @@ export default function useGetUsers(params?: UserListParams): UseQueryResult<Use
       if (filter) {
         searchParams.append('filter', filter);
       }
+      searchParams.append('include', 'display');
 
       const queryString: string = searchParams.toString();
 

--- a/frontend/apps/thunder-develop/src/features/users/components/UsersList.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/components/UsersList.tsx
@@ -20,7 +20,6 @@ import {useEffect, useMemo, useState, useCallback} from 'react';
 import {useNavigate} from 'react-router';
 import {
   Avatar,
-  Chip,
   IconButton,
   Tooltip,
   Typography,
@@ -35,37 +34,24 @@ import {
   Button,
   DataGrid,
 } from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
 import {useLogger} from '@thunder/logger/react';
 import useDataGridLocaleText from '../../../hooks/useDataGridLocaleText';
 import useGetUsers from '../api/useGetUsers';
-import useGetUserSchema from '../api/useGetUserSchema';
 import useDeleteUser from '../api/useDeleteUser';
 import type {UserWithDetails} from '../types/users';
 
-interface UsersListProps {
-  selectedSchema: string;
-}
-
-export default function UsersList(props: UsersListProps) {
-  const {selectedSchema} = props;
+export default function UsersList() {
   const navigate = useNavigate();
   const {t} = useTranslation();
   const logger = useLogger('UsersList');
   const dataGridLocaleText = useDataGridLocaleText();
 
-  const {data: userData, isLoading: isUsersRequestLoading, error: usersRequestError} = useGetUsers();
+  const {data: userData, isLoading, error: usersRequestError} = useGetUsers();
   const deleteUserMutation = useDeleteUser();
 
-  const {
-    data: defaultUserSchema,
-    isLoading: isDefaultUserSchemaRequestLoading,
-    error: defaultUserSchemaRequestError,
-  } = useGetUserSchema(selectedSchema);
-
-  const error = usersRequestError ?? defaultUserSchemaRequestError;
-  const isLoading = isUsersRequestLoading || isDefaultUserSchemaRequestLoading;
+  const error = usersRequestError;
 
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
@@ -127,211 +113,90 @@ export default function UsersList(props: UsersListProps) {
       .slice(0, 2);
   };
 
-  const columns: DataGrid.GridColDef<UserWithDetails>[] = useMemo(() => {
-    if (!defaultUserSchema) {
-      // Return basic columns if schema is not loaded yet
-      return [];
-    }
-
-    const schemaColumns: DataGrid.GridColDef<UserWithDetails>[] = [];
-    const schemaEntries = Object.entries(defaultUserSchema.schema);
-
-    // Helper function to format field names
-    const formatHeaderName = (fieldName: string): string =>
-      fieldName
-        .replace(/([A-Z])/g, ' $1')
-        .replace(/^./, (str) => str.toUpperCase())
-        .trim();
-
-    // Dynamically generate columns from schema
-    schemaEntries.forEach(([fieldName, fieldDef]) => {
-      // Special handling for username to show with avatar
-      if (fieldName === 'username') {
-        schemaColumns.push({
-          field: fieldName,
-          headerName: formatHeaderName(fieldName),
-          flex: 1,
-          minWidth: 200,
-          renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => {
-            const usernameVal = (params.row.attributes?.username as string | undefined) ?? '-';
-            const firstnameVal = params.row.attributes?.firstname as string | undefined;
-            const lastnameVal = params.row.attributes?.lastname as string | undefined;
-            const displayName = [firstnameVal, lastnameVal, usernameVal].filter(Boolean).join(' ');
-
-            return (
-              <ListingTable.CellIcon
-                sx={{width: '100%'}}
-                icon={
-                  <Avatar
-                    sx={{
-                      width: 30,
-                      height: 30,
-                      bgcolor: 'primary.main',
-                      fontSize: '0.875rem',
-                    }}
-                  >
-                    {getInitials(displayName)}
-                  </Avatar>
-                }
-                primary={usernameVal}
-              />
-            );
-          },
-        });
-        return;
-      }
-
-      // Skip firstname/lastname as they're shown with username
-      if (fieldName === 'firstname' || fieldName === 'lastname') {
-        return;
-      }
-
-      // Skip credential fields as they are not returned in the user list response
-      if ('credential' in fieldDef && fieldDef.credential) {
-        return;
-      }
-
-      // Special handling for isActive/status fields with Chip
-      if (fieldName === 'isActive' || fieldName === 'active' || fieldName === 'status') {
-        schemaColumns.push({
-          field: fieldName,
-          headerName: formatHeaderName(fieldName),
-          width: 120,
-          renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => {
-            const value = params.row.attributes?.[fieldName] as boolean | string | undefined;
-            if (value === undefined || value === null) return null;
-
-            const isActive = typeof value === 'boolean' ? value : value === 'active';
-            return (
-              <Chip
-                label={isActive ? t('common:status.active') : t('common:status.inactive')}
-                size="small"
-                color={isActive ? 'success' : 'default'}
-              />
-            );
-          },
-        });
-        return;
-      }
-
-      // Handle different field types
-      const columnDef: DataGrid.GridColDef<UserWithDetails> = {
-        field: fieldName,
-        headerName: formatHeaderName(fieldName),
+  const columns: DataGrid.GridColDef<UserWithDetails>[] = useMemo(
+    () => [
+      {
+        field: 'display',
+        headerName: t('users:displayName', 'Display Name'),
         flex: 1,
-        minWidth: 150,
-      };
+        minWidth: 200,
+        renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => {
+          const displayVal = params.row.display ?? params.row.id;
 
-      // Type-specific configuration
-      switch (fieldDef.type) {
-        case 'boolean':
-          columnDef.renderCell = (params: DataGrid.GridRenderCellParams<UserWithDetails>) => {
-            const value = params.row.attributes?.[fieldName] as boolean | undefined;
-            if (value === undefined || value === null) return '-';
-            return value ? t('common:actions.yes') : t('common:actions.no');
-          };
-          break;
-
-        case 'number':
-          columnDef.type = 'number';
-          columnDef.valueGetter = (_value: unknown, row: UserWithDetails) => {
-            const value = row.attributes?.[fieldName] as number | undefined;
-            return value ?? null;
-          };
-          break;
-
-        case 'array':
-          columnDef.sortable = false;
-          columnDef.renderCell = (params: DataGrid.GridRenderCellParams<UserWithDetails>) => {
-            const value = params.row.attributes?.[fieldName] as unknown[] | undefined;
-            if (!value || !Array.isArray(value) || value.length === 0) return '-';
-            return value.join(', ');
-          };
-          break;
-
-        case 'object':
-          columnDef.sortable = false;
-          columnDef.renderCell = (params: DataGrid.GridRenderCellParams<UserWithDetails>) => {
-            const value = params.row.attributes?.[fieldName] as Record<string, unknown> | undefined;
-            if (!value || typeof value !== 'object') return '-';
-            return JSON.stringify(value);
-          };
-          break;
-
-        default:
-          // String and other types
-          columnDef.valueGetter = (_value, row) => {
-            const value = row.attributes?.[fieldName] as string | number | undefined;
-            return value ?? null;
-          };
-      }
-
-      schemaColumns.push(columnDef);
-    });
-
-    // Add actions column at the end (pinned to the right)
-    schemaColumns.push({
-      field: 'actions',
-      headerName: t('users:actions'),
-      width: 150,
-      align: 'center',
-      headerAlign: 'center',
-      sortable: false,
-      filterable: false,
-      hideable: false,
-      renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => (
-        <ListingTable.RowActions visibility="hover">
-          <Tooltip title={t('common:actions.edit')}>
-            <IconButton
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleViewClick(params.row.id);
-              }}
-            >
-              <Pencil size={16} />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title={t('common:actions.delete')}>
-            <IconButton
-              size="small"
-              color="error"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleDeleteClick(params.row.id);
-              }}
-            >
-              <Trash2 size={16} />
-            </IconButton>
-          </Tooltip>
-        </ListingTable.RowActions>
-      ),
-    });
-
-    return schemaColumns;
-  }, [defaultUserSchema, handleDeleteClick, handleViewClick, t]);
-
-  // Calculate initial column visibility: show first 4 columns, hide the rest
-  const initialColumnVisibility = useMemo(() => {
-    if (!columns || columns.length === 0) return {};
-
-    const visibility: Record<string, boolean> = {};
-    const VISIBLE_COLUMN_COUNT = 4;
-
-    columns.forEach((column, index) => {
-      // Always show actions column
-      if (column.field === 'actions') {
-        visibility[column.field] = true;
-      } else {
-        // Show first VISIBLE_COLUMN_COUNT data columns, hide the rest
-        const dataColumnIndex = columns.slice(0, index).filter((col) => col.field !== 'actions').length;
-
-        visibility[column.field] = dataColumnIndex < VISIBLE_COLUMN_COUNT;
-      }
-    });
-
-    return visibility;
-  }, [columns]);
+          return (
+            <ListingTable.CellIcon
+              sx={{width: '100%'}}
+              icon={
+                <Avatar
+                  sx={{
+                    width: 30,
+                    height: 30,
+                    bgcolor: 'primary.main',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {getInitials(displayVal)}
+                </Avatar>
+              }
+              primary={displayVal}
+            />
+          );
+        },
+      },
+      {
+        field: 'id',
+        headerName: t('users:userId', 'User ID'),
+        flex: 1,
+        minWidth: 200,
+        renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => (
+          <Typography
+            variant="body2"
+            sx={{fontFamily: 'monospace', fontSize: '0.875rem'}}
+          >
+            {params.row.id}
+          </Typography>
+        ),
+      },
+      {
+        field: 'actions',
+        headerName: t('users:actions'),
+        width: 150,
+        align: 'center',
+        headerAlign: 'center',
+        sortable: false,
+        filterable: false,
+        hideable: false,
+        renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => (
+          <ListingTable.RowActions visibility="hover">
+            <Tooltip title={t('common:actions.view')}>
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleViewClick(params.row.id);
+                }}
+              >
+                <Eye size={16} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={t('common:actions.delete')}>
+              <IconButton
+                size="small"
+                color="error"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDeleteClick(params.row.id);
+                }}
+              >
+                <Trash2 size={16} />
+              </IconButton>
+            </Tooltip>
+          </ListingTable.RowActions>
+        ),
+      },
+    ],
+    [handleDeleteClick, handleViewClick, t],
+  );
 
   return (
     <>
@@ -347,9 +212,6 @@ export default function UsersList(props: UsersListProps) {
             initialState={{
               pagination: {
                 paginationModel: {pageSize: 10},
-              },
-              columns: {
-                columnVisibilityModel: initialColumnVisibility,
               },
             }}
             pageSizeOptions={[5, 10, 25, 50]}

--- a/frontend/apps/thunder-develop/src/features/users/components/__tests__/UsersList.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/components/__tests__/UsersList.test.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import type * as OxygenUI from '@wso2/oxygen-ui';
 import {DataGrid} from '@wso2/oxygen-ui';
 import UsersList from '../UsersList';
-import type {UserListResponse, ApiUserSchema} from '../../types/users';
+import type {UserListResponse} from '../../types/users';
 
 const {mockLoggerError} = vi.hoisted(() => ({
   mockLoggerError: vi.fn(),
@@ -34,6 +34,7 @@ const mockDeleteMutateAsync = vi.fn();
 // Mock DataGrid to avoid CSS import issues
 interface MockRow {
   id: string;
+  display?: string;
   attributes?: Record<string, unknown>;
   [key: string]: unknown;
 }
@@ -69,8 +70,7 @@ vi.mock('@wso2/oxygen-ui', async () => {
         <div data-testid="data-grid" data-loading={loading}>
           {rows.map((row) => {
             const rowId = getRowId ? getRowId(row) : row.id;
-            const username = row.attributes?.username;
-            const displayText = typeof username === 'string' ? username : rowId;
+            const displayText = row.display ?? rowId;
 
             return (
               <div key={rowId} className="MuiDataGrid-row-container">
@@ -167,12 +167,6 @@ interface UseGetUsersReturn {
   error: Error | null;
 }
 
-interface UseGetUserSchemaReturn {
-  data: ApiUserSchema | undefined;
-  isLoading: boolean;
-  error: Error | null;
-}
-
 interface UseDeleteUserReturn {
   mutate: ReturnType<typeof vi.fn>;
   mutateAsync: ReturnType<typeof vi.fn>;
@@ -186,15 +180,10 @@ interface UseDeleteUserReturn {
 }
 
 const mockUseGetUsers = vi.fn<() => UseGetUsersReturn>();
-const mockUseGetUserSchema = vi.fn<(schemaId: string) => UseGetUserSchemaReturn>();
 const mockUseDeleteUser = vi.fn<() => UseDeleteUserReturn>();
 
 vi.mock('../../api/useGetUsers', () => ({
   default: () => mockUseGetUsers(),
-}));
-
-vi.mock('../../api/useGetUserSchema', () => ({
-  default: (schemaId: string) => mockUseGetUserSchema(schemaId),
 }));
 
 vi.mock('../../api/useDeleteUser', () => ({
@@ -211,39 +200,27 @@ describe('UsersList', () => {
         id: 'user1',
         organizationUnit: 'org1',
         type: 'schema1',
+        display: 'John Doe',
         attributes: {
           username: 'john.doe',
           firstname: 'John',
           lastname: 'Doe',
           email: 'john@example.com',
-          isActive: true,
         },
       },
       {
         id: 'user2',
         organizationUnit: 'org2',
         type: 'schema2',
+        display: 'Jane Smith',
         attributes: {
           username: 'jane.smith',
           firstname: 'Jane',
           lastname: 'Smith',
           email: 'jane@example.com',
-          isActive: false,
         },
       },
     ],
-  };
-
-  const mockSchema: ApiUserSchema = {
-    id: 'schema1',
-    name: 'Default Schema',
-    schema: {
-      username: {type: 'string', required: true},
-      firstname: {type: 'string'},
-      lastname: {type: 'string'},
-      email: {type: 'string'},
-      isActive: {type: 'boolean'},
-    },
   };
 
   const defaultDeleteReturn: UseDeleteUserReturn = {
@@ -266,25 +243,20 @@ describe('UsersList', () => {
       isLoading: false,
       error: null,
     });
-    mockUseGetUserSchema.mockReturnValue({
-      data: mockSchema,
-      isLoading: false,
-      error: null,
-    });
     mockUseDeleteUser.mockReturnValue({...defaultDeleteReturn});
   });
 
   it('renders DataGrid with users', async () => {
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
-      expect(screen.getByTestId('row-user2')).toHaveTextContent('jane.smith');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
+      expect(screen.getByTestId('row-user2')).toHaveTextContent('Jane Smith');
     });
   });
 
   it('displays user avatars with initials', async () => {
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
       const grid = screen.getByTestId('data-grid');
@@ -299,7 +271,7 @@ describe('UsersList', () => {
       error: null,
     });
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     const grid = screen.getByTestId('data-grid');
     expect(grid).toBeInTheDocument();
@@ -312,45 +284,30 @@ describe('UsersList', () => {
       error: new Error('Failed to load users'),
     });
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
       expect(screen.getByText('Failed to load users')).toBeInTheDocument();
     });
   });
 
-  it('displays error from schema request', async () => {
-    mockUseGetUserSchema.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Failed to load schema'),
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Failed to load schema')).toBeInTheDocument();
-    });
-  });
-
   it('should render inline delete buttons for each row', async () => {
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
-    // Actions are now inline buttons (Trash2), not a dropdown menu
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
     expect(deleteButtons.length).toBeGreaterThan(0);
   });
 
   it('navigates to view page when row is clicked', async () => {
     const user = userEvent.setup();
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const row = screen.getByTestId('row-user1');
@@ -363,10 +320,10 @@ describe('UsersList', () => {
 
   it('opens delete dialog when Delete is clicked', async () => {
     const user = userEvent.setup();
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
@@ -381,10 +338,10 @@ describe('UsersList', () => {
   it('deletes user when confirmed', async () => {
     const user = userEvent.setup();
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
@@ -402,122 +359,12 @@ describe('UsersList', () => {
     });
   });
 
-  it('navigates when row is clicked', async () => {
-    const user = userEvent.setup();
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
-    });
-
-    const row = screen.getByTestId('row-user1');
-    await user.click(row);
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/users/user1');
-    });
-  });
-
-  it('displays active status with chip', async () => {
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Active')).toBeInTheDocument();
-      expect(screen.getByText('Inactive')).toBeInTheDocument();
-    });
-  });
-
-  it('renders empty grid when no data', async () => {
-    mockUseGetUsers.mockReturnValue({
-      data: {
-        totalResults: 0,
-        startIndex: 1,
-        count: 0,
-        users: [],
-      },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      const grid = screen.getByTestId('data-grid');
-      expect(grid).toBeInTheDocument();
-    });
-  });
-
-  it('renders empty columns when schema is not loaded', () => {
-    mockUseGetUserSchema.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    const grid = screen.getByTestId('data-grid');
-    expect(grid).toBeInTheDocument();
-  });
-
-  it('handles different field types correctly', async () => {
-    const schemaWithTypes: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        age: {type: 'number'},
-        verified: {type: 'boolean'},
-        tags: {type: 'array', items: {type: 'string'}},
-        metadata: {type: 'object', properties: {}},
-      },
-    };
-
-    const usersWithTypes: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'testuser',
-            age: 25,
-            verified: true,
-            tags: ['tag1', 'tag2'],
-            metadata: {key: 'value'},
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithTypes,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithTypes,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('testuser');
-    });
-  });
-
   it('cancels delete when Cancel button is clicked', async () => {
     const user = userEvent.setup();
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
@@ -545,10 +392,10 @@ describe('UsersList', () => {
       isIdle: false,
     });
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
@@ -568,7 +415,7 @@ describe('UsersList', () => {
       error: new Error('Failed to load users'),
     });
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
       expect(screen.getByText('Failed to load users')).toBeInTheDocument();
@@ -591,10 +438,10 @@ describe('UsersList', () => {
       mutateAsync: failingDeleteMutateAsync,
     });
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
@@ -617,10 +464,10 @@ describe('UsersList', () => {
     const navigationError = new Error('Navigation failed');
     mockNavigate.mockRejectedValue(navigationError);
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const row = screen.getByTestId('row-user1');
@@ -631,55 +478,55 @@ describe('UsersList', () => {
     });
   });
 
-  it('should navigate to user when Edit action button is clicked', async () => {
+  it('should navigate to user when View action button is clicked', async () => {
     const user = userEvent.setup();
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
-    const editButtons = screen.getAllByRole('button', {name: /^edit$/i});
-    expect(editButtons.length).toBeGreaterThan(0);
-    await user.click(editButtons[0]);
+    const viewButtons = screen.getAllByRole('button', {name: /^view$/i});
+    expect(viewButtons.length).toBeGreaterThan(0);
+    await user.click(viewButtons[0]);
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/users/user1');
     });
   });
 
-  it('should navigate to correct user when Edit action is clicked for second row', async () => {
+  it('should navigate to correct user when View action is clicked for second row', async () => {
     const user = userEvent.setup();
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user2')).toHaveTextContent('jane.smith');
+      expect(screen.getByTestId('row-user2')).toHaveTextContent('Jane Smith');
     });
 
-    const editButtons = screen.getAllByRole('button', {name: /^edit$/i});
-    expect(editButtons.length).toBeGreaterThan(1);
-    await user.click(editButtons[1]);
+    const viewButtons = screen.getAllByRole('button', {name: /^view$/i});
+    expect(viewButtons.length).toBeGreaterThan(1);
+    await user.click(viewButtons[1]);
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/users/user2');
     });
   });
 
-  it('should log error when Edit button navigation fails', async () => {
+  it('should log error when View button navigation fails', async () => {
     const user = userEvent.setup();
     const navigationError = new Error('Navigation failed');
     mockNavigate.mockRejectedValueOnce(navigationError);
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
-    const editButtons = screen.getAllByRole('button', {name: /^edit$/i});
-    await user.click(editButtons[0]);
+    const viewButtons = screen.getAllByRole('button', {name: /^view$/i});
+    await user.click(viewButtons[0]);
 
     await waitFor(() => {
       expect(mockLoggerError).toHaveBeenCalledWith(
@@ -692,29 +539,19 @@ describe('UsersList', () => {
     });
   });
 
-  it('renders schema without avatar when name fields are not present', async () => {
-    const schemaWithoutNameFields: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        email: {type: 'string'},
-        phone: {type: 'string'},
-      },
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithoutNameFields,
-      isLoading: false,
-      error: null,
-    });
-
+  it('renders empty grid when no data', async () => {
     mockUseGetUsers.mockReturnValue({
-      data: mockUsersData,
+      data: {
+        totalResults: 0,
+        startIndex: 1,
+        count: 0,
+        users: [],
+      },
       isLoading: false,
       error: null,
     });
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
       const grid = screen.getByTestId('data-grid');
@@ -722,514 +559,41 @@ describe('UsersList', () => {
     });
   });
 
-  it('displays null values for missing attributes', async () => {
-    const usersWithMissingAttrs: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-          },
-        },
-      ],
-    };
-
+  it('falls back to user ID when display is not set', async () => {
     mockUseGetUsers.mockReturnValue({
-      data: usersWithMissingAttrs,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
-  });
-
-  it('handles array field with empty array', async () => {
-    const schemaWithArray: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        tags: {type: 'array', items: {type: 'string'}},
+      data: {
+        totalResults: 1,
+        startIndex: 1,
+        count: 1,
+        users: [
+          {
+            id: 'user1',
+            organizationUnit: 'org1',
+            type: 'schema1',
+          },
+        ],
       },
-    };
-
-    const usersWithEmptyArray: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            tags: [],
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithArray,
       isLoading: false,
       error: null,
     });
 
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithEmptyArray,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
-  });
-
-  it('handles array field with null value', async () => {
-    const schemaWithArray: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        tags: {type: 'array', items: {type: 'string'}},
-      },
-    };
-
-    const usersWithNullArray: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            tags: null,
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithArray,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithNullArray,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
-  });
-
-  it('handles object field with null value', async () => {
-    const schemaWithObject: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        metadata: {type: 'object', properties: {}},
-      },
-    };
-
-    const usersWithNullObject: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            metadata: null,
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithObject,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithNullObject,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
-  });
-
-  it('handles boolean field with null value', async () => {
-    const schemaWithBoolean: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        verified: {type: 'boolean'},
-      },
-    };
-
-    const usersWithNullBoolean: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            verified: null,
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithBoolean,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithNullBoolean,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
-  });
-
-  it('handles status field with string value', async () => {
-    const schemaWithStatus: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        status: {type: 'string'},
-      },
-    };
-
-    const usersWithStatus: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            status: 'active',
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithStatus,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithStatus,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Active')).toBeInTheDocument();
-    });
-  });
-
-  it('handles status field with inactive string value', async () => {
-    const schemaWithStatus: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        status: {type: 'string'},
-      },
-    };
-
-    const usersWithInactiveStatus: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            status: 'inactive',
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithStatus,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithInactiveStatus,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Inactive')).toBeInTheDocument();
-    });
-  });
-
-  it('handles active field with null value', async () => {
-    const schemaWithActive: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        active: {type: 'boolean'},
-      },
-    };
-
-    const usersWithNullActive: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            active: null,
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithActive,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithNullActive,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('user1');
     });
   });
 
   it('renders independent inline delete buttons for each user row', async () => {
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
-      expect(screen.getByTestId('row-user2')).toHaveTextContent('jane.smith');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
+      expect(screen.getByTestId('row-user2')).toHaveTextContent('Jane Smith');
     });
 
-    // Each user row has its own inline delete button
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
     expect(deleteButtons.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it('handles number field with null value', async () => {
-    const schemaWithNumber: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        age: {type: 'number'},
-      },
-    };
-
-    const usersWithNullNumber: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            age: null,
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithNumber,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithNullNumber,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
-  });
-
-  it('displays avatar with only username', async () => {
-    const usersWithOnlyUsername: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john',
-            firstname: '',
-            lastname: '',
-          },
-        },
-      ],
-    };
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithOnlyUsername,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
-  });
-
-  it('handles schema with empty schema entries', async () => {
-    const emptySchema: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Empty Schema',
-      schema: {},
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: emptySchema,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      const grid = screen.getByTestId('data-grid');
-      expect(grid).toBeInTheDocument();
-    });
-  });
-
-  it('displays false boolean value correctly', async () => {
-    const schemaWithBoolean: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Test Schema',
-      schema: {
-        username: {type: 'string'},
-        verified: {type: 'boolean'},
-      },
-    };
-
-    const usersWithFalseBoolean: UserListResponse = {
-      totalResults: 1,
-      startIndex: 1,
-      count: 1,
-      users: [
-        {
-          id: 'user1',
-          organizationUnit: 'org1',
-          type: 'schema1',
-          attributes: {
-            username: 'john.doe',
-            verified: false,
-          },
-        },
-      ],
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: schemaWithBoolean,
-      isLoading: false,
-      error: null,
-    });
-
-    mockUseGetUsers.mockReturnValue({
-      data: usersWithFalseBoolean,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toBeInTheDocument();
-    });
   });
 
   it('displays loading state when deleting user', async () => {
@@ -1240,10 +604,10 @@ describe('UsersList', () => {
       isIdle: false,
     });
 
-    render(<UsersList selectedSchema="schema1" />);
+    render(<UsersList />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('john.doe');
+      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
@@ -1252,35 +616,6 @@ describe('UsersList', () => {
     await waitFor(() => {
       const confirmButton = screen.getByRole('button', {name: /loading/i});
       expect(confirmButton).toBeDisabled();
-    });
-  });
-
-  it('handles schema loading with all field types', async () => {
-    const comprehensiveSchema: ApiUserSchema = {
-      id: 'schema1',
-      name: 'Comprehensive Schema',
-      schema: {
-        username: {type: 'string'},
-        firstname: {type: 'string'},
-        lastname: {type: 'string'},
-        isActive: {type: 'boolean'},
-        age: {type: 'number'},
-        tags: {type: 'array', items: {type: 'string'}},
-        profile: {type: 'object', properties: {}},
-      },
-    };
-
-    mockUseGetUserSchema.mockReturnValue({
-      data: comprehensiveSchema,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<UsersList selectedSchema="schema1" />);
-
-    await waitFor(() => {
-      const grid = screen.getByTestId('data-grid');
-      expect(grid).toBeInTheDocument();
     });
   });
 });

--- a/frontend/apps/thunder-develop/src/features/users/pages/UsersListPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/UsersListPage.tsx
@@ -17,14 +17,12 @@
  */
 
 import {useNavigate} from 'react-router';
-import {Stack, TextField, Button, InputAdornment, Select, MenuItem, PageContent, PageTitle} from '@wso2/oxygen-ui';
-import {useMemo, useState} from 'react';
+import {Stack, TextField, Button, InputAdornment, PageContent, PageTitle} from '@wso2/oxygen-ui';
+import {useState} from 'react';
 import {Plus, Search, Mail} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
 import {useLogger} from '@thunder/logger/react';
 import UsersList from '../components/UsersList';
-import useGetUserSchemas from '../api/useGetUserSchemas';
-import type {SchemaInterface} from '../types/users';
 import InviteUserDialog from '../components/InviteUserDialog';
 
 export default function UsersListPage() {
@@ -32,20 +30,7 @@ export default function UsersListPage() {
   const {t} = useTranslation();
   const logger = useLogger('UsersListPage');
 
-  const [selectedSchema, setSelectedSchema] = useState<string>();
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
-
-  const {data: originalUserSchemas} = useGetUserSchemas();
-
-  const userSchemas: SchemaInterface[] = useMemo(() => {
-    if (!originalUserSchemas?.schemas) {
-      return [];
-    }
-
-    setSelectedSchema(originalUserSchemas.schemas[0]?.id);
-
-    return originalUserSchemas?.schemas;
-  }, [originalUserSchemas]);
 
   const handleOpenInviteDialog = () => {
     setIsInviteDialogOpen(true);
@@ -87,7 +72,7 @@ export default function UsersListPage() {
         </PageTitle.Actions>
       </PageTitle>
 
-      {/* Search and Filters */}
+      {/* Search */}
       <Stack direction="row" spacing={2} mb={4} flexWrap="wrap" useFlexGap>
         <TextField
           placeholder={t('users:searchUsers')}
@@ -101,21 +86,8 @@ export default function UsersListPage() {
             ),
           }}
         />
-        <Select
-          id="user-type-select"
-          value={selectedSchema ?? ''}
-          size="small"
-          sx={{minWidth: 200}}
-          onChange={(e) => setSelectedSchema(e.target.value)}
-        >
-          {userSchemas.map((schema) => (
-            <MenuItem key={schema.id} value={schema.id}>
-              {schema.name}
-            </MenuItem>
-          ))}
-        </Select>
       </Stack>
-      <UsersList selectedSchema={selectedSchema ?? ''} />
+      <UsersList />
 
       {/* User Onboarding Dialog */}
       <InviteUserDialog open={isInviteDialogOpen} onClose={handleCloseInviteDialog} onSuccess={handleInviteSuccess} />

--- a/frontend/apps/thunder-develop/src/features/users/pages/__tests__/UsersListPage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/__tests__/UsersListPage.test.tsx
@@ -21,7 +21,6 @@ import {render, screen, waitFor, userEvent} from '@thunder/test-utils';
 import type {JSX} from 'react';
 import type {InviteUserRenderProps} from '@asgardeo/react';
 import UsersListPage from '../UsersListPage';
-import type {UserSchemaListResponse} from '../../types/users';
 
 const mockNavigate = vi.fn();
 const mockLoggerError = vi.fn();
@@ -87,22 +86,11 @@ vi.mock('react-router', async () => {
 
 // Mock the UsersList component
 vi.mock('../../components/UsersList', () => ({
-  default: ({selectedSchema}: {selectedSchema: string}) => (
-    <div data-testid="users-list" data-schema={selectedSchema}>
+  default: () => (
+    <div data-testid="users-list">
       Users List Component
     </div>
   ),
-}));
-
-// Define the return type for the hook
-interface UseGetUserSchemasReturn {
-  data: UserSchemaListResponse | undefined;
-}
-
-// Mock the useGetUserSchemas hook
-const mockUseGetUserSchemas = vi.fn<() => UseGetUserSchemasReturn>();
-vi.mock('../../api/useGetUserSchemas', () => ({
-  default: () => mockUseGetUserSchemas(),
 }));
 
 // Mock useTemplateLiteralResolver
@@ -142,22 +130,9 @@ vi.mock('../../components/InviteUserDialog', () => ({
 }));
 
 describe('UsersListPage', () => {
-  const mockSchemas: UserSchemaListResponse = {
-    totalResults: 2,
-    startIndex: 1,
-    count: 2,
-    schemas: [
-      {id: 'schema1', name: 'Employee Schema', ouId: 'root-ou'},
-      {id: 'schema2', name: 'Contractor Schema', ouId: 'child-ou'},
-    ],
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoggerError.mockReset();
-    mockUseGetUserSchemas.mockReturnValue({
-      data: mockSchemas,
-    });
   });
 
   it('renders page title', () => {
@@ -214,65 +189,10 @@ describe('UsersListPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/users/create');
   });
 
-  it('renders schema select dropdown', () => {
-    render(<UsersListPage />);
-
-    const select = screen.getByRole('combobox');
-    expect(select).toBeInTheDocument();
-  });
-
-  it('displays schema options from API', async () => {
-    const user = userEvent.setup();
-    render(<UsersListPage />);
-
-    const select = screen.getByRole('combobox');
-    await user.click(select);
-
-    await waitFor(() => {
-      const employeeOptions = screen.getAllByText('Employee Schema');
-      const contractorOptions = screen.getAllByText('Contractor Schema');
-      expect(employeeOptions.length).toBeGreaterThan(0);
-      expect(contractorOptions.length).toBeGreaterThan(0);
-    });
-  });
-
-  it('selects first schema by default', () => {
-    render(<UsersListPage />);
-
-    const usersList = screen.getByTestId('users-list');
-    expect(usersList).toHaveAttribute('data-schema', 'schema1');
-  });
-
-  it('changes selected schema when dropdown value changes', async () => {
-    const user = userEvent.setup();
-    render(<UsersListPage />);
-
-    const select = screen.getByRole('combobox');
-    await user.click(select);
-
-    await waitFor(() => {
-      expect(screen.getByText('Contractor Schema')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText('Contractor Schema'));
-
-    await waitFor(() => {
-      const usersList = screen.getByTestId('users-list');
-      expect(usersList).toHaveAttribute('data-schema', 'schema2');
-    });
-  });
-
   it('renders UsersList component', () => {
     render(<UsersListPage />);
 
     expect(screen.getByTestId('users-list')).toBeInTheDocument();
-  });
-
-  it('passes selected schema to UsersList', () => {
-    render(<UsersListPage />);
-
-    const usersList = screen.getByTestId('users-list');
-    expect(usersList).toHaveAttribute('data-schema');
   });
 
   it('renders plus icon in create user button', () => {
@@ -282,28 +202,6 @@ describe('UsersListPage', () => {
     // Check that button has an icon by checking for svg within the button
     const icon = createButton.querySelector('svg');
     expect(icon).toBeInTheDocument();
-  });
-
-  it('handles empty schemas list', () => {
-    mockUseGetUserSchemas.mockReturnValue({
-      data: {totalResults: 0, startIndex: 1, count: 0, schemas: []},
-    });
-
-    render(<UsersListPage />);
-
-    const usersList = screen.getByTestId('users-list');
-    expect(usersList).toHaveAttribute('data-schema', '');
-  });
-
-  it('handles undefined schemas data', () => {
-    mockUseGetUserSchemas.mockReturnValue({
-      data: undefined,
-    });
-
-    render(<UsersListPage />);
-
-    expect(screen.getByText('User Management')).toBeInTheDocument();
-    expect(screen.getByTestId('users-list')).toBeInTheDocument();
   });
 
   it('has correct heading level', () => {

--- a/frontend/apps/thunder-develop/src/features/users/types/users.ts
+++ b/frontend/apps/thunder-develop/src/features/users/types/users.ts
@@ -41,6 +41,7 @@ export interface ApiUser {
   organizationUnit: string;
   type: string;
   attributes?: Record<string, unknown>;
+  display?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds display attribute selection UI to user type create and edit forms (`systemAttributes.display`)
- Passes `include=display` query parameter to user listing, group member listing, and OU user listing API calls
- Displays resolved display names (with fallback to user ID) in user lists, group member lists, and OU user sections
- Adds `display` field to `ApiUser` and `Member` TypeScript types
- Adds `SystemAttributes` type and `systemAttributes` field to schema types (`ApiUserSchema`, `UserSchemaListItem`, `CreateUserSchemaRequest`, `UpdateUserSchemaRequest`)

Closes #1519, closes #1520
Depends on #1710

## Test plan
- [ ] Verify display attribute select appears in user type create form (filters eligible string/enum non-credential properties)
- [ ] Verify display attribute is shown and editable in user type edit/view page
- [ ] Verify user list shows display names from `include=display` API response
- [ ] Verify group member list shows display names
- [ ] Verify OU user list shows display names
- [ ] Verify fallback to user ID when display is not available
- [ ] Existing tests pass