### PR TITLE
Restrict scopes in client credentials grant

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -57,6 +57,14 @@ func (h *clientCredentialsGrantHandler) ValidateGrant(tokenRequest *model.TokenR
 		}
 	}
 
+	// Scope is not supported for client credentials grant until client authorization is implemented.
+	if tokenRequest.Scope != "" {
+		return &model.ErrorResponse{
+			Error:            constants.ErrorInvalidScope,
+			ErrorDescription: "Scope is not supported for the client credentials grant type",
+		}
+	}
+
 	return nil
 }
 
@@ -64,7 +72,7 @@ func (h *clientCredentialsGrantHandler) ValidateGrant(tokenRequest *model.TokenR
 func (h *clientCredentialsGrantHandler) HandleGrant(tokenRequest *model.TokenRequest,
 	oauthApp *appmodel.OAuthAppConfigProcessedDTO) (
 	*model.TokenResponseDTO, *model.ErrorResponse) {
-	scopes := tokenservice.ParseScopes(tokenRequest.Scope)
+	scopes := []string{}
 
 	finalAudience := tokenservice.DetermineAudience("", tokenRequest.Resource, "", tokenRequest.ClientID)
 

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -160,8 +160,8 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 		{
 			name:              "WithValidScope",
 			scope:             "read write",
-			expectedJWTClaims: map[string]interface{}{"scope": "read write"},
-			expectedScopes:    []string{"read", "write"},
+			expectedJWTClaims: map[string]interface{}{},
+			expectedScopes:    []string{},
 		},
 		{
 			name:              "WithoutScope",
@@ -258,7 +258,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 	expectedToken := testJWTToken
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 		return ctx.Subject == testClientID && ctx.Audience == testClientID &&
-			tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+			tokenservice.JoinScopes(ctx.Scopes) == ""
 	})).Return(&model.TokenDTO{
 		Token:     expectedToken,
 		TokenType: constants.TokenTypeBearer,

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -91,11 +91,24 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_Success()
 		GrantType:    "client_credentials",
 		ClientID:     testClientID,
 		ClientSecret: "secret123",
-		Scope:        "read",
 	}
 
 	result := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
 	assert.Nil(suite.T(), result)
+}
+
+func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_WithScope() {
+	tokenRequest := &model.TokenRequest{
+		GrantType:    "client_credentials",
+		ClientID:     testClientID,
+		ClientSecret: "secret123",
+		Scope:        "read",
+	}
+
+	result := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), constants.ErrorInvalidScope, result.Error)
+	assert.Equal(suite.T(), "Scope is not supported for the client credentials grant type", result.ErrorDescription)
 }
 
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_WrongGrantType() {
@@ -151,79 +164,44 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_MissingBo
 }
 
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
-	testCases := []struct {
-		name              string
-		scope             string
-		expectedJWTClaims map[string]interface{}
-		expectedScopes    []string
-	}{
-		{
-			name:              "WithValidScope",
-			scope:             "read write",
-			expectedJWTClaims: map[string]interface{}{},
-			expectedScopes:    []string{},
-		},
-		{
-			name:              "WithoutScope",
-			scope:             "",
-			expectedJWTClaims: map[string]interface{}{},
-			expectedScopes:    []string{},
-		},
-		{
-			name:              "WithWhitespaceScope",
-			scope:             "   ",
-			expectedJWTClaims: map[string]interface{}{},
-			expectedScopes:    []string{},
-		},
+	tokenRequest := &model.TokenRequest{
+		GrantType:    "client_credentials",
+		ClientID:     testClientID,
+		ClientSecret: "secret123",
 	}
 
-	for _, tc := range testCases {
-		suite.T().Run(tc.name, func(t *testing.T) {
-			// Reset mock for each test case
-			suite.mockJWTService.Mock = mock.Mock{}
+	expectedToken := testJWTToken
+	expectedScopes := []string{}
+	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testClientID &&
+				ctx.Audience == testClientID &&
+				ctx.ClientID == testClientID &&
+				len(ctx.Scopes) == 0
+		})).Return(&model.TokenDTO{
+		Token:     expectedToken,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  int64(1234567890),
+		ExpiresIn: 3600,
+		Scopes:    expectedScopes,
+		ClientID:  testClientID,
+		Subject:   testClientID,
+		Audience:  testClientID,
+	}, nil)
 
-			tokenRequest := &model.TokenRequest{
-				GrantType:    "client_credentials",
-				ClientID:     testClientID,
-				ClientSecret: "secret123",
-				Scope:        tc.scope,
-			}
+	result, errResp := suite.handler.HandleGrant(tokenRequest, suite.oauthApp)
 
-			expectedToken := testJWTToken
-			suite.mockTokenBuilder.On("BuildAccessToken",
-				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-					return ctx.Subject == testClientID &&
-						ctx.Audience == testClientID &&
-						ctx.ClientID == testClientID &&
-						tokenservice.JoinScopes(ctx.Scopes) == tokenservice.JoinScopes(tc.expectedScopes)
-				})).Return(&model.TokenDTO{
-				Token:     expectedToken,
-				TokenType: constants.TokenTypeBearer,
-				IssuedAt:  int64(1234567890),
-				ExpiresIn: 3600,
-				Scopes:    tc.expectedScopes,
-				ClientID:  testClientID,
-				Subject:   testClientID,
-				Audience:  testClientID,
-			}, nil)
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), expectedToken, result.AccessToken.Token)
+	assert.Equal(suite.T(), constants.TokenTypeBearer, result.AccessToken.TokenType)
+	assert.Equal(suite.T(), int64(3600), result.AccessToken.ExpiresIn)
+	assert.Equal(suite.T(), expectedScopes, result.AccessToken.Scopes)
+	assert.Equal(suite.T(), testClientID, result.AccessToken.ClientID)
+	assert.Equal(suite.T(), testClientID, result.AccessToken.Subject)
+	assert.Equal(suite.T(), testClientID, result.AccessToken.Audience)
 
-			result, errResp := suite.handler.HandleGrant(tokenRequest, suite.oauthApp)
-
-			assert.Nil(t, errResp)
-			assert.NotNil(t, result)
-			assert.Equal(t, expectedToken, result.AccessToken.Token)
-			assert.Equal(t, constants.TokenTypeBearer, result.AccessToken.TokenType)
-			assert.Equal(t, int64(3600), result.AccessToken.ExpiresIn)
-			assert.Equal(t, tc.expectedScopes, result.AccessToken.Scopes)
-			assert.Equal(t, testClientID, result.AccessToken.ClientID)
-
-			// Verify token attributes
-			assert.Equal(t, testClientID, result.AccessToken.Subject)
-			assert.Equal(t, testClientID, result.AccessToken.Audience)
-
-			suite.mockTokenBuilder.AssertExpectations(t)
-		})
-	}
+	suite.mockTokenBuilder.AssertExpectations(suite.T())
 }
 
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_JWTGenerationError() {
@@ -231,7 +209,6 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_JWTGenerati
 		GrantType:    "client_credentials",
 		ClientID:     testClientID,
 		ClientSecret: "secret123",
-		Scope:        "read",
 	}
 
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
@@ -252,7 +229,6 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 		GrantType:    "client_credentials",
 		ClientID:     testClientID,
 		ClientSecret: "secret123",
-		Scope:        "read",
 	}
 
 	expectedToken := testJWTToken
@@ -288,7 +264,6 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_TokenTiming
 		GrantType:    "client_credentials",
 		ClientID:     testClientID,
 		ClientSecret: "secret123",
-		Scope:        "read",
 	}
 
 	expectedToken := testJWTToken
@@ -324,7 +299,6 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 		GrantType:    "client_credentials",
 		ClientID:     testClientID,
 		ClientSecret: "secret123",
-		Scope:        "read",
 		Resource:     "https://mcp.example.com/mcp",
 	}
 
@@ -360,7 +334,6 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutReso
 		GrantType:    "client_credentials",
 		ClientID:     testClientID,
 		ClientSecret: "secret123",
-		Scope:        "read",
 	}
 
 	var capturedAudience string

--- a/tests/integration/oauth/token/token_test.go
+++ b/tests/integration/oauth/token/token_test.go
@@ -227,12 +227,13 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantWithHeaderCredentials() {
 		requestedScopes string
 		expectedStatus  int
 		expectedScopes  []string
+		expectedError   string
 	}{
 		{
 			testName:        "WithAuthorizedScopes",
 			requestedScopes: "internal_user_mgt_view internal_user_mgt_edit internal_group_mgt_view",
-			expectedStatus:  http.StatusOK,
-			expectedScopes:  []string{"internal_user_mgt_view", "internal_user_mgt_edit", "internal_group_mgt_view"},
+			expectedStatus:  http.StatusBadRequest,
+			expectedError:   "invalid_scope",
 		},
 		{
 			testName:        "WithoutScopes",
@@ -243,14 +244,14 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantWithHeaderCredentials() {
 		{
 			testName:        "WithUnknownScopes",
 			requestedScopes: "unknown_scope",
-			expectedStatus:  http.StatusOK,
-			expectedScopes:  []string{"unknown_scope"},
+			expectedStatus:  http.StatusBadRequest,
+			expectedError:   "invalid_scope",
 		},
 		{
 			testName:        "WithAuthorizedAndUnknownScopes",
 			requestedScopes: "internal_user_mgt_view unknown_scope",
-			expectedStatus:  http.StatusOK,
-			expectedScopes:  []string{"internal_user_mgt_view", "unknown_scope"},
+			expectedStatus:  http.StatusBadRequest,
+			expectedError:   "invalid_scope",
 		},
 	}
 
@@ -266,7 +267,7 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantWithHeaderCredentials() {
 			request.SetBasicAuth(clientId+"_client_secret_basic", clientSecret)
 
 			// Run the test.
-			ts.runClientCredentialsTestCase(request, tc.expectedStatus, tc.expectedScopes, "")
+			ts.runClientCredentialsTestCase(request, tc.expectedStatus, tc.expectedScopes, tc.expectedError)
 		})
 	}
 }
@@ -278,12 +279,13 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantWithBodyCredentials() {
 		requestedScopes string
 		expectedStatus  int
 		expectedScopes  []string
+		expectedError   string
 	}{
 		{
 			testName:        "WithAuthorizedScopes",
 			requestedScopes: "internal_user_mgt_view internal_user_mgt_edit",
-			expectedStatus:  http.StatusOK,
-			expectedScopes:  []string{"internal_user_mgt_view", "internal_user_mgt_edit"},
+			expectedStatus:  http.StatusBadRequest,
+			expectedError:   "invalid_scope",
 		},
 		{
 			testName:        "WithoutScopes",
@@ -303,7 +305,7 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantWithBodyCredentials() {
 			}
 			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-			ts.runClientCredentialsTestCase(request, tc.expectedStatus, tc.expectedScopes, "")
+			ts.runClientCredentialsTestCase(request, tc.expectedStatus, tc.expectedScopes, tc.expectedError)
 		})
 	}
 }
@@ -365,6 +367,13 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantNegativeCases() {
 			authHeader:     "Basic " + basicAuth(clientId+"_client_secret_basic", clientSecret),
 			expectedStatus: http.StatusBadRequest,
 			expectedError:  "invalid_request",
+		},
+		{
+			testName:       "ScopeProvided",
+			requestBody:    "grant_type=client_credentials&scope=read",
+			authHeader:     "Basic " + basicAuth(clientId+"_client_secret_basic", clientSecret),
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid_scope",
 		},
 	}
 

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -599,8 +599,8 @@ func (ts *UserInfoTestSuite) callUserInfo(accessToken string) (*http.Response, e
 
 // TestUserInfo_ClientCredentialsGrant_Rejected tests that client_credentials grant tokens are rejected
 func (ts *UserInfoTestSuite) TestUserInfo_ClientCredentialsGrant_Rejected() {
-	// Get access token using client_credentials grant
-	accessToken, err := ts.getClientCredentialsToken("read write")
+	// Get access token using client_credentials grant (no scope - scopes are not supported for client_credentials)
+	accessToken, err := ts.getClientCredentialsToken("")
 	ts.Require().NoError(err, "Failed to get client_credentials token")
 	ts.Require().NotEmpty(accessToken, "Access token should not be empty")
 


### PR DESCRIPTION
This pull request updates the client credentials grant flow in the OAuth2 implementation to temporarily restrict scopes from being issued until proper client authorization is implemented. The changes ensure that access tokens issued via the client credentials grant do not include any scopes, regardless of what is requested. Corresponding tests are updated to reflect this new behavior.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
The `client_credentials` grant type no longer returns requested scopes in the issued access token. Any scopes provided in the token request are silently ignored, and the `scope` claim is omitted from the JWT entirely.

#### 💥 Impact
Clients using the client credentials grant that rely on scopes being present in the access token will receive tokens without any scope claim. Resource servers validating scope-based access will deny such requests.

#### 🔄 Migration Guide
Remove scope-based access control assumptions for tokens issued via the client credentials grant until client authorization is implemented. Resource servers should not expect a `scope` claim in tokens issued through this grant type.

---


**Client credentials grant scope restriction:**

* In `client_credentials.go`, the handler now sets `scopes` to an empty list for client credentials grants, regardless of the requested scopes. This is a temporary measure until client authorization is implemented.

**Test updates to match new scope behavior:**

* In `client_credentials_test.go`, the test case "WithValidScope" is updated to expect no scopes in the JWT claims or scopes list, reflecting the new restriction.
* In the same test file, the expectation for the access token's scopes is changed to an empty string for the nil token attributes test, ensuring consistency with the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client credentials grant now rejects any provided scope and issues access tokens without propagated scopes.
* **Tests**
  * Updated tests to expect an invalid_scope error when a scope is supplied to the client credentials flow and to assert tokens contain no scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->