### PR TITLE
Allow number type properties as display attributes

### DIFF
--- a/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/AddMemberDialog.tsx
+++ b/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/AddMemberDialog.tsx
@@ -27,6 +27,8 @@ import {
   Alert,
   DataGrid,
   Avatar,
+  Chip,
+  Typography,
   useTheme,
 } from '@wso2/oxygen-ui';
 import {User} from '@wso2/oxygen-ui-icons-react';
@@ -49,6 +51,7 @@ export default function AddMemberDialog({open, onClose, onAdd}: AddMemberDialogP
   const {t} = useTranslation();
   const theme = useTheme();
   const dataGridLocaleText = useDataGridLocaleText();
+
   const [selectionModel, setSelectionModel] = useState<DataGrid.GridRowSelectionModel>({
     type: 'include',
     ids: new Set(),
@@ -102,10 +105,27 @@ export default function AddMemberDialog({open, onClose, onAdd}: AddMemberDialogP
       },
       {
         field: 'display',
-        headerName: t('groups:addMember.columns.userId'),
+        headerName: t('groups:addMember.columns.displayName'),
         flex: 1,
-        minWidth: 250,
-        valueGetter: (_value: unknown, row: ApiUser) => row.display ?? row.id,
+        minWidth: 200,
+        renderCell: (params: DataGrid.GridRenderCellParams<ApiUser>): JSX.Element => (
+          <Box sx={{display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%', overflow: 'hidden'}}>
+            <Typography variant="body2" noWrap>
+              {params.row.display ?? params.row.id}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" noWrap sx={{fontFamily: 'monospace', fontSize: '0.7rem'}}>
+              {params.row.id}
+            </Typography>
+          </Box>
+        ),
+      },
+      {
+        field: 'type',
+        headerName: t('groups:addMember.columns.userType'),
+        width: 150,
+        renderCell: (params: DataGrid.GridRenderCellParams<ApiUser>): JSX.Element => (
+          <Chip label={params.row.type} size="small" variant="outlined" sx={{textTransform: 'capitalize'}} />
+        ),
       },
     ],
     [theme, t],
@@ -123,7 +143,7 @@ export default function AddMemberDialog({open, onClose, onAdd}: AddMemberDialogP
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
       <DialogTitle>{t('groups:addMember.title')}</DialogTitle>
       <DialogContent>
         {usersError && !usersLoading && (

--- a/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/ManageMembersSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/groups/components/edit-group/members-settings/ManageMembersSection.tsx
@@ -17,7 +17,7 @@
  */
 
 import {useState, useMemo, type JSX, type ReactNode} from 'react';
-import {Box, Avatar, Chip, DataGrid, IconButton, useTheme} from '@wso2/oxygen-ui';
+import {Box, Avatar, Chip, DataGrid, IconButton, Typography, useTheme} from '@wso2/oxygen-ui';
 import {User, Users, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
 import SettingsCard from '@/components/SettingsCard';
@@ -88,7 +88,16 @@ export default function ManageMembersSection({groupId, onRemoveMember, headerAct
         headerName: t('groups:edit.members.sections.manage.listing.columns.id'),
         flex: 1,
         minWidth: 250,
-        valueGetter: (_value: unknown, row: Member) => row.display ?? row.id,
+        renderCell: (params: DataGrid.GridRenderCellParams<Member>): JSX.Element => (
+          <Box sx={{display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%', overflow: 'hidden'}}>
+            <Typography variant="body2" noWrap>
+              {params.row.display ?? params.row.id}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" noWrap sx={{fontFamily: 'monospace', fontSize: '0.7rem'}}>
+              {params.row.id}
+            </Typography>
+          </Box>
+        ),
       },
       {
         field: 'type',

--- a/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
@@ -76,7 +76,10 @@ export default function ConfigureProperties({
   const eligibleDisplayProperties = useMemo(
     () =>
       properties.filter(
-        (p) => (p.type === 'string' || p.type === 'enum') && !p.credential && p.name.trim().length > 0,
+        (p) =>
+          (p.type === 'string' || p.type === 'number' || p.type === 'enum') &&
+          !p.credential &&
+          p.name.trim().length > 0,
       ),
     [properties],
   );

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
@@ -96,7 +96,10 @@ export default function ViewUserTypePage() {
   const eligibleDisplayProperties = useMemo(
     () =>
       properties.filter(
-        (p) => (p.type === 'string' || p.type === 'enum') && !p.credential && p.name.trim().length > 0,
+        (p) =>
+          (p.type === 'string' || p.type === 'number' || p.type === 'enum') &&
+          !p.credential &&
+          p.name.trim().length > 0,
       ),
     [properties],
   );

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/CreateUserTypePage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/CreateUserTypePage.test.tsx
@@ -846,6 +846,7 @@ describe('CreateUserTypePage', () => {
             unique: true,
           },
         },
+        systemAttributes: {display: 'employeeId'},
       });
     });
   });

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -657,6 +657,8 @@ const translations = {
     'addMember.search.placeholder': 'Search users...',
     'addMember.noResults': 'No users found',
     'addMember.add': 'Add Selected',
+    'addMember.columns.displayName': 'Display Name',
+    'addMember.columns.userType': 'User Type',
     'addMember.columns.userId': 'User ID',
     'addMember.error': 'Failed to add member. Please try again.',
     'addMember.fetchError': 'Failed to load users. Please try again.',


### PR DESCRIPTION
## Summary
- Updated the display attribute selector in both create and edit user type UIs to include `number` type properties alongside `string` and `enum` types
- This aligns the UI with backend validation, which accepts both string and number types (including nested via dot notation) as valid display attributes

## Test plan
- [ ] Create a user type with a number property and verify it appears in the display attribute dropdown
- [ ] Edit an existing user type and verify number properties are selectable as display attributes
- [ ] Verify boolean, object, array, and credential properties remain excluded from the dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric properties are now eligible as display attributes when configuring user types.
  * Group members UI enhanced: member rows show a primary name with a monospace ID beneath and a visible member type chip; dialog width increased for improved layout.
* **Tests**
  * Updated test expectations to cover numeric display attribute behavior.
* **Documentation**
  * Added two translation keys for the Add Member dialog (display name and user type).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->