### PR TITLE
Add consent components to flow builder UI

### DIFF
--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/CommonElementFactory.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/CommonElementFactory.tsx
@@ -34,6 +34,8 @@ import IconAdapter from './adapters/IconAdapter';
 import StackAdapter from './adapters/StackAdapter';
 import CaptchaAdapter from './adapters/CaptchaAdapter';
 import ResendButtonAdapter from './adapters/ResendButtonAdapter';
+import TimerAdapter from './adapters/TimerAdapter';
+import ConsentAdapter from './adapters/ConsentAdapter';
 
 /**
  * Props interface of {@link CommonElementFactory}
@@ -95,11 +97,7 @@ function CommonElementFactory({
     }
 
     return (
-      <BlockAdapter
-        resource={resource}
-        availableElements={availableElements}
-        onAddElementToForm={onAddElementToForm}
-      />
+      <BlockAdapter resource={resource} availableElements={availableElements} onAddElementToForm={onAddElementToForm} />
     );
   }
   if (resource.type === ElementTypes.Checkbox) {
@@ -156,6 +154,12 @@ function CommonElementFactory({
   }
   if (resource.type === ElementTypes.Resend) {
     return <ResendButtonAdapter stepId={stepId} resource={resource} />;
+  }
+  if (resource.type === ElementTypes.Timer) {
+    return <TimerAdapter resource={resource} />;
+  }
+  if (resource.type === ElementTypes.Consent) {
+    return <ConsentAdapter />;
   }
 
   return null;

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
@@ -150,6 +150,14 @@ vi.mock('../adapters/StackAdapter', () => ({
   ),
 }));
 
+vi.mock('../adapters/TimerAdapter', () => ({
+  default: ({resource}: {resource: Element}) => (
+    <div data-testid="timer-adapter" data-resource-id={resource.id}>
+      Timer Adapter
+    </div>
+  ),
+}));
+
 describe('CommonElementFactory', () => {
   const createMockElement = (overrides: Partial<Element> = {}): Element =>
     ({
@@ -435,10 +443,23 @@ describe('CommonElementFactory', () => {
     });
   });
 
+  describe('Timer Element', () => {
+    it('should render TimerAdapter for Timer type', () => {
+      const timerElement = createMockElement({
+        type: ElementTypes.Timer,
+      });
+
+      render(<CommonElementFactory stepId="step-1" resource={timerElement} />);
+
+      expect(screen.getByTestId('timer-adapter')).toBeInTheDocument();
+      expect(screen.getByTestId('timer-adapter')).toHaveAttribute('data-resource-id', 'element-1');
+    });
+  });
+
   describe('Unknown Element Type', () => {
     it('should return null for unknown element type', () => {
       const unknownElement = createMockElement({
-        type: 'UNKNOWN_TYPE' as typeof ElementTypes[keyof typeof ElementTypes],
+        type: 'UNKNOWN_TYPE' as (typeof ElementTypes)[keyof typeof ElementTypes],
       });
 
       const {container} = render(<CommonElementFactory stepId="step-1" resource={unknownElement} />);

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/ConsentAdapter.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/ConsentAdapter.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import {Typography, Box} from '@wso2/oxygen-ui';
+import type {Resource} from '../../../../models/resources';
+
+/**
+ * Props interface for ConsentAdapter
+ */
+export interface ConsentAdapterPropsInterface {
+  resource?: Resource;
+}
+
+/**
+ * A canvas placeholder for the Consent element.
+ *
+ * @returns The ConsentAdapter placeholder component.
+ */
+function ConsentAdapter(): ReactElement {
+  const {t} = useTranslation();
+
+  return (
+    <Box sx={{width: '100%', py: 1}}>
+      <Typography variant="body2" color="textSecondary" sx={{fontStyle: 'italic'}}>
+        {t('flows:core.elements.consent.placeholder', 'Consent attributes will appear here at runtime')}
+      </Typography>
+    </Box>
+  );
+}
+
+export default ConsentAdapter;

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/TimerAdapter.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/TimerAdapter.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {type ReactElement} from 'react';
+import {Typography, Box} from '@wso2/oxygen-ui';
+import type {Resource} from '../../../../models/resources';
+
+/**
+ * Props interface for TimerAdapter
+ */
+export interface TimerAdapterPropsInterface {
+  resource?: Resource;
+}
+
+/**
+ * A canvas placeholder for the Timer element. Features a simulated timer value
+ * based on the configured text value replacing the `{time}` dynamic placeholder.
+ *
+ * @param props - Custom props containing the resource.
+ * @returns The TimerAdapter placeholder component.
+ */
+function TimerAdapter({resource = undefined}: TimerAdapterPropsInterface): ReactElement {
+  // Extract text from resource label, default to generic string if missing
+  const templateText = (resource as {label?: string})?.label ?? 'Time remaining: {time}';
+
+  // Replace backend dynamic variable format `{time}` with a fake canvas placeholder `05:00`
+  const displayText = templateText.replace('{time}', '05:00');
+
+  return (
+    <Box sx={{width: '100%', py: 1}}>
+      <Typography variant="body2" color="textSecondary" sx={{fontFamily: 'monospace'}}>
+        {displayText}
+      </Typography>
+    </Box>
+  );
+}
+
+export default TimerAdapter;

--- a/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/__tests__/TimerAdapter.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resources/elements/adapters/__tests__/TimerAdapter.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import type {Resource} from '@/features/flows/models/resources';
+import TimerAdapter from '../TimerAdapter';
+
+describe('TimerAdapter', () => {
+  const createResource = (label?: string): Resource =>
+    ({
+      id: 'timer-1',
+      ...(label !== undefined ? {label} : {}),
+    }) as unknown as Resource;
+
+  it('should replace the dynamic time placeholder with a canvas value', () => {
+    render(<TimerAdapter resource={createResource('Try again in {time}')} />);
+
+    expect(screen.getByText('Try again in 05:00')).toBeInTheDocument();
+  });
+
+  it('should render default text when resource label is missing', () => {
+    render(<TimerAdapter resource={createResource()} />);
+
+    expect(screen.getByText('Time remaining: 05:00')).toBeInTheDocument();
+  });
+
+  it('should render default text when resource is undefined', () => {
+    render(<TimerAdapter />);
+
+    expect(screen.getByText('Time remaining: 05:00')).toBeInTheDocument();
+  });
+
+  it('should render default text when resource label property is missing', () => {
+    const resourceWithoutLabel = {
+      id: 'timer-no-label',
+    } as unknown as Resource;
+
+    render(<TimerAdapter resource={resourceWithoutLabel} />);
+
+    expect(screen.getByText('Time remaining: 05:00')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/thunder-develop/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/constants/VisualFlowConstants.ts
@@ -84,6 +84,7 @@ class VisualFlowConstants {
     WidgetTypes.GithubFederation,
     WidgetTypes.PasskeyAuthentication,
     WidgetTypes.MagicLink,
+    ElementTypes.Timer,
   ];
 
   public static readonly FLOW_BUILDER_VIEW_ALLOWED_RESOURCE_TYPES: string[] = [
@@ -116,6 +117,7 @@ class VisualFlowConstants {
     WidgetTypes.GithubFederation,
     WidgetTypes.PasskeyAuthentication,
     WidgetTypes.MagicLink,
+    ElementTypes.Timer,
   ];
 
   public static readonly FLOW_BUILDER_FLOW_COMPLETION_VIEW_ALLOWED_RESOURCE_TYPES: string[] = [
@@ -144,6 +146,7 @@ class VisualFlowConstants {
     ElementTypes.RichText,
     ElementTypes.Divider,
     ElementTypes.Image,
+    ElementTypes.Timer,
   ];
 
   public static readonly FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES: string[] = [

--- a/frontend/apps/thunder-develop/src/features/flows/data/elements.json
+++ b/frontend/apps/thunder-develop/src/features/flows/data/elements.json
@@ -406,5 +406,16 @@
     "name": "User",
     "size": 24,
     "color": "currentColor"
+  },
+  {
+    "resourceType": "ELEMENT",
+    "category": "DISPLAY",
+    "type": "TIMER",
+    "display": {
+      "label": "Timer",
+      "image": "assets/images/icons/clock.svg",
+      "showOnResourcePanel": true
+    },
+    "label": "Time remaining: {time}"
   }
 ]

--- a/frontend/apps/thunder-develop/src/features/flows/models/__tests__/elements.test.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/__tests__/elements.test.ts
@@ -69,14 +69,17 @@ describe('elements models', () => {
       expect(ElementTypes.Action).toBe('ACTION');
       expect(ElementTypes.Captcha).toBe('CAPTCHA');
       expect(ElementTypes.Divider).toBe('DIVIDER');
+      expect(ElementTypes.Icon).toBe('ICON');
       expect(ElementTypes.Image).toBe('IMAGE');
       expect(ElementTypes.RichText).toBe('RICH_TEXT');
+      expect(ElementTypes.Stack).toBe('STACK');
       expect(ElementTypes.Text).toBe('TEXT');
       expect(ElementTypes.Resend).toBe('RESEND');
+      expect(ElementTypes.Timer).toBe('TIMER');
     });
 
-    it('should have exactly 18 element types', () => {
-      expect(Object.keys(ElementTypes)).toHaveLength(18);
+    it('should have exactly 20 element types', () => {
+      expect(Object.keys(ElementTypes)).toHaveLength(20);
     });
   });
 

--- a/frontend/apps/thunder-develop/src/features/flows/models/__tests__/steps.test.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/__tests__/steps.test.ts
@@ -106,6 +106,10 @@ describe('steps models', () => {
       expect(ExecutionTypes.GithubFederation).toBe('GithubOAuthExecutor');
     });
 
+    it('should have PasskeyAuth type', () => {
+      expect(ExecutionTypes.PasskeyAuth).toBe('PasskeyAuthExecutor');
+    });
+
     it('should have ConfirmationCode type', () => {
       expect(ExecutionTypes.ConfirmationCode).toBe('ConfirmationCodeValidationExecutor');
     });
@@ -126,8 +130,12 @@ describe('steps models', () => {
       expect(ExecutionTypes.SMSOTPAuth).toBe('SMSOTPAuthExecutor');
     });
 
-    it('should have exactly 11 execution types', () => {
-      expect(Object.keys(ExecutionTypes)).toHaveLength(11);
+    it('should have ConsentExecutor type', () => {
+      expect(ExecutionTypes.ConsentExecutor).toBe('ConsentExecutor');
+    });
+
+    it('should have exactly 12 execution types', () => {
+      expect(Object.keys(ExecutionTypes)).toHaveLength(12);
     });
   });
 

--- a/frontend/apps/thunder-develop/src/features/flows/models/elements.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/elements.ts
@@ -59,6 +59,8 @@ export const ElementTypes = {
   Stack: 'STACK',
   Text: 'TEXT',
   Resend: 'RESEND',
+  Timer: 'TIMER',
+  Consent: 'CONSENT',
 } as const;
 
 export const BlockTypes = {

--- a/frontend/apps/thunder-develop/src/features/flows/models/steps.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/steps.ts
@@ -103,6 +103,7 @@ export const ExecutionTypes = {
   SendEmailOTP: 'SendEmailOTPExecutor',
   VerifyEmailOTP: 'VerifyEmailOTPExecutor',
   SMSOTPAuth: 'SMSOTPAuthExecutor',
+  ConsentExecutor: 'ConsentExecutor',
 } as const;
 
 export const ExecutionStepViewTypes = {

--- a/frontend/apps/thunder-develop/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -292,7 +292,7 @@ describe('reactFlowTransformer', () => {
       });
 
       it('should extract inputs from deeply nested block structures (Block A -> Block B -> Action)', () => {
-        // Structure: 
+        // Structure:
         // Outer Block (contains email input)
         //   -> Inner Block (contains password input and submit button)
         // Expected: Submit action should have BOTH email and password inputs
@@ -339,13 +339,13 @@ describe('reactFlowTransformer', () => {
         // Verification
         expect(result.nodes[0].prompts).toHaveLength(1);
         const prompt = result.nodes[0].prompts?.[0];
-        
+
         // Should have inputs from both blocks
         expect(prompt?.inputs).toHaveLength(2);
-        
-        const identifiers = prompt?.inputs?.map(i => i.identifier).sort();
+
+        const identifiers = prompt?.inputs?.map((i) => i.identifier).sort();
         expect(identifiers).toEqual(['email', 'password'].sort());
-        
+
         expect(prompt?.action?.ref).toBe('submit-btn');
       });
 
@@ -721,6 +721,67 @@ describe('reactFlowTransformer', () => {
         expect(execNode?.executor?.inputs?.[0].identifier).toBe('username');
       });
 
+      it('should use ref as execution input identifier when name is missing', () => {
+        const promptComponents: Element[] = [
+          {
+            id: 'input-ref-1',
+            type: ElementTypes.TextInput,
+            category: ElementCategories.Field,
+            ref: 'usernameRef',
+          } as unknown as Element,
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [
+            createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: promptComponents}),
+            createNode(
+              'exec-1',
+              StepTypes.Execution,
+              {x: 100, y: 0},
+              {
+                action: {executor: {name: 'PasswordValidator'}},
+              },
+            ),
+          ],
+          edges: [createEdge('edge-1', 'view-1', 'exec-1')],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        const execNode = result.nodes.find((n) => n.id === 'exec-1');
+        expect(execNode?.executor?.inputs?.[0].identifier).toBe('usernameRef');
+      });
+
+      it('should use id as execution input identifier when both name and ref are missing', () => {
+        const promptComponents: Element[] = [
+          {
+            id: 'input-id-fallback',
+            type: ElementTypes.TextInput,
+            category: ElementCategories.Field,
+          } as unknown as Element,
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [
+            createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: promptComponents}),
+            createNode(
+              'exec-1',
+              StepTypes.Execution,
+              {x: 100, y: 0},
+              {
+                action: {executor: {name: 'PasswordValidator'}},
+              },
+            ),
+          ],
+          edges: [createEdge('edge-1', 'view-1', 'exec-1')],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        const execNode = result.nodes.find((n) => n.id === 'exec-1');
+        expect(execNode?.executor?.inputs?.[0].identifier).toBe('input-id-fallback');
+      });
+
       it('should use code input for OAuth executors', () => {
         const canvasData: ReactFlowCanvasData = {
           nodes: [
@@ -767,6 +828,34 @@ describe('reactFlowTransformer', () => {
         expect(execNode?.executor?.inputs?.[0].identifier).toBe('code');
       });
 
+      it('should use consent_decisions input for ConsentExecutor', () => {
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [
+            createNode(
+              'exec-consent-1',
+              StepTypes.Execution,
+              {x: 0, y: 0},
+              {
+                action: {executor: {name: 'ConsentExecutor'}},
+              },
+            ),
+          ],
+          edges: [],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        const execNode = result.nodes.find((n) => n.id === 'exec-consent-1');
+        expect(execNode?.executor?.inputs).toEqual([
+          {
+            ref: 'input-generated-id',
+            type: 'CONSENT_INPUT',
+            identifier: 'consent_decisions',
+            required: true,
+          },
+        ]);
+      });
+
       it('should collect inputs from PROMPT node connected via START node', () => {
         // Scenario: START -> PROMPT -> EXECUTION
         // The EXECUTION node should collect inputs from the PROMPT node
@@ -792,10 +881,7 @@ describe('reactFlowTransformer', () => {
               },
             ),
           ],
-          edges: [
-            createEdge('edge-1', 'start-1', 'view-1'),
-            createEdge('edge-2', 'view-1', 'exec-1'),
-          ],
+          edges: [createEdge('edge-1', 'start-1', 'view-1'), createEdge('edge-2', 'view-1', 'exec-1')],
         };
 
         const result = transformReactFlow(canvasData);
@@ -831,10 +917,7 @@ describe('reactFlowTransformer', () => {
             ),
           ],
           // START -> PROMPT and START -> EXECUTION (execution coming from start)
-          edges: [
-            createEdge('edge-1', 'start-1', 'view-1'),
-            createEdge('edge-2', 'start-1', 'exec-1'),
-          ],
+          edges: [createEdge('edge-1', 'start-1', 'view-1'), createEdge('edge-2', 'start-1', 'exec-1')],
         };
 
         const result = transformReactFlow(canvasData);
@@ -1123,6 +1206,104 @@ describe('reactFlowTransformer', () => {
         expect(result.nodes[0].prompts?.[0].inputs).toHaveLength(inputTypes.length);
       });
     });
+
+    describe('Consent Prompt Input Assignment', () => {
+      it('should assign consent input only for prompt actions routed to ConsentExecutor', () => {
+        const components: Element[] = [
+          {
+            id: 'consent-block',
+            type: 'BLOCK',
+            category: ElementCategories.Block,
+            components: [
+              {
+                id: 'username-input',
+                type: ElementTypes.TextInput,
+                category: ElementCategories.Field,
+                name: 'username',
+              } as unknown as Element,
+              {
+                id: 'allow-btn',
+                type: ElementTypes.Action,
+                category: ElementCategories.Action,
+                action: {onSuccess: 'consent-exec-1'},
+              } as Element,
+            ],
+          } as unknown as Element,
+          {
+            id: 'deny-btn',
+            type: ElementTypes.Action,
+            category: ElementCategories.Action,
+            action: {onSuccess: 'consent-exec-1'},
+          } as Element,
+          {
+            id: 'other-btn',
+            type: ElementTypes.Action,
+            category: ElementCategories.Action,
+            action: {onSuccess: 'end-1'},
+          } as Element,
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [
+            createNode('view-consent-1', StepTypes.View, {x: 0, y: 0}, {components}),
+            createNode(
+              'consent-exec-1',
+              StepTypes.Execution,
+              {x: 300, y: 0},
+              {
+                action: {executor: {name: 'ConsentExecutor'}},
+              },
+            ),
+            createNode('end-1', StepTypes.End, {x: 600, y: 0}),
+          ],
+          edges: [
+            createEdge('edge-allow', 'view-consent-1', 'consent-exec-1', 'allow-btn_NEXT'),
+            createEdge('edge-deny', 'view-consent-1', 'consent-exec-1', 'deny-btn_NEXT'),
+            createEdge('edge-other', 'view-consent-1', 'end-1', 'other-btn_NEXT'),
+            createEdge('edge-success', 'consent-exec-1', 'end-1'),
+            createEdge(
+              'edge-incomplete',
+              'consent-exec-1',
+              'view-consent-1',
+              `consent-exec-1${VisualFlowConstants.FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX}`,
+            ),
+          ],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        const promptNode = result.nodes.find((n) => n.id === 'view-consent-1');
+        const allowPrompt = promptNode?.prompts?.find((prompt) => prompt.action?.ref === 'allow-btn');
+        const denyPrompt = promptNode?.prompts?.find((prompt) => prompt.action?.ref === 'deny-btn');
+        const otherPrompt = promptNode?.prompts?.find((prompt) => prompt.action?.ref === 'other-btn');
+
+        expect(allowPrompt?.inputs).toEqual([
+          {
+            ref: 'username-input',
+            type: ElementTypes.TextInput,
+            identifier: 'username',
+            required: false,
+          },
+          {
+            ref: 'input-generated-id',
+            type: 'CONSENT_INPUT',
+            identifier: 'consent_decisions',
+            required: true,
+          },
+        ]);
+
+        expect(denyPrompt?.inputs).toEqual([
+          {
+            ref: 'input-generated-id',
+            type: 'CONSENT_INPUT',
+            identifier: 'consent_decisions',
+            required: true,
+          },
+        ]);
+
+        expect(otherPrompt?.inputs).toBeUndefined();
+      });
+    });
   });
 
   describe('validateFlowGraph', () => {
@@ -1212,6 +1393,25 @@ describe('reactFlowTransformer', () => {
       const errors = validateFlowGraph(flowGraph);
 
       expect(errors).toContain('Node exec-1: onFailure references non-existent node non-existent');
+    });
+
+    it('should detect invalid onIncomplete reference', () => {
+      const flowGraph: FlowGraph = {
+        nodes: [
+          {id: 'start-1', type: 'START', layout: {size: {width: 100, height: 50}, position: {x: 0, y: 0}}},
+          {
+            id: 'exec-1',
+            type: 'TASK_EXECUTION',
+            layout: {size: {width: 100, height: 50}, position: {x: 50, y: 0}},
+            onIncomplete: 'non-existent',
+          },
+          {id: 'end-1', type: 'END', layout: {size: {width: 100, height: 50}, position: {x: 100, y: 0}}},
+        ],
+      };
+
+      const errors = validateFlowGraph(flowGraph);
+
+      expect(errors).toContain('Node exec-1: onIncomplete references non-existent node non-existent');
     });
 
     it('should detect invalid action nextNode reference', () => {

--- a/frontend/apps/thunder-develop/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/utils/reactFlowTransformer.ts
@@ -400,8 +400,14 @@ function extractPrompts(components: Element[], nodeId: string, edges: Edge[]): F
  * flow was loaded.
  */
 function findNextNode(canvasNode: Node<StepData>, edges: Edge[]): string | undefined {
-  // First try to find from edges (these are the source of truth for connections)
-  const outgoingEdges = edges.filter((edge) => edge.source === canvasNode.id);
+  // Try to find from edges (these are the source of truth for connections)
+  // Exclude 'failure' and 'incomplete' edges, as they map to specific handles properties
+  const outgoingEdges = edges.filter(
+    (edge) =>
+      edge.source === canvasNode.id &&
+      edge.sourceHandle !== 'failure' &&
+      !edge.sourceHandle?.endsWith(VisualFlowConstants.FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX),
+  );
 
   if (outgoingEdges.length > 0) {
     // Prefer edges without sourceHandle (default connection)
@@ -410,7 +416,7 @@ function findNextNode(canvasNode: Node<StepData>, edges: Edge[]): string | undef
       return defaultEdge.target;
     }
 
-    // Otherwise use the first edge
+    // Otherwise use the first valid edge
     return outgoingEdges[0].target;
   }
 
@@ -595,6 +601,19 @@ function createOAuthCodeInput(): FlowInput {
 }
 
 /**
+ * Creates the consent decisions input for the ConsentExecutor.
+ * The consent_decisions input carries the user's JSON-encoded consent choices.
+ */
+function createConsentDecisionsInput(): FlowInput {
+  return {
+    ref: generateResourceId('input'),
+    type: 'CONSENT_INPUT',
+    identifier: 'consent_decisions',
+    required: true,
+  };
+}
+
+/**
  * Collects inputs for TASK_EXECUTION nodes from their preceding PROMPT nodes.
  * This is done in a second pass after all nodes are transformed.
  * Returns a new array of flow nodes with inputs added where applicable.
@@ -626,6 +645,20 @@ function collectInputsForExecutionNodes(
       };
     }
 
+    // ConsentExecutor gets a fixed consent_decisions input.
+    // Consent inputs are not standard form fields, so they cannot be inferred from the
+    // preceding PROMPT node's visual component tree via extractInputs.
+    if (executorName === 'ConsentExecutor') {
+      return {
+        ...flowNode,
+        executor: {
+          ...flowNode.executor,
+          name: executorName,
+          inputs: [createConsentDecisionsInput()],
+        },
+      };
+    }
+
     // Find the preceding PROMPT node
     const precedingPromptNode = findPrecedingPromptNode(flowNode.id, canvasNodes, edges);
 
@@ -652,6 +685,65 @@ function collectInputsForExecutionNodes(
 }
 
 /**
+ * Assigns consent_decisions input to prompt actions that route back to a ConsentExecutor.
+ *
+ * Consent prompts are special: the CONSENT_INPUT display elements live inside a
+ * CONSENT_PURPOSE block but aren't standard form fields. Both the "Allow" and
+ * "Deny" actions route back to the ConsentExecutor and must carry the
+ * consent_decisions input so the executor can process the user's choices.
+ *
+ * Flow graph structure:
+ *   ConsentExecutor --onIncomplete--> Consent PROMPT
+ *   Consent PROMPT  --Allow action--> ConsentExecutor  (needs consent_decisions)
+ *   Consent PROMPT  --Deny action-->  ConsentExecutor  (needs consent_decisions)
+ */
+function assignConsentInputsToPromptNodes(flowNodes: FlowNode[]): FlowNode[] {
+  // Find all ConsentExecutor nodes
+  const consentExecutorIds = new Set(
+    flowNodes
+      .filter((node) => node.type === 'TASK_EXECUTION' && node.executor?.name === 'ConsentExecutor')
+      .map((node) => node.id),
+  );
+
+  if (consentExecutorIds.size === 0) {
+    return flowNodes;
+  }
+
+  // Build a map of which PROMPT nodes are the onIncomplete target of a ConsentExecutor
+  const consentPromptIds = new Set(
+    flowNodes
+      .filter((node) => consentExecutorIds.has(node.id) && typeof node.onIncomplete === 'string')
+      .map((node) => node.onIncomplete!),
+  );
+
+  // For each consent PROMPT node, add consent_decisions to the actions
+  // that route back to the ConsentExecutor. Both Allow and Deny actions
+  // will receive this input.
+  return flowNodes.map((node) => {
+    if (node.type !== 'PROMPT' || !consentPromptIds.has(node.id) || !node.prompts) {
+      return node;
+    }
+
+    const consentInput = createConsentDecisionsInput();
+    const prompts = node.prompts.map((prompt) => {
+      if (!prompt.action || !consentExecutorIds.has(prompt.action.nextNode)) {
+        return prompt;
+      }
+
+      return {
+        ...prompt,
+        inputs: prompt.inputs ? [...prompt.inputs, consentInput] : [consentInput],
+      };
+    });
+
+    return {
+      ...node,
+      prompts,
+    };
+  });
+}
+
+/**
  * Main transformer function that converts React Flow canvas data to flow graph format
  *
  * @param canvasData - The output from React Flow's toObject() method
@@ -664,8 +756,14 @@ export function transformReactFlow(canvasData: ReactFlowCanvasData): FlowGraph {
   // Second pass: collect inputs for TASK_EXECUTION nodes from preceding PROMPT nodes
   const nodesWithInputs = collectInputsForExecutionNodes(flowNodes, canvasData.nodes, canvasData.edges);
 
+  // Third pass: assign consent inputs to the correct PROMPT node actions.
+  // ConsentExecutor's onIncomplete points to the consent PROMPT view. Any
+  // action that routes back to the ConsentExecutor (both Allow and Deny) gets
+  // the consent_decisions input.
+  const nodesWithConsentInputs = assignConsentInputsToPromptNodes(nodesWithInputs);
+
   return {
-    nodes: nodesWithInputs,
+    nodes: nodesWithConsentInputs,
   };
 }
 

--- a/frontend/apps/thunder-develop/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
+++ b/frontend/apps/thunder-develop/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
@@ -130,6 +130,31 @@ function ExecutionExtendedProperties({resource, onChange}: ExecutionExtendedProp
   // Check if this is a Passkey executor
   const isPasskeyExecutor = executorName === ExecutionTypes.PasskeyAuth;
 
+  // Check if this is a Consent executor
+  const isConsentExecutor = executorName === ExecutionTypes.ConsentExecutor;
+
+  // Get the current timeout for Consent executor
+  const currentTimeout = useMemo(() => {
+    const stepData = resource?.data as StepData | undefined;
+    return (stepData?.properties as {timeout?: string})?.timeout ?? '0';
+  }, [resource]);
+
+  // Handle timeout change for Consent executor
+  const handleTimeoutChange = (value: string): void => {
+    if (value === '') {
+      onChange('data.properties.timeout', '0', resource);
+      return;
+    }
+
+    const num = Number(value);
+    if (Number.isNaN(num)) {
+      return;
+    }
+
+    const parsed = Math.max(0, Math.floor(num));
+    onChange('data.properties.timeout', String(parsed), resource);
+  };
+
   // Check if current Passkey mode requires relying party configuration
   const showRelyingPartyConfig =
     isPasskeyExecutor &&
@@ -314,6 +339,32 @@ function ExecutionExtendedProperties({resource, onChange}: ExecutionExtendedProp
         {!isLoadingSenders && !hasSenders && (
           <Alert severity="warning">{t('flows:core.executions.smsOtp.sender.noSenders')}</Alert>
         )}
+      </Stack>
+    );
+  }
+
+  // Render Consent executor timeout configuration
+  if (isConsentExecutor) {
+    return (
+      <Stack gap={2}>
+        <Typography variant="body2" color="text.secondary">
+          {t('flows:core.executions.consent.description')}
+        </Typography>
+
+        <div>
+          <FormLabel htmlFor="consent-timeout">{t('flows:core.executions.consent.timeout.label')}</FormLabel>
+          <TextField
+            id="consent-timeout"
+            value={currentTimeout}
+            onChange={(e) => handleTimeoutChange(e.target.value)}
+            placeholder={t('flows:core.executions.consent.timeout.placeholder')}
+            fullWidth
+            size="small"
+            type="number"
+            inputProps={{min: 0}}
+          />
+          <FormHelperText>{t('flows:core.executions.consent.timeout.hint')}</FormHelperText>
+        </div>
       </Stack>
     );
   }

--- a/frontend/apps/thunder-develop/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ExecutionTypes} from '@/features/flows/models/steps';
 import type {Resource} from '@/features/flows/models/resources';
@@ -44,6 +44,19 @@ vi.mock('react-i18next', () => ({
         'flows:core.executions.passkey.mode.placeholder': 'Select mode',
         'flows:core.executions.passkey.mode.challenge': 'Passkey Challenge',
         'flows:core.executions.passkey.mode.verify': 'Passkey Verify',
+        'flows:core.executions.passkey.mode.registerStart': 'Passkey Register Start',
+        'flows:core.executions.passkey.mode.registerFinish': 'Passkey Register Finish',
+        'flows:core.executions.passkey.relyingPartyId.label': 'Relying Party ID',
+        'flows:core.executions.passkey.relyingPartyId.placeholder': 'Enter relying party ID',
+        'flows:core.executions.passkey.relyingPartyId.hint': 'Relying party identifier hint',
+        'flows:core.executions.passkey.relyingPartyName.label': 'Relying Party Name',
+        'flows:core.executions.passkey.relyingPartyName.placeholder': 'Enter relying party name',
+        'flows:core.executions.passkey.relyingPartyName.hint': 'Relying party name hint',
+        'flows:core.executions.consent.description': 'Configure the consent executor settings.',
+        'flows:core.executions.consent.timeout.label': 'Consent Timeout (seconds)',
+        'flows:core.executions.consent.timeout.placeholder': '0',
+        'flows:core.executions.consent.timeout.hint':
+          'Time in seconds before the consent request expires. Use 0 for no timeout.',
       };
       return translations[key] || key;
     },
@@ -108,16 +121,16 @@ describe('ExecutionExtendedProperties', () => {
 
     it('should render connection selector for Google executor', () => {
       mockIdentityProviders.mockReturnValue({
-        data: [
-          {id: 'google-idp-1', name: 'Google IDP', type: IdentityProviderTypes.GOOGLE},
-        ],
+        data: [{id: 'google-idp-1', name: 'Google IDP', type: IdentityProviderTypes.GOOGLE}],
         isLoading: false,
       });
 
       render(<ExecutionExtendedProperties resource={googleResource} onChange={mockOnChange} />);
 
       expect(screen.getByText('Connection')).toBeInTheDocument();
-      expect(screen.getByText('Select a connection from the following list to link it with the login flow.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Select a connection from the following list to link it with the login flow.'),
+      ).toBeInTheDocument();
     });
 
     it('should show available Google connections in dropdown', async () => {
@@ -142,9 +155,7 @@ describe('ExecutionExtendedProperties', () => {
     it('should call onChange when connection is selected', async () => {
       const user = userEvent.setup();
       mockIdentityProviders.mockReturnValue({
-        data: [
-          {id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE},
-        ],
+        data: [{id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE}],
         isLoading: false,
       });
 
@@ -159,9 +170,7 @@ describe('ExecutionExtendedProperties', () => {
 
     it('should show error when connection is placeholder', () => {
       mockIdentityProviders.mockReturnValue({
-        data: [
-          {id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE},
-        ],
+        data: [{id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE}],
         isLoading: false,
       });
 
@@ -183,9 +192,7 @@ describe('ExecutionExtendedProperties', () => {
       mockSelectedNotification.getResourceFieldNotification.mockReturnValue('Custom validation error');
 
       mockIdentityProviders.mockReturnValue({
-        data: [
-          {id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE},
-        ],
+        data: [{id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE}],
         isLoading: false,
       });
 
@@ -202,7 +209,9 @@ describe('ExecutionExtendedProperties', () => {
 
       render(<ExecutionExtendedProperties resource={googleResource} onChange={mockOnChange} />);
 
-      expect(screen.getByText('No connections available. Please create a connection to link with the login flow.')).toBeInTheDocument();
+      expect(
+        screen.getByText('No connections available. Please create a connection to link with the login flow.'),
+      ).toBeInTheDocument();
     });
 
     it('should disable dropdown while loading', () => {
@@ -234,9 +243,7 @@ describe('ExecutionExtendedProperties', () => {
 
     it('should show selected connection value', () => {
       mockIdentityProviders.mockReturnValue({
-        data: [
-          {id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE},
-        ],
+        data: [{id: 'google-idp-1', name: 'My Google IDP', type: IdentityProviderTypes.GOOGLE}],
         isLoading: false,
       });
 
@@ -271,9 +278,7 @@ describe('ExecutionExtendedProperties', () => {
 
     it('should render connection selector for GitHub executor', () => {
       mockIdentityProviders.mockReturnValue({
-        data: [
-          {id: 'github-idp-1', name: 'GitHub IDP', type: IdentityProviderTypes.GITHUB},
-        ],
+        data: [{id: 'github-idp-1', name: 'GitHub IDP', type: IdentityProviderTypes.GITHUB}],
         isLoading: false,
       });
 
@@ -629,11 +634,11 @@ describe('ExecutionExtendedProperties', () => {
     });
 
     it('should show validation error for sender field', () => {
-      (mockSelectedNotification.hasResourceFieldNotification as unknown as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
-        key === 'sms-otp-executor-1_data.properties.senderId'
+      (mockSelectedNotification.hasResourceFieldNotification as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (key: string) => key === 'sms-otp-executor-1_data.properties.senderId',
       );
-      (mockSelectedNotification.getResourceFieldNotification as unknown as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
-        key === 'sms-otp-executor-1_data.properties.senderId' ? 'Sender ID is invalid' : ''
+      (mockSelectedNotification.getResourceFieldNotification as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (key: string) => (key === 'sms-otp-executor-1_data.properties.senderId' ? 'Sender ID is invalid' : ''),
       );
       mockNotificationSenders.mockReturnValue({
         data: [{id: 'sender-1', name: 'Twilio Sender'}],
@@ -691,6 +696,8 @@ describe('ExecutionExtendedProperties', () => {
 
       expect(screen.getByText('Passkey Challenge')).toBeInTheDocument();
       expect(screen.getByText('Passkey Verify')).toBeInTheDocument();
+      expect(screen.getByText('Passkey Register Start')).toBeInTheDocument();
+      expect(screen.getByText('Passkey Register Finish')).toBeInTheDocument();
     });
 
     it('should call onChange with updated data when mode is selected', async () => {
@@ -791,6 +798,229 @@ describe('ExecutionExtendedProperties', () => {
         resourceWithExistingData,
       );
     });
+
+    it('should show relying party fields for challenge mode', () => {
+      const resourceWithChallengeMode = {
+        ...passkeyResource,
+        data: {
+          ...(passkeyResource as unknown as {data: object}).data,
+          action: {
+            executor: {
+              name: ExecutionTypes.PasskeyAuth,
+              mode: 'challenge',
+            },
+          },
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={resourceWithChallengeMode} onChange={mockOnChange} />);
+
+      expect(screen.getByLabelText('Relying Party ID')).toBeInTheDocument();
+      expect(screen.getByLabelText('Relying Party Name')).toBeInTheDocument();
+    });
+
+    it('should show relying party fields for register_start mode', () => {
+      const resourceWithRegisterStartMode = {
+        ...passkeyResource,
+        data: {
+          ...(passkeyResource as unknown as {data: object}).data,
+          action: {
+            executor: {
+              name: ExecutionTypes.PasskeyAuth,
+              mode: 'register_start',
+            },
+          },
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={resourceWithRegisterStartMode} onChange={mockOnChange} />);
+
+      expect(screen.getByLabelText('Relying Party ID')).toBeInTheDocument();
+      expect(screen.getByLabelText('Relying Party Name')).toBeInTheDocument();
+    });
+
+    it('should not show relying party fields for verify mode', () => {
+      const resourceWithVerifyMode = {
+        ...passkeyResource,
+        data: {
+          ...(passkeyResource as unknown as {data: object}).data,
+          action: {
+            executor: {
+              name: ExecutionTypes.PasskeyAuth,
+              mode: 'verify',
+            },
+          },
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={resourceWithVerifyMode} onChange={mockOnChange} />);
+
+      expect(screen.queryByLabelText('Relying Party ID')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Relying Party Name')).not.toBeInTheDocument();
+    });
+
+    it('should call onChange for relying party fields', async () => {
+      const resourceWithChallengeMode = {
+        ...passkeyResource,
+        data: {
+          ...(passkeyResource as unknown as {data: object}).data,
+          action: {
+            executor: {
+              name: ExecutionTypes.PasskeyAuth,
+              mode: 'challenge',
+            },
+          },
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={resourceWithChallengeMode} onChange={mockOnChange} />);
+
+      fireEvent.change(screen.getByLabelText('Relying Party ID'), {
+        target: {value: 'localhost'},
+      });
+      fireEvent.change(screen.getByLabelText('Relying Party Name'), {
+        target: {value: 'Thunder'},
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'data.properties.relyingPartyId',
+        'localhost',
+        resourceWithChallengeMode,
+      );
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'data.properties.relyingPartyName',
+        'Thunder',
+        resourceWithChallengeMode,
+      );
+    });
+
+    it('should update display label when mode changes to register_start', async () => {
+      const user = userEvent.setup();
+
+      render(<ExecutionExtendedProperties resource={passkeyResource} onChange={mockOnChange} />);
+
+      const modeSelect = screen.getByRole('combobox');
+      await user.click(modeSelect);
+      await user.click(screen.getByText('Passkey Register Start'));
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'data',
+        expect.objectContaining({
+          action: expect.objectContaining({
+            executor: expect.objectContaining({
+              mode: 'register_start',
+            }) as unknown,
+          }) as unknown,
+          display: expect.objectContaining({
+            label: 'Start Passkey Registration',
+          }) as unknown,
+        }),
+        passkeyResource,
+      );
+    });
+
+    it('should update display label when mode changes to register_finish', async () => {
+      const user = userEvent.setup();
+
+      render(<ExecutionExtendedProperties resource={passkeyResource} onChange={mockOnChange} />);
+
+      const modeSelect = screen.getByRole('combobox');
+      await user.click(modeSelect);
+      await user.click(screen.getByText('Passkey Register Finish'));
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'data',
+        expect.objectContaining({
+          action: expect.objectContaining({
+            executor: expect.objectContaining({
+              mode: 'register_finish',
+            }) as unknown,
+          }) as unknown,
+          display: expect.objectContaining({
+            label: 'Finish Passkey Registration',
+          }) as unknown,
+        }),
+        passkeyResource,
+      );
+    });
+  });
+
+  describe('Consent Executor', () => {
+    const consentResource = {
+      id: 'consent-executor-1',
+      data: {
+        action: {
+          executor: {
+            name: ExecutionTypes.ConsentExecutor,
+          },
+        },
+        properties: {},
+      },
+    } as unknown as Resource;
+
+    it('should render timeout configuration for consent executor', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      expect(screen.getByText('Configure the consent executor settings.')).toBeInTheDocument();
+      expect(screen.getByLabelText('Consent Timeout (seconds)')).toBeInTheDocument();
+      expect(
+        screen.getByText('Time in seconds before the consent request expires. Use 0 for no timeout.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should default timeout to 0 when value is not set', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      expect(screen.getByLabelText('Consent Timeout (seconds)')).toHaveValue(0);
+    });
+
+    it('should call onChange when timeout changes', async () => {
+      const consentResourceWithTimeout = {
+        ...consentResource,
+        data: {
+          ...(consentResource as unknown as {data: object}).data,
+          properties: {
+            timeout: '20',
+          },
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={consentResourceWithTimeout} onChange={mockOnChange} />);
+
+      const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
+      fireEvent.change(timeoutInput, {
+        target: {value: '45'},
+      });
+
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '45', consentResourceWithTimeout);
+    });
+
+    it('should normalize empty timeout to 0', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
+      fireEvent.change(timeoutInput, {target: {value: ''}});
+
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '0', consentResource);
+    });
+
+    it('should clamp negative timeout to 0', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
+      fireEvent.change(timeoutInput, {target: {value: '-5'}});
+
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '0', consentResource);
+    });
+
+    it('should floor decimal timeout to integer', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
+      fireEvent.change(timeoutInput, {target: {value: '3.7'}});
+
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '3', consentResource);
+    });
   });
 
   describe('Edge Cases', () => {
@@ -848,9 +1078,7 @@ describe('ExecutionExtendedProperties', () => {
       } as unknown as Resource;
 
       mockIdentityProviders.mockReturnValue({
-        data: [
-          {id: 'google-idp-1', name: 'Google IDP', type: IdentityProviderTypes.GOOGLE},
-        ],
+        data: [{id: 'google-idp-1', name: 'Google IDP', type: IdentityProviderTypes.GOOGLE}],
         isLoading: false,
       });
 

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/executors.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/executors.json
@@ -625,5 +625,30 @@
         "onIncomplete": ""
       }
     }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "EXECUTOR",
+    "type": "TASK_EXECUTION",
+    "display": {
+      "header": "Consent Executor",
+      "label": "User Consent",
+      "image": "assets/images/icons/stamp.svg",
+      "showOnResourcePanel": true
+    },
+    "data": {
+      "action": {
+        "type": "EXECUTOR",
+        "executor": {
+          "name": "ConsentExecutor"
+        },
+        "onSuccess": "",
+        "onFailure": "",
+        "onIncomplete": ""
+      },
+      "properties": {
+        "timeout": "0"
+      }
+    }
   }
 ]

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/steps.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/steps.json
@@ -54,5 +54,68 @@
         }
       ]
     }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "INTERFACE",
+    "type": "VIEW",
+    "display": {
+      "label": "Consent View",
+      "image": "assets/images/icons/stamp.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {},
+    "data": {
+      "components": [
+        {
+          "id": "{{ID}}",
+          "category": "DISPLAY",
+          "type": "TEXT",
+          "variant": "HEADING_3",
+          "label": "{{meta(application.name)}} wants to access your account"
+        },
+        {
+          "id": "{{ID}}",
+          "category": "DISPLAY",
+          "type": "TEXT",
+          "variant": "BODY_1",
+          "label": "Please review the information requested by the application and provide your consent to proceed."
+        },
+        {
+          "id": "{{ID}}",
+          "category": "BLOCK",
+          "type": "BLOCK",
+          "components": [
+            {
+              "id": "{{ID}}",
+              "category": "DISPLAY",
+              "type": "CONSENT"
+            },
+            {
+              "id": "{{ID}}",
+              "category": "ACTION",
+              "type": "ACTION",
+              "variant": "PRIMARY",
+              "eventType": "SUBMIT",
+              "label": "Allow",
+              "action": {
+                "type": "NEXT"
+              }
+            },
+            {
+              "id": "{{ID}}",
+              "category": "ACTION",
+              "type": "ACTION",
+              "variant": "SECONDARY",
+              "eventType": "SUBMIT",
+              "label": "Deny",
+              "action": {
+                "type": "NEXT"
+              }
+            }
+          ]
+        }
+      ]
+    }
   }
 ]

--- a/frontend/apps/thunder-gate/src/components/flow/FlowComponentRenderer.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/FlowComponentRenderer.tsx
@@ -116,29 +116,34 @@ export default function FlowComponentRenderer({
     );
   }
 
+  // TIMER (standalone countdown timer component)
+  if (comp.type === 'TIMER') {
+    const stepTimeout = additionalData?.stepTimeout;
+    const expiresIn = stepTimeout != null ? Math.max(0, Math.floor((Number(stepTimeout) - Date.now()) / 1000)) : 0;
+    const textTemplate = resolve(comp.label) ?? 'Time remaining: {time}';
+
+    return <TimerAdapter expiresIn={expiresIn} textTemplate={textTemplate} />;
+  }
+
   // BLOCK (form block or trigger block)
-  // When additionalData contains consent/timer data, inject those adapters alongside the block.
+  // When additionalData contains consent data, inject ConsentAdapter alongside the block.
   if ((comp.type as EmbeddedFlowComponentType) === EmbeddedFlowComponentType.Block || comp.type === 'BLOCK') {
     const hasConsent = additionalData?.consentPrompt != null;
     const hasTimer = additionalData?.stepTimeout != null;
+    const stepTimeout = additionalData?.stepTimeout;
+    const expiresIn = stepTimeout != null ? Math.max(0, Math.floor((Number(stepTimeout) - Date.now()) / 1000)) : 0;
+    const isExpiredOnMount = hasTimer && expiresIn <= 0;
 
-    if (hasConsent || hasTimer) {
-      const stepTimeout = additionalData?.stepTimeout;
-      const expiresIn = stepTimeout != null ? Math.max(0, Math.floor((Number(stepTimeout) - Date.now()) / 1000)) : 0;
-      const isExpiredOnMount = hasTimer && expiresIn <= 0;
-
+    if (hasConsent) {
       return (
         <>
-          {hasTimer && <TimerAdapter expiresIn={expiresIn} />}
-          {hasConsent && (
-            <ConsentAdapter
-              consentData={
-                additionalData?.consentPrompt as string | ConsentPurpose[] | {purposes: ConsentPurpose[]} | undefined
-              }
-              formValues={values}
-              onInputChange={onInputChange}
-            />
-          )}
+          <ConsentAdapter
+            consentData={
+              additionalData?.consentPrompt as string | ConsentPurpose[] | {purposes: ConsentPurpose[]} | undefined
+            }
+            formValues={values}
+            onInputChange={onInputChange}
+          />
           <BlockAdapter
             component={component}
             index={index}
@@ -162,7 +167,7 @@ export default function FlowComponentRenderer({
         values={values}
         touched={touched}
         fieldErrors={fieldErrors}
-        isLoading={isLoading}
+        isLoading={isLoading || isExpiredOnMount}
         resolve={resolve}
         onInputChange={onInputChange}
         onSubmit={onSubmit}

--- a/frontend/apps/thunder-gate/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@asgardeo/react', () => ({
     Image: 'IMAGE',
     Stack: 'STACK',
     Text: 'TEXT',
+    Timer: 'TIMER',
   },
   EmbeddedFlowEventType: {
     Trigger: 'TRIGGER',
@@ -173,7 +174,23 @@ describe('FlowComponentRenderer', () => {
     );
   });
 
-  it('injects TimerAdapter for BLOCK when stepTimeout is present', () => {
+  it('renders TimerAdapter for TIMER component type', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+
+    render(
+      <FlowComponentRenderer
+        {...baseProps}
+        component={{id: 'timer-1', type: 'TIMER', label: 'Expires in {time}'}}
+        additionalData={{stepTimeout: String(7000)}}
+      />,
+    );
+
+    expect(screen.getByTestId('timer-adapter')).toBeInTheDocument();
+    expect(screen.getByTestId('timer-adapter')).toHaveAttribute('data-expires-in', '6');
+    expect(timerPropsSpy).toHaveBeenCalledWith(expect.objectContaining({textTemplate: 'Expires in {time}'}));
+  });
+
+  it('does not render TimerAdapter inside BLOCK when stepTimeout is present', () => {
     vi.spyOn(Date, 'now').mockReturnValue(1000);
 
     render(
@@ -184,8 +201,7 @@ describe('FlowComponentRenderer', () => {
       />,
     );
 
-    expect(screen.getByTestId('timer-adapter')).toBeInTheDocument();
-    expect(screen.getByTestId('timer-adapter')).toHaveAttribute('data-expires-in', '6');
+    expect(screen.queryByTestId('timer-adapter')).toBeNull();
     expect(screen.getByTestId('block-adapter')).toHaveAttribute('data-loading', 'false');
   });
 
@@ -200,7 +216,7 @@ describe('FlowComponentRenderer', () => {
       />,
     );
 
-    expect(screen.getByTestId('timer-adapter')).toHaveAttribute('data-expires-in', '0');
+    expect(screen.queryByTestId('timer-adapter')).toBeNull();
     expect(screen.getByTestId('block-adapter')).toHaveAttribute('data-loading', 'true');
   });
 

--- a/frontend/apps/thunder-gate/src/components/flow/adapters/TimerAdapter.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/adapters/TimerAdapter.tsx
@@ -26,6 +26,8 @@ import {FlowTimer, type FlowTimerRenderProps} from '@asgardeo/react';
 interface TimerAdapterProps {
   /** Duration in seconds until the step expires */
   expiresIn: number;
+  /** Text template with {time} placeholder, resolved from the component label */
+  textTemplate?: string;
 }
 
 /**
@@ -34,17 +36,20 @@ interface TimerAdapterProps {
  * Uses the SDK's `FlowTimer` render-prop component to manage
  * the countdown, then renders oxygen-ui styled text.
  */
-export default function TimerAdapter({expiresIn}: TimerAdapterProps): JSX.Element {
+export default function TimerAdapter({
+  expiresIn,
+  textTemplate = 'Time remaining: {time}',
+}: TimerAdapterProps): JSX.Element {
   return (
     <FlowTimer expiresIn={expiresIn}>
       {({isExpired, formattedTime}: FlowTimerRenderProps) =>
         isExpired ? (
           <Alert severity="warning" sx={{mt: 1}}>
-            <Typography variant="body2">This step has timed out.</Typography>
+            <Typography variant="body2">{formattedTime}</Typography>
           </Alert>
         ) : (
           <Typography variant="body2" color="warning.main" sx={{mt: 1}}>
-            Time remaining: {formattedTime}
+            {textTemplate.replace('{time}', formattedTime)}
           </Typography>
         )
       }

--- a/frontend/apps/thunder-gate/src/components/flow/adapters/__tests__/TimerAdapter.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/adapters/__tests__/TimerAdapter.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@wso2/oxygen-ui', () => ({
 vi.mock('@asgardeo/react', () => ({
   FlowTimer: ({expiresIn, children}: any) => {
     const isExpired = expiresIn <= 0;
-    const formattedTime = isExpired ? '0:00' : '1:15';
+    const formattedTime = isExpired ? 'Timed out' : '1:15';
 
     return (
       <div data-testid="sdk-flow-timer" data-expires-in={String(expiresIn)}>
@@ -56,7 +56,7 @@ describe('TimerAdapter', () => {
     expect(screen.getByTestId('sdk-flow-timer')).toHaveAttribute('data-expires-in', '45');
   });
 
-  it('renders active countdown text when not expired', () => {
+  it('renders active countdown text with default template when not expired', () => {
     render(<TimerAdapter expiresIn={45} />);
 
     expect(screen.getByTestId('timer-text')).toHaveTextContent('Time remaining: 1:15');
@@ -64,11 +64,17 @@ describe('TimerAdapter', () => {
     expect(screen.queryByTestId('timer-alert')).toBeNull();
   });
 
+  it('renders active countdown text with custom textTemplate', () => {
+    render(<TimerAdapter expiresIn={45} textTemplate="Expires in {time}" />);
+
+    expect(screen.getByTestId('timer-text')).toHaveTextContent('Expires in 1:15');
+  });
+
   it('renders timeout alert when expired', () => {
     render(<TimerAdapter expiresIn={0} />);
 
     expect(screen.getByTestId('timer-alert')).toHaveAttribute('data-severity', 'warning');
-    expect(screen.getByText('This step has timed out.')).toBeInTheDocument();
+    expect(screen.getByText('Timed out')).toBeInTheDocument();
     expect(screen.queryByText(/Time remaining/i)).toBeNull();
   });
 });

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -1466,6 +1466,12 @@ const translations = {
     'core.executions.smsOtp.sender.noSenders':
       'No notification senders available. Please create a notification sender first.',
 
+    // Consent executor
+    'core.executions.consent.description': 'Configure the consent executor settings.',
+    'core.executions.consent.timeout.label': 'Consent Timeout (seconds)',
+    'core.executions.consent.timeout.placeholder': '0',
+    'core.executions.consent.timeout.hint': 'Time in seconds before the consent request expires. Use 0 for no timeout.',
+
     // Passkey executor modes
     'core.executions.passkey.mode.challenge': 'Challenge',
     'core.executions.passkey.mode.verify': 'Verify',

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.14.2
-      version: 0.14.2
+      specifier: 0.14.3
+      version: 0.14.3
     '@asgardeo/react-router':
       specifier: 1.1.0
       version: 1.1.0
@@ -256,7 +256,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.14.2(@types/react@19.2.7)(react@19.2.3)
+        version: 0.14.3(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
         version: 1.1.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -467,7 +467,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.14.2(@types/react@19.2.7)(react@19.2.3)
+        version: 0.14.3(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
         version: 1.1.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -725,7 +725,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.14.2(@types/react@19.2.7)(react@19.2.3)
+        version: 0.14.3(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -900,7 +900,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.14.2(@types/react@19.2.7)(react@19.2.3)
+        version: 0.14.3(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1312,8 +1312,8 @@ packages:
       react: '>=19.1.4'
       react-router: '>=6.30.1'
 
-  '@asgardeo/react@0.14.2':
-    resolution: {integrity: sha512-pI8ZOsSl3VXzPYOeM9Toc6fhwpR0Sttl3OLVq7ZyPuIvZzNcc8J4ZtqLi2qVIkMOzbLoLXebFNS+Wf98otmDNw==}
+  '@asgardeo/react@0.14.3':
+    resolution: {integrity: sha512-2zF/nTaVhppO+SNmvWD5wkRFh7V4SB0N7qfaN0fE1yWVx607g22EXGO/DCgMYyQUDBYUtrMYP+8/4lHdfPkcQw==}
     peerDependencies:
       '@types/react': '>=19.1.5'
       react: '>=19.1.4'
@@ -11342,7 +11342,7 @@ snapshots:
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.14.2(@types/react@19.2.7)(react@19.2.3)':
+  '@asgardeo/react@0.14.3(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@asgardeo/browser': 0.5.2(esbuild@0.25.9)
       '@asgardeo/i18n': 0.4.4

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - ../docs
 
 catalog:
-  '@asgardeo/react': 0.14.2
+  '@asgardeo/react': 0.14.3
   '@asgardeo/react-router': 1.1.0
   '@hookform/resolvers': 5.2.2
   '@tanstack/react-query': 5.90.5


### PR DESCRIPTION
### Purpose
This pull request introduces support for user consent flows in the login flow builder, including a new consent collection step, a consent prompt view, and a Timer display element. It adds the necessary data models, UI components, and flow transformation logic to correctly handle consent actions and their inputs. Additionally, it improves the handling of flow connections and provides a new timeout configuration for the consent executor.

<img width="646" height="740" alt="Screenshot 2026-03-11 at 10 58 09 AM" src="https://github.com/user-attachments/assets/84777216-7f97-4b52-9329-90d6e95abb2f" />

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/1738

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timer element added to display countdowns, with customizable display text.
  * Consent element added to surface consent attributes.
  * Consent Executor step type introduced with configurable timeout.
  * New Consent View interface providing a consent prompt with Allow/Deny routing.

* **Tests**
  * Added test coverage for Timer and Consent adapters, consent executor behavior, and consent wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->