### PR TITLE
Remove redundant client credentials grant validation

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -49,14 +49,6 @@ func (h *clientCredentialsGrantHandler) ValidateGrant(tokenRequest *model.TokenR
 		}
 	}
 
-	// Validate the client ID and secret.
-	if tokenRequest.ClientID == "" || tokenRequest.ClientSecret == "" {
-		return &model.ErrorResponse{
-			Error:            constants.ErrorInvalidRequest,
-			ErrorDescription: "Client Id and secret are required",
-		}
-	}
-
 	return nil
 }
 

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -111,45 +111,6 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_WrongGran
 	assert.Equal(suite.T(), "Unsupported grant type", result.ErrorDescription)
 }
 
-func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_MissingClientID() {
-	tokenRequest := &model.TokenRequest{
-		GrantType:    "client_credentials",
-		ClientID:     "",
-		ClientSecret: "secret123",
-	}
-
-	result := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
-	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, result.Error)
-	assert.Equal(suite.T(), "Client Id and secret are required", result.ErrorDescription)
-}
-
-func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_MissingClientSecret() {
-	tokenRequest := &model.TokenRequest{
-		GrantType:    "client_credentials",
-		ClientID:     testClientID,
-		ClientSecret: "",
-	}
-
-	result := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
-	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, result.Error)
-	assert.Equal(suite.T(), "Client Id and secret are required", result.ErrorDescription)
-}
-
-func (suite *ClientCredentialsGrantHandlerTestSuite) TestValidateGrant_MissingBothCredentials() {
-	tokenRequest := &model.TokenRequest{
-		GrantType:    "client_credentials",
-		ClientID:     "",
-		ClientSecret: "",
-	}
-
-	result := suite.handler.ValidateGrant(tokenRequest, suite.oauthApp)
-	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, result.Error)
-	assert.Equal(suite.T(), "Client Id and secret are required", result.ErrorDescription)
-}
-
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 	testCases := []struct {
 		name              string


### PR DESCRIPTION
This pull request removes validation for missing client credentials (client ID and secret) from the client credentials grant handler, along with the associated unit tests. This means the handler no longer checks if the client ID or secret are present during validation. This validation is already handled at the Client Authentication Middleware, and with this redundant validation, Private Key JWT cannot be used for client credentials grant.

Removed client credentials validation:

* Removed the check for missing `ClientID` and `ClientSecret` in the `ValidateGrant` method of `client_credentials.go`, so the handler no longer returns an error if either is missing.

Removed related tests:

* Deleted three unit tests in `client_credentials_test.go` that verified error handling when the client ID, client secret, or both were missing from the token request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed validation requirements for client credentials in the OAuth2 client credentials grant flow.

* **Tests**
  * Removed validation-related unit tests from the client credentials grant handler suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->