### PR TITLE
Add database cleanup  procedure for expired data

### DIFF
--- a/backend/dbscripts/runtimedb/postgres-cleanup.sql
+++ b/backend/dbscripts/runtimedb/postgres-cleanup.sql
@@ -1,0 +1,59 @@
+-- ----------------------------------------------------------------------------
+-- Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+--
+-- WSO2 LLC. licenses this file to you under the Apache License,
+-- Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+-- ----------------------------------------------------------------------------
+
+-- ============================================================
+-- Stored procedure: purge all expired runtimedb rows.
+--
+-- Run once manually (ad-hoc / on-demand):
+--   PGPASSWORD=<pass> psql -h <host> -p <port> -U <user> -d <runtimedb> \
+--     -c "CALL cleanup_expired_runtimedb_data();"
+--
+-- Scheduled execution options:
+--
+--   1. pg_cron (RECOMMENDED, requires the pg_cron extension):
+--      CREATE EXTENSION IF NOT EXISTS pg_cron;
+--      SELECT cron.schedule(
+--        'cleanup-runtimedb-expired',
+--        '*/60 * * * *',
+--        $$CALL cleanup_expired_runtimedb_data()$$
+--      );
+--      -- To verify: SELECT * FROM cron.job WHERE jobname = 'cleanup-runtimedb-expired';
+--      -- To remove: SELECT cron.unschedule('cleanup-runtimedb-expired');
+--
+--   2. Kubernetes CronJob: call CALL cleanup_expired_runtimedb_data()
+--      via a psql container on the desired schedule.
+--
+--   3. OS cron (every 60 minutes):
+-- --      */60 * * * * postgres PGPASSWORD=<pass> psql -h <host> -p <port> \
+-- --        -U <user> -d <runtimedb> -c "CALL cleanup_expired_runtimedb_data();" \
+-- --        >> /var/log/thunder-cleanup.log 2>&1
+-- ============================================================
+
+CREATE OR REPLACE PROCEDURE cleanup_expired_runtimedb_data()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_now TIMESTAMP := NOW() AT TIME ZONE 'UTC';
+BEGIN
+    -- FLOW_USER_DATA is cascade-deleted via FK when FLOW_CONTEXT rows are deleted.
+    DELETE FROM FLOW_CONTEXT          WHERE EXPIRY_TIME < v_now;
+    DELETE FROM AUTHORIZATION_CODE    WHERE EXPIRY_TIME < v_now;
+    DELETE FROM AUTHORIZATION_REQUEST WHERE EXPIRY_TIME < v_now;
+    DELETE FROM WEBAUTHN_SESSION      WHERE EXPIRY_TIME < v_now;
+    DELETE FROM ATTRIBUTE_CACHE       WHERE EXPIRY_TIME < v_now;
+END;
+$$;


### PR DESCRIPTION
### Purpose
This pull request introduces automated cleanup mechanisms for expired runtime database rows in PostgreSQL. The main goal is to ensure that stale data is regularly purged to maintain optimal database performance and integrity.

**Automated cleanup procedure for _PostgreSQL:_:**


* Added a new stored procedure `cleanup_expired_runtimedb_data` in `postgres-cleanup.sql` to delete expired rows from `FLOW_CONTEXT`, `AUTHORIZATION_CODE`, `AUTHORIZATION_REQUEST`, `WEBAUTHN_SESSION`, and `ATTRIBUTE_CACHE`. The procedure can be run manually or scheduled via cron, Kubernetes CronJob, or pg_cron.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1759

### Related PRs
- https://github.com/asgardeo/thunder/pull/1731
- https://github.com/asgardeo/thunder/pull/1734

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a database maintenance procedure to remove expired runtime records, helping keep the system clean and performant. It can be run manually or scheduled via OS cron, Kubernetes CronJob, or database scheduling tools. Cascade behavior is respected so related runtime data is cleaned up automatically. No schema changes that affect application behavior or data contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->