### PR TITLE
Initialize transactioner regardless the DB mode

### DIFF
--- a/backend/internal/notification/init.go
+++ b/backend/internal/notification/init.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
-	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -33,27 +32,24 @@ import (
 // Initialize creates and configures the notification service components.
 func Initialize(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) (
 	NotificationSenderMgtSvcInterface, OTPServiceInterface, declarativeresource.ResourceExporter, error) {
-	var notificationStore notificationStoreInterface
-	var tx transaction.Transactioner
+	client, err := provider.GetDBProvider().GetConfigDBClient()
+	if err != nil {
+		log.GetLogger().Error("Failed to initialize database client for notification service",
+			log.Error(err))
+		return nil, nil, nil, err
+	}
+	tx, err := client.GetTransactioner()
+	if err != nil {
+		log.GetLogger().Error("Failed to initialize database transactioner for notification service",
+			log.Error(err))
+		return nil, nil, nil, err
+	}
 
+	var notificationStore notificationStoreInterface
 	if config.GetThunderRuntime().Config.DeclarativeResources.Enabled {
 		notificationStore = newNotificationFileBasedStore()
 	} else {
 		notificationStore = newNotificationStore()
-		client, err := provider.GetDBProvider().GetConfigDBClient()
-		if err != nil {
-			log.GetLogger().Error("Failed to initialize database client for notification service",
-				log.Error(err))
-			return nil, nil, nil, err
-		}
-
-		var txErr error
-		tx, txErr = client.GetTransactioner()
-		if txErr != nil {
-			log.GetLogger().Error("Failed to initialize database transactioner for notification service",
-				log.Error(txErr))
-			return nil, nil, nil, txErr
-		}
 	}
 
 	mgtService := newNotificationSenderMgtService(notificationStore, tx)

--- a/backend/internal/notification/init_test.go
+++ b/backend/internal/notification/init_test.go
@@ -496,6 +496,12 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesEnabled_Inval
 				Key: testCryptoKey,
 			},
 		},
+		Database: config.DatabaseConfig{
+			Config: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+		},
 		DeclarativeResources: config.DeclarativeResources{
 			Enabled: true,
 		},
@@ -566,6 +572,12 @@ properties:
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
 				Key: testCryptoKey,
+			},
+		},
+		Database: config.DatabaseConfig{
+			Config: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
 			},
 		},
 		DeclarativeResources: config.DeclarativeResources{

--- a/backend/internal/ou/init.go
+++ b/backend/internal/ou/init.go
@@ -24,7 +24,6 @@ import (
 
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
-	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/system/sysauthz"
@@ -41,14 +40,9 @@ func Initialize(
 		return nil, nil, nil, err
 	}
 
-	var transactioner transaction.Transactioner
-	storeMode := getOrganizationUnitStoreMode()
-	if storeMode == serverconst.StoreModeComposite || storeMode == serverconst.StoreModeMutable {
-		var err error
-		transactioner, err = provider.GetDBProvider().GetUserDBTransactioner()
-		if err != nil {
-			return nil, nil, nil, err
-		}
+	transactioner, err := provider.GetDBProvider().GetUserDBTransactioner()
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	ouService := newOrganizationUnitService(authzService, ouStore, transactioner)

--- a/backend/internal/user/init.go
+++ b/backend/internal/user/init.go
@@ -26,7 +26,6 @@ import (
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/crypto/hash"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
-	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/system/sysauthz"
@@ -48,18 +47,15 @@ func Initialize(
 		return nil, nil, err
 	}
 
-	// Step 2: Get database transactioner (only needed for mutable modes)
-	var transactioner transaction.Transactioner
-	if storeMode == serverconst.StoreModeComposite || storeMode == serverconst.StoreModeMutable {
-		dbProvider := provider.GetDBProvider()
-		dbClient, err := dbProvider.GetUserDBClient()
-		if err != nil {
-			return nil, nil, err
-		}
-		transactioner, err = dbClient.GetTransactioner()
-		if err != nil {
-			return nil, nil, err
-		}
+	// Step 2: Get database transactioner
+	dbProvider := provider.GetDBProvider()
+	dbClient, err := dbProvider.GetUserDBClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	transactioner, err := dbClient.GetTransactioner()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Step 3: Create service with store

--- a/backend/internal/userschema/init.go
+++ b/backend/internal/userschema/init.go
@@ -25,7 +25,6 @@ import (
 	oupkg "github.com/asgardeo/thunder/internal/ou"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
-	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/system/sysauthz"
@@ -42,15 +41,11 @@ func Initialize(
 	storeMode := getUserSchemaStoreMode()
 	userSchemaStore := initializeStore(storeMode)
 
-	// Step 2: Get database transactioner (only needed for mutable modes)
-	var transactioner transaction.Transactioner
-	var err error
-	if storeMode == serverconst.StoreModeComposite || storeMode == serverconst.StoreModeMutable {
-		dbProvider := provider.GetDBProvider()
-		transactioner, err = dbProvider.GetConfigDBTransactioner()
-		if err != nil {
-			return nil, nil, err
-		}
+	// Step 2: Get database transactioner
+	dbProvider := provider.GetDBProvider()
+	transactioner, err := dbProvider.GetConfigDBTransactioner()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Step 3: Create service with store

--- a/backend/internal/userschema/init_test.go
+++ b/backend/internal/userschema/init_test.go
@@ -1092,6 +1092,12 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidYAML(t *testing.T) {
 		DeclarativeResources: config.DeclarativeResources{
 			Enabled: true,
 		},
+		Database: config.DatabaseConfig{
+			Config: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+		},
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
 				Key: testCryptoKey,
@@ -1146,6 +1152,12 @@ schema: |
 		DeclarativeResources: config.DeclarativeResources{
 			Enabled: true,
 		},
+		Database: config.DatabaseConfig{
+			Config: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
+		},
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
 				Key: testCryptoKey,
@@ -1198,6 +1210,12 @@ schema: |
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{
 			Enabled: true,
+		},
+		Database: config.DatabaseConfig{
+			Config: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
 		},
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{
@@ -1261,6 +1279,12 @@ schema: |
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{
 			Enabled: true,
+		},
+		Database: config.DatabaseConfig{
+			Config: config.DataSource{
+				Type: "sqlite",
+				Path: ":memory:",
+			},
 		},
 		Crypto: config.CryptoConfig{
 			Encryption: config.EncryptionConfig{


### PR DESCRIPTION
### Purpose

With the current usage of the transactioner, we initialize the transactioner only if the store mode is StoreModeComposite or StoreModeMutable. We decided to modify this to initialize the transactioner regardless the mode. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified and unified backend database initialization to reduce duplication and streamline transaction setup across services.
* **Tests**
  * Switched relevant test runs to use an in-memory SQLite database for more consistent and isolated test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->