### PR TITLE
Create a `ToastProvider` for managing CRUD alerts in the Frontends

### DIFF
--- a/frontend/apps/thunder-develop/src/App.tsx
+++ b/frontend/apps/thunder-develop/src/App.tsx
@@ -19,6 +19,7 @@
 import {BrowserRouter, Route, Routes} from 'react-router';
 import type {JSX} from 'react';
 import {ProtectedRoute} from '@asgardeo/react-router';
+import {ToastProvider} from '@thunder/shared-contexts';
 import UsersListPage from './features/users/pages/UsersListPage';
 import CreateUserPage from './features/users/pages/CreateUserPage';
 import ViewUserPage from './features/users/pages/ViewUserPage';
@@ -58,180 +59,182 @@ import GroupCreateProvider from './features/groups/contexts/GroupCreate/GroupCre
 export default function App(): JSX.Element {
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <Routes>
-        <Route
-          path="/"
-          element={
-            <ProtectedRoute>
-              <DashboardLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<UsersListPage />} />
-          <Route path="users" element={<UsersListPage />} />
-          <Route path="users/:userId" element={<ViewUserPage />} />
-          <Route path="user-types" element={<UserTypesListPage />} />
-          <Route path="user-types/:id" element={<ViewUserTypePage />} />
-          <Route path="integrations" element={<IntegrationsPage />} />
-          <Route path="groups" element={<GroupsListPage />} />
-          <Route path="groups/:groupId" element={<GroupEditPage />} />
-          <Route path="applications" element={<ApplicationsListPage />} />
-          <Route path="applications/:applicationId" element={<ApplicationEditPage />} />
-          <Route path="flows" element={<FlowsListPage />} />
-        </Route>
-        {/* Organization Units - wrapped in OrganizationUnitProvider to preserve tree state across navigation */}
-        <Route
-          path="/organization-units"
-          element={
-            <ProtectedRoute>
-              <OrganizationUnitProvider />
-            </ProtectedRoute>
-          }
-        >
-          <Route element={<DashboardLayout />}>
-            <Route index element={<OrganizationUnitsListPage />} />
-            <Route path=":id" element={<OrganizationUnitEditPage />} />
-          </Route>
-          <Route path="create" element={<FullScreenLayout />}>
-            <Route index element={<CreateOrganizationUnitPage />} />
-          </Route>
-        </Route>
-        <Route
-          path="/groups/create"
-          element={
-            <ProtectedRoute>
-              <GroupCreateProvider>
-                <FullScreenLayout />
-              </GroupCreateProvider>
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<CreateGroupPage />} />
-        </Route>
-        <Route
-          path="/users/create"
-          element={
-            <ProtectedRoute>
-              <UserCreateProvider>
-                <FullScreenLayout />
-              </UserCreateProvider>
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<CreateUserPage />} />
-        </Route>
-        <Route
-          path="/user-types/create"
-          element={
-            <ProtectedRoute>
-              <UserTypeCreateProvider>
-                <FullScreenLayout />
-              </UserTypeCreateProvider>
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<CreateUserTypePage />} />
-        </Route>
-        <Route
-          path="/applications/create"
-          element={
-            <ProtectedRoute>
-              <ApplicationCreateProvider>
-                <FullScreenLayout />
-              </ApplicationCreateProvider>
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<ApplicationCreatePage />} />
-        </Route>
-        <Route
-          path="/flows/signin"
-          element={
-            <ProtectedRoute>
-              <DashboardLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<LoginFlowBuilderPage />} />
-        </Route>
-        <Route
-          path="/flows/signin/:flowId"
-          element={
-            <ProtectedRoute>
-              <DashboardLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<LoginFlowBuilderPage />} />
-        </Route>
-        <Route
-          path="/design"
-          element={
-            <ProtectedRoute>
-              <DashboardLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<DesignPage />} />
-        </Route>
-        <Route
-          path="/design/themes/create"
-          element={
-            <ProtectedRoute>
-              <FullScreenLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<ThemeCreatePage />} />
-        </Route>
-        <Route
-          path="/design/themes/:themeId"
-          element={
-            <ProtectedRoute>
-              <ThemeBuilderProvider>
+      <ToastProvider>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
                 <DashboardLayout />
-              </ThemeBuilderProvider>
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<ThemeBuilderPage />} />
-        </Route>
-        <Route
-          path="/design/layouts/:layoutId"
-          element={
-            <ProtectedRoute>
-              <LayoutBuilderProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<UsersListPage />} />
+            <Route path="users" element={<UsersListPage />} />
+            <Route path="users/:userId" element={<ViewUserPage />} />
+            <Route path="user-types" element={<UserTypesListPage />} />
+            <Route path="user-types/:id" element={<ViewUserTypePage />} />
+            <Route path="integrations" element={<IntegrationsPage />} />
+            <Route path="groups" element={<GroupsListPage />} />
+            <Route path="groups/:groupId" element={<GroupEditPage />} />
+            <Route path="applications" element={<ApplicationsListPage />} />
+            <Route path="applications/:applicationId" element={<ApplicationEditPage />} />
+            <Route path="flows" element={<FlowsListPage />} />
+          </Route>
+          {/* Organization Units - wrapped in OrganizationUnitProvider to preserve tree state across navigation */}
+          <Route
+            path="/organization-units"
+            element={
+              <ProtectedRoute>
+                <OrganizationUnitProvider />
+              </ProtectedRoute>
+            }
+          >
+            <Route element={<DashboardLayout />}>
+              <Route index element={<OrganizationUnitsListPage />} />
+              <Route path=":id" element={<OrganizationUnitEditPage />} />
+            </Route>
+            <Route path="create" element={<FullScreenLayout />}>
+              <Route index element={<CreateOrganizationUnitPage />} />
+            </Route>
+          </Route>
+          <Route
+            path="/groups/create"
+            element={
+              <ProtectedRoute>
+                <GroupCreateProvider>
+                  <FullScreenLayout />
+                </GroupCreateProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<CreateGroupPage />} />
+          </Route>
+          <Route
+            path="/users/create"
+            element={
+              <ProtectedRoute>
+                <UserCreateProvider>
+                  <FullScreenLayout />
+                </UserCreateProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<CreateUserPage />} />
+          </Route>
+          <Route
+            path="/user-types/create"
+            element={
+              <ProtectedRoute>
+                <UserTypeCreateProvider>
+                  <FullScreenLayout />
+                </UserTypeCreateProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<CreateUserTypePage />} />
+          </Route>
+          <Route
+            path="/applications/create"
+            element={
+              <ProtectedRoute>
+                <ApplicationCreateProvider>
+                  <FullScreenLayout />
+                </ApplicationCreateProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<ApplicationCreatePage />} />
+          </Route>
+          <Route
+            path="/flows/signin"
+            element={
+              <ProtectedRoute>
                 <DashboardLayout />
-              </LayoutBuilderProvider>
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<LayoutBuilderPage />} />
-        </Route>
-        <Route
-          path="/translations/create"
-          element={
-            <ProtectedRoute>
-              <TranslationCreateProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<LoginFlowBuilderPage />} />
+          </Route>
+          <Route
+            path="/flows/signin/:flowId"
+            element={
+              <ProtectedRoute>
+                <DashboardLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<LoginFlowBuilderPage />} />
+          </Route>
+          <Route
+            path="/design"
+            element={
+              <ProtectedRoute>
+                <DashboardLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<DesignPage />} />
+          </Route>
+          <Route
+            path="/design/themes/create"
+            element={
+              <ProtectedRoute>
                 <FullScreenLayout />
-              </TranslationCreateProvider>
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<TranslationCreatePage />} />
-        </Route>
-        <Route
-          path="/translations"
-          element={
-            <ProtectedRoute>
-              <DashboardLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<TranslationsListPage />} />
-          <Route path=":language" element={<TranslationsEditPage />} />
-        </Route>
-      </Routes>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<ThemeCreatePage />} />
+          </Route>
+          <Route
+            path="/design/themes/:themeId"
+            element={
+              <ProtectedRoute>
+                <ThemeBuilderProvider>
+                  <DashboardLayout />
+                </ThemeBuilderProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<ThemeBuilderPage />} />
+          </Route>
+          <Route
+            path="/design/layouts/:layoutId"
+            element={
+              <ProtectedRoute>
+                <LayoutBuilderProvider>
+                  <DashboardLayout />
+                </LayoutBuilderProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<LayoutBuilderPage />} />
+          </Route>
+          <Route
+            path="/translations/create"
+            element={
+              <ProtectedRoute>
+                <TranslationCreateProvider>
+                  <FullScreenLayout />
+                </TranslationCreateProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<TranslationCreatePage />} />
+          </Route>
+          <Route
+            path="/translations"
+            element={
+              <ProtectedRoute>
+                <DashboardLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<TranslationsListPage />} />
+            <Route path=":language" element={<TranslationsEditPage />} />
+          </Route>
+        </Routes>
+      </ToastProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/apps/thunder-develop/src/features/applications/api/useCreateApplication.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/api/useCreateApplication.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {Application} from '../models/application';
 import type {CreateApplicationRequest} from '../models/requests';
 import ApplicationQueryKeys from '../constants/application-query-keys';
@@ -63,6 +64,8 @@ export default function useCreateApplication(): UseMutationResult<Application, E
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('applications');
+  const {showToast} = useToast();
 
   return useMutation<Application, Error, CreateApplicationRequest>({
     mutationFn: async (applicationData: CreateApplicationRequest): Promise<Application> => {
@@ -85,6 +88,10 @@ export default function useCreateApplication(): UseMutationResult<Application, E
       queryClient.invalidateQueries({queryKey: [ApplicationQueryKeys.APPLICATIONS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('create.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('create.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/applications/api/useDeleteApplication.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/api/useDeleteApplication.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import ApplicationQueryKeys from '../constants/application-query-keys';
 
 /**
@@ -63,6 +64,8 @@ export default function useDeleteApplication(): UseMutationResult<void, Error, s
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('applications');
+  const {showToast} = useToast();
 
   return useMutation<void, Error, string>({
     mutationFn: async (applicationId: string): Promise<void> => {
@@ -82,6 +85,10 @@ export default function useDeleteApplication(): UseMutationResult<void, Error, s
       queryClient.invalidateQueries({queryKey: [ApplicationQueryKeys.APPLICATIONS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('delete.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('delete.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/applications/api/useRegenerateClientSecret.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/api/useRegenerateClientSecret.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {Application} from '../models/application';
 import type {InboundAuthConfig} from '../models/inbound-auth';
 import ApplicationQueryKeys from '../constants/application-query-keys';
@@ -138,6 +139,8 @@ export default function useRegenerateClientSecret(): UseMutationResult<
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
+  const {t} = useTranslation('applications');
+  const {showToast} = useToast();
 
   return useMutation<RegenerateSecretResult, Error, RegenerateSecretVariables>({
     mutationFn: async ({applicationId}: RegenerateSecretVariables): Promise<RegenerateSecretResult> => {
@@ -200,6 +203,10 @@ export default function useRegenerateClientSecret(): UseMutationResult<
       queryClient.invalidateQueries({queryKey: [ApplicationQueryKeys.APPLICATIONS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('regenerateSecret.snackbar.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('regenerateSecret.dialog.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/applications/api/useUpdateApplication.ts
+++ b/frontend/apps/thunder-develop/src/features/applications/api/useUpdateApplication.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {Application} from '../models/application';
 import type {CreateApplicationRequest} from '../models/requests';
 import ApplicationQueryKeys from '../constants/application-query-keys';
@@ -82,6 +83,8 @@ export default function useUpdateApplication(): UseMutationResult<Application, E
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('applications');
+  const {showToast} = useToast();
 
   return useMutation<Application, Error, UpdateApplicationVariables>({
     mutationFn: async ({applicationId, data}: UpdateApplicationVariables): Promise<Application> => {
@@ -110,6 +113,10 @@ export default function useUpdateApplication(): UseMutationResult<Application, E
       queryClient.invalidateQueries({queryKey: [ApplicationQueryKeys.APPLICATIONS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('update.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('update.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/QuickCopySection.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/QuickCopySection.tsx
@@ -106,40 +106,44 @@ export default function QuickCopySection({
           />
         </FormControl>
 
-        <FormControl fullWidth>
-          <FormLabel htmlFor="client-id-input">{t('applications:edit.general.labels.clientId')}</FormLabel>
-          <TextField
-            fullWidth
-            id="client-id-input"
-            value={oauth2Config?.client_id ?? ''}
-            InputProps={{
-              readOnly: true,
-              endAdornment: (
-                <InputAdornment position="end">
-                  <Tooltip title={copiedField === 'client_id' ? t('common:actions.copied') : t('common:actions.copy')}>
-                    <IconButton
-                      onClick={() => {
-                        if (oauth2Config?.client_id) {
-                          onCopyToClipboard(oauth2Config.client_id, 'client_id').catch(() => {});
-                        }
-                      }}
-                      edge="end"
+        {oauth2Config?.client_id && (
+          <FormControl fullWidth>
+            <FormLabel htmlFor="client-id-input">{t('applications:edit.general.labels.clientId')}</FormLabel>
+            <TextField
+              fullWidth
+              id="client-id-input"
+              value={oauth2Config?.client_id ?? ''}
+              InputProps={{
+                readOnly: true,
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Tooltip
+                      title={copiedField === 'client_id' ? t('common:actions.copied') : t('common:actions.copy')}
                     >
-                      {copiedField === 'client_id' ? <Check size={16} /> : <Copy size={16} />}
-                    </IconButton>
-                  </Tooltip>
-                </InputAdornment>
-              ),
-            }}
-            helperText={t('applications:edit.general.clientId.hint')}
-            sx={{
-              '& input': {
-                fontFamily: 'monospace',
-                fontSize: '0.875rem',
-              },
-            }}
-          />
-        </FormControl>
+                      <IconButton
+                        onClick={() => {
+                          if (oauth2Config?.client_id) {
+                            onCopyToClipboard(oauth2Config.client_id, 'client_id').catch(() => {});
+                          }
+                        }}
+                        edge="end"
+                      >
+                        {copiedField === 'client_id' ? <Check size={16} /> : <Copy size={16} />}
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ),
+              }}
+              helperText={t('applications:edit.general.clientId.hint')}
+              sx={{
+                '& input': {
+                  fontFamily: 'monospace',
+                  fontSize: '0.875rem',
+                },
+              }}
+            />
+          </FormControl>
+        )}
       </Stack>
     </SettingsCard>
   );

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/QuickCopySection.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/QuickCopySection.test.tsx
@@ -86,13 +86,12 @@ describe('QuickCopySection', () => {
       expect(screen.getByDisplayValue('client-123')).toBeInTheDocument();
     });
 
-    it('should render empty client ID field when OAuth2 config is not provided', () => {
+    it('should not render client ID field when OAuth2 config is not provided', () => {
       render(
         <QuickCopySection application={mockApplication} copiedField={null} onCopyToClipboard={mockOnCopyToClipboard} />,
       );
 
-      const clientIdInput = screen.getByLabelText('Client ID');
-      expect(clientIdInput).toHaveAttribute('value', '');
+      expect(screen.queryByLabelText('Client ID')).not.toBeInTheDocument();
     });
 
     it('should render both copy buttons', () => {
@@ -140,16 +139,13 @@ describe('QuickCopySection', () => {
       expect(mockOnCopyToClipboard).toHaveBeenCalledWith('client-123', 'client_id');
     });
 
-    it('should not call onCopyToClipboard when client ID is not available', async () => {
-      const user = userEvent.setup();
+    it('should not render client ID copy button when client ID is not available', () => {
       render(
         <QuickCopySection application={mockApplication} copiedField={null} onCopyToClipboard={mockOnCopyToClipboard} />,
       );
 
       const copyButtons = screen.getAllByRole('button');
-      await user.click(copyButtons[1]);
-
-      expect(mockOnCopyToClipboard).not.toHaveBeenCalled();
+      expect(copyButtons).toHaveLength(1);
     });
 
     it('should handle copy errors gracefully', async () => {

--- a/frontend/apps/thunder-develop/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -117,15 +117,16 @@ vi.mock('@/features/notification-senders/api/useNotificationSenders', () => ({
 }));
 
 // Use vi.hoisted for mocks that need to be referenced in vi.mock
-const {mockToObject, mockGetNodes, mockGetEdges, mockUpdateNodeData, mockFitView, mockUpdateNodeInternals} =
-  vi.hoisted(() => ({
+const {mockToObject, mockGetNodes, mockGetEdges, mockUpdateNodeData, mockFitView, mockUpdateNodeInternals} = vi.hoisted(
+  () => ({
     mockToObject: vi.fn(() => ({viewport: {x: 0, y: 0, zoom: 1}})),
     mockGetNodes: vi.fn((): Node[] => []),
     mockGetEdges: vi.fn((): Edge[] => []),
     mockUpdateNodeData: vi.fn(),
     mockFitView: vi.fn().mockResolvedValue(undefined),
     mockUpdateNodeInternals: vi.fn(),
-  }));
+  }),
+);
 
 vi.mock('@xyflow/react', () => ({
   useReactFlow: () => ({
@@ -141,15 +142,15 @@ vi.mock('@xyflow/react', () => ({
 // Store callbacks for testing
 type DragEndCallback = (event: {
   operation: {
-    source: { data: Record<string, unknown> } | null;
-    target: { id: string; data: Record<string, unknown> } | null;
+    source: {data: Record<string, unknown>} | null;
+    target: {id: string; data: Record<string, unknown>} | null;
   };
   canceled: boolean;
 }) => void;
 type DragOverCallback = (event: {
   operation: {
-    source: { id?: string; data?: Record<string, unknown> } | null;
-    target?: { id: string; data: Record<string, unknown> } | null;
+    source: {id?: string; data?: Record<string, unknown>} | null;
+    target?: {id: string; data: Record<string, unknown>} | null;
   };
 }) => void;
 
@@ -158,7 +159,11 @@ let capturedOnDragOver: DragOverCallback | null = null;
 
 // Mock @dnd-kit/react
 vi.mock('@dnd-kit/react', () => ({
-  DragDropProvider: ({children, onDragEnd, onDragOver}: {
+  DragDropProvider: ({
+    children,
+    onDragEnd,
+    onDragOver,
+  }: {
     children: React.ReactNode;
     onDragEnd?: DragEndCallback;
     onDragOver?: DragOverCallback;
@@ -190,12 +195,18 @@ vi.mock('@dnd-kit/abstract', () => ({
 
 // Mock @wso2/oxygen-ui
 vi.mock('@wso2/oxygen-ui', () => ({
+  Alert: ({children, severity}: any) => (
+    <div data-testid="alert-component" data-severity={severity}>
+      {children}
+    </div>
+  ),
   Box: ({children, className}: any) => (
     <div data-testid="box-component" className={className}>
       {children}
     </div>
   ),
   OxygenUIThemeProvider: ({children}: any) => children,
+  Snackbar: ({children, open}: any) => (open ? <div data-testid="snackbar-component">{children}</div> : null),
 }));
 
 // Mock classnames
@@ -273,7 +284,6 @@ vi.mock('../../../utils/generateResourceId', () => ({
 }));
 
 describe('DecoratedVisualFlow', () => {
-
   const mockBaseResource: Base = {
     id: '',
     type: '',
@@ -333,10 +343,7 @@ describe('DecoratedVisualFlow', () => {
     executors: [],
   };
 
-  const renderWithContext = (
-    ui: React.ReactElement,
-    contextValue: FlowBuilderCoreContextProps = defaultContextValue,
-  ) =>
+  const renderWithContext = (ui: React.ReactElement, contextValue: FlowBuilderCoreContextProps = defaultContextValue) =>
     render(<FlowBuilderCoreContext.Provider value={contextValue}>{ui}</FlowBuilderCoreContext.Provider>);
 
   const defaultProps = {
@@ -968,7 +975,7 @@ describe('DecoratedVisualFlow', () => {
       renderWithContext(<DecoratedVisualFlow {...defaultProps} />);
 
       // Capture the callback passed to updateNodeData
-      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => { components: unknown[] }) => {
+      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => {components: unknown[]}) => {
         // Simulate a node with nested components (form with children)
         const mockNode: Node = {
           id: stepId,
@@ -976,7 +983,14 @@ describe('DecoratedVisualFlow', () => {
           data: {
             components: [
               {id: 'button-1', type: 'BUTTON'},
-              {id: 'form-1', type: 'FORM', components: [{id: 'input-1', type: 'TEXT_INPUT'}, {id: 'input-2', type: 'TEXT_INPUT'}]},
+              {
+                id: 'form-1',
+                type: 'FORM',
+                components: [
+                  {id: 'input-1', type: 'TEXT_INPUT'},
+                  {id: 'input-2', type: 'TEXT_INPUT'},
+                ],
+              },
               {id: 'text-1', type: 'TEXT'},
             ],
           },
@@ -1013,7 +1027,7 @@ describe('DecoratedVisualFlow', () => {
       renderWithContext(<DecoratedVisualFlow {...defaultProps} />);
 
       // Capture the callback passed to updateNodeData
-      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => { components: unknown[] }) => {
+      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => {components: unknown[]}) => {
         // Simulate a node with no components
         const mockNode: Node = {
           id: stepId,
@@ -1178,9 +1192,7 @@ describe('DecoratedVisualFlow', () => {
         id: 'step-1',
         position: {x: 0, y: 0},
         data: {
-          components: [
-            {id: 'form-1', type: 'BLOCK', components: [{id: 'input-1', type: 'TEXT_INPUT'}]},
-          ],
+          components: [{id: 'form-1', type: 'BLOCK', components: [{id: 'input-1', type: 'TEXT_INPUT'}]}],
         },
       };
       mockGetNodes.mockReturnValue([targetNode]);
@@ -1371,7 +1383,7 @@ describe('DecoratedVisualFlow', () => {
       renderWithContext(<DecoratedVisualFlow {...defaultProps} />);
 
       // Capture the callback passed to updateNodeData
-      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => { components: unknown[] }) => {
+      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => {components: unknown[]}) => {
         // Simulate a node with nested components (form with children)
         const mockNode: Node = {
           id: stepId,
@@ -1379,7 +1391,14 @@ describe('DecoratedVisualFlow', () => {
           data: {
             components: [
               {id: 'button-1', type: 'BUTTON'},
-              {id: 'form-1', type: 'FORM', components: [{id: 'input-1', type: 'TEXT_INPUT'}, {id: 'input-2', type: 'TEXT_INPUT'}]},
+              {
+                id: 'form-1',
+                type: 'FORM',
+                components: [
+                  {id: 'input-1', type: 'TEXT_INPUT'},
+                  {id: 'input-2', type: 'TEXT_INPUT'},
+                ],
+              },
               {id: 'divider-1', type: 'DIVIDER'},
             ],
           },
@@ -1414,7 +1433,7 @@ describe('DecoratedVisualFlow', () => {
       renderWithContext(<DecoratedVisualFlow {...defaultProps} />);
 
       // Capture the callback passed to updateNodeData
-      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => { components: unknown[] }) => {
+      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => {components: unknown[]}) => {
         // Simulate a node with components that have no nested children
         const mockNode: Node = {
           id: stepId,
@@ -1455,7 +1474,7 @@ describe('DecoratedVisualFlow', () => {
       renderWithContext(<DecoratedVisualFlow {...defaultProps} />);
 
       // Capture the callback passed to updateNodeData
-      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => { components: unknown[] }) => {
+      mockUpdateNodeData.mockImplementation((stepId: string, callback: (node: Node) => {components: unknown[]}) => {
         // Simulate a node with undefined data
         const mockNode: Node = {
           id: stepId,

--- a/frontend/apps/thunder-develop/src/features/groups/api/useAddGroupMembers.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/api/useAddGroupMembers.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {Member} from '../models/group';
 import GroupQueryKeys from '../constants/group-query-keys';
 
@@ -39,6 +40,8 @@ export default function useAddGroupMembers(): UseMutationResult<void, Error, Add
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('groups');
+  const {showToast} = useToast();
 
   return useMutation<void, Error, AddGroupMembersVariables>({
     mutationFn: async ({groupId, members}: AddGroupMembersVariables): Promise<void> => {
@@ -62,6 +65,10 @@ export default function useAddGroupMembers(): UseMutationResult<void, Error, Add
       queryClient.invalidateQueries({queryKey: [GroupQueryKeys.GROUP_MEMBERS, groupId]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('addMember.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('addMember.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/groups/api/useCreateGroup.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/api/useCreateGroup.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {Group} from '../models/group';
 import type {CreateGroupRequest} from '../models/requests';
 import GroupQueryKeys from '../constants/group-query-keys';
@@ -32,6 +33,8 @@ export default function useCreateGroup(): UseMutationResult<Group, Error, Create
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('groups');
+  const {showToast} = useToast();
 
   return useMutation<Group, Error, CreateGroupRequest>({
     mutationFn: async (groupData: CreateGroupRequest): Promise<Group> => {
@@ -53,6 +56,10 @@ export default function useCreateGroup(): UseMutationResult<Group, Error, Create
       queryClient.invalidateQueries({queryKey: [GroupQueryKeys.GROUPS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('create.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('create.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/groups/api/useDeleteGroup.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/api/useDeleteGroup.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import GroupQueryKeys from '../constants/group-query-keys';
 
 /**
@@ -30,6 +31,8 @@ export default function useDeleteGroup(): UseMutationResult<void, Error, string>
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('groups');
+  const {showToast} = useToast();
 
   return useMutation<void, Error, string>({
     mutationFn: async (groupId: string): Promise<void> => {
@@ -44,6 +47,10 @@ export default function useDeleteGroup(): UseMutationResult<void, Error, string>
       queryClient.invalidateQueries({queryKey: [GroupQueryKeys.GROUPS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('delete.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('delete.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/groups/api/useRemoveGroupMembers.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/api/useRemoveGroupMembers.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {Member} from '../models/group';
 import GroupQueryKeys from '../constants/group-query-keys';
 
@@ -39,6 +40,8 @@ export default function useRemoveGroupMembers(): UseMutationResult<void, Error, 
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('groups');
+  const {showToast} = useToast();
 
   return useMutation<void, Error, RemoveGroupMembersVariables>({
     mutationFn: async ({groupId, members}: RemoveGroupMembersVariables): Promise<void> => {
@@ -62,6 +65,10 @@ export default function useRemoveGroupMembers(): UseMutationResult<void, Error, 
       queryClient.invalidateQueries({queryKey: [GroupQueryKeys.GROUP_MEMBERS, groupId]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('removeMember.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('removeMember.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/groups/api/useUpdateGroup.ts
+++ b/frontend/apps/thunder-develop/src/features/groups/api/useUpdateGroup.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {Group} from '../models/group';
 import type {UpdateGroupRequest} from '../models/requests';
 import GroupQueryKeys from '../constants/group-query-keys';
@@ -40,6 +41,8 @@ export default function useUpdateGroup(): UseMutationResult<Group, Error, Update
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('groups');
+  const {showToast} = useToast();
 
   return useMutation<Group, Error, UpdateGroupVariables>({
     mutationFn: async ({groupId, data}: UpdateGroupVariables): Promise<Group> => {
@@ -67,6 +70,10 @@ export default function useUpdateGroup(): UseMutationResult<Group, Error, Update
       queryClient.invalidateQueries({queryKey: [GroupQueryKeys.GROUP_MEMBERS, groupId]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('update.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('update.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/groups/pages/GroupEditPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/groups/pages/GroupEditPage.tsx
@@ -32,7 +32,6 @@ import {
   CircularProgress,
   Tabs,
   Tab,
-  Snackbar,
   Tooltip,
   PageContent,
   PageTitle,
@@ -40,6 +39,7 @@ import {
 import {ArrowLeft, Copy, Check, Edit, Users} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
 import {useLogger} from '@thunder/logger/react';
+import {useToast} from '@thunder/shared-contexts';
 import useGetGroup from '../api/useGetGroup';
 import useUpdateGroup from '../api/useUpdateGroup';
 import type {Group} from '../models/group';
@@ -72,6 +72,7 @@ export default function GroupEditPage(): JSX.Element {
   const navigate = useNavigate();
   const {t} = useTranslation();
   const logger = useLogger('GroupEditPage');
+  const {showToast} = useToast();
 
   const {data: group, isLoading, error: fetchError, refetch} = useGetGroup(groupId ?? '');
   const updateGroup = useUpdateGroup();
@@ -79,7 +80,6 @@ export default function GroupEditPage(): JSX.Element {
   const [activeTab, setActiveTab] = useState(0);
   const [editedGroup, setEditedGroup] = useState<Partial<Group>>({});
   const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
-  const [snackbar, setSnackbar] = useState<{open: boolean; message: string}>({open: false, message: ''});
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [tempName, setTempName] = useState('');
@@ -139,12 +139,10 @@ export default function GroupEditPage(): JSX.Element {
       await refetch();
     } catch (err: unknown) {
       logger.error('Failed to update group', {error: err});
-      setSnackbar({
-        open: true,
-        message: err instanceof Error ? err.message : t('groups:edit.page.error'),
-      });
+      const message = err instanceof Error ? err.message : t('groups:edit.page.saveError');
+      showToast(message, 'error');
     }
-  }, [group, groupId, editedGroup, updateGroup, refetch, logger, t]);
+  }, [group, groupId, editedGroup, updateGroup, refetch, logger, showToast, t]);
 
   const hasChanges = useMemo(() => Object.keys(editedGroup).length > 0, [editedGroup]);
 
@@ -213,9 +211,7 @@ export default function GroupEditPage(): JSX.Element {
     <PageContent>
       {/* Header */}
       <PageTitle>
-        <PageTitle.BackButton component={<Link to={listUrl} />}>
-          {t('groups:edit.page.back')}
-        </PageTitle.BackButton>
+        <PageTitle.BackButton component={<Link to={listUrl} />}>{t('groups:edit.page.back')}</PageTitle.BackButton>
         <PageTitle.Avatar>
           <Avatar>
             <Users size={32} />
@@ -370,10 +366,7 @@ export default function GroupEditPage(): JSX.Element {
                 '&:focus-visible .copy-icon': {opacity: 1},
               }}
             >
-              <Typography
-                variant="caption"
-                sx={{fontFamily: 'monospace', color: 'text.disabled', fontSize: '0.75rem'}}
-              >
+              <Typography variant="caption" sx={{fontFamily: 'monospace', color: 'text.disabled', fontSize: '0.75rem'}}>
                 {group.id}
               </Typography>
               {copiedField === 'groupId' ? (
@@ -420,20 +413,6 @@ export default function GroupEditPage(): JSX.Element {
         onClose={() => setDeleteDialogOpen(false)}
         onSuccess={handleDeleteSuccess}
       />
-
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={(_event, reason) => {
-          if (reason === 'clickaway') return;
-          setSnackbar((prev) => ({...prev, open: false}));
-        }}
-        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
-      >
-        <Alert onClose={() => setSnackbar((prev) => ({...prev, open: false}))} severity="error" sx={{width: '100%'}}>
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
 
       {/* Floating Action Bar */}
       {hasChanges && (

--- a/frontend/apps/thunder-develop/src/features/organization-units/api/useCreateOrganizationUnit.ts
+++ b/frontend/apps/thunder-develop/src/features/organization-units/api/useCreateOrganizationUnit.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {OrganizationUnit} from '../models/organization-unit';
 import type {CreateOrganizationUnitRequest} from '../models/requests';
 import OrganizationUnitQueryKeys from '../constants/organization-unit-query-keys';
@@ -60,6 +61,8 @@ export default function useCreateOrganizationUnit(): UseMutationResult<
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('organizationUnits');
+  const {showToast} = useToast();
 
   return useMutation<OrganizationUnit, Error, CreateOrganizationUnitRequest>({
     mutationFn: async (data: CreateOrganizationUnitRequest): Promise<OrganizationUnit> => {
@@ -86,6 +89,10 @@ export default function useCreateOrganizationUnit(): UseMutationResult<
       queryClient.invalidateQueries({queryKey: [OrganizationUnitQueryKeys.CHILD_ORGANIZATION_UNITS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('create.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('create.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/organization-units/api/useDeleteOrganizationUnit.ts
+++ b/frontend/apps/thunder-develop/src/features/organization-units/api/useDeleteOrganizationUnit.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import OrganizationUnitQueryKeys from '../constants/organization-unit-query-keys';
 
 /**
@@ -60,6 +61,8 @@ export default function useDeleteOrganizationUnit(): UseMutationResult<void, Err
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('organizationUnits');
+  const {showToast} = useToast();
 
   return useMutation<void, Error, string>({
     mutationFn: async (id: string): Promise<void> => {
@@ -83,6 +86,10 @@ export default function useDeleteOrganizationUnit(): UseMutationResult<void, Err
       queryClient.invalidateQueries({queryKey: [OrganizationUnitQueryKeys.CHILD_ORGANIZATION_UNITS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('delete.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('delete.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/organization-units/api/useUpdateOrganizationUnit.ts
+++ b/frontend/apps/thunder-develop/src/features/organization-units/api/useUpdateOrganizationUnit.ts
@@ -17,8 +17,9 @@
  */
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
 import {useAsgardeo} from '@asgardeo/react';
+import {useTranslation} from 'react-i18next';
 import type {OrganizationUnit} from '../models/organization-unit';
 import type {UpdateOrganizationUnitRequest} from '../models/requests';
 import OrganizationUnitQueryKeys from '../constants/organization-unit-query-keys';
@@ -68,6 +69,8 @@ export default function useUpdateOrganizationUnit(): UseMutationResult<
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('organizationUnits');
+  const {showToast} = useToast();
 
   return useMutation<OrganizationUnit, Error, UpdateOrganizationUnitVariables>({
     mutationFn: async ({id, data}: UpdateOrganizationUnitVariables): Promise<OrganizationUnit> => {
@@ -90,9 +93,15 @@ export default function useUpdateOrganizationUnit(): UseMutationResult<
       queryClient.invalidateQueries({queryKey: [OrganizationUnitQueryKeys.ORGANIZATION_UNITS]}).catch(() => {
         // Ignore invalidation errors
       });
-      queryClient.invalidateQueries({queryKey: [OrganizationUnitQueryKeys.ORGANIZATION_UNIT, variables.id]}).catch(() => {
-        // Ignore invalidation errors
-      });
+      queryClient
+        .invalidateQueries({queryKey: [OrganizationUnitQueryKeys.ORGANIZATION_UNIT, variables.id]})
+        .catch(() => {
+          // Ignore invalidation errors
+        });
+      showToast(t('update.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('update.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/user-types/api/useCreateUserType.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/useCreateUserType.ts
@@ -18,7 +18,8 @@
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useAsgardeo} from '@asgardeo/react';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
+import {useTranslation} from 'react-i18next';
 import type {ApiUserSchema, CreateUserSchemaRequest} from '../types/user-types';
 import UserTypeQueryKeys from '../constants/userTypeQueryKeys';
 
@@ -31,6 +32,8 @@ export default function useCreateUserType(): UseMutationResult<ApiUserSchema, Er
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('userTypes');
+  const {showToast} = useToast();
 
   return useMutation<ApiUserSchema, Error, CreateUserSchemaRequest>({
     mutationFn: async (requestData: CreateUserSchemaRequest): Promise<ApiUserSchema> => {
@@ -52,6 +55,10 @@ export default function useCreateUserType(): UseMutationResult<ApiUserSchema, Er
       queryClient.invalidateQueries({queryKey: [UserTypeQueryKeys.USER_TYPES]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('create.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('create.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/user-types/api/useDeleteUserType.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/useDeleteUserType.ts
@@ -18,7 +18,8 @@
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useAsgardeo} from '@asgardeo/react';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
+import {useTranslation} from 'react-i18next';
 import UserTypeQueryKeys from '../constants/userTypeQueryKeys';
 
 /**
@@ -30,6 +31,8 @@ export default function useDeleteUserType(): UseMutationResult<void, Error, stri
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('userTypes');
+  const {showToast} = useToast();
 
   return useMutation<void, Error, string>({
     mutationFn: async (userTypeId: string): Promise<void> => {
@@ -47,6 +50,10 @@ export default function useDeleteUserType(): UseMutationResult<void, Error, stri
       queryClient.invalidateQueries({queryKey: [UserTypeQueryKeys.USER_TYPES]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('delete.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('delete.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/user-types/api/useUpdateUserType.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/api/useUpdateUserType.ts
@@ -18,7 +18,8 @@
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useAsgardeo} from '@asgardeo/react';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
+import {useTranslation} from 'react-i18next';
 import type {ApiUserSchema, UpdateUserSchemaRequest} from '../types/user-types';
 import UserTypeQueryKeys from '../constants/userTypeQueryKeys';
 
@@ -45,6 +46,8 @@ export default function useUpdateUserType(): UseMutationResult<ApiUserSchema, Er
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('userTypes');
+  const {showToast} = useToast();
 
   return useMutation<ApiUserSchema, Error, UpdateUserTypeVariables>({
     mutationFn: async ({userTypeId, data}: UpdateUserTypeVariables): Promise<ApiUserSchema> => {
@@ -63,14 +66,16 @@ export default function useUpdateUserType(): UseMutationResult<ApiUserSchema, Er
       return response.data;
     },
     onSuccess: (_data, variables) => {
-      queryClient
-        .invalidateQueries({queryKey: [UserTypeQueryKeys.USER_TYPE, variables.userTypeId]})
-        .catch(() => {
-          // Ignore invalidation errors
-        });
+      queryClient.invalidateQueries({queryKey: [UserTypeQueryKeys.USER_TYPE, variables.userTypeId]}).catch(() => {
+        // Ignore invalidation errors
+      });
       queryClient.invalidateQueries({queryKey: [UserTypeQueryKeys.USER_TYPES]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('update.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('update.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/users/api/useCreateUser.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useCreateUser.ts
@@ -18,7 +18,8 @@
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useAsgardeo} from '@asgardeo/react';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
+import {useTranslation} from 'react-i18next';
 import type {ApiUser, CreateUserRequest} from '../types/users';
 import UserQueryKeys from '../constants/user-query-keys';
 
@@ -31,6 +32,8 @@ export default function useCreateUser(): UseMutationResult<ApiUser, Error, Creat
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('users');
+  const {showToast} = useToast();
 
   return useMutation<ApiUser, Error, CreateUserRequest>({
     mutationFn: async (userData: CreateUserRequest): Promise<ApiUser> => {
@@ -53,6 +56,10 @@ export default function useCreateUser(): UseMutationResult<ApiUser, Error, Creat
       queryClient.invalidateQueries({queryKey: [UserQueryKeys.USERS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('create.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('create.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/users/api/useDeleteUser.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useDeleteUser.ts
@@ -18,7 +18,8 @@
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useAsgardeo} from '@asgardeo/react';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
+import {useTranslation} from 'react-i18next';
 import UserQueryKeys from '../constants/user-query-keys';
 
 /**
@@ -30,6 +31,8 @@ export default function useDeleteUser(): UseMutationResult<void, Error, string> 
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('users');
+  const {showToast} = useToast();
 
   return useMutation<void, Error, string>({
     mutationFn: async (userId: string): Promise<void> => {
@@ -48,6 +51,10 @@ export default function useDeleteUser(): UseMutationResult<void, Error, string> 
       queryClient.invalidateQueries({queryKey: [UserQueryKeys.USERS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('delete.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('delete.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/features/users/api/useUpdateUser.ts
+++ b/frontend/apps/thunder-develop/src/features/users/api/useUpdateUser.ts
@@ -18,7 +18,8 @@
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useAsgardeo} from '@asgardeo/react';
-import {useConfig} from '@thunder/shared-contexts';
+import {useConfig, useToast} from '@thunder/shared-contexts';
+import {useTranslation} from 'react-i18next';
 import type {ApiUser, UpdateUserRequest} from '../types/users';
 import UserQueryKeys from '../constants/user-query-keys';
 
@@ -39,6 +40,8 @@ export default function useUpdateUser(): UseMutationResult<ApiUser, Error, Updat
   const {http} = useAsgardeo();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation('users');
+  const {showToast} = useToast();
 
   return useMutation<ApiUser, Error, UpdateUserVariables>({
     mutationFn: async ({userId, data}: UpdateUserVariables): Promise<ApiUser> => {
@@ -58,14 +61,16 @@ export default function useUpdateUser(): UseMutationResult<ApiUser, Error, Updat
       return response.data;
     },
     onSuccess: (_data, variables) => {
-      queryClient
-        .invalidateQueries({queryKey: [UserQueryKeys.USER, variables.userId]})
-        .catch(() => {
-          // Ignore invalidation errors
-        });
+      queryClient.invalidateQueries({queryKey: [UserQueryKeys.USER, variables.userId]}).catch(() => {
+        // Ignore invalidation errors
+      });
       queryClient.invalidateQueries({queryKey: [UserQueryKeys.USERS]}).catch(() => {
         // Ignore invalidation errors
       });
+      showToast(t('update.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('update.error'), 'error');
     },
   });
 }

--- a/frontend/apps/thunder-develop/src/hooks/__tests__/useDataGridLocaleText.test.tsx
+++ b/frontend/apps/thunder-develop/src/hooks/__tests__/useDataGridLocaleText.test.tsx
@@ -300,7 +300,9 @@ describe('useDataGridLocaleText', () => {
         <div>
           <span data-testid="count">{count}</span>
           <span data-testid="label">{localeText.noRowsLabel}</span>
-          <button type="button" onClick={() => setCount((c) => c + 1)}>increment</button>
+          <button type="button" onClick={() => setCount((c) => c + 1)}>
+            increment
+          </button>
         </div>
       );
     }
@@ -346,9 +348,7 @@ describe('useDataGridLocaleText', () => {
     expect(result.current.toolbarFiltersTooltipActive).toBeUndefined();
 
     // Should have logged a warning in DEV mode
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('dataTable.toolbarFiltersTooltipActive'),
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('dataTable.toolbarFiltersTooltipActive'));
 
     import.meta.env.DEV = originalDev;
     consoleSpy.mockRestore();
@@ -379,7 +379,9 @@ describe('useDataGridLocaleText', () => {
     // Mock i18n to return undefined from getResourceBundle to cover the ?? {} fallback
     const i18nModule = await import('i18next');
 
-    vi.spyOn(i18nModule.default, 'getResourceBundle').mockImplementation(() => undefined as unknown as Record<string, unknown>);
+    vi.spyOn(i18nModule.default, 'getResourceBundle').mockImplementation(
+      () => undefined as unknown as Record<string, unknown>,
+    );
 
     const {result} = renderHook(() => useDataGridLocaleText());
 
@@ -424,28 +426,20 @@ describe('useDataGridLocaleText', () => {
     // Mock i18n to return a bundle where ALL function keys are non-function values
     // This covers both the typeof !== 'function' branch AND the DEV warning branch for each key
     const i18nModule = await import('i18next');
-    const originalGetResourceBundle = i18nModule.default.getResourceBundle.bind(i18nModule.default);
 
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    // Ensure DEV mode is enabled so the console.warn path executes
-    const originalDev = import.meta.env.DEV;
-    import.meta.env.DEV = true;
-
-    vi.spyOn(i18nModule.default, 'getResourceBundle').mockImplementation((lng: string, ns: string) => {
-      const bundle = originalGetResourceBundle(lng, ns) as Record<string, unknown>;
-      return {
-        ...bundle,
-        // Override ALL function keys with non-function values to trigger DEV warnings
-        'dataTable.toolbarFiltersTooltipActive': 'not-a-function',
-        'dataTable.columnHeaderFiltersTooltipActive': 42,
-        'dataTable.footerRowSelected': true,
-        'dataTable.footerTotalVisibleRows': [],
-        'dataTable.groupColumn': {},
-        'dataTable.unGroupColumn': 'string-value',
-        'dataTable.paginationDisplayedRows': 0,
-      };
-    });
+    // Return only the non-function overrides — string translations use t(), not getResourceBundle,
+    // so there's no need to spread from the original bundle (which would risk re-entrant spy calls).
+    vi.spyOn(i18nModule.default, 'getResourceBundle').mockReturnValue({
+      'dataTable.toolbarFiltersTooltipActive': 'not-a-function',
+      'dataTable.columnHeaderFiltersTooltipActive': 42,
+      'dataTable.footerRowSelected': true,
+      'dataTable.footerTotalVisibleRows': [],
+      'dataTable.groupColumn': {},
+      'dataTable.unGroupColumn': 'string-value',
+      'dataTable.paginationDisplayedRows': 0,
+    } as unknown as Record<string, unknown>);
 
     const {result} = renderHook(() => useDataGridLocaleText());
 
@@ -458,7 +452,7 @@ describe('useDataGridLocaleText', () => {
     expect(result.current.unGroupColumn).toBeUndefined();
     expect(result.current.paginationDisplayedRows).toBeUndefined();
 
-    // Should have logged warnings for non-function, non-undefined values
+    // Should have logged warnings for non-function, non-undefined values (DEV is true in test env)
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('dataTable.toolbarFiltersTooltipActive'));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('dataTable.columnHeaderFiltersTooltipActive'));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('dataTable.footerRowSelected'));
@@ -466,9 +460,5 @@ describe('useDataGridLocaleText', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('dataTable.groupColumn'));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('dataTable.unGroupColumn'));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('dataTable.paginationDisplayedRows'));
-
-    import.meta.env.DEV = originalDev;
-    consoleSpy.mockRestore();
-    vi.restoreAllMocks();
   });
 });

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -388,6 +388,12 @@ const translations = {
     'createWizard.errors.noOuAccess':
       'You do not have permission to access the organization units for the selected user type, and no organization unit could be resolved.',
     'createWizard.errors.childOuProbeFailed': 'Unable to retrieve organization units for the selected user type.',
+    'create.success': 'User created successfully.',
+    'create.error': 'Failed to create user. Please try again.',
+    'update.success': 'User updated successfully.',
+    'update.error': 'Failed to update user. Please try again.',
+    'delete.success': 'User deleted successfully.',
+    'delete.error': 'Failed to delete user. Please try again.',
   },
 
   // ============================================================================
@@ -461,6 +467,12 @@ const translations = {
     'createWizard.general.subtitle': 'Choose an organization unit and set registration preferences',
     'createWizard.properties.title': 'Define your schema properties',
     'createWizard.properties.subtitle': 'Add the fields that make up this user type',
+    'create.success': 'User type created successfully.',
+    'create.error': 'Failed to create user type. Please try again.',
+    'update.success': 'User type updated successfully.',
+    'update.error': 'Failed to update user type. Please try again.',
+    'delete.success': 'User type deleted successfully.',
+    'delete.error': 'Failed to delete user type. Please try again.',
   },
 
   // ============================================================================
@@ -575,6 +587,11 @@ const translations = {
     'edit.customization.labels.theme': 'Theme',
     'edit.customization.theme.placeholder': 'Select a theme',
     'edit.customization.theme.hint': 'The theme applied to this organization unit.',
+    'create.success': 'Organization unit created successfully.',
+    'update.success': 'Organization unit updated successfully.',
+    'update.error': 'Failed to update organization unit. Please try again.',
+    'delete.success': 'Organization unit deleted successfully.',
+    'delete.error': 'Failed to delete organization unit. Please try again.',
   },
 
   // ============================================================================
@@ -669,6 +686,12 @@ const translations = {
     'delete.message': 'Are you sure you want to delete this group?',
     'delete.disclaimer': 'This action cannot be undone. All group associations will be permanently removed.',
     'delete.error': 'Failed to delete group. Please try again.',
+    'create.success': 'Group created successfully.',
+    'update.success': 'Group updated successfully.',
+    'update.error': 'Failed to update group. Please try again.',
+    'delete.success': 'Group deleted successfully.',
+    'addMember.success': 'Member added successfully.',
+    'removeMember.success': 'Member removed successfully.',
   },
 
   // ============================================================================
@@ -1280,6 +1303,13 @@ const translations = {
     'edit.advanced.certificate.placeholder.jwks': 'Enter JWKS JSON',
     'edit.advanced.certificate.hint.jwksUri': 'URL to the JWKS endpoint',
     'edit.advanced.certificate.hint.jwks': 'JSON Web Key Set',
+    'create.success': 'Application created successfully.',
+    'create.error': 'Failed to create application. Please try again.',
+    'update.success': 'Application updated successfully.',
+    'update.error': 'Failed to update application. Please try again.',
+    'delete.success': 'Application deleted successfully.',
+    'delete.error': 'Failed to delete application. Please try again.',
+    'regenerateSecret.snackbar.success': 'Client secret regenerated successfully.',
   },
 
   // ============================================================================

--- a/frontend/packages/thunder-shared-contexts/package.json
+++ b/frontend/packages/thunder-shared-contexts/package.json
@@ -52,6 +52,7 @@
     "@thunder/eslint-plugin-thunder": "workspace:^",
     "@thunder/prettier-config": "workspace:^",
     "@types/node": "catalog:",
+    "@wso2/oxygen-ui": "catalog:",
     "@types/react": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
@@ -72,6 +73,7 @@
     "tslib": "catalog:"
   },
   "peerDependencies": {
+    "@wso2/oxygen-ui": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
   }

--- a/frontend/packages/thunder-shared-contexts/src/Toast/ToastContext.tsx
+++ b/frontend/packages/thunder-shared-contexts/src/Toast/ToastContext.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {type Context, createContext} from 'react';
+
+/**
+ * Severity level for a toast notification.
+ *
+ * @public
+ */
+export type ToastSeverity = 'success' | 'error' | 'warning' | 'info';
+
+/**
+ * Toast context interface that provides access to the global toast notification system.
+ *
+ * @public
+ */
+export interface ToastContextType {
+  /**
+   * Displays a toast notification with the given message and severity.
+   *
+   * @param message - The text to display inside the toast
+   * @param severity - The visual style of the toast. Defaults to `'success'`
+   */
+  showToast: (message: string, severity?: ToastSeverity) => void;
+}
+
+/**
+ * React context for triggering toast notifications from anywhere in the component tree.
+ *
+ * This context provides a `showToast` function that renders a temporary snackbar message
+ * at the bottom-right of the screen. It should be consumed via the `useToast` hook
+ * inside a component tree wrapped by `ToastProvider`.
+ *
+ * @example
+ * ```tsx
+ * import ToastContext from './ToastContext';
+ * import { useContext } from 'react';
+ *
+ * const MyComponent = () => {
+ *   const context = useContext(ToastContext);
+ *   if (!context) {
+ *     throw new Error('Component must be used within ToastProvider');
+ *   }
+ *
+ *   return <button onClick={() => context.showToast('Done!', 'success')}>Save</button>;
+ * };
+ * ```
+ *
+ * @public
+ */
+const ToastContext: Context<ToastContextType | undefined> = createContext<ToastContextType | undefined>(undefined);
+
+export default ToastContext;

--- a/frontend/packages/thunder-shared-contexts/src/Toast/ToastProvider.tsx
+++ b/frontend/packages/thunder-shared-contexts/src/Toast/ToastProvider.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useState, useCallback, useMemo} from 'react';
+import type {SyntheticEvent, PropsWithChildren, JSX} from 'react';
+import {Alert, Snackbar} from '@wso2/oxygen-ui';
+import ToastContext, {type ToastSeverity} from './ToastContext';
+
+/**
+ * Internal state shape for the active toast notification.
+ */
+interface ToastState {
+  open: boolean;
+  message: string;
+  severity: ToastSeverity;
+}
+
+/**
+ * Props for the ToastProvider component.
+ *
+ * @public
+ */
+export type ToastProviderProps = PropsWithChildren;
+
+/**
+ * React context provider component that enables toast notifications throughout the application.
+ *
+ * This component manages the lifecycle of a single snackbar notification rendered at the
+ * bottom-right of the viewport. It exposes a `showToast` function via `ToastContext` so
+ * that any descendant component or hook can trigger a notification without needing to manage
+ * local state.
+ *
+ * Wrap your application (or a subtree) with this provider and consume notifications using
+ * the `useToast` hook.
+ *
+ * @example
+ * Basic setup in the application root:
+ * ```tsx
+ * import ToastProvider from './ToastProvider';
+ *
+ * function App() {
+ *   return (
+ *     <ToastProvider>
+ *       <Routes />
+ *     </ToastProvider>
+ *   );
+ * }
+ * ```
+ *
+ * @example
+ * Triggering a toast from a mutation hook:
+ * ```ts
+ * import useToast from './useToast';
+ *
+ * function useCreateItem() {
+ *   const { showToast } = useToast();
+ *
+ *   return useMutation({
+ *     mutationFn: createItem,
+ *     onSuccess: () => showToast('Item created successfully.', 'success'),
+ *     onError: () => showToast('Failed to create item.', 'error'),
+ *   });
+ * }
+ * ```
+ *
+ * @public
+ */
+export default function ToastProvider({children}: ToastProviderProps): JSX.Element {
+  const [toast, setToast] = useState<ToastState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  const showToast = useCallback((message: string, severity: ToastSeverity = 'success'): void => {
+    setToast({open: true, message, severity});
+  }, []);
+
+  const handleClose = useCallback((_event?: SyntheticEvent | Event, reason?: string): void => {
+    if (reason === 'clickaway') return;
+    setToast((prev) => ({...prev, open: false}));
+  }, []);
+
+  const contextValue = useMemo(() => ({showToast}), [showToast]);
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
+      >
+        <Alert onClose={handleClose} severity={toast.severity} sx={{width: '100%'}}>
+          {toast.message}
+        </Alert>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/packages/thunder-shared-contexts/src/Toast/useToast.ts
+++ b/frontend/packages/thunder-shared-contexts/src/Toast/useToast.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useContext} from 'react';
+import ToastContext, {type ToastContextType} from './ToastContext';
+
+/**
+ * React hook for triggering toast notifications from any component within a `ToastProvider`.
+ *
+ * This hook provides access to the `showToast` function exposed by `ToastContext`.
+ * It must be called inside a component tree that is wrapped by `ToastProvider`,
+ * otherwise it will throw an error.
+ *
+ * @returns The toast context containing the `showToast` function
+ *
+ * @throws {Error} Throws if called outside of a `ToastProvider`
+ *
+ * @example
+ * Basic usage in a component:
+ * ```tsx
+ * import useToast from './useToast';
+ *
+ * function SaveButton() {
+ *   const { showToast } = useToast();
+ *
+ *   return (
+ *     <button onClick={() => showToast('Saved successfully!', 'success')}>
+ *       Save
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @example
+ * Usage in a TanStack Query mutation hook:
+ * ```ts
+ * import useToast from './useToast';
+ * import { useMutation } from '@tanstack/react-query';
+ *
+ * function useDeleteItem() {
+ *   const { showToast } = useToast();
+ *
+ *   return useMutation({
+ *     mutationFn: deleteItem,
+ *     onSuccess: () => showToast('Item deleted.', 'success'),
+ *     onError: () => showToast('Failed to delete item.', 'error'),
+ *   });
+ * }
+ * ```
+ *
+ * @public
+ */
+export default function useToast(): ToastContextType {
+  const context = useContext(ToastContext);
+
+  if (context === undefined) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+
+  return context;
+}

--- a/frontend/packages/thunder-shared-contexts/src/index.ts
+++ b/frontend/packages/thunder-shared-contexts/src/index.ts
@@ -18,8 +18,12 @@
 
 // Export types
 export type {ThunderConfig, ServerConfig} from './Config/types';
+export type {ToastContextType, ToastSeverity} from './Toast/ToastContext';
 
 // Export React components and hooks
 export {default as ConfigContext, type ConfigContextType} from './Config/ConfigContext';
 export {default as ConfigProvider, type ConfigProviderProps} from './Config/ConfigProvider';
 export {default as useConfig} from './Config/useConfig';
+export {default as ToastContext} from './Toast/ToastContext';
+export {default as ToastProvider, type ToastProviderProps} from './Toast/ToastProvider';
+export {default as useToast} from './Toast/useToast';

--- a/frontend/packages/thunder-test-utils/src/test-utils.tsx
+++ b/frontend/packages/thunder-test-utils/src/test-utils.tsx
@@ -27,7 +27,7 @@ import {
 } from '@testing-library/react';
 import {MemoryRouter} from 'react-router';
 import {OxygenUIThemeProvider} from '@wso2/oxygen-ui';
-import {ConfigProvider} from '@thunder/shared-contexts';
+import {ConfigProvider, ToastProvider} from '@thunder/shared-contexts';
 import {LoggerProvider, LogLevel} from '@thunder/logger';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
@@ -127,7 +127,9 @@ function Providers({children, queryClient = undefined, config = undefined}: Prov
               transports: [],
             }}
           >
-            <OxygenUIThemeProvider>{children}</OxygenUIThemeProvider>
+            <ToastProvider>
+              <OxygenUIThemeProvider>{children}</OxygenUIThemeProvider>
+            </ToastProvider>
           </LoggerProvider>
         </ConfigProvider>
       </QueryClientProvider>

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -868,6 +868,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.0.17(playwright@1.58.1)(rolldown-vite@7.1.14(@types/node@24.7.2)(esbuild@0.25.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.17)
+      '@wso2/oxygen-ui':
+        specifier: 'catalog:'
+        version: 0.8.0(@mui/system@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(@wso2/oxygen-ui-icons-react@0.8.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -3600,21 +3603,25 @@ packages:
     resolution: {integrity: sha512-GNxei+lwhzhrO9m+nNkibgxLhbkYKyFXPSRpOKLwv9VavNzJn5UmLfKJyhjNQPBOSYuNhiVPbU1Ja/qOBcozYw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.5.1':
     resolution: {integrity: sha512-VDJtdJP2nCgS8ommbfWFAKjoZCE51VH7tZyIfh8RFI5fxwoB3Pk6d6f6cmNHI/1t98YI3V7Onuf3Y9KBkYtyfQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.5.1':
     resolution: {integrity: sha512-BZ/i+KTplEJmE8ZHKgPGD513Zl86DuSGyRAvbDZ7Qf19Tei7Of6vxW+ypvVDIwmDbyXfe13u54M5gDt8iiqFGQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.5.1':
     resolution: {integrity: sha512-e0VdiV6fe88Dbhill2gUjYAD9jMhHjYsafGOPR+/uaGMAYPoI1jKur6uPGY+ik6fvwvDFFl0VT2+HACKVn7RoA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.5.1':
     resolution: {integrity: sha512-3vWZO9y7uHKeyepcU55pE8VQTKGome3mLdicvx1TCoKKl0cA3bTR341Jdo2Zl4Waa2ENk7pGQbLWRQ3ZkaA92A==}
@@ -3682,41 +3689,49 @@ packages:
     resolution: {integrity: sha512-Cwm6A071ww60QouJ9LoHAwBgEoZzHQ0Qaqk2E7WLfBdiQN9mLXIDhnrpn04hlRElRPhLiu/dtg+o5PPLvaINXQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.17.1':
     resolution: {integrity: sha512-+hwlE2v3m0r3sk93SchJL1uyaKcPjf+NGO/TD2DZUDo+chXx7FfaEj0nUMewigSt7oZ2sQN9Z4NJOtUa75HE5Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.17.1':
     resolution: {integrity: sha512-bO+rsaE5Ox8cFyeL5Ct5tzot1TnQpFa/Wmu5k+hqBYSH2dNVDGoi0NizBN5QV8kOIC6O5MZr81UG4yW/2FyDTA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.17.1':
     resolution: {integrity: sha512-B/P+hxKQ1oX4YstI9Lyh4PGzqB87Ddqj/A4iyRBbPdXTcxa+WW3oRLx1CsJKLmHPdDk461Hmbghq1Bm3pl+8Aw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.17.1':
     resolution: {integrity: sha512-ulp2H3bFXzd/th2maH+QNKj5qgOhJ3v9Yspdf1svTw3CDOuuTl6sRKsWQ7MUw0vnkSNvQndtflBwVXgzZvURsQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.17.1':
     resolution: {integrity: sha512-LAXYVe3rKk09Zo9YKF2ZLBcH8sz8Oj+JIyiUxiHtq0hiYLMsN6dOpCf2hzQEjPAmsSEA/hdC1PVKeXo+oma8mQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.17.1':
     resolution: {integrity: sha512-3RAhxipMKE8RCSPn7O//sj440i+cYTgYbapLeOoDvQEt6R1QcJjTsFgI4iz99FhVj3YbPxlZmcLB5VW+ipyRTA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.17.1':
     resolution: {integrity: sha512-wpjMEubGU8r9VjZTLdZR3aPHaBqTl8Jl8F4DBbgNoZ+yhkhQD1/MGvY70v2TLnAI6kAHSvcqgfvaqKDa2iWsPQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.17.1':
     resolution: {integrity: sha512-XIE4w17RYAVIgx+9Gs3deTREq5tsmalbatYOOBGNdH7n0DfTE600c7wYXsp7ANc3BPDXsInnOzXDEPCvO1F6cg==}
@@ -3772,36 +3787,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -3955,48 +3976,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.45':
     resolution: {integrity: sha512-LE1gjAwQRrbCOorJJ7LFr10s5vqYf5a00V5Ea9wXcT2+56n5YosJkcp8eQ12FxRBv2YX8dsdQJb+ZTtYJwb6XQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.45':
     resolution: {integrity: sha512-tdy8ThO/fPp40B81v0YK3QC+KODOmzJzSUOO37DinQxzlTJ026gqUSOM8tzlVixRbQJltgVDCTYF8HNPRErQTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
     resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
     resolution: {integrity: sha512-lS082ROBWdmOyVY/0YB3JmsiClaWoxvC+dA8/rbhyB9VLkvVEaihLEOr4CYmrMse151C4+S6hCw6oa1iewox7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
     resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.45':
     resolution: {integrity: sha512-Hi73aYY0cBkr1/SvNQqH8Cd+rSV6S9RB5izCv0ySBcRnd/Wfn5plguUoGYwBnhHgFbh6cPw9m2dUVBR6BG1gxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
     resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
@@ -4363,48 +4392,56 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-gnu@1.15.8':
     resolution: {integrity: sha512-o+1y5u6k2FfPYbTRUPvurwzNt5qd0NTumCTFscCNuBksycloXY16J8L+SMW5QRX59n4Hp9EmFa3vpvNHRVv1+Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.17':
     resolution: {integrity: sha512-D0/6Hj4CkgSTTahtlGxv9IDsLTuvQz30mkZEMDp8TqwYhCL8AomznkibwlQU8HtY4q/dqd1OGRPH+FmNb4BBEA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-arm64-musl@1.15.8':
     resolution: {integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.17':
     resolution: {integrity: sha512-1s2OFsg6DeRkWU7c+PIfIHZsFCbiZ34akXFHrg7KjpF8zIvpHZNoUUZimoWEwcB6GquXSkAO+1b5KpG5nusTeQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.8':
     resolution: {integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.17':
     resolution: {integrity: sha512-gtxGMGYtRWWmCcgx6xM2Yos43uiE/j8kZwkeL/LNGG9zM0tatd23NsfL9PnQJ45hY7QZ+dx2rM68e4ArgG4kJg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-musl@1.15.8':
     resolution: {integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.17':
     resolution: {integrity: sha512-gxi+/Miytez/O9vJ/QiheIivA3oWZjPp9nJu3VmAfLMWUzcZORMwgaI1ygtDTLjz7CzcwlGMJz/Ab66Y5DfNpg==}
@@ -4921,41 +4958,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -8070,24 +8115,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -9963,48 +10012,56 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-arm@1.93.3:
     resolution: {integrity: sha512-yeiv2y+dp8B4wNpd3+JsHYD0mvpXSfov7IGyQ1tMIR40qv+ROkRqYiqQvAOXf76Qwh4Y9OaYZtLpnsPjfeq6mA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.93.3:
     resolution: {integrity: sha512-PS829l+eUng+9W4PFclXGb4uA2+965NHV3/Sa5U7qTywjeeUUYTZg70dJHSqvhrBEfCc2XJABeW3adLJbyQYkw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-arm@1.93.3:
     resolution: {integrity: sha512-fU0fwAwbp7sBE3h5DVU5UPzvaLg7a4yONfFWkkcCp6ZrOiPuGRHXXYriWQ0TUnWy4wE+svsVuWhwWgvlb/tkKg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.93.3:
     resolution: {integrity: sha512-cK1oBY+FWQquaIGEeQ5H74KTO8cWsSWwXb/WaildOO9U6wmUypTgUYKQ0o5o/29nZbWWlM1PHuwVYTSnT23Jjg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-x64@1.93.3:
     resolution: {integrity: sha512-A7wkrsHu2/I4Zpa0NMuPGkWDVV7QGGytxGyUq3opSXgAexHo/vBPlGoDXoRlSdex0cV+aTMRPjoGIfdmNlHwyg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-riscv64@1.93.3:
     resolution: {integrity: sha512-vWkW1+HTF5qcaHa6hO80gx/QfB6GGjJUP0xLbnAoY4pwEnw5ulGv6RM8qYr8IDhWfVt/KH+lhJ2ZFxnJareisQ==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-x64@1.93.3:
     resolution: {integrity: sha512-k6uFxs+e5jSuk1Y0niCwuq42F9ZC5UEP7P+RIOurIm8w/5QFa0+YqeW+BPWEW5M1FqVOsNZH3qGn4ahqvAEjPA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-unknown-all@1.93.3:
     resolution: {integrity: sha512-o5wj2rLpXH0C+GJKt/VpWp6AnMsCCbfFmnMAttcrsa+U3yrs/guhZ3x55KAqqUsE8F47e3frbsDL+1OuQM5DAA==}
@@ -11456,7 +11513,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -11497,7 +11554,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -11506,13 +11563,13 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -11526,7 +11583,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -12189,7 +12246,7 @@ snapshots:
   '@base-ui-components/utils@0.1.2(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/utils': 0.2.11
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       reselect: 5.1.1


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request introduces user feedback via toast notifications for key CRUD operations across the applications and groups features. It also wraps the application in a `ToastProvider` and adds a new `HomePage` route. The most significant changes are grouped below:

**User Feedback with Toast Notifications:**

* Added toast notifications for success and error outcomes in the following mutation hooks: `useCreateApplication`, `useUpdateApplication`, `useDeleteApplication`, `useRegenerateClientSecret`, `useCreateGroup`, `useUpdateGroup`, `useDeleteGroup`, `useAddGroupMembers`, and `useRemoveGroupMembers`. This provides immediate feedback to users after create, update, delete, and other actions. [[1]](diffhunk://#diff-6684f9a81251c48f807578bb9275fb8110960179224edc2bd16131c0d47bb4baL20-R22) [[2]](diffhunk://#diff-6684f9a81251c48f807578bb9275fb8110960179224edc2bd16131c0d47bb4baR67-R68) [[3]](diffhunk://#diff-6684f9a81251c48f807578bb9275fb8110960179224edc2bd16131c0d47bb4baR91-R94) [[4]](diffhunk://#diff-8729bb551ac3a15501af165e778bfb476accc8842f0443135140006a45a73d11L20-R22) [[5]](diffhunk://#diff-8729bb551ac3a15501af165e778bfb476accc8842f0443135140006a45a73d11R86-R87) [[6]](diffhunk://#diff-8729bb551ac3a15501af165e778bfb476accc8842f0443135140006a45a73d11R116-R119) [[7]](diffhunk://#diff-d9cb1aebca303c73dcee76e2aa9ae062e7de864f113c9f52bf2a06d28d5ac243L20-R22) [[8]](diffhunk://#diff-d9cb1aebca303c73dcee76e2aa9ae062e7de864f113c9f52bf2a06d28d5ac243R142-R143) [[9]](diffhunk://#diff-d9cb1aebca303c73dcee76e2aa9ae062e7de864f113c9f52bf2a06d28d5ac243R206-R209) [[10]](diffhunk://#diff-7d91ec72703d92d3773996094da191dbbac16c5df334de69006e999e0d276ddaL20-R22) [[11]](diffhunk://#diff-7d91ec72703d92d3773996094da191dbbac16c5df334de69006e999e0d276ddaR36-R37) [[12]](diffhunk://#diff-7d91ec72703d92d3773996094da191dbbac16c5df334de69006e999e0d276ddaR59-R62) [[13]](diffhunk://#diff-dd095c3830fbe8f9a3bdc7344ad14c89886229109daf46764771598a74db35d1L20-R22) [[14]](diffhunk://#diff-dd095c3830fbe8f9a3bdc7344ad14c89886229109daf46764771598a74db35d1R44-R45) [[15]](diffhunk://#diff-71338192d43ba224826ac4b08bbfa5ca0acd6927c43d24c0102f91b3d9765945L20-R22) [[16]](diffhunk://#diff-71338192d43ba224826ac4b08bbfa5ca0acd6927c43d24c0102f91b3d9765945R34-R35) [[17]](diffhunk://#diff-71338192d43ba224826ac4b08bbfa5ca0acd6927c43d24c0102f91b3d9765945R50-R53) [[18]](diffhunk://#diff-4468921402d553ec66f7b46cc886f9f59d2ab79e9b496fd7e7a575bd3228dc44L20-R22) [[19]](diffhunk://#diff-4468921402d553ec66f7b46cc886f9f59d2ab79e9b496fd7e7a575bd3228dc44R43-R44) [[20]](diffhunk://#diff-4468921402d553ec66f7b46cc886f9f59d2ab79e9b496fd7e7a575bd3228dc44R68-R71) [[21]](diffhunk://#diff-ab00952688082b937db880759cc3c6693391678bc4bf1166a22af33324653c6aL20-R22) [[22]](diffhunk://#diff-ab00952688082b937db880759cc3c6693391678bc4bf1166a22af33324653c6aR43-R44) [[23]](diffhunk://#diff-ab00952688082b937db880759cc3c6693391678bc4bf1166a22af33324653c6aR68-R71) [[24]](diffhunk://#diff-e5de8b450ba32633cc830c2fbc46145b80c24439998427ce62595945f59033aeL20-R22) [[25]](diffhunk://#diff-e5de8b450ba32633cc830c2fbc46145b80c24439998427ce62595945f59033aeR67-R68) [[26]](diffhunk://#diff-e5de8b450ba32633cc830c2fbc46145b80c24439998427ce62595945f59033aeR88-R91)

**Application Layout and Routing:**

* Wrapped the app in a `ToastProvider` to enable toast notifications throughout the application. [[1]](diffhunk://#diff-4d17d8a075bcb1c20be4f286bb1d9ba7489809d32abe8ebcc0d97785d252d487R22) [[2]](diffhunk://#diff-4d17d8a075bcb1c20be4f286bb1d9ba7489809d32abe8ebcc0d97785d252d487R58-R63) [[3]](diffhunk://#diff-4d17d8a075bcb1c20be4f286bb1d9ba7489809d32abe8ebcc0d97785d252d487R239)
* Added a `HomePage` route and set it as the default landing page for the application. [[1]](diffhunk://#diff-4d17d8a075bcb1c20be4f286bb1d9ba7489809d32abe8ebcc0d97785d252d487R58-R63) [[2]](diffhunk://#diff-4d17d8a075bcb1c20be4f286bb1d9ba7489809d32abe8ebcc0d97785d252d487L70-R74)

These changes improve the user experience by providing real-time feedback and a more intuitive navigation structure.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

<img width="437" height="185" alt="Screenshot 2026-03-12 at 13 46 52" src="https://github.com/user-attachments/assets/abd14ba3-19cb-4ac0-b7ee-deb8c1104595" />

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/1767

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide toast system and provider; routing restructured with nested dashboard and full‑screen create flows, plus new organization-unit, auth flow, design, and translation pages.

* **Localization**
  * Added translated success/error messages for applications, groups, users, user types, and organization units (used in CRUD/toast feedback).

* **UI**
  * Client ID field now only shows when available; group edit no longer uses inline snackbar—uses global toasts.

* **Tests**
  * Test provider wrapper updated to include the global toast provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->