### PR TITLE
Fix consent filtering for the default client

### DIFF
--- a/backend/internal/consent/default_client.go
+++ b/backend/internal/consent/default_client.go
@@ -601,9 +601,37 @@ func (c *defaultClient) searchConsents(ctx context.Context, ouID string, filter 
 		return nil, &serviceerror.InternalServerErrorWithI18n
 	}
 
+	// Currently the default client does not apply the filtering correctly for some consent statuses (e.g. EXPIRED)
+	// due to the limitations in the consent service API. As a workaround, we apply additional filtering logic here
+	// based on the validity time and status to ensure the expected results are returned to the service layer.
+	// This can be removed once the consent service API is enhanced to support proper filtering by status.
+	statusFilter := map[ConsentStatus]bool{}
+	if filter != nil {
+		for _, status := range filter.ConsentStatuses {
+			statusFilter[status] = true
+		}
+	}
+	applyStatusFilter := len(statusFilter) > 0
+	nowUnix := time.Now().Unix()
+
 	out := make([]Consent, 0, len(result.Data))
 	for _, dto := range result.Data {
-		out = append(out, c.dtoToConsent(&dto))
+		consent := c.dtoToConsent(&dto)
+
+		// Currently the default client doesn't set the expired status for consents based on the validity time
+		// due to the limitations in the consent service API. As a workaround, we set the expired status here
+		// based on the validity time to ensure the expected results are returned
+		if consent.Status == ConsentStatusActive && consent.ValidityTime > 0 && consent.ValidityTime <= nowUnix {
+			consent.Status = ConsentStatusExpired
+		}
+
+		if applyStatusFilter {
+			if _, ok := statusFilter[consent.Status]; !ok {
+				continue
+			}
+		}
+
+		out = append(out, consent)
 	}
 
 	return out, nil

--- a/backend/internal/consent/default_client_test.go
+++ b/backend/internal/consent/default_client_test.go
@@ -690,6 +690,50 @@ func (s *DefaultClientTestSuite) TestSearchConsents_EmptyFilter_Success() {
 	s.Empty(result)
 }
 
+func (s *DefaultClientTestSuite) TestSearchConsents_ExpiredStatusFilter_ValidityTimeNormalization() {
+	nowUnix := time.Now().Unix()
+	tests := []struct {
+		name string
+		data []consentResponseDTO
+	}{
+		{
+			name: "converts active consent to expired when validity time has elapsed",
+			data: []consentResponseDTO{
+				{ID: "c-expired", Type: "authentication", Status: "ACTIVE", ValidityTime: nowUnix - 60},
+				{ID: "c-active", Type: "authentication", Status: "ACTIVE", ValidityTime: nowUnix + 3600},
+			},
+		},
+		{
+			name: "does not convert non-active consent status",
+			data: []consentResponseDTO{
+				{ID: "c-revoked", Type: "authentication", Status: "REVOKED", ValidityTime: nowUnix - 60},
+				{ID: "c-expired", Type: "authentication", Status: "ACTIVE", ValidityTime: nowUnix - 60},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		s.Run(tc.name, func() {
+			httpMock := httpmock.NewHTTPClientInterfaceMock(s.T())
+			c := newTestClient(s.T(), httpMock)
+
+			respBody := consentSearchResponseDTO{Data: tc.data}
+			httpMock.EXPECT().Do(mock.AnythingOfType("*http.Request")).
+				Return(buildHTTPResponse(s.T(), http.StatusOK, respBody), nil)
+
+			result, svcErr := c.searchConsents(context.Background(), "ou1", &ConsentSearchFilter{
+				ConsentStatuses: []ConsentStatus{ConsentStatusExpired},
+			})
+
+			s.Nil(svcErr)
+			s.Len(result, 1)
+			s.Equal("c-expired", result[0].ID)
+			s.Equal(ConsentStatusExpired, result[0].Status)
+		})
+	}
+}
+
 // ----- validateConsent -----
 
 func (s *DefaultClientTestSuite) TestValidateConsent_Valid() {


### PR DESCRIPTION
### Purpose
This pull request addresses issues with filtering consent statuses in the `defaultClient` implementation due to limitations in the consent service API. It introduces additional logic to correctly identify expired consents based on their validity time and ensures that filtering by status returns accurate results. The changes are verified with new unit tests.

Enhancements to consent status filtering:

* Added logic in `default_client.go` to determine if a consent is expired based on its `ValidityTime`, setting its status to `ConsentStatusExpired` when appropriate. This ensures expired consents are correctly identified even if the API does not mark them as such.
* Implemented additional filtering in `default_client.go` to ensure only consents with the requested statuses are returned, applying the filter after adjusting for expired status.

Testing improvements:

* Added a unit test `TestSearchConsents_ExpiredStatusFilter_UsesValidityTime` in `default_client_test.go` to verify that expired consents are correctly filtered and identified based on their validity time.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/1774

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved consent filtering logic to properly handle status filters and validity time-based expiry detection.
  * Consents are now accurately marked as expired when their validity period has ended.

* **Tests**
  * Added test coverage for expired consent filtering using validity timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->