### PR TITLE
Add optional displayName field to user schema property definitions

### DIFF
--- a/backend/internal/userschema/model/array.go
+++ b/backend/internal/userschema/model/array.go
@@ -27,8 +27,9 @@ import (
 )
 
 type array struct {
-	required bool
-	items    property
+	required    bool
+	displayName string
+	items       property
 }
 
 func (p *array) isRequired() bool {
@@ -86,9 +87,10 @@ func (p *array) validateUniqueness(
 
 func compileArrayProperty(propName string, propMap map[string]json.RawMessage) (property, error) {
 	allowedFields := map[string]struct{}{
-		"type":     {},
-		"items":    {},
-		"required": {},
+		"type":        {},
+		"items":       {},
+		"required":    {},
+		"displayName": {},
 	}
 
 	for field := range propMap {
@@ -102,6 +104,12 @@ func compileArrayProperty(propName string, propMap map[string]json.RawMessage) (
 	if raw, exists := propMap["required"]; exists {
 		if err := json.Unmarshal(raw, &prop.required); err != nil {
 			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["displayName"]; exists {
+		if err := json.Unmarshal(raw, &prop.displayName); err != nil {
+			return nil, fmt.Errorf("'displayName' field must be a string")
 		}
 	}
 

--- a/backend/internal/userschema/model/boolean.go
+++ b/backend/internal/userschema/model/boolean.go
@@ -27,7 +27,8 @@ import (
 
 // boolean represents a boolean property in the user schema.
 type boolean struct {
-	required bool
+	required    bool
+	displayName string
 }
 
 func (p *boolean) isRequired() bool {
@@ -63,8 +64,9 @@ func (p *boolean) validateUniqueness(
 
 func compileBooleanProperty(propMap map[string]json.RawMessage) (property, error) {
 	allowedFields := map[string]struct{}{
-		"type":     {},
-		"required": {},
+		"type":        {},
+		"required":    {},
+		"displayName": {},
 	}
 
 	for field := range propMap {
@@ -78,6 +80,12 @@ func compileBooleanProperty(propMap map[string]json.RawMessage) (property, error
 	if raw, exists := propMap["required"]; exists {
 		if err := json.Unmarshal(raw, &prop.required); err != nil {
 			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["displayName"]; exists {
+		if err := json.Unmarshal(raw, &prop.displayName); err != nil {
+			return nil, fmt.Errorf("'displayName' field must be a string")
 		}
 	}
 

--- a/backend/internal/userschema/model/number.go
+++ b/backend/internal/userschema/model/number.go
@@ -26,10 +26,11 @@ import (
 )
 
 type number struct {
-	required   bool
-	unique     bool
-	credential bool
-	enum       map[float64]struct{}
+	required    bool
+	unique      bool
+	credential  bool
+	displayName string
+	enum        map[float64]struct{}
 }
 
 func (p *number) isRequired() bool {
@@ -84,11 +85,12 @@ func (p *number) validateUniqueness(
 
 func compileNumberProperty(propMap map[string]json.RawMessage) (property, error) {
 	allowedFields := map[string]struct{}{
-		"type":       {},
-		"required":   {},
-		"unique":     {},
-		"credential": {},
-		"enum":       {},
+		"type":        {},
+		"required":    {},
+		"unique":      {},
+		"credential":  {},
+		"displayName": {},
+		"enum":        {},
 	}
 
 	for field := range propMap {
@@ -114,6 +116,12 @@ func compileNumberProperty(propMap map[string]json.RawMessage) (property, error)
 	if raw, exists := propMap["credential"]; exists {
 		if err := json.Unmarshal(raw, &prop.credential); err != nil {
 			return nil, fmt.Errorf("'credential' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["displayName"]; exists {
+		if err := json.Unmarshal(raw, &prop.displayName); err != nil {
+			return nil, fmt.Errorf("'displayName' field must be a string")
 		}
 	}
 

--- a/backend/internal/userschema/model/object.go
+++ b/backend/internal/userschema/model/object.go
@@ -26,8 +26,9 @@ import (
 )
 
 type object struct {
-	required   bool
-	properties map[string]property
+	required    bool
+	displayName string
+	properties  map[string]property
 }
 
 func (p *object) isRequired() bool {
@@ -120,9 +121,10 @@ func (p *object) validateUniqueness(
 
 func compileObjectProperty(propMap map[string]json.RawMessage) (property, error) {
 	allowedFields := map[string]struct{}{
-		"type":       {},
-		"properties": {},
-		"required":   {},
+		"type":        {},
+		"properties":  {},
+		"required":    {},
+		"displayName": {},
 	}
 
 	for field := range propMap {
@@ -138,6 +140,12 @@ func compileObjectProperty(propMap map[string]json.RawMessage) (property, error)
 	if raw, exists := propMap["required"]; exists {
 		if err := json.Unmarshal(raw, &prop.required); err != nil {
 			return nil, fmt.Errorf("'required' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["displayName"]; exists {
+		if err := json.Unmarshal(raw, &prop.displayName); err != nil {
+			return nil, fmt.Errorf("'displayName' field must be a string")
 		}
 	}
 

--- a/backend/internal/userschema/model/schema_test.go
+++ b/backend/internal/userschema/model/schema_test.go
@@ -182,3 +182,59 @@ func (s *SchemaValidateTestSuite) TestValidNestedObjectAttributes_Pass() {
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }
+
+func (s *SchemaValidateTestSuite) TestDisplayNameOnAllPropertyTypes_CompileSuccess() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"given_name": {"type": "string", "required": true, "displayName": "First Name"},
+		"age": {"type": "number", "displayName": "Age"},
+		"active": {"type": "boolean", "displayName": "Is Active"},
+		"address": {
+			"type": "object",
+			"displayName": "Home Address",
+			"properties": {
+				"city": {"type": "string", "displayName": "City"}
+			}
+		},
+		"tags": {
+			"type": "array",
+			"displayName": "Tags",
+			"items": {"type": "string"}
+		}
+	}`))
+	s.Require().NoError(err)
+	s.Require().NotNil(schema)
+
+	ok, err := schema.Validate(json.RawMessage(`{
+		"given_name": "John",
+		"age": 30,
+		"active": true,
+		"address": {"city": "NYC"},
+		"tags": ["admin"]
+	}`), s.logger)
+	s.Require().NoError(err)
+	s.Require().True(ok)
+}
+
+func (s *SchemaValidateTestSuite) TestDisplayNameWithI18nPattern_CompileSuccess() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"family_name": {"type": "string", "displayName": "{{t(custom:user.familyName)}}"}
+	}`))
+	s.Require().NoError(err)
+	s.Require().NotNil(schema)
+}
+
+func (s *SchemaValidateTestSuite) TestDisplayNameInvalidType_CompileError() {
+	_, err := CompileUserSchema(json.RawMessage(`{
+		"email": {"type": "string", "displayName": 123}
+	}`))
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "'displayName' field must be a string")
+}
+
+func (s *SchemaValidateTestSuite) TestSchemaWithoutDisplayName_CompileSuccess() {
+	schema, err := CompileUserSchema(json.RawMessage(`{
+		"email": {"type": "string", "required": true}
+	}`))
+	s.Require().NoError(err)
+	s.Require().NotNil(schema)
+}

--- a/backend/internal/userschema/model/string.go
+++ b/backend/internal/userschema/model/string.go
@@ -27,11 +27,12 @@ import (
 )
 
 type str struct {
-	required   bool
-	unique     bool
-	credential bool
-	enum       map[string]struct{}
-	pattern    *regexp.Regexp
+	required    bool
+	unique      bool
+	credential  bool
+	displayName string
+	enum        map[string]struct{}
+	pattern     *regexp.Regexp
 }
 
 func (p *str) isRequired() bool {
@@ -90,13 +91,14 @@ func (p *str) validateUniqueness(
 
 func compileStringProperty(propMap map[string]json.RawMessage) (property, error) {
 	allowedFields := map[string]struct{}{
-		"type":       {},
-		"required":   {},
-		"unique":     {},
-		"credential": {},
-		"enum":       {},
-		"regex":      {},
-		"pattern":    {},
+		"type":        {},
+		"required":    {},
+		"unique":      {},
+		"credential":  {},
+		"displayName": {},
+		"enum":        {},
+		"regex":       {},
+		"pattern":     {},
 	}
 
 	for field := range propMap {
@@ -122,6 +124,12 @@ func compileStringProperty(propMap map[string]json.RawMessage) (property, error)
 	if raw, exists := propMap["credential"]; exists {
 		if err := json.Unmarshal(raw, &prop.credential); err != nil {
 			return nil, fmt.Errorf("'credential' field must be a boolean")
+		}
+	}
+
+	if raw, exists := propMap["displayName"]; exists {
+		if err := json.Unmarshal(raw, &prop.displayName); err != nil {
+			return nil, fmt.Errorf("'displayName' field must be a string")
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add an optional `displayName` string field to all property types (string, number, boolean, object, array) in the user schema model
- The field stores a human-readable label for attributes, supporting both plain strings (e.g., `"First Name"`) and i18n template patterns (e.g., `"{{t(custom:user.firstName)}}"`)
- The backend treats it as metadata — stored and returned as-is, no pattern resolution
- Fully backward compatible — schemas without `displayName` continue to work unchanged

## Related

- Closes #1780
- Design discussion: #1779
- Frontend counterpart: #1781

## Test plan

- [x] All existing `userschema/model` tests pass
- [x] New tests added:
  - `displayName` accepted on all 5 property types (string, number, boolean, object, array)
  - `displayName` with i18n template pattern compiles successfully
  - Non-string `displayName` value rejected with error
  - Schemas without `displayName` compile successfully (backward compat)
- [x] Full backend build passes (`go build ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Schema properties can now include display names for enhanced presentation and user interface customization.

* **Tests**
  * Added comprehensive test coverage for display name functionality across all property types, including internationalization patterns and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->