### PR TITLE
Add display name and avatar support to OU UIs

### DIFF
--- a/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/group-settings/ManageGroupsSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/group-settings/ManageGroupsSection.tsx
@@ -89,7 +89,7 @@ export default function ManageGroupsSection({organizationUnitId}: ManageGroupsSe
       },
       {
         field: 'name',
-        headerName: t('organizationUnits:edit.users.sections.manage.listing.columns.name'),
+        headerName: t('organizationUnits:edit.groups.sections.manage.listing.columns.name'),
         flex: 1,
         minWidth: 200,
       },

--- a/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/group-settings/__tests__/ManageGroupsSection.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/group-settings/__tests__/ManageGroupsSection.test.tsx
@@ -39,7 +39,7 @@ vi.mock('react-i18next', () => ({
       const translations: Record<string, string> = {
         'organizationUnits:edit.groups.sections.manage.title': 'Manage Groups',
         'organizationUnits:edit.groups.sections.manage.description': 'View and manage groups in this organization unit',
-        'organizationUnits:edit.users.sections.manage.listing.columns.name': 'Group Name',
+        'organizationUnits:edit.groups.sections.manage.listing.columns.name': 'Group Name',
         'organizationUnits:edit.groups.sections.manage.listing.columns.id': 'Group ID',
       };
       return translations[key] ?? key;

--- a/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
@@ -17,8 +17,7 @@
  */
 
 import {useMemo, type JSX} from 'react';
-import {Box, DataGrid, Avatar, useTheme} from '@wso2/oxygen-ui';
-import {User} from '@wso2/oxygen-ui-icons-react';
+import {Box, DataGrid, Avatar} from '@wso2/oxygen-ui';
 import {useTranslation} from 'react-i18next';
 import SettingsCard from '@/components/SettingsCard';
 import useDataGridLocaleText from '../../../../../hooks/useDataGridLocaleText';
@@ -35,11 +34,22 @@ interface ManageUsersSectionProps {
   organizationUnitId: string;
 }
 
+const getInitials = (name?: string) => {
+  if (!name) return '?';
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+};
+
 /**
  * Section component for managing users belonging to an organization unit.
  *
  * Displays a DataGrid of users with:
- * - Avatar icon
+ * - Avatar with initials
+ * - Display Name (falls back to User ID)
  * - User ID
  * - User Type
  *
@@ -48,7 +58,6 @@ interface ManageUsersSectionProps {
  */
 export default function ManageUsersSection({organizationUnitId}: ManageUsersSectionProps): JSX.Element {
   const {t} = useTranslation();
-  const theme = useTheme();
   const dataGridLocaleText = useDataGridLocaleText();
 
   const {data: usersData, isLoading} = useGetOrganizationUnitUsers(organizationUnitId);
@@ -61,47 +70,53 @@ export default function ManageUsersSection({organizationUnitId}: ManageUsersSect
         width: 70,
         sortable: false,
         filterable: false,
-        renderCell: (): JSX.Element => (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              height: '100%',
-            }}
-          >
-            <Avatar
+        renderCell: (params: DataGrid.GridRenderCellParams<ApiUser>): JSX.Element => {
+          const displayVal = params.row.display ?? params.row.id;
+
+          return (
+            <Box
               sx={{
-                p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
-                width: 30,
-                height: 30,
-                fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {
-                  backgroundColor: theme.vars?.palette.grey[900],
-                }),
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '100%',
               }}
             >
-              <User size={14} />
-            </Avatar>
-          </Box>
-        ),
+              <Avatar
+                sx={{
+                  width: 30,
+                  height: 30,
+                  bgcolor: 'primary.main',
+                  fontSize: '0.875rem',
+                }}
+              >
+                {getInitials(displayVal)}
+              </Avatar>
+            </Box>
+          );
+        },
       },
       {
         field: 'display',
-        headerName: t('organizationUnits:edit.users.sections.manage.listing.columns.id'),
+        headerName: t('organizationUnits:edit.users.sections.manage.listing.columns.name'),
         flex: 1,
         minWidth: 200,
         valueGetter: (_value: unknown, row: ApiUser) => row.display ?? row.id,
       },
       {
+        field: 'id',
+        headerName: t('organizationUnits:edit.users.sections.manage.listing.columns.id'),
+        flex: 1,
+        minWidth: 250,
+      },
+      {
         field: 'type',
         headerName: t('organizationUnits:edit.users.sections.manage.listing.columns.type'),
-        flex: 1,
-        minWidth: 150,
+        flex: 0.6,
+        minWidth: 120,
       },
     ],
-    [t, theme],
+    [t],
   );
 
   return (

--- a/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/user-settings/__tests__/ManageUsersSection.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/components/edit-organization-unit/user-settings/__tests__/ManageUsersSection.test.tsx
@@ -39,6 +39,7 @@ vi.mock('react-i18next', () => ({
       const translations: Record<string, string> = {
         'organizationUnits:edit.users.sections.manage.title': 'Manage Users',
         'organizationUnits:edit.users.sections.manage.description': 'View and manage users in this organization unit',
+        'organizationUnits:edit.users.sections.manage.listing.columns.name': 'Display Name',
         'organizationUnits:edit.users.sections.manage.listing.columns.id': 'User ID',
         'organizationUnits:edit.users.sections.manage.listing.columns.type': 'Type',
       };
@@ -49,8 +50,8 @@ vi.mock('react-i18next', () => ({
 
 describe('ManageUsersSection', () => {
   const mockUsers: ApiUser[] = [
-    {id: 'user-1', type: 'internal', organizationUnit: 'ou-123'},
-    {id: 'user-2', type: 'external', organizationUnit: 'ou-123'},
+    {id: 'user-1', type: 'internal', organizationUnit: 'ou-123', display: 'John Doe'},
+    {id: 'user-2', type: 'external', organizationUnit: 'ou-123', display: 'Jane Smith'},
     {id: 'user-3', type: 'internal', organizationUnit: 'ou-123'},
   ];
 
@@ -70,7 +71,7 @@ describe('ManageUsersSection', () => {
     expect(screen.getByText('View and manage users in this organization unit')).toBeInTheDocument();
   });
 
-  it('should render data grid with users', () => {
+  it('should render data grid with users showing display names', () => {
     mockUseGetOrganizationUnitUsers.mockReturnValue({
       data: {users: mockUsers},
       isLoading: false,
@@ -79,9 +80,24 @@ describe('ManageUsersSection', () => {
     renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
 
     expect(screen.getByRole('grid')).toBeInTheDocument();
-    expect(screen.getByText('user-1')).toBeInTheDocument();
-    expect(screen.getByText('user-2')).toBeInTheDocument();
-    expect(screen.getByText('user-3')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    // user-3 has no display, should fall back to id
+    expect(screen.getAllByText('user-3').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should show initials in avatar', () => {
+    mockUseGetOrganizationUnitUsers.mockReturnValue({
+      data: {users: mockUsers},
+      isLoading: false,
+    });
+
+    renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
+
+    expect(screen.getByText('JD')).toBeInTheDocument();
+    expect(screen.getByText('JS')).toBeInTheDocument();
+    // user-3 falls back to id 'user-3', initials would be 'U'
+    expect(screen.getByText('U')).toBeInTheDocument();
   });
 
   it('should render column headers', () => {
@@ -92,6 +108,7 @@ describe('ManageUsersSection', () => {
 
     renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
 
+    expect(screen.getByText('Display Name')).toBeInTheDocument();
     expect(screen.getByText('User ID')).toBeInTheDocument();
     expect(screen.getByText('Type')).toBeInTheDocument();
   });
@@ -106,7 +123,6 @@ describe('ManageUsersSection', () => {
 
     const grid = screen.getByRole('grid');
     expect(grid).toBeInTheDocument();
-    // DataGrid shows loading overlay when isLoading is true
   });
 
   it('should handle empty users list', () => {
@@ -118,7 +134,6 @@ describe('ManageUsersSection', () => {
     renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
 
     expect(screen.getByRole('grid')).toBeInTheDocument();
-    // Grid should show "No rows" message
   });
 
   it('should handle null users data', () => {
@@ -156,5 +171,17 @@ describe('ManageUsersSection', () => {
 
     expect(internalCells.length).toBeGreaterThan(0);
     expect(externalCells.length).toBeGreaterThan(0);
+  });
+
+  it('should show user IDs in the grid', () => {
+    mockUseGetOrganizationUnitUsers.mockReturnValue({
+      data: {users: mockUsers},
+      isLoading: false,
+    });
+
+    renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
+
+    expect(screen.getByText('user-1')).toBeInTheDocument();
+    expect(screen.getByText('user-2')).toBeInTheDocument();
   });
 });

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -574,11 +574,12 @@ const translations = {
     'edit.users.sections.manage.description': 'View users belonging to this organization unit',
     'edit.users.sections.manage.listing.columns.id': 'User ID',
     'edit.users.sections.manage.listing.columns.type': 'User Type',
-    'edit.users.sections.manage.listing.columns.name': 'Group Name',
+    'edit.users.sections.manage.listing.columns.name': 'Display Name',
 
     // Groups Section
     'edit.groups.sections.manage.title': 'Groups',
     'edit.groups.sections.manage.description': 'View groups belonging to this organization unit',
+    'edit.groups.sections.manage.listing.columns.name': 'Group Name',
     'edit.groups.sections.manage.listing.columns.id': 'Group ID',
 
     // Customization tab


### PR DESCRIPTION
## Summary
- Updates OU user table to show avatar with initials, display name, and user ID columns
- Updates OU group table to use initials-based avatars instead of generic icon
- Fixes incorrect i18n key for user table column header (was "Group Name", now "Display Name")
- Adds dedicated i18n key for group table column header

## Related Issues
- https://github.com/asgardeo/thunder/issues/1516

## Related PRs
- Depends on https://github.com/asgardeo/thunder/pull/1768

## Test plan
- [ ] Verify OU Users tab shows avatar with initials, display name, and user ID columns
- [ ] Verify OU Groups tab shows avatar with initials, group name, and group ID columns
- [ ] Verify display name falls back to user ID when not available
- [ ] Unit tests pass for ManageUsersSection and ManageGroupsSection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user avatars with initials in the manage users view, replacing generic icons.

* **Bug Fixes**
  * Corrected the Group Name column header label in the manage groups section.

* **Improvements**
  * Reorganized user list columns to separately display user display names and user IDs.
  * Updated localization strings for improved consistency across user and group management interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->