### PR TITLE
Add `Sign Up URL Widget` to Flows & remove the static sign up url in `Thunder Gate`

### DIFF
--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/MetaConfigurationCard.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/MetaConfigurationCard.tsx
@@ -46,6 +46,7 @@ const COMMON_META_FIELDS: string[] = [
   'application.description',
   'application.loginPageUrl',
   'application.logoUrl',
+  'application.signUpUrl',
   'ou.name',
   'ou.handle',
   'ou.description',

--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/CustomLinkPlugin.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/CustomLinkPlugin.tsx
@@ -19,22 +19,21 @@
 import {$isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
-import {$getSelection, $isRangeSelection, CLICK_COMMAND, KEY_ESCAPE_COMMAND, SELECTION_CHANGE_COMMAND} from 'lexical';
-import type {CommandListenerPriority, EditorState, ElementNode, BaseSelection, TextNode} from 'lexical';
 import {
-  type ChangeEvent,
-  type KeyboardEvent,
-  type ReactElement,
-  type MouseEvent as ReactMouseEvent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  CLICK_COMMAND,
+  KEY_ESCAPE_COMMAND,
+  SELECTION_CHANGE_COMMAND,
+} from 'lexical';
+import type {CommandListenerPriority, EditorState, ElementNode, BaseSelection, TextNode} from 'lexical';
+import {type ChangeEvent, type KeyboardEvent, type ReactElement, useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {useTranslation} from 'react-i18next';
-import {Box, Button, Card, IconButton, Link, MenuItem, Select, TextField} from '@wso2/oxygen-ui';
-import {EditIcon, SaveIcon, X} from '@wso2/oxygen-ui-icons-react';
+import {Box, Button, Card, IconButton, InputAdornment, TextField, Tooltip} from '@wso2/oxygen-ui';
+import {AlignLeft, Link2, SquareFunction} from '@wso2/oxygen-ui-icons-react';
+import DynamicValuePopover from '../../DynamicValuePopover';
 import getSelectedNode from '../utils/getSelectedNode';
 import TOGGLE_SAFE_LINK_COMMAND from './commands';
 
@@ -131,6 +130,13 @@ const getPlaceholderUrl = (url: string): string => {
     return selectedOption ? selectedOption.placeholder : '';
   }
 
+  // Template URLs doesn't need the `http(s)://` prefix, so we return the raw URL which may contain the template.
+  const templateMatch: RegExpExecArray | null = /(\{\{(?:meta|t)\([^)]+\)\}\})/.exec(url);
+
+  if (templateMatch) {
+    return templateMatch[1];
+  }
+
   return url;
 };
 
@@ -143,9 +149,10 @@ function LinkEditor(): ReactElement {
   const editorRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [linkUrl, setLinkUrl] = useState('');
-  const [isEditMode, setEditMode] = useState(false);
+  const [linkText, setLinkText] = useState('');
   const [lastSelection, setLastSelection] = useState<BaseSelection | null>(null);
-  const [selectedUrlType, setSelectedUrlType] = useState<string>('CUSTOM');
+  const [isDynamicValuePopoverOpen, setIsDynamicValuePopoverOpen] = useState<boolean>(false);
+  const dynamicValueBtnRef = useRef<HTMLButtonElement>(null);
 
   const {t} = useTranslation();
 
@@ -168,16 +175,15 @@ function LinkEditor(): ReactElement {
         const url: string = parent.getURL();
 
         setLinkUrl(getPlaceholderUrl(url));
-        setSelectedUrlType(determineUrlType(url));
+        setLinkText(parent.getTextContent());
       } else if ($isLinkNode(node)) {
         const url: string = node.getURL();
 
         setLinkUrl(getPlaceholderUrl(url));
-        setSelectedUrlType(determineUrlType(url));
+        setLinkText(node.getTextContent());
       } else {
         setLinkUrl('');
-        setSelectedUrlType('CUSTOM');
-        setEditMode(false);
+        setLinkText('');
         if (editorElem) {
           positionEditorElement(editorElem, null);
         }
@@ -228,48 +234,10 @@ function LinkEditor(): ReactElement {
         positionEditorElement(editorElem, null);
       }
       setLastSelection(null);
-      setEditMode(false);
       setLinkUrl('');
+      setLinkText('');
     }
   }, [editor]);
-
-  /**
-   * Handles URL type selection change.
-   */
-  const handleUrlTypeChange = (event: {target: {value: unknown}}): void => {
-    const newType: string = event.target.value as string;
-
-    setSelectedUrlType(newType);
-
-    if (newType !== 'CUSTOM') {
-      const selectedOption: PredefinedUrlOption | undefined = PREDEFINED_URLS.find(
-        (option: PredefinedUrlOption) => option.value === newType,
-      );
-
-      if (selectedOption) {
-        setLinkUrl(selectedOption.placeholder);
-        editor.dispatchCommand(TOGGLE_SAFE_LINK_COMMAND, selectedOption.value);
-      }
-    } else {
-      setLinkUrl('https://');
-      editor.dispatchCommand(TOGGLE_SAFE_LINK_COMMAND, 'https://');
-    }
-  };
-
-  /**
-   * Gets the current URL for editing mode.
-   */
-  const getCurrentUrl = (): string => {
-    if (selectedUrlType !== 'CUSTOM') {
-      const selectedOption: PredefinedUrlOption | undefined = PREDEFINED_URLS.find(
-        (option: PredefinedUrlOption) => option.value === selectedUrlType,
-      );
-
-      return selectedOption ? selectedOption.value : linkUrl;
-    }
-
-    return linkUrl;
-  };
 
   /**
    * Sets up event listeners for window resize and scroll to update the link editor position.
@@ -315,13 +283,14 @@ function LinkEditor(): ReactElement {
         editor.registerCommand(
           KEY_ESCAPE_COMMAND,
           () => {
-            if (isEditMode) {
-              setEditMode(false);
-
-              return true;
+            if (editorRef.current) {
+              positionEditorElement(editorRef.current, null);
             }
+            setLastSelection(null);
+            setLinkUrl('');
+            setLinkText('');
 
-            return false;
+            return true;
           },
           LowPriority,
         ),
@@ -359,7 +328,7 @@ function LinkEditor(): ReactElement {
           HighPriority,
         ),
       ),
-    [editor, updateLinkEditor, isEditMode],
+    [editor, updateLinkEditor],
   );
 
   /**
@@ -371,23 +340,40 @@ function LinkEditor(): ReactElement {
     });
   }, [editor, updateLinkEditor]);
 
-  /**
-   * Focuses the input field when in edit mode.
-   */
-  useEffect(() => {
-    if (isEditMode && inputRef?.current) {
-      inputRef.current.focus();
-    }
-  }, [isEditMode]);
-
   const handleClose = useCallback(() => {
     if (editorRef.current) {
       positionEditorElement(editorRef.current, null);
     }
     setLastSelection(null);
-    setEditMode(false);
     setLinkUrl('');
+    setLinkText('');
   }, []);
+
+  const handleApply = useCallback(() => {
+    if (lastSelection !== null && linkUrl !== '') {
+      editor.dispatchCommand(TOGGLE_SAFE_LINK_COMMAND, linkUrl);
+      // Update the display text of the link node if it changed.
+      if (linkText) {
+        editor.update(() => {
+          const selection: BaseSelection | null = $getSelection();
+
+          if ($isRangeSelection(selection)) {
+            const node: TextNode | ElementNode = getSelectedNode(selection);
+            const linkNode: ElementNode | null = $isLinkNode(node) ? node : node.getParent();
+
+            if ($isLinkNode(linkNode)) {
+              const firstChild = linkNode.getFirstChild();
+
+              if ($isTextNode(firstChild)) {
+                firstChild.setTextContent(linkText);
+              }
+            }
+          }
+        });
+      }
+    }
+    handleClose();
+  }, [editor, handleClose, lastSelection, linkUrl, linkText]);
 
   return (
     <Card
@@ -397,103 +383,82 @@ function LinkEditor(): ReactElement {
         position: 'absolute',
         right: 1.25,
         zIndex: 1200,
-        maxWidth: 350,
+        width: 280,
         padding: 1,
         display: 'flex',
         flexDirection: 'column',
         gap: 1,
       }}
     >
-      <Box display="flex" justifyContent="space-between" alignItems="center">
-        <Box component="span" sx={{fontSize: '14px', fontWeight: 500}}>
-          {isEditMode
-            ? t('flows:core.elements.richText.linkEditor.editLink')
-            : t('flows:core.elements.richText.linkEditor.viewLink')}
-        </Box>
-        <IconButton size="small" onClick={handleClose}>
-          <X size={16} />
-        </IconButton>
-      </Box>
-      {isEditMode ? (
-        <Box width="100%" display="flex" flexDirection="column" gap={1}>
-          {PREDEFINED_URLS.length > 0 && (
-            <Select
-              value={selectedUrlType}
-              label={t('flows:core.elements.richText.linkEditor.urlTypeLabel')}
-              onChange={handleUrlTypeChange}
-              size="small"
-            >
-              {PREDEFINED_URLS.map((option: PredefinedUrlOption) => (
-                <MenuItem key={option.value} value={option.value}>
-                  {t(option.label)}
-                </MenuItem>
-              ))}
-            </Select>
-          )}
-          <TextField
-            inputRef={inputRef}
-            fullWidth
-            value={linkUrl}
-            onChange={(event: ChangeEvent<HTMLInputElement>) => {
-              setLinkUrl(event.target.value);
-            }}
-            placeholder={t('flows:core.elements.richText.linkEditor.placeholder')}
-            onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                if (lastSelection !== null) {
-                  const currentUrl: string = getCurrentUrl();
-
-                  if (currentUrl !== '') {
-                    editor.dispatchCommand(TOGGLE_SAFE_LINK_COMMAND, currentUrl);
-                  }
-                  setEditMode(false);
-                }
-              } else if (event.key === 'Escape') {
-                event.preventDefault();
-                setEditMode(false);
-              }
-            }}
-          />
-          <Button
-            size="small"
-            variant="outlined"
-            sx={{
-              marginTop: 2,
-            }}
-            onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
+      <TextField
+        fullWidth
+        size="small"
+        value={linkText}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          setLinkText(event.target.value);
+        }}
+        placeholder={t('flows:core.elements.richText.linkEditor.textPlaceholder')}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <AlignLeft size={16} />
+            </InputAdornment>
+          ),
+        }}
+      />
+      <Box display="flex" gap={1} alignItems="center">
+        <TextField
+          inputRef={inputRef}
+          fullWidth
+          size="small"
+          value={linkUrl}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            setLinkUrl(event.target.value);
+          }}
+          placeholder={t('flows:core.elements.richText.linkEditor.placeholder')}
+          onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter') {
               event.preventDefault();
-              if (lastSelection !== null) {
-                const currentUrl: string = getCurrentUrl();
-
-                if (currentUrl !== '') {
-                  editor.dispatchCommand(TOGGLE_SAFE_LINK_COMMAND, currentUrl);
-                }
-              }
-              setEditMode(false);
-            }}
-            startIcon={<SaveIcon size={20} />}
-          >
-            {t('common:save')}
-          </Button>
-        </Box>
-      ) : (
-        <Box width="100%" display="flex" flexDirection="column" gap={1}>
-          <Link
-            paddingTop={1}
-            paddingBottom={3}
-            paddingLeft={2}
-            href={linkUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {linkUrl}
-          </Link>
-          <Button size="small" variant="outlined" onClick={() => setEditMode(true)} startIcon={<EditIcon size={20} />}>
-            {t('common:edit')}
-          </Button>
-        </Box>
-      )}
+              handleApply();
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              handleClose();
+            }
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Link2 size={16} />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <InputAdornment position="end">
+                <Tooltip title={t('flows:core.elements.textPropertyField.tooltip.configureDynamicValue')}>
+                  <IconButton
+                    ref={dynamicValueBtnRef}
+                    onClick={() => setIsDynamicValuePopoverOpen((prev) => !prev)}
+                    size="small"
+                    edge="end"
+                  >
+                    <SquareFunction size={16} />
+                  </IconButton>
+                </Tooltip>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Button size="small" variant="outlined" onClick={handleApply}>
+          {t('flows:core.elements.richText.linkEditor.apply')}
+        </Button>
+      </Box>
+      <DynamicValuePopover
+        open={isDynamicValuePopoverOpen}
+        anchorEl={dynamicValueBtnRef.current}
+        propertyKey="linkUrl"
+        onClose={() => setIsDynamicValuePopoverOpen(false)}
+        value={linkUrl}
+        onChange={(newValue: string) => setLinkUrl(newValue)}
+      />
     </Card>
   );
 }
@@ -536,6 +501,7 @@ const CustomLinkPlugin = (): ReactElement => {
     [editor],
   );
 
+  // TODO: Refactor this to use `Popover` from Oxygen UI instead.
   return createPortal(<LinkEditor />, document.body);
 };
 

--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/HTMLPlugin.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/HTMLPlugin.tsx
@@ -100,6 +100,10 @@ function HTMLPlugin({onChange, resource, disabled = false}: HTMLPluginProps): Re
    */
   const postProcessHTML = (html: string): string => {
     let processedHtml = html;
+
+    // Restore template URLs that were previously mangled by Lexical's URL formatter
+    // (which prepends https:// to URLs without a protocol, e.g. {{meta(...)}} → https://{{meta(...)}}/).
+    processedHtml = processedHtml.replace(/href="https?:\/\/(\{\{(?:meta|t)\([^)]+\)\}\})\/?"/g, 'href="$1"');
     // Reverse text alignment class replacements.
     TEXT_ALIGN_TYPES.forEach((textAlign) => {
       processedHtml = processedHtml.replaceAll(
@@ -168,7 +172,11 @@ function HTMLPlugin({onChange, resource, disabled = false}: HTMLPluginProps): Re
       editorState.read(() => {
         updateType.current = UPDATE_TYPES.INTERNAL;
 
-        const htmlString: string = $generateHtmlFromNodes(editor);
+        let htmlString: string = $generateHtmlFromNodes(editor);
+
+        // Lexical's formatUrl prepends https:// to template URLs (e.g. {{meta(...)}}) during
+        // HTML serialization. Strip the prefix so the raw template is preserved in storage.
+        htmlString = htmlString.replace(/href="https?:\/\/(\{\{(?:meta|t)\([^)]+\)\}\})\/?"/g, 'href="$1"');
 
         const processedHTML: string = preProcessHTML(htmlString);
 

--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/CustomLinkPlugin.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/CustomLinkPlugin.test.tsx
@@ -31,6 +31,7 @@ const {
   mockIsRangeSelection,
   mockIsLinkNode,
   mockGetSelectedNode,
+  mockEditorUpdate,
 } = vi.hoisted(() => ({
   mockDispatchCommand: vi.fn<(...args: unknown[]) => unknown>(),
   mockRegisterUpdateListener: vi.fn<(...args: unknown[]) => () => void>(() => vi.fn()),
@@ -47,8 +48,10 @@ const {
     getURL: () => 'https://example.com',
     setTarget: vi.fn(),
     setRel: vi.fn(),
+    getTextContent: () => '',
     type: 'text',
   })),
+  mockEditorUpdate: vi.fn(),
 }));
 
 // Mock react-i18next
@@ -60,24 +63,31 @@ vi.mock('react-i18next', () => ({
 
 // Mock the lexical composer context
 vi.mock('@lexical/react/LexicalComposerContext', () => ({
-  useLexicalComposerContext: () => [{
-    dispatchCommand: mockDispatchCommand,
-    registerUpdateListener: mockRegisterUpdateListener,
-    registerCommand: mockRegisterCommand,
-    getRootElement: mockGetRootElement,
-    getEditorState: mockGetEditorState,
-  }],
+  useLexicalComposerContext: () => [
+    {
+      dispatchCommand: mockDispatchCommand,
+      registerUpdateListener: mockRegisterUpdateListener,
+      registerCommand: mockRegisterCommand,
+      getRootElement: mockGetRootElement,
+      getEditorState: mockGetEditorState,
+      update: mockEditorUpdate,
+    },
+  ],
 }));
 
 // Mock lexical utils
 vi.mock('@lexical/utils', () => ({
-  mergeRegister: (...fns: (() => void)[]) => () => fns.forEach(fn => fn()),
+  mergeRegister:
+    (...fns: (() => void)[]) =>
+    () =>
+      fns.forEach((fn) => fn()),
 }));
 
 // Mock lexical
 vi.mock('lexical', () => ({
   $getSelection: mockGetSelection,
   $isRangeSelection: mockIsRangeSelection,
+  $isTextNode: vi.fn(() => false),
   CLICK_COMMAND: 'CLICK_COMMAND',
   KEY_ESCAPE_COMMAND: 'KEY_ESCAPE_COMMAND',
   SELECTION_CHANGE_COMMAND: 'SELECTION_CHANGE_COMMAND',
@@ -97,6 +107,11 @@ vi.mock('../../utils/getSelectedNode', () => ({
 // Mock commands
 vi.mock('../commands', () => ({
   default: 'TOGGLE_SAFE_LINK_COMMAND',
+}));
+
+// Mock DynamicValuePopover
+vi.mock('../../../DynamicValuePopover', () => ({
+  default: () => null,
 }));
 
 // Mock createPortal to render directly
@@ -119,11 +134,13 @@ describe('CustomLinkPlugin', () => {
     mockGetSelection.mockImplementation(() => ({type: 'range'}));
     mockIsRangeSelection.mockImplementation(() => true);
     mockIsLinkNode.mockImplementation(() => false);
+    mockEditorUpdate.mockImplementation(vi.fn());
     mockGetSelectedNode.mockImplementation(() => ({
       getParent: () => null,
       getURL: () => 'https://example.com',
       setTarget: vi.fn(),
       setRel: vi.fn(),
+      getTextContent: () => '',
       type: 'text',
     }));
 
@@ -144,10 +161,10 @@ describe('CustomLinkPlugin', () => {
       expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
 
-    it('should render view link title by default', () => {
+    it('should render apply button', () => {
       render(<CustomLinkPlugin />);
 
-      expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
+      expect(screen.getByText('flows:core.elements.richText.linkEditor.apply')).toBeInTheDocument();
     });
 
     it('should render close button', () => {
@@ -158,10 +175,11 @@ describe('CustomLinkPlugin', () => {
       expect(closeButtons.length).toBeGreaterThan(0);
     });
 
-    it('should render edit button in view mode', () => {
+    it('should render URL input field', () => {
       render(<CustomLinkPlugin />);
 
-      expect(screen.getByText('common:edit')).toBeInTheDocument();
+      const inputs = document.querySelectorAll('input');
+      expect(inputs.length).toBeGreaterThan(0);
     });
   });
 
@@ -198,178 +216,111 @@ describe('CustomLinkPlugin', () => {
   });
 
   describe('Edit Mode', () => {
-    it('should switch to edit mode when edit button is clicked', async () => {
+    it('should show URL input field and apply button', () => {
       render(<CustomLinkPlugin />);
 
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      // After clicking edit, the component should show edit mode title
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
+      // The component always shows the URL input and apply button
+      expect(document.querySelector('.MuiTextField-root')).toBeInTheDocument();
+      expect(screen.getByText('flows:core.elements.richText.linkEditor.apply')).toBeInTheDocument();
     });
 
-    it('should show save button in edit mode', async () => {
+    it('should show apply button instead of save button', () => {
       render(<CustomLinkPlugin />);
 
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('common:save')).toBeInTheDocument();
-      });
+      expect(screen.getByText('flows:core.elements.richText.linkEditor.apply')).toBeInTheDocument();
     });
 
-    it('should show text field in edit mode', async () => {
+    it('should show text field', () => {
       render(<CustomLinkPlugin />);
 
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        const textField = document.querySelector('.MuiTextField-root');
-        expect(textField).toBeInTheDocument();
-      });
-    });
-
-    it('should exit edit mode when escape key is pressed in text field', async () => {
-      render(<CustomLinkPlugin />);
-
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Press escape in the text field
-      const textField = document.querySelector('input');
-      if (textField) {
-        await act(async () => {
-          fireEvent.keyDown(textField, {key: 'Escape'});
-        });
-      }
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
-    });
-
-    it('should handle enter key press in text field', async () => {
-      render(<CustomLinkPlugin />);
-
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type a URL and press enter
-      const textField = document.querySelector('input');
+      const textField = document.querySelector('.MuiTextField-root');
       expect(textField).toBeInTheDocument();
-      if (textField) {
+    });
+
+    it('should handle escape key press in URL field', async () => {
+      render(<CustomLinkPlugin />);
+
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // Second input is the URL field
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://test.com'}});
-          fireEvent.keyDown(textField, {key: 'Enter'});
+          fireEvent.keyDown(urlInput, {key: 'Escape'});
+        });
+      }
+
+      // The card should still be in the document
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
+    });
+
+    it('should handle enter key press in URL field', async () => {
+      render(<CustomLinkPlugin />);
+
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // Second input is the URL field
+      expect(urlInput).toBeInTheDocument();
+      if (urlInput) {
+        await act(async () => {
+          fireEvent.change(urlInput, {target: {value: 'https://test.com'}});
         });
 
-        // Verify the input value was updated
-        expect(textField).toHaveValue('https://test.com');
+        // Verify the input value was updated before Enter key
+        expect(urlInput).toHaveValue('https://test.com');
+
+        await act(async () => {
+          fireEvent.keyDown(urlInput, {key: 'Enter'});
+        });
+
+        // After Enter, handleApply -> handleClose resets the value
+        expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
       }
     });
 
-    it('should save link when save button is clicked', async () => {
+    it('should call handleApply when apply button is clicked', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
       await act(async () => {
-        fireEvent.click(editButton);
+        fireEvent.click(applyButton);
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('common:save')).toBeInTheDocument();
-      });
-
-      // Type a URL
-      const textField = document.querySelector('input');
-      if (textField) {
-        await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://test.com'}});
-        });
-      }
-
-      // Click save
-      const saveButton = screen.getByText('common:save');
-      await act(async () => {
-        fireEvent.click(saveButton);
-      });
-
-      // Should exit edit mode
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Component should still be in the document
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
 
   describe('URL Display', () => {
-    it('should display link in view mode', () => {
+    it('should show URL input field', () => {
       render(<CustomLinkPlugin />);
 
-      const link = document.querySelector('.MuiLink-root');
-      expect(link).toBeInTheDocument();
+      const inputs = document.querySelectorAll('input');
+      expect(inputs.length).toBeGreaterThan(0);
     });
 
-    it('should open link in new tab with security attributes', () => {
+    it('should show apply button for submitting the link', () => {
       render(<CustomLinkPlugin />);
 
-      const link = document.querySelector('.MuiLink-root');
-      expect(link).toHaveAttribute('target', '_blank');
-      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
+      expect(applyButton).toBeInTheDocument();
     });
   });
 
   describe('Close Functionality', () => {
-    it('should reset state when close button is clicked', async () => {
+    it('should reset state when escape key is pressed in URL field', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode first
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Find and click close button (the IconButton with X icon)
-      const closeButtons = screen.getAllByRole('button');
-      const closeButton = closeButtons.find(btn => btn.querySelector('svg.lucide-x'));
-      if (closeButton) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.click(closeButton);
+          fireEvent.change(urlInput, {target: {value: 'https://test.com'}});
+        });
+        await act(async () => {
+          fireEvent.keyDown(urlInput, {key: 'Escape'});
         });
       }
 
-      // Should reset to view mode
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Card should still be in DOM (just repositioned off-screen)
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
 
@@ -403,28 +354,18 @@ describe('CustomLinkPlugin', () => {
     it('should handle empty URL', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('common:save')).toBeInTheDocument();
-      });
-
-      // Clear the URL field
-      const textField = document.querySelector('input');
-      if (textField) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: ''}});
+          fireEvent.change(urlInput, {target: {value: ''}});
         });
       }
 
-      // Click save
-      const saveButton = screen.getByText('common:save');
+      // Click apply
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
       await act(async () => {
-        fireEvent.click(saveButton);
+        fireEvent.click(applyButton);
       });
 
       // Should not dispatch command with empty URL
@@ -434,23 +375,14 @@ describe('CustomLinkPlugin', () => {
     it('should handle text field input changes', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        const textField = document.querySelector('input');
-        expect(textField).toBeInTheDocument();
-      });
-
-      const textField = document.querySelector('input');
-      if (textField) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      expect(urlInput).toBeInTheDocument();
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://new-url.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://new-url.com'}});
         });
-        expect(textField).toHaveValue('https://new-url.com');
+        expect(urlInput).toHaveValue('https://new-url.com');
       }
     });
   });
@@ -468,9 +400,9 @@ describe('CustomLinkPlugin', () => {
     it('should detect when parent is a link node', async () => {
       // Mock to return a link node parent
       const {$isLinkNode} = await vi.importMock<typeof import('@lexical/link')>('@lexical/link');
-      (
-        $isLinkNode as ReturnType<typeof vi.fn>
-      ).mockImplementation((node: {type?: string} | null) => node && node.type === 'link');
+      ($isLinkNode as ReturnType<typeof vi.fn>).mockImplementation(
+        (node: {type?: string} | null) => node && node.type === 'link',
+      );
 
       render(<CustomLinkPlugin />);
 
@@ -479,9 +411,9 @@ describe('CustomLinkPlugin', () => {
 
     it('should detect when node itself is a link node', async () => {
       const {$isLinkNode} = await vi.importMock<typeof import('@lexical/link')>('@lexical/link');
-      (
-        $isLinkNode as ReturnType<typeof vi.fn>
-      ).mockImplementation((node: {type?: string} | null) => node && node.type === 'link');
+      ($isLinkNode as ReturnType<typeof vi.fn>).mockImplementation(
+        (node: {type?: string} | null) => node && node.type === 'link',
+      );
 
       render(<CustomLinkPlugin />);
 
@@ -587,17 +519,9 @@ describe('CustomLinkPlugin', () => {
     it('should handle URL type change to CUSTOM', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode first
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // The handleUrlTypeChange function sets the URL to 'https://' for CUSTOM type
+      // The URL field is always visible in the new design
+      const inputs = document.querySelectorAll('input');
+      expect(inputs.length).toBeGreaterThan(0);
     });
   });
 
@@ -605,23 +529,13 @@ describe('CustomLinkPlugin', () => {
     it('should return linkUrl for CUSTOM type', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type a custom URL
-      const textField = document.querySelector('input');
-      if (textField) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://custom-url.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://custom-url.com'}});
         });
-        expect(textField).toHaveValue('https://custom-url.com');
+        expect(urlInput).toHaveValue('https://custom-url.com');
       }
     });
   });
@@ -636,28 +550,18 @@ describe('CustomLinkPlugin', () => {
   });
 
   describe('Escape Key Handling', () => {
-    it('should handle KEY_ESCAPE_COMMAND in edit mode', async () => {
+    it('should handle KEY_ESCAPE_COMMAND', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // KEY_ESCAPE_COMMAND is registered and should exit edit mode
+      // KEY_ESCAPE_COMMAND is always registered (no separate edit mode)
       expect(mockRegisterCommand).toHaveBeenCalled();
     });
 
-    it('should not handle KEY_ESCAPE_COMMAND in view mode', () => {
+    it('should handle KEY_ESCAPE_COMMAND and always return true', () => {
       render(<CustomLinkPlugin />);
 
-      // In view mode, KEY_ESCAPE_COMMAND returns false
-      expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
+      // KEY_ESCAPE_COMMAND always returns true in the new design
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
 
@@ -709,18 +613,12 @@ describe('CustomLinkPlugin', () => {
   });
 
   describe('Focus Handling', () => {
-    it('should focus input when entering edit mode', async () => {
+    it('should have URL input field available', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
       await waitFor(() => {
-        const textField = document.querySelector('input');
-        expect(textField).toBeInTheDocument();
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBeGreaterThan(0);
       });
     });
   });
@@ -729,40 +627,32 @@ describe('CustomLinkPlugin', () => {
     it('should not dispatch command when lastSelection is null', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
+        await act(async () => {
+          fireEvent.change(urlInput, {target: {value: 'https://test.com'}});
+        });
+      }
+
+      // Click apply (lastSelection is null in default test setup)
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
       await act(async () => {
-        fireEvent.click(editButton);
+        fireEvent.click(applyButton);
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('common:save')).toBeInTheDocument();
-      });
-
-      // Type a URL
-      const textField = document.querySelector('input');
-      if (textField) {
-        await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://test.com'}});
-        });
-      }
-
-      // Press Enter (lastSelection may be null in this test setup)
-      if (textField) {
-        await act(async () => {
-          fireEvent.keyDown(textField, {key: 'Enter'});
-        });
-      }
+      // lastSelection is null so command should not be dispatched
+      expect(mockDispatchCommand).not.toHaveBeenCalledWith('TOGGLE_SAFE_LINK_COMMAND', expect.anything());
     });
   });
 
   describe('Link Attributes', () => {
-    it('should set target and rel attributes on link', () => {
+    it('should have apply button to set link with safe attributes', () => {
       render(<CustomLinkPlugin />);
 
-      const link = document.querySelector('.MuiLink-root');
-      expect(link).toHaveAttribute('target', '_blank');
-      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      // Apply button triggers TOGGLE_SAFE_LINK_COMMAND which sets safe attributes
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
+      expect(applyButton).toBeInTheDocument();
     });
   });
 
@@ -775,6 +665,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://clicked-link.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -782,12 +673,10 @@ describe('CustomLinkPlugin', () => {
 
       // Capture the command callback
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       const mockOpen = vi.spyOn(window, 'open').mockImplementation(vi.fn());
 
@@ -812,18 +701,17 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://ctrl-clicked-link.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       const mockOpen = vi.spyOn(window, 'open').mockImplementation(vi.fn());
 
@@ -847,18 +735,17 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -877,18 +764,17 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockTextNode);
       mockIsLinkNode.mockReturnValue(false);
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -907,18 +793,17 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockTextNode);
       mockIsLinkNode.mockReturnValue(false);
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -945,12 +830,10 @@ describe('CustomLinkPlugin', () => {
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -968,12 +851,10 @@ describe('CustomLinkPlugin', () => {
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -992,18 +873,17 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockTextNode);
       mockIsLinkNode.mockReturnValue(false);
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -1016,56 +896,40 @@ describe('CustomLinkPlugin', () => {
 
     it('should execute KEY_ESCAPE_COMMAND in edit mode', async () => {
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode first
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Verify escapeCallback was captured
+      // KEY_ESCAPE_COMMAND is always registered (no separate edit mode)
       expect(callbacks.KEY_ESCAPE_COMMAND).toBeDefined();
     });
 
-    it('should execute KEY_ESCAPE_COMMAND in view mode and return false', () => {
+    it('should execute KEY_ESCAPE_COMMAND and return true', () => {
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
-      // In view mode, escape should return false
+      // KEY_ESCAPE_COMMAND always returns true in the new design
       const escapeCallback = callbacks.KEY_ESCAPE_COMMAND as (() => boolean) | undefined;
       if (escapeCallback) {
         const result = escapeCallback();
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       }
     });
 
     it('should execute SELECTION_CHANGE_COMMAND callback', () => {
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -1084,6 +948,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://parent-link.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       const mockTextNode = {
         type: 'text',
@@ -1091,6 +956,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockTextNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockParentLinkNode);
@@ -1108,6 +974,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://direct-link.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -1125,6 +992,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockTextNode);
       mockIsLinkNode.mockReturnValue(false);
@@ -1388,28 +1256,11 @@ describe('CustomLinkPlugin', () => {
 
   describe('handleUrlTypeChange', () => {
     it('should handle URL type change to CUSTOM and set URL to https://', async () => {
-      const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
-
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // The handleUrlTypeChange is triggered via Select component
-      // Since PREDEFINED_URLS is empty, clicking to change type would fall through to CUSTOM
+      // The URL field is always visible in the new design (no mode toggle)
+      const inputs = document.querySelectorAll('input');
+      expect(inputs.length).toBeGreaterThan(0);
     });
   });
 
@@ -1417,63 +1268,38 @@ describe('CustomLinkPlugin', () => {
     it('should return linkUrl for CUSTOM selectedUrlType', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type a URL
-      const textField = document.querySelector('input');
-      if (textField) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://custom.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://custom.com'}});
         });
 
-        // Press Enter to trigger getCurrentUrl
-        await act(async () => {
-          fireEvent.keyDown(textField, {key: 'Enter'});
-        });
+        expect(urlInput).toHaveValue('https://custom.com');
       }
     });
   });
 
   describe('Save Button Click with Empty URL', () => {
-    it('should not dispatch command when URL is empty on save button click', async () => {
+    it('should not dispatch command when URL is empty on apply button click', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('common:save')).toBeInTheDocument();
-      });
-
-      // Clear URL
-      const textField = document.querySelector('input');
-      if (textField) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: ''}});
+          fireEvent.change(urlInput, {target: {value: ''}});
         });
       }
 
-      // Click save
-      const saveButton = screen.getByText('common:save');
+      // Click apply
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
       await act(async () => {
-        fireEvent.click(saveButton);
+        fireEvent.click(applyButton);
       });
 
-      // Component should exit edit mode without dispatching command
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Component should handle empty URL gracefully
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
 
@@ -1481,28 +1307,18 @@ describe('CustomLinkPlugin', () => {
     it('should not dispatch command when URL is empty on Enter key', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Clear URL and press Enter
-      const textField = document.querySelector('input');
-      if (textField) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: ''}});
-          fireEvent.keyDown(textField, {key: 'Enter'});
+          fireEvent.change(urlInput, {target: {value: ''}});
+          fireEvent.keyDown(urlInput, {key: 'Enter'});
         });
       }
 
       // The component should handle the Enter key press with empty URL
       // The command should not be dispatched with an empty URL
-      expect(textField).toHaveValue('');
+      expect(urlInput).toHaveValue('');
     });
   });
 
@@ -1510,12 +1326,10 @@ describe('CustomLinkPlugin', () => {
     it('should execute update listener callback', () => {
       type UpdateCallback = (state: {editorState: {read: (cb: () => void) => void}}) => void;
       const capturedCallbacks: UpdateCallback[] = [];
-      (mockRegisterUpdateListener as ReturnType<typeof vi.fn>).mockImplementation(
-        (callback: unknown) => {
-          capturedCallbacks.push(callback as UpdateCallback);
-          return vi.fn();
-        },
-      );
+      (mockRegisterUpdateListener as ReturnType<typeof vi.fn>).mockImplementation((callback: unknown) => {
+        capturedCallbacks.push(callback as UpdateCallback);
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -1531,20 +1345,16 @@ describe('CustomLinkPlugin', () => {
   });
 
   describe('Handle Close with Editor Ref', () => {
-    it('should call positionEditorElement with null on close', async () => {
+    it('should call positionEditorElement with null on apply', async () => {
       render(<CustomLinkPlugin />);
 
-      // Find the close button
-      const buttons = screen.getAllByRole('button');
-      const closeButton = buttons.find(btn => btn.querySelector('svg'));
+      // Click the apply button (which calls handleApply -> handleClose)
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
+      await act(async () => {
+        fireEvent.click(applyButton);
+      });
 
-      if (closeButton) {
-        await act(async () => {
-          fireEvent.click(closeButton);
-        });
-      }
-
-      // The card should still be in the document (just repositioned)
+      // The card should still be in the document (just repositioned off-screen)
       expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
@@ -1556,6 +1366,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
         type: 'text',
       });
       mockIsRangeSelection.mockReturnValue(true);
@@ -1570,36 +1381,18 @@ describe('CustomLinkPlugin', () => {
     it('should handle URL type change when selectedOption is found', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Since PREDEFINED_URLS is empty, the Select won't be rendered
-      // But we can verify the component handles this correctly
+      // The URL field is always visible in the new design
+      const inputs = document.querySelectorAll('input');
+      expect(inputs.length).toBeGreaterThan(0);
     });
 
     it('should set linkUrl to https:// when switching to CUSTOM type', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // The default type is CUSTOM, and URL should be set appropriately
-      const textField = document.querySelector('input');
-      expect(textField).toBeInTheDocument();
+      // The URL input field is always available
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      expect(urlInput).toBeInTheDocument();
     });
   });
 
@@ -1607,51 +1400,31 @@ describe('CustomLinkPlugin', () => {
     it('should return linkUrl when selectedUrlType is CUSTOM', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type a URL
-      const textField = document.querySelector('input');
-      if (textField) {
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://myurl.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://myurl.com'}});
         });
 
-        // Click save - this triggers getCurrentUrl()
-        const saveButton = screen.getByText('common:save');
+        // Click apply - this triggers getCurrentUrl()
+        const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
         await act(async () => {
-          fireEvent.click(saveButton);
+          fireEvent.click(applyButton);
         });
       }
 
-      // Should exit edit mode
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Card should still be in the document
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
 
     it('should return selectedOption.value when selectedUrlType is not CUSTOM but option not found', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
       // Since PREDEFINED_URLS is empty, even if we had a non-CUSTOM type,
-      // it would fall back to returning linkUrl
+      // it would fall back to returning linkUrl. Verify URL field is present.
+      const inputs = document.querySelectorAll('input');
+      expect(inputs.length).toBeGreaterThan(0);
     });
   });
 
@@ -1685,40 +1458,31 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
 
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type a URL
-      const textField = document.querySelector('input');
-      if (textField) {
+      // Type a new URL in the URL input (second input field)
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://newurl.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://newurl.com'}});
         });
       }
 
-      // Click save
-      const saveButton = screen.getByText('common:save');
+      // Click the apply button
+      const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
       await act(async () => {
-        fireEvent.click(saveButton);
+        fireEvent.click(applyButton);
       });
 
-      // Should dispatch command and exit edit mode
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Should dispatch command since lastSelection is set and URL is not empty
+      // The URL dispatched is the one set by updateLinkEditor (from getURL() mock)
+      expect(mockDispatchCommand).toHaveBeenCalledWith('TOGGLE_SAFE_LINK_COMMAND', expect.stringContaining('https://'));
     });
   });
 
@@ -1752,35 +1516,25 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
 
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type a URL and press Enter
-      const textField = document.querySelector('input');
-      if (textField) {
+      // Press Enter in the URL input field
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://enterkey.com'}});
-          fireEvent.keyDown(textField, {key: 'Enter'});
+          fireEvent.change(urlInput, {target: {value: 'https://enterkey.com'}});
+          fireEvent.keyDown(urlInput, {key: 'Enter'});
         });
       }
 
-      // Should exit edit mode after Enter
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Should dispatch command since lastSelection is set and URL is not empty
+      expect(mockDispatchCommand).toHaveBeenCalledWith('TOGGLE_SAFE_LINK_COMMAND', 'https://enterkey.com');
     });
   });
 
@@ -1888,6 +1642,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -1934,6 +1689,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -1983,6 +1739,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2028,6 +1785,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2073,6 +1831,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2118,6 +1877,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2179,6 +1939,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://parent-link.com',
         setTarget: mockSetTarget,
         setRel: mockSetRel,
+        getTextContent: () => '',
       };
       const mockTextNode = {
         type: 'text',
@@ -2186,6 +1947,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockTextNode);
@@ -2194,12 +1956,10 @@ describe('CustomLinkPlugin', () => {
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       render(<CustomLinkPlugin />);
 
@@ -2220,6 +1980,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://parent-url.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       const mockTextNode = {
         type: 'text',
@@ -2227,6 +1988,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockTextNode);
@@ -2256,9 +2018,10 @@ describe('CustomLinkPlugin', () => {
 
       render(<CustomLinkPlugin />);
 
-      // The link URL from parent should be set
-      const link = document.querySelector('.MuiLink-root');
-      expect(link).toBeInTheDocument();
+      // The link URL from parent should be set in the URL input field
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      expect(urlInput).toBeInTheDocument();
     });
 
     it('should set URL and type when node itself is a link node', () => {
@@ -2268,6 +2031,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://direct-link-url.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
@@ -2297,8 +2061,10 @@ describe('CustomLinkPlugin', () => {
 
       render(<CustomLinkPlugin />);
 
-      const link = document.querySelector('.MuiLink-root');
-      expect(link).toBeInTheDocument();
+      // The link URL from node should be set in the URL input field
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1]; // URL input
+      expect(urlInput).toBeInTheDocument();
     });
 
     it('should reset URL and hide editor when neither node nor parent is a link', () => {
@@ -2308,6 +2074,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockTextNode);
@@ -2334,6 +2101,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
@@ -2371,6 +2139,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
@@ -2408,6 +2177,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
@@ -2446,6 +2216,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
@@ -2472,6 +2243,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://parent-link-to-open.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       const mockTextNode = {
         type: 'text',
@@ -2479,6 +2251,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
 
       mockGetSelectedNode.mockReturnValue(mockTextNode);
@@ -2486,12 +2259,10 @@ describe('CustomLinkPlugin', () => {
       mockIsRangeSelection.mockReturnValue(true);
 
       const callbacks: Record<string, unknown> = {};
-      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation(
-        (command: unknown, callback: unknown) => {
-          callbacks[command as string] = callback;
-          return vi.fn();
-        },
-      );
+      (mockRegisterCommand as ReturnType<typeof vi.fn>).mockImplementation((command: unknown, callback: unknown) => {
+        callbacks[command as string] = callback;
+        return vi.fn();
+      });
 
       const mockOpen = vi.spyOn(window, 'open').mockImplementation(vi.fn());
 
@@ -2558,6 +2329,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2606,6 +2378,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2629,6 +2402,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockTextNode);
       mockIsLinkNode.mockReturnValue(false);
@@ -2653,6 +2427,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2703,6 +2478,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2754,6 +2530,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2777,6 +2554,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2830,6 +2608,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://test.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2879,6 +2658,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://test.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);
@@ -2902,6 +2682,7 @@ describe('CustomLinkPlugin', () => {
         getURL: () => 'https://example.com',
         setTarget: vi.fn(),
         setRel: vi.fn(),
+        getTextContent: () => '',
       };
       mockGetSelectedNode.mockReturnValue(mockLinkNode);
       mockIsLinkNode.mockImplementation((node: unknown) => node === mockLinkNode);

--- a/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/CustomLinkPluginPredefinedUrls.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/CustomLinkPluginPredefinedUrls.test.tsx
@@ -24,7 +24,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
+import {render, screen, fireEvent, act} from '@testing-library/react';
 import type React from 'react';
 
 // Use vi.hoisted for mock functions
@@ -67,18 +67,23 @@ vi.mock('react-i18next', () => ({
 
 // Mock the lexical composer context
 vi.mock('@lexical/react/LexicalComposerContext', () => ({
-  useLexicalComposerContext: () => [{
-    dispatchCommand: mockDispatchCommand,
-    registerUpdateListener: mockRegisterUpdateListener,
-    registerCommand: mockRegisterCommand,
-    getRootElement: mockGetRootElement,
-    getEditorState: mockGetEditorState,
-  }],
+  useLexicalComposerContext: () => [
+    {
+      dispatchCommand: mockDispatchCommand,
+      registerUpdateListener: mockRegisterUpdateListener,
+      registerCommand: mockRegisterCommand,
+      getRootElement: mockGetRootElement,
+      getEditorState: mockGetEditorState,
+    },
+  ],
 }));
 
 // Mock lexical utils
 vi.mock('@lexical/utils', () => ({
-  mergeRegister: (...fns: (() => void)[]) => () => fns.forEach(fn => fn()),
+  mergeRegister:
+    (...fns: (() => void)[]) =>
+    () =>
+      fns.forEach((fn) => fn()),
 }));
 
 // Mock lexical
@@ -132,6 +137,7 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
     mockGetSelectedNode.mockImplementation(() => ({
       getParent: () => null,
       getURL: () => 'https://example.com',
+      getTextContent: () => '',
       setTarget: vi.fn(),
       setRel: vi.fn(),
       type: 'text',
@@ -154,6 +160,7 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
         type: 'link',
         getParent: () => ({type: 'paragraph'}),
         getURL: () => 'https://any-custom-url.com',
+        getTextContent: () => 'link text',
         setTarget: vi.fn(),
         setRel: vi.fn(),
       };
@@ -183,9 +190,8 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
 
       render(<CustomLinkPlugin />);
 
-      // The link should be displayed (determineUrlType returns CUSTOM for any URL)
-      const link = document.querySelector('.MuiLink-root');
-      expect(link).toBeInTheDocument();
+      // The component renders the editing card (determineUrlType returns CUSTOM for any URL)
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
 
     it('should exercise determineUrlType when URL matches no predefined option', () => {
@@ -194,6 +200,7 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
         type: 'link',
         getParent: () => ({type: 'paragraph'}),
         getURL: () => 'https://random-url.com',
+        getTextContent: () => 'link text',
         setTarget: vi.fn(),
         setRel: vi.fn(),
       };
@@ -215,6 +222,7 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
         type: 'link',
         getParent: () => ({type: 'paragraph'}),
         getURL: () => testUrl,
+        getTextContent: () => 'link text',
         setTarget: vi.fn(),
         setRel: vi.fn(),
       };
@@ -244,29 +252,22 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
 
       render(<CustomLinkPlugin />);
 
-      // The link should display the URL itself as placeholder
-      const link = document.querySelector('.MuiLink-root');
-      expect(link).toBeInTheDocument();
+      // The component renders the editing card; placeholder URL value is set in the input
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
 
   describe('handleUrlTypeChange function behavior', () => {
     it('should set URL to https:// when switching to CUSTOM type', async () => {
       // This tests the else branch behavior when newType is CUSTOM
+      // Since PREDEFINED_URLS is empty, all URLs are treated as CUSTOM type
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
+      // Verify the component renders the editing interface directly
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
 
       // Since PREDEFINED_URLS is empty, Select won't render
-      // But we verify the component is in edit mode correctly
+      // Verify the component renders the URL input field
       const textField = document.querySelector('input');
       expect(textField).toBeInTheDocument();
     });
@@ -277,35 +278,27 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
       // This tests the else branch that returns linkUrl
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
+      // The component renders the editing interface directly
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type a custom URL
-      const textField = document.querySelector('input');
-      if (textField) {
+      // Type a custom URL into the URL input field (second input)
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1];
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://test-current-url.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://test-current-url.com'}});
         });
-        expect(textField).toHaveValue('https://test-current-url.com');
+        expect(urlInput).toHaveValue('https://test-current-url.com');
 
-        // Click save to trigger getCurrentUrl
-        const saveButton = screen.getByText('common:save');
+        // Click apply to submit the link (getCurrentUrl returns linkUrl for CUSTOM type)
+        const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
         await act(async () => {
-          fireEvent.click(saveButton);
+          fireEvent.click(applyButton);
         });
       }
 
-      // Should exit edit mode
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Card should still be present in the DOM
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
 
@@ -314,15 +307,8 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
       // This tests the conditional rendering when PREDEFINED_URLS is empty
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
+      // The component renders the editing interface directly
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
 
       // Select should NOT be rendered since PREDEFINED_URLS is empty
       const select = document.querySelector('.MuiSelect-root');
@@ -336,6 +322,7 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
         type: 'link',
         getParent: () => ({type: 'paragraph'}),
         getURL: () => '',
+        getTextContent: () => '',
         setTarget: vi.fn(),
         setRel: vi.fn(),
       };
@@ -353,6 +340,7 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
         type: 'link',
         getParent: () => ({type: 'paragraph'}),
         getURL: () => 'https://example.com/path?query=value&other=test#hash',
+        getTextContent: () => 'link text',
         setTarget: vi.fn(),
         setRel: vi.fn(),
       };
@@ -370,6 +358,7 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
         type: 'link',
         getParent: () => ({type: 'paragraph'}),
         getURL: () => 'https://example.com/路径/页面',
+        getTextContent: () => 'link text',
         setTarget: vi.fn(),
         setRel: vi.fn(),
       };
@@ -387,67 +376,55 @@ describe('CustomLinkPlugin - URL Type Detection Functions', () => {
     it('should handle rapid URL type changes', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
+      // The component renders the editing interface directly
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      // Type multiple URLs rapidly
-      const textField = document.querySelector('input');
-      if (textField) {
+      // Type multiple URLs rapidly into the URL input field (second input)
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1];
+      if (urlInput) {
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://url1.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://url1.com'}});
         });
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://url2.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://url2.com'}});
         });
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://final-url.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://final-url.com'}});
         });
-        expect(textField).toHaveValue('https://final-url.com');
+        expect(urlInput).toHaveValue('https://final-url.com');
       }
     });
 
     it('should handle save with valid URL after initially empty', async () => {
       render(<CustomLinkPlugin />);
 
-      // Enter edit mode
-      const editButton = screen.getByText('common:edit');
-      await act(async () => {
-        fireEvent.click(editButton);
-      });
+      // The component renders the editing interface directly
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.editLink')).toBeInTheDocument();
-      });
-
-      const textField = document.querySelector('input');
-      if (textField) {
+      // Use the URL input field (second input)
+      const inputs = document.querySelectorAll('input');
+      const urlInput = inputs[1];
+      if (urlInput) {
         // Clear the field first
         await act(async () => {
-          fireEvent.change(textField, {target: {value: ''}});
+          fireEvent.change(urlInput, {target: {value: ''}});
         });
         // Then add a valid URL
         await act(async () => {
-          fireEvent.change(textField, {target: {value: 'https://valid-url.com'}});
+          fireEvent.change(urlInput, {target: {value: 'https://valid-url.com'}});
         });
-        expect(textField).toHaveValue('https://valid-url.com');
+        expect(urlInput).toHaveValue('https://valid-url.com');
 
-        // Save
-        const saveButton = screen.getByText('common:save');
+        // Apply the link
+        const applyButton = screen.getByText('flows:core.elements.richText.linkEditor.apply');
         await act(async () => {
-          fireEvent.click(saveButton);
+          fireEvent.click(applyButton);
         });
       }
 
-      await waitFor(() => {
-        expect(screen.getByText('flows:core.elements.richText.linkEditor.viewLink')).toBeInTheDocument();
-      });
+      // Card should still be present in the DOM
+      expect(document.querySelector('.MuiCard-root')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/apps/thunder-develop/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/constants/VisualFlowConstants.ts
@@ -84,6 +84,7 @@ class VisualFlowConstants {
     WidgetTypes.GithubFederation,
     WidgetTypes.PasskeyAuthentication,
     WidgetTypes.MagicLink,
+    WidgetTypes.SelfSignUpLink,
     ElementTypes.Timer,
   ];
 
@@ -117,6 +118,7 @@ class VisualFlowConstants {
     WidgetTypes.GithubFederation,
     WidgetTypes.PasskeyAuthentication,
     WidgetTypes.MagicLink,
+    WidgetTypes.SelfSignUpLink,
     ElementTypes.Timer,
   ];
 

--- a/frontend/apps/thunder-develop/src/features/flows/models/widget.ts
+++ b/frontend/apps/thunder-develop/src/features/flows/models/widget.ts
@@ -50,6 +50,7 @@ export const WidgetTypes = {
   GithubFederation: 'GITHUB_FEDERATION',
   PasskeyAuthentication: 'PASSKEY_AUTHENTICATION',
   MagicLink: 'MAGIC_LINK',
+  SelfSignUpLink: 'SELF_SIGN_UP_LINK',
 } as const;
 
 export type WidgetTypes = (typeof WidgetTypes)[keyof typeof WidgetTypes];

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
@@ -220,7 +220,7 @@
                     },
                     {
                       "category": "DISPLAY",
-                      "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{application.selfRegisterUrl}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
+                      "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.signUpUrl)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
                       "id": "{{ID}}",
                       "type": "RICH_TEXT"
                     }
@@ -1203,7 +1203,7 @@
                     },
                     {
                       "category": "DISPLAY",
-                      "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{application.selfRegisterUrl}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
+                      "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.signUpUrl)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
                       "id": "{{ID}}",
                       "type": "RICH_TEXT"
                     }

--- a/frontend/apps/thunder-develop/src/features/login-flow/data/widgets.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/widgets.json
@@ -1111,5 +1111,41 @@
         ]
       }
     }
+  },
+  {
+    "resourceType": "WIDGET",
+    "category": "COMPOSITE",
+    "type": "SELF_SIGN_UP_LINK",
+    "display": {
+      "label": "Self Sign Up Link",
+      "description": "A rich text link to redirect users to the self-registration page",
+      "image": "UserPlus",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "strategy": "MERGE_WITH_DROP_POINT"
+        },
+        "steps": [
+          {
+            "__generationMeta__": {
+              "strategy": "MERGE_WITH_DROP_POINT"
+            },
+            "type": "VIEW",
+            "data": {
+              "components": [
+                {
+                  "category": "DISPLAY",
+                  "type": "RICH_TEXT",
+                  "id": "{{ID}}",
+                  "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.signUpUrl)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
   }
 ]

--- a/frontend/apps/thunder-gate/package.json
+++ b/frontend/apps/thunder-gate/package.json
@@ -47,6 +47,7 @@
     "@thunder/utils": "workspace:^",
     "@wso2/oxygen-ui": "catalog:",
     "@wso2/oxygen-ui-icons-react": "catalog:",
+    "dompurify": "catalog:",
     "i18next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/frontend/apps/thunder-gate/src/components/SignIn/SignInBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/SignInBox.tsx
@@ -17,28 +17,17 @@
  */
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type {JSX} from 'react';
-import {
-  Box,
-  Button,
-  Alert,
-  Typography,
-  styled,
-  Paper,
-  ColorSchemeImage,
-  Stack,
-  CircularProgress,
-} from '@wso2/oxygen-ui';
+import {Box, Alert, styled, Paper, ColorSchemeImage, Stack, CircularProgress} from '@wso2/oxygen-ui';
 import {useState} from 'react';
-import {EmbeddedFlowComponentType, SignIn, SignUp, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {EmbeddedFlowComponentType, SignIn, type EmbeddedFlowComponent} from '@asgardeo/react';
 import {useTemplateLiteralResolver} from '@thunder/shared-hooks';
 import {TemplateLiteralType} from '@thunder/utils';
-import {useNavigate, useSearchParams} from 'react-router';
-import {Trans, useTranslation} from 'react-i18next';
-import ROUTES from '../../constants/routes';
+import {useSearchParams} from 'react-router';
+import {useTranslation} from 'react-i18next';
 import FlowComponentRenderer from '../flow/FlowComponentRenderer';
+import generateFallbackSignUpUrl from '../../utils/generateFallbackSignUpUrl';
 
 const StyledPaper = styled(Paper)(({theme}) => ({
   display: 'flex',
@@ -53,10 +42,11 @@ const StyledPaper = styled(Paper)(({theme}) => ({
 }));
 
 export default function SignInBox(): JSX.Element {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const {resolve, resolveAll} = useTemplateLiteralResolver();
   const {t} = useTranslation();
+
+  const signUpFallbackUrl = generateFallbackSignUpUrl(searchParams);
 
   const [formInputs, setFormInputs] = useState<Record<string, string>>({});
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -141,6 +131,7 @@ export default function SignInBox(): JSX.Element {
                             fieldErrors={fieldErrors}
                             isLoading={isLoading}
                             additionalData={additionalData}
+                            signUpFallbackUrl={signUpFallbackUrl}
                             resolve={(template) =>
                               resolveAll(template, {
                                 [TemplateLiteralType.TRANSLATION]: t,
@@ -183,47 +174,6 @@ export default function SignInBox(): JSX.Element {
             )
           }
         </SignIn>
-
-        <SignUp>
-          {({components}: any) => {
-            if (components && components.length > 0) {
-              return (
-                <Typography sx={{textAlign: 'center', mt: 2}}>
-                  <Trans i18nKey="signin:redirect.to.signup">
-                    Don&apos;t have an account?
-                    <Button
-                      variant="text"
-                      onClick={() => {
-                        const currentParams: string = searchParams.toString();
-                        const createUrl: string = currentParams
-                          ? `${ROUTES.AUTH.SIGN_UP}?${currentParams}`
-                          : ROUTES.AUTH.SIGN_UP;
-
-                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                        navigate(createUrl);
-                      }}
-                      sx={{
-                        p: 0,
-                        minWidth: 'auto',
-                        textTransform: 'none',
-                        color: 'primary.main',
-                        textDecoration: 'underline',
-                        '&:hover': {
-                          textDecoration: 'underline',
-                          backgroundColor: 'transparent',
-                        },
-                      }}
-                    >
-                      Sign up
-                    </Button>
-                  </Trans>
-                </Typography>
-              );
-            }
-
-            return null;
-          }}
-        </SignUp>
       </StyledPaper>
     </Stack>
   );

--- a/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignInBox.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignInBox.test.tsx
@@ -49,10 +49,12 @@ vi.mock('@thunder/shared-branding', () => ({
 }));
 
 // Mock useTemplateLiteralResolver
+const mockResolveAll = vi.fn().mockImplementation((template: string) => template);
 vi.mock('@thunder/shared-hooks', () => ({
   useTemplateLiteralResolver: () => ({
     resolve: (key: string) => key,
-    resolveAll: (key: string) => key,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    resolveAll: (...args: [string, Record<string, (key: string) => string | undefined>?]) => mockResolveAll(...args),
   }),
 }));
 
@@ -95,6 +97,8 @@ interface MockSignInRenderProps {
   components: MockFlowComponent[];
   error: {message?: string} | null;
   isInitialized: boolean;
+  meta?: Record<string, unknown>;
+  additionalData?: Record<string, unknown>;
 }
 
 interface MockSignUpRenderProps {
@@ -108,6 +112,7 @@ const createMockSignInRenderProps = (overrides: Partial<MockSignInRenderProps> =
   components: [],
   error: null,
   isInitialized: true,
+  meta: {},
   ...overrides,
 });
 
@@ -148,6 +153,7 @@ vi.mock('@asgardeo/react', async () => {
 describe('SignInBox', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockResolveAll.mockImplementation((template: string) => template);
     mockUseDesign.mockReturnValue({
       isDesignEnabled: false,
     });
@@ -496,26 +502,44 @@ describe('SignInBox', () => {
   });
 
   it('renders sign up redirect link when signup components exist', () => {
-    mockSignUpRenderProps = createMockSignUpRenderProps({
-      components: [{id: 'signup-form', type: 'BLOCK'}],
+    mockResolveAll.mockImplementation(
+      (template: string, handlers?: Record<string, (key: string) => string | undefined>) =>
+        template.replace(/\{\{meta\(([^)]+)\)\}\}/g, (_match, path: string) => handlers?.meta?.(path) ?? _match),
+    );
+    mockSignInRenderProps = createMockSignInRenderProps({
+      meta: {is_registration_flow_enabled: 'true'},
+      components: [
+        {
+          id: 'rich-text-signup',
+          type: 'RICH_TEXT',
+          label: '<p>Don\'t have an account? <a href="{{meta(application.signUpUrl)}}">Sign up</a></p>',
+        },
+      ],
     });
     render(<SignInBox />);
     expect(screen.getByText('Sign up')).toBeInTheDocument();
   });
 
   it('navigates to sign up page when clicking sign up link', async () => {
-    mockSignUpRenderProps = createMockSignUpRenderProps({
-      components: [{id: 'signup-form', type: 'BLOCK'}],
+    mockResolveAll.mockImplementation(
+      (template: string, handlers?: Record<string, (key: string) => string | undefined>) =>
+        template.replace(/\{\{meta\(([^)]+)\)\}\}/g, (_match, path: string) => handlers?.meta?.(path) ?? _match),
+    );
+    mockSignInRenderProps = createMockSignInRenderProps({
+      meta: {is_registration_flow_enabled: 'true'},
+      components: [
+        {
+          id: 'rich-text-signup',
+          type: 'RICH_TEXT',
+          label: '<p>Don\'t have an account? <a href="{{meta(application.signUpUrl)}}">Sign up</a></p>',
+        },
+      ],
     });
     render(<SignInBox />);
 
     const signUpLink = screen.getByText('Sign up');
-    await userEvent.click(signUpLink);
-
-    // Navigate is called with /signup or /signup with query params
-    expect(mockNavigate).toHaveBeenCalled();
-    const navigateCalls = mockNavigate.mock.calls;
-    expect(navigateCalls[0][0]).toMatch(/^\/signup/);
+    // Sign-up link is now a plain anchor using the fallback URL
+    expect(signUpLink.closest('a')).toHaveAttribute('href', '/signup');
   });
 
   it('renders correctly when design is enabled', () => {
@@ -642,24 +666,25 @@ describe('SignInBox', () => {
   });
 
   it('navigates to sign up with query params preserved', async () => {
-    vi.mock('react-router', async () => {
-      const actual = await vi.importActual('react-router');
-      return {
-        ...actual,
-        useNavigate: () => mockNavigate,
-        useSearchParams: () => [new URLSearchParams('client_id=test&redirect_uri=http://example.com'), vi.fn()],
-      };
-    });
-
-    mockSignUpRenderProps = createMockSignUpRenderProps({
-      components: [{id: 'signup-form', type: 'BLOCK'}],
+    mockResolveAll.mockImplementation(
+      (template: string, handlers?: Record<string, (key: string) => string | undefined>) =>
+        template.replace(/\{\{meta\(([^)]+)\)\}\}/g, (_match, path: string) => handlers?.meta?.(path) ?? _match),
+    );
+    mockSignInRenderProps = createMockSignInRenderProps({
+      meta: {is_registration_flow_enabled: 'true'},
+      components: [
+        {
+          id: 'rich-text-signup',
+          type: 'RICH_TEXT',
+          label: '<p>Don\'t have an account? <a href="{{meta(application.signUpUrl)}}">Sign up</a></p>',
+        },
+      ],
     });
 
     render(<SignInBox />);
     const signUpLink = screen.getByText('Sign up');
-    await userEvent.click(signUpLink);
-
-    expect(mockNavigate).toHaveBeenCalled();
+    // Sign-up link is now a plain anchor using the fallback URL
+    expect(signUpLink.closest('a')).toHaveAttribute('href', '/signup');
   });
 
   it('handles password input change', async () => {
@@ -1926,16 +1951,25 @@ describe('SignInBox', () => {
   });
 
   it('handles sign up link navigation', async () => {
-    mockSignUpRenderProps = createMockSignUpRenderProps({
-      components: [{id: 'signup-form', type: 'BLOCK'}],
+    mockResolveAll.mockImplementation(
+      (template: string, handlers?: Record<string, (key: string) => string | undefined>) =>
+        template.replace(/\{\{meta\(([^)]+)\)\}\}/g, (_match, path: string) => handlers?.meta?.(path) ?? _match),
+    );
+    mockSignInRenderProps = createMockSignInRenderProps({
+      meta: {is_registration_flow_enabled: 'true'},
+      components: [
+        {
+          id: 'rich-text-signup',
+          type: 'RICH_TEXT',
+          label: '<p>Don\'t have an account? <a href="{{meta(application.signUpUrl)}}">Sign up</a></p>',
+        },
+      ],
     });
     render(<SignInBox />);
 
     const signUpLink = screen.getByText('Sign up');
-    await userEvent.click(signUpLink);
-
-    // Navigate is called (with or without query params depending on mock state)
-    expect(mockNavigate).toHaveBeenCalled();
+    // Sign-up link is now a plain anchor using the fallback URL
+    expect(signUpLink.closest('a')).toHaveAttribute('href', '/signup');
   });
 
   it('renders social login trigger with missing label and image', () => {

--- a/frontend/apps/thunder-gate/src/components/flow/FlowComponentRenderer.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/FlowComponentRenderer.tsx
@@ -76,6 +76,7 @@ export default function FlowComponentRenderer({
   onValidate,
   maxImageSize,
   additionalData,
+  signUpFallbackUrl,
 }: FlowComponentRendererProps): JSX.Element | null {
   const comp = component as FlowComponent;
 
@@ -86,7 +87,7 @@ export default function FlowComponentRenderer({
 
   // RICH_TEXT
   if (comp.type === 'RICH_TEXT') {
-    return <RichTextAdapter component={comp} resolve={resolve} />;
+    return <RichTextAdapter component={comp} resolve={resolve} signUpFallbackUrl={signUpFallbackUrl} />;
   }
 
   // IMAGE
@@ -112,6 +113,7 @@ export default function FlowComponentRenderer({
         onInputChange={onInputChange}
         onSubmit={onSubmit}
         onValidate={onValidate}
+        signUpFallbackUrl={signUpFallbackUrl}
       />
     );
   }
@@ -155,6 +157,7 @@ export default function FlowComponentRenderer({
             onInputChange={onInputChange}
             onSubmit={onSubmit}
             onValidate={onValidate}
+            signUpFallbackUrl={signUpFallbackUrl}
           />
         </>
       );
@@ -172,6 +175,7 @@ export default function FlowComponentRenderer({
         onInputChange={onInputChange}
         onSubmit={onSubmit}
         onValidate={onValidate}
+        signUpFallbackUrl={signUpFallbackUrl}
       />
     );
   }

--- a/frontend/apps/thunder-gate/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/adapters/BlockAdapter.tsx
@@ -21,6 +21,7 @@ import {Box, Button} from '@wso2/oxygen-ui';
 import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type EmbeddedFlowComponent} from '@asgardeo/react';
 import {useTranslation} from 'react-i18next';
 import getIntegrationIcon from '../../../utils/getIntegrationIcon';
+import RichTextAdapter from './RichTextAdapter';
 import TextInputAdapter from './TextInputAdapter';
 import PasswordInputAdapter from './PasswordInputAdapter';
 import OtpInputAdapter from './OtpInputAdapter';
@@ -42,6 +43,8 @@ interface BlockContext {
   hasMultipleSubmits?: boolean;
   /** ID of the primary submit action that stays as type="submit" */
   primarySubmitId?: string;
+  /** Fallback sign-up URL for RICH_TEXT elements that embed `application.signUpUrl` */
+  signUpFallbackUrl?: string;
 }
 
 interface SubmitButtonAdapterProps {
@@ -179,6 +182,17 @@ function renderFormSubComponent(
 
   if (sub.type === 'SELECT') {
     return <SelectAdapter key={sub.id ?? compIndex} {...fieldProps} />;
+  }
+
+  if (sub.type === 'RICH_TEXT') {
+    return (
+      <RichTextAdapter
+        key={sub.id ?? compIndex}
+        component={sub}
+        resolve={ctx.resolve}
+        signUpFallbackUrl={ctx.signUpFallbackUrl}
+      />
+    );
   }
 
   if (

--- a/frontend/apps/thunder-gate/src/components/flow/adapters/RichTextAdapter.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/adapters/RichTextAdapter.tsx
@@ -19,22 +19,69 @@
 import type {JSX} from 'react';
 import {Box} from '@wso2/oxygen-ui';
 import {useDesign} from '@thunder/shared-design';
+import {containsMetaTemplate, replaceMetaTemplate} from '@thunder/utils';
+import DOMPurify from 'dompurify';
 import type {FlowComponent} from '../../../models/flow';
+
+/** The meta key used by the server to embed the application's sign-up URL. */
+const SIGN_UP_URL_META_KEY = 'application.signUpUrl';
+
+/** The meta key that controls whether self registration is enabled. */
+const REGISTRATION_ENABLED_META_KEY = 'is_registration_flow_enabled';
 
 interface RichTextAdapterProps {
   component: FlowComponent;
   resolve: (template: string | undefined) => string | undefined;
+  /**
+   * Fallback sign-up URL used when the flow meta does not supply
+   * `application.signUpUrl` but self registration is enabled.
+   */
+  signUpFallbackUrl?: string;
 }
 
-export default function RichTextAdapter({component, resolve}: RichTextAdapterProps): JSX.Element {
+export default function RichTextAdapter({
+  component,
+  resolve,
+  signUpFallbackUrl = undefined,
+}: RichTextAdapterProps): JSX.Element | null {
   const {isDesignEnabled} = useDesign();
-  const resolvedLabel = resolve(typeof component.label === 'string' ? component.label : undefined);
+  const rawLabel = typeof component.label === 'string' ? component.label : undefined;
+
+  // When any component label embeds a sign-up URL meta template we treat the
+  // whole element as the "sign up link" block.  Show it only when self
+  // registration is enabled; hide it entirely otherwise.
+  if (rawLabel && containsMetaTemplate(rawLabel, SIGN_UP_URL_META_KEY)) {
+    const isRegistrationEnabled = resolve(`{{meta(${REGISTRATION_ENABLED_META_KEY})}}`) === 'true';
+
+    if (!isRegistrationEnabled) {
+      return null;
+    }
+
+    // Resolve the label so all other meta/i18n tokens are processed first.
+    let resolvedLabel = resolve(rawLabel) ?? rawLabel;
+
+    // If the sign-up URL token is still present after resolution (i.e. the
+    // server did not provide application.signUpUrl in meta), substitute the
+    // fallback URL so the link still works.
+    if (containsMetaTemplate(resolvedLabel, SIGN_UP_URL_META_KEY) && signUpFallbackUrl) {
+      resolvedLabel = replaceMetaTemplate(resolvedLabel, SIGN_UP_URL_META_KEY, signUpFallbackUrl);
+    }
+
+    return (
+      <Box
+        sx={{mb: 1, textAlign: isDesignEnabled ? 'center' : 'left'}}
+        dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(resolvedLabel)}}
+      />
+    );
+  }
+
+  const resolvedLabel = resolve(rawLabel);
 
   return (
     <Box
       sx={{mb: 1, textAlign: isDesignEnabled ? 'center' : 'left'}}
       dangerouslySetInnerHTML={{
-        __html: resolvedLabel ?? (typeof component.label === 'string' ? component.label : ''),
+        __html: DOMPurify.sanitize(resolvedLabel ?? rawLabel ?? ''),
       }}
     />
   );

--- a/frontend/apps/thunder-gate/src/components/flow/adapters/StackAdapter.tsx
+++ b/frontend/apps/thunder-gate/src/components/flow/adapters/StackAdapter.tsx
@@ -35,6 +35,7 @@ interface StackAdapterProps {
   onInputChange?: (field: string, value: string) => void;
   onSubmit?: (action: EmbeddedFlowComponent, inputs: Record<string, string>) => void;
   onValidate?: (components: EmbeddedFlowComponent[]) => boolean;
+  signUpFallbackUrl?: string;
 }
 
 export default function StackAdapter({
@@ -47,6 +48,7 @@ export default function StackAdapter({
   onInputChange = () => {},
   onSubmit = () => {},
   onValidate = undefined,
+  signUpFallbackUrl = undefined,
 }: StackAdapterProps): JSX.Element {
   const nestedComponents = (component.components ?? []) as FlowComponent[];
 
@@ -71,6 +73,7 @@ export default function StackAdapter({
           onSubmit={onSubmit}
           onValidate={onValidate}
           maxImageSize={STACK_IMAGE_MAX_SIZE}
+          signUpFallbackUrl={signUpFallbackUrl}
         />
       ))}
     </Stack>

--- a/frontend/apps/thunder-gate/src/models/flow.ts
+++ b/frontend/apps/thunder-gate/src/models/flow.ts
@@ -129,4 +129,9 @@ export interface FlowComponentRendererProps {
   maxImageSize?: number;
   /** Additional step data from the flow response */
   additionalData?: Record<string, unknown>;
+  /**
+   * Fallback sign-up URL used when the flow meta contains a sign-up URL template
+   * but `application.signUpUrl` is absent from the meta object.
+   */
+  signUpFallbackUrl?: string;
 }

--- a/frontend/apps/thunder-gate/src/utils/__tests__/generateFallbackSignUpUrl.test.ts
+++ b/frontend/apps/thunder-gate/src/utils/__tests__/generateFallbackSignUpUrl.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import generateFallbackSignUpUrl from '../generateFallbackSignUpUrl';
+
+describe('generateFallbackSignUpUrl', () => {
+  let originalBaseUrl: string;
+
+  beforeEach(() => {
+    originalBaseUrl = import.meta.env.BASE_URL;
+  });
+
+  afterEach(() => {
+    import.meta.env.BASE_URL = originalBaseUrl;
+  });
+
+  describe('base URL handling', () => {
+    it('should produce a URL that ends with the sign-up path when BASE_URL has a trailing slash', () => {
+      import.meta.env.BASE_URL = '/gate/';
+      const result = generateFallbackSignUpUrl(new URLSearchParams());
+
+      expect(result).toBe('/gate/signup');
+    });
+
+    it('should produce a URL that ends with the sign-up path when BASE_URL has no trailing slash', () => {
+      import.meta.env.BASE_URL = '/gate';
+      const result = generateFallbackSignUpUrl(new URLSearchParams());
+
+      expect(result).toBe('/gate/signup');
+    });
+
+    it('should handle a root BASE_URL with trailing slash', () => {
+      import.meta.env.BASE_URL = '/';
+      const result = generateFallbackSignUpUrl(new URLSearchParams());
+
+      expect(result).toBe('/signup');
+    });
+
+    it('should handle an empty BASE_URL', () => {
+      import.meta.env.BASE_URL = '';
+      const result = generateFallbackSignUpUrl(new URLSearchParams());
+
+      expect(result).toBe('/signup');
+    });
+  });
+
+  describe('query string handling', () => {
+    it('should append a single query parameter', () => {
+      import.meta.env.BASE_URL = '/gate/';
+      const params = new URLSearchParams({client_id: 'abc'});
+      const result = generateFallbackSignUpUrl(params);
+
+      expect(result).toBe('/gate/signup?client_id=abc');
+    });
+
+    it('should append multiple query parameters', () => {
+      import.meta.env.BASE_URL = '/gate/';
+      const params = new URLSearchParams({client_id: 'abc', redirect_uri: 'https://example.com/callback'});
+      const result = generateFallbackSignUpUrl(params);
+
+      // URLSearchParams serialises in insertion order.
+      expect(result).toContain('/gate/signup?');
+      expect(result).toContain('client_id=abc');
+      expect(result).toContain('redirect_uri=');
+    });
+
+    it('should not append a "?" when there are no query params', () => {
+      import.meta.env.BASE_URL = '/gate/';
+      const result = generateFallbackSignUpUrl(new URLSearchParams());
+
+      expect(result).not.toContain('?');
+    });
+
+    it('should return only the sign-up path when params are empty', () => {
+      import.meta.env.BASE_URL = '/';
+      const result = generateFallbackSignUpUrl(new URLSearchParams());
+
+      expect(result).toBe('/signup');
+    });
+  });
+});

--- a/frontend/apps/thunder-gate/src/utils/generateFallbackSignUpUrl.ts
+++ b/frontend/apps/thunder-gate/src/utils/generateFallbackSignUpUrl.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import ROUTES from '../constants/routes';
+
+/**
+ * Generate a fallback sign-up URL preserving the current query string.
+ *
+ * Used when self sign-up is enabled but the flow meta does not provide an
+ * explicit `application.signUpUrl`.  The generated URL preserves whatever
+ * query parameters are currently in the address bar so the auth flow context
+ * (e.g. `client_id`, `redirect_uri`) is carried over.
+ *
+ * @param searchParams - The current {@link URLSearchParams} from the page URL.
+ * @returns A absolute-path URL string pointing to the sign-up route.
+ *
+ * @example
+ * ```ts
+ * // BASE_URL = '/gate/', URL: /gate/login?client_id=abc
+ * generateFallbackSignUpUrl(searchParams);
+ * // => '/gate/signup?client_id=abc'
+ *
+ * // BASE_URL = '/', URL: /login (no query params)
+ * generateFallbackSignUpUrl(searchParams);
+ * // => '/signup'
+ * ```
+ */
+export default function generateFallbackSignUpUrl(searchParams: URLSearchParams): string {
+  // import.meta.env.BASE_URL is injected by Vite (e.g. '/gate/' or '/').
+  // Strip the trailing slash so concatenation with the route path works cleanly.
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const signUpPath = `${base}${ROUTES.AUTH.SIGN_UP}`;
+  const currentParams: string = searchParams.toString();
+
+  return currentParams ? `${signUpPath}?${currentParams}` : signUpPath;
+}

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -1601,7 +1601,9 @@ const translations = {
     'core.elements.richText.placeholder': 'Enter text here...',
     'core.elements.richText.resolvedI18nValue': 'Resolved i18n value',
     'core.elements.richText.linkEditor.urlTypeLabel': 'URL Type',
-    'core.elements.richText.linkEditor.placeholder': 'Enter URL',
+    'core.elements.richText.linkEditor.placeholder': 'Type or paste a link',
+    'core.elements.richText.linkEditor.textPlaceholder': 'Text',
+    'core.elements.richText.linkEditor.apply': 'Apply',
     'core.elements.richText.linkEditor.editLink': 'Edit Link',
     'core.elements.richText.linkEditor.viewLink': 'Link',
 

--- a/frontend/packages/thunder-utils/src/index.ts
+++ b/frontend/packages/thunder-utils/src/index.ts
@@ -30,6 +30,7 @@ export {default as merge} from './object/merge';
 // Template Pattern Utilities
 export {default as isI18nTemplatePattern, I18N_PATTERN, I18N_KEY_PATTERN} from './template/isI18nTemplatePattern';
 export {default as isMetaTemplatePattern, META_PATTERN, META_KEY_PATTERN} from './template/isMetaTemplatePattern';
+export {default as containsMetaTemplate, replaceMetaTemplate} from './template/containsMetaTemplate';
 export {
   default as parseTemplateLiteral,
   TEMPLATE_LITERAL_REGEX,

--- a/frontend/packages/thunder-utils/src/template/__tests__/containsMetaTemplate.test.ts
+++ b/frontend/packages/thunder-utils/src/template/__tests__/containsMetaTemplate.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import containsMetaTemplate, {replaceMetaTemplate} from '../containsMetaTemplate';
+
+describe('containsMetaTemplate', () => {
+  describe('returns true when meta template is present', () => {
+    it('should detect an exact meta template', () => {
+      expect(containsMetaTemplate('{{meta(application.signUpUrl)}}', 'application.signUpUrl')).toBe(true);
+    });
+
+    it('should detect a meta template embedded in an HTML string', () => {
+      expect(
+        containsMetaTemplate('<a href="{{meta(application.signUpUrl)}}">Sign up</a>', 'application.signUpUrl'),
+      ).toBe(true);
+    });
+
+    it('should allow whitespace around double braces', () => {
+      expect(containsMetaTemplate('{{ meta(application.signUpUrl) }}', 'application.signUpUrl')).toBe(true);
+    });
+
+    it('should allow whitespace inside the braces only', () => {
+      expect(containsMetaTemplate('{{  meta(application.signUpUrl)  }}', 'application.signUpUrl')).toBe(true);
+    });
+
+    it('should detect the template when it appears in the middle of text', () => {
+      expect(containsMetaTemplate('Hello {{meta(ou.name)}} world', 'ou.name')).toBe(true);
+    });
+
+    it('should detect a meta key with dots in it', () => {
+      expect(containsMetaTemplate('{{meta(application.loginPageUrl)}}', 'application.loginPageUrl')).toBe(true);
+    });
+
+    it('should find the template among multiple tokens', () => {
+      expect(
+        containsMetaTemplate('{{meta(ou.name)}} and {{meta(application.signUpUrl)}}', 'application.signUpUrl'),
+      ).toBe(true);
+    });
+  });
+
+  describe('returns false when meta template is absent', () => {
+    it('should return false for a plain URL string', () => {
+      expect(containsMetaTemplate('https://example.com/signup', 'application.signUpUrl')).toBe(false);
+    });
+
+    it('should return false when a different key is present', () => {
+      expect(containsMetaTemplate('{{meta(ou.name)}}', 'application.signUpUrl')).toBe(false);
+    });
+
+    it('should return false for an empty string', () => {
+      expect(containsMetaTemplate('', 'application.signUpUrl')).toBe(false);
+    });
+
+    it('should return false for a partial key match', () => {
+      // "signUpUrl" alone should not match "application.signUpUrl"
+      expect(containsMetaTemplate('{{meta(signUpUrl)}}', 'application.signUpUrl')).toBe(false);
+    });
+
+    it('should return false when the meta() call is missing', () => {
+      expect(containsMetaTemplate('{{application.signUpUrl}}', 'application.signUpUrl')).toBe(false);
+    });
+  });
+
+  describe('special regex characters in key', () => {
+    it('should escape dots in the key so they match literally', () => {
+      // A dot in the key should not act as a regex wildcard
+      expect(containsMetaTemplate('{{meta(applicationXsignUpUrl)}}', 'application.signUpUrl')).toBe(false);
+    });
+  });
+});
+
+describe('replaceMetaTemplate', () => {
+  it('should replace a single meta template occurrence', () => {
+    const result = replaceMetaTemplate(
+      '{{meta(application.signUpUrl)}}',
+      'application.signUpUrl',
+      'https://example.com/signup',
+    );
+
+    expect(result).toBe('https://example.com/signup');
+  });
+
+  it('should replace a meta template embedded inside an HTML string', () => {
+    const result = replaceMetaTemplate(
+      '<a href="{{meta(application.signUpUrl)}}">Sign up</a>',
+      'application.signUpUrl',
+      'https://example.com/signup',
+    );
+
+    expect(result).toBe('<a href="https://example.com/signup">Sign up</a>');
+  });
+
+  it('should replace all occurrences globally', () => {
+    const result = replaceMetaTemplate('{{meta(ou.name)}} — {{meta(ou.name)}}', 'ou.name', 'Acme');
+
+    expect(result).toBe('Acme — Acme');
+  });
+
+  it('should replace when there is whitespace around braces', () => {
+    const result = replaceMetaTemplate('{{ meta(application.signUpUrl) }}', 'application.signUpUrl', '/signup');
+
+    expect(result).toBe('/signup');
+  });
+
+  it('should leave other tokens untouched', () => {
+    const result = replaceMetaTemplate(
+      '{{meta(ou.name)}} visits {{meta(application.signUpUrl)}}',
+      'application.signUpUrl',
+      '/signup',
+    );
+
+    expect(result).toBe('{{meta(ou.name)}} visits /signup');
+  });
+
+  it('should return the original string unchanged when the key is not found', () => {
+    const original = 'No template here';
+
+    expect(replaceMetaTemplate(original, 'application.signUpUrl', '/signup')).toBe(original);
+  });
+
+  it('should return an empty string unchanged', () => {
+    expect(replaceMetaTemplate('', 'application.signUpUrl', '/signup')).toBe('');
+  });
+});

--- a/frontend/packages/thunder-utils/src/template/__tests__/isI18nTemplatePattern.test.ts
+++ b/frontend/packages/thunder-utils/src/template/__tests__/isI18nTemplatePattern.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import isI18nTemplatePattern, {I18N_PATTERN, I18N_KEY_PATTERN} from '../isI18nTemplatePattern';
+
+describe('isI18nTemplatePattern', () => {
+  describe('valid i18n patterns', () => {
+    it('should return true for a simple i18n key', () => {
+      expect(isI18nTemplatePattern('{{t(signin:heading)}}')).toBe(true);
+    });
+
+    it('should return true for a key without a namespace', () => {
+      expect(isI18nTemplatePattern('{{t(heading)}}')).toBe(true);
+    });
+
+    it('should return true for a key with nested dots', () => {
+      expect(isI18nTemplatePattern('{{t(common:button.submit)}}')).toBe(true);
+    });
+
+    it('should return true when the value has leading and trailing whitespace', () => {
+      expect(isI18nTemplatePattern('  {{t(signin:heading)}}  ')).toBe(true);
+    });
+  });
+
+  describe('invalid i18n patterns', () => {
+    it('should return false for a plain string', () => {
+      expect(isI18nTemplatePattern('hello world')).toBe(false);
+    });
+
+    it('should return false for a meta template', () => {
+      expect(isI18nTemplatePattern('{{meta(application.name)}}')).toBe(false);
+    });
+
+    it('should return false when the template is embedded in other text', () => {
+      expect(isI18nTemplatePattern('Click {{t(signin:heading)}} here')).toBe(false);
+    });
+
+    it('should return false for missing closing braces', () => {
+      expect(isI18nTemplatePattern('{{t(signin:heading)')).toBe(false);
+    });
+
+    it('should return false for an empty string', () => {
+      expect(isI18nTemplatePattern('')).toBe(false);
+    });
+
+    it('should return false for empty parentheses', () => {
+      expect(isI18nTemplatePattern('{{t()}}')).toBe(false);
+    });
+  });
+});
+
+describe('I18N_PATTERN', () => {
+  it('should match a full i18n template string', () => {
+    expect(I18N_PATTERN.test('{{t(signin:heading)}}')).toBe(true);
+  });
+
+  it('should not match a partial string', () => {
+    expect(I18N_PATTERN.test('prefix{{t(signin:heading)}}')).toBe(false);
+  });
+});
+
+describe('I18N_KEY_PATTERN', () => {
+  it('should capture the key from an i18n template', () => {
+    const match = I18N_KEY_PATTERN.exec('{{t(signin:heading)}}');
+
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('signin:heading');
+  });
+
+  it('should return null for a non-matching string', () => {
+    expect(I18N_KEY_PATTERN.exec('hello')).toBeNull();
+  });
+});

--- a/frontend/packages/thunder-utils/src/template/__tests__/isMetaTemplatePattern.test.ts
+++ b/frontend/packages/thunder-utils/src/template/__tests__/isMetaTemplatePattern.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import isMetaTemplatePattern, {META_PATTERN, META_KEY_PATTERN} from '../isMetaTemplatePattern';
+
+describe('isMetaTemplatePattern', () => {
+  describe('valid meta patterns', () => {
+    it('should return true for a simple meta key', () => {
+      expect(isMetaTemplatePattern('{{meta(application.name)}}')).toBe(true);
+    });
+
+    it('should return true for a key with nested dots', () => {
+      expect(isMetaTemplatePattern('{{meta(ou.description)}}')).toBe(true);
+    });
+
+    it('should return true for a boolean meta key', () => {
+      expect(isMetaTemplatePattern('{{meta(is_registration_flow_enabled)}}')).toBe(true);
+    });
+
+    it('should return true when the value has leading and trailing whitespace', () => {
+      expect(isMetaTemplatePattern('  {{meta(application.name)}}  ')).toBe(true);
+    });
+  });
+
+  describe('invalid meta patterns', () => {
+    it('should return false for a plain string', () => {
+      expect(isMetaTemplatePattern('hello world')).toBe(false);
+    });
+
+    it('should return false for an i18n template', () => {
+      expect(isMetaTemplatePattern('{{t(signin:heading)}}')).toBe(false);
+    });
+
+    it('should return false when the template is embedded in other text', () => {
+      expect(isMetaTemplatePattern('Visit {{meta(application.signUpUrl)}} today')).toBe(false);
+    });
+
+    it('should return false for missing closing braces', () => {
+      expect(isMetaTemplatePattern('{{meta(application.name)')).toBe(false);
+    });
+
+    it('should return false for an empty string', () => {
+      expect(isMetaTemplatePattern('')).toBe(false);
+    });
+
+    it('should return false for empty parentheses', () => {
+      expect(isMetaTemplatePattern('{{meta()}}')).toBe(false);
+    });
+  });
+});
+
+describe('META_PATTERN', () => {
+  it('should match a full meta template string', () => {
+    expect(META_PATTERN.test('{{meta(application.name)}}')).toBe(true);
+  });
+
+  it('should not match a partial string', () => {
+    expect(META_PATTERN.test('prefix{{meta(application.name)}}')).toBe(false);
+  });
+});
+
+describe('META_KEY_PATTERN', () => {
+  it('should capture the key from a meta template', () => {
+    const match = META_KEY_PATTERN.exec('{{meta(application.signUpUrl)}}');
+
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('application.signUpUrl');
+  });
+
+  it('should return null for a non-matching string', () => {
+    expect(META_KEY_PATTERN.exec('hello')).toBeNull();
+  });
+});

--- a/frontend/packages/thunder-utils/src/template/__tests__/parseTemplateLiteral.test.ts
+++ b/frontend/packages/thunder-utils/src/template/__tests__/parseTemplateLiteral.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import parseTemplateLiteral, {
+  TEMPLATE_LITERAL_REGEX,
+  FUNCTION_CALL_REGEX,
+  TemplateLiteralType,
+} from '../parseTemplateLiteral';
+
+describe('parseTemplateLiteral', () => {
+  describe('translation (t) templates', () => {
+    it('should parse a simple translation key', () => {
+      const result = parseTemplateLiteral('t(signin:heading)');
+
+      expect(result.type).toBe(TemplateLiteralType.TRANSLATION);
+      expect(result.key).toBe('signin:heading');
+      expect(result.originalValue).toBe('t(signin:heading)');
+    });
+
+    it('should strip surrounding single quotes from the key', () => {
+      const result = parseTemplateLiteral("t('signin:heading')");
+
+      expect(result.type).toBe(TemplateLiteralType.TRANSLATION);
+      expect(result.key).toBe('signin:heading');
+    });
+
+    it('should strip surrounding double quotes from the key', () => {
+      const result = parseTemplateLiteral('t("signin:heading")');
+
+      expect(result.type).toBe(TemplateLiteralType.TRANSLATION);
+      expect(result.key).toBe('signin:heading');
+    });
+
+    it('should trim whitespace from the key', () => {
+      const result = parseTemplateLiteral('t( signin:heading )');
+
+      expect(result.type).toBe(TemplateLiteralType.TRANSLATION);
+      expect(result.key).toBe('signin:heading');
+    });
+
+    it('should handle a key without a namespace', () => {
+      const result = parseTemplateLiteral('t(heading)');
+
+      expect(result.type).toBe(TemplateLiteralType.TRANSLATION);
+      expect(result.key).toBe('heading');
+    });
+
+    it('should handle a key with nested dots', () => {
+      const result = parseTemplateLiteral('t(common:button.submit)');
+
+      expect(result.type).toBe(TemplateLiteralType.TRANSLATION);
+      expect(result.key).toBe('common:button.submit');
+    });
+  });
+
+  describe('meta templates', () => {
+    it('should parse a simple meta key', () => {
+      const result = parseTemplateLiteral('meta(application.name)');
+
+      expect(result.type).toBe(TemplateLiteralType.META);
+      expect(result.key).toBe('application.name');
+      expect(result.originalValue).toBe('meta(application.name)');
+    });
+
+    it('should parse a boolean meta key', () => {
+      const result = parseTemplateLiteral('meta(is_registration_flow_enabled)');
+
+      expect(result.type).toBe(TemplateLiteralType.META);
+      expect(result.key).toBe('is_registration_flow_enabled');
+    });
+
+    it('should strip surrounding quotes from a meta key', () => {
+      const result = parseTemplateLiteral("meta('application.signUpUrl')");
+
+      expect(result.type).toBe(TemplateLiteralType.META);
+      expect(result.key).toBe('application.signUpUrl');
+    });
+  });
+
+  describe('unknown / unrecognised templates', () => {
+    it('should return UNKNOWN type for a non-function-call format', () => {
+      const result = parseTemplateLiteral('not-a-function-call');
+
+      expect(result.type).toBe(TemplateLiteralType.UNKNOWN);
+      expect(result.key).toBeUndefined();
+      expect(result.originalValue).toBe('not-a-function-call');
+    });
+
+    it('should return UNKNOWN type for an unsupported function name', () => {
+      const result = parseTemplateLiteral('custom(key)');
+
+      expect(result.type).toBe(TemplateLiteralType.UNKNOWN);
+      expect(result.key).toBeUndefined();
+    });
+
+    it('should return UNKNOWN type for an empty string', () => {
+      const result = parseTemplateLiteral('');
+
+      expect(result.type).toBe(TemplateLiteralType.UNKNOWN);
+    });
+  });
+});
+
+describe('TEMPLATE_LITERAL_REGEX', () => {
+  it('should match a double-brace template expression', () => {
+    expect(TEMPLATE_LITERAL_REGEX.test('{{t(signin:heading)}}')).toBe(true);
+  });
+
+  it('should match a template with whitespace inside braces', () => {
+    expect(TEMPLATE_LITERAL_REGEX.test('{{ meta(application.name) }}')).toBe(true);
+  });
+
+  it('should not match a plain string without braces', () => {
+    expect(TEMPLATE_LITERAL_REGEX.test('hello world')).toBe(false);
+  });
+});
+
+describe('FUNCTION_CALL_REGEX', () => {
+  it('should match and capture a function call', () => {
+    const match = FUNCTION_CALL_REGEX.exec('t(signin:heading)');
+
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('t');
+    expect(match?.[2]).toBe('signin:heading');
+  });
+
+  it('should match a meta function call', () => {
+    const match = FUNCTION_CALL_REGEX.exec('meta(application.name)');
+
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('meta');
+    expect(match?.[2]).toBe('application.name');
+  });
+
+  it('should return null for a non-function-call string', () => {
+    expect(FUNCTION_CALL_REGEX.exec('not-a-function')).toBeNull();
+  });
+});

--- a/frontend/packages/thunder-utils/src/template/containsMetaTemplate.ts
+++ b/frontend/packages/thunder-utils/src/template/containsMetaTemplate.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Build a regex that matches `{{ meta(key) }}` (with optional whitespace) anywhere
+ * within a string, escaping any special regex characters in `key`.
+ */
+function buildMetaTemplateRegex(key: string): RegExp {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  return new RegExp(`\\{\\{\\s*meta\\(${escapedKey}\\)\\s*\\}\\}`);
+}
+
+/**
+ * Check whether a string contains a `{{ meta(key) }}` template anywhere within it.
+ *
+ * Unlike {@link isMetaTemplatePattern}, which requires the whole string to be the
+ * template, this function detects the pattern embedded inside a larger string such
+ * as an HTML label.
+ *
+ * Whitespace around `{{` / `}}` is allowed, e.g. `{{ meta(application.signUpUrl) }}`.
+ *
+ * @param str - The string to search (may be a plain value or an HTML fragment).
+ * @param key - The meta key to look for, e.g. `"application.signUpUrl"`.
+ * @returns `true` if the pattern is found anywhere in `str`, `false` otherwise.
+ *
+ * @example
+ * ```typescript
+ * containsMetaTemplate('<a href="{{meta(application.signUpUrl)}}">Sign up</a>', 'application.signUpUrl')
+ * // true
+ *
+ * containsMetaTemplate('<a href="https://example.com">Sign up</a>', 'application.signUpUrl')
+ * // false
+ * ```
+ */
+export default function containsMetaTemplate(str: string, key: string): boolean {
+  return buildMetaTemplateRegex(key).test(str);
+}
+
+/**
+ * Replace all occurrences of `{{ meta(key) }}` (with optional whitespace) in `str`
+ * with `replacement`.
+ *
+ * @param str - The source string.
+ * @param key - The meta key to replace, e.g. `"application.signUpUrl"`.
+ * @param replacement - The value to substitute for each match.
+ * @returns A new string with all occurrences replaced.
+ */
+export function replaceMetaTemplate(str: string, key: string, replacement: string): string {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`\\{\\{\\s*meta\\(${escapedKey}\\)\\s*\\}\\}`, 'g');
+
+  return str.replace(regex, replacement);
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -504,6 +504,9 @@ importers:
       '@wso2/oxygen-ui-icons-react':
         specifier: 'catalog:'
         version: 0.8.0(react@19.2.3)
+      dompurify:
+        specifier: 'catalog:'
+        version: 3.3.0
       i18next:
         specifier: 'catalog:'
         version: 25.6.0(typescript@5.9.3)

--- a/tests/e2e/utils/thunder-setup/mfa-flow-nodes.json
+++ b/tests/e2e/utils/thunder-setup/mfa-flow-nodes.json
@@ -75,6 +75,13 @@
                             "resourceType": "ELEMENT",
                             "type": "ACTION",
                             "variant": "PRIMARY"
+                        },
+                        {
+                            "category": "DISPLAY",
+                            "id": "rich-text-signup",
+                            "resourceType": "ELEMENT",
+                            "type": "RICH_TEXT",
+                            "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.signUpUrl)}}\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>"
                         }
                     ]
                 }


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request introduces support for a new "Self Sign Up Link" widget in the login flow, improves handling of dynamic/template URLs in the rich text editor, and updates references to use the new `application.signUpUrl` meta field. It also streamlines the link editing experience and ensures template URLs are correctly preserved in HTML serialization.

**Self Sign Up Link Widget Support**
- Added a new `SelfSignUpLink` widget type to `WidgetTypes`, `VisualFlowConstants`, and registered it in `widgets.json` with a rich text link to the self-registration page using `{{meta(application.signUpUrl)}}`. [[1]](diffhunk://#diff-28456d031b9038451555b1fe386af70dbaec9b1dc41b5a2a3640252006da8eeaR53) [[2]](diffhunk://#diff-0481757480180804d7c438472cf9d7efefa4e4fcb22ef43fc199f36e2d4e8a2bR87) [[3]](diffhunk://#diff-0481757480180804d7c438472cf9d7efefa4e4fcb22ef43fc199f36e2d4e8a2bR121) [[4]](diffhunk://#diff-31d8481074556866d3d58e1d5a729688a671f355973015411c2b7e05025e8eeaR1114-R1149)

**Meta Field and Template Updates**
- Added `application.signUpUrl` to the list of common meta fields, replacing previous references to `application.selfRegisterUrl` in login flow templates. [[1]](diffhunk://#diff-86889fbff68cb2cbeb90136cdd79ee50a617aa7baca222ced6a1ca6cf31bf9bbR49) [[2]](diffhunk://#diff-18d70afaf790a68cc13b82f37b95c15a89ddc7b5b33f1bd18f5b4813e687eebeL223-R223) [[3]](diffhunk://#diff-18d70afaf790a68cc13b82f37b95c15a89ddc7b5b33f1bd18f5b4813e687eebeL1206-R1206)

**Rich Text Editor Improvements**
- Refactored the link editor UI: removed the "edit/view" mode distinction, allowing direct editing of both link text and URL; added a button to insert dynamic/template values. [[1]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL22-R36) [[2]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL146-R156) [[3]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL400-R414) [[4]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL444-R462)
- Improved handling of template expressions in URLs so that Lexical's URL formatter no longer prepends `https://` to template URLs like `{{meta(...)}}` or `{{t(...)}}`, both in the editor and during HTML serialization. [[1]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eR133-R140) [[2]](diffhunk://#diff-836d9ffbd3fc3277164116a602f061639ef66b6b7889b615d35a7dde78d3a47dR103-R106) [[3]](diffhunk://#diff-836d9ffbd3fc3277164116a602f061639ef66b6b7889b615d35a7dde78d3a47dL171-R179)

**Code Cleanup and Refactoring**
- Removed unused or obsolete state and handlers related to the old link editor mode and URL type selection. [[1]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL171-R187) [[2]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL231-L273) [[3]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL318-R294) [[4]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL362-R332) [[5]](diffhunk://#diff-26baee9e9a215a03e9a7a0850c4d73ba001b3e13465cfcf7846431bfc7c36e5eL374-R378)
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
1. Add new widget in flows
<img width="338" height="576" alt="Screenshot 2026-03-13 at 08 55 19" src="https://github.com/user-attachments/assets/f65f53d4-8ad5-4a87-b0f7-e70a7a310c77" />

2. Remove hardcoded Sign Up URL section in Gate

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/1770

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Self Sign‑Up Link widget, support for application.signUpUrl meta token, and a fallback sign‑up URL threaded through renderers.

* **Bug Fixes**
  * Preserve and correctly serialize template-style URLs in rich text; sanitize rendered HTML to prevent unsafe content.

* **Refactor**
  * Unified link editor into a single text + URL input with an Apply action and dynamic-value support.

* **i18n**
  * Updated link editor copy and added new UI labels.

* **Tests**
  * Added comprehensive tests for template utilities, link editor, and fallback URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->