### PR TITLE
Add a Make command to Run backend in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ run:
 run_backend:
 	./build.sh run_backend $(OS) $(ARCH)
 
+debug_backend:
+	./build.sh debug_backend $(OS) $(ARCH)
+
 run_frontend:
 	./build.sh run_frontend $(OS) $(ARCH)
 
@@ -160,6 +163,7 @@ help:
 	@echo "  test                          - Run all tests (unit and integration)."
 	@echo "  run                           - Build and run the Thunder server locally."
 	@echo "  run_backend                   - Build and run the Thunder backend locally."
+	@echo "  debug_backend                 - Build and run the Thunder backend locally in debug mode."
 	@echo "  run_frontend                  - Build and run the frontend applications locally."
 	@echo "  run_docs                      - Run the documentation development server with live reload."
 	@echo "  docker-build                  - Build single-arch Docker image with version tag."
@@ -180,7 +184,7 @@ help:
 .PHONY: test_unit test_integration build_with_coverage build_with_coverage_only test
 .PHONY: help go_install_tool
 .PHONY: lint lint_backend lint_frontend golangci-lint mockery install-mockery
-.PHONY: run_backend run_frontend run_docs
+.PHONY: run_backend debug_backend run_frontend run_docs
 
 define go_install_tool
 	cd /tmp && \

--- a/build.sh
+++ b/build.sh
@@ -1025,8 +1025,13 @@ function run() {
     wait $BACKEND_PID 2>/dev/null
 }
 
+function debug_backend() {
+    run_backend true true
+}
+
 function run_backend() {
     local show_final_output=${1:-true}
+    local debug=${2:-false}
 
     echo "=== Ensuring server certificates exist ==="
     ensure_certificates "$BACKEND_DIR/$SECURITY_DIR" "server"
@@ -1041,11 +1046,12 @@ function run_backend() {
     echo "Initializing databases..."
     initialize_databases
 
-    start_backend "$show_final_output"
+    start_backend "$show_final_output" "$debug"
 }
 
 function start_backend() {
     local show_final_output=${1:-true}
+    local debug=${2:-false}
 
     # Kill known ports
     function kill_port() {
@@ -1055,9 +1061,18 @@ function start_backend() {
 
     kill_port $PORT
 
-    echo "=== Starting backend on $BASE_URL ==="
-    go run -C "$BACKEND_DIR" . &
-    BACKEND_PID=$!
+    if [ "$debug" = "true" ]; then
+        echo "=== Starting backend on $BASE_URL in debug mode ==="
+        (
+            cd "$BACKEND_DIR" || exit 1
+            dlv debug --headless --listen=127.0.0.1:2345 --api-version=2 --accept-multiclient --continue -- .
+        ) &
+        BACKEND_PID=$!
+    else
+        echo "=== Starting backend on $BASE_URL ==="
+        go run -C "$BACKEND_DIR" . &
+        BACKEND_PID=$!
+    fi
 
     if [ "$show_final_output" = "true" ]; then
         echo ""
@@ -1174,6 +1189,9 @@ case "$1" in
     run_backend)
         run_backend
         ;;
+    debug_backend)
+        debug_backend
+        ;;
     run_frontend)
         run_frontend
         ;;
@@ -1195,6 +1213,7 @@ case "$1" in
         echo "  test                     - Run all tests (unit and integration)"
         echo "  run                      - Run the Thunder server for development (with automatic initial data setup)"
         echo "  run_backend              - Run the Thunder backend for development"
+        echo "  debug_backend            - Run the Thunder backend for development in debug mode"
         echo "  run_frontend             - Run the Thunder frontend for development"
         echo "  run_docs                 - Run the documentation development server with live reload"
         exit 1


### PR DESCRIPTION
### Purpose

This pull request adds support for running the backend in debug mode, making it easier to debug the Thunder server locally. The changes include new commands in the `Makefile` and `build.sh` scripts, as well as logic to launch the backend using `dlv` (Delve) for debugging.

### Approach

* Added a `debug_backend` command to the `Makefile`, which builds and runs the Thunder backend in debug mode.
* Updated the `help` section in the `Makefile` to document the new `debug_backend` command.
* Added a `debug_backend` function to `build.sh`, which invokes `run_backend` with debug flags. [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R1028-R1034) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R1189-R1191)
* Modified the `run_backend` and `start_backend` functions in `build.sh` to accept a debug flag and start the backend with Delve (`dlv debug`) when debugging is enabled. [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L1044-R1054) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R1064-R1072)
* Updated the `build.sh` script's help output to include the new `debug_backend` option.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backend debug mode that can be invoked from the build tooling.

* **Chores**
  * Introduced a new build target for running the backend in debug mode and updated command help/output to reflect the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->