### PR TITLE
Display name UI for user type attributes

### DIFF
--- a/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
@@ -38,7 +38,10 @@ import {Plus, Trash2, Info} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
+import {useResolveDisplayName} from '@thunder/shared-hooks';
+
 import type {SchemaPropertyInput, UIPropertyType} from '../../types/user-types';
+import I18nTextInput from './I18nTextInput';
 
 /**
  * Props for the {@link ConfigureProperties} component.
@@ -53,6 +56,7 @@ export interface ConfigurePropertiesProps {
   displayAttribute: string;
   onDisplayAttributeChange: (displayAttribute: string) => void;
   onReadyChange?: (isReady: boolean) => void;
+  userTypeName?: string;
 }
 
 /**
@@ -68,8 +72,11 @@ export default function ConfigureProperties({
   displayAttribute,
   onDisplayAttributeChange,
   onReadyChange = undefined,
+  userTypeName = undefined,
 }: ConfigurePropertiesProps): JSX.Element {
   const {t} = useTranslation();
+  const {resolveDisplayName} = useResolveDisplayName({handlers: {t}});
+
   const nextId = useRef(properties.length + 1);
 
   // Eligible properties for display attribute: string/enum type, non-credential, with a name
@@ -123,6 +130,7 @@ export default function ConfigureProperties({
     const newProperty: SchemaPropertyInput = {
       id,
       name: '',
+      displayName: '',
       type: 'string',
       required: false,
       unique: false,
@@ -265,6 +273,17 @@ export default function ConfigureProperties({
                 <MenuItem value="enum">{t('userTypes:types.enum')}</MenuItem>
               </Select>
             </FormControl>
+          </Box>
+
+          {/* Display Name with i18n support */}
+          <Box sx={{mt: 2}}>
+            <I18nTextInput
+              label={t('userTypes:displayName', 'Display Name')}
+              value={property.displayName}
+              onChange={(newValue: string) => handlePropertyChange(property.id, 'displayName', newValue)}
+              placeholder={t('userTypes:displayNamePlaceholder', 'e.g., First Name')}
+              defaultNewKey={userTypeName && property.name.trim() ? `${userTypeName}.${property.name.trim()}` : undefined}
+            />
           </Box>
 
           {/* Checkbox options with info tooltips */}
@@ -418,7 +437,9 @@ export default function ConfigureProperties({
                     </Typography>
                   );
                 }
-                return value;
+                const matchedProp = eligibleDisplayProperties.find((p) => p.name.trim() === value);
+                const resolved = matchedProp?.displayName ? resolveDisplayName(matchedProp.displayName) : '';
+                return resolved && resolved !== value ? `${resolved} (${value})` : value;
               }}
             >
               <MenuItem value="">
@@ -426,11 +447,15 @@ export default function ConfigureProperties({
                   {t('common:none', 'None')}
                 </Typography>
               </MenuItem>
-              {eligibleDisplayProperties.map((prop) => (
-                <MenuItem key={prop.id} value={prop.name.trim()}>
-                  {prop.name.trim()}
-                </MenuItem>
-              ))}
+              {eligibleDisplayProperties.map((prop) => {
+                const name = prop.name.trim();
+                const resolved = prop.displayName ? resolveDisplayName(prop.displayName) : '';
+                return (
+                  <MenuItem key={prop.id} value={name}>
+                    {resolved && resolved !== name ? `${resolved} (${name})` : name}
+                  </MenuItem>
+                );
+              })}
             </Select>
           </FormControl>
         </Paper>

--- a/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/I18nTextInput.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/I18nTextInput.tsx
@@ -1,0 +1,491 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {type ChangeEvent, type ReactElement, type SyntheticEvent, useCallback, useMemo, useRef, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {
+  Alert,
+  Autocomplete,
+  type AutocompleteRenderInputParams,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  Divider,
+  FormControl,
+  FormLabel,
+  IconButton,
+  InputAdornment,
+  Popover,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {PlusIcon, SquareFunction, XIcon} from '@wso2/oxygen-ui-icons-react';
+import {useGetLanguages, useGetTranslations, useUpdateTranslation, NamespaceConstants} from '@thunder/i18n';
+import {isI18nTemplatePattern, I18N_KEY_PATTERN} from '@thunder/utils';
+import {useTemplateLiteralResolver} from '@thunder/shared-hooks';
+import {invalidateI18nCache} from '../../../../i18n/invalidate-i18n-cache';
+
+const DEFAULT_LANGUAGE = 'en-US';
+
+/**
+ * Sanitizes a string for use as a translation key.
+ * Replaces spaces with underscores, lowercases, and strips invalid characters.
+ */
+function sanitizeTranslationKey(key: string): string {
+  return key
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-zA-Z0-9._-]/g, '');
+}
+
+/**
+ * Props interface of {@link I18nTextInput}
+ */
+export interface I18nTextInputProps {
+  label: string;
+  value: string;
+  onChange: (newValue: string) => void;
+  placeholder?: string;
+  defaultNewKey?: string;
+}
+
+/**
+ * Props for the i18n content component.
+ */
+interface I18nContentProps {
+  i18nKey: string;
+  isActive: boolean;
+  isCreateMode: boolean;
+  onChange: (key: string) => void;
+  onCreateModeChange: (isCreateMode: boolean) => void;
+  defaultNewKey?: string;
+}
+
+/**
+ * Content component for the i18n popover with select and create modes.
+ */
+function I18nContent({i18nKey, isActive, isCreateMode, onChange, onCreateModeChange, defaultNewKey = undefined}: I18nContentProps): ReactElement {
+  const {t, i18n} = useTranslation();
+  const {data: languagesData} = useGetLanguages();
+  const {data: translationsData, isLoading} = useGetTranslations({
+    language: DEFAULT_LANGUAGE,
+    namespace: NamespaceConstants.CUSTOM_NAMESPACE,
+    enabled: isActive,
+  });
+  const updateTranslation = useUpdateTranslation({
+    onMutationSuccess: () => {
+      invalidateI18nCache();
+    },
+  });
+
+  const sanitizedDefaultKey = defaultNewKey ? sanitizeTranslationKey(defaultNewKey) : '';
+  const [newKey, setNewKey] = useState(sanitizedDefaultKey);
+  const [newValue, setNewValue] = useState('');
+  const [selectedLanguage, setSelectedLanguage] = useState(DEFAULT_LANGUAGE);
+  const [error, setError] = useState<string | null>(null);
+
+  const availableKeys = useMemo(() => {
+    if (!translationsData?.translations) return [];
+
+    const keys: string[] = [];
+    Object.entries(translationsData.translations).forEach(
+      ([namespace, translations]: [string, Record<string, string>]) => {
+        keys.push(...Object.keys(translations).map((key: string) => `${namespace}:${key}`));
+      },
+    );
+    return keys;
+  }, [translationsData]);
+
+  const resolvedValue = useMemo(() => {
+    if (!i18nKey || !translationsData?.translations) return '';
+
+    // i18nKey may be namespaced (e.g. "custom:myKey") — split and look up in the correct namespace
+    const colonIdx = i18nKey.indexOf(':');
+    if (colonIdx !== -1) {
+      const ns = i18nKey.slice(0, colonIdx);
+      const bareKey = i18nKey.slice(colonIdx + 1);
+      return translationsData.translations[ns]?.[bareKey] ?? '';
+    }
+
+    // Bare key — search across all namespaces
+    let found = '';
+    Object.values(translationsData.translations).some((translations: Record<string, string>) => {
+      if (translations[i18nKey]) {
+        found = translations[i18nKey];
+        return true;
+      }
+      return false;
+    });
+    return found;
+  }, [i18nKey, translationsData]);
+
+  const availableLanguages = useMemo(() => {
+    if (languagesData?.languages && languagesData.languages.length > 0) {
+      return languagesData.languages;
+    }
+    return [DEFAULT_LANGUAGE];
+  }, [languagesData]);
+
+  const resetCreateForm = useCallback(() => {
+    setNewKey(sanitizedDefaultKey);
+    setNewValue('');
+    setSelectedLanguage(DEFAULT_LANGUAGE);
+    setError(null);
+  }, [sanitizedDefaultKey]);
+
+  const handleCreate = useCallback(() => {
+    if (!newKey.trim()) {
+      setError(t('userTypes:displayNameI18n.keyRequired', 'Translation key is required'));
+      return;
+    }
+    if (!newValue.trim()) {
+      setError(t('userTypes:displayNameI18n.valueRequired', 'Translation value is required'));
+      return;
+    }
+    if (!/^[a-zA-Z0-9._-]+$/.test(newKey)) {
+      setError(t('userTypes:displayNameI18n.invalidKeyFormat', 'Key may only contain letters, numbers, dots, hyphens, and underscores'));
+      return;
+    }
+
+    updateTranslation.mutate(
+      {
+        language: selectedLanguage,
+        namespace: NamespaceConstants.CUSTOM_NAMESPACE,
+        key: newKey,
+        value: newValue,
+      },
+      {
+        onSuccess: () => {
+          // Synchronously add the new translation to i18next so t() can resolve it
+          // immediately when the parent re-renders (before the async I18nProvider refresh)
+          i18n.addResourceBundle(
+            selectedLanguage,
+            NamespaceConstants.CUSTOM_NAMESPACE,
+            {[newKey]: newValue},
+            true,
+            true,
+          );
+          onChange(`${NamespaceConstants.CUSTOM_NAMESPACE}:${newKey}`);
+          onCreateModeChange(false);
+          resetCreateForm();
+        },
+        onError: (err: Error) => {
+          setError(err.message ?? t('common:errors.unknown'));
+        },
+      },
+    );
+  }, [newKey, newValue, selectedLanguage, updateTranslation, onChange, onCreateModeChange, resetCreateForm, t, i18n]);
+
+  if (isLoading) {
+    return (
+      <Box sx={{display: 'flex', justifyContent: 'center', p: 2}}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+
+  if (isCreateMode) {
+    return (
+      <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
+        {error && (
+          <Alert severity="error" onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        <div>
+          <Typography variant="subtitle2" gutterBottom>
+            {t('userTypes:displayNameI18n.language', 'Language')}
+          </Typography>
+          <Autocomplete
+            options={availableLanguages}
+            value={selectedLanguage}
+            onChange={(_e: SyntheticEvent, newLang: string | null) =>
+              setSelectedLanguage(newLang ?? DEFAULT_LANGUAGE)
+            }
+            renderInput={(params: AutocompleteRenderInputParams) => <TextField {...params} size="small" />}
+            disableClearable
+          />
+        </div>
+        <div>
+          <Typography variant="subtitle2" gutterBottom>
+            {t('userTypes:displayNameI18n.i18nKey', 'Translation Key')}
+          </Typography>
+          <TextField
+            fullWidth
+            size="small"
+            value={newKey}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setNewKey(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="e.g., user.firstName"
+          />
+        </div>
+        <div>
+          <Typography variant="subtitle2" gutterBottom>
+            {t('userTypes:displayNameI18n.translationValue', 'Translation Value')}
+          </Typography>
+          <TextField
+            fullWidth
+            size="small"
+            multiline
+            rows={2}
+            value={newValue}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setNewValue(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="e.g., First Name"
+          />
+        </div>
+        <Box sx={{display: 'flex', gap: 1, justifyContent: 'flex-end'}}>
+          <Button
+            variant="text"
+            onClick={() => {
+              onCreateModeChange(false);
+              resetCreateForm();
+            }}
+          >
+            {t('common:cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={updateTranslation.isPending || !newKey.trim() || !newValue.trim()}
+          >
+            {updateTranslation.isPending ? <CircularProgress size={16} /> : t('common:create')}
+          </Button>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
+      <div>
+        <Typography variant="subtitle2" gutterBottom>
+          {t('userTypes:displayNameI18n.i18nKey', 'Translation Key')}
+        </Typography>
+        <Autocomplete
+          options={availableKeys}
+          value={i18nKey === '' ? null : i18nKey}
+          onChange={(_e: SyntheticEvent, selected: string | null) => onChange(selected ?? '')}
+          renderInput={(params: AutocompleteRenderInputParams) => (
+            <TextField
+              {...params}
+              placeholder={t('userTypes:displayNameI18n.selectKey', 'Select a translation key')}
+              size="small"
+            />
+          )}
+          renderOption={({key, ...props}: React.HTMLAttributes<HTMLLIElement> & {key: string}, option: string) => (
+            <li key={key} {...props}>
+              <span>{option}</span>
+            </li>
+          )}
+        />
+      </div>
+
+      {i18nKey && resolvedValue && (
+        <Box
+          sx={{
+            p: 1.5,
+            backgroundColor: 'action.hover',
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 0.5}}>
+            {t('userTypes:displayNameI18n.resolvedValue', 'Resolved value')}
+          </Typography>
+          <Typography variant="body2" sx={{wordBreak: 'break-word'}}>
+            {resolvedValue}
+          </Typography>
+        </Box>
+      )}
+
+      <Divider />
+
+      <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+        <Tooltip title={t('userTypes:displayNameI18n.createTooltip', 'Create a new translation key')}>
+          <Button variant="text" startIcon={<PlusIcon size={16} />} onClick={() => onCreateModeChange(true)}>
+            {t('userTypes:displayNameI18n.createTitle', 'Create New Translation')}
+          </Button>
+        </Tooltip>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Props for the i18n popover component.
+ */
+interface I18nPopoverProps {
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  value: string;
+  onChange: (newValue: string) => void;
+  defaultNewKey?: string;
+}
+
+/**
+ * Popover with i18n key selection and creation UI.
+ */
+function I18nPopover({open, anchorEl, onClose, value, onChange, defaultNewKey = undefined}: I18nPopoverProps): ReactElement {
+  const {t} = useTranslation();
+  const [isCreateMode, setIsCreateMode] = useState(false);
+
+  const handleClose = useCallback(() => {
+    setIsCreateMode(false);
+    onClose();
+  }, [onClose]);
+
+  const i18nKey = useMemo(() => I18N_KEY_PATTERN.exec(value.trim())?.[1] ?? '', [value]);
+
+  const handleChange = useCallback(
+    (key: string) => {
+      onChange(key ? `{{t(${key})}}` : '');
+    },
+    [onChange],
+  );
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={handleClose}
+      anchorOrigin={{vertical: 'top', horizontal: 'right'}}
+      transformOrigin={{vertical: 'top', horizontal: 'left'}}
+    >
+      <Card sx={{width: 400}}>
+        <CardHeader
+          title={
+            isCreateMode
+              ? t('userTypes:displayNameI18n.createTitle', 'Create New Translation')
+              : t('userTypes:displayNameI18n.title', 'Translation')
+          }
+          action={
+            <IconButton aria-label={t('common:close')} onClick={handleClose} size="small">
+              <XIcon />
+            </IconButton>
+          }
+        />
+        <CardContent>
+          <I18nContent
+            i18nKey={i18nKey}
+            isActive={open}
+            isCreateMode={isCreateMode}
+            onChange={handleChange}
+            onCreateModeChange={setIsCreateMode}
+            defaultNewKey={defaultNewKey}
+          />
+        </CardContent>
+      </Card>
+    </Popover>
+  );
+}
+
+/**
+ * A text input field with an i18n button that opens a popover for selecting
+ * or creating translation keys. Similar to the flow builder's TextPropertyField
+ * but standalone (no flow builder context dependency).
+ */
+export default function I18nTextInput({label, value, onChange, placeholder = undefined, defaultNewKey = undefined}: I18nTextInputProps): ReactElement {
+  const {t} = useTranslation();
+  const {resolve} = useTemplateLiteralResolver();
+  const iconButtonRef = useRef<HTMLButtonElement>(null);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const isDynamic = isI18nTemplatePattern(value);
+  const resolvedValue = isDynamic ? resolve(value, {t}) ?? '' : '';
+
+  return (
+    <FormControl fullWidth>
+      <FormLabel>{label}</FormLabel>
+      <TextField
+        fullWidth
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        placeholder={placeholder}
+        size="small"
+        sx={
+          isDynamic
+            ? {
+                '& .MuiOutlinedInput-root': {
+                  backgroundColor: 'rgba(var(--mui-palette-primary-mainChannel) / 0.1)',
+                  '& fieldset': {borderColor: 'primary.main'},
+                  '&:hover fieldset': {borderColor: 'primary.dark'},
+                  '&.Mui-focused fieldset': {borderColor: 'primary.main'},
+                },
+              }
+            : undefined
+        }
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <Tooltip title={t('userTypes:displayNameI18n.tooltip', 'Configure translation')}>
+                <IconButton
+                  ref={iconButtonRef}
+                  onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                  size="small"
+                  edge="end"
+                  color={isDynamic ? 'primary' : 'default'}
+                >
+                  <SquareFunction size={16} />
+                </IconButton>
+              </Tooltip>
+            </InputAdornment>
+          ),
+        }}
+      />
+      {isDynamic && resolvedValue && (
+        <Box
+          sx={{
+            mt: 1,
+            p: 1.5,
+            backgroundColor: 'action.hover',
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 0.5}}>
+            {t('userTypes:displayNameI18n.resolvedValue', 'Resolved value')}
+          </Typography>
+          <Typography variant="body2" sx={{wordBreak: 'break-word'}}>
+            {resolvedValue}
+          </Typography>
+        </Box>
+      )}
+      <I18nPopover
+        open={isPopoverOpen}
+        anchorEl={iconButtonRef.current}
+        onClose={() => setIsPopoverOpen(false)}
+        value={value}
+        onChange={onChange}
+        defaultNewKey={defaultNewKey}
+      />
+    </FormControl>
+  );
+}

--- a/frontend/apps/thunder-develop/src/features/user-types/contexts/UserTypeCreate/UserTypeCreateProvider.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/contexts/UserTypeCreate/UserTypeCreateProvider.tsx
@@ -36,6 +36,7 @@ const INITIAL_STATE = {
     {
       id: '1',
       name: '',
+      displayName: '',
       type: 'string' as const,
       required: false,
       unique: false,

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/CreateUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/CreateUserTypePage.tsx
@@ -162,6 +162,7 @@ export default function CreateUserTypePage(): JSX.Element {
       const propDef: Partial<PropertyDefinition> = {
         type: actualType,
         required: prop.required,
+        ...(prop.displayName.trim() ? {displayName: prop.displayName.trim()} : {}),
       };
 
       if (actualType === 'string' || actualType === 'number') {
@@ -268,6 +269,7 @@ export default function CreateUserTypePage(): JSX.Element {
             displayAttribute={displayAttribute}
             onDisplayAttributeChange={setDisplayAttribute}
             onReadyChange={handlePropertiesStepReadyChange}
+            userTypeName={name.trim()}
           />
         );
       default:

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
@@ -53,11 +53,13 @@ import {
   PageTitle,
 } from '@wso2/oxygen-ui';
 import {ArrowLeft, Edit, Save, X, Trash2, Check} from '@wso2/oxygen-ui-icons-react';
+import {useResolveDisplayName} from '@thunder/shared-hooks';
 import useGetUserType from '../api/useGetUserType';
 import useUpdateUserType from '../api/useUpdateUserType';
 import useDeleteUserType from '../api/useDeleteUserType';
 import useGetOrganizationUnits from '../../organization-units/api/useGetOrganizationUnits';
 import type {PropertyDefinition, UserSchemaDefinition, PropertyType, SchemaPropertyInput} from '../types/user-types';
+import I18nTextInput from '../components/create-user-type/I18nTextInput';
 
 export default function ViewUserTypePage() {
   const navigate = useNavigate();
@@ -67,6 +69,7 @@ export default function ViewUserTypePage() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const {resolveDisplayName} = useResolveDisplayName({handlers: {t}});
 
   const {data: userType, isLoading: isUserTypeLoading, error: userTypeError} = useGetUserType(id);
   const updateUserTypeMutation = useUpdateUserType();
@@ -108,6 +111,7 @@ export default function ViewUserTypePage() {
     const props: SchemaPropertyInput[] = Object.entries(schema).map(([key, value], index) => ({
       id: `${index}`,
       name: key,
+      displayName: 'displayName' in value ? (value.displayName ?? '') : '',
       type: value.type,
       required: value.required ?? false,
       unique: 'unique' in value ? (value.unique ?? false) : false,
@@ -222,6 +226,7 @@ export default function ViewUserTypePage() {
         const propDef: Partial<PropertyDefinition> = {
           type: actualType,
           required: prop.required,
+          ...(prop.displayName.trim() ? {displayName: prop.displayName.trim()} : {}),
         };
 
         if (prop.type === 'string' || prop.type === 'number' || prop.type === 'enum') {
@@ -499,7 +504,9 @@ export default function ViewUserTypePage() {
                         </Typography>
                       );
                     }
-                    return value;
+                    const matchedProp = eligibleDisplayProperties.find((p) => p.name.trim() === value);
+                    const resolved = matchedProp?.displayName ? resolveDisplayName(matchedProp.displayName) : '';
+                    return resolved && resolved !== value ? `${resolved} (${value})` : value;
                   }}
                 >
                   <MenuItem value="">
@@ -507,11 +514,15 @@ export default function ViewUserTypePage() {
                       {t('common:none', 'None')}
                     </Typography>
                   </MenuItem>
-                  {eligibleDisplayProperties.map((prop) => (
-                    <MenuItem key={prop.id} value={prop.name.trim()}>
-                      {prop.name.trim()}
-                    </MenuItem>
-                  ))}
+                  {eligibleDisplayProperties.map((prop) => {
+                    const propName = prop.name.trim();
+                    const resolved = prop.displayName ? resolveDisplayName(prop.displayName) : '';
+                    return (
+                      <MenuItem key={prop.id} value={propName}>
+                        {resolved && resolved !== propName ? `${resolved} (${propName})` : propName}
+                      </MenuItem>
+                    );
+                  })}
                 </Select>
               )}
             </Box>
@@ -533,7 +544,8 @@ export default function ViewUserTypePage() {
               <Table sx={{'& .MuiTableCell-root': {py: 2}}}>
                 <TableHead>
                   <TableRow>
-                    <TableCell sx={{fontWeight: 600}}>Property Name</TableCell>
+                    <TableCell sx={{fontWeight: 600}}>{t('userTypes:propertyName')}</TableCell>
+                    <TableCell sx={{fontWeight: 600}}>{t('userTypes:displayName', 'Display Name')}</TableCell>
                     <TableCell sx={{fontWeight: 600}}>Type</TableCell>
                     <TableCell sx={{fontWeight: 600}}>Required</TableCell>
                     <TableCell sx={{fontWeight: 600}}>Unique</TableCell>
@@ -547,6 +559,16 @@ export default function ViewUserTypePage() {
                         <Typography variant="body2" sx={{fontWeight: 500}}>
                           {key}
                         </Typography>
+                      </TableCell>
+                      <TableCell>
+                        {(() => {
+                          const resolved = value.displayName ? resolveDisplayName(value.displayName) : '';
+                          return (
+                            <Typography variant="body2" color={resolved ? 'text.primary' : 'text.secondary'}>
+                              {resolved || '-'}
+                            </Typography>
+                          );
+                        })()}
                       </TableCell>
                       <TableCell>
                         <Typography
@@ -653,6 +675,14 @@ export default function ViewUserTypePage() {
                         </Select>
                       </FormControl>
                     </Box>
+
+                    <I18nTextInput
+                      label={t('userTypes:displayName', 'Display Name')}
+                      value={property.displayName}
+                      onChange={(newValue: string) => handlePropertyChange(property.id, 'displayName', newValue)}
+                      placeholder={t('userTypes:displayNamePlaceholder', 'e.g., First Name')}
+                      defaultNewKey={name.trim() && property.name.trim() ? `${name.trim()}.${property.name.trim()}` : undefined}
+                    />
 
                     <Stack direction="row" spacing={2}>
                       <FormControlLabel

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/CreateUserTypePage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/CreateUserTypePage.test.tsx
@@ -83,9 +83,13 @@ vi.mock('../../../organization-units/components/OrganizationUnitTreePicker', () 
   ),
 }));
 
-vi.mock('@thunder/utils', () => ({
-  generateRandomHumanReadableIdentifiers: () => ['Alpha Users', 'Beta Users', 'Gamma Users'],
-}));
+vi.mock('@thunder/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunder/utils')>();
+  return {
+    ...actual,
+    generateRandomHumanReadableIdentifiers: () => ['Alpha Users', 'Beta Users', 'Gamma Users'],
+  };
+});
 
 /**
  * Helper to render the wizard page wrapped in provider.

--- a/frontend/apps/thunder-develop/src/features/user-types/types/user-types.ts
+++ b/frontend/apps/thunder-develop/src/features/user-types/types/user-types.ts
@@ -27,6 +27,7 @@
 interface BasePropertyDefinition {
   required?: boolean;
   unique?: boolean;
+  displayName?: string;
 }
 
 /**
@@ -202,6 +203,7 @@ export type UIPropertyType = PropertyType | 'enum';
 export interface SchemaPropertyInput {
   id: string;
   name: string;
+  displayName: string;
   type: UIPropertyType;
   required: boolean;
   unique: boolean;

--- a/frontend/apps/thunder-develop/src/features/users/components/create-user/ConfigureUserDetails.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/components/create-user/ConfigureUserDetails.tsx
@@ -21,6 +21,7 @@ import {useForm} from 'react-hook-form';
 import {Box, Stack, Typography} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import {useResolveDisplayName} from '@thunder/shared-hooks';
 import type {ApiUserSchema} from '../../types/users';
 import renderSchemaField from '../../utils/renderSchemaField';
 
@@ -50,6 +51,7 @@ export default function ConfigureUserDetails({
   onReadyChange = undefined,
 }: ConfigureUserDetailsProps): JSX.Element {
   const {t} = useTranslation();
+  const {resolveDisplayName} = useResolveDisplayName({handlers: {t}});
 
   const {
     control,
@@ -86,7 +88,7 @@ export default function ConfigureUserDetails({
       <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
         {schema.schema &&
           Object.entries(schema.schema).map(([fieldName, fieldDef]) =>
-            renderSchemaField(fieldName, fieldDef, control, errors),
+            renderSchemaField(fieldName, fieldDef, control, errors, resolveDisplayName),
           )}
       </Box>
     </Stack>

--- a/frontend/apps/thunder-develop/src/features/users/pages/ViewUserPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/pages/ViewUserPage.tsx
@@ -39,6 +39,7 @@ import {
 import {ArrowLeft, Edit, Save, X, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
 import {useLogger} from '@thunder/logger/react';
+import {useResolveDisplayName} from '@thunder/shared-hooks';
 import useGetUser from '../api/useGetUser';
 import useGetUserSchemas from '../api/useGetUserSchemas';
 import useGetUserSchema from '../api/useGetUserSchema';
@@ -52,7 +53,9 @@ export default function ViewUserPage() {
   const navigate = useNavigate();
   const {t} = useTranslation();
   const logger = useLogger('ViewUserPage');
+  const {resolveDisplayName} = useResolveDisplayName({handlers: {t}});
   const {userId} = useParams<{userId: string}>();
+
   const [isEditMode, setIsEditMode] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -292,10 +295,17 @@ export default function ViewUserPage() {
                     displayValue = '-';
                   }
 
+                  const fieldDef = userSchema?.schema?.[key];
+                  let attributeLabel = key;
+                  if (fieldDef?.displayName) {
+                    const resolved = resolveDisplayName(fieldDef.displayName);
+                    attributeLabel = resolved || key;
+                  }
+
                   return (
                     <Box key={key}>
                       <Typography variant="caption" color="text.secondary">
-                        {key}
+                        {attributeLabel}
                       </Typography>
                       <Typography variant="body1">{displayValue}</Typography>
                     </Box>
@@ -323,7 +333,7 @@ export default function ViewUserPage() {
               {userSchema?.schema ? (
                 Object.entries(userSchema.schema)
                   .filter(([, fieldDef]) => !((fieldDef.type === 'string' || fieldDef.type === 'number') && fieldDef.credential))
-                  .map(([fieldName, fieldDef]) => renderSchemaField(fieldName, fieldDef, control, errors))
+                  .map(([fieldName, fieldDef]) => renderSchemaField(fieldName, fieldDef, control, errors, resolveDisplayName))
               ) : (
                 <Typography variant="body2" color="text.secondary">
                   No schema available for editing

--- a/frontend/apps/thunder-develop/src/features/users/types/users.ts
+++ b/frontend/apps/thunder-develop/src/features/users/types/users.ts
@@ -134,6 +134,7 @@ export interface UserGroupListResponse {
 export interface BasePropertyDefinition {
   type: string;
   required?: boolean;
+  displayName?: string;
 }
 
 /**

--- a/frontend/apps/thunder-develop/src/features/users/utils/renderSchemaField.tsx
+++ b/frontend/apps/thunder-develop/src/features/users/utils/renderSchemaField.tsx
@@ -30,6 +30,7 @@ import CredentialFieldInput from '../components/CredentialFieldInput';
  * @param fieldDef - The property definition from the schema
  * @param control - React Hook Form control object
  * @param errors - Form validation errors
+ * @param resolveDisplayName - Optional callback to resolve display name (handles plain strings and i18n patterns)
  * @returns A rendered form field component or null for unsupported types
  */
 const renderSchemaField = <T extends Record<string, unknown>>(
@@ -37,9 +38,15 @@ const renderSchemaField = <T extends Record<string, unknown>>(
   fieldDef: PropertyDefinition,
   control: Control<T>,
   errors: FieldErrors<T>,
+  resolveDisplayName?: (displayName: string) => string,
 ) => {
   const isRequired = fieldDef.required ?? false;
-  const fieldLabel = fieldName;
+
+  let fieldLabel = fieldName;
+  if (fieldDef.displayName) {
+    const resolved = resolveDisplayName?.(fieldDef.displayName);
+    fieldLabel = (resolved !== '' ? resolved : undefined) ?? fieldDef.displayName;
+  }
 
   // String fields
   if (fieldDef.type === 'string') {

--- a/frontend/packages/thunder-shared-hooks/src/__tests__/useResolveDisplayName.test.tsx
+++ b/frontend/packages/thunder-shared-hooks/src/__tests__/useResolveDisplayName.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {renderHook} from '@thunder/test-utils';
+import useResolveDisplayName from '../useResolveDisplayName';
+
+describe('useResolveDisplayName', () => {
+  describe('plain text display names', () => {
+    it('should return plain text as-is', () => {
+      const t = vi.fn();
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('First Name')).toBe('First Name');
+      expect(t).not.toHaveBeenCalled();
+    });
+
+    it('should return empty string for empty input', () => {
+      const t = vi.fn();
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('')).toBe('');
+    });
+
+    it('should return empty string for whitespace-only input', () => {
+      const t = vi.fn();
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('   ')).toBe('');
+    });
+  });
+
+  describe('i18n template patterns', () => {
+    it('should resolve a translated i18n pattern', () => {
+      const t = vi.fn((key: string) => {
+        if (key === 'custom:firstName') return 'First Name';
+        return key;
+      });
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('{{t(custom:firstName)}}')).toBe('First Name');
+    });
+
+    it('should return empty string when translation key is missing (t returns raw key)', () => {
+      const t = vi.fn((key: string) => key);
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('{{t(custom:missingKey)}}')).toBe('');
+    });
+
+    it('should return empty string when t returns namespace-stripped key (fallback behavior)', () => {
+      // i18next strips namespace on fallback: "custom:myKey" -> "myKey"
+      const t = vi.fn(() => 'myKey');
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('{{t(custom:myKey)}}')).toBe('');
+    });
+
+    it('should return empty string when t returns undefined', () => {
+      const t = vi.fn(() => undefined as unknown as string);
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('{{t(custom:someKey)}}')).toBe('');
+    });
+
+    it('should handle keys without namespace', () => {
+      const t = vi.fn((key: string) => {
+        if (key === 'greeting') return 'Hello';
+        return key;
+      });
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('{{t(greeting)}}')).toBe('Hello');
+    });
+
+    it('should return empty string for non-namespaced key when t returns the key unchanged', () => {
+      const t = vi.fn((key: string) => key);
+      const {result} = renderHook(() => useResolveDisplayName({handlers: {t}}));
+
+      expect(result.current.resolveDisplayName('{{t(missingKey)}}')).toBe('');
+    });
+  });
+});

--- a/frontend/packages/thunder-shared-hooks/src/index.ts
+++ b/frontend/packages/thunder-shared-hooks/src/index.ts
@@ -18,6 +18,8 @@
 
 export {default as useTemplateLiteralResolver, type TemplateLiteralResolverResult} from './useTemplateLiteralResolver';
 
+export {default as useResolveDisplayName, type ResolveDisplayNameResult} from './useResolveDisplayName';
+
 export {
   default as useCopyToClipboard,
   type UseCopyToClipboardOptions,

--- a/frontend/packages/thunder-shared-hooks/src/useResolveDisplayName.ts
+++ b/frontend/packages/thunder-shared-hooks/src/useResolveDisplayName.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useCallback} from 'react';
+import {isI18nTemplatePattern, type TemplateLiteralHandlers} from '@thunder/utils';
+import useTemplateLiteralResolver from './useTemplateLiteralResolver';
+
+/**
+ * Options for the useResolveDisplayName hook.
+ */
+export interface UseResolveDisplayNameOptions {
+  /** Template literal handlers (typically `{ t }` from `useTranslation()`). */
+  handlers: TemplateLiteralHandlers;
+}
+
+/**
+ * Return type for useResolveDisplayName hook.
+ */
+export interface ResolveDisplayNameResult {
+  /**
+   * Resolves a display name string. If the value is an i18n template pattern,
+   * it resolves the translation. Returns the resolved string, or an empty string
+   * if resolution fails or the value is empty.
+   */
+  resolveDisplayName: (displayName: string) => string;
+}
+
+/**
+ * React hook that provides a memoized function for resolving display names,
+ * handling both plain text and i18n template patterns (e.g. `{{t(namespace:key)}}`).
+ *
+ * For i18n patterns, it checks whether the translation actually resolved to a
+ * meaningful value (not just the raw key) before returning it.
+ *
+ * @param options - Options containing template literal handlers.
+ * @returns Object containing the resolveDisplayName function.
+ *
+ * @example
+ * ```tsx
+ * const { t } = useTranslation();
+ * const { resolveDisplayName } = useResolveDisplayName({ handlers: { t } });
+ * resolveDisplayName('First Name');          // "First Name"
+ * resolveDisplayName('{{t(custom:fname)}}'); // "First Name" (if translation exists)
+ * resolveDisplayName('{{t(custom:fname)}}'); // "" (if translation key is missing)
+ * ```
+ */
+export default function useResolveDisplayName({handlers}: UseResolveDisplayNameOptions): ResolveDisplayNameResult {
+  const {resolve} = useTemplateLiteralResolver();
+
+  const resolveDisplayName = useCallback(
+    (displayName: string): string => {
+      if (!displayName.trim()) return '';
+      if (isI18nTemplatePattern(displayName)) {
+        const resolved = resolve(displayName, handlers);
+        const rawKey = resolve(displayName);
+        // t() strips namespace prefix on fallback (e.g. "custom:key" -> "key"), check both forms
+        const keyWithoutNs = rawKey?.includes(':') ? rawKey.split(':').pop() : rawKey;
+        if (!resolved || resolved === rawKey || resolved === keyWithoutNs) return '';
+        return resolved;
+      }
+      return displayName;
+    },
+    [handlers, resolve],
+  );
+
+  return {resolveDisplayName};
+}


### PR DESCRIPTION
### Purpose
This pull request introduces support for a new `displayName` field across all user schema property types, enabling custom and internationalized display names for properties. The changes span both backend and frontend, ensuring that `displayName` is validated, stored, and rendered with i18n support in the UI. Comprehensive tests are added to verify correct behavior and error handling.

**Backend: User Schema Model Enhancements**

* Added a `displayName` field to all property structs (`string`, `number`, `boolean`, `object`, `array`) and updated their compile functions to support and validate the new field, including error handling for non-string values. [[1]](diffhunk://#diff-0de0c8cdc4da84f3dbd952c15fba59f8abb0af0c4b9422fb47d4a8c8fe9acb45R33) [[2]](diffhunk://#diff-4818559bf72a626d7d38f08a819042fa4eee3ea9d6a51eb279e1b59f173c9d33R32) [[3]](diffhunk://#diff-0d72bba972237a85ef9ec9348f0ef2749ceeb2251bc6e873a6de44861ea1645cR31) [[4]](diffhunk://#diff-1c5cfba20aa31e726f71789c0027ac3a224330236f0c83bad03a447e999fa0b3R30) [[5]](diffhunk://#diff-d5461f917076db6e798b20492cf73e9a5d30d66e932523962a230d23f71a7f9fR31) [[6]](diffhunk://#diff-0de0c8cdc4da84f3dbd952c15fba59f8abb0af0c4b9422fb47d4a8c8fe9acb45R98) [[7]](diffhunk://#diff-4818559bf72a626d7d38f08a819042fa4eee3ea9d6a51eb279e1b59f173c9d33R92) [[8]](diffhunk://#diff-0d72bba972237a85ef9ec9348f0ef2749ceeb2251bc6e873a6de44861ea1645cR69) [[9]](diffhunk://#diff-1c5cfba20aa31e726f71789c0027ac3a224330236f0c83bad03a447e999fa0b3R127) [[10]](diffhunk://#diff-d5461f917076db6e798b20492cf73e9a5d30d66e932523962a230d23f71a7f9fR93) [[11]](diffhunk://#diff-0de0c8cdc4da84f3dbd952c15fba59f8abb0af0c4b9422fb47d4a8c8fe9acb45R130-R135) [[12]](diffhunk://#diff-4818559bf72a626d7d38f08a819042fa4eee3ea9d6a51eb279e1b59f173c9d33R122-R127) [[13]](diffhunk://#diff-0d72bba972237a85ef9ec9348f0ef2749ceeb2251bc6e873a6de44861ea1645cR86-R91) [[14]](diffhunk://#diff-1c5cfba20aa31e726f71789c0027ac3a224330236f0c83bad03a447e999fa0b3R146-R151) [[15]](diffhunk://#diff-d5461f917076db6e798b20492cf73e9a5d30d66e932523962a230d23f71a7f9fR110-R115)

* Added tests to validate successful compilation and error handling for `displayName` on all property types, including i18n patterns and invalid types.

**Frontend: UI and Property Configuration Improvements**

* Updated property creation and editing flows to include a `displayName` field, ensuring it is persisted and handled in state and API interactions. [[1]](diffhunk://#diff-4bee35c1de0724ea4563e6eaa365991b680c48b3c83c8985b30c959474b35f9aR39) [[2]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aR185-R188) [[3]](diffhunk://#diff-0e7b27de7d8f1f1214ac586f5a678abde0f840c165f4118f99dee4211955005aR275) [[4]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R127) [[5]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R259-R262)

* Enhanced `ConfigureProperties` component to support editing `displayName` with i18n template patterns, including resolving translations and displaying fallback values. [[1]](diffhunk://#diff-705ba75638e0cf880f47684cbd474168e53b740f710ebe332a53e0abc8225761R41-R45) [[2]](diffhunk://#diff-705ba75638e0cf880f47684cbd474168e53b740f710ebe332a53e0abc8225761R60) [[3]](diffhunk://#diff-705ba75638e0cf880f47684cbd474168e53b740f710ebe332a53e0abc8225761R76-R93) [[4]](diffhunk://#diff-705ba75638e0cf880f47684cbd474168e53b740f710ebe332a53e0abc8225761R147) [[5]](diffhunk://#diff-705ba75638e0cf880f47684cbd474168e53b740f710ebe332a53e0abc8225761R292-R302) [[6]](diffhunk://#diff-705ba75638e0cf880f47684cbd474168e53b740f710ebe332a53e0abc8225761L421-R472)

* Updated property display attribute selection and property listing to show resolved display names with i18n support, improving usability and clarity for end users. [[1]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R56-R63) [[2]](diffhunk://#diff-2a12b7759e3467a902071407c8350e99bdde9f0aad69824d4800f68f5b165fd3R73-R85)

**Overall, these changes allow user schema properties to have customizable, translatable display names, improving both backend flexibility and frontend user experience.**

### Related Issues
- Resolves https://github.com/asgardeo/thunder/issues/1781

### Related PRs
- https://github.com/asgardeo/thunder/pull/1782

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-property editable i18n-aware Display Name with a dedicated input; new properties include a display name field.
  * I18nTextInput allowing selecting/creating translation keys with live preview.
  * Resolved (localized) display names shown throughout property tables, dropdowns, attribute views, and persisted when provided.
  * Added a shared resolver to consistently compute localized display names across screens.
* **Tests**
  * Added tests covering display-name resolution and i18n patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->