### PR TITLE
Fix Application URL update issues in `Edit` view

### DIFF
--- a/frontend/apps/thunder-develop/src/components/UnsavedChangesBar.tsx
+++ b/frontend/apps/thunder-develop/src/components/UnsavedChangesBar.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Button, Paper, Stack, Typography} from '@wso2/oxygen-ui';
+
+export interface UnsavedChangesBarProps {
+  /** Label for the unsaved changes message. */
+  message: string;
+  /** Label for the reset button. */
+  resetLabel: string;
+  /** Label for the save button in idle state. */
+  saveLabel: string;
+  /** Label for the save button while saving is in progress. */
+  savingLabel: string;
+  /** Whether a save operation is currently in progress. */
+  isSaving: boolean;
+  /** Called when the reset button is clicked. */
+  onReset: () => void;
+  /** Called when the save button is clicked. */
+  onSave: () => void;
+}
+
+/**
+ * A fixed bottom action bar shown when a form has unsaved changes.
+ * Provides reset and save actions.
+ */
+export default function UnsavedChangesBar({
+  message,
+  resetLabel,
+  saveLabel,
+  savingLabel,
+  isSaving,
+  onReset,
+  onSave,
+}: UnsavedChangesBarProps) {
+  return (
+    <Paper
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        p: 2,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        borderRadius: '12px 12px 0 0',
+        boxShadow: '0 -4px 20px rgba(0, 0, 0, 0.1)',
+        zIndex: 1000,
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Stack direction="row" spacing={2} alignItems="center">
+        <Typography variant="body2" sx={{display: 'flex', alignItems: 'center', gap: 1}}>
+          <Box
+            component="span"
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              border: '2px solid',
+              borderColor: 'warning.main',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '12px',
+              fontWeight: 'bold',
+            }}
+          >
+            !
+          </Box>
+          {message}
+        </Typography>
+        <Button variant="outlined" color="error" onClick={onReset}>
+          {resetLabel}
+        </Button>
+        <Button variant="contained" onClick={onSave} disabled={isSaving}>
+          {isSaving ? savingLabel : saveLabel}
+        </Button>
+      </Stack>
+    </Paper>
+  );
+}

--- a/frontend/apps/thunder-develop/src/components/__tests__/UnsavedChangesBar.test.tsx
+++ b/frontend/apps/thunder-develop/src/components/__tests__/UnsavedChangesBar.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UnsavedChangesBar from '../UnsavedChangesBar';
+
+const defaultProps = {
+  message: 'You have unsaved changes',
+  resetLabel: 'Reset',
+  saveLabel: 'Save',
+  savingLabel: 'Saving...',
+  isSaving: false,
+  onReset: vi.fn(),
+  onSave: vi.fn(),
+};
+
+describe('UnsavedChangesBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render the message text', () => {
+      render(<UnsavedChangesBar {...defaultProps} />);
+
+      expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+    });
+
+    it('should render the reset button with the provided label', () => {
+      render(<UnsavedChangesBar {...defaultProps} />);
+
+      expect(screen.getByRole('button', {name: 'Reset'})).toBeInTheDocument();
+    });
+
+    it('should render the save button with saveLabel when not saving', () => {
+      render(<UnsavedChangesBar {...defaultProps} isSaving={false} />);
+
+      expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+    });
+
+    it('should render the save button with savingLabel when saving', () => {
+      render(<UnsavedChangesBar {...defaultProps} isSaving />);
+
+      expect(screen.getByRole('button', {name: 'Saving...'})).toBeInTheDocument();
+    });
+
+    it('should render a warning indicator', () => {
+      render(<UnsavedChangesBar {...defaultProps} />);
+
+      expect(screen.getByText('!')).toBeInTheDocument();
+    });
+  });
+
+  describe('Save Button State', () => {
+    it('should enable the save button when not saving', () => {
+      render(<UnsavedChangesBar {...defaultProps} isSaving={false} />);
+
+      expect(screen.getByRole('button', {name: 'Save'})).not.toBeDisabled();
+    });
+
+    it('should disable the save button when saving is in progress', () => {
+      render(<UnsavedChangesBar {...defaultProps} isSaving />);
+
+      expect(screen.getByRole('button', {name: 'Saving...'})).toBeDisabled();
+    });
+  });
+
+  describe('Interactions', () => {
+    it('should call onReset when the reset button is clicked', async () => {
+      const user = userEvent.setup();
+      const onReset = vi.fn();
+      render(<UnsavedChangesBar {...defaultProps} onReset={onReset} />);
+
+      await user.click(screen.getByRole('button', {name: 'Reset'}));
+
+      expect(onReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onSave when the save button is clicked', async () => {
+      const user = userEvent.setup();
+      const onSave = vi.fn();
+      render(<UnsavedChangesBar {...defaultProps} onSave={onSave} />);
+
+      await user.click(screen.getByRole('button', {name: 'Save'}));
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onSave when the save button is disabled (isSaving)', () => {
+      const onSave = vi.fn();
+      render(<UnsavedChangesBar {...defaultProps} isSaving onSave={onSave} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Saving...'}));
+
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('should not call onReset when save is clicked', async () => {
+      const user = userEvent.setup();
+      const onReset = vi.fn();
+      render(<UnsavedChangesBar {...defaultProps} onReset={onReset} />);
+
+      await user.click(screen.getByRole('button', {name: 'Save'}));
+
+      expect(onReset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Custom Labels', () => {
+    it('should render custom message, resetLabel, saveLabel, and savingLabel', () => {
+      render(
+        <UnsavedChangesBar
+          message="Pending changes detected"
+          resetLabel="Discard"
+          saveLabel="Apply"
+          savingLabel="Applying..."
+          isSaving={false}
+          onReset={vi.fn()}
+          onSave={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Pending changes detected')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Discard'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Apply'})).toBeInTheDocument();
+    });
+
+    it('should render custom savingLabel when isSaving is true', () => {
+      render(
+        <UnsavedChangesBar
+          message="Pending changes"
+          resetLabel="Discard"
+          saveLabel="Apply"
+          savingLabel="Applying..."
+          isSaving
+          onReset={vi.fn()}
+          onSave={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', {name: 'Applying...'})).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/customization-settings/UrlsSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/customization-settings/UrlsSection.tsx
@@ -18,7 +18,6 @@
 
 import {Box, Stack, Typography, TextField} from '@wso2/oxygen-ui';
 import {useTranslation} from 'react-i18next';
-import {useEffect} from 'react';
 import {useForm, Controller} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {z} from 'zod';
@@ -71,7 +70,6 @@ export default function UrlsSection({application, editedApp, onFieldChange}: Url
   const {
     control,
     formState: {errors},
-    watch,
   } = useForm<UrlsFormData>({
     resolver: zodResolver(urlsSchema),
     mode: 'onChange',
@@ -80,21 +78,6 @@ export default function UrlsSection({application, editedApp, onFieldChange}: Url
       policyUri: editedApp.policy_uri ?? application.policy_uri ?? '',
     },
   });
-
-  const tosUri = watch('tosUri');
-  const policyUri = watch('policyUri');
-
-  useEffect(() => {
-    if (tosUri !== (editedApp.tos_uri ?? application.tos_uri ?? '')) {
-      onFieldChange('tos_uri', tosUri);
-    }
-  }, [tosUri, editedApp.tos_uri, application.tos_uri, onFieldChange]);
-
-  useEffect(() => {
-    if (policyUri !== (editedApp.policy_uri ?? application.policy_uri ?? '')) {
-      onFieldChange('policy_uri', policyUri);
-    }
-  }, [policyUri, editedApp.policy_uri, application.policy_uri, onFieldChange]);
 
   return (
     <SettingsCard
@@ -112,6 +95,10 @@ export default function UrlsSection({application, editedApp, onFieldChange}: Url
             render={({field}) => (
               <TextField
                 {...field}
+                onChange={(e) => {
+                  field.onChange(e);
+                  onFieldChange('tos_uri', e.target.value);
+                }}
                 fullWidth
                 placeholder={t('applications:edit.customization.tosUri.placeholder')}
                 error={!!errors.tosUri}
@@ -131,6 +118,10 @@ export default function UrlsSection({application, editedApp, onFieldChange}: Url
             render={({field}) => (
               <TextField
                 {...field}
+                onChange={(e) => {
+                  field.onChange(e);
+                  onFieldChange('policy_uri', e.target.value);
+                }}
                 fullWidth
                 placeholder={t('applications:edit.customization.policyUri.placeholder')}
                 error={!!errors.policyUri}

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
@@ -101,7 +101,6 @@ export default function AccessSection({
   const {
     control,
     formState: {errors},
-    watch,
   } = useForm<GeneralSettingsFormData>({
     resolver: zodResolver(generalSettingsSchema),
     mode: 'onChange',
@@ -109,14 +108,6 @@ export default function AccessSection({
       url: editedApp.url ?? application.url ?? '',
     },
   });
-
-  const url = watch('url');
-
-  useEffect(() => {
-    if (url !== (editedApp.url ?? application.url ?? '')) {
-      onFieldChange('url', url);
-    }
-  }, [url, editedApp.url, application.url, onFieldChange]);
 
   useEffect(() => {
     if (oauth2Config?.redirect_uris) {
@@ -153,7 +144,8 @@ export default function AccessSection({
   };
 
   const handleRemoveUri = (index: number) => {
-    setRedirectUris((prev) => prev.filter((_, i) => i !== index));
+    const newUris = redirectUris.filter((_, i) => i !== index);
+    setRedirectUris(newUris);
     setUriErrors((prev) => {
       const newErrors = {...prev};
       delete newErrors[index];
@@ -171,6 +163,20 @@ export default function AccessSection({
 
       return reindexed;
     });
+
+    if (!oauth2Config) return;
+    const validUris = newUris.filter((uri) => uri.trim() !== '');
+    const updatedConfig = {
+      ...oauth2Config,
+      redirect_uris: validUris,
+    };
+    const updatedInboundAuth = application.inbound_auth_config?.map((config) => {
+      if (config.type === 'oauth2') {
+        return {...config, config: updatedConfig};
+      }
+      return config;
+    });
+    onFieldChange('inbound_auth_config', updatedInboundAuth);
   };
 
   const handleUriChange = (index: number, value: string) => {
@@ -265,6 +271,10 @@ export default function AccessSection({
             render={({field}) => (
               <TextField
                 {...field}
+                onChange={(e) => {
+                  field.onChange(e);
+                  onFieldChange('url', e.target.value);
+                }}
                 fullWidth
                 id="application-url-input"
                 placeholder="https://example.com"
@@ -284,7 +294,9 @@ export default function AccessSection({
 
             <Stack spacing={2} id="redirect-uris-section">
               {redirectUris.map((uri, index) => (
-                <Stack key={uri} direction="row" spacing={1} alignItems="flex-start">
+                // IMPORTANT: Do not remove the suppression since it affects functionality.
+                // eslint-disable-next-line react/no-array-index-key
+                <Stack key={index} direction="row" spacing={1} alignItems="flex-start">
                   <FormControl fullWidth required sx={{flex: 1}}>
                     <TextField
                       fullWidth

--- a/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/pages/ApplicationEditPage.tsx
@@ -23,7 +23,6 @@ import {
   Stack,
   Typography,
   Button,
-  Paper,
   CircularProgress,
   Alert,
   Avatar,
@@ -43,6 +42,7 @@ import useUpdateApplication from '../api/useUpdateApplication';
 import type {Application} from '../models/application';
 import type {OAuth2Config} from '../models/oauth';
 import LogoUpdateModal from '../../../components/LogoUpdateModal';
+import UnsavedChangesBar from '../../../components/UnsavedChangesBar';
 import IntegrationGuides from '../components/edit-application/integration-guides/IntegrationGuides';
 import EditGeneralSettings from '../components/edit-application/general-settings/EditGeneralSettings';
 import EditFlowsSettings from '../components/edit-application/flows-settings/EditFlowsSettings';
@@ -464,58 +464,17 @@ export default function ApplicationEditPage() {
 
       {/* Floating Action Bar */}
       {hasChanges && (
-        <Paper
-          sx={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            p: 2,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 2,
-            borderRadius: '12px 12px 0 0',
-            boxShadow: '0 -4px 20px rgba(0, 0, 0, 0.1)',
-            zIndex: 1000,
-            bgcolor: 'background.paper',
+        <UnsavedChangesBar
+          message={t('applications:edit.page.unsavedChanges')}
+          resetLabel={t('applications:edit.page.reset')}
+          saveLabel={t('applications:edit.page.save')}
+          savingLabel={t('applications:edit.page.saving')}
+          isSaving={updateApplication.isPending}
+          onReset={() => setEditedApp({})}
+          onSave={() => {
+            handleSave().catch(() => {});
           }}
-        >
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Typography variant="body2" sx={{display: 'flex', alignItems: 'center', gap: 1}}>
-              <Box
-                component="span"
-                sx={{
-                  width: 20,
-                  height: 20,
-                  borderRadius: '50%',
-                  border: '2px solid',
-                  borderColor: 'warning.main',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: '12px',
-                  fontWeight: 'bold',
-                }}
-              >
-                !
-              </Box>
-              {t('applications:edit.page.unsavedChanges')}
-            </Typography>
-            <Button variant="outlined" color="error" onClick={() => setEditedApp({})}>
-              {t('applications:edit.page.reset')}
-            </Button>
-            <Button
-              variant="contained"
-              onClick={() => {
-                handleSave().catch(() => {});
-              }}
-              disabled={updateApplication.isPending}
-            >
-              {updateApplication.isPending ? t('applications:edit.page.saving') : t('applications:edit.page.save')}
-            </Button>
-          </Stack>
-        </Paper>
+        />
       )}
     </PageContent>
   );

--- a/frontend/apps/thunder-develop/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
@@ -136,6 +136,38 @@ vi.mock('../../../../components/LogoUpdateModal', () => ({
   ),
 }));
 
+vi.mock('../../../../components/UnsavedChangesBar', () => ({
+  default: vi.fn(
+    ({
+      message,
+      resetLabel,
+      saveLabel,
+      savingLabel,
+      isSaving,
+      onReset,
+      onSave,
+    }: {
+      message: string;
+      resetLabel: string;
+      saveLabel: string;
+      savingLabel: string;
+      isSaving: boolean;
+      onReset: () => void;
+      onSave: () => void;
+    }) => (
+      <div data-testid="unsaved-changes-bar">
+        <span>{message}</span>
+        <button type="button" onClick={onReset}>
+          {resetLabel}
+        </button>
+        <button type="button" onClick={onSave} disabled={isSaving}>
+          {isSaving ? savingLabel : saveLabel}
+        </button>
+      </div>
+    ),
+  ),
+}));
+
 const mockUseGetApplication = useGetApplication as ReturnType<typeof vi.fn>;
 const mockUseUpdateApplication = useUpdateApplication as ReturnType<typeof vi.fn>;
 const mockGetTemplateMetadata = getTemplateMetadata as ReturnType<typeof vi.fn>;

--- a/frontend/apps/thunder-develop/src/features/organization-units/pages/OrganizationUnitEditPage.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/pages/OrganizationUnitEditPage.tsx
@@ -26,7 +26,6 @@ import {
   Typography,
   Button,
   TextField,
-  Paper,
   Alert,
   IconButton,
   CircularProgress,
@@ -51,6 +50,7 @@ import EditUsers from '../components/edit-organization-unit/user-settings/EditUs
 import EditGroups from '../components/edit-organization-unit/group-settings/EditGroupSettings';
 import EditCustomization from '../components/edit-organization-unit/customization-settings/EditCustomizationSettings';
 import LogoUpdateModal from '../../../components/LogoUpdateModal';
+import UnsavedChangesBar from '../../../components/UnsavedChangesBar';
 
 interface TabPanelProps {
   children?: ReactNode;
@@ -463,61 +463,18 @@ export default function OrganizationUnitEditPage(): JSX.Element {
 
       {/* Floating Action Bar */}
       {hasChanges && (
-        <Paper
-          sx={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            p: 2,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 2,
-            borderRadius: '12px 12px 0 0',
-            boxShadow: '0 -4px 20px rgba(0, 0, 0, 0.1)',
-            zIndex: 1000,
-            bgcolor: 'background.paper',
+        <UnsavedChangesBar
+          message={t('organizationUnits:edit.actions.unsavedChanges.label')}
+          resetLabel={t('organizationUnits:edit.actions.reset.label')}
+          saveLabel={t('organizationUnits:edit.actions.save.label')}
+          savingLabel={t('organizationUnits:edit.actions.saving.label')}
+          isSaving={updateOrganizationUnit.isPending}
+          onReset={() => setEditedOU({})}
+          onSave={() => {
+            // Errors are handled in handleSave
+            handleSave().catch(() => {});
           }}
-        >
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Typography variant="body2" sx={{display: 'flex', alignItems: 'center', gap: 1}}>
-              <Box
-                component="span"
-                sx={{
-                  width: 20,
-                  height: 20,
-                  borderRadius: '50%',
-                  border: '2px solid',
-                  borderColor: 'warning.main',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: '12px',
-                  fontWeight: 'bold',
-                }}
-              >
-                !
-              </Box>
-              {t('organizationUnits:edit.actions.unsavedChanges.label')}
-            </Typography>
-            <Button variant="outlined" color="error" onClick={() => setEditedOU({})}>
-              {t('organizationUnits:edit.actions.reset.label')}
-            </Button>
-            <Button
-              variant="contained"
-              onClick={() => {
-                // Errors are handled in handleSave
-                handleSave().catch(() => {});
-              }}
-              disabled={updateOrganizationUnit.isPending}
-            >
-              {updateOrganizationUnit.isPending
-                ? t('organizationUnits:edit.actions.saving.label')
-                : t('organizationUnits:edit.actions.save.label')}
-            </Button>
-          </Stack>
-        </Paper>
+        />
       )}
     </PageContent>
   );

--- a/frontend/apps/thunder-develop/src/features/organization-units/pages/__tests__/OrganizationUnitEditPage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/organization-units/pages/__tests__/OrganizationUnitEditPage.test.tsx
@@ -137,6 +137,39 @@ vi.mock('../../../../components/LogoUpdateModal', () => ({
   ),
 }));
 
+// Mock UnsavedChangesBar
+vi.mock('../../../../components/UnsavedChangesBar', () => ({
+  default: vi.fn(
+    ({
+      message,
+      resetLabel,
+      saveLabel,
+      savingLabel,
+      isSaving,
+      onReset,
+      onSave,
+    }: {
+      message: string;
+      resetLabel: string;
+      saveLabel: string;
+      savingLabel: string;
+      isSaving: boolean;
+      onReset: () => void;
+      onSave: () => void;
+    }) => (
+      <div data-testid="unsaved-changes-bar">
+        <span>{message}</span>
+        <button type="button" onClick={onReset}>
+          {resetLabel}
+        </button>
+        <button type="button" onClick={onSave} disabled={isSaving}>
+          {isSaving ? savingLabel : saveLabel}
+        </button>
+      </div>
+    ),
+  ),
+}));
+
 // Mock translations
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -1071,45 +1104,41 @@ describe('OrganizationUnitEditPage', () => {
   });
 
   describe('Edited OU Fallbacks', () => {
-    it(
-      'should display edited name when re-editing after a name change',
-      async () => {
-        renderWithProviders(<OrganizationUnitEditPage />);
+    it('should display edited name when re-editing after a name change', async () => {
+      renderWithProviders(<OrganizationUnitEditPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Organization Unit')).toBeInTheDocument();
+      });
+
+      // First edit: change name
+      const editButtons = screen.getAllByRole('button');
+      const nameEditButton = editButtons.find(
+        (btn) => btn.querySelector('svg') && btn.closest('div')?.textContent?.includes('Test Organization Unit'),
+      );
+
+      if (nameEditButton) {
+        fireEvent.click(nameEditButton);
+        const nameInput = screen.getByDisplayValue('Test Organization Unit');
+        fireEvent.change(nameInput, {target: {value: 'Updated Name'}});
+        fireEvent.blur(nameInput);
 
         await waitFor(() => {
-          expect(screen.getByText('Test Organization Unit')).toBeInTheDocument();
+          expect(screen.getByText('Updated Name')).toBeInTheDocument();
         });
 
-        // First edit: change name
-        const editButtons = screen.getAllByRole('button');
-        const nameEditButton = editButtons.find(
-          (btn) => btn.querySelector('svg') && btn.closest('div')?.textContent?.includes('Test Organization Unit'),
+        // Second edit: the input should show the edited name
+        const editButtons2 = screen.getAllByRole('button');
+        const nameEditButton2 = editButtons2.find(
+          (btn) => btn.querySelector('svg') && btn.closest('div')?.textContent?.includes('Updated Name'),
         );
 
-        if (nameEditButton) {
-          fireEvent.click(nameEditButton);
-          const nameInput = screen.getByDisplayValue('Test Organization Unit');
-          fireEvent.change(nameInput, {target: {value: 'Updated Name'}});
-          fireEvent.blur(nameInput);
-
-          await waitFor(() => {
-            expect(screen.getByText('Updated Name')).toBeInTheDocument();
-          });
-
-          // Second edit: the input should show the edited name
-          const editButtons2 = screen.getAllByRole('button');
-          const nameEditButton2 = editButtons2.find(
-            (btn) => btn.querySelector('svg') && btn.closest('div')?.textContent?.includes('Updated Name'),
-          );
-
-          if (nameEditButton2) {
-            fireEvent.click(nameEditButton2);
-            expect(screen.getByDisplayValue('Updated Name')).toBeInTheDocument();
-          }
+        if (nameEditButton2) {
+          fireEvent.click(nameEditButton2);
+          expect(screen.getByDisplayValue('Updated Name')).toBeInTheDocument();
         }
-      },
-      15_000,
-    );
+      }
+    }, 15_000);
 
     it('should display edited description when re-editing after a description change', async () => {
       renderWithProviders(<OrganizationUnitEditPage />);


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request introduces a reusable `UnsavedChangesBar` component to standardize the UI and logic for displaying unsaved changes notifications and actions across the application. It also refactors form components to ensure changes are propagated immediately through explicit `onChange` handlers, and cleans up related code for improved maintainability and correctness.

**Componentization and UI Consistency:**

* Added a new reusable `UnsavedChangesBar` component in `frontend/apps/thunder-develop/src/components/UnsavedChangesBar.tsx` to display a fixed action bar for unsaved changes, including customizable labels and handlers for reset and save actions.
* Replaced inline unsaved changes bars in `ApplicationEditPage` and prepared `OrganizationUnitEditPage` to use the new `UnsavedChangesBar` for consistency and code reuse. [[1]](diffhunk://#diff-f3943f48e2370a238cb5604af64e8e7243f03945660d27146ecfd9b4fa3d9016R45) [[2]](diffhunk://#diff-f3943f48e2370a238cb5604af64e8e7243f03945660d27146ecfd9b4fa3d9016L467-R477) [[3]](diffhunk://#diff-72ddeed0506134d13b204b845124a586825e53c504b18c09108d942a779d2fb0R53)

**Testing Improvements:**

* Added a comprehensive test suite for the new `UnsavedChangesBar` component, covering rendering, button states, interactions, and custom labels.
* Updated the `ApplicationEditPage` test to mock the new `UnsavedChangesBar` component.

**Form Handling and Data Flow:**

* Refactored `UrlsSection` and `AccessSection` components to immediately propagate field changes via explicit `onChange` handlers, removing the previous use of `watch` and `useEffect` for updating parent state. [[1]](diffhunk://#diff-53fb6e4e7643a6becce12ab8c493380a9f8bd6584f5e9c1e116d0a6853f2f2c3L21) [[2]](diffhunk://#diff-53fb6e4e7643a6becce12ab8c493380a9f8bd6584f5e9c1e116d0a6853f2f2c3L74) [[3]](diffhunk://#diff-53fb6e4e7643a6becce12ab8c493380a9f8bd6584f5e9c1e116d0a6853f2f2c3L84-L98) [[4]](diffhunk://#diff-53fb6e4e7643a6becce12ab8c493380a9f8bd6584f5e9c1e116d0a6853f2f2c3R98-R101) [[5]](diffhunk://#diff-53fb6e4e7643a6becce12ab8c493380a9f8bd6584f5e9c1e116d0a6853f2f2c3R121-R124) [[6]](diffhunk://#diff-6ff7605c5bf1873b2ea97d3bc28c091f81d1123e7be5404ffb2cb6f2653fb3bbL104) [[7]](diffhunk://#diff-6ff7605c5bf1873b2ea97d3bc28c091f81d1123e7be5404ffb2cb6f2653fb3bbL113-L120) [[8]](diffhunk://#diff-6ff7605c5bf1873b2ea97d3bc28c091f81d1123e7be5404ffb2cb6f2653fb3bbR274-R277)
* Improved the redirect URIs removal logic in `AccessSection` to update both the local state and the parent configuration, ensuring correct data synchronization. [[1]](diffhunk://#diff-6ff7605c5bf1873b2ea97d3bc28c091f81d1123e7be5404ffb2cb6f2653fb3bbL156-R148) [[2]](diffhunk://#diff-6ff7605c5bf1873b2ea97d3bc28c091f81d1123e7be5404ffb2cb6f2653fb3bbR166-R179)
* Fixed the key prop for redirect URIs list rendering to use the array index, preventing potential React warnings.

**Code Cleanup:**

* Removed unused imports and code related to the now-replaced inline unsaved changes bar. [[1]](diffhunk://#diff-f3943f48e2370a238cb5604af64e8e7243f03945660d27146ecfd9b4fa3d9016L26) [[2]](diffhunk://#diff-72ddeed0506134d13b204b845124a586825e53c504b18c09108d942a779d2fb0L29)

These changes collectively improve code maintainability, UI consistency, and the reliability of form state management.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
N/A

### Related Issues
- https://github.com/asgardeo/thunder/issues/1795

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent unsaved-changes action bar on edit pages with message, reset and save actions and a saving state.

* **Bug Fixes**
  * More reliable URL, TOS and policy field updates via direct change handlers.
  * Improved redirect-URI removal flow and downstream config sync to avoid stale values.

* **Tests**
  * Added unit tests and test mocks covering the new action bar and its interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->