### PR TITLE
Improve application validation logic

### DIFF
--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -260,32 +260,9 @@ func (as *applicationService) ValidateApplication(ctx context.Context, app *mode
 		return nil, nil, svcErr
 	}
 
-	if svcErr := as.validateAuthFlowID(ctx, app); svcErr != nil {
+	if svcErr := as.validateApplicationFields(ctx, app); svcErr != nil {
 		return nil, nil, svcErr
 	}
-	if svcErr := as.validateRegistrationFlowID(ctx, app); svcErr != nil {
-		return nil, nil, svcErr
-	}
-
-	if svcErr := as.validateThemeID(app.ThemeID); svcErr != nil {
-		return nil, nil, svcErr
-	}
-	if svcErr := as.validateLayoutID(app.LayoutID); svcErr != nil {
-		return nil, nil, svcErr
-	}
-
-	if app.URL != "" && !sysutils.IsValidURI(app.URL) {
-		return nil, nil, &ErrorInvalidApplicationURL
-	}
-	if app.LogoURL != "" && !sysutils.IsValidLogoURI(app.LogoURL) {
-		return nil, nil, &ErrorInvalidLogoURL
-	}
-
-	if svcErr := as.validateAllowedUserTypes(ctx, app.AllowedUserTypes); svcErr != nil {
-		return nil, nil, svcErr
-	}
-
-	as.validateConsentConfig(app)
 
 	appID := app.ID
 	if appID == "" {
@@ -350,7 +327,7 @@ func (as *applicationService) ValidateApplication(ctx context.Context, app *mode
 	return processedDTO, inboundAuthConfig, nil
 }
 
-func (as *applicationService) ValidateApplicationForUpdate(
+func (as *applicationService) validateApplicationForUpdate(
 	ctx context.Context, appID string, app *model.ApplicationDTO) (
 	*model.ApplicationProcessedDTO, *model.InboundAuthConfigDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationService"))
@@ -396,32 +373,9 @@ func (as *applicationService) ValidateApplicationForUpdate(
 		}
 	}
 
-	if svcErr := as.validateAuthFlowID(ctx, app); svcErr != nil {
+	if svcErr := as.validateApplicationFields(ctx, app); svcErr != nil {
 		return nil, nil, svcErr
 	}
-	if svcErr := as.validateRegistrationFlowID(ctx, app); svcErr != nil {
-		return nil, nil, svcErr
-	}
-
-	if svcErr := as.validateThemeID(app.ThemeID); svcErr != nil {
-		return nil, nil, svcErr
-	}
-	if svcErr := as.validateLayoutID(app.LayoutID); svcErr != nil {
-		return nil, nil, svcErr
-	}
-
-	if app.URL != "" && !sysutils.IsValidURI(app.URL) {
-		return nil, nil, &ErrorInvalidApplicationURL
-	}
-	if app.LogoURL != "" && !sysutils.IsValidLogoURI(app.LogoURL) {
-		return nil, nil, &ErrorInvalidLogoURL
-	}
-
-	if svcErr := as.validateAllowedUserTypes(ctx, app.AllowedUserTypes); svcErr != nil {
-		return nil, nil, svcErr
-	}
-
-	as.validateConsentConfig(app)
 
 	inboundAuthConfig, svcErr := as.processInboundAuthConfig(ctx, app, existingApp)
 	if svcErr != nil {
@@ -617,7 +571,7 @@ func (as *applicationService) UpdateApplication(ctx context.Context, appID strin
 	*model.ApplicationDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationService"))
 
-	existingApp, inboundAuthConfig, svcErr := as.ValidateApplicationForUpdate(ctx, appID, app)
+	existingApp, inboundAuthConfig, svcErr := as.validateApplicationForUpdate(ctx, appID, app)
 
 	if svcErr != nil {
 		return nil, svcErr
@@ -1049,6 +1003,34 @@ func (as *applicationService) validateConsentConfig(appDTO *model.ApplicationDTO
 	if appDTO.LoginConsent.ValidityPeriod < 0 {
 		appDTO.LoginConsent.ValidityPeriod = 0
 	}
+}
+
+// validateApplicationFields validates application fields that are common to both create and update operations.
+func (as *applicationService) validateApplicationFields(
+	ctx context.Context, app *model.ApplicationDTO) *serviceerror.ServiceError {
+	if svcErr := as.validateAuthFlowID(ctx, app); svcErr != nil {
+		return svcErr
+	}
+	if svcErr := as.validateRegistrationFlowID(ctx, app); svcErr != nil {
+		return svcErr
+	}
+	if svcErr := as.validateThemeID(app.ThemeID); svcErr != nil {
+		return svcErr
+	}
+	if svcErr := as.validateLayoutID(app.LayoutID); svcErr != nil {
+		return svcErr
+	}
+	if app.URL != "" && !sysutils.IsValidURI(app.URL) {
+		return &ErrorInvalidApplicationURL
+	}
+	if app.LogoURL != "" && !sysutils.IsValidLogoURI(app.LogoURL) {
+		return &ErrorInvalidLogoURL
+	}
+	if svcErr := as.validateAllowedUserTypes(ctx, app.AllowedUserTypes); svcErr != nil {
+		return svcErr
+	}
+	as.validateConsentConfig(app)
+	return nil
 }
 
 // validateOAuthParamsForCreateAndUpdate validates the OAuth parameters for creating or updating an application.

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -1373,7 +1373,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_EmptyAppID() {
 		Name: "Test App",
 	}
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), "", app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), "", app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1384,7 +1384,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_EmptyAppID() {
 func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_NilApp() {
 	service, _, _, _ := suite.setupTestService()
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, nil)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, nil)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1399,7 +1399,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_EmptyName() {
 		Name: "",
 	}
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1426,7 +1426,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_DeclarativeResou
 
 	mockStore.On("IsApplicationDeclarative", mock.Anything, testServiceAppID).Return(true)
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1454,7 +1454,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_ApplicationNotFo
 	mockStore.On("IsApplicationDeclarative", mock.Anything, testServiceAppID).Return(false)
 	mockStore.On("GetApplicationByID", mock.Anything, testServiceAppID).Return(nil, model.ApplicationNotFoundError)
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1482,7 +1482,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_ApplicationNilFr
 	mockStore.On("IsApplicationDeclarative", mock.Anything, testServiceAppID).Return(false)
 	mockStore.On("GetApplicationByID", mock.Anything, testServiceAppID).Return(nil, nil)
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1510,7 +1510,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_StoreError() {
 	mockStore.On("IsApplicationDeclarative", mock.Anything, testServiceAppID).Return(false)
 	mockStore.On("GetApplicationByID", mock.Anything, testServiceAppID).Return(nil, errors.New("database error"))
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1549,7 +1549,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_NameConflict() {
 	mockStore.On("GetApplicationByID", mock.Anything, testServiceAppID).Return(existingApp, nil)
 	mockStore.On("GetApplicationByName", mock.Anything, "New Name").Return(conflictingApp, nil)
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1583,7 +1583,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_NameCheckStoreEr
 	mockStore.On("GetApplicationByID", mock.Anything, testServiceAppID).Return(existingApp, nil)
 	mockStore.On("GetApplicationByName", mock.Anything, "New Name").Return(nil, errors.New("database error"))
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -1684,7 +1684,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_FieldValidationE
 
 			tt.setupMocks(mockThemeMgtService)
 
-			result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(
+			result, inboundAuth, svcErr := service.validateApplicationForUpdate(
 				context.Background(), testServiceAppID, tt.app)
 
 			assert.Nil(suite.T(), result)
@@ -1740,7 +1740,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_Success() {
 		Return(defaultRegFlow, nil)
 	mockFlowMgtService.EXPECT().IsValidFlow(mock.Anything, mock.Anything).Return(true).Maybe()
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.NotNil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -6505,7 +6505,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_ErrorFromValidat
 	mockStore.On("GetApplicationByID", mock.Anything, testServiceAppID).Return(existingApp, nil)
 	mockFlowMgtService.EXPECT().IsValidFlow(mock.Anything, "invalid-flow-id").Return(false)
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -6544,7 +6544,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_ErrorFromValidat
 	mockFlowMgtService.EXPECT().IsValidFlow(mock.Anything, "valid-auth-flow-id").Return(true)
 	mockFlowMgtService.EXPECT().IsValidFlow(mock.Anything, "invalid-reg-flow-id").Return(false)
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)
@@ -6607,7 +6607,7 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_ErrorFromValidat
 		}, nil)
 	mockLayoutMgtService.EXPECT().IsLayoutExist("non-existent-layout-id").Return(false, nil)
 
-	result, inboundAuth, svcErr := service.ValidateApplicationForUpdate(context.Background(), testServiceAppID, app)
+	result, inboundAuth, svcErr := service.validateApplicationForUpdate(context.Background(), testServiceAppID, app)
 
 	assert.Nil(suite.T(), result)
 	assert.Nil(suite.T(), inboundAuth)


### PR DESCRIPTION
This pull request refactors the validation logic for application creation and update in the backend service, consolidating shared field validation into a single method and updating usages throughout the codebase. This change improves maintainability and reduces code duplication. Additionally, the update changes the visibility of the update validation method to unexport it, and updates all related tests accordingly.

Refactoring and code consolidation:

* Introduced a new private method `validateApplicationFields` in `applicationService` to handle validation of fields common to both application creation and update, replacing repeated validation logic in both code paths. (`backend/internal/application/service.go`) [[1]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L262-L288) [[2]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L398-L424) [[3]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831R1009-R1036)

API and visibility changes:

* Changed `ValidateApplicationForUpdate` to a private method `validateApplicationForUpdate` to better reflect its intended usage within the service, and updated all internal calls and test references accordingly. (`backend/internal/application/service.go`, `backend/internal/application/service_test.go`) [[1]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L352-R329) [[2]](diffhunk://#diff-8bbc286860623a5e65fd4f32dbc314f8bf15106e84bc3fe633b6237d8f32f831L619-R573) [[3]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1376-R1376) [[4]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1387-R1387) [[5]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1402-R1402) [[6]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1429-R1429) [[7]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1457-R1457) [[8]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1485-R1485) [[9]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1513-R1513) [[10]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1552-R1552) [[11]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1586-R1586) [[12]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1687-R1687) [[13]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L1743-R1743) [[14]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L6508-R6508) [[15]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L6547-R6547) [[16]](diffhunk://#diff-2c9e6c3bc539dcce7d3a1045066d8f6f600b37f2be25db1a935e653f53ea6361L6610-R6610)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized application validation into a single, consistent flow to improve reliability and maintainability; field checks and consent-related validation are now unified.
* **Tests**
  * Updated unit tests to align with the new validation structure; test behavior and expectations remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->