### PR TITLE
Remove secret regenerate component for public client in develop app

### DIFF
--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
@@ -20,6 +20,7 @@ import {useState, useCallback} from 'react';
 import type {JSX} from 'react';
 import {Stack} from '@wso2/oxygen-ui';
 import type {Application} from '../../../models/application';
+import {TokenEndpointAuthMethods} from '../../../models/oauth';
 import type {OAuth2Config} from '../../../models/oauth';
 import QuickCopySection from './QuickCopySection';
 import AccessSection from './AccessSection';
@@ -84,6 +85,10 @@ export default function EditGeneralSettings({
   const [secretDialogOpen, setSecretDialogOpen] = useState(false);
   const [newClientSecret, setNewClientSecret] = useState<string>('');
 
+  const isConfidentialClient =
+    oauth2Config?.token_endpoint_auth_method === TokenEndpointAuthMethods.CLIENT_SECRET_BASIC ||
+    oauth2Config?.token_endpoint_auth_method === TokenEndpointAuthMethods.CLIENT_SECRET_POST;
+
   const handleRegenerateClick = useCallback((): void => {
     setRegenerateDialogOpen(true);
   }, []);
@@ -113,7 +118,7 @@ export default function EditGeneralSettings({
           oauth2Config={oauth2Config}
           onFieldChange={onFieldChange}
         />
-        <DangerZoneSection onRegenerateClick={handleRegenerateClick} />
+        {isConfidentialClient && <DangerZoneSection onRegenerateClick={handleRegenerateClick} />}
       </Stack>
 
       {/* Regenerate Client Secret Confirmation Dialog */}

--- a/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/EditGeneralSettings.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/applications/components/edit-application/general-settings/__tests__/EditGeneralSettings.test.tsx
@@ -114,6 +114,7 @@ describe('EditGeneralSettings', () => {
   const mockOAuth2Config: OAuth2Config = {
     client_id: 'client-123',
     client_secret: 'secret-456',
+    token_endpoint_auth_method: 'client_secret_basic',
   } as OAuth2Config;
 
   beforeEach(() => {
@@ -276,12 +277,13 @@ describe('EditGeneralSettings', () => {
   });
 
   describe('Layout', () => {
-    it('should render sections in correct order', () => {
+    it('should render sections in correct order for confidential clients', () => {
       const {container} = render(
         <EditGeneralSettings
           application={mockApplication}
           editedApp={{}}
           onFieldChange={mockOnFieldChange}
+          oauth2Config={mockOAuth2Config}
           copiedField={null}
           onCopyToClipboard={mockOnCopyToClipboard}
         />,
@@ -293,12 +295,88 @@ describe('EditGeneralSettings', () => {
       expect(sections[2]).toHaveAttribute('data-testid', 'danger-zone-section');
     });
 
-    it('should render DangerZoneSection', () => {
+    it('should render DangerZoneSection for confidential client', () => {
       render(
         <EditGeneralSettings
           application={mockApplication}
           editedApp={{}}
           onFieldChange={mockOnFieldChange}
+          oauth2Config={mockOAuth2Config}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      expect(screen.getByTestId('danger-zone-section')).toBeInTheDocument();
+    });
+
+    it('should not render DangerZoneSection for public client (none auth method)', () => {
+      const publicClientConfig: OAuth2Config = {
+        client_id: 'public-client-123',
+        token_endpoint_auth_method: 'none',
+      } as OAuth2Config;
+
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          oauth2Config={publicClientConfig}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      expect(screen.queryByTestId('danger-zone-section')).not.toBeInTheDocument();
+    });
+
+    it('should not render DangerZoneSection when no oauth2Config provided', () => {
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      expect(screen.queryByTestId('danger-zone-section')).not.toBeInTheDocument();
+    });
+
+    it('should not render DangerZoneSection for private_key_jwt auth method', () => {
+      const pkjwtClientConfig: OAuth2Config = {
+        client_id: 'pkjwt-client-123',
+        token_endpoint_auth_method: 'private_key_jwt',
+      } as OAuth2Config;
+
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          oauth2Config={pkjwtClientConfig}
+          copiedField={null}
+          onCopyToClipboard={mockOnCopyToClipboard}
+        />,
+      );
+
+      expect(screen.queryByTestId('danger-zone-section')).not.toBeInTheDocument();
+    });
+
+    it('should render DangerZoneSection for client_secret_post auth method', () => {
+      const postClientConfig: OAuth2Config = {
+        client_id: 'post-client-123',
+        client_secret: 'secret-456',
+        token_endpoint_auth_method: 'client_secret_post',
+      } as OAuth2Config;
+
+      render(
+        <EditGeneralSettings
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          oauth2Config={postClientConfig}
           copiedField={null}
           onCopyToClipboard={mockOnCopyToClipboard}
         />,
@@ -315,6 +393,7 @@ describe('EditGeneralSettings', () => {
           application={mockApplication}
           editedApp={{}}
           onFieldChange={mockOnFieldChange}
+          oauth2Config={mockOAuth2Config}
           copiedField={null}
           onCopyToClipboard={mockOnCopyToClipboard}
         />,
@@ -332,6 +411,7 @@ describe('EditGeneralSettings', () => {
           application={mockApplication}
           editedApp={{}}
           onFieldChange={mockOnFieldChange}
+          oauth2Config={mockOAuth2Config}
           copiedField={null}
           onCopyToClipboard={mockOnCopyToClipboard}
         />,
@@ -349,6 +429,7 @@ describe('EditGeneralSettings', () => {
           application={mockApplication}
           editedApp={{}}
           onFieldChange={mockOnFieldChange}
+          oauth2Config={mockOAuth2Config}
           copiedField={null}
           onCopyToClipboard={mockOnCopyToClipboard}
         />,
@@ -371,6 +452,7 @@ describe('EditGeneralSettings', () => {
           application={mockApplication}
           editedApp={{}}
           onFieldChange={mockOnFieldChange}
+          oauth2Config={mockOAuth2Config}
           copiedField={null}
           onCopyToClipboard={mockOnCopyToClipboard}
         />,
@@ -392,6 +474,7 @@ describe('EditGeneralSettings', () => {
           application={mockApplication}
           editedApp={{}}
           onFieldChange={mockOnFieldChange}
+          oauth2Config={mockOAuth2Config}
           copiedField={null}
           onCopyToClipboard={mockOnCopyToClipboard}
         />,


### PR DESCRIPTION
This pull request updates the `EditGeneralSettings` component to conditionally render the `DangerZoneSection` only for confidential OAuth2 clients (those using `client_secret_basic` or `client_secret_post` authentication methods). It also enhances the test suite to verify this behavior for various OAuth2 configurations.

Conditional rendering logic:

* Added logic in `EditGeneralSettings.tsx` to show the `DangerZoneSection` only if the `oauth2Config.token_endpoint_auth_method` indicates a confidential client (`client_secret_basic` or `client_secret_post`). [[1]](diffhunk://#diff-1e4e534b8d0a5b1d22f5fa8a682fcd5dd1871d4bdb97344ca2efecd2a024ba29R23) [[2]](diffhunk://#diff-1e4e534b8d0a5b1d22f5fa8a682fcd5dd1871d4bdb97344ca2efecd2a024ba29R88-R91) [[3]](diffhunk://#diff-1e4e534b8d0a5b1d22f5fa8a682fcd5dd1871d4bdb97344ca2efecd2a024ba29L116-R121)

Testing improvements:

* Expanded the test suite in `EditGeneralSettings.test.tsx` to:
  - Check that `DangerZoneSection` is rendered for confidential clients and not for public or other types of clients (e.g., `none`, `private_key_jwt`).
  - Add and update test cases to cover scenarios with and without `oauth2Config`, and for different auth methods. [[1]](diffhunk://#diff-50ebe3deff497600f7b19202751ab542f800dfad5567c62855f14d07934c334eL279-R286) [[2]](diffhunk://#diff-50ebe3deff497600f7b19202751ab542f800dfad5567c62855f14d07934c334eR396) [[3]](diffhunk://#diff-50ebe3deff497600f7b19202751ab542f800dfad5567c62855f14d07934c334eR414) [[4]](diffhunk://#diff-50ebe3deff497600f7b19202751ab542f800dfad5567c62855f14d07934c334eR432) [[5]](diffhunk://#diff-50ebe3deff497600f7b19202751ab542f800dfad5567c62855f14d07934c334eR455) [[6]](diffhunk://#diff-50ebe3deff497600f7b19202751ab542f800dfad5567c62855f14d07934c334eR477)
  - Update mock data to include the `token_endpoint_auth_method` property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Danger Zone section is now conditionally displayed based on the application's authentication method configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->