### PR TITLE
Change the email client warn log to debug

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -189,7 +189,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	var emailClient email.EmailClientInterface
 	emailClient, err = email.Initialize()
 	if err != nil {
-		logger.Warn("Email client not configured. "+
+		logger.Debug("Email client not configured. "+
 			"EmailExecutor will be registered but will not send emails.", log.Error(err))
 		emailClient = nil
 	}


### PR DESCRIPTION
### Purpose
Remove following log from the startup.
```
time=2026-03-13T18:55:42.002+05:30 level=WARN msg="Email client not configured. EmailExecutor will be registered but will not send emails." error="invalid sender: the sender email address is invalid or empty"
```


### Approach
This pull request makes a minor adjustment to the logging behavior in the `registerServices` function. The log level for cases where the email client is not configured has been changed from "Warn" to "Debug" to reduce unnecessary warning logs.

* Logging behavior update:
  * Changed the log level from `Warn` to `Debug` when the email client fails to initialize in `servicemanager.go`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced logging verbosity for failed email setup during startup so such initialization issues are logged at a lower level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->