### PR TITLE
Fix scopes not returned for group-assigned roles

### DIFF
--- a/backend/internal/flow/executor/authz_executor.go
+++ b/backend/internal/flow/executor/authz_executor.go
@@ -20,12 +20,15 @@ package executor
 
 import (
 	"encoding/json"
+	"errors"
 
 	authzsvc "github.com/asgardeo/thunder/internal/authz"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
+	"github.com/asgardeo/thunder/internal/userprovider"
 )
 
 const (
@@ -39,6 +42,7 @@ const (
 type authorizationExecutor struct {
 	core.ExecutorInterface
 	authzService authzsvc.AuthorizationServiceInterface
+	userProvider userprovider.UserProviderInterface
 	logger       *log.Logger
 }
 
@@ -48,6 +52,7 @@ var _ core.ExecutorInterface = (*authorizationExecutor)(nil)
 func newAuthorizationExecutor(
 	flowFactory core.FlowFactoryInterface,
 	authZService authzsvc.AuthorizationServiceInterface,
+	userProvider userprovider.UserProviderInterface,
 ) *authorizationExecutor {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, authzLoggerComponentName),
 		log.String(log.LoggerKeyExecutorName, ExecutorNameAuthorization))
@@ -58,6 +63,7 @@ func newAuthorizationExecutor(
 	return &authorizationExecutor{
 		ExecutorInterface: base,
 		authzService:      authZService,
+		userProvider:      userProvider,
 		logger:            logger,
 	}
 }
@@ -97,7 +103,10 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 
 	// Extract user ID and group IDs
 	userID := ctx.AuthenticatedUser.UserID
-	groupIDs := a.extractGroupIDs(ctx)
+	groupIDs, err := a.extractGroupIDs(ctx)
+	if err != nil {
+		return nil, errors.Join(errors.New("Failed to extract group IDs"), err)
+	}
 
 	logger.Debug("Calling authorization service",
 		log.String("userID", userID),
@@ -143,13 +152,14 @@ func setAuthorizedPermissions(execResp *common.ExecutorResponse, authorizedPermi
 }
 
 // extractGroupIDs extracts group IDs from the authenticated user's attributes or runtime data.
-func (a *authorizationExecutor) extractGroupIDs(ctx *core.NodeContext) []string {
+// If neither provides group information, it fetches them using the user service.
+func (a *authorizationExecutor) extractGroupIDs(ctx *core.NodeContext) ([]string, error) {
 	// Try to get groups from authenticated user attributes
 	if groupsAttr, ok := ctx.AuthenticatedUser.Attributes[userAttributeGroups]; ok {
 		// Handle different group attribute formats
 		switch v := groupsAttr.(type) {
 		case []string:
-			return v
+			return v, nil
 		case []interface{}:
 			groups := make([]string, 0, len(v))
 			for _, item := range v {
@@ -157,10 +167,10 @@ func (a *authorizationExecutor) extractGroupIDs(ctx *core.NodeContext) []string 
 					groups = append(groups, str)
 				}
 			}
-			return groups
+			return groups, nil
 		case string:
 			// Single group as string
-			return []string{v}
+			return []string{v}, nil
 		}
 	}
 
@@ -168,10 +178,29 @@ func (a *authorizationExecutor) extractGroupIDs(ctx *core.NodeContext) []string 
 	if groupsJSON, ok := ctx.RuntimeData[userAttributeGroups]; ok && groupsJSON != "" {
 		var groups []string
 		if err := json.Unmarshal([]byte(groupsJSON), &groups); err == nil {
-			return groups
+			return groups, nil
+		}
+	}
+
+	// If no groups found in context, fetch from user service
+	if a.userProvider != nil && ctx.AuthenticatedUser.UserID != "" {
+		a.logger.Debug("Groups not found in context, fetching from user service",
+			log.String("userID", ctx.AuthenticatedUser.UserID))
+
+		groupsResp, err := a.userProvider.GetUserGroups(ctx.AuthenticatedUser.UserID,
+			oauth2const.DefaultGroupListLimit, 0)
+		if err != nil {
+			return nil, err
+		}
+		if groupsResp != nil {
+			groups := make([]string, 0, len(groupsResp.Groups))
+			for _, g := range groupsResp.Groups {
+				groups = append(groups, g.ID)
+			}
+			return groups, nil
 		}
 	}
 
 	// No groups found
-	return []string{}
+	return []string{}, nil
 }

--- a/backend/internal/flow/executor/authz_executor_test.go
+++ b/backend/internal/flow/executor/authz_executor_test.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,14 +29,18 @@ import (
 	authzsvc "github.com/asgardeo/thunder/internal/authz"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/userprovider"
 	"github.com/asgardeo/thunder/tests/mocks/authzmock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/userprovidermock"
 )
 
 // createTestAuthzExecutor creates an authorization executor with mocks for testing
 func createTestAuthzExecutor(t *testing.T,
-	mockAuthzService *authzmock.AuthorizationServiceInterfaceMock) *authorizationExecutor {
+	mockAuthzService *authzmock.AuthorizationServiceInterfaceMock,
+	mockUserProvider *userprovidermock.UserProviderInterfaceMock) *authorizationExecutor {
 	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(t)
 
 	// Mock the CreateExecutor method to return a base executor
@@ -43,7 +48,7 @@ func createTestAuthzExecutor(t *testing.T,
 		[]common.Input{}, []common.Input{}).
 		Return(createMockExecutor(t, "AuthorizationExecutor", common.ExecutorTypeUtility))
 
-	return newAuthorizationExecutor(mockFlowFactory, mockAuthzService)
+	return newAuthorizationExecutor(mockFlowFactory, mockAuthzService, mockUserProvider)
 }
 
 // createMockExecutor creates a mock executor for testing purposes
@@ -58,7 +63,8 @@ func createMockExecutor(t *testing.T, name string, executorType common.ExecutorT
 
 func TestNewAuthorizationExecutor(t *testing.T) {
 	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(t)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := userprovidermock.NewUserProviderInterfaceMock(t)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	assert.NotNil(t, executor)
 	assert.Equal(t, "AuthorizationExecutor", executor.GetName())
@@ -69,7 +75,8 @@ func TestNewAuthorizationExecutor(t *testing.T) {
 func TestAuthorizationExecutor_Execute_Success(t *testing.T) {
 	// Setup
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-flow",
@@ -116,7 +123,8 @@ func TestAuthorizationExecutor_Execute_Success(t *testing.T) {
 func TestAuthorizationExecutor_Execute_PartialPermissions(t *testing.T) {
 	// Setup - user requests multiple permissions but only gets some
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-flow",
@@ -129,6 +137,11 @@ func TestAuthorizationExecutor_Execute_PartialPermissions(t *testing.T) {
 			requestedPermissionsKey: "read:documents write:documents delete:documents",
 		},
 	}
+
+	mockUserProvider.On("GetUserGroups", "user123",
+		oauth2const.DefaultGroupListLimit, 0).Return(&userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{},
+	}, nil).Maybe()
 
 	// User only has read permission
 	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything).Return(
@@ -150,7 +163,8 @@ func TestAuthorizationExecutor_Execute_PartialPermissions(t *testing.T) {
 func TestAuthorizationExecutor_Execute_NoPermissions(t *testing.T) {
 	// Setup - user has no permissions at all
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-flow",
@@ -163,6 +177,11 @@ func TestAuthorizationExecutor_Execute_NoPermissions(t *testing.T) {
 			requestedPermissionsKey: "read:documents write:documents",
 		},
 	}
+
+	mockUserProvider.On("GetUserGroups", "user123",
+		oauth2const.DefaultGroupListLimit, 0).Return(&userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{},
+	}, nil).Maybe()
 
 	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything).Return(
 		&authzsvc.GetAuthorizedPermissionsResponse{
@@ -183,7 +202,8 @@ func TestAuthorizationExecutor_Execute_NoPermissions(t *testing.T) {
 func TestAuthorizationExecutor_Execute_NotAuthenticated(t *testing.T) {
 	// Setup - user not authenticated
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-flow",
@@ -209,7 +229,8 @@ func TestAuthorizationExecutor_Execute_NotAuthenticated(t *testing.T) {
 func TestAuthorizationExecutor_Execute_ServiceError(t *testing.T) {
 	// Setup - service returns error
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-flow",
@@ -222,6 +243,11 @@ func TestAuthorizationExecutor_Execute_ServiceError(t *testing.T) {
 			requestedPermissionsKey: "read:documents write:documents",
 		},
 	}
+
+	mockUserProvider.On("GetUserGroups", "user123",
+		oauth2const.DefaultGroupListLimit, 0).Return(&userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{},
+	}, nil).Maybe()
 
 	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything).Return(
 		nil, &serviceerror.ServiceError{Error: "service error"})
@@ -236,12 +262,49 @@ func TestAuthorizationExecutor_Execute_ServiceError(t *testing.T) {
 	mockAuthzService.AssertExpectations(t)
 }
 
+func TestAuthorizationExecutor_Execute_GroupExtractionError(t *testing.T) {
+	// Setup - user group retrieval fails and execution should fail before authz service call
+	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
+
+	ctx := &core.NodeContext{
+		FlowID:   "test-flow",
+		FlowType: common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user123",
+			Attributes:      map[string]interface{}{},
+		},
+		RuntimeData: map[string]string{
+			requestedPermissionsKey: "read:documents write:documents",
+		},
+	}
+
+	mockUserProvider.On("GetUserGroups", "user123", oauth2const.DefaultGroupListLimit, 0).Return(
+		nil, userprovider.NewUserProviderError(
+			userprovider.ErrorCodeSystemError,
+			"failed to retrieve groups",
+			"failed to retrieve groups"))
+
+	// Execute
+	resp, err := executor.Execute(ctx)
+
+	// Assert
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	mockAuthzService.AssertNotCalled(t, "GetAuthorizedPermissions")
+	mockUserProvider.AssertExpectations(t)
+}
+
 func TestAuthorizationExecutor_Execute_NoRequestedPermissions(t *testing.T) {
 	// This test verifies behavior when extractRequestedPermissions returns empty
 	// The service should NOT be called, and should return early with ExecComplete
 
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-flow",
@@ -267,7 +330,8 @@ func TestAuthorizationExecutor_Execute_NoRequestedPermissions(t *testing.T) {
 
 func TestAuthorizationExecutor_ExtractGroupIDs_FromAttributes(t *testing.T) {
 	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(t)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := userprovidermock.NewUserProviderInterfaceMock(t)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	tests := []struct {
 		name       string
@@ -311,7 +375,8 @@ func TestAuthorizationExecutor_ExtractGroupIDs_FromAttributes(t *testing.T) {
 				RuntimeData: make(map[string]string),
 			}
 
-			groupIDs := executor.extractGroupIDs(ctx)
+			groupIDs, err := executor.extractGroupIDs(ctx)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, groupIDs)
 		})
 	}
@@ -319,7 +384,8 @@ func TestAuthorizationExecutor_ExtractGroupIDs_FromAttributes(t *testing.T) {
 
 func TestAuthorizationExecutor_ExtractGroupIDs_FromRuntimeData(t *testing.T) {
 	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(t)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := userprovidermock.NewUserProviderInterfaceMock(t)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		AuthenticatedUser: authncm.AuthenticatedUser{
@@ -330,7 +396,8 @@ func TestAuthorizationExecutor_ExtractGroupIDs_FromRuntimeData(t *testing.T) {
 		},
 	}
 
-	groupIDs := executor.extractGroupIDs(ctx)
+	groupIDs, err := executor.extractGroupIDs(ctx)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"runtime-group1", "runtime-group2"}, groupIDs)
 }
 
@@ -402,7 +469,8 @@ func TestExtractRequestedPermissions(t *testing.T) {
 
 func TestAuthorizationExecutor_ExtractGroupIDs_WithNoGroups(t *testing.T) {
 	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(t)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := userprovidermock.NewUserProviderInterfaceMock(t)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		AuthenticatedUser: authncm.AuthenticatedUser{
@@ -413,13 +481,20 @@ func TestAuthorizationExecutor_ExtractGroupIDs_WithNoGroups(t *testing.T) {
 		RuntimeData: make(map[string]string),
 	}
 
-	groupIDs := executor.extractGroupIDs(ctx)
+	mockUserProvider.On("GetUserGroups", "user123",
+		oauth2const.DefaultGroupListLimit, 0).Return(&userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{},
+	}, nil).Maybe()
+
+	groupIDs, err := executor.extractGroupIDs(ctx)
+	assert.NoError(t, err)
 	assert.Empty(t, groupIDs)
 }
 
 func TestAuthorizationExecutor_Execute_WithMultipleGroups(t *testing.T) {
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-flow",
@@ -496,7 +571,8 @@ func TestSetAuthorizedPermissions(t *testing.T) {
 func TestAuthorizationExecutor_Execute_RegistrationFlow_UnauthenticatedWithoutPermissions(t *testing.T) {
 	// Setup - registration flow with unauthenticated user and no requested permissions
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-registration-flow",
@@ -522,7 +598,8 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_UnauthenticatedWithoutPe
 func TestAuthorizationExecutor_Execute_RegistrationFlow_UnauthenticatedWithPermissions(t *testing.T) {
 	// Setup - registration flow with unauthenticated user but WITH requested permissions
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-registration-flow",
@@ -550,7 +627,8 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_UnauthenticatedWithPermi
 func TestAuthorizationExecutor_Execute_RegistrationFlow_AuthenticatedWithPermissions(t *testing.T) {
 	// Setup - registration flow with authenticated user (edge case but possible)
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
 		FlowID:   "test-registration-flow",
@@ -592,7 +670,8 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_AuthenticatedWithPermiss
 func TestAuthorizationExecutor_Execute_NonRegistrationFlow_UnauthenticatedShouldFail(t *testing.T) {
 	// Setup - non-registration flow types should fail if unauthenticated
 	mockAuthzService := new(authzmock.AuthorizationServiceInterfaceMock)
-	executor := createTestAuthzExecutor(t, mockAuthzService)
+	mockUserProvider := new(userprovidermock.UserProviderInterfaceMock)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	testCases := []struct {
 		name     string
@@ -633,4 +712,60 @@ func TestAuthorizationExecutor_Execute_NonRegistrationFlow_UnauthenticatedShould
 			mockAuthzService.AssertNotCalled(t, "GetAuthorizedPermissions")
 		})
 	}
+}
+
+func TestAuthorizationExecutor_ExtractGroupIDs_FromUserService(t *testing.T) {
+	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(t)
+	mockUserProvider := userprovidermock.NewUserProviderInterfaceMock(t)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
+
+	ctx := &core.NodeContext{
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "test-user-123",
+			Attributes:      map[string]interface{}{}, // No groups in attributes
+		},
+		RuntimeData: make(map[string]string), // No groups in runtime data
+	}
+
+	mockUserProvider.On("GetUserGroups", "test-user-123",
+		oauth2const.DefaultGroupListLimit, 0).Return(&userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{
+			{ID: "svc-group-1"},
+			{ID: "svc-group-2"},
+		},
+	}, nil)
+
+	groupIDs, err := executor.extractGroupIDs(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"svc-group-1", "svc-group-2"}, groupIDs)
+	mockUserProvider.AssertExpectations(t)
+}
+
+func TestAuthorizationExecutor_ExtractGroupIDs_FromUserService_Error(t *testing.T) {
+	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(t)
+	mockUserProvider := userprovidermock.NewUserProviderInterfaceMock(t)
+	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
+
+	ctx := &core.NodeContext{
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "test-user-err",
+			Attributes:      map[string]interface{}{}, // No groups in attributes
+		},
+		RuntimeData: make(map[string]string), // No groups in runtime data
+	}
+
+	mockUserProvider.On("GetUserGroups", "test-user-err", oauth2const.DefaultGroupListLimit, 0).Return(
+		nil, userprovider.NewUserProviderError(
+			userprovider.ErrorCodeSystemError,
+			"failed to retrieve groups",
+			"failed to retrieve groups"))
+
+	groupIDs, err := executor.extractGroupIDs(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, groupIDs)
+	mockUserProvider.AssertExpectations(t)
 }

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -81,7 +81,7 @@ func Initialize(
 	reg.RegisterExecutor(ExecutorNameAuthAssert, newAuthAssertExecutor(flowFactory, jwtService,
 		ouService, authRegistry.AuthAssertGenerator, authRegistry.CredentialsAuthnService, userProvider,
 		attributeCacheSvc))
-	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService))
+	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService, userProvider))
 	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory))
 	reg.RegisterExecutor(ExecutorNameUserTypeResolver, newUserTypeResolver(flowFactory, userSchemaService))
 	reg.RegisterExecutor(ExecutorNameInviteExecutor, newInviteExecutor(flowFactory))

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -41,6 +41,8 @@ var (
 	scopeTestRoleID         string
 	scopeUserWithRole       string
 	scopeUserNoRole         string
+	scopeUserWithGroup      string
+	scopeGroupID            string
 	scopeUserSchemaID       string
 	scopeTestResourceServer string
 	scopeTestUserSchema     = testutils.UserSchema{
@@ -163,6 +165,40 @@ func (ts *OAuthAuthzScopeTestSuite) SetupSuite() {
 		ts.T().Fatalf("Failed to create user without role: %v", err)
 	}
 
+	// Create user to be assigned to the authz group
+	userWithGroup := testutils.User{
+		OrganizationUnit: scopeTestOUID,
+		Type:             "authz-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "oauth_authorized_group_user",
+			"password": "SecurePass123!",
+			"email": "oauth_authorized_group@test.com",
+			"given_name": "OAuth",
+			"family_name": "Authorized"
+		}`),
+	}
+	scopeUserWithGroup, err = testutils.CreateUser(userWithGroup)
+	if err != nil {
+		ts.T().Fatalf("Failed to create user with group: %v", err)
+	}
+
+	// Create group and assign user to group
+	group := testutils.Group{
+		Name:               "OAuth_DocumentEditors",
+		Description:        "Group for document editors (OAuth test)",
+		OrganizationUnitId: scopeTestOUID,
+		Members: []testutils.Member{
+			{
+				Id:   scopeUserWithGroup,
+				Type: "user",
+			},
+		},
+	}
+	scopeGroupID, err = testutils.CreateGroup(group)
+	if err != nil {
+		ts.T().Fatalf("Failed to create group: %v", err)
+	}
+
 	// Create resource server with actions for permissions
 	resourceServer := testutils.ResourceServer{
 		Name:               "OAuth Document Management System",
@@ -200,6 +236,7 @@ func (ts *OAuthAuthzScopeTestSuite) SetupSuite() {
 		},
 		Assignments: []testutils.Assignment{
 			{ID: scopeUserWithRole, Type: "user"},
+			{ID: scopeGroupID, Type: "group"},
 		},
 	}
 	scopeTestRoleID, err = testutils.CreateRole(role)
@@ -225,6 +262,18 @@ func (ts *OAuthAuthzScopeTestSuite) TearDownSuite() {
 	if scopeUserNoRole != "" {
 		if err := testutils.DeleteUser(scopeUserNoRole); err != nil {
 			ts.T().Logf("Failed to delete user without role: %v", err)
+		}
+	}
+
+	if scopeUserWithGroup != "" {
+		if err := testutils.DeleteUser(scopeUserWithGroup); err != nil {
+			ts.T().Logf("Failed to delete user with group: %v", err)
+		}
+	}
+
+	if scopeGroupID != "" {
+		if err := testutils.DeleteGroup(scopeGroupID); err != nil {
+			ts.T().Logf("Failed to delete group: %v", err)
 		}
 	}
 
@@ -259,64 +308,39 @@ func (ts *OAuthAuthzScopeTestSuite) TearDownSuite() {
 	}
 }
 
-// TestOAuthAuthzFlow_WithAuthorizedScopes tests complete OAuth flow with authorized scopes
-func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithAuthorizedScopes() {
-	// Step 1: Initiate OAuth authorization request
-	scope := "openid read write"
-	state := "test_state_with_scopes"
+// TestOAuthAuthzFlow_WithAuthorizedScopesWithRoleUserAssignment tests the complete OAuth flow for a user
+// with role assignment and verifies that the access token contains the authorized scopes based
+//
+//	on the user's role permissions.
+func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithAuthorizedScopesWithRoleUserAssignment() {
+	ts.testOAuthAuthzFlow_WithAuthorizedScopes("oauth_authorized_user")
+}
 
-	authResp, err := testutils.InitiateAuthorizationFlow(scopeTestClientID, scopeTestRedirectURI,
-		"code", scope, state)
-	ts.Require().NoError(err, "Failed to initiate authorization")
-	ts.Require().NotNil(authResp, "Authorization response should not be nil")
+// TestOAuthAuthzFlow_WithAuthorizedScopesWithRoleGroupAssignment tests the complete OAuth flow for a user
+// with group assignment and verifies that the access token contains the authorized scopes based
+// on the user's group role permissions.
+func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithAuthorizedScopesWithRoleGroupAssignment() {
+	ts.testOAuthAuthzFlow_WithAuthorizedScopes("oauth_authorized_group_user")
+}
 
-	// Step 2: Extract auth ID and flow ID from redirect
-	location := authResp.Header.Get("Location")
-	ts.Require().NotEmpty(location, "Location header should not be empty")
+// testOAuthAuthzFlow_WithAuthorizedScopes tests complete OAuth flow with authorized scopes
+func (ts *OAuthAuthzScopeTestSuite) testOAuthAuthzFlow_WithAuthorizedScopes(username string) {
+	// Step 1: Execute full OAuth flow and obtain token for authorized user
+	tokenResp, err := testutils.ObtainAccessTokenWithPassword(
+		scopeTestClientID,
+		scopeTestRedirectURI,
+		"openid read write",
+		username,
+		"SecurePass123!",
+		false,
+		scopeTestClientSecret,
+	)
+	ts.Require().NoError(err, "Failed to obtain access token")
+	ts.Require().NotNil(tokenResp, "Token response should not be nil")
+	ts.Require().NotEmpty(tokenResp.AccessToken, "Access token should not be empty")
 
-	authId, flowID, err := testutils.ExtractAuthData(location)
-	ts.Require().NoError(err, "Failed to extract auth ID")
-	ts.Require().NotEmpty(authId, "Auth ID should not be empty")
-	ts.Require().NotEmpty(flowID, "Flow ID should not be empty")
-
-	// Step 3: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "")
-	ts.Require().NoError(err, "Failed to initiate authentication flow")
-
-	// Step 4: Execute authentication flow with authorized user
-	flowInputs := map[string]string{
-		"username": "oauth_authorized_user",
-		"password": "SecurePass123!",
-	}
-
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, flowInputs, "action_001")
-	ts.Require().NoError(err, "Failed to execute authentication flow")
-	ts.Require().NotNil(flowStep, "Flow step should not be nil")
-	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")
-	ts.Require().NotEmpty(flowStep.Assertion, "Assertion should not be empty")
-
-	// Step 5: Complete authorization with assertion
-	authzResponse, err := testutils.CompleteAuthorization(authId, flowStep.Assertion)
-	ts.Require().NoError(err, "Failed to complete authorization")
-	ts.Require().NotNil(authzResponse, "Authorization response should not be nil")
-	ts.Require().NotEmpty(authzResponse.RedirectURI, "Redirect URI should not be empty")
-
-	// Step 6: Extract authorization code
-	code, err := testutils.ExtractAuthorizationCode(authzResponse.RedirectURI)
-	ts.Require().NoError(err, "Failed to extract authorization code")
-	ts.Require().NotEmpty(code, "Authorization code should not be empty")
-
-	// Step 7: Exchange code for token
-	tokenResult, err := testutils.RequestToken(scopeTestClientID, scopeTestClientSecret, code,
-		scopeTestRedirectURI, "authorization_code")
-	ts.Require().NoError(err, "Failed to exchange code for token")
-	ts.Require().NotNil(tokenResult, "Token result should not be nil")
-	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, "Token endpoint should return 200")
-	ts.Require().NotNil(tokenResult.Token, "Token response should not be nil")
-	ts.Require().NotEmpty(tokenResult.Token.AccessToken, "Access token should not be empty")
-
-	// Step 8: Decode access token and verify scopes
-	claims, err := testutils.DecodeJWT(tokenResult.Token.AccessToken)
+	// Step 2: Decode access token and verify scopes
+	claims, err := testutils.DecodeJWT(tokenResp.AccessToken)
 	ts.Require().NoError(err, "Failed to decode access token")
 	ts.Require().NotNil(claims, "Claims should not be nil")
 
@@ -336,62 +360,22 @@ func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithAuthorizedScopes() {
 
 // TestOAuthAuthzFlow_WithNoAuthorizedScopes tests OAuth flow when user has no custom scopes
 func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithNoAuthorizedScopes() {
-	// Step 1: Initiate OAuth authorization request
-	scope := "openid read write"
-	state := "test_state_no_scopes"
+	// Step 1: Execute full OAuth flow and obtain token for user without role assignments
+	tokenResp, err := testutils.ObtainAccessTokenWithPassword(
+		scopeTestClientID,
+		scopeTestRedirectURI,
+		"openid read write",
+		"oauth_unauthorized_user",
+		"SecurePass123!",
+		false,
+		scopeTestClientSecret,
+	)
+	ts.Require().NoError(err, "Failed to obtain access token")
+	ts.Require().NotNil(tokenResp, "Token response should not be nil")
+	ts.Require().NotEmpty(tokenResp.AccessToken, "Access token should not be empty")
 
-	authResp, err := testutils.InitiateAuthorizationFlow(scopeTestClientID, scopeTestRedirectURI,
-		"code", scope, state)
-	ts.Require().NoError(err, "Failed to initiate authorization")
-	ts.Require().NotNil(authResp, "Authorization response should not be nil")
-
-	// Step 2: Extract auth ID and flow ID from redirect
-	location := authResp.Header.Get("Location")
-	ts.Require().NotEmpty(location, "Location header should not be empty")
-
-	authId, flowID, err := testutils.ExtractAuthData(location)
-	ts.Require().NoError(err, "Failed to extract auth ID")
-	ts.Require().NotEmpty(authId, "Auth ID should not be empty")
-	ts.Require().NotEmpty(flowID, "Flow ID should not be empty")
-
-	// Step 2: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "")
-	ts.Require().NoError(err, "Failed to initiate authentication flow")
-
-	// Step 4: Execute authentication flow with unauthorized user (no role)
-	flowInputs := map[string]string{
-		"username": "oauth_unauthorized_user",
-		"password": "SecurePass123!",
-	}
-
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, flowInputs, "action_001")
-	ts.Require().NoError(err, "Failed to execute authentication flow")
-	ts.Require().NotNil(flowStep, "Flow step should not be nil")
-	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")
-	ts.Require().NotEmpty(flowStep.Assertion, "Assertion should not be empty")
-
-	// Step 5: Complete authorization with assertion
-	authzResponse, err := testutils.CompleteAuthorization(authId, flowStep.Assertion)
-	ts.Require().NoError(err, "Failed to complete authorization")
-	ts.Require().NotNil(authzResponse, "Authorization response should not be nil")
-	ts.Require().NotEmpty(authzResponse.RedirectURI, "Redirect URI should not be empty")
-
-	// Step 6: Extract authorization code
-	code, err := testutils.ExtractAuthorizationCode(authzResponse.RedirectURI)
-	ts.Require().NoError(err, "Failed to extract authorization code")
-	ts.Require().NotEmpty(code, "Authorization code should not be empty")
-
-	// Step 7: Exchange code for token
-	tokenResult, err := testutils.RequestToken(scopeTestClientID, scopeTestClientSecret, code,
-		scopeTestRedirectURI, "authorization_code")
-	ts.Require().NoError(err, "Failed to exchange code for token")
-	ts.Require().NotNil(tokenResult, "Token result should not be nil")
-	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, "Token endpoint should return 200")
-	ts.Require().NotNil(tokenResult.Token, "Token response should not be nil")
-	ts.Require().NotEmpty(tokenResult.Token.AccessToken, "Access token should not be empty")
-
-	// Step 8: Decode access token and verify scopes
-	claims, err := testutils.DecodeJWT(tokenResult.Token.AccessToken)
+	// Step 2: Decode access token and verify scopes
+	claims, err := testutils.DecodeJWT(tokenResp.AccessToken)
 	ts.Require().NoError(err, "Failed to decode access token")
 	ts.Require().NotNil(claims, "Claims should not be nil")
 
@@ -434,7 +418,7 @@ func (ts *OAuthAuthzScopeTestSuite) createOAuthApplication(authFlowID string) (s
 					"redirect_uris":              []string{scopeTestRedirectURI},
 					"grant_types":                []string{"authorization_code", "refresh_token"},
 					"response_types":             []string{"code"},
-					"token_endpoint_auth_method": "client_secret_basic",
+					"token_endpoint_auth_method": "client_secret_post",
 				},
 			},
 		},

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -125,10 +125,17 @@ type GroupMember struct {
 
 // Group represents a group in the system
 type Group struct {
-	ID                 string `json:"id,omitempty"`
-	Name               string `json:"name"`
-	Description        string `json:"description,omitempty"`
-	OrganizationUnitId string `json:"organizationUnitId,omitempty"`
+	ID                 string   `json:"id,omitempty"`
+	Name               string   `json:"name"`
+	Description        string   `json:"description,omitempty"`
+	OrganizationUnitId string   `json:"organizationUnitId,omitempty"`
+	Members            []Member `json:"members,omitempty"`
+}
+
+// Member represents a member of a group (either user or another group).
+type Member struct {
+	Id   string `json:"id"`
+	Type string `json:"type"` // "user" or "group"
 }
 
 // Assignment represents a role assignment

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -392,8 +392,15 @@ func ValidateOAuth2ErrorRedirect(location string, expectedError string,
 
 // ObtainAccessTokenWithPassword performs the complete OAuth authorization code flow with password
 // authentication and returns a TokenResponse with the access token and expiry information.
+// clientSecret is optional and can be provided for confidential clients 
+// and use client_secret_post authentication in the token request.
 func ObtainAccessTokenWithPassword(clientID, redirectURI, scope, username, password string,
-	usePKCE bool) (*TokenResponse, error) {
+	usePKCE bool, optionalParams ...string) (*TokenResponse, error) {
+	clientSecret := ""
+	if len(optionalParams) > 0 {
+		clientSecret = optionalParams[0]
+	}
+
 	var codeVerifier string
 	var codeChallenge string
 
@@ -473,7 +480,7 @@ func ObtainAccessTokenWithPassword(clientID, redirectURI, scope, username, passw
 	}
 
 	// Step 7: Exchange code for token with PKCE verifier
-	tokenResult, err := RequestTokenWithPKCE(clientID, "", code, redirectURI, "authorization_code",
+	tokenResult, err := RequestTokenWithPKCE(clientID, clientSecret, code, redirectURI, "authorization_code",
 		codeVerifier)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request token: %w", err)


### PR DESCRIPTION
### Purpose
Fix https://github.com/asgardeo/thunder/issues/1814

This pull request enhances the `authorizationExecutor` by enabling it to fetch user group information from the user service if group data is not present in the user's attributes or runtime data. It updates both the implementation and the test suite to support and verify this new fallback behavior.

Key changes include:

**Core logic enhancements:**

* Updated the `authorizationExecutor` to accept and store a `UserProviderInterface`, allowing it to fetch group IDs from the user service when not available in the user context. (`authz_executor.go` [[1]](diffhunk://#diff-8af02a4b4e28254a9b97fd3ce51f9ff97e7347ff61be11eecca4287989ffce52R29) [[2]](diffhunk://#diff-8af02a4b4e28254a9b97fd3ce51f9ff97e7347ff61be11eecca4287989ffce52R43) [[3]](diffhunk://#diff-8af02a4b4e28254a9b97fd3ce51f9ff97e7347ff61be11eecca4287989ffce52R53) [[4]](diffhunk://#diff-8af02a4b4e28254a9b97fd3ce51f9ff97e7347ff61be11eecca4287989ffce52R64)
* Enhanced the `extractGroupIDs` method to attempt retrieving user groups from the user service as a fallback, and to log errors if the fetch fails. (`authz_executor.go` [[1]](diffhunk://#diff-8af02a4b4e28254a9b97fd3ce51f9ff97e7347ff61be11eecca4287989ffce52R150) [[2]](diffhunk://#diff-8af02a4b4e28254a9b97fd3ce51f9ff97e7347ff61be11eecca4287989ffce52R180-R195)

**Testing improvements:**

* Refactored test setup to inject a mock user provider into the `authorizationExecutor`, ensuring all test cases are compatible with the new dependency. (`authz_executor_test.go` [[1]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fR22) [[2]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fR33-R50) [[3]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL61-R66) [[4]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL72-R78) [[5]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL119-R126) [[6]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL153-R165) [[7]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL186-R203) [[8]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL212-R230) [[9]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fR244-R247) [[10]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL244-R267) [[11]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL270-R294) [[12]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL322-R347) [[13]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL405-R431) [[14]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fR442-R453) [[15]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL499-R531) [[16]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL525-R558) [[17]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL553-R587) [[18]](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fL595-R630)
* Added new tests to verify that group IDs are correctly fetched from the user service both in successful and error scenarios, ensuring robust fallback and error handling. (`authz_executor_test.go` [backend/internal/flow/executor/authz_executor_test.goR672-R724](diffhunk://#diff-335d829cc1c75870fed8ad00383a00d3886149820cec863074ee9ae3c5d6815fR672-R724))

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Groups now include member entries for clearer membership management.
  * Authorization can resolve user groups from the user service when not present locally.
  * Token retrieval supports an optional client secret for confidential clients.
  * Initial setup now creates/uses an Administrators group for admin role assignment.

* **Bug Fixes**
  * Improved handling and user-facing reporting when group lookup fails during authorization.

* **Tests**
  * Expanded unit and integration tests for group-based authorization and token flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->