### PR TITLE
Add credential support and disable unique when credential is checked

### DIFF
--- a/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/components/create-user-type/ConfigureProperties.tsx
@@ -159,6 +159,8 @@ export default function ConfigureProperties({
           ? {
               ...prop,
               [field]: value,
+              // Clear unique when credential is enabled
+              ...(field === 'credential' && value && {unique: false}),
               // Reset type-specific fields when type changes
               ...(field === 'type' && {
                 enum: (value as UIPropertyType) === 'enum' ? prop.enum : [],
@@ -310,6 +312,7 @@ export default function ConfigureProperties({
                   control={
                     <Checkbox
                       checked={property.unique}
+                      disabled={property.credential}
                       onChange={(e) => handlePropertyChange(property.id, 'unique', e.target.checked)}
                     />
                   }

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/ViewUserTypePage.tsx
@@ -782,12 +782,13 @@ export default function ViewUserTypePage() {
                             }
                           />
                         </Tooltip>
-                        {(property.type === 'string' || property.type === 'number' || property.type === 'enum') && !property.credential && (
+                        {(property.type === 'string' || property.type === 'number' || property.type === 'enum') && (
                           <Tooltip title={t('userTypes:tooltips.unique', 'Each user must have a distinct value for this field')} placement="top" arrow>
                             <FormControlLabel
                               control={
                                 <Checkbox
                                   checked={property.unique}
+                                  disabled={property.credential}
                                   onChange={(e) => handlePropertyChange(property.id, 'unique', e.target.checked)}
                                 />
                               }

--- a/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
+++ b/frontend/apps/thunder-develop/src/features/user-types/pages/__tests__/ViewUserTypePage.test.tsx
@@ -1425,6 +1425,225 @@ describe('ViewUserTypePage', () => {
     });
   });
 
+  describe('Credential Support', () => {
+    it('displays credential column in view mode', () => {
+      const userTypeWithCredential: ApiUserSchema = {
+        id: 'schema-123',
+        name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
+        schema: {
+          password: {
+            type: 'string',
+            required: true,
+            credential: true,
+          },
+          email: {
+            type: 'string',
+            required: true,
+          },
+        },
+      };
+
+      mockUseGetUserType.mockReturnValue({
+        data: userTypeWithCredential,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<ViewUserTypePage />);
+
+      expect(screen.getByText('Credential')).toBeInTheDocument();
+    });
+
+    it('allows toggling credential checkbox in edit mode', async () => {
+      const user = userEvent.setup();
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByRole('button', {name: /edit/i}));
+
+      // email is string type, so credential checkbox should appear
+      const credentialCheckboxes = screen.getAllByRole('checkbox', {name: /values will be hashed/i});
+      expect(credentialCheckboxes.length).toBeGreaterThan(0);
+
+      await user.click(credentialCheckboxes[0]);
+
+      await waitFor(() => {
+        expect(credentialCheckboxes[0]).toBeChecked();
+      });
+    });
+
+    it('disables unique checkbox when credential is checked', async () => {
+      const user = userEvent.setup();
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByRole('button', {name: /edit/i}));
+
+      // Find the unique checkbox for email (first string property)
+      const uniqueCheckboxes = screen.getAllByRole('checkbox', {name: /each user must have a distinct value/i});
+      const credentialCheckboxes = screen.getAllByRole('checkbox', {name: /values will be hashed/i});
+
+      // Initially unique should be enabled
+      expect(uniqueCheckboxes[0]).not.toBeDisabled();
+
+      // Toggle credential on
+      await user.click(credentialCheckboxes[0]);
+
+      await waitFor(() => {
+        expect(uniqueCheckboxes[0]).toBeDisabled();
+      });
+    });
+
+    it('clears unique when credential is enabled', async () => {
+      const user = userEvent.setup();
+
+      const userTypeWithUnique: ApiUserSchema = {
+        id: 'schema-123',
+        name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
+        schema: {
+          email: {
+            type: 'string',
+            required: true,
+            unique: true,
+          },
+        },
+      };
+
+      mockUseGetUserType.mockReturnValue({
+        data: userTypeWithUnique,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByRole('button', {name: /edit/i}));
+
+      const uniqueCheckbox = screen.getByRole('checkbox', {name: /each user must have a distinct value/i});
+      const credentialCheckbox = screen.getByRole('checkbox', {name: /values will be hashed/i});
+
+      expect(uniqueCheckbox).toBeChecked();
+
+      // Toggle credential on — should clear unique
+      await user.click(credentialCheckbox);
+
+      await waitFor(() => {
+        expect(uniqueCheckbox).not.toBeChecked();
+        expect(uniqueCheckbox).toBeDisabled();
+      });
+    });
+
+    it('shows credential hint when credential is checked', async () => {
+      const user = userEvent.setup();
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByRole('button', {name: /edit/i}));
+
+      const credentialCheckboxes = screen.getAllByRole('checkbox', {name: /values will be hashed/i});
+      await user.click(credentialCheckboxes[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/this field will be treated as a secret/i)).toBeInTheDocument();
+      });
+    });
+
+    it('saves schema with credential flag', async () => {
+      const user = userEvent.setup();
+
+      const userTypeWithSingleString: ApiUserSchema = {
+        id: 'schema-123',
+        name: 'Test Schema',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
+        schema: {
+          password: {
+            type: 'string',
+            required: true,
+          },
+        },
+      };
+
+      mockUseGetUserType.mockReturnValue({
+        data: userTypeWithSingleString,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      mockUpdateMutateAsync.mockResolvedValue(undefined);
+
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByRole('button', {name: /edit/i}));
+
+      const credentialCheckbox = screen.getByRole('checkbox', {name: /values will be hashed/i});
+      await user.click(credentialCheckbox);
+
+      await user.click(screen.getByRole('button', {name: /save changes/i}));
+
+      await waitFor(() => {
+        expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+          userTypeId: 'schema-123',
+          data: expect.objectContaining({
+            schema: expect.objectContaining({
+              password: expect.objectContaining({
+                credential: true,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }),
+        });
+      });
+    });
+  });
+
+  describe('Add and Remove Properties', () => {
+    it('adds a new property when add button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByRole('button', {name: /edit/i}));
+
+      // Count initial property name inputs
+      const initialInputs = screen.getAllByRole('textbox').filter(
+        (el) => (el as HTMLInputElement).value === 'email' || (el as HTMLInputElement).value === 'age' || (el as HTMLInputElement).value === 'isActive',
+      );
+      const initialCount = initialInputs.length;
+
+      // Click add property button
+      const addButton = screen.getByRole('button', {name: /add property/i});
+      await user.click(addButton);
+
+      // Should have one more property
+      await waitFor(() => {
+        const typeSelects = getPropertyTypeSelects();
+        expect(typeSelects.length).toBe(initialCount + 1);
+      });
+    });
+
+    it('removes a property when delete button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByRole('button', {name: /edit/i}));
+
+      const typeSelectsBefore = getPropertyTypeSelects();
+      const countBefore = typeSelectsBefore.length;
+
+      // Find and click a remove property button
+      const removeButtons = screen.getAllByRole('button', {name: /remove property/i});
+      await user.click(removeButtons[0]);
+
+      await waitFor(() => {
+        const typeSelectsAfter = getPropertyTypeSelects();
+        expect(typeSelectsAfter.length).toBe(countBefore - 1);
+      });
+    });
+  });
+
   describe('Schema Property Handling with Enum Type', () => {
     it('saves schema with enum type converted to string', async () => {
       const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- Disable (instead of hide) the **Unique** checkbox when **Credential** is checked on the user type edit page — keeps the UI consistent and less jarring
- Apply the same Unique-disable behavior to the **create user type** wizard (`ConfigureProperties.tsx`) for consistency
- Clear `unique` flag automatically when `credential` is toggled on (both create and edit flows)
- Add 8 new tests covering credential toggling, unique disabling, add/remove properties, and save with credential flag

## Test plan
- [ ] Verify Unique checkbox is visible but disabled (greyed out) when Credential is checked in edit mode
- [ ] Verify same behavior in create wizard
- [ ] Verify toggling Credential on clears Unique if it was checked
- [ ] Verify credential hint alert appears when credential is enabled
- [ ] Verify save persists credential flag to API

🤖 Generated with [Claude Code](https://claude.com/claude-code)