### PR TITLE
Remove usage of context.TODO 

### DIFF
--- a/backend/internal/application/cache_backed_store_test.go
+++ b/backend/internal/application/cache_backed_store_test.go
@@ -211,7 +211,7 @@ func (suite *CacheBackedStoreTestSuite) TestCreateApplication_Success() {
 
 	suite.mockStore.On("CreateApplication", mock.Anything, *app).Return(nil).Once()
 
-	err := suite.cachedStore.CreateApplication(context.TODO(), *app)
+	err := suite.cachedStore.CreateApplication(context.Background(), *app)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 
@@ -231,7 +231,7 @@ func (suite *CacheBackedStoreTestSuite) TestCreateApplication_WithOAuth() {
 
 	suite.mockStore.On("CreateApplication", mock.Anything, *app).Return(nil).Once()
 
-	err := suite.cachedStore.CreateApplication(context.TODO(), *app)
+	err := suite.cachedStore.CreateApplication(context.Background(), *app)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 
@@ -247,7 +247,7 @@ func (suite *CacheBackedStoreTestSuite) TestCreateApplication_StoreError() {
 
 	suite.mockStore.On("CreateApplication", mock.Anything, *app).Return(storeErr).Once()
 
-	err := suite.cachedStore.CreateApplication(context.TODO(), *app)
+	err := suite.cachedStore.CreateApplication(context.Background(), *app)
 	suite.Equal(storeErr, err)
 	suite.mockStore.AssertExpectations(suite.T())
 
@@ -267,7 +267,7 @@ func (suite *CacheBackedStoreTestSuite) TestCreateApplication_CacheSetError() {
 	suite.mockStore.On("CreateApplication", mock.Anything, *app).Return(nil).Once()
 
 	// Should not fail even if cache set fails
-	err := suite.cachedStore.CreateApplication(context.TODO(), *app)
+	err := suite.cachedStore.CreateApplication(context.Background(), *app)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -276,7 +276,7 @@ func (suite *CacheBackedStoreTestSuite) TestCreateApplication_CacheSetError() {
 func (suite *CacheBackedStoreTestSuite) TestGetTotalApplicationCount_Success() {
 	suite.mockStore.On("GetTotalApplicationCount", mock.Anything).Return(10, nil).Once()
 
-	count, err := suite.cachedStore.GetTotalApplicationCount(context.TODO())
+	count, err := suite.cachedStore.GetTotalApplicationCount(context.Background())
 	suite.Nil(err)
 	suite.Equal(10, count)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -286,7 +286,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetTotalApplicationCount_StoreError(
 	storeErr := errors.New("store error")
 	suite.mockStore.On("GetTotalApplicationCount", mock.Anything).Return(0, storeErr).Once()
 
-	count, err := suite.cachedStore.GetTotalApplicationCount(context.TODO())
+	count, err := suite.cachedStore.GetTotalApplicationCount(context.Background())
 	suite.Equal(storeErr, err)
 	suite.Equal(0, count)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -309,7 +309,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationList_Success() {
 
 	suite.mockStore.On("GetApplicationList", mock.Anything).Return(expectedList, nil).Once()
 
-	list, err := suite.cachedStore.GetApplicationList(context.TODO())
+	list, err := suite.cachedStore.GetApplicationList(context.Background())
 	suite.Nil(err)
 	suite.Equal(expectedList, list)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -319,7 +319,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationList_StoreError() {
 	storeErr := errors.New("store error")
 	suite.mockStore.On("GetApplicationList", mock.Anything).Return(([]model.BasicApplicationDTO)(nil), storeErr).Once()
 
-	list, err := suite.cachedStore.GetApplicationList(context.TODO())
+	list, err := suite.cachedStore.GetApplicationList(context.Background())
 	suite.Equal(storeErr, err)
 	suite.Nil(list)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -330,7 +330,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetOAuthApplication_CacheHit() {
 	oauthApp := suite.createTestOAuthApp()
 	_ = suite.oauthAppCache.Set(cache.CacheKey{Key: "test-client-id"}, oauthApp)
 
-	result, err := suite.cachedStore.GetOAuthApplication(context.TODO(), "test-client-id")
+	result, err := suite.cachedStore.GetOAuthApplication(context.Background(), "test-client-id")
 	suite.Nil(err)
 	suite.Equal(oauthApp, result)
 
@@ -343,7 +343,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetOAuthApplication_CacheMiss() {
 
 	suite.mockStore.On("GetOAuthApplication", mock.Anything, "test-client-id").Return(oauthApp, nil).Once()
 
-	result, err := suite.cachedStore.GetOAuthApplication(context.TODO(), "test-client-id")
+	result, err := suite.cachedStore.GetOAuthApplication(context.Background(), "test-client-id")
 	suite.Nil(err)
 	suite.Equal(oauthApp, result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -359,7 +359,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetOAuthApplication_StoreError() {
 	suite.mockStore.On("GetOAuthApplication", mock.Anything, "test-client-id").
 		Return((*model.OAuthAppConfigProcessedDTO)(nil), storeErr).Once()
 
-	result, err := suite.cachedStore.GetOAuthApplication(context.TODO(), "test-client-id")
+	result, err := suite.cachedStore.GetOAuthApplication(context.Background(), "test-client-id")
 	suite.Equal(storeErr, err)
 	suite.Nil(result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -369,7 +369,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetOAuthApplication_NilResult() {
 	suite.mockStore.On("GetOAuthApplication", mock.Anything, "test-client-id").
 		Return((*model.OAuthAppConfigProcessedDTO)(nil), nil).Once()
 
-	result, err := suite.cachedStore.GetOAuthApplication(context.TODO(), "test-client-id")
+	result, err := suite.cachedStore.GetOAuthApplication(context.Background(), "test-client-id")
 	suite.Nil(err)
 	suite.Nil(result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -384,7 +384,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByID_CacheHit() {
 	app := suite.createTestApp()
 	_ = suite.appByIDCache.Set(cache.CacheKey{Key: app.ID}, app)
 
-	result, err := suite.cachedStore.GetApplicationByID(context.TODO(), app.ID)
+	result, err := suite.cachedStore.GetApplicationByID(context.Background(), app.ID)
 	suite.Nil(err)
 	suite.Equal(app, result)
 
@@ -397,7 +397,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByID_CacheMiss() {
 
 	suite.mockStore.On("GetApplicationByID", mock.Anything, app.ID).Return(app, nil).Once()
 
-	result, err := suite.cachedStore.GetApplicationByID(context.TODO(), app.ID)
+	result, err := suite.cachedStore.GetApplicationByID(context.Background(), app.ID)
 	suite.Nil(err)
 	suite.Equal(app, result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -413,7 +413,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByID_StoreError() {
 	suite.mockStore.On("GetApplicationByID", mock.Anything, "test-id").
 		Return((*model.ApplicationProcessedDTO)(nil), storeErr).Once()
 
-	result, err := suite.cachedStore.GetApplicationByID(context.TODO(), "test-id")
+	result, err := suite.cachedStore.GetApplicationByID(context.Background(), "test-id")
 	suite.Equal(storeErr, err)
 	suite.Nil(result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -423,7 +423,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByID_NilResult() {
 	suite.mockStore.On("GetApplicationByID", mock.Anything, "test-id").
 		Return((*model.ApplicationProcessedDTO)(nil), nil).Once()
 
-	result, err := suite.cachedStore.GetApplicationByID(context.TODO(), "test-id")
+	result, err := suite.cachedStore.GetApplicationByID(context.Background(), "test-id")
 	suite.Nil(err)
 	suite.Nil(result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -438,7 +438,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByName_CacheHit() {
 	app := suite.createTestApp()
 	_ = suite.appByNameCache.Set(cache.CacheKey{Key: app.Name}, app)
 
-	result, err := suite.cachedStore.GetApplicationByName(context.TODO(), app.Name)
+	result, err := suite.cachedStore.GetApplicationByName(context.Background(), app.Name)
 	suite.Nil(err)
 	suite.Equal(app, result)
 
@@ -451,7 +451,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByName_CacheMiss() {
 
 	suite.mockStore.On("GetApplicationByName", mock.Anything, app.Name).Return(app, nil).Once()
 
-	result, err := suite.cachedStore.GetApplicationByName(context.TODO(), app.Name)
+	result, err := suite.cachedStore.GetApplicationByName(context.Background(), app.Name)
 	suite.Nil(err)
 	suite.Equal(app, result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -467,7 +467,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByName_StoreError() {
 	suite.mockStore.On("GetApplicationByName", mock.Anything, "test-name").
 		Return((*model.ApplicationProcessedDTO)(nil), storeErr).Once()
 
-	result, err := suite.cachedStore.GetApplicationByName(context.TODO(), "test-name")
+	result, err := suite.cachedStore.GetApplicationByName(context.Background(), "test-name")
 	suite.Equal(storeErr, err)
 	suite.Nil(result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -477,7 +477,7 @@ func (suite *CacheBackedStoreTestSuite) TestGetApplicationByName_NilResult() {
 	suite.mockStore.On("GetApplicationByName", mock.Anything, "test-name").
 		Return((*model.ApplicationProcessedDTO)(nil), nil).Once()
 
-	result, err := suite.cachedStore.GetApplicationByName(context.TODO(), "test-name")
+	result, err := suite.cachedStore.GetApplicationByName(context.Background(), "test-name")
 	suite.Nil(err)
 	suite.Nil(result)
 	suite.mockStore.AssertExpectations(suite.T())
@@ -496,7 +496,7 @@ func (suite *CacheBackedStoreTestSuite) TestUpdateApplication_Success() {
 
 	suite.mockStore.On("UpdateApplication", mock.Anything, existingApp, updatedApp).Return(nil).Once()
 
-	err := suite.cachedStore.UpdateApplication(context.TODO(), existingApp, updatedApp)
+	err := suite.cachedStore.UpdateApplication(context.Background(), existingApp, updatedApp)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 
@@ -521,7 +521,7 @@ func (suite *CacheBackedStoreTestSuite) TestUpdateApplication_WithOAuth() {
 
 	suite.mockStore.On("UpdateApplication", mock.Anything, existingApp, updatedApp).Return(nil).Once()
 
-	err := suite.cachedStore.UpdateApplication(context.TODO(), existingApp, updatedApp)
+	err := suite.cachedStore.UpdateApplication(context.Background(), existingApp, updatedApp)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 
@@ -539,7 +539,7 @@ func (suite *CacheBackedStoreTestSuite) TestUpdateApplication_StoreError() {
 
 	suite.mockStore.On("UpdateApplication", mock.Anything, existingApp, updatedApp).Return(storeErr).Once()
 
-	err := suite.cachedStore.UpdateApplication(context.TODO(), existingApp, updatedApp)
+	err := suite.cachedStore.UpdateApplication(context.Background(), existingApp, updatedApp)
 	suite.Equal(storeErr, err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -556,7 +556,7 @@ func (suite *CacheBackedStoreTestSuite) TestUpdateApplication_CacheInvalidationE
 	suite.mockStore.On("UpdateApplication", mock.Anything, existingApp, updatedApp).Return(nil).Once()
 
 	// Should not fail even if cache invalidation fails
-	err := suite.cachedStore.UpdateApplication(context.TODO(), existingApp, updatedApp)
+	err := suite.cachedStore.UpdateApplication(context.Background(), existingApp, updatedApp)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -568,7 +568,7 @@ func (suite *CacheBackedStoreTestSuite) TestDeleteApplication_FoundInCache() {
 
 	suite.mockStore.On("DeleteApplication", mock.Anything, app.ID).Return(nil).Once()
 
-	err := suite.cachedStore.DeleteApplication(context.TODO(), app.ID)
+	err := suite.cachedStore.DeleteApplication(context.Background(), app.ID)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 
@@ -587,7 +587,7 @@ func (suite *CacheBackedStoreTestSuite) TestDeleteApplication_NotFoundInCache() 
 	suite.mockStore.On("GetApplicationByID", mock.Anything, app.ID).Return(app, nil).Once()
 	suite.mockStore.On("DeleteApplication", mock.Anything, app.ID).Return(nil).Once()
 
-	err := suite.cachedStore.DeleteApplication(context.TODO(), app.ID)
+	err := suite.cachedStore.DeleteApplication(context.Background(), app.ID)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -598,7 +598,7 @@ func (suite *CacheBackedStoreTestSuite) TestDeleteApplication_GetApplicationErro
 	suite.mockStore.On("GetApplicationByID", mock.Anything, "test-id").
 		Return((*model.ApplicationProcessedDTO)(nil), storeErr).Once()
 
-	err := suite.cachedStore.DeleteApplication(context.TODO(), "test-id")
+	err := suite.cachedStore.DeleteApplication(context.Background(), "test-id")
 	suite.Equal(storeErr, err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -607,7 +607,7 @@ func (suite *CacheBackedStoreTestSuite) TestDeleteApplication_ApplicationNotFoun
 	suite.mockStore.On("GetApplicationByID", mock.Anything, "test-id").
 		Return((*model.ApplicationProcessedDTO)(nil), model.ApplicationNotFoundError).Once()
 
-	err := suite.cachedStore.DeleteApplication(context.TODO(), "test-id")
+	err := suite.cachedStore.DeleteApplication(context.Background(), "test-id")
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -616,7 +616,7 @@ func (suite *CacheBackedStoreTestSuite) TestDeleteApplication_NilApplication() {
 	suite.mockStore.On("GetApplicationByID", mock.Anything, "test-id").
 		Return((*model.ApplicationProcessedDTO)(nil), nil).Once()
 
-	err := suite.cachedStore.DeleteApplication(context.TODO(), "test-id")
+	err := suite.cachedStore.DeleteApplication(context.Background(), "test-id")
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -628,7 +628,7 @@ func (suite *CacheBackedStoreTestSuite) TestDeleteApplication_StoreError() {
 
 	suite.mockStore.On("DeleteApplication", mock.Anything, app.ID).Return(storeErr).Once()
 
-	err := suite.cachedStore.DeleteApplication(context.TODO(), app.ID)
+	err := suite.cachedStore.DeleteApplication(context.Background(), app.ID)
 	suite.Equal(storeErr, err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -645,7 +645,7 @@ func (suite *CacheBackedStoreTestSuite) TestDeleteApplication_CacheInvalidationE
 	suite.mockStore.On("DeleteApplication", mock.Anything, app.ID).Return(nil).Once()
 
 	// Should not fail even if cache invalidation fails
-	err := suite.cachedStore.DeleteApplication(context.TODO(), app.ID)
+	err := suite.cachedStore.DeleteApplication(context.Background(), app.ID)
 	suite.Nil(err)
 	suite.mockStore.AssertExpectations(suite.T())
 }
@@ -870,7 +870,7 @@ func (suite *CacheBackedStoreTestSuite) TestIsApplicationExists_Success() {
 
 	suite.mockStore.EXPECT().IsApplicationExists(mock.Anything, appID).Return(true, nil).Once()
 
-	exists, err := suite.cachedStore.IsApplicationExists(context.TODO(), appID)
+	exists, err := suite.cachedStore.IsApplicationExists(context.Background(), appID)
 
 	suite.NoError(err)
 	suite.True(exists)
@@ -881,7 +881,7 @@ func (suite *CacheBackedStoreTestSuite) TestIsApplicationExists_NotFound() {
 
 	suite.mockStore.EXPECT().IsApplicationExists(mock.Anything, appID).Return(false, nil).Once()
 
-	exists, err := suite.cachedStore.IsApplicationExists(context.TODO(), appID)
+	exists, err := suite.cachedStore.IsApplicationExists(context.Background(), appID)
 
 	suite.NoError(err)
 	suite.False(exists)
@@ -893,7 +893,7 @@ func (suite *CacheBackedStoreTestSuite) TestIsApplicationExists_Error() {
 
 	suite.mockStore.EXPECT().IsApplicationExists(mock.Anything, appID).Return(false, expectedErr).Once()
 
-	exists, err := suite.cachedStore.IsApplicationExists(context.TODO(), appID)
+	exists, err := suite.cachedStore.IsApplicationExists(context.Background(), appID)
 
 	suite.Error(err)
 	suite.False(exists)
@@ -905,7 +905,7 @@ func (suite *CacheBackedStoreTestSuite) TestIsApplicationExistsByName_Success() 
 
 	suite.mockStore.EXPECT().IsApplicationExistsByName(mock.Anything, appName).Return(true, nil).Once()
 
-	exists, err := suite.cachedStore.IsApplicationExistsByName(context.TODO(), appName)
+	exists, err := suite.cachedStore.IsApplicationExistsByName(context.Background(), appName)
 
 	suite.NoError(err)
 	suite.True(exists)
@@ -916,7 +916,7 @@ func (suite *CacheBackedStoreTestSuite) TestIsApplicationExistsByName_NotFound()
 
 	suite.mockStore.EXPECT().IsApplicationExistsByName(mock.Anything, appName).Return(false, nil).Once()
 
-	exists, err := suite.cachedStore.IsApplicationExistsByName(context.TODO(), appName)
+	exists, err := suite.cachedStore.IsApplicationExistsByName(context.Background(), appName)
 
 	suite.NoError(err)
 	suite.False(exists)
@@ -928,7 +928,7 @@ func (suite *CacheBackedStoreTestSuite) TestIsApplicationExistsByName_Error() {
 
 	suite.mockStore.EXPECT().IsApplicationExistsByName(mock.Anything, appName).Return(false, expectedErr).Once()
 
-	exists, err := suite.cachedStore.IsApplicationExistsByName(context.TODO(), appName)
+	exists, err := suite.cachedStore.IsApplicationExistsByName(context.Background(), appName)
 
 	suite.Error(err)
 	suite.False(exists)

--- a/backend/internal/application/composite_store_test.go
+++ b/backend/internal/application/composite_store_test.go
@@ -89,7 +89,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationByID() {
 			appID: "file-app-1",
 			setupFileStore: func() {
 				// Add app to file store
-				err := suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+				err := suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 					ID:   "file-app-1",
 					Name: "File App",
 				})
@@ -126,7 +126,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationByID() {
 			tc.setupFileStore()
 			tc.setupDBStore()
 
-			got, err := suite.compositeStore.GetApplicationByID(context.TODO(), tc.appID)
+			got, err := suite.compositeStore.GetApplicationByID(context.Background(), tc.appID)
 
 			if tc.wantErr {
 				suite.Error(err)
@@ -150,7 +150,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationByName() 
 			}, nil).
 			Once()
 
-		got, err := suite.compositeStore.GetApplicationByName(context.TODO(), "DB App")
+		got, err := suite.compositeStore.GetApplicationByName(context.Background(), "DB App")
 		suite.NoError(err)
 		suite.Equal("db-app-1", got.ID)
 		suite.Equal("DB App", got.Name)
@@ -159,7 +159,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationByName() 
 	suite.Run("retrieves from file store when not in DB", func() {
 		suite.SetupTest() // Fresh setup
 
-		err := suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+		err := suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 			ID:   "file-app-1",
 			Name: "File App",
 		})
@@ -169,7 +169,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationByName() 
 			Return(nil, model.ApplicationNotFoundError).
 			Once()
 
-		got, err := suite.compositeStore.GetApplicationByName(context.TODO(), "File App")
+		got, err := suite.compositeStore.GetApplicationByName(context.Background(), "File App")
 		suite.NoError(err)
 		suite.Equal("file-app-1", got.ID)
 		suite.Equal("File App", got.Name)
@@ -180,7 +180,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationByName() 
 			Return(nil, model.ApplicationNotFoundError).
 			Once()
 
-		got, err := suite.compositeStore.GetApplicationByName(context.TODO(), "Nonexistent")
+		got, err := suite.compositeStore.GetApplicationByName(context.Background(), "Nonexistent")
 		suite.Error(err)
 		suite.Nil(got)
 		suite.True(errors.Is(err, model.ApplicationNotFoundError))
@@ -196,7 +196,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetOAuthApplication() {
 			}, nil).
 			Once()
 
-		got, err := suite.compositeStore.GetOAuthApplication(context.TODO(), "client-123")
+		got, err := suite.compositeStore.GetOAuthApplication(context.Background(), "client-123")
 		suite.NoError(err)
 		suite.Equal("client-123", got.ClientID)
 	})
@@ -206,7 +206,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetOAuthApplication() {
 			Return(nil, model.ApplicationNotFoundError).
 			Once()
 
-		got, err := suite.compositeStore.GetOAuthApplication(context.TODO(), "client-456")
+		got, err := suite.compositeStore.GetOAuthApplication(context.Background(), "client-456")
 		suite.Error(err)
 		suite.Nil(got)
 	})
@@ -224,7 +224,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_CreateApplication() {
 			Return(nil).
 			Once()
 
-		err := suite.compositeStore.CreateApplication(context.TODO(), app)
+		err := suite.compositeStore.CreateApplication(context.Background(), app)
 		suite.NoError(err)
 	})
 
@@ -239,7 +239,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_CreateApplication() {
 			Return(dbErr).
 			Once()
 
-		err := suite.compositeStore.CreateApplication(context.TODO(), app)
+		err := suite.compositeStore.CreateApplication(context.Background(), app)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 	})
@@ -261,7 +261,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_UpdateApplication() {
 			Return(nil).
 			Once()
 
-		err := suite.compositeStore.UpdateApplication(context.TODO(), existing, updated)
+		err := suite.compositeStore.UpdateApplication(context.Background(), existing, updated)
 		suite.NoError(err)
 	})
 
@@ -278,7 +278,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_UpdateApplication() {
 			Return(dbErr).
 			Once()
 
-		err := suite.compositeStore.UpdateApplication(context.TODO(), existing, updated)
+		err := suite.compositeStore.UpdateApplication(context.Background(), existing, updated)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 	})
@@ -291,7 +291,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_DeleteApplication() {
 			Return(nil).
 			Once()
 
-		err := suite.compositeStore.DeleteApplication(context.TODO(), "app-1")
+		err := suite.compositeStore.DeleteApplication(context.Background(), "app-1")
 		suite.NoError(err)
 	})
 
@@ -301,7 +301,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_DeleteApplication() {
 			Return(dbErr).
 			Once()
 
-		err := suite.compositeStore.DeleteApplication(context.TODO(), "app-2")
+		err := suite.compositeStore.DeleteApplication(context.Background(), "app-2")
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 	})
@@ -315,7 +315,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationExists() {
 			Return(true, nil).
 			Once()
 
-		exists, err := suite.compositeStore.IsApplicationExists(context.TODO(), "db-app-1")
+		exists, err := suite.compositeStore.IsApplicationExists(context.Background(), "db-app-1")
 		suite.NoError(err)
 		suite.True(exists)
 		suite.dbStoreMock.AssertExpectations(suite.T())
@@ -325,14 +325,14 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationExists() {
 		suite.SetupTest() // Fresh setup
 
 		// Add app to file store
-		err := suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+		err := suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 			ID:   "file-app-1",
 			Name: "File App",
 		})
 		suite.NoError(err)
 
 		// DB mock should NOT be called since file store has it
-		exists, err := suite.compositeStore.IsApplicationExists(context.TODO(), "file-app-1")
+		exists, err := suite.compositeStore.IsApplicationExists(context.Background(), "file-app-1")
 		suite.NoError(err)
 		suite.True(exists)
 	})
@@ -342,7 +342,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationExists() {
 			Return(false, nil).
 			Once()
 
-		exists, err := suite.compositeStore.IsApplicationExists(context.TODO(), "nonexistent")
+		exists, err := suite.compositeStore.IsApplicationExists(context.Background(), "nonexistent")
 		suite.NoError(err)
 		suite.False(exists)
 		suite.dbStoreMock.AssertExpectations(suite.T())
@@ -354,7 +354,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationExists() {
 			Return(false, dbErr).
 			Once()
 
-		exists, err := suite.compositeStore.IsApplicationExists(context.TODO(), "error-app")
+		exists, err := suite.compositeStore.IsApplicationExists(context.Background(), "error-app")
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.False(exists)
@@ -369,7 +369,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationExistsByNa
 			Return(true, nil).
 			Once()
 
-		exists, err := suite.compositeStore.IsApplicationExistsByName(context.TODO(), "App Name")
+		exists, err := suite.compositeStore.IsApplicationExistsByName(context.Background(), "App Name")
 		suite.NoError(err)
 		suite.True(exists)
 	})
@@ -377,13 +377,13 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationExistsByNa
 	suite.Run("name exists in file store", func() {
 		suite.SetupTest() // Fresh setup
 
-		err := suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+		err := suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 			ID:   "file-app-1",
 			Name: "Unique App Name",
 		})
 		suite.NoError(err)
 
-		exists, err := suite.compositeStore.IsApplicationExistsByName(context.TODO(), "Unique App Name")
+		exists, err := suite.compositeStore.IsApplicationExistsByName(context.Background(), "Unique App Name")
 		suite.NoError(err)
 		suite.True(exists)
 	})
@@ -393,7 +393,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationExistsByNa
 			Return(false, nil).
 			Once()
 
-		exists, err := suite.compositeStore.IsApplicationExistsByName(context.TODO(), "Nonexistent Name")
+		exists, err := suite.compositeStore.IsApplicationExistsByName(context.Background(), "Nonexistent Name")
 		suite.NoError(err)
 		suite.False(exists)
 	})
@@ -405,23 +405,23 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_IsApplicationDeclarativ
 		suite.SetupTest() // Fresh setup
 
 		// Add app to file store
-		err := suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+		err := suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 			ID:   "immutable-app-1",
 			Name: "Declarative App",
 		})
 		suite.NoError(err)
 
-		isDeclarative := suite.compositeStore.IsApplicationDeclarative(context.TODO(), "immutable-app-1")
+		isDeclarative := suite.compositeStore.IsApplicationDeclarative(context.Background(), "immutable-app-1")
 		suite.True(isDeclarative)
 	})
 
 	suite.Run("returns false for mutable app (not in file store)", func() {
-		isDeclarative := suite.compositeStore.IsApplicationDeclarative(context.TODO(), "db-app-1")
+		isDeclarative := suite.compositeStore.IsApplicationDeclarative(context.Background(), "db-app-1")
 		suite.False(isDeclarative)
 	})
 
 	suite.Run("returns false for non-existent app", func() {
-		isDeclarative := suite.compositeStore.IsApplicationDeclarative(context.TODO(), "nonexistent")
+		isDeclarative := suite.compositeStore.IsApplicationDeclarative(context.Background(), "nonexistent")
 		suite.False(isDeclarative)
 	})
 }
@@ -433,7 +433,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetTotalApplicationCoun
 			Return(5, nil).
 			Once()
 
-		count, err := suite.compositeStore.GetTotalApplicationCount(context.TODO())
+		count, err := suite.compositeStore.GetTotalApplicationCount(context.Background())
 		suite.NoError(err)
 		suite.Equal(5, count)
 	})
@@ -442,11 +442,11 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetTotalApplicationCoun
 		suite.SetupTest() // Fresh setup
 
 		// Add apps to file store
-		_ = suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+		_ = suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 			ID:   "file-app-1",
 			Name: "File App 1",
 		})
-		_ = suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+		_ = suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 			ID:   "file-app-2",
 			Name: "File App 2",
 		})
@@ -455,7 +455,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetTotalApplicationCoun
 			Return(3, nil).
 			Once()
 
-		count, err := suite.compositeStore.GetTotalApplicationCount(context.TODO())
+		count, err := suite.compositeStore.GetTotalApplicationCount(context.Background())
 		suite.NoError(err)
 		suite.Equal(5, count) // 3 from DB + 2 from file
 	})
@@ -466,7 +466,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetTotalApplicationCoun
 			Return(0, dbErr).
 			Once()
 
-		count, err := suite.compositeStore.GetTotalApplicationCount(context.TODO())
+		count, err := suite.compositeStore.GetTotalApplicationCount(context.Background())
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Equal(0, count)
@@ -495,13 +495,13 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationList() {
 
 		// Add file apps
 		for _, app := range fileApps {
-			_ = suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+			_ = suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 				ID:   app.ID,
 				Name: app.Name,
 			})
 		}
 
-		list, err := suite.compositeStore.GetApplicationList(context.TODO())
+		list, err := suite.compositeStore.GetApplicationList(context.Background())
 		suite.NoError(err)
 		suite.Len(list, 3)
 
@@ -531,12 +531,12 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationList() {
 			Once()
 
 		// Add to file store with same ID
-		_ = suite.fileStore.CreateApplication(context.TODO(), model.ApplicationProcessedDTO{
+		_ = suite.fileStore.CreateApplication(context.Background(), model.ApplicationProcessedDTO{
 			ID:   "app-1",
 			Name: "File Version",
 		})
 
-		list, err := suite.compositeStore.GetApplicationList(context.TODO())
+		list, err := suite.compositeStore.GetApplicationList(context.Background())
 		suite.NoError(err)
 		suite.Len(list, 1)
 		suite.Equal("DB Version", list[0].Name)
@@ -549,7 +549,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_GetApplicationList() {
 			Return(0, dbErr).
 			Once()
 
-		list, err := suite.compositeStore.GetApplicationList(context.TODO())
+		list, err := suite.compositeStore.GetApplicationList(context.Background())
 		suite.Error(err)
 		suite.Nil(list)
 	})

--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -251,7 +251,7 @@ func validateApplicationWrapper(
 	}
 
 	// Check for duplicate ID in the file store
-	exists, err := fileStore.IsApplicationExists(context.TODO(), app.ID)
+	exists, err := fileStore.IsApplicationExists(context.Background(), app.ID)
 	if err != nil {
 		return fmt.Errorf("failed to check application existence: %w", err)
 	}
@@ -262,7 +262,7 @@ func validateApplicationWrapper(
 
 	// COMPOSITE MODE: Check for duplicate ID in the database store
 	if dbStore != nil {
-		exists, err := dbStore.IsApplicationExists(context.TODO(), app.ID)
+		exists, err := dbStore.IsApplicationExists(context.Background(), app.ID)
 		if err != nil {
 			return fmt.Errorf("failed to check application existence: %w", err)
 		}

--- a/backend/internal/application/file_based_store.go
+++ b/backend/internal/application/file_based_store.go
@@ -35,7 +35,7 @@ type fileBasedStore struct {
 // Create implements declarativeresource.Storer interface for resource loader
 func (f *fileBasedStore) Create(id string, data interface{}) error {
 	app := data.(*model.ApplicationProcessedDTO)
-	return f.CreateApplication(context.TODO(), *app)
+	return f.CreateApplication(context.Background(), *app)
 }
 
 // CreateApplication implements applicationStoreInterface.

--- a/backend/internal/application/service_consent_test.go
+++ b/backend/internal/application/service_consent_test.go
@@ -264,7 +264,7 @@ func (s *ApplicationServiceConsentTestSuite) TestCreateMissingConsentElements_Em
 	cMock := consentmock.NewConsentServiceInterfaceMock(s.T())
 	svc := newTestApplicationServiceWithConsent(cMock)
 
-	result := svc.createMissingConsentElements(context.TODO(), "default", []string{})
+	result := svc.createMissingConsentElements(context.Background(), "default", []string{})
 
 	s.Nil(result)
 }
@@ -277,7 +277,7 @@ func (s *ApplicationServiceConsentTestSuite) TestCreateMissingConsentElements_Al
 	cMock.EXPECT().ValidateConsentElements(mock.Anything, "default", names).
 		Return([]string{"email", "phone"}, nil)
 
-	result := svc.createMissingConsentElements(context.TODO(), "default", names)
+	result := svc.createMissingConsentElements(context.Background(), "default", names)
 
 	s.Nil(result)
 }
@@ -297,7 +297,7 @@ func (s *ApplicationServiceConsentTestSuite) TestCreateMissingConsentElements_So
 	cMock.EXPECT().CreateConsentElements(mock.Anything, "default", expectedInput).
 		Return([]consent.ConsentElement{{ID: "e1", Name: "phone"}}, nil)
 
-	result := svc.createMissingConsentElements(context.TODO(), "default", names)
+	result := svc.createMissingConsentElements(context.Background(), "default", names)
 
 	s.Nil(result)
 }
@@ -310,7 +310,7 @@ func (s *ApplicationServiceConsentTestSuite) TestCreateMissingConsentElements_Va
 	cMock.EXPECT().ValidateConsentElements(mock.Anything, "default", names).
 		Return(nil, &serviceerror.InternalServerErrorWithI18n)
 
-	result := svc.createMissingConsentElements(context.TODO(), "default", names)
+	result := svc.createMissingConsentElements(context.Background(), "default", names)
 
 	s.NotNil(result)
 	s.Equal(serviceerror.ServerErrorType, result.Type)
@@ -327,7 +327,7 @@ func (s *ApplicationServiceConsentTestSuite) TestCreateMissingConsentElements_Cr
 	cMock.EXPECT().CreateConsentElements(mock.Anything, "default", mock.Anything).
 		Return(nil, &serviceerror.InternalServerErrorWithI18n)
 
-	result := svc.createMissingConsentElements(context.TODO(), "default", names)
+	result := svc.createMissingConsentElements(context.Background(), "default", names)
 
 	s.NotNil(result)
 	s.Equal(serviceerror.ServerErrorType, result.Type)

--- a/backend/internal/authn/AuthenticationServiceInterface_mock_test.go
+++ b/backend/internal/authn/AuthenticationServiceInterface_mock_test.go
@@ -130,8 +130,8 @@ func (_c *AuthenticationServiceInterfaceMock_AuthenticateWithCredentials_Call) R
 }
 
 // FinishIDPAuthentication provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) FinishIDPAuthentication(requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+func (_mock *AuthenticationServiceInterfaceMock) FinishIDPAuthentication(ctx context.Context, requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FinishIDPAuthentication")
@@ -139,18 +139,18 @@ func (_mock *AuthenticationServiceInterfaceMock) FinishIDPAuthentication(request
 
 	var r0 *common.AuthenticationResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 	}
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string, bool, string, string) *common.AuthenticationResponse); ok {
-		r0 = returnFunc(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string, bool, string, string) *common.AuthenticationResponse); ok {
+		r0 = returnFunc(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthenticationResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(idp.IDPType, string, bool, string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, idp.IDPType, string, bool, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -165,36 +165,41 @@ type AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call struct {
 }
 
 // FinishIDPAuthentication is a helper method to define mock.On call
+//   - ctx context.Context
 //   - requestedType idp.IDPType
 //   - sessionToken string
 //   - skipAssertion bool
 //   - existingAssertion string
 //   - code string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) FinishIDPAuthentication(requestedType interface{}, sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, code interface{}) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
-	return &AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call{Call: _e.mock.On("FinishIDPAuthentication", requestedType, sessionToken, skipAssertion, existingAssertion, code)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) FinishIDPAuthentication(ctx interface{}, requestedType interface{}, sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, code interface{}) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
+	return &AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call{Call: _e.mock.On("FinishIDPAuthentication", ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Run(run func(requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Run(run func(ctx context.Context, requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 idp.IDPType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(idp.IDPType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 idp.IDPType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(idp.IDPType)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
 		}
-		var arg3 string
+		var arg3 bool
 		if args[3] != nil {
-			arg3 = args[3].(string)
+			arg3 = args[3].(bool)
 		}
 		var arg4 string
 		if args[4] != nil {
 			arg4 = args[4].(string)
+		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
 		}
 		run(
 			arg0,
@@ -202,6 +207,7 @@ func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Run(r
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -212,7 +218,7 @@ func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Retur
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) RunAndReturn(run func(requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) RunAndReturn(run func(ctx context.Context, requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -480,8 +486,8 @@ func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func
 }
 
 // StartIDPAuthentication provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) StartIDPAuthentication(requestedType idp.IDPType, idpID string) (*IDPAuthInitData, *serviceerror.ServiceError) {
-	ret := _mock.Called(requestedType, idpID)
+func (_mock *AuthenticationServiceInterfaceMock) StartIDPAuthentication(ctx context.Context, requestedType idp.IDPType, idpID string) (*IDPAuthInitData, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, requestedType, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartIDPAuthentication")
@@ -489,18 +495,18 @@ func (_mock *AuthenticationServiceInterfaceMock) StartIDPAuthentication(requeste
 
 	var r0 *IDPAuthInitData
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string) (*IDPAuthInitData, *serviceerror.ServiceError)); ok {
-		return returnFunc(requestedType, idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string) (*IDPAuthInitData, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, requestedType, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string) *IDPAuthInitData); ok {
-		r0 = returnFunc(requestedType, idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string) *IDPAuthInitData); ok {
+		r0 = returnFunc(ctx, requestedType, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*IDPAuthInitData)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(idp.IDPType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(requestedType, idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, idp.IDPType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, requestedType, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -515,25 +521,31 @@ type AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call struct {
 }
 
 // StartIDPAuthentication is a helper method to define mock.On call
+//   - ctx context.Context
 //   - requestedType idp.IDPType
 //   - idpID string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) StartIDPAuthentication(requestedType interface{}, idpID interface{}) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
-	return &AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call{Call: _e.mock.On("StartIDPAuthentication", requestedType, idpID)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) StartIDPAuthentication(ctx interface{}, requestedType interface{}, idpID interface{}) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
+	return &AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call{Call: _e.mock.On("StartIDPAuthentication", ctx, requestedType, idpID)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) Run(run func(requestedType idp.IDPType, idpID string)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) Run(run func(ctx context.Context, requestedType idp.IDPType, idpID string)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 idp.IDPType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(idp.IDPType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 idp.IDPType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(idp.IDPType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -544,7 +556,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) Return
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) RunAndReturn(run func(requestedType idp.IDPType, idpID string) (*IDPAuthInitData, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) RunAndReturn(run func(ctx context.Context, requestedType idp.IDPType, idpID string) (*IDPAuthInitData, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/authn/github/service.go
+++ b/backend/internal/authn/github/service.go
@@ -20,6 +20,7 @@
 package github
 
 import (
+	"context"
 	"slices"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
@@ -64,21 +65,22 @@ func newGithubOAuthAuthnService(idpSvc idp.IDPServiceInterface,
 }
 
 // BuildAuthorizeURL constructs the authorization request URL for GitHub OAuth authentication.
-func (g *githubOAuthAuthnService) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	return g.internal.BuildAuthorizeURL(idpID)
+func (g *githubOAuthAuthnService) BuildAuthorizeURL(
+	ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	return g.internal.BuildAuthorizeURL(ctx, idpID)
 }
 
 // ExchangeCodeForToken exchanges the authorization code for a token with GitHub.
-func (g *githubOAuthAuthnService) ExchangeCodeForToken(idpID, code string, validateResponse bool) (
+func (g *githubOAuthAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
 	*authnoauth.TokenResponse, *serviceerror.ServiceError) {
-	return g.internal.ExchangeCodeForToken(idpID, code, validateResponse)
+	return g.internal.ExchangeCodeForToken(ctx, idpID, code, validateResponse)
 }
 
 // FetchUserInfo retrieves user information from the Github API, ensuring email resolution if necessary.
-func (g *githubOAuthAuthnService) FetchUserInfo(idpID, accessToken string) (
+func (g *githubOAuthAuthnService) FetchUserInfo(ctx context.Context, idpID, accessToken string) (
 	map[string]interface{}, *serviceerror.ServiceError) {
 	logger := g.logger
-	oAuthClientConfig, svcErr := g.internal.GetOAuthClientConfig(idpID)
+	oAuthClientConfig, svcErr := g.internal.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -153,9 +155,9 @@ func (g *githubOAuthAuthnService) GetInternalUser(sub string) (*userprovider.Use
 }
 
 // GetOAuthClientConfig retrieves and validates the OAuth client configuration for the given identity provider ID.
-func (g *githubOAuthAuthnService) GetOAuthClientConfig(idpID string) (
+func (g *githubOAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID string) (
 	*authnoauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	return g.internal.GetOAuthClientConfig(idpID)
+	return g.internal.GetOAuthClientConfig(ctx, idpID)
 }
 
 // getMetadata returns the authenticator metadata for GitHub OAuth authenticator.

--- a/backend/internal/authn/github/service_test.go
+++ b/backend/internal/authn/github/service_test.go
@@ -20,6 +20,7 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -83,9 +84,9 @@ func (suite *GithubOAuthAuthnServiceTestSuite) SetupTest() {
 
 func (suite *GithubOAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	expectedURL := "https://github.com/login/oauth/authorize?client_id=test"
-	suite.mockOAuthService.On("BuildAuthorizeURL", testGithubIDPID).Return(expectedURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).Return(expectedURL, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(testGithubIDPID)
+	url, err := suite.service.BuildAuthorizeURL(context.Background(), testGithubIDPID)
 	suite.Nil(err)
 	suite.Equal(expectedURL, url)
 }
@@ -95,9 +96,9 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestBuildAuthorizeURLError() {
 		Code:             "ERROR",
 		ErrorDescription: "Failed to build URL",
 	}
-	suite.mockOAuthService.On("BuildAuthorizeURL", testGithubIDPID).Return("", svcErr)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).Return("", svcErr)
 
-	url, err := suite.service.BuildAuthorizeURL(testGithubIDPID)
+	url, err := suite.service.BuildAuthorizeURL(context.Background(), testGithubIDPID)
 	suite.Empty(url)
 	suite.NotNil(err)
 	suite.Equal(svcErr.Code, err.Code)
@@ -109,9 +110,10 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess()
 		AccessToken: testAccessToken,
 		TokenType:   "Bearer",
 	}
-	suite.mockOAuthService.On("ExchangeCodeForToken", testGithubIDPID, code, false).Return(tokenResp, nil)
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testGithubIDPID, code, false).
+		Return(tokenResp, nil)
 
-	result, err := suite.service.ExchangeCodeForToken(testGithubIDPID, code, false)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testGithubIDPID, code, false)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(tokenResp.AccessToken, result.AccessToken)
@@ -123,9 +125,9 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestExchangeCodeForTokenError() {
 		Code:             "TOKEN_ERROR",
 		ErrorDescription: "Failed to exchange token",
 	}
-	suite.mockOAuthService.On("ExchangeCodeForToken", testGithubIDPID, code, false).Return(nil, svcErr)
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testGithubIDPID, code, false).Return(nil, svcErr)
 
-	result, err := suite.service.ExchangeCodeForToken(testGithubIDPID, code, false)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testGithubIDPID, code, false)
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(svcErr.Code, err.Code)
@@ -146,11 +148,11 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoSuccess() {
 		},
 	}
 
-	suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).Return(config, nil)
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).Return(config, nil)
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, accessToken).
 		Return(userInfo, nil)
 
-	result, err := suite.service.FetchUserInfo(testGithubIDPID, accessToken)
+	result, err := suite.service.FetchUserInfo(context.Background(), testGithubIDPID, accessToken)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("12345", result["sub"])
@@ -185,11 +187,11 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoSuccessWithEmail
 	}
 
 	// Mock GetOAuthClientConfig once for FetchUserInfo (config is passed to fetchPrimaryEmail)
-	suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).Return(config, nil).Once()
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).Return(config, nil).Once()
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, accessToken).Return(userInfo, nil)
 	suite.mockHTTPClient.On("Do", mock.Anything).Return(resp, nil)
 
-	result, err := suite.service.FetchUserInfo(testGithubIDPID, accessToken)
+	result, err := suite.service.FetchUserInfo(context.Background(), testGithubIDPID, accessToken)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("test@example.com", result["email"])
@@ -204,7 +206,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithFailure() {
 		{
 			name: "ConfigRetrievalFailure",
 			setupMock: func() {
-				suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).
 					Return(nil, &serviceerror.ServiceError{Code: "CONFIG-001"}).Once()
 			},
 			errCode: "CONFIG-001",
@@ -218,7 +220,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithFailure() {
 						UserInfoEndpoint: githubUserInfoEndpoint,
 					},
 				}
-				suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).
 					Return(config, nil).Once()
 				suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, testAccessToken).
 					Return(nil, &serviceerror.ServiceError{Code: "FETCH-001"}).Once()
@@ -231,7 +233,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithFailure() {
 		suite.Run(tc.name, func() {
 			tc.setupMock()
 
-			result, err := suite.service.FetchUserInfo(testGithubIDPID, testAccessToken)
+			result, err := suite.service.FetchUserInfo(context.Background(), testGithubIDPID, testAccessToken)
 			suite.Nil(result)
 			suite.NotNil(err)
 			suite.Equal(tc.errCode, err.Code)
@@ -260,7 +262,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithEmailFetchFa
 					},
 				}
 
-				suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).
 					Return(config, nil).Once()
 				suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, testAccessToken).
 					Return(userInfo, nil).Once()
@@ -289,7 +291,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithEmailFetchFa
 					Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":"forbidden"}`))),
 				}
 
-				suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).
 					Return(config, nil).Once()
 				suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, testAccessToken).
 					Return(userInfo, nil).Once()
@@ -317,7 +319,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithEmailFetchFa
 					Body:       io.NopCloser(bytes.NewReader([]byte(`invalid json`))),
 				}
 
-				suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).
 					Return(config, nil).Once()
 				suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, testAccessToken).
 					Return(userInfo, nil).Once()
@@ -331,7 +333,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithEmailFetchFa
 		suite.Run(tc.name, func() {
 			tc.setupMock()
 
-			result, err := suite.service.FetchUserInfo(testGithubIDPID, testAccessToken)
+			result, err := suite.service.FetchUserInfo(context.Background(), testGithubIDPID, testAccessToken)
 			suite.Nil(result)
 			suite.NotNil(err)
 			suite.Equal(tc.errCode, err.Code)
@@ -391,9 +393,9 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestGetOAuthClientConfig() {
 		ClientSecret: "test-secret",
 		Scopes:       []string{"user"},
 	}
-	suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).Return(expectedConfig, nil)
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).Return(expectedConfig, nil)
 
-	config, err := suite.service.GetOAuthClientConfig(testGithubIDPID)
+	config, err := suite.service.GetOAuthClientConfig(context.Background(), testGithubIDPID)
 	suite.Nil(err)
 	suite.NotNil(config)
 	suite.Equal("test-client", config.ClientID)
@@ -454,15 +456,16 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestConstructorAndInjectInternal(
 
 	// test BuildAuthorizeURL delegation
 	expectedURL := "https://github.com/login/oauth/authorize?client_id=test"
-	suite.mockOAuthService.On("BuildAuthorizeURL", testGithubIDPID).Return(expectedURL, nil)
-	url, err := gsvc.BuildAuthorizeURL(testGithubIDPID)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).Return(expectedURL, nil)
+	url, err := gsvc.BuildAuthorizeURL(context.Background(), testGithubIDPID)
 	suite.Nil(err)
 	suite.Equal(expectedURL, url)
 
 	// test ExchangeCodeForToken delegation
 	tokenResp := &oauth.TokenResponse{AccessToken: "atoken", TokenType: "Bearer"}
-	suite.mockOAuthService.On("ExchangeCodeForToken", testGithubIDPID, "code", false).Return(tokenResp, nil)
-	tr, err2 := gsvc.ExchangeCodeForToken(testGithubIDPID, "code", false)
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testGithubIDPID, "code", false).
+		Return(tokenResp, nil)
+	tr, err2 := gsvc.ExchangeCodeForToken(context.Background(), testGithubIDPID, "code", false)
 	suite.Nil(err2)
 	suite.Equal("atoken", tr.AccessToken)
 }
@@ -481,10 +484,10 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoNoEmailScope() {
 		},
 	}
 
-	suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).Return(config, nil)
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).Return(config, nil)
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, accessToken).Return(userInfo, nil)
 
-	result, err := suite.service.FetchUserInfo(testGithubIDPID, accessToken)
+	result, err := suite.service.FetchUserInfo(context.Background(), testGithubIDPID, accessToken)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("12345", result["sub"])
@@ -505,10 +508,10 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchPrimaryEmailWithEmptyEnd
 		},
 	}
 
-	suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).Return(config, nil).Once()
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).Return(config, nil).Once()
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, accessToken).Return(userInfo, nil)
 
-	result, err := suite.service.FetchUserInfo(testGithubIDPID, accessToken)
+	result, err := suite.service.FetchUserInfo(context.Background(), testGithubIDPID, accessToken)
 	suite.NotNil(err)
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 	suite.Nil(result)
@@ -542,11 +545,11 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchUserInfoWithEmptyPrimary
 		Body:       io.NopCloser(bytes.NewReader(emailJSON)),
 	}
 
-	suite.mockOAuthService.On("GetOAuthClientConfig", testGithubIDPID).Return(config, nil).Once()
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).Return(config, nil).Once()
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", config, accessToken).Return(userInfo, nil)
 	suite.mockHTTPClient.On("Do", mock.Anything).Return(resp, nil)
 
-	result, err := suite.service.FetchUserInfo(testGithubIDPID, accessToken)
+	result, err := suite.service.FetchUserInfo(context.Background(), testGithubIDPID, accessToken)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("12345", result["sub"])

--- a/backend/internal/authn/google/service.go
+++ b/backend/internal/authn/google/service.go
@@ -20,6 +20,7 @@
 package google
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -68,21 +69,22 @@ func newGoogleOIDCAuthnService(idpSvc idp.IDPServiceInterface, userProvider user
 }
 
 // BuildAuthorizeURL constructs the authorization request URL for Google OIDC authentication.
-func (g *googleOIDCAuthnService) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	return g.internal.BuildAuthorizeURL(idpID)
+func (g *googleOIDCAuthnService) BuildAuthorizeURL(
+	ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	return g.internal.BuildAuthorizeURL(ctx, idpID)
 }
 
 // ExchangeCodeForToken exchanges the authorization code for a token with Google
 // and validates the token response if validateResponse is true.
-func (g *googleOIDCAuthnService) ExchangeCodeForToken(idpID, code string, validateResponse bool) (
+func (g *googleOIDCAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
 	*authnoauth.TokenResponse, *serviceerror.ServiceError) {
-	tokenResp, svcErr := g.internal.ExchangeCodeForToken(idpID, code, false)
+	tokenResp, svcErr := g.internal.ExchangeCodeForToken(ctx, idpID, code, false)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
 	if validateResponse {
-		svcErr = g.ValidateTokenResponse(idpID, tokenResp)
+		svcErr = g.ValidateTokenResponse(ctx, idpID, tokenResp)
 		if svcErr != nil {
 			return nil, svcErr
 		}
@@ -94,21 +96,22 @@ func (g *googleOIDCAuthnService) ExchangeCodeForToken(idpID, code string, valida
 // ValidateTokenResponse validates the token response returned from Google.
 // ExchangeCodeForToken method calls this method to validate the token response if validateResponse is set
 // to true. Hence generally you may not need to call this method explicitly.
-func (g *googleOIDCAuthnService) ValidateTokenResponse(idpID string,
+func (g *googleOIDCAuthnService) ValidateTokenResponse(ctx context.Context, idpID string,
 	tokenResp *authnoauth.TokenResponse) *serviceerror.ServiceError {
-	svcErr := g.internal.ValidateTokenResponse(idpID, tokenResp, false)
+	svcErr := g.internal.ValidateTokenResponse(ctx, idpID, tokenResp, false)
 	if svcErr != nil {
 		return svcErr
 	}
 
-	return g.ValidateIDToken(idpID, tokenResp.IDToken)
+	return g.ValidateIDToken(ctx, idpID, tokenResp.IDToken)
 }
 
 // ValidateIDToken validates the ID token from Google with additional Google-specific validations.
 // ValidateTokenResponse method calls this method to validate the token response if validateIDToken is set
 // to true. Hence generally you may not need to call this method explicitly if ExchangeCodeForToken method
 // is called with validateResponse set to true.
-func (g *googleOIDCAuthnService) ValidateIDToken(idpID, idToken string) *serviceerror.ServiceError {
+func (g *googleOIDCAuthnService) ValidateIDToken(
+	ctx context.Context, idpID, idToken string) *serviceerror.ServiceError {
 	logger := g.logger.With(log.String("idpId", idpID))
 	logger.Debug("Validating ID token")
 
@@ -118,7 +121,7 @@ func (g *googleOIDCAuthnService) ValidateIDToken(idpID, idToken string) *service
 	}
 
 	// Get the OAuth client config for token validations
-	oAuthClientConfig, svcErr := g.internal.GetOAuthClientConfig(idpID)
+	oAuthClientConfig, svcErr := g.internal.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return svcErr
 	}
@@ -211,9 +214,9 @@ func (g *googleOIDCAuthnService) GetIDTokenClaims(idToken string) (
 }
 
 // FetchUserInfo retrieves user information from Google, ensuring email resolution if necessary.
-func (g *googleOIDCAuthnService) FetchUserInfo(idpID, accessToken string) (
+func (g *googleOIDCAuthnService) FetchUserInfo(ctx context.Context, idpID, accessToken string) (
 	map[string]interface{}, *serviceerror.ServiceError) {
-	return g.internal.FetchUserInfo(idpID, accessToken)
+	return g.internal.FetchUserInfo(ctx, idpID, accessToken)
 }
 
 // GetInternalUser retrieves the internal user based on the external subject identifier.
@@ -222,9 +225,9 @@ func (g *googleOIDCAuthnService) GetInternalUser(sub string) (*userprovider.User
 }
 
 // GetOAuthClientConfig retrieves and validates the OAuth client configuration for the given identity provider ID.
-func (g *googleOIDCAuthnService) GetOAuthClientConfig(idpID string) (
+func (g *googleOIDCAuthnService) GetOAuthClientConfig(ctx context.Context, idpID string) (
 	*authnoauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	return g.internal.GetOAuthClientConfig(idpID)
+	return g.internal.GetOAuthClientConfig(ctx, idpID)
 }
 
 // getMetadata returns the authenticator metadata for Google OIDC authenticator.

--- a/backend/internal/authn/google/service_test.go
+++ b/backend/internal/authn/google/service_test.go
@@ -19,10 +19,14 @@
 package google
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"testing"
+
 	"time"
+
+	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/suite"
 
@@ -73,9 +77,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) SetupTest() {
 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	expectedURL := "https://accounts.google.com/o/oauth2/v2/auth?client_id=test"
-	suite.mockOIDCService.On("BuildAuthorizeURL", testGoogleIDPID).Return(expectedURL, nil)
+	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, testGoogleIDPID).Return(expectedURL, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(testGoogleIDPID)
+	url, err := suite.service.BuildAuthorizeURL(context.Background(), testGoogleIDPID)
 	suite.Nil(err)
 	suite.Equal(expectedURL, url)
 }
@@ -86,10 +90,10 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess() 
 		IDToken:     "id_token",
 		TokenType:   "Bearer",
 	}
-	suite.mockOIDCService.On("ExchangeCodeForToken", testGoogleIDPID, testAuthCode, false).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testGoogleIDPID, testAuthCode, false).
 		Return(tokenResp, nil)
 
-	result, err := suite.service.ExchangeCodeForToken(testGoogleIDPID, testAuthCode, false)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testGoogleIDPID, testAuthCode, false)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(tokenResp.AccessToken, result.AccessToken)
@@ -118,23 +122,23 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestExchangeCodeForTokenWithValida
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", testGoogleIDPID, testAuthCode, false).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testGoogleIDPID, testAuthCode, false).
 		Return(tokenResp, nil)
-	suite.mockOIDCService.On("ValidateTokenResponse", testGoogleIDPID, tokenResp, false).
+	suite.mockOIDCService.On("ValidateTokenResponse", mock.Anything, testGoogleIDPID, tokenResp, false).
 		Return(nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil)
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 
-	result, err := suite.service.ExchangeCodeForToken(testGoogleIDPID, testAuthCode, true)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testGoogleIDPID, testAuthCode, true)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(tokenResp.AccessToken, result.AccessToken)
 }
 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestExchangeCodeForTokenFailure() {
-	suite.mockOIDCService.On("ExchangeCodeForToken", testGoogleIDPID, testAuthCode, false).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testGoogleIDPID, testAuthCode, false).
 		Return(nil, &serviceerror.ServiceError{Code: "TOKEN-001"})
 
-	result, err := suite.service.ExchangeCodeForToken(testGoogleIDPID, testAuthCode, false)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testGoogleIDPID, testAuthCode, false)
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal("TOKEN-001", err.Code)
@@ -162,13 +166,13 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestExchangeCodeForTokenValidation
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", testGoogleIDPID, testAuthCode, false).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testGoogleIDPID, testAuthCode, false).
 		Return(tokenResp, nil)
-	suite.mockOIDCService.On("ValidateTokenResponse", testGoogleIDPID, tokenResp, false).
+	suite.mockOIDCService.On("ValidateTokenResponse", mock.Anything, testGoogleIDPID, tokenResp, false).
 		Return(nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil)
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 
-	result, err := suite.service.ExchangeCodeForToken(testGoogleIDPID, testAuthCode, true)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testGoogleIDPID, testAuthCode, true)
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
@@ -197,11 +201,11 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateTokenResponseSuccess()
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("ValidateTokenResponse", testGoogleIDPID, tokenResp, false).
+	suite.mockOIDCService.On("ValidateTokenResponse", mock.Anything, testGoogleIDPID, tokenResp, false).
 		Return(nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil)
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 
-	err := suite.service.ValidateTokenResponse(testGoogleIDPID, tokenResp)
+	err := suite.service.ValidateTokenResponse(context.Background(), testGoogleIDPID, tokenResp)
 	suite.Nil(err)
 }
 
@@ -212,10 +216,10 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateTokenResponseInternalV
 		TokenType:   "Bearer",
 	}
 
-	suite.mockOIDCService.On("ValidateTokenResponse", testGoogleIDPID, tokenResp, false).
+	suite.mockOIDCService.On("ValidateTokenResponse", mock.Anything, testGoogleIDPID, tokenResp, false).
 		Return(&serviceerror.ServiceError{Code: "VALIDATION-001"})
 
-	err := suite.service.ValidateTokenResponse(testGoogleIDPID, tokenResp)
+	err := suite.service.ValidateTokenResponse(context.Background(), testGoogleIDPID, tokenResp)
 	suite.NotNil(err)
 	suite.Equal("VALIDATION-001", err.Code)
 }
@@ -242,11 +246,11 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateTokenResponseIDTokenVa
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("ValidateTokenResponse", testGoogleIDPID, tokenResp, false).
+	suite.mockOIDCService.On("ValidateTokenResponse", mock.Anything, testGoogleIDPID, tokenResp, false).
 		Return(nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil)
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 
-	err := suite.service.ValidateTokenResponse(testGoogleIDPID, tokenResp)
+	err := suite.service.ValidateTokenResponse(context.Background(), testGoogleIDPID, tokenResp)
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
 }
@@ -275,7 +279,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 				OAuthEndpoints: oauth.OAuthEndpoints{},
 			},
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -293,7 +298,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 				OAuthEndpoints: oauth.OAuthEndpoints{},
 			},
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -313,7 +319,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 				},
 			},
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 				suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", idToken, config.OAuthEndpoints.JwksEndpoint).
 					Return(nil).Once()
 			},
@@ -339,7 +346,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 				},
 			},
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 				suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", idToken, config.OAuthEndpoints.JwksEndpoint).
 					Return(nil).Once()
 			},
@@ -359,7 +367,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 				OAuthEndpoints: oauth.OAuthEndpoints{},
 			},
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -380,7 +389,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 				},
 			},
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 	}
@@ -390,7 +400,7 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 			idToken := generateTestJWT(tc.claims)
 			tc.setupMocks(idToken, tc.oAuthConfig)
 
-			err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+			err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 			suite.Nil(err)
 		})
 	}
@@ -398,6 +408,23 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 	now := time.Now()
+
+	hostedDomainConfig := &oauth.OAuthClientConfig{
+		ClientID:     testClientID,
+		ClientSecret: "test-secret",
+		OAuthEndpoints: oauth.OAuthEndpoints{
+			JwksEndpoint: "https://www.googleapis.com/oauth2/v3/certs",
+		},
+		AdditionalParams: map[string]string{
+			"hd": "example.com",
+		},
+	}
+	hostedDomainSetupMocks := func(idToken string, config *oauth.OAuthClientConfig) {
+		suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+			Return(config, nil).Once()
+		suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", idToken, config.OAuthEndpoints.JwksEndpoint).
+			Return(nil).Once()
+	}
 
 	testCases := []struct {
 		name                string
@@ -430,7 +457,7 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			},
 			expectedErrorCode: "CONFIG-001",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
 					Return(nil, &serviceerror.ServiceError{Code: "CONFIG-001"}).Once()
 			},
 		},
@@ -451,7 +478,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			},
 			expectedErrorCode: oidc.ErrorInvalidIDTokenSignature.Code,
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 				suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", idToken, config.OAuthEndpoints.JwksEndpoint).
 					Return(&serviceerror.ServiceError{
 						Type:             serviceerror.ServerErrorType,
@@ -471,7 +499,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			},
 			expectedErrorCode: oidc.ErrorInvalidIDToken.Code,
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -490,7 +519,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "issuer",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -507,7 +537,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			},
 			expectedErrorCode: oidc.ErrorInvalidIDToken.Code,
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -526,7 +557,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "audience",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -543,7 +575,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			},
 			expectedErrorCode: oidc.ErrorInvalidIDToken.Code,
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -562,7 +595,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "expired",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -580,7 +614,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "expiration",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -599,7 +634,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "expiration",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -618,7 +654,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "future",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -636,7 +673,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "iat",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -655,7 +693,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "iat",
 			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
+				suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).
+					Return(config, nil).Once()
 			},
 		},
 		{
@@ -667,23 +706,10 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 				"iat": float64(now.Add(-1 * time.Minute).Unix()),
 				"hd":  "wrongdomain.com",
 			},
-			oAuthConfig: &oauth.OAuthClientConfig{
-				ClientID:     testClientID,
-				ClientSecret: "test-secret",
-				OAuthEndpoints: oauth.OAuthEndpoints{
-					JwksEndpoint: "https://www.googleapis.com/oauth2/v3/certs",
-				},
-				AdditionalParams: map[string]string{
-					"hd": "example.com",
-				},
-			},
+			oAuthConfig:         hostedDomainConfig,
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "hosted domain",
-			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
-				suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", idToken, config.OAuthEndpoints.JwksEndpoint).
-					Return(nil).Once()
-			},
+			setupMocks:          hostedDomainSetupMocks,
 		},
 		{
 			name: "HostedDomainWrongType",
@@ -694,23 +720,10 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 				"iat": float64(now.Add(-1 * time.Minute).Unix()),
 				"hd":  123,
 			},
-			oAuthConfig: &oauth.OAuthClientConfig{
-				ClientID:     testClientID,
-				ClientSecret: "test-secret",
-				OAuthEndpoints: oauth.OAuthEndpoints{
-					JwksEndpoint: "https://www.googleapis.com/oauth2/v3/certs",
-				},
-				AdditionalParams: map[string]string{
-					"hd": "example.com",
-				},
-			},
+			oAuthConfig:         hostedDomainConfig,
 			expectedErrorCode:   oidc.ErrorInvalidIDToken.Code,
 			expectedErrContains: "hosted domain",
-			setupMocks: func(idToken string, config *oauth.OAuthClientConfig) {
-				suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(config, nil).Once()
-				suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", idToken, config.OAuthEndpoints.JwksEndpoint).
-					Return(nil).Once()
-			},
+			setupMocks:          hostedDomainSetupMocks,
 		},
 	}
 
@@ -728,7 +741,7 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDTokenWithFailure() {
 			tc.setupMocks(idToken, tc.oAuthConfig)
 
 			// Execute test
-			err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+			err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 
 			// Assertions
 			suite.NotNil(err)
@@ -762,9 +775,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestFetchUserInfoSuccess() {
 		"sub":   "user123",
 		"email": "user@gmail.com",
 	}
-	suite.mockOIDCService.On("FetchUserInfo", testGoogleIDPID, accessToken).Return(userInfo, nil)
+	suite.mockOIDCService.On("FetchUserInfo", mock.Anything, testGoogleIDPID, accessToken).Return(userInfo, nil)
 
-	result, err := suite.service.FetchUserInfo(testGoogleIDPID, accessToken)
+	result, err := suite.service.FetchUserInfo(context.Background(), testGoogleIDPID, accessToken)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(userInfo["sub"], result["sub"])
@@ -823,9 +836,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_Expired
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil).Once()
 
-	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 	suite.Nil(err)
 }
 
@@ -847,9 +860,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_Expired
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil).Once()
 
-	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
 	suite.Contains(err.ErrorDescription, "expired")
@@ -873,9 +886,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IssuedI
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil).Once()
 
-	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 	suite.Nil(err)
 }
 
@@ -897,9 +910,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IssuedI
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil).Once()
 
-	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
 	suite.Contains(err.ErrorDescription, "future")
@@ -932,9 +945,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_ZeroLee
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil).Once()
 
-	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
 	suite.Contains(err.ErrorDescription, "expired")
@@ -969,9 +982,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IatExac
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil).Once()
 
-	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 	suite.Nil(err)
 }
 
@@ -1004,9 +1017,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IatJust
 		OAuthEndpoints: oauth.OAuthEndpoints{},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", testGoogleIDPID).Return(oAuthConfig, nil).Once()
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil).Once()
 
-	err := suite.service.ValidateIDToken(testGoogleIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testGoogleIDPID, idToken)
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
 	suite.Contains(err.ErrorDescription, "future")

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -119,13 +119,14 @@ func (ah *authenticationHandler) HandleVerifySMSOTPRequest(w http.ResponseWriter
 
 // HandleGoogleAuthStartRequest handles the Google OAuth start authentication request.
 func (ah *authenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	authResponse, svcErr := ah.authService.StartIDPAuthentication(idp.IDPTypeGoogle, authRequest.IDPID)
+	authResponse, svcErr := ah.authService.StartIDPAuthentication(ctx, idp.IDPTypeGoogle, authRequest.IDPID)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
@@ -137,13 +138,14 @@ func (ah *authenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWri
 
 // HandleGoogleAuthFinishRequest handles the Google OAuth finish authentication request.
 func (ah *authenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	authResponse, svcErr := ah.authService.FinishIDPAuthentication(idp.IDPTypeGoogle, authRequest.SessionToken,
+	authResponse, svcErr := ah.authService.FinishIDPAuthentication(ctx, idp.IDPTypeGoogle, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
@@ -156,13 +158,14 @@ func (ah *authenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWr
 
 // HandleGithubAuthStartRequest handles the GitHub OAuth start authentication request.
 func (ah *authenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	authResponse, svcErr := ah.authService.StartIDPAuthentication(idp.IDPTypeGitHub, authRequest.IDPID)
+	authResponse, svcErr := ah.authService.StartIDPAuthentication(ctx, idp.IDPTypeGitHub, authRequest.IDPID)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
@@ -174,13 +177,14 @@ func (ah *authenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWri
 
 // HandleGithubAuthFinishRequest handles the GitHub OAuth finish authentication request.
 func (ah *authenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	authResponse, svcErr := ah.authService.FinishIDPAuthentication(idp.IDPTypeGitHub, authRequest.SessionToken,
+	authResponse, svcErr := ah.authService.FinishIDPAuthentication(ctx, idp.IDPTypeGitHub, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
@@ -193,13 +197,14 @@ func (ah *authenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWr
 
 // HandleStandardOAuthStartRequest handles the standard OAuth start authentication request.
 func (ah *authenticationHandler) HandleStandardOAuthStartRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	authResponse, svcErr := ah.authService.StartIDPAuthentication(idp.IDPTypeOAuth, authRequest.IDPID)
+	authResponse, svcErr := ah.authService.StartIDPAuthentication(ctx, idp.IDPTypeOAuth, authRequest.IDPID)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)
 		return
@@ -211,13 +216,14 @@ func (ah *authenticationHandler) HandleStandardOAuthStartRequest(w http.Response
 
 // HandleStandardOAuthFinishRequest handles the standard OAuth finish authentication request.
 func (ah *authenticationHandler) HandleStandardOAuthFinishRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
 		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
-	authResponse, svcErr := ah.authService.FinishIDPAuthentication(idp.IDPTypeOAuth, authRequest.SessionToken,
+	authResponse, svcErr := ah.authService.FinishIDPAuthentication(ctx, idp.IDPTypeOAuth, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code)
 	if svcErr != nil {
 		ah.handleServiceError(w, svcErr)

--- a/backend/internal/authn/handler_test.go
+++ b/backend/internal/authn/handler_test.go
@@ -76,7 +76,7 @@ func (suite *AuthenticationHandlerTestSuite) testIDPAuthFinishSuccess(
 		Assertion:        "jwt-token",
 	}
 
-	suite.mockService.On("FinishIDPAuthentication", idpType, authRequest.SessionToken,
+	suite.mockService.On("FinishIDPAuthentication", mock.Anything, idpType, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code).Return(authResponse, nil)
 
 	body, _ := json.Marshal(authRequest)
@@ -454,7 +454,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleGoogleAuthStartRequestSuc
 		SessionToken: testSessionTkn,
 	}
 
-	suite.mockService.On("StartIDPAuthentication", idp.IDPTypeGoogle, authRequest.IDPID).
+	suite.mockService.On("StartIDPAuthentication", mock.Anything, idp.IDPTypeGoogle, authRequest.IDPID).
 		Return(authResponse, nil)
 
 	body, _ := json.Marshal(authRequest)
@@ -486,7 +486,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleGoogleAuthStartRequestSer
 	}
 	serviceError := &common.ErrorInvalidIDPID
 
-	suite.mockService.On("StartIDPAuthentication", idp.IDPTypeGoogle, authRequest.IDPID).
+	suite.mockService.On("StartIDPAuthentication", mock.Anything, idp.IDPTypeGoogle, authRequest.IDPID).
 		Return(nil, serviceError)
 
 	body, _ := json.Marshal(authRequest)
@@ -524,7 +524,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleGoogleAuthFinishRequestSe
 	}
 	serviceError := &common.ErrorInvalidSessionToken
 
-	suite.mockService.On("FinishIDPAuthentication", idp.IDPTypeGoogle, mock.Anything, mock.Anything,
+	suite.mockService.On("FinishIDPAuthentication", mock.Anything, idp.IDPTypeGoogle, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(nil, serviceError)
 
 	body, _ := json.Marshal(authRequest)
@@ -549,7 +549,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleGithubAuthStartRequestSuc
 		SessionToken: testSessionTkn,
 	}
 
-	suite.mockService.On("StartIDPAuthentication", idp.IDPTypeGitHub, authRequest.IDPID).
+	suite.mockService.On("StartIDPAuthentication", mock.Anything, idp.IDPTypeGitHub, authRequest.IDPID).
 		Return(authResponse, nil)
 
 	body, _ := json.Marshal(authRequest)
@@ -580,7 +580,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleGithubAuthStartRequestSer
 	}
 	serviceError := &common.ErrorClientErrorWhileRetrievingIDP
 
-	suite.mockService.On("StartIDPAuthentication", idp.IDPTypeGitHub, authRequest.IDPID).
+	suite.mockService.On("StartIDPAuthentication", mock.Anything, idp.IDPTypeGitHub, authRequest.IDPID).
 		Return(nil, serviceError)
 
 	body, _ := json.Marshal(authRequest)
@@ -604,7 +604,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleGithubAuthFinishRequestSu
 		OrganizationUnit: "test-ou",
 	}
 
-	suite.mockService.On("FinishIDPAuthentication", idp.IDPTypeGitHub, authRequest.SessionToken,
+	suite.mockService.On("FinishIDPAuthentication", mock.Anything, idp.IDPTypeGitHub, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code).Return(authResponse, nil)
 
 	body, _ := json.Marshal(authRequest)
@@ -643,7 +643,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleGithubAuthFinishRequestSe
 		ErrorDescription: "Internal error description",
 	}
 
-	suite.mockService.On("FinishIDPAuthentication", idp.IDPTypeGitHub, mock.Anything, mock.Anything,
+	suite.mockService.On("FinishIDPAuthentication", mock.Anything, idp.IDPTypeGitHub, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(nil, serviceError)
 
 	body, _ := json.Marshal(authRequest)
@@ -664,7 +664,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleStandardOAuthStartRequest
 		SessionToken: testSessionTkn,
 	}
 
-	suite.mockService.On("StartIDPAuthentication", idp.IDPTypeOAuth, authRequest.IDPID).
+	suite.mockService.On("StartIDPAuthentication", mock.Anything, idp.IDPTypeOAuth, authRequest.IDPID).
 		Return(authResponse, nil)
 
 	body, _ := json.Marshal(authRequest)
@@ -695,7 +695,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleStandardOAuthStartRequest
 	}
 	serviceError := &common.ErrorInvalidIDPType
 
-	suite.mockService.On("StartIDPAuthentication", idp.IDPTypeOAuth, authRequest.IDPID).
+	suite.mockService.On("StartIDPAuthentication", mock.Anything, idp.IDPTypeOAuth, authRequest.IDPID).
 		Return(nil, serviceError)
 
 	body, _ := json.Marshal(authRequest)
@@ -729,7 +729,7 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleStandardOAuthFinishReques
 	}
 	serviceError := &common.ErrorEmptyAuthCode
 
-	suite.mockService.On("FinishIDPAuthentication", idp.IDPTypeOAuth, mock.Anything, mock.Anything,
+	suite.mockService.On("FinishIDPAuthentication", mock.Anything, idp.IDPTypeOAuth, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(nil, serviceError)
 
 	body, _ := json.Marshal(authRequest)

--- a/backend/internal/authn/oauth/service.go
+++ b/backend/internal/authn/oauth/service.go
@@ -39,11 +39,12 @@ const (
 
 // OAuthAuthnCoreServiceInterface defines the core contract for OAuth based authenticator services.
 type OAuthAuthnCoreServiceInterface interface {
-	BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError)
-	ExchangeCodeForToken(idpID, code string, validateResponse bool) (*TokenResponse, *serviceerror.ServiceError)
-	FetchUserInfo(idpID, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)
+	BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError)
+	ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
+		*TokenResponse, *serviceerror.ServiceError)
+	FetchUserInfo(ctx context.Context, idpID, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)
 	GetInternalUser(sub string) (*userprovider.User, *serviceerror.ServiceError)
-	GetOAuthClientConfig(idpID string) (*OAuthClientConfig, *serviceerror.ServiceError)
+	GetOAuthClientConfig(ctx context.Context, idpID string) (*OAuthClientConfig, *serviceerror.ServiceError)
 }
 
 // OAuthAuthnServiceInterface defines the contract for OAuth based authenticator services.
@@ -86,14 +87,14 @@ func NewOAuthAuthnService(httpClient syshttp.HTTPClientInterface,
 }
 
 // GetOAuthClientConfig retrieves the OAuth client configuration for the given identity provider ID.
-func (s *oAuthAuthnService) GetOAuthClientConfig(idpID string) (
+func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID string) (
 	*OAuthClientConfig, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
 	if strings.TrimSpace(idpID) == "" {
 		return nil, &ErrorEmptyIdpID
 	}
 
-	idp, svcErr := s.idpService.GetIdentityProvider(context.TODO(), idpID)
+	idp, svcErr := s.idpService.GetIdentityProvider(ctx, idpID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			return nil, serviceerror.CustomServiceError(ErrorClientErrorWhileRetrievingIDP,
@@ -117,11 +118,11 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(idpID string) (
 }
 
 // BuildAuthorizeURL constructs the authorization request URL for the external identity provider.
-func (s *oAuthAuthnService) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
+func (s *oAuthAuthnService) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
 	logger.Debug("Building authorize URL")
 
-	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(idpID)
+	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return "", svcErr
 	}
@@ -158,7 +159,7 @@ func (s *oAuthAuthnService) BuildAuthorizeURL(idpID string) (string, *serviceerr
 
 // ExchangeCodeForToken exchanges the authorization code for a token with the external identity provider
 // and validates the token response if validateResponse is true.
-func (s *oAuthAuthnService) ExchangeCodeForToken(idpID, code string, validateResponse bool) (
+func (s *oAuthAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
 	*TokenResponse, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
 	logger.Debug("Exchanging authorization code for token")
@@ -167,7 +168,7 @@ func (s *oAuthAuthnService) ExchangeCodeForToken(idpID, code string, validateRes
 		return nil, &ErrorEmptyAuthorizationCode
 	}
 
-	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(idpID)
+	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -216,9 +217,9 @@ func (s *oAuthAuthnService) ValidateTokenResponse(idpID string, tokenResp *Token
 }
 
 // FetchUserInfo retrieves user information from the external identity provider.
-func (s *oAuthAuthnService) FetchUserInfo(idpID, accessToken string) (
+func (s *oAuthAuthnService) FetchUserInfo(ctx context.Context, idpID, accessToken string) (
 	map[string]interface{}, *serviceerror.ServiceError) {
-	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(idpID)
+	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return nil, svcErr
 	}

--- a/backend/internal/authn/oauth/service_test.go
+++ b/backend/internal/authn/oauth/service_test.go
@@ -20,6 +20,7 @@ package oauth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -111,7 +112,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestGetOAuthClientConfigSuccess() {
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	config, err := suite.service.GetOAuthClientConfig(testIDPID)
+	config, err := suite.service.GetOAuthClientConfig(context.Background(), testIDPID)
 	suite.Nil(err)
 	suite.NotNil(config)
 	suite.Equal("test_client_id", config.ClientID)
@@ -174,7 +175,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestGetOAuthClientConfigWithError() {
 				tc.mockSetup(freshIDPMock)
 			}
 
-			config, err := suite.service.GetOAuthClientConfig(tc.idpID)
+			config, err := suite.service.GetOAuthClientConfig(context.Background(), tc.idpID)
 			suite.Nil(config)
 			suite.NotNil(err)
 			suite.Equal(tc.expectedErrCode, err.Code)
@@ -199,7 +200,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(testIDPID)
+	url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
 	suite.Nil(err)
 	suite.NotNil(url)
 	suite.Contains(url, "https://example.com/oauth/authorize?")
@@ -261,7 +262,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccessWithAdditio
 			}
 			suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-			url, err := suite.service.BuildAuthorizeURL(testIDPID)
+			url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
 			suite.Nil(err)
 			suite.NotNil(url)
 			suite.Contains(url, "https://example.com/oauth/authorize?")
@@ -286,14 +287,14 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLWithError() {
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(nil, serverErr)
 
-	url, err := suite.service.BuildAuthorizeURL(testIDPID)
+	url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
 	suite.Empty(url)
 	suite.NotNil(err)
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
 func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenEmptyCode() {
-	tokenResp, err := suite.service.ExchangeCodeForToken(testIDPID, "", false)
+	tokenResp, err := suite.service.ExchangeCodeForToken(context.Background(), testIDPID, "", false)
 	suite.Nil(tokenResp)
 	suite.NotNil(err)
 	suite.Equal(ErrorEmptyAuthorizationCode.Code, err.Code)
@@ -344,7 +345,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess() {
 			suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpData, nil).Once()
 			suite.mockHTTPClient.On("Do", mock.Anything).Return(resp, nil).Once()
 
-			result, err := suite.service.ExchangeCodeForToken(testIDPID, tc.code, tc.validateResponse)
+			result, err := suite.service.ExchangeCodeForToken(
+				context.Background(), testIDPID, tc.code, tc.validateResponse)
 			suite.Nil(err)
 			suite.NotNil(result)
 			suite.Equal("access123", result.AccessToken)
@@ -429,7 +431,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenWithFailure() {
 		suite.Run(tc.name, func() {
 			tc.setupMocks()
 
-			result, err := suite.service.ExchangeCodeForToken(testIDPID, "auth_code", false)
+			result, err := suite.service.ExchangeCodeForToken(context.Background(), testIDPID, "auth_code", false)
 			suite.Nil(result)
 			suite.NotNil(err)
 			suite.Equal(tc.expectedError, err.Code)
@@ -453,7 +455,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestFetchUserInfoEmptyAccessToken() {
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	userInfo, err := suite.service.FetchUserInfo(testIDPID, "")
+	userInfo, err := suite.service.FetchUserInfo(context.Background(), testIDPID, "")
 	suite.Nil(userInfo)
 	suite.NotNil(err)
 	suite.Equal(ErrorEmptyAccessToken.Code, err.Code)
@@ -648,28 +650,39 @@ func (suite *OAuthAuthnServiceTestSuite) TestValidateTokenResponseWithError() {
 	}
 }
 
-func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLURIError() {
-	// Create idp DTO with invalid authorization endpoint so GetURIWithQueryParams fails
-	clientIDProp, _ := cmodels.NewProperty("client_id", "test_client_id", false)
-	clientSecretProp, _ := cmodels.NewProperty("client_secret", "test_client_secret", false)
-	redirectURIProp, _ := cmodels.NewProperty("redirect_uri", "https://app.example.com/callback", false)
-	scopesProp, _ := cmodels.NewProperty("scopes", "openid profile", false)
-	authzEndpointProp, _ := cmodels.NewProperty("authorization_endpoint", "://invalid-url", false)
-
-	idpDTO := &idp.IDPDTO{
-		ID:   testIDPID,
-		Name: "Test OAuth Provider",
-		Type: idp.IDPTypeOAuth,
-		Properties: []cmodels.Property{
-			*clientIDProp, *clientSecretProp, *redirectURIProp, *scopesProp, *authzEndpointProp,
-		},
+func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLErrors() {
+	tests := []struct {
+		name          string
+		authzEndpoint string
+	}{
+		{name: "URIError", authzEndpoint: "://invalid-url"},
+		{name: "MissingAuthorizationEndpoint", authzEndpoint: ""},
 	}
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(testIDPID)
-	suite.Empty(url)
-	suite.NotNil(err)
-	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			clientIDProp, _ := cmodels.NewProperty("client_id", "test_client", false)
+			clientSecretProp, _ := cmodels.NewProperty("client_secret", "test_secret", false)
+			redirectURIProp, _ := cmodels.NewProperty("redirect_uri", "https://app.com/callback", false)
+			scopesProp, _ := cmodels.NewProperty("scopes", "openid", false)
+			authzEndpointProp, _ := cmodels.NewProperty("authorization_endpoint", tc.authzEndpoint, false)
+
+			idpDTO := &idp.IDPDTO{
+				ID:   testIDPID,
+				Name: "Test OAuth Provider",
+				Type: idp.IDPTypeOAuth,
+				Properties: []cmodels.Property{
+					*clientIDProp, *clientSecretProp, *redirectURIProp, *scopesProp, *authzEndpointProp,
+				},
+			}
+			suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+
+			url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
+			suite.Empty(url)
+			suite.NotNil(err)
+			suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+		})
+	}
 }
 
 func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenWithValidationFailure() {
@@ -699,7 +712,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenWithValidationF
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpData, nil).Once()
 	suite.mockHTTPClient.On("Do", mock.Anything).Return(resp, nil).Once()
 
-	result, err := suite.service.ExchangeCodeForToken(testIDPID, "code123", true)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testIDPID, "code123", true)
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidTokenResponse.Code, err.Code)
@@ -722,29 +735,6 @@ func (suite *OAuthAuthnServiceTestSuite) TestFetchUserInfoWithClientConfigMissin
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
-func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLMissingAuthorizationEndpoint() {
-	clientIDProp, _ := cmodels.NewProperty("client_id", "test_client", false)
-	clientSecretProp, _ := cmodels.NewProperty("client_secret", "test_secret", false)
-	redirectURIProp, _ := cmodels.NewProperty("redirect_uri", "https://app.com/callback", false)
-	scopesProp, _ := cmodels.NewProperty("scopes", "openid", false)
-	authzEndpointProp, _ := cmodels.NewProperty("authorization_endpoint", "", false)
-
-	idpDTO := &idp.IDPDTO{
-		ID:   testIDPID,
-		Name: "Test OAuth Provider",
-		Type: idp.IDPTypeOAuth,
-		Properties: []cmodels.Property{
-			*clientIDProp, *clientSecretProp, *redirectURIProp, *scopesProp, *authzEndpointProp,
-		},
-	}
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
-
-	url, err := suite.service.BuildAuthorizeURL(testIDPID)
-	suite.Empty(url)
-	suite.NotNil(err)
-	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
-}
-
 func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenMissingTokenEndpoint() {
 	clientIDProp, _ := cmodels.NewProperty("client_id", "test_client", false)
 	clientSecretProp, _ := cmodels.NewProperty("client_secret", "test_secret", false)
@@ -762,7 +752,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenMissingTokenEnd
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	token, err := suite.service.ExchangeCodeForToken(testIDPID, "code123", false)
+	token, err := suite.service.ExchangeCodeForToken(context.Background(), testIDPID, "code123", false)
 	suite.Nil(token)
 	suite.NotNil(err)
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
@@ -785,7 +775,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestFetchUserInfoMissingUserInfoEndpoin
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	userInfo, err := suite.service.FetchUserInfo(testIDPID, "access_token")
+	userInfo, err := suite.service.FetchUserInfo(context.Background(), testIDPID, "access_token")
 	suite.Nil(userInfo)
 	suite.NotNil(err)
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -20,6 +20,7 @@
 package oidc
 
 import (
+	"context"
 	"strings"
 
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
@@ -39,14 +40,14 @@ const (
 // OIDCAuthnCoreServiceInterface defines the core contract for OIDC based authenticator services.
 type OIDCAuthnCoreServiceInterface interface {
 	authnoauth.OAuthAuthnCoreServiceInterface
-	ValidateIDToken(idpID, idToken string) *serviceerror.ServiceError
+	ValidateIDToken(ctx context.Context, idpID, idToken string) *serviceerror.ServiceError
 	GetIDTokenClaims(idToken string) (map[string]interface{}, *serviceerror.ServiceError)
 }
 
 // OIDCAuthnServiceInterface defines the contract for OIDC based authenticator services.
 type OIDCAuthnServiceInterface interface {
 	OIDCAuthnCoreServiceInterface
-	ValidateTokenResponse(idpID string, tokenResp *authnoauth.TokenResponse,
+	ValidateTokenResponse(ctx context.Context, idpID string, tokenResp *authnoauth.TokenResponse,
 		validateIDToken bool) *serviceerror.ServiceError
 }
 
@@ -83,27 +84,27 @@ func NewOIDCAuthnService(httpClient httpservice.HTTPClientInterface,
 }
 
 // GetOAuthClientConfig retrieves the OAuth client configuration for the given identity provider ID.
-func (s *oidcAuthnService) GetOAuthClientConfig(idpID string) (
+func (s *oidcAuthnService) GetOAuthClientConfig(ctx context.Context, idpID string) (
 	*authnoauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	return s.internal.GetOAuthClientConfig(idpID)
+	return s.internal.GetOAuthClientConfig(ctx, idpID)
 }
 
 // BuildAuthorizeURL constructs the authorization request URL for the external identity provider.
-func (s *oidcAuthnService) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	return s.internal.BuildAuthorizeURL(idpID)
+func (s *oidcAuthnService) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	return s.internal.BuildAuthorizeURL(ctx, idpID)
 }
 
 // ExchangeCodeForToken exchanges the authorization code for a token with the external identity provider
 // and validates the token response if validateResponse is true.
-func (s *oidcAuthnService) ExchangeCodeForToken(idpID, code string, validateResponse bool) (
+func (s *oidcAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
 	*authnoauth.TokenResponse, *serviceerror.ServiceError) {
-	tokenResp, svcErr := s.internal.ExchangeCodeForToken(idpID, code, false)
+	tokenResp, svcErr := s.internal.ExchangeCodeForToken(ctx, idpID, code, false)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
 	if validateResponse {
-		svcErr = s.ValidateTokenResponse(idpID, tokenResp, true)
+		svcErr = s.ValidateTokenResponse(ctx, idpID, tokenResp, true)
 		if svcErr != nil {
 			return nil, svcErr
 		}
@@ -115,8 +116,8 @@ func (s *oidcAuthnService) ExchangeCodeForToken(idpID, code string, validateResp
 // ValidateTokenResponse validates the token response returned by the identity provider.
 // ExchangeCodeForToken method calls this method to validate the token response if validateResponse is set
 // to true. Hence generally you may not need to call this method explicitly.
-func (s *oidcAuthnService) ValidateTokenResponse(idpID string, tokenResp *authnoauth.TokenResponse,
-	validateIDToken bool) *serviceerror.ServiceError {
+func (s *oidcAuthnService) ValidateTokenResponse(ctx context.Context, idpID string,
+	tokenResp *authnoauth.TokenResponse, validateIDToken bool) *serviceerror.ServiceError {
 	logger := s.logger
 	logger.Debug("Validating token response")
 
@@ -134,7 +135,7 @@ func (s *oidcAuthnService) ValidateTokenResponse(idpID string, tokenResp *authno
 	}
 
 	if validateIDToken {
-		svcErr := s.ValidateIDToken(idpID, tokenResp.IDToken)
+		svcErr := s.ValidateIDToken(ctx, idpID, tokenResp.IDToken)
 		if svcErr != nil {
 			return svcErr
 		}
@@ -147,7 +148,7 @@ func (s *oidcAuthnService) ValidateTokenResponse(idpID string, tokenResp *authno
 // ValidateTokenResponse method calls this method to validate the token response if validateIDToken is set
 // to true. Hence generally you may not need to call this method explicitly if ExchangeCodeForToken method
 // is called with validateResponse set to true.
-func (s *oidcAuthnService) ValidateIDToken(idpID, idToken string) *serviceerror.ServiceError {
+func (s *oidcAuthnService) ValidateIDToken(ctx context.Context, idpID, idToken string) *serviceerror.ServiceError {
 	logger := s.logger.With(log.String("idpId", idpID))
 	logger.Debug("Validating ID token")
 
@@ -156,7 +157,7 @@ func (s *oidcAuthnService) ValidateIDToken(idpID, idToken string) *serviceerror.
 		return &ErrorInvalidIDToken
 	}
 
-	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(idpID)
+	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return svcErr
 	}
@@ -200,9 +201,9 @@ func (s *oidcAuthnService) GetIDTokenClaims(idToken string) (
 }
 
 // FetchUserInfo retrieves user information from the external identity provider.
-func (s *oidcAuthnService) FetchUserInfo(idpID, accessToken string) (
+func (s *oidcAuthnService) FetchUserInfo(ctx context.Context, idpID, accessToken string) (
 	map[string]interface{}, *serviceerror.ServiceError) {
-	return s.internal.FetchUserInfo(idpID, accessToken)
+	return s.internal.FetchUserInfo(ctx, idpID, accessToken)
 }
 
 // GetInternalUser retrieves the internal user based on the external subject identifier.

--- a/backend/internal/authn/oidc/service_test.go
+++ b/backend/internal/authn/oidc/service_test.go
@@ -19,7 +19,10 @@
 package oidc
 
 import (
+	"context"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/suite"
 
@@ -81,9 +84,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestGetOAuthClientConfigWithOpenIDScope(
 		ClientSecret: "secret",
 		Scopes:       []string{"openid", "profile", "email"},
 	}
-	suite.mockOAuthService.On("GetOAuthClientConfig", idpID).Return(config, nil)
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, idpID).Return(config, nil)
 
-	result, err := suite.service.GetOAuthClientConfig(idpID)
+	result, err := suite.service.GetOAuthClientConfig(context.Background(), idpID)
 	suite.Nil(err)
 	suite.NotNil(result)
 
@@ -102,9 +105,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestGetOAuthClientConfigWithoutOpenIDSco
 		ClientSecret: "secret",
 		Scopes:       []string{"profile"},
 	}
-	suite.mockOAuthService.On("GetOAuthClientConfig", idpID).Return(config, nil)
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, idpID).Return(config, nil)
 
-	result, err := suite.service.GetOAuthClientConfig(idpID)
+	result, err := suite.service.GetOAuthClientConfig(context.Background(), idpID)
 	suite.Nil(err)
 	suite.NotNil(result)
 
@@ -115,9 +118,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestGetOAuthClientConfigWithoutOpenIDSco
 
 func (suite *OIDCAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	expectedURL := "https://example.com/authorize?client_id=test"
-	suite.mockOAuthService.On("BuildAuthorizeURL", testOIDCIDPID).Return(expectedURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testOIDCIDPID).Return(expectedURL, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(testOIDCIDPID)
+	url, err := suite.service.BuildAuthorizeURL(context.Background(), testOIDCIDPID)
 	suite.Nil(err)
 	suite.Equal(expectedURL, url)
 }
@@ -127,9 +130,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestBuildAuthorizeURLError() {
 		Code:             "ERROR",
 		ErrorDescription: "Failed to build URL",
 	}
-	suite.mockOAuthService.On("BuildAuthorizeURL", testOIDCIDPID).Return("", svcErr)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testOIDCIDPID).Return("", svcErr)
 
-	url, err := suite.service.BuildAuthorizeURL(testOIDCIDPID)
+	url, err := suite.service.BuildAuthorizeURL(context.Background(), testOIDCIDPID)
 	suite.Empty(url)
 	suite.NotNil(err)
 	suite.Equal(svcErr.Code, err.Code)
@@ -151,10 +154,13 @@ func (suite *OIDCAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess() {
 					IDToken:     "id_token",
 					TokenType:   "Bearer",
 				}
-				suite.mockOAuthService.On("ExchangeCodeForToken", testOIDCIDPID, code, false).Return(tokenResp, nil)
-				suite.mockOAuthService.On("GetOAuthClientConfig", testOIDCIDPID).Return(&oauth.OAuthClientConfig{
+				suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, code, false).
+					Return(tokenResp, nil)
+				cfg := &oauth.OAuthClientConfig{
 					OAuthEndpoints: oauth.OAuthEndpoints{JwksEndpoint: "https://example.com/jwks"},
-				}, nil)
+				}
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).
+					Return(cfg, nil)
 				suite.mockJWTService.On("VerifyJWTWithJWKS", "id_token",
 					"https://example.com/jwks", "", "").Return(nil)
 			},
@@ -169,7 +175,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess() {
 					IDToken:     "id_token",
 					TokenType:   "Bearer",
 				}
-				suite.mockOAuthService.On("ExchangeCodeForToken", testOIDCIDPID, code, false).Return(tokenResp, nil)
+				suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, code, false).
+					Return(tokenResp, nil)
 			},
 		},
 	}
@@ -188,7 +195,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess() {
 
 			tc.setupMocks()
 
-			result, err := suite.service.ExchangeCodeForToken(testOIDCIDPID, "auth_code", tc.validateResponse)
+			result, err := suite.service.ExchangeCodeForToken(context.Background(), testOIDCIDPID, "auth_code",
+				tc.validateResponse)
+
 			suite.Nil(err)
 			suite.NotNil(result)
 			suite.Equal("access_token", result.AccessToken)
@@ -206,9 +215,11 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseSuccess() {
 			name:            "WithIDTokenValidation",
 			validateIDToken: true,
 			setupMocks: func() {
-				suite.mockOAuthService.On("GetOAuthClientConfig", testOIDCIDPID).Return(&oauth.OAuthClientConfig{
+				cfg := &oauth.OAuthClientConfig{
 					OAuthEndpoints: oauth.OAuthEndpoints{JwksEndpoint: "https://example.com/jwks"},
-				}, nil)
+				}
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).
+					Return(cfg, nil)
 				suite.mockJWTService.On("VerifyJWTWithJWKS", "id_token",
 					"https://example.com/jwks", "", "").Return(nil)
 			},
@@ -239,7 +250,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseSuccess() {
 				IDToken:     "id_token",
 				TokenType:   "Bearer",
 			}
-			err := suite.service.ValidateTokenResponse(testOIDCIDPID, tokenResp, tc.validateIDToken)
+			err := suite.service.ValidateTokenResponse(
+				context.Background(), testOIDCIDPID, tokenResp, tc.validateIDToken)
 			suite.Nil(err)
 		})
 	}
@@ -266,7 +278,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseWithError() {
 
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
-			err := suite.service.ValidateTokenResponse(testOIDCIDPID, tc.resp, false)
+			err := suite.service.ValidateTokenResponse(context.Background(), testOIDCIDPID, tc.resp, false)
 			suite.NotNil(err)
 			suite.Equal(oauth.ErrorInvalidTokenResponse.Code, err.Code)
 		})
@@ -281,9 +293,11 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 		{
 			name: "WithJWKSEndpoint",
 			setupMocks: func() {
-				suite.mockOAuthService.On("GetOAuthClientConfig", testOIDCIDPID).Return(&oauth.OAuthClientConfig{
+				cfg := &oauth.OAuthClientConfig{
 					OAuthEndpoints: oauth.OAuthEndpoints{JwksEndpoint: "https://example.com/jwks"},
-				}, nil)
+				}
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).
+					Return(cfg, nil)
 				suite.mockJWTService.On("VerifyJWTWithJWKS", "valid_id_token",
 					"https://example.com/jwks", "", "").Return(nil)
 			},
@@ -291,9 +305,11 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 		{
 			name: "WithoutJWKSEndpoint",
 			setupMocks: func() {
-				suite.mockOAuthService.On("GetOAuthClientConfig", testOIDCIDPID).Return(&oauth.OAuthClientConfig{
+				cfg := &oauth.OAuthClientConfig{
 					OAuthEndpoints: oauth.OAuthEndpoints{},
-				}, nil)
+				}
+				suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).
+					Return(cfg, nil)
 			},
 		},
 	}
@@ -312,14 +328,14 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 
 			tc.setupMocks()
 
-			err := suite.service.ValidateIDToken(testOIDCIDPID, "valid_id_token")
+			err := suite.service.ValidateIDToken(context.Background(), testOIDCIDPID, "valid_id_token")
 			suite.Nil(err)
 		})
 	}
 }
 
 func (suite *OIDCAuthnServiceTestSuite) TestValidateIDTokenEmptyToken() {
-	err := suite.service.ValidateIDToken(testOIDCIDPID, "")
+	err := suite.service.ValidateIDToken(context.Background(), testOIDCIDPID, "")
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidIDToken.Code, err.Code)
 }
@@ -349,9 +365,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestFetchUserInfoSuccess() {
 		"sub":   "user123",
 		"email": "user@example.com",
 	}
-	suite.mockOAuthService.On("FetchUserInfo", testOIDCIDPID, accessToken).Return(userInfo, nil)
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testOIDCIDPID, accessToken).Return(userInfo, nil)
 
-	result, err := suite.service.FetchUserInfo(testOIDCIDPID, accessToken)
+	result, err := suite.service.FetchUserInfo(context.Background(), testOIDCIDPID, accessToken)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(userInfo["sub"], result["sub"])
@@ -372,10 +388,10 @@ func (suite *OIDCAuthnServiceTestSuite) TestGetInternalUserSuccess() {
 }
 
 func (suite *OIDCAuthnServiceTestSuite) TestExchangeCodeForTokenInternalError() {
-	suite.mockOAuthService.On("ExchangeCodeForToken", testOIDCIDPID, "auth_code", false).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(nil, &serviceerror.ServiceError{Code: "INT-ERR"})
 
-	result, err := suite.service.ExchangeCodeForToken(testOIDCIDPID, "auth_code", false)
+	result, err := suite.service.ExchangeCodeForToken(context.Background(), testOIDCIDPID, "auth_code", false)
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal("INT-ERR", err.Code)
@@ -394,7 +410,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseValidateIDToken
 	suite.service.internal = suite.mockOAuthService
 
 	// GetOAuthClientConfig returns a config with jwks endpoint
-	suite.mockOAuthService.On("GetOAuthClientConfig", testOIDCIDPID).Return(&oauth.OAuthClientConfig{
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(&oauth.OAuthClientConfig{
 		OAuthEndpoints: oauth.OAuthEndpoints{JwksEndpoint: "https://example.com/jwks"},
 	}, nil)
 
@@ -408,7 +424,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseValidateIDToken
 		})
 
 	tokenResp := &oauth.TokenResponse{AccessToken: "access", IDToken: "id_token"}
-	err := suite.service.ValidateTokenResponse(testOIDCIDPID, tokenResp, true)
+	err := suite.service.ValidateTokenResponse(context.Background(), testOIDCIDPID, tokenResp, true)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidIDTokenSignature.Code, err.Code)
 }
@@ -446,10 +462,10 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateIDTokenWithJWKSEndpoint() {
 		},
 	}
 
-	suite.mockOAuthService.On("GetOAuthClientConfig", testOIDCIDPID).Return(config, nil)
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(config, nil)
 	suite.mockJWTService.On("VerifyJWTWithJWKS", idToken, "https://idp.com/jwks", "", "").Return(nil)
 
-	err := suite.service.ValidateIDToken(testOIDCIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testOIDCIDPID, idToken)
 	suite.Nil(err)
 }
 
@@ -468,9 +484,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateIDTokenWithoutJWKSEndpoint()
 		},
 	}
 
-	suite.mockOAuthService.On("GetOAuthClientConfig", testOIDCIDPID).Return(config, nil)
+	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(config, nil)
 	// VerifyJWTWithJWKS should not be called when JWKS endpoint is empty
 
-	err := suite.service.ValidateIDToken(testOIDCIDPID, idToken)
+	err := suite.service.ValidateIDToken(context.Background(), testOIDCIDPID, idToken)
 	suite.Nil(err)
 }

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -60,9 +60,9 @@ type AuthenticationServiceInterface interface {
 		string, *serviceerror.ServiceError)
 	VerifyOTP(ctx context.Context, sessionToken string, skipAssertion bool, existingAssertion, otp string) (
 		*common.AuthenticationResponse, *serviceerror.ServiceError)
-	StartIDPAuthentication(requestedType idp.IDPType, idpID string) (
+	StartIDPAuthentication(ctx context.Context, requestedType idp.IDPType, idpID string) (
 		*IDPAuthInitData, *serviceerror.ServiceError)
-	FinishIDPAuthentication(requestedType idp.IDPType, sessionToken string, skipAssertion bool,
+	FinishIDPAuthentication(ctx context.Context, requestedType idp.IDPType, sessionToken string, skipAssertion bool,
 		existingAssertion, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError)
 	// Passkey methods
 	StartPasskeyRegistration(ctx context.Context, userID, relyingPartyID, relyingPartyName string,
@@ -233,7 +233,7 @@ func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken str
 }
 
 // StartIDPAuthentication initiates authentication against an IDP.
-func (as *authenticationService) StartIDPAuthentication(requestedType idp.IDPType, idpID string) (
+func (as *authenticationService) StartIDPAuthentication(ctx context.Context, requestedType idp.IDPType, idpID string) (
 	*IDPAuthInitData, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
 	logger.Debug("Starting IDP authentication", log.String("idpId", idpID))
@@ -242,7 +242,7 @@ func (as *authenticationService) StartIDPAuthentication(requestedType idp.IDPTyp
 		return nil, &common.ErrorInvalidIDPID
 	}
 
-	identityProvider, svcErr := as.idpService.GetIdentityProvider(context.TODO(), idpID)
+	identityProvider, svcErr := as.idpService.GetIdentityProvider(ctx, idpID)
 	if svcErr != nil {
 		return nil, as.handleIDPServiceError(idpID, svcErr, logger)
 	}
@@ -255,13 +255,13 @@ func (as *authenticationService) StartIDPAuthentication(requestedType idp.IDPTyp
 	var redirectURL string
 	switch identityProvider.Type {
 	case idp.IDPTypeOAuth:
-		redirectURL, svcErr = as.oauthService.BuildAuthorizeURL(idpID)
+		redirectURL, svcErr = as.oauthService.BuildAuthorizeURL(ctx, idpID)
 	case idp.IDPTypeOIDC:
-		redirectURL, svcErr = as.oidcService.BuildAuthorizeURL(idpID)
+		redirectURL, svcErr = as.oidcService.BuildAuthorizeURL(ctx, idpID)
 	case idp.IDPTypeGoogle:
-		redirectURL, svcErr = as.googleService.BuildAuthorizeURL(idpID)
+		redirectURL, svcErr = as.googleService.BuildAuthorizeURL(ctx, idpID)
 	case idp.IDPTypeGitHub:
-		redirectURL, svcErr = as.githubService.BuildAuthorizeURL(idpID)
+		redirectURL, svcErr = as.githubService.BuildAuthorizeURL(ctx, idpID)
 	default:
 		logger.Error("Unsupported IDP type", log.String("idpId", idpID),
 			log.String("type", string(identityProvider.Type)))
@@ -286,8 +286,9 @@ func (as *authenticationService) StartIDPAuthentication(requestedType idp.IDPTyp
 }
 
 // FinishIDPAuthentication completes authentication against an IDP.
-func (as *authenticationService) FinishIDPAuthentication(requestedType idp.IDPType, sessionToken string,
-	skipAssertion bool, existingAssertion, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
+func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, requestedType idp.IDPType,
+	sessionToken string, skipAssertion bool, existingAssertion, code string) (
+	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
 	logger.Debug("Finishing IDP authentication")
 
@@ -312,13 +313,13 @@ func (as *authenticationService) FinishIDPAuthentication(requestedType idp.IDPTy
 	var user *userprovider.User
 	switch sessionData.IDPType {
 	case idp.IDPTypeOAuth:
-		_, user, svcErr = as.finishOAuthAuthentication(sessionData.IDPID, code, logger)
+		_, user, svcErr = as.finishOAuthAuthentication(ctx, sessionData.IDPID, code, logger)
 	case idp.IDPTypeOIDC:
-		_, user, svcErr = as.finishOIDCAuthentication(sessionData.IDPID, code, logger)
+		_, user, svcErr = as.finishOIDCAuthentication(ctx, sessionData.IDPID, code, logger)
 	case idp.IDPTypeGoogle:
-		_, user, svcErr = as.finishGoogleAuthentication(sessionData.IDPID, code, logger)
+		_, user, svcErr = as.finishGoogleAuthentication(ctx, sessionData.IDPID, code, logger)
 	case idp.IDPTypeGitHub:
-		_, user, svcErr = as.finishGithubAuthentication(sessionData.IDPID, code, logger)
+		_, user, svcErr = as.finishGithubAuthentication(ctx, sessionData.IDPID, code, logger)
 	default:
 		logger.Error("Unsupported IDP type in session", log.String("idpId", sessionData.IDPID),
 			log.String("type", string(sessionData.IDPType)))
@@ -494,14 +495,14 @@ func (as *authenticationService) extractClaimsFromAssertion(assertion string,
 }
 
 // finishOAuthAuthentication handles OAuth authentication completion.
-func (as *authenticationService) finishOAuthAuthentication(idpID, code string, logger *log.Logger) (
-	string, *userprovider.User, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.oauthService.ExchangeCodeForToken(idpID, code, true)
+func (as *authenticationService) finishOAuthAuthentication(ctx context.Context, idpID, code string,
+	logger *log.Logger) (string, *userprovider.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.oauthService.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
 		return "", nil, svcErr
 	}
 
-	userInfo, svcErr := as.oauthService.FetchUserInfo(idpID, tokenResp.AccessToken)
+	userInfo, svcErr := as.oauthService.FetchUserInfo(ctx, idpID, tokenResp.AccessToken)
 	if svcErr != nil {
 		return "", nil, svcErr
 	}
@@ -520,9 +521,9 @@ func (as *authenticationService) finishOAuthAuthentication(idpID, code string, l
 }
 
 // finishOIDCAuthentication handles OIDC authentication completion.
-func (as *authenticationService) finishOIDCAuthentication(idpID, code string, logger *log.Logger) (
-	string, *userprovider.User, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.oidcService.ExchangeCodeForToken(idpID, code, true)
+func (as *authenticationService) finishOIDCAuthentication(ctx context.Context, idpID, code string,
+	logger *log.Logger) (string, *userprovider.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.oidcService.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
 		return "", nil, svcErr
 	}
@@ -549,9 +550,9 @@ func (as *authenticationService) finishOIDCAuthentication(idpID, code string, lo
 }
 
 // finishGoogleAuthentication handles Google authentication completion.
-func (as *authenticationService) finishGoogleAuthentication(idpID, code string, logger *log.Logger) (
-	string, *userprovider.User, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.googleService.ExchangeCodeForToken(idpID, code, true)
+func (as *authenticationService) finishGoogleAuthentication(ctx context.Context, idpID, code string,
+	logger *log.Logger) (string, *userprovider.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.googleService.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
 		return "", nil, svcErr
 	}
@@ -578,14 +579,14 @@ func (as *authenticationService) finishGoogleAuthentication(idpID, code string, 
 }
 
 // finishGithubAuthentication handles GitHub authentication completion.
-func (as *authenticationService) finishGithubAuthentication(idpID, code string, logger *log.Logger) (
-	string, *userprovider.User, *serviceerror.ServiceError) {
-	tokenResp, svcErr := as.githubService.ExchangeCodeForToken(idpID, code, true)
+func (as *authenticationService) finishGithubAuthentication(ctx context.Context, idpID, code string,
+	logger *log.Logger) (string, *userprovider.User, *serviceerror.ServiceError) {
+	tokenResp, svcErr := as.githubService.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
 		return "", nil, svcErr
 	}
 
-	userInfo, svcErr := as.githubService.FetchUserInfo(idpID, tokenResp.AccessToken)
+	userInfo, svcErr := as.githubService.FetchUserInfo(ctx, idpID, tokenResp.AccessToken)
 	if svcErr != nil {
 		return "", nil, svcErr
 	}

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -622,12 +622,12 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOAuthSucc
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOAuth, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOAuth, idpID)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -644,12 +644,12 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOIDCSucce
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOIDCService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
+	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOIDC, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOIDC, idpID)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -665,12 +665,12 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGoogleSuc
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockGoogleService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
+	suite.mockGoogleService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeGoogle, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeGoogle, idpID)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -686,12 +686,12 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuc
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockGithubService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
+	suite.mockGithubService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeGitHub, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeGitHub, idpID)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -699,7 +699,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuc
 }
 
 func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationEmptyIDPID() {
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOAuth, "")
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOAuth, "")
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -717,7 +717,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationIDPNotFou
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(nil, svcErr)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOAuth, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOAuth, idpID)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -733,7 +733,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationInvalidID
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeGitHub, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeGitHub, idpID)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -749,12 +749,12 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationCrossType
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOIDC, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOIDC, idpID)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -769,7 +769,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", idpID).Return(redirectURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
 	suite.mockJWTService.On("GenerateJWT", "auth-svc", "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &serviceerror.ServiceError{
@@ -779,7 +779,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 			ErrorDescription: "Failed to generate session token",
 		})
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOAuth, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOAuth, idpID)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -802,11 +802,13 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationOAuthSuc
 
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil)
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil)
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOAuth, sessionToken, true, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOAuth, sessionToken, true, "",
+		testAuthCode)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -857,9 +859,10 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 			setupMocks: func() {
 				sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
-				suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).
+				suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
 					Return(tokenResp, nil).Once()
-				suite.mockOAuthService.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil).Once()
+				suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).
+					Return(userInfo, nil).Once()
 				suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
 				suite.mockAssertGenerator.On("GenerateAssertion", mock.Anything).Return(
 					&assert.AssertionResult{
@@ -884,9 +887,10 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 				existingAssertion := suite.createTestAssertion(testUserID)
 				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
 				suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil).Once()
-				suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).
+				suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
 					Return(tokenResp, nil).Once()
-				suite.mockOAuthService.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil).Once()
+				suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).
+					Return(userInfo, nil).Once()
 				suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
 				suite.mockAssertGenerator.On("UpdateAssertion", mock.Anything, mock.Anything).Return(
 					&assert.AssertionResult{
@@ -914,7 +918,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 			tc.setupMocks()
 
 			sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
-			result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOAuth, sessionToken,
+			result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOAuth, sessionToken,
 				tc.skipAssertion, tc.existingAssertion, testAuthCode)
 
 			suite.Nil(err)
@@ -926,7 +930,8 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationEmptySessionToken() {
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOAuth, "", false, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOAuth, "", false, "",
+		testAuthCode)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -936,7 +941,9 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationEmptySes
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationEmptyAuthCode() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOAuth, sessionToken, false, "", "")
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeOAuth, sessionToken, false, "",
+		"")
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -952,7 +959,8 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationInvalidS
 			ErrorDescription: "The session token is invalid",
 		})
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOAuth, "invalid_token", false, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeOAuth, "invalid_token", false, "", testAuthCode)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -963,7 +971,9 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationTypeMism
 	sessionToken := suite.createSessionToken(idp.IDPTypeGoogle)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeGitHub, sessionToken, false, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeGitHub, sessionToken, false, "",
+		testAuthCode)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -981,10 +991,13 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationSubClaim
 
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil)
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
+		Return(tokenResp, nil)
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOAuth, sessionToken, false, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeOAuth, sessionToken, false, "",
+		testAuthCode)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -1130,9 +1143,9 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationBuildURLE
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", idpID).Return("", svcErr)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return("", svcErr)
 
-	result, err := suite.service.StartIDPAuthentication(idp.IDPTypeOAuth, idpID)
+	result, err := suite.service.StartIDPAuthentication(context.Background(), idp.IDPTypeOAuth, idpID)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -1154,10 +1167,12 @@ func (suite *AuthenticationServiceTestSuite) TestFinishOIDCAuthenticationFetchUs
 
 	sessionToken := suite.createSessionToken(idp.IDPTypeOIDC)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockOIDCService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
+		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_123").Return(nil, svcErr)
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOIDC, sessionToken, true, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOIDC, sessionToken, true, "",
+		testAuthCode)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -1182,11 +1197,14 @@ func (suite *AuthenticationServiceTestSuite) TestFinishGoogleAuthenticationGetIn
 
 	sessionToken := suite.createSessionToken(idp.IDPTypeGoogle)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
-	suite.mockGoogleService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
+	suite.mockGoogleService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
+		Return(tokenResp, nil)
 	suite.mockGoogleService.On("GetIDTokenClaims", "id_token_123").Return(claims, nil)
 	suite.mockGoogleService.On("GetInternalUser", testUserID).Return(nil, svcErr)
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeGoogle, sessionToken, true, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeGoogle, sessionToken, true, "",
+		testAuthCode)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -1216,16 +1234,17 @@ func (suite *AuthenticationServiceTestSuite) testFinishOIDCBasedAuth(
 
 	switch service := mockService.(type) {
 	case *oidcmock.OIDCAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
+		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
 		service.On("GetIDTokenClaims", "id_token_123").Return(claims, nil)
 		service.On("GetInternalUser", testUserID).Return(testUser, nil)
 	case *googlemock.GoogleOIDCAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
+		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
 		service.On("GetIDTokenClaims", "id_token_123").Return(claims, nil)
 		service.On("GetInternalUser", testUserID).Return(testUser, nil)
 	}
 
-	result, err := suite.service.FinishIDPAuthentication(idpType, sessionToken, true, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(context.Background(), idpType, sessionToken, true, "",
+		testAuthCode)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -1252,16 +1271,17 @@ func (suite *AuthenticationServiceTestSuite) testFinishOAuthBasedAuth(
 
 	switch service := mockService.(type) {
 	case *githubmock.GithubOAuthAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
-		service.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil)
+		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
+		service.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
 		service.On("GetInternalUser", testUserID).Return(testUser, nil)
 	case *oauthmock.OAuthAuthnServiceInterfaceMock:
-		service.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).Return(tokenResp, nil)
-		service.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil)
+		service.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).Return(tokenResp, nil)
+		service.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil)
 		service.On("GetInternalUser", testUserID).Return(testUser, nil)
 	}
 
-	result, err := suite.service.FinishIDPAuthentication(idpType, sessionToken, true, "", testAuthCode)
+	result, err := suite.service.FinishIDPAuthentication(context.Background(), idpType, sessionToken, true, "",
+		testAuthCode)
 
 	suite.Nil(err)
 	suite.NotNil(result)
@@ -1338,9 +1358,9 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationAssertio
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", testIDPID, testAuthCode, true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testIDPID, testAuthCode, true).
 		Return(tokenResp, nil).Once()
-	suite.mockOAuthService.On("FetchUserInfo", testIDPID, testToken).Return(userInfo, nil).Once()
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testIDPID, testToken).Return(userInfo, nil).Once()
 	suite.mockOAuthService.On("GetInternalUser", testUserID).Return(testUser, nil).Once()
 
 	// Create invalid existing assertion that will fail JWT verification
@@ -1352,7 +1372,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationAssertio
 			ErrorDescription: "The JWT signature is invalid",
 		}).Once()
 
-	result, err := suite.service.FinishIDPAuthentication(idp.IDPTypeOAuth, sessionToken, false,
+	result, err := suite.service.FinishIDPAuthentication(context.Background(), idp.IDPTypeOAuth, sessionToken, false,
 		invalidAssertion, testAuthCode)
 	suite.Nil(result)
 	suite.NotNil(err)

--- a/backend/internal/authz/engine/engine.go
+++ b/backend/internal/authz/engine/engine.go
@@ -18,6 +18,8 @@
 
 package engine
 
+import "context"
+
 // AuthorizationEngine is the internal interface for authorization engines.
 // This interface is NOT exported and is used internally by the authorization service.
 // Different engines can be plugged in (RBAC, ABAC, ReBAC, Custom) by implementing this interface.
@@ -25,6 +27,7 @@ type AuthorizationEngine interface {
 	// GetAuthorizedPermissions returns the subset of requested permissions
 	// that the user (directly or through groups) is authorized for.
 	GetAuthorizedPermissions(
+		ctx context.Context,
 		userID string,
 		groupIDs []string,
 		requestedPermissions []string,

--- a/backend/internal/authz/engine/rbacengine.go
+++ b/backend/internal/authz/engine/rbacengine.go
@@ -44,13 +44,14 @@ func NewRBACEngine(roleService role.RoleServiceInterface) AuthorizationEngine {
 // GetAuthorizedPermissions returns the subset of requested permissions
 // that the user is authorized for based on their role assignments.
 func (e *rbacEngine) GetAuthorizedPermissions(
+	ctx context.Context,
 	userID string,
 	groupIDs []string,
 	requestedPermissions []string,
 ) ([]string, error) {
 	// Delegate to role service
 	authorizedPerms, svcErr := e.roleService.GetAuthorizedPermissions(
-		context.TODO(), userID, groupIDs, requestedPermissions)
+		ctx, userID, groupIDs, requestedPermissions)
 	if svcErr != nil {
 		return nil, fmt.Errorf("role service error: %s", svcErr.Error)
 	}

--- a/backend/internal/authz/engine/rbacengine_test.go
+++ b/backend/internal/authz/engine/rbacengine_test.go
@@ -19,6 +19,7 @@
 package engine
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -57,7 +58,7 @@ func (suite *RBACEngineTestSuite) TestGetAuthorizedPermissions_Success() {
 	suite.mockRoleService.On("GetAuthorizedPermissions", mock.Anything, userID, groupIDs, requestedPermissions).
 		Return(authorizedPermissions, nil)
 
-	result, err := suite.engine.GetAuthorizedPermissions(userID, groupIDs, requestedPermissions)
+	result, err := suite.engine.GetAuthorizedPermissions(context.Background(), userID, groupIDs, requestedPermissions)
 
 	suite.Nil(err)
 	suite.Equal(authorizedPermissions, result)
@@ -72,7 +73,7 @@ func (suite *RBACEngineTestSuite) TestGetAuthorizedPermissions_UserOnly() {
 	suite.mockRoleService.On("GetAuthorizedPermissions", mock.Anything, userID, groupIDs, requestedPermissions).
 		Return(authorizedPermissions, nil)
 
-	result, err := suite.engine.GetAuthorizedPermissions(userID, groupIDs, requestedPermissions)
+	result, err := suite.engine.GetAuthorizedPermissions(context.Background(), userID, groupIDs, requestedPermissions)
 
 	suite.Nil(err)
 	suite.Equal(authorizedPermissions, result)
@@ -87,7 +88,7 @@ func (suite *RBACEngineTestSuite) TestGetAuthorizedPermissions_GroupsOnly() {
 	suite.mockRoleService.On("GetAuthorizedPermissions", mock.Anything, userID, groupIDs, requestedPermissions).
 		Return(authorizedPermissions, nil)
 
-	result, err := suite.engine.GetAuthorizedPermissions(userID, groupIDs, requestedPermissions)
+	result, err := suite.engine.GetAuthorizedPermissions(context.Background(), userID, groupIDs, requestedPermissions)
 
 	suite.Nil(err)
 	suite.Equal(authorizedPermissions, result)
@@ -102,7 +103,7 @@ func (suite *RBACEngineTestSuite) TestGetAuthorizedPermissions_NoAuthorizedPermi
 	suite.mockRoleService.On("GetAuthorizedPermissions", mock.Anything, userID, groupIDs, requestedPermissions).
 		Return(authorizedPermissions, nil)
 
-	result, err := suite.engine.GetAuthorizedPermissions(userID, groupIDs, requestedPermissions)
+	result, err := suite.engine.GetAuthorizedPermissions(context.Background(), userID, groupIDs, requestedPermissions)
 
 	suite.Nil(err)
 	suite.Empty(result)
@@ -123,7 +124,7 @@ func (suite *RBACEngineTestSuite) TestGetAuthorizedPermissions_RoleServiceError(
 	suite.mockRoleService.On("GetAuthorizedPermissions", mock.Anything, userID, groupIDs, requestedPermissions).
 		Return([]string(nil), roleServiceError)
 
-	result, err := suite.engine.GetAuthorizedPermissions(userID, groupIDs, requestedPermissions)
+	result, err := suite.engine.GetAuthorizedPermissions(context.Background(), userID, groupIDs, requestedPermissions)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -138,7 +139,7 @@ func (suite *RBACEngineTestSuite) TestGetAuthorizedPermissions_AllPermissionsAut
 	suite.mockRoleService.On("GetAuthorizedPermissions", mock.Anything, userID, groupIDs, requestedPermissions).
 		Return(requestedPermissions, nil)
 
-	result, err := suite.engine.GetAuthorizedPermissions(userID, groupIDs, requestedPermissions)
+	result, err := suite.engine.GetAuthorizedPermissions(context.Background(), userID, groupIDs, requestedPermissions)
 
 	suite.Nil(err)
 	suite.Equal(requestedPermissions, result)

--- a/backend/internal/authz/service.go
+++ b/backend/internal/authz/service.go
@@ -20,6 +20,8 @@
 package authz
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authz/engine"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
@@ -33,6 +35,7 @@ type AuthorizationServiceInterface interface {
 	// GetAuthorizedPermissions returns the subset of requested permissions
 	// that the user (directly or through groups) is authorized for.
 	GetAuthorizedPermissions(
+		ctx context.Context,
 		request GetAuthorizedPermissionsRequest,
 	) (*GetAuthorizedPermissionsResponse, *serviceerror.ServiceError)
 }
@@ -51,6 +54,7 @@ func newAuthorizationService(engine engine.AuthorizationEngine) AuthorizationSer
 
 // GetAuthorizedPermissions returns the subset of requested permissions that the user is authorized for.
 func (s *authorizationService) GetAuthorizedPermissions(
+	ctx context.Context,
 	request GetAuthorizedPermissionsRequest,
 ) (*GetAuthorizedPermissionsResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
@@ -73,6 +77,7 @@ func (s *authorizationService) GetAuthorizedPermissions(
 
 	// Delegate to engine (engine/underlying service handles validation)
 	authorizedPerms, err := s.engine.GetAuthorizedPermissions(
+		ctx,
 		request.UserID,
 		request.GroupIDs,
 		request.RequestedPermissions,

--- a/backend/internal/authz/service_test.go
+++ b/backend/internal/authz/service_test.go
@@ -19,8 +19,11 @@
 package authz
 
 import (
+	"context"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	enginemock "github.com/asgardeo/thunder/tests/mocks/authz/engine"
 
@@ -51,10 +54,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_Success
 	}
 	expectedPermissions := []string{"perm1", "perm3"}
 
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, request.GroupIDs, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, request.GroupIDs,
+		request.RequestedPermissions).
 		Return(expectedPermissions, nil)
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)
@@ -69,10 +73,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_Missing
 	}
 
 	// Mock engine to return error (validation happens in underlying service)
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, request.GroupIDs, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, request.GroupIDs,
+		request.RequestedPermissions).
 		Return(nil, errors.New("role service error: Either userId or groups must be provided"))
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(response)
 	suite.NotNil(err)
@@ -87,10 +92,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_Missing
 	}
 
 	// Mock engine to return error (validation happens in underlying service)
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, []string{}, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, []string{},
+		request.RequestedPermissions).
 		Return(nil, errors.New("role service error: Either userId or groups must be provided"))
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(response)
 	suite.NotNil(err)
@@ -104,7 +110,7 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_EmptyRe
 		RequestedPermissions: []string{},
 	}
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)
@@ -118,7 +124,7 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_NilRequ
 		RequestedPermissions: nil,
 	}
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)
@@ -133,10 +139,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_UserOnl
 	}
 	expectedPermissions := []string{"perm1"}
 
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, request.GroupIDs, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, request.GroupIDs,
+		request.RequestedPermissions).
 		Return(expectedPermissions, nil)
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)
@@ -151,10 +158,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_GroupsO
 	}
 	expectedPermissions := []string{"perm2"}
 
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, request.GroupIDs, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, request.GroupIDs,
+		request.RequestedPermissions).
 		Return(expectedPermissions, nil)
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)
@@ -169,10 +177,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_NilGrou
 	}
 	expectedPermissions := []string{"perm1"}
 
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, []string{}, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, []string{},
+		request.RequestedPermissions).
 		Return(expectedPermissions, nil)
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)
@@ -186,10 +195,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_EngineE
 		RequestedPermissions: []string{"perm1", "perm2"},
 	}
 
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, request.GroupIDs, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, request.GroupIDs,
+		request.RequestedPermissions).
 		Return(nil, errors.New("engine failed"))
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(response)
 	suite.NotNil(err)
@@ -203,10 +213,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_NoAutho
 		RequestedPermissions: []string{"perm1", "perm2"},
 	}
 
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, request.GroupIDs, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, request.GroupIDs,
+		request.RequestedPermissions).
 		Return([]string{}, nil)
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)
@@ -220,10 +231,11 @@ func (suite *AuthorizationServiceTestSuite) TestGetAuthorizedPermissions_AllPerm
 		RequestedPermissions: []string{"perm1", "perm2"},
 	}
 
-	suite.mockEngine.On("GetAuthorizedPermissions", request.UserID, request.GroupIDs, request.RequestedPermissions).
+	suite.mockEngine.On("GetAuthorizedPermissions", mock.Anything, request.UserID, request.GroupIDs,
+		request.RequestedPermissions).
 		Return(request.RequestedPermissions, nil)
 
-	response, err := suite.service.GetAuthorizedPermissions(request)
+	response, err := suite.service.GetAuthorizedPermissions(context.Background(), request)
 
 	suite.Nil(err)
 	suite.NotNil(response)

--- a/backend/internal/design/resolve/DesignResolveServiceInterface_mock_test.go
+++ b/backend/internal/design/resolve/DesignResolveServiceInterface_mock_test.go
@@ -5,6 +5,8 @@
 package resolve
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/design/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *DesignResolveServiceInterfaceMock) EXPECT() *DesignResolveServiceInter
 }
 
 // ResolveDesign provides a mock function for the type DesignResolveServiceInterfaceMock
-func (_mock *DesignResolveServiceInterfaceMock) ResolveDesign(resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(resolveType, id)
+func (_mock *DesignResolveServiceInterfaceMock) ResolveDesign(ctx context.Context, resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, resolveType, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResolveDesign")
@@ -47,18 +49,18 @@ func (_mock *DesignResolveServiceInterfaceMock) ResolveDesign(resolveType common
 
 	var r0 *common.DesignResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.DesignResolveType, string) (*common.DesignResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(resolveType, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.DesignResolveType, string) (*common.DesignResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, resolveType, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.DesignResolveType, string) *common.DesignResponse); ok {
-		r0 = returnFunc(resolveType, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.DesignResolveType, string) *common.DesignResponse); ok {
+		r0 = returnFunc(ctx, resolveType, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.DesignResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.DesignResolveType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(resolveType, id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.DesignResolveType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, resolveType, id)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,25 +75,31 @@ type DesignResolveServiceInterfaceMock_ResolveDesign_Call struct {
 }
 
 // ResolveDesign is a helper method to define mock.On call
+//   - ctx context.Context
 //   - resolveType common.DesignResolveType
 //   - id string
-func (_e *DesignResolveServiceInterfaceMock_Expecter) ResolveDesign(resolveType interface{}, id interface{}) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
-	return &DesignResolveServiceInterfaceMock_ResolveDesign_Call{Call: _e.mock.On("ResolveDesign", resolveType, id)}
+func (_e *DesignResolveServiceInterfaceMock_Expecter) ResolveDesign(ctx interface{}, resolveType interface{}, id interface{}) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
+	return &DesignResolveServiceInterfaceMock_ResolveDesign_Call{Call: _e.mock.On("ResolveDesign", ctx, resolveType, id)}
 }
 
-func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) Run(run func(resolveType common.DesignResolveType, id string)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
+func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) Run(run func(ctx context.Context, resolveType common.DesignResolveType, id string)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.DesignResolveType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.DesignResolveType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 common.DesignResolveType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(common.DesignResolveType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -102,7 +110,7 @@ func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) Return(designRes
 	return _c
 }
 
-func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) RunAndReturn(run func(resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
+func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) RunAndReturn(run func(ctx context.Context, resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/design/resolve/handler.go
+++ b/backend/internal/design/resolve/handler.go
@@ -48,10 +48,11 @@ func newDesignResolveHandler(resolveService DesignResolveServiceInterface) *desi
 
 // HandleResolveRequest handles the resolve design configuration request.
 func (rh *designResolveHandler) HandleResolveRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	resolveType := common.DesignResolveType(strings.ToUpper(r.URL.Query().Get("type")))
 	id := r.URL.Query().Get("id")
 
-	designResponse, svcErr := rh.resolveService.ResolveDesign(resolveType, id)
+	designResponse, svcErr := rh.resolveService.ResolveDesign(ctx, resolveType, id)
 	if svcErr != nil {
 		rh.handleError(w, svcErr)
 		return

--- a/backend/internal/design/resolve/handler_test.go
+++ b/backend/internal/design/resolve/handler_test.go
@@ -19,6 +19,7 @@
 package resolve
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -34,15 +35,16 @@ import (
 // Mock for DesignResolveServiceInterface
 type mockDesignResolveService struct {
 	resolveDesignFn func(
+		ctx context.Context,
 		resolveType common.DesignResolveType,
 		id string,
 	) (*common.DesignResponse, *serviceerror.ServiceError)
 }
 
 func (m *mockDesignResolveService) ResolveDesign(
-	resolveType common.DesignResolveType, id string,
+	ctx context.Context, resolveType common.DesignResolveType, id string,
 ) (*common.DesignResponse, *serviceerror.ServiceError) {
-	return m.resolveDesignFn(resolveType, id)
+	return m.resolveDesignFn(ctx, resolveType, id)
 }
 
 // Test Suite
@@ -63,6 +65,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_Success() {
 
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {
@@ -89,6 +92,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_CaseInsensitiveTy
 
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {
@@ -110,6 +114,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_CaseInsensitiveTy
 func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_InvalidResolveType() {
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {
@@ -130,6 +135,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_InvalidResolveTyp
 func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_MissingID() {
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {
@@ -150,6 +156,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_MissingID() {
 func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_UnsupportedType() {
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {
@@ -170,6 +177,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_UnsupportedType()
 func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_ApplicationNotFound() {
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {
@@ -190,6 +198,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_ApplicationNotFou
 func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_ApplicationHasNoDesign() {
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {
@@ -210,6 +219,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_ApplicationHasNoD
 func (suite *ResolveHandlerTestSuite) TestHandleResolveRequest_InternalServerError() {
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {

--- a/backend/internal/design/resolve/init_test.go
+++ b/backend/internal/design/resolve/init_test.go
@@ -19,6 +19,7 @@
 package resolve
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -59,6 +60,7 @@ func (suite *InitTestSuite) TestRegisterRoutes() {
 	mux := http.NewServeMux()
 	mockService := &mockDesignResolveService{
 		resolveDesignFn: func(
+			ctx context.Context,
 			resolveType common.DesignResolveType,
 			id string,
 		) (*common.DesignResponse, *serviceerror.ServiceError) {

--- a/backend/internal/design/resolve/service.go
+++ b/backend/internal/design/resolve/service.go
@@ -36,7 +36,7 @@ const serviceLogger = "DesignResolveService"
 // DesignResolveServiceInterface defines the interface for the design resolve service.
 type DesignResolveServiceInterface interface {
 	ResolveDesign(
-		resolveType common.DesignResolveType, id string,
+		ctx context.Context, resolveType common.DesignResolveType, id string,
 	) (*common.DesignResponse, *serviceerror.ServiceError)
 }
 
@@ -66,7 +66,7 @@ func newDesignResolveService(
 // ResolveDesign resolves a design configuration by type and ID.
 // TODO: Add support for OU type and fallback logic.
 func (drs *designResolveService) ResolveDesign(
-	resolveType common.DesignResolveType, id string,
+	ctx context.Context, resolveType common.DesignResolveType, id string,
 ) (*common.DesignResponse, *serviceerror.ServiceError) {
 	if resolveType == "" {
 		return nil, &common.ErrorInvalidResolveType
@@ -87,7 +87,7 @@ func (drs *designResolveService) ResolveDesign(
 		return nil, &serviceerror.InternalServerError
 	}
 
-	app, svcErr := drs.applicationService.GetApplication(context.TODO(), id)
+	app, svcErr := drs.applicationService.GetApplication(ctx, id)
 	if svcErr != nil {
 		// Convert application service errors to design resolve errors
 		if svcErr.Code == application.ErrorInvalidApplicationID.Code {

--- a/backend/internal/design/resolve/service_test.go
+++ b/backend/internal/design/resolve/service_test.go
@@ -19,12 +19,12 @@
 package resolve
 
 import (
-	"github.com/stretchr/testify/mock"
-
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/application"
@@ -60,7 +60,7 @@ func (suite *ResolveServiceTestSuite) SetupTest() {
 
 // Test ResolveDesign - Empty resolve type
 func (suite *ResolveServiceTestSuite) TestResolveDesign_EmptyResolveType() {
-	result, err := suite.service.ResolveDesign("", "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), "", "00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -69,7 +69,7 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_EmptyResolveType() {
 
 // Test ResolveDesign - Empty ID
 func (suite *ResolveServiceTestSuite) TestResolveDesign_EmptyID() {
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP, "")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -78,7 +78,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_EmptyID() {
 
 // Test ResolveDesign - Unsupported resolve type
 func (suite *ResolveServiceTestSuite) TestResolveDesign_UnsupportedType() {
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeOU, "00000000-0000-0000-0000-000000000002")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeOU,
+		"00000000-0000-0000-0000-000000000002")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -89,7 +90,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_UnsupportedType() {
 func (suite *ResolveServiceTestSuite) TestResolveDesign_NilApplicationService() {
 	service := newDesignResolveService(suite.mockThemeService, suite.mockLayoutService, nil)
 
-	result, err := service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -101,7 +103,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_ApplicationNotFound() {
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000099").
 		Return(nil, &application.ErrorApplicationNotFound)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000099")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000099")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -110,7 +113,7 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_ApplicationNotFound() {
 
 // Test ResolveDesign - Invalid application ID
 func (suite *ResolveServiceTestSuite) TestResolveDesign_InvalidApplicationID() {
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "invalid")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP, "invalid")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -125,7 +128,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_ApplicationServiceError(
 	}
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(nil, svcErr)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -142,7 +146,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_ApplicationHasNoDesign()
 	}
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(app, nil)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -166,7 +171,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_SuccessWithThemeOnly() {
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(app, nil)
 	suite.mockThemeService.On("GetTheme", "theme-123").Return(themeConfig, nil)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -191,7 +197,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_SuccessWithLayoutOnly() 
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(app, nil)
 	suite.mockLayoutService.On("GetLayout", "layout-123").Return(layoutConfig, nil)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -222,7 +229,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_SuccessWithBoth() {
 	suite.mockThemeService.On("GetTheme", "theme-123").Return(themeConfig, nil)
 	suite.mockLayoutService.On("GetLayout", "layout-123").Return(layoutConfig, nil)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -242,7 +250,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_ThemeNotFound() {
 	suite.mockThemeService.On("GetTheme", "theme-missing").
 		Return(nil, &thememgt.ErrorThemeNotFound)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -264,7 +273,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_ThemeServiceError() {
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(app, nil)
 	suite.mockThemeService.On("GetTheme", "theme-123").Return(nil, svcErr)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -282,7 +292,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_NilThemeService() {
 	}
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(app, nil)
 
-	result, err := service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -301,7 +312,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_LayoutNotFound() {
 	suite.mockLayoutService.On("GetLayout", "layout-missing").
 		Return(nil, &layoutmgt.ErrorLayoutNotFound)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -323,7 +335,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_LayoutServiceError() {
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(app, nil)
 	suite.mockLayoutService.On("GetLayout", "layout-123").Return(nil, svcErr)
 
-	result, err := suite.service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := suite.service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -341,7 +354,8 @@ func (suite *ResolveServiceTestSuite) TestResolveDesign_NilLayoutService() {
 	}
 	suite.mockAppService.On("GetApplication", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(app, nil)
 
-	result, err := service.ResolveDesign(common.DesignResolveTypeAPP, "00000000-0000-0000-0000-000000000001")
+	result, err := service.ResolveDesign(context.Background(), common.DesignResolveTypeAPP,
+		"00000000-0000-0000-0000-000000000001")
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)

--- a/backend/internal/flow/executor/authz_executor.go
+++ b/backend/internal/flow/executor/authz_executor.go
@@ -120,7 +120,7 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 		RequestedPermissions: requestedPerms,
 	}
 
-	authzResp, svcErr := a.authzService.GetAuthorizedPermissions(authzReq)
+	authzResp, svcErr := a.authzService.GetAuthorizedPermissions(ctx.Context, authzReq)
 	if svcErr != nil {
 		logger.Error("Authorization service call failed", log.String("error", svcErr.Error))
 		execResp.Status = common.ExecFailure

--- a/backend/internal/flow/executor/authz_executor_test.go
+++ b/backend/internal/flow/executor/authz_executor_test.go
@@ -95,6 +95,7 @@ func TestAuthorizationExecutor_Execute_Success(t *testing.T) {
 
 	expectedAuthorizedPerms := []string{"read:documents", "write:documents"}
 	mockAuthzService.On("GetAuthorizedPermissions",
+		mock.Anything,
 		mock.MatchedBy(func(req authzsvc.GetAuthorizedPermissionsRequest) bool {
 			return req.UserID == "user123" &&
 				len(req.GroupIDs) == 2 &&
@@ -144,7 +145,7 @@ func TestAuthorizationExecutor_Execute_PartialPermissions(t *testing.T) {
 	}, nil).Maybe()
 
 	// User only has read permission
-	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything).Return(
+	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything, mock.Anything).Return(
 		&authzsvc.GetAuthorizedPermissionsResponse{
 			AuthorizedPermissions: []string{"read:documents"},
 		}, nil)
@@ -183,7 +184,12 @@ func TestAuthorizationExecutor_Execute_NoPermissions(t *testing.T) {
 		Groups: []userprovider.UserGroup{},
 	}, nil).Maybe()
 
-	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything).Return(
+	mockUserProvider.On("GetUserGroups", "user123",
+		oauth2const.DefaultGroupListLimit, 0).Return(&userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{},
+	}, nil).Maybe()
+
+	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything, mock.Anything).Return(
 		&authzsvc.GetAuthorizedPermissionsResponse{
 			AuthorizedPermissions: []string{},
 		}, nil)
@@ -249,7 +255,12 @@ func TestAuthorizationExecutor_Execute_ServiceError(t *testing.T) {
 		Groups: []userprovider.UserGroup{},
 	}, nil).Maybe()
 
-	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything).Return(
+	mockUserProvider.On("GetUserGroups", "user123",
+		oauth2const.DefaultGroupListLimit, 0).Return(&userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{},
+	}, nil).Maybe()
+
+	mockAuthzService.On("GetAuthorizedPermissions", mock.Anything, mock.Anything).Return(
 		nil, &serviceerror.ServiceError{Error: "service error"})
 
 	// Execute
@@ -512,6 +523,7 @@ func TestAuthorizationExecutor_Execute_WithMultipleGroups(t *testing.T) {
 	}
 
 	mockAuthzService.On("GetAuthorizedPermissions",
+		mock.Anything,
 		mock.MatchedBy(func(req authzsvc.GetAuthorizedPermissionsRequest) bool {
 			return req.UserID == "user123" &&
 				len(req.GroupIDs) == 3 &&
@@ -647,6 +659,7 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_AuthenticatedWithPermiss
 
 	expectedAuthorizedPerms := []string{"read:profile"}
 	mockAuthzService.On("GetAuthorizedPermissions",
+		mock.Anything,
 		mock.MatchedBy(func(req authzsvc.GetAuthorizedPermissionsRequest) bool {
 			return req.UserID == "existing-user-123" &&
 				len(req.GroupIDs) == 1 &&

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -162,7 +162,7 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 		return err
 	}
 
-	authorizeURL, svcErr := o.authService.BuildAuthorizeURL(idpID)
+	authorizeURL, svcErr := o.authService.BuildAuthorizeURL(ctx.Context, idpID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			execResp.Status = common.ExecFailure
@@ -176,7 +176,7 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 	}
 
 	// Get the idp name for additional data
-	idpName, err := o.getIDPName(idpID)
+	idpName, err := o.getIDPName(ctx.Context, idpID)
 	if err != nil {
 		return fmt.Errorf("failed to get idp name: %w", err)
 	}
@@ -285,7 +285,7 @@ func (o *oAuthExecutor) ExchangeCodeForToken(ctx *core.NodeContext, execResp *co
 		return nil, err
 	}
 
-	tokenResp, svcErr := o.authService.ExchangeCodeForToken(idpID, code, true)
+	tokenResp, svcErr := o.authService.ExchangeCodeForToken(ctx.Context, idpID, code, true)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			execResp.Status = common.ExecFailure
@@ -319,7 +319,7 @@ func (o *oAuthExecutor) GetUserInfo(ctx *core.NodeContext, execResp *common.Exec
 		return nil, err
 	}
 
-	userInfo, svcErr := o.authService.FetchUserInfo(idpID, accessToken)
+	userInfo, svcErr := o.authService.FetchUserInfo(ctx.Context, idpID, accessToken)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			execResp.Status = common.ExecFailure
@@ -348,11 +348,11 @@ func (o *oAuthExecutor) GetIdpID(ctx *core.NodeContext) (string, error) {
 }
 
 // getIDPName retrieves the name of the identity provider using its ID.
-func (o *oAuthExecutor) getIDPName(idpID string) (string, error) {
+func (o *oAuthExecutor) getIDPName(ctx context.Context, idpID string) (string, error) {
 	logger := o.logger
 	logger.Debug("Retrieving IDP name for the given IDP ID")
 
-	idp, svcErr := o.idpService.GetIdentityProvider(context.TODO(), idpID)
+	idp, svcErr := o.idpService.GetIdentityProvider(ctx, idpID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			return "", fmt.Errorf("failed to get identity provider: %s", svcErr.ErrorDescription)

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -83,7 +83,7 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorize
 		},
 	}
 
-	suite.mockOAuthService.On("BuildAuthorizeURL", "idp-123").
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
 		Return("https://oauth.provider.com/authorize?client_id=abc", nil)
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
@@ -131,9 +131,9 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser(
 		UserType:           "INTERNAL",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "user-sub-123").
 		Return(existingUser, nil)
@@ -164,7 +164,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_Success() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockOAuthService.On("BuildAuthorizeURL", "idp-123").
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
 		Return("https://oauth.provider.com/authorize", nil)
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
 		Return(&idp.IDPDTO{ID: "idp-123", Name: "GoogleIDP"}, nil)
@@ -211,7 +211,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLClientError(
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockOAuthService.On("BuildAuthorizeURL", "idp-123").
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
 		Return("", &serviceerror.ServiceError{
 			Type:             serviceerror.ClientErrorType,
 			ErrorDescription: "Invalid IDP configuration",
@@ -239,7 +239,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLServerError(
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockOAuthService.On("BuildAuthorizeURL", "idp-123").
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
 		Return("", &serviceerror.ServiceError{
 			Type:             serviceerror.ServerErrorType,
 			Code:             "OAUTH-5000",
@@ -276,7 +276,7 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_Success() {
 		ExpiresIn:    3600,
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code", true).
 		Return(tokenResp, nil)
 
 	result, err := suite.executor.ExchangeCodeForToken(ctx, execResp, "auth_code")
@@ -304,7 +304,7 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ClientError() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "invalid_code", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "invalid_code", true).
 		Return(nil, &serviceerror.ServiceError{
 			Type:             serviceerror.ClientErrorType,
 			ErrorDescription: "Invalid authorization code",
@@ -333,7 +333,7 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ServerError() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code", true).
 		Return(nil, &serviceerror.ServiceError{
 			Type:             serviceerror.ServerErrorType,
 			Code:             "OAUTH-5000",
@@ -368,7 +368,7 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_Success() {
 		"name":  "Test User",
 	}
 
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token").
 		Return(userInfo, nil)
 
 	result, err := suite.executor.GetUserInfo(ctx, execResp, "access_token")
@@ -395,7 +395,7 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ClientError() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "invalid_token").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "invalid_token").
 		Return(nil, &serviceerror.ServiceError{
 			Type:             serviceerror.ClientErrorType,
 			ErrorDescription: "Invalid access token",
@@ -424,7 +424,7 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ServerError() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token").
 		Return(nil, &serviceerror.ServiceError{
 			Type:             serviceerror.ServerErrorType,
 			Code:             "OAUTH-5000",
@@ -498,9 +498,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 		"name":  "New User",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
 		Return(nil, &serviceerror.ServiceError{
@@ -547,9 +547,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNo
 		"email": "unknown@example.com",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "unknown-user").
 		Return(nil, &serviceerror.ServiceError{
@@ -599,9 +599,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExis
 		OrganizationUnitID: "ou-456",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "existing-user-sub").
 		Return(existingUser, nil)
@@ -659,7 +659,7 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyScope() {
 		ExpiresIn:   3600,
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -699,9 +699,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
 		"name":  "Test User",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -860,9 +860,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 		"name":  "New User",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
 		Return(nil, &serviceerror.ServiceError{
@@ -935,9 +935,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithou
 		"name":  "New User",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
 		Return(nil, &serviceerror.ServiceError{
@@ -993,9 +993,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthWith
 		"email": "newuser@example.com",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "new-user-sub").
 		Return(nil, &serviceerror.ServiceError{
@@ -1048,9 +1048,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrati
 		UserType:           "INTERNAL",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "existing-user-sub").
 		Return(existingUser, nil)
@@ -1101,9 +1101,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistra
 		UserType:           "INTERNAL",
 	}
 
-	suite.mockOAuthService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
-	suite.mockOAuthService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 	suite.mockOAuthService.On("GetInternalUser", "existing-user-sub").
 		Return(existingUser, nil)

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -248,7 +248,7 @@ func (o *oidcAuthExecutor) getContextUserAttributes(ctx *core.NodeContext, execR
 		return nil, err
 	}
 
-	oauthConfigs, svcErr := o.authService.GetOAuthClientConfig(idpID)
+	oauthConfigs, svcErr := o.authService.GetOAuthClientConfig(ctx.Context, idpID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			execResp.Status = common.ExecFailure

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -83,7 +83,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthor
 		},
 	}
 
-	suite.mockOIDCService.On("BuildAuthorizeURL", "idp-123").
+	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
 		Return("https://oidc.provider.com/authorize?client_id=abc&scope=openid", nil)
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
@@ -140,13 +140,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_Au
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt_123").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-123").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -203,13 +203,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidIDToken
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-456").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -251,7 +251,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce
 		"nonce": "different_nonce_456",
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -294,7 +294,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim()
 		"name":  "Test User",
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -342,7 +342,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -351,7 +351,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 			Code: authncm.ErrorUserNotFound.Code,
 			Type: serviceerror.ClientErrorType,
 		})
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -392,7 +392,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_Use
 		"sub": "unknown-user",
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -444,7 +444,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyE
 		OrganizationUnitID: "ou-789",
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -591,15 +591,15 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_WithAddition
 		Scopes: []string{"openid", "profile", "email"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-123").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
-	suite.mockOIDCService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOIDCService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -680,13 +680,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUs
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-123").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -747,13 +747,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -808,13 +808,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoEmailInIDT
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -869,13 +869,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyEmailIn
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -925,7 +925,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -934,7 +934,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 			Code: authncm.ErrorUserNotFound.Code,
 			Type: serviceerror.ClientErrorType,
 		})
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -996,15 +996,15 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailFromUse
 		Scopes: []string{"openid", "profile", "email"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-789").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
-	suite.mockOIDCService.On("FetchUserInfo", "idp-123", "access_token_123").
+	suite.mockOIDCService.On("FetchUserInfo", mock.Anything, "idp-123", "access_token_123").
 		Return(userInfo, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -1059,13 +1059,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "user-sub-999").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -1122,7 +1122,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWit
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -1137,7 +1137,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWit
 			AllowSelfRegistration: true,
 			OrganizationUnitID:    "ou-123",
 		}, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -1186,7 +1186,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthW
 		"iat": float64(1234567000),
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -1250,13 +1250,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistr
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
 	suite.mockOIDCService.On("GetInternalUser", "existing-user-sub").
 		Return(existingUser, nil)
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
@@ -1309,7 +1309,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegis
 		UserType:           "INTERNAL",
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)
@@ -1383,7 +1383,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OAuthClient
 				RuntimeData:    make(map[string]string),
 			}
 
-			suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+			suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 				Return(nil, tt.serviceError)
 
 			attributes, err := suite.executor.(*oidcAuthExecutor).getContextUserAttributes(
@@ -1432,7 +1432,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OnlyOpenIDS
 		Scopes: []string{"openid"},
 	}
 
-	suite.mockOIDCService.On("GetOAuthClientConfig", "idp-123").
+	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, "idp-123").
 		Return(oauthConfig, nil)
 
 	attributes, err := suite.executor.(*oidcAuthExecutor).getContextUserAttributes(
@@ -1489,7 +1489,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NonStringSub
 		"aud": "client-123",
 	}
 
-	suite.mockOIDCService.On("ExchangeCodeForToken", "idp-123", "auth_code_123", true).
+	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, "idp-123", "auth_code_123", true).
 		Return(tokenResp, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", "id_token_jwt").
 		Return(idTokenClaims, nil)

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -19,7 +19,6 @@
 package executor
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -504,7 +503,7 @@ func (s *smsOTPAuthExecutor) generateAndSendOTP(mobileNumber string, ctx *core.N
 		Channel:   string(notifcommon.ChannelTypeSMS),
 	}
 
-	sendResult, svcErr := s.otpService.SendOTP(context.TODO(), sendOTPRequest)
+	sendResult, svcErr := s.otpService.SendOTP(ctx.Context, sendOTPRequest)
 	if svcErr != nil {
 		return fmt.Errorf("failed to send OTP: %s", svcErr.ErrorDescription)
 	}
@@ -579,7 +578,7 @@ func (s *smsOTPAuthExecutor) validateOTP(ctx *core.NodeContext, execResp *common
 		OTPCode:      providedOTP,
 	}
 
-	verifyResult, svcErr := s.otpService.VerifyOTP(context.TODO(), verifyOTPRequest)
+	verifyResult, svcErr := s.otpService.VerifyOTP(ctx.Context, verifyOTPRequest)
 	if svcErr != nil {
 		logger.Error("Failed to verify OTP", log.String("userID", userID), log.Any("serviceError", svcErr))
 		return fmt.Errorf("failed to verify OTP: %s", svcErr.ErrorDescription)

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -193,7 +193,7 @@ func (fms *flowMetaService) GetFlowMetadata(
 		designID = ouID
 	}
 
-	designResp, svcErr := fms.designResolve.ResolveDesign(designType, designID)
+	designResp, svcErr := fms.designResolve.ResolveDesign(ctx, designType, designID)
 	if svcErr != nil {
 		// Design is optional, log and continue with empty design
 		fms.logger.Debug("Failed to get design configuration",

--- a/backend/internal/flow/flowmeta/service_test.go
+++ b/backend/internal/flow/flowmeta/service_test.go
@@ -130,7 +130,8 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_APP_Success() {
 	suite.mockAppService.On("GetApplication", mock.Anything, appID).Return(mockApp, nil)
 	suite.mockOUService.On("GetOrganizationUnitList", mock.Anything, 1, 0).Return(mockOUList, nil)
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, ouID).Return(mockOU, nil)
-	suite.mockDesignResolve.On("ResolveDesign", common.DesignResolveTypeAPP, appID).Return(mockDesign, nil)
+	suite.mockDesignResolve.On("ResolveDesign", mock.Anything, common.DesignResolveTypeAPP, appID).
+		Return(mockDesign, nil)
 	suite.mockI18nService.On("ResolveTranslations", language, namespace).Return(mockTranslations, nil)
 	suite.mockI18nService.On("ListLanguages").Return([]string{"en", "es"}, nil)
 
@@ -177,7 +178,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_OU_Success() {
 	}
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, ouID).Return(mockOU, nil)
-	suite.mockDesignResolve.On("ResolveDesign", common.DesignResolveTypeOU, ouID).Return(mockDesign, nil)
+	suite.mockDesignResolve.On("ResolveDesign", mock.Anything, common.DesignResolveTypeOU, ouID).Return(mockDesign, nil)
 	suite.mockI18nService.On("ResolveTranslations", "en-US", "").Return(mockTranslations, nil)
 	suite.mockI18nService.On("ListLanguages").Return([]string{"en"}, nil)
 
@@ -269,7 +270,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_DesignResolveError_Co
 	suite.mockAppService.On("GetApplication", mock.Anything, appID).Return(mockApp, nil)
 	suite.mockOUService.On("GetOrganizationUnitList", mock.Anything, 1, 0).Return(mockOUList, nil)
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, ouID).Return(mockOU, nil)
-	suite.mockDesignResolve.On("ResolveDesign", common.DesignResolveTypeAPP, appID).
+	suite.mockDesignResolve.On("ResolveDesign", mock.Anything, common.DesignResolveTypeAPP, appID).
 		Return(nil, &serviceerror.InternalServerError)
 	suite.mockI18nService.On("ResolveTranslations", "en-US", "").
 		Return(&i18nmgt.LanguageTranslationsResponse{
@@ -301,7 +302,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_I18nError_ContinuesWi
 	}
 
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, ouID).Return(mockOU, nil)
-	suite.mockDesignResolve.On("ResolveDesign", common.DesignResolveTypeOU, ouID).
+	suite.mockDesignResolve.On("ResolveDesign", mock.Anything, common.DesignResolveTypeOU, ouID).
 		Return(&common.DesignResponse{
 			Theme:  json.RawMessage(`{}`),
 			Layout: json.RawMessage(`{}`),

--- a/backend/internal/notification/file_based_store.go
+++ b/backend/internal/notification/file_based_store.go
@@ -34,7 +34,7 @@ type notificationFileBasedStore struct {
 // Create implements declarativeresource.Storer interface for resource loader
 func (f *notificationFileBasedStore) Create(id string, data interface{}) error {
 	sender := data.(*common.NotificationSenderDTO)
-	return f.createSender(context.TODO(), *sender)
+	return f.createSender(context.Background(), *sender)
 }
 
 // createSender implements notificationStoreInterface.

--- a/backend/internal/notification/mgt_service_test.go
+++ b/backend/internal/notification/mgt_service_test.go
@@ -83,7 +83,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender() {
 		return s.Name == sender.Name && s.ID != ""
 	})).Return(nil).Once()
 
-	result, err := suite.service.CreateSender(context.TODO(), sender)
+	result, err := suite.service.CreateSender(context.Background(), sender)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(sender.Name, result.Name)
@@ -165,7 +165,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailure
 				tc.setupMock(mockStore, sender)
 			}
 
-			result, err := svc.CreateSender(context.TODO(), sender)
+			result, err := svc.CreateSender(context.Background(), sender)
 			require := require.New(t)
 			require.Nil(result)
 			require.NotNil(err)
@@ -185,7 +185,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders() {
 
 	suite.mockStore.EXPECT().listSenders(mock.Anything).Return(senders, nil).Once()
 
-	result, err := suite.service.ListSenders(context.TODO())
+	result, err := suite.service.ListSenders(context.Background())
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Len(result, 2)
@@ -194,7 +194,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders() {
 func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders_EmptyList() {
 	suite.mockStore.EXPECT().listSenders(mock.Anything).Return([]common.NotificationSenderDTO{}, nil).Once()
 
-	result, err := suite.service.ListSenders(context.TODO())
+	result, err := suite.service.ListSenders(context.Background())
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Len(result, 0)
@@ -203,7 +203,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders_EmptyList() 
 func (suite *NotificationSenderMgtServiceTestSuite) TestListSenders_StoreError() {
 	suite.mockStore.EXPECT().listSenders(mock.Anything).Return(nil, errors.New("database error")).Once()
 
-	result, err := suite.service.ListSenders(context.TODO())
+	result, err := suite.service.ListSenders(context.Background())
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -214,7 +214,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender() {
 	sender.ID = testSenderID
 	suite.mockStore.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(&sender, nil).Once()
 
-	result, err := suite.service.GetSender(context.TODO(), testSenderID)
+	result, err := suite.service.GetSender(context.Background(), testSenderID)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(testSenderID, result.ID)
@@ -223,13 +223,13 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender() {
 func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_NotFound() {
 	suite.mockStore.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(nil, nil).Once()
 
-	result, err := suite.service.GetSender(context.TODO(), testSenderID)
+	result, err := suite.service.GetSender(context.Background(), testSenderID)
 	suite.Nil(err)
 	suite.Nil(result)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_EmptyID() {
-	result, err := suite.service.GetSender(context.TODO(), "")
+	result, err := suite.service.GetSender(context.Background(), "")
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -239,7 +239,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_EmptyID() {
 func (suite *NotificationSenderMgtServiceTestSuite) TestGetSender_StoreError() {
 	suite.mockStore.EXPECT().getSenderByID(mock.Anything, testSenderID).Return(nil, errors.New("database error")).Once()
 
-	result, err := suite.service.GetSender(context.TODO(), testSenderID)
+	result, err := suite.service.GetSender(context.Background(), testSenderID)
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
@@ -285,7 +285,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName() {
 				tc.setup(mockStore)
 			}
 
-			result, err := svc.GetSenderByName(context.TODO(), tc.arg)
+			result, err := svc.GetSenderByName(context.Background(), tc.arg)
 			require := require.New(t)
 			require.Nil(err)
 			if tc.wantName == "" {
@@ -334,7 +334,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName_WithFail
 				tc.setup(mockStore)
 			}
 
-			result, err := svc.GetSenderByName(context.TODO(), tc.arg)
+			result, err := svc.GetSenderByName(context.Background(), tc.arg)
 			require := require.New(t)
 			require.Nil(result)
 			require.NotNil(err)
@@ -399,7 +399,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender() {
 
 			tc.setupMock(mockStore, sender)
 
-			result, err := svc.UpdateSender(context.TODO(), testSenderID, sender)
+			result, err := svc.UpdateSender(context.Background(), testSenderID, sender)
 			require := require.New(t)
 			require.Nil(err)
 			require.NotNil(result)
@@ -527,7 +527,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 			sender = tc.inputMod(sender)
 
 			if tc.name == "EmptyID" {
-				result, err := svc.UpdateSender(context.TODO(), "", sender)
+				result, err := svc.UpdateSender(context.Background(), "", sender)
 				require := require.New(t)
 				require.Nil(result)
 				require.NotNil(err)
@@ -539,7 +539,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 				tc.setupMock(mockStore, sender)
 			}
 
-			result, err := svc.UpdateSender(context.TODO(), testSenderID, sender)
+			result, err := svc.UpdateSender(context.Background(), testSenderID, sender)
 			require := require.New(t)
 			require.Nil(result)
 			require.NotNil(err)
@@ -551,19 +551,20 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender() {
 	suite.mockStore.EXPECT().deleteSender(mock.Anything, testSenderID).Return(nil).Once()
-	err := suite.service.DeleteSender(context.TODO(), testSenderID)
+	err := suite.service.DeleteSender(context.Background(), testSenderID)
 	suite.Nil(err)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender_EmptyID() {
-	err := suite.service.DeleteSender(context.TODO(), "")
+	err := suite.service.DeleteSender(context.Background(), "")
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidSenderID.Code, err.Code)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender_StoreError() {
-	suite.mockStore.EXPECT().deleteSender(context.TODO(), testSenderID).Return(errors.New("database error")).Once()
-	err := suite.service.DeleteSender(context.TODO(), testSenderID)
+	suite.mockStore.EXPECT().deleteSender(context.Background(), testSenderID).
+		Return(errors.New("database error")).Once()
+	err := suite.service.DeleteSender(context.Background(), testSenderID)
 	suite.NotNil(err)
 	suite.Equal(ErrorInternalServerError.Code, err.Code)
 }
@@ -580,7 +581,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_Declarative
 	config.GetThunderRuntime().Config.DeclarativeResources.Enabled = true
 
 	sender := suite.getValidTwilioSender()
-	result, err := suite.service.CreateSender(context.TODO(), sender)
+	result, err := suite.service.CreateSender(context.Background(), sender)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -599,7 +600,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_Declarative
 	config.GetThunderRuntime().Config.DeclarativeResources.Enabled = true
 
 	sender := suite.getValidTwilioSender()
-	result, err := suite.service.UpdateSender(context.TODO(), testSenderID, sender)
+	result, err := suite.service.UpdateSender(context.Background(), testSenderID, sender)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -617,7 +618,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestDeleteSender_Declarative
 	// Enable declarative resources
 	config.GetThunderRuntime().Config.DeclarativeResources.Enabled = true
 
-	err := suite.service.DeleteSender(context.TODO(), testSenderID)
+	err := suite.service.DeleteSender(context.Background(), testSenderID)
 
 	suite.NotNil(err)
 	suite.Equal("DCR-1003", err.Code)

--- a/backend/internal/notification/store_test.go
+++ b/backend/internal/notification/store_test.go
@@ -91,19 +91,19 @@ func (suite *StoreTestSuite) TestCreateSender() {
 	propsJSON, err := cmodels.SerializePropertiesToJSONArray([]cmodels.Property{*p})
 	suite.NoError(err)
 	suite.mockDBClient.EXPECT().ExecuteContext(
-		context.TODO(),
+		context.Background(),
 		queryCreateNotificationSender, sender.Name, sender.ID, sender.Description,
 		string(sender.Type), string(sender.Provider), propsJSON, testDeploymentID,
 	).Return(int64(1), nil).Once()
 
-	err = suite.store.createSender(context.TODO(), sender)
+	err = suite.store.createSender(context.Background(), sender)
 	suite.NoError(err)
 }
 
 func (suite *StoreTestSuite) TestCreateSender_GetConfigDBClientError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
 	sender := common.NotificationSenderDTO{ID: "s1"}
-	err := suite.store.createSender(context.TODO(), sender)
+	err := suite.store.createSender(context.Background(), sender)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
 }
@@ -120,11 +120,12 @@ func (suite *StoreTestSuite) TestCreateSender_DBExecuteError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	propsJSON, err := cmodels.SerializePropertiesToJSONArray([]cmodels.Property{*p})
 	suite.NoError(err)
-	suite.mockDBClient.EXPECT().ExecuteContext(context.TODO(), queryCreateNotificationSender, sender.Name, sender.ID,
+	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryCreateNotificationSender,
+		sender.Name, sender.ID,
 		sender.Description, string(sender.Type), string(sender.Provider), propsJSON, testDeploymentID).Return(
 		int64(0), errors.New("exec fail")).Once()
 
-	err = suite.store.createSender(context.TODO(), sender)
+	err = suite.store.createSender(context.Background(), sender)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to execute query")
 }
@@ -143,7 +144,7 @@ func (suite *StoreTestSuite) TestCreateSender_SerializeError() {
 
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 
-	err = suite.store.createSender(context.TODO(), sender)
+	err = suite.store.createSender(context.Background(), sender)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to serialize properties to JSON")
 }
@@ -175,10 +176,12 @@ func (suite *StoreTestSuite) TestListSenders_WithPropertiesStringAndBytes() {
 	}
 
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetAllNotificationSenders, testDeploymentID).Return(
-		[]map[string]interface{}{row1, row2}, nil).Once()
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetAllNotificationSenders, testDeploymentID).
+		Return(
 
-	senders, err := suite.store.listSenders(context.TODO())
+			[]map[string]interface{}{row1, row2}, nil).Once()
+
+	senders, err := suite.store.listSenders(context.Background())
 	suite.NoError(err)
 	suite.Len(senders, 2)
 	suite.Len(senders[0].Properties, 1)
@@ -187,7 +190,7 @@ func (suite *StoreTestSuite) TestListSenders_WithPropertiesStringAndBytes() {
 
 func (suite *StoreTestSuite) TestListSenders_GetConfigDBClientError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
-	res, err := suite.store.listSenders(context.TODO())
+	res, err := suite.store.listSenders(context.Background())
 	suite.Error(err)
 	suite.Nil(res)
 	suite.Contains(err.Error(), "failed to get database client")
@@ -195,20 +198,22 @@ func (suite *StoreTestSuite) TestListSenders_GetConfigDBClientError() {
 
 func (suite *StoreTestSuite) TestListSenders_WithError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetAllNotificationSenders, testDeploymentID).
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetAllNotificationSenders, testDeploymentID).
 		Return(nil, errors.New("query fail")).Once()
 
-	res, err := suite.store.listSenders(context.TODO())
+	res, err := suite.store.listSenders(context.Background())
 	suite.Error(err)
 	suite.Nil(res)
 	suite.Contains(err.Error(), "failed to execute query")
 
 	badRow := map[string]interface{}{"name": "n1"}
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetAllNotificationSenders, testDeploymentID).Return(
-		[]map[string]interface{}{badRow}, nil).Once()
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetAllNotificationSenders, testDeploymentID).
+		Return(
 
-	res2, err := suite.store.listSenders(context.TODO())
+			[]map[string]interface{}{badRow}, nil).Once()
+
+	res2, err := suite.store.listSenders(context.Background())
 	suite.Error(err)
 	suite.Nil(res2)
 	suite.Contains(err.Error(), "failed to build sender from result row")
@@ -223,10 +228,12 @@ func (suite *StoreTestSuite) TestListSenders_WithError() {
 		"properties":  "not-json",
 	}
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetAllNotificationSenders, testDeploymentID).Return(
-		[]map[string]interface{}{row}, nil).Once()
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetAllNotificationSenders, testDeploymentID).
+		Return(
 
-	res3, err := suite.store.listSenders(context.TODO())
+			[]map[string]interface{}{row}, nil).Once()
+
+	res3, err := suite.store.listSenders(context.Background())
 	suite.Error(err)
 	suite.Nil(res3)
 	suite.Contains(err.Error(), "failed to deserialize properties from JSON")
@@ -243,44 +250,44 @@ func (suite *StoreTestSuite) TestGetSenderByID() {
 		"properties":  "",
 	}
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 		"s1", testDeploymentID).Return(
 		[]map[string]interface{}{row}, nil).Once()
 
-	s, err := suite.store.getSenderByID(context.TODO(), "s1")
+	s, err := suite.store.getSenderByID(context.Background(), "s1")
 	suite.NoError(err)
 	suite.NotNil(s)
 	suite.Equal("s1", s.ID)
 
 	// not found
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 		"s-x", testDeploymentID).Return(
 		[]map[string]interface{}{}, nil).Once()
-	s2, err := suite.store.getSenderByID(context.TODO(), "s-x")
+	s2, err := suite.store.getSenderByID(context.Background(), "s-x")
 	suite.NoError(err)
 	suite.Nil(s2)
 
 	// multiple results -> error
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 		"s-multi", testDeploymentID).Return(
 		[]map[string]interface{}{row, row}, nil).Once()
-	s3, err := suite.store.getSenderByID(context.TODO(), "s-multi")
+	s3, err := suite.store.getSenderByID(context.Background(), "s-multi")
 	suite.Error(err)
 	suite.Nil(s3)
 }
 
 func (suite *StoreTestSuite) TestGetSenderByID_GetConfigDBClientError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
-	res, err := suite.store.getSenderByID(context.TODO(), "s1")
+	res, err := suite.store.getSenderByID(context.Background(), "s1")
 	suite.Error(err)
 	suite.Nil(res)
 }
 
 func (suite *StoreTestSuite) TestGetSenderByName_GetConfigDBClientError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
-	res, err := suite.store.getSenderByName(context.TODO(), "n1")
+	res, err := suite.store.getSenderByName(context.Background(), "n1")
 	suite.Error(err)
 	suite.Nil(res)
 }
@@ -295,7 +302,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 			name: "query error",
 			setup: func(t *testing.T) {
 				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-				suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+				suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 					"s1", testDeploymentID).
 					Return(nil, errors.New("query fail")).Once()
 			},
@@ -312,7 +319,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 					"provider":    "twilio",
 				}
 				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-				suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+				suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 					"s1", testDeploymentID).
 					Return([]map[string]interface{}{row, row}, nil).Once()
 			},
@@ -323,7 +330,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 			setup: func(t *testing.T) {
 				badRow := map[string]interface{}{"name": "n1"}
 				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-				suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+				suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 					"s1", testDeploymentID).
 					Return([]map[string]interface{}{badRow}, nil).Once()
 			},
@@ -341,7 +348,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 					"properties":  "not-json",
 				}
 				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-				suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+				suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 					"s1", testDeploymentID).
 					Return([]map[string]interface{}{row}, nil).Once()
 			},
@@ -352,7 +359,7 @@ func (suite *StoreTestSuite) TestGetSender_WithError() {
 	for _, tc := range cases {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			tc.setup(t)
-			s, err := suite.store.getSenderByID(context.TODO(), "s1")
+			s, err := suite.store.getSenderByID(context.Background(), "s1")
 			suite.Error(err)
 			suite.Nil(s)
 			suite.Contains(err.Error(), tc.wantErr)
@@ -375,11 +382,11 @@ func (suite *StoreTestSuite) TestGetSender_WithProperties() {
 		"properties":  propsJSON,
 	}
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().QueryContext(context.TODO(), queryGetNotificationSenderByID,
+	suite.mockDBClient.EXPECT().QueryContext(context.Background(), queryGetNotificationSenderByID,
 		"s1", testDeploymentID).Return(
 		[]map[string]interface{}{row}, nil).Once()
 
-	s, err := suite.store.getSender(context.TODO(), queryGetNotificationSenderByID, "s1")
+	s, err := suite.store.getSender(context.Background(), queryGetNotificationSenderByID, "s1")
 	suite.NoError(err)
 	suite.NotNil(s)
 	suite.Len(s.Properties, 1)
@@ -389,11 +396,11 @@ func (suite *StoreTestSuite) TestUpdateSender() {
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.MessageProviderTypeTwilio}
 
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().ExecuteContext(context.TODO(), queryUpdateNotificationSender,
+	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryUpdateNotificationSender,
 		sender.Name, sender.Description,
 		string(sender.Provider), "", "s1", string(sender.Type), testDeploymentID).Return(int64(1), nil).Once()
 
-	err := suite.store.updateSender(context.TODO(), "s1", sender)
+	err := suite.store.updateSender(context.Background(), "s1", sender)
 	suite.NoError(err)
 }
 
@@ -406,17 +413,17 @@ func (suite *StoreTestSuite) TestUpdateSender_WithProperties() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 	propsJSON, err := cmodels.SerializePropertiesToJSONArray([]cmodels.Property{*p})
 	suite.NoError(err)
-	suite.mockDBClient.EXPECT().ExecuteContext(context.TODO(), queryUpdateNotificationSender,
+	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryUpdateNotificationSender,
 		sender.Name, sender.Description,
 		string(sender.Provider), propsJSON, "s1", string(sender.Type), testDeploymentID).Return(int64(1), nil).Once()
 
-	err = suite.store.updateSender(context.TODO(), "s1", sender)
+	err = suite.store.updateSender(context.Background(), "s1", sender)
 	suite.NoError(err)
 }
 
 func (suite *StoreTestSuite) TestUpdateSender_GetConfigDBClientError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
-	err := suite.store.updateSender(context.TODO(), "s1", common.NotificationSenderDTO{})
+	err := suite.store.updateSender(context.Background(), "s1", common.NotificationSenderDTO{})
 	suite.Error(err)
 }
 
@@ -438,7 +445,8 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 			setup: func(t *testing.T) {
 				sender := common.NotificationSenderDTO{Name: "n1", Provider: common.MessageProviderTypeTwilio}
 				suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-				suite.mockDBClient.EXPECT().ExecuteContext(context.TODO(), queryUpdateNotificationSender, sender.Name,
+				suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryUpdateNotificationSender,
+					sender.Name,
 					sender.Description, string(sender.Provider), "", "s1", string(sender.Type), testDeploymentID).
 					Return(int64(0), errors.New("exec fail")).Once()
 			},
@@ -452,7 +460,7 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 			// use a sender without properties for these failure-case checks
 			sender := common.NotificationSenderDTO{ID: "s1", Name: "n1",
 				Provider: common.MessageProviderTypeTwilio}
-			err := suite.store.updateSender(context.TODO(), "s1", sender)
+			err := suite.store.updateSender(context.Background(), "s1", sender)
 			suite.Error(err)
 			suite.Contains(err.Error(), tc.wantErr)
 		})
@@ -462,12 +470,12 @@ func (suite *StoreTestSuite) TestUpdateSender_WithError() {
 func (suite *StoreTestSuite) TestUpdateSender_ExecuteError() {
 	sender := common.NotificationSenderDTO{ID: "s1", Name: "n1", Provider: common.MessageProviderTypeTwilio}
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().ExecuteContext(context.TODO(), queryUpdateNotificationSender,
+	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryUpdateNotificationSender,
 		sender.Name, sender.Description,
 		string(sender.Provider), "", "s1", string(sender.Type), testDeploymentID).
 		Return(int64(0), errors.New("exec fail")).Once()
 
-	err := suite.store.updateSender(context.TODO(), "s1", sender)
+	err := suite.store.updateSender(context.Background(), "s1", sender)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to execute query")
 }
@@ -486,7 +494,7 @@ func (suite *StoreTestSuite) TestUpdateSender_SerializeError() {
 
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
 
-	err = suite.store.updateSender(context.TODO(), "s1", sender)
+	err = suite.store.updateSender(context.Background(), "s1", sender)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to serialize properties to JSON")
 }
@@ -494,26 +502,27 @@ func (suite *StoreTestSuite) TestUpdateSender_SerializeError() {
 func (suite *StoreTestSuite) TestDeleteSender_NoRows() {
 	// delete with 0 rows affected (should not return error)
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().ExecuteContext(context.TODO(), queryDeleteNotificationSender, "s1", testDeploymentID).
+	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryDeleteNotificationSender, "s1",
+		testDeploymentID).
 		Return(int64(0), nil).Once()
 
-	err := suite.store.deleteSender(context.TODO(), "s1")
+	err := suite.store.deleteSender(context.Background(), "s1")
 	suite.NoError(err)
 }
 
 func (suite *StoreTestSuite) TestDeleteSender_GetConfigDBClientError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(nil, errors.New("db err")).Once()
-	err := suite.store.deleteSender(context.TODO(), "s1")
+	err := suite.store.deleteSender(context.Background(), "s1")
 	suite.Error(err)
 }
 
 func (suite *StoreTestSuite) TestDeleteSender_ExecuteError() {
 	suite.mockDBProvider.EXPECT().GetConfigDBClient().Return(suite.mockDBClient, nil).Once()
-	suite.mockDBClient.EXPECT().ExecuteContext(context.TODO(), queryDeleteNotificationSender,
+	suite.mockDBClient.EXPECT().ExecuteContext(context.Background(), queryDeleteNotificationSender,
 		"s1", testDeploymentID).Return(
 		int64(0), errors.New("exec fail")).Once()
 
-	err := suite.store.deleteSender(context.TODO(), "s1")
+	err := suite.store.deleteSender(context.Background(), "s1")
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to execute delete query")
 }

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -159,7 +159,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	}
 
 	// Retrieve the OAuth application based on the client ID.
-	app, svcErr := as.appService.GetOAuthApplication(context.TODO(), clientID)
+	app, svcErr := as.appService.GetOAuthApplication(ctx, clientID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
 			as.logger.Error("Failed to retrieve OAuth application",
@@ -257,7 +257,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		RuntimeData:   runtimeData,
 	}
 
-	flowID, flowErr := as.flowExecService.InitiateFlow(context.TODO(), flowInitCtx)
+	flowID, flowErr := as.flowExecService.InitiateFlow(ctx, flowInitCtx)
 	if flowErr != nil {
 		as.logger.Error("Failed to initiate authentication flow",
 			log.String("error_code", flowErr.Code))

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -1015,7 +1015,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NilCertificate() {
 	}
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client",
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client",
 		"some.jwt.token")
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no certificate configured")
@@ -1031,7 +1031,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_CertificateTypeNon
 	}
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client",
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client",
 		"some.jwt.token")
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no certificate configured")
@@ -1059,7 +1059,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_JWKSURI_Success() 
 		Return(nil)
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", assertion)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", assertion)
 	assert.Nil(suite.T(), err)
 }
 
@@ -1085,7 +1085,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_JWKSURI_Verificati
 		Return(&serviceerror.ServiceError{Error: "verification failed"})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", assertion)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", assertion)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "client assertion verification with JWKS URI failed")
 }
@@ -1105,7 +1105,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKSJSON() 
 			TokenEndpoint: "https://localhost:9443/oauth2/token",
 		})
 
-	err := validateClientAssertion(context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService,
+	err := validateClientAssertion(context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService,
 		"test-client", "some.jwt.token")
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "invalid JWKS certificate format")
@@ -1127,7 +1127,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWTFormat()
 			TokenEndpoint: "https://localhost:9443/oauth2/token",
 		})
 
-	err := validateClientAssertion(context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService,
+	err := validateClientAssertion(context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService,
 		"test-client", "invalid-jwt")
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to decode header")
@@ -1152,7 +1152,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_MissingKidInHeader
 		})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "JWT header missing 'kid' claim")
 }
@@ -1177,7 +1177,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_EmptyKidInHeader()
 		})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "JWT header missing 'kid' claim")
 }
@@ -1202,7 +1202,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_KidNotAString() {
 		})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "JWT header missing 'kid' claim")
 }
@@ -1227,7 +1227,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NoMatchingKidInJWK
 		})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no matching key found in JWKS")
 }
@@ -1258,7 +1258,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKCannotCo
 		})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to convert JWK to public key")
 }
@@ -1290,7 +1290,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_VerificationFails(
 		})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "client assertion verification failed")
 }
@@ -1318,7 +1318,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_Success() {
 		Return(nil)
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.Nil(suite.T(), err)
 }
 
@@ -1344,7 +1344,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_EmptyJWKSKeys() {
 		})
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no matching key found in JWKS")
 }
@@ -1385,6 +1385,6 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_MultipleKeysMatche
 		Return(nil)
 
 	err := validateClientAssertion(
-		context.TODO(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
+		context.Background(), oauthApp, suite.mockJwtService, suite.mockDiscoveryService, "test-client", fakeJWT)
 	assert.Nil(suite.T(), err)
 }

--- a/backend/internal/oauth/oauth2/clientauth/context_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/context_test.go
@@ -38,7 +38,7 @@ func TestContextTestSuite(t *testing.T) {
 }
 
 func (suite *ContextTestSuite) TestGetOAuthClient_WithNilContext() {
-	client := GetOAuthClient(context.TODO())
+	client := GetOAuthClient(context.Background())
 	assert.Nil(suite.T(), client)
 }
 
@@ -89,7 +89,7 @@ func (suite *ContextTestSuite) TestWithOAuthClient_NilContext() {
 		ClientID: "test-client-id",
 	}
 
-	ctx := withOAuthClient(context.TODO(), expectedClient)
+	ctx := withOAuthClient(context.Background(), expectedClient)
 	client := GetOAuthClient(ctx)
 
 	assert.NotNil(suite.T(), client)

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -103,7 +103,7 @@ func (s *userInfoService) GetUserInfo(
 		return nil, svcErr
 	}
 
-	oauthApp := s.getOAuthApp(tokenClaims)
+	oauthApp := s.getOAuthApp(ctx, tokenClaims)
 
 	// Extract allowed user attributes
 	var allowedUserAttributes []string
@@ -223,13 +223,14 @@ func (s *userInfoService) validateOpenIDScope(scopes []string) *serviceerror.Ser
 }
 
 // getOAuthApp retrieves the OAuth application configuration if client_id is present in claims.
-func (s *userInfoService) getOAuthApp(claims map[string]interface{}) *appmodel.OAuthAppConfigProcessedDTO {
+func (s *userInfoService) getOAuthApp(
+	ctx context.Context, claims map[string]interface{}) *appmodel.OAuthAppConfigProcessedDTO {
 	clientID, ok := claims["client_id"].(string)
 	if !ok || clientID == "" {
 		return nil
 	}
 
-	app, err := s.applicationService.GetOAuthApplication(context.TODO(), clientID)
+	app, err := s.applicationService.GetOAuthApplication(ctx, clientID)
 	if err != nil || app == nil {
 		return nil
 	}

--- a/backend/internal/ou/file_based_store.go
+++ b/backend/internal/ou/file_based_store.go
@@ -41,7 +41,7 @@ func newFileBasedStore() organizationUnitStoreInterface {
 // Create implements declarativeresource.Storer interface for resource loader
 func (f *fileBasedStore) Create(id string, data interface{}) error {
 	ou := data.(*OrganizationUnit)
-	return f.CreateOrganizationUnit(context.TODO(), *ou)
+	return f.CreateOrganizationUnit(context.Background(), *ou)
 }
 
 // CreateOrganizationUnit implements organizationUnitStoreInterface.

--- a/backend/internal/system/security/middleware_test.go
+++ b/backend/internal/system/security/middleware_test.go
@@ -95,7 +95,7 @@ func (suite *MiddlewareTestSuite) TestMiddleware_AuthenticationFailure_Unauthori
 	w := httptest.NewRecorder()
 
 	// Mock authentication failure
-	suite.mockService.EXPECT().Process(req).Return(context.TODO(), errUnauthorized)
+	suite.mockService.EXPECT().Process(req).Return(context.Background(), errUnauthorized)
 
 	handler := suite.middleware(suite.testHandler)
 	handler.ServeHTTP(w, req)
@@ -112,7 +112,7 @@ func (suite *MiddlewareTestSuite) TestMiddleware_AuthenticationFailure_InvalidTo
 	req := httptest.NewRequest(http.MethodPost, "/api/groups", nil)
 	w := httptest.NewRecorder()
 
-	suite.mockService.EXPECT().Process(req).Return(context.TODO(), errInvalidToken)
+	suite.mockService.EXPECT().Process(req).Return(context.Background(), errInvalidToken)
 
 	handler := suite.middleware(suite.testHandler)
 	handler.ServeHTTP(w, req)
@@ -126,7 +126,7 @@ func (suite *MiddlewareTestSuite) TestMiddleware_AuthenticationFailure_MissingAu
 	req := httptest.NewRequest(http.MethodPut, "/api/roles", nil)
 	w := httptest.NewRecorder()
 
-	suite.mockService.EXPECT().Process(req).Return(context.TODO(), errMissingAuthHeader)
+	suite.mockService.EXPECT().Process(req).Return(context.Background(), errMissingAuthHeader)
 
 	handler := suite.middleware(suite.testHandler)
 	handler.ServeHTTP(w, req)
@@ -140,7 +140,7 @@ func (suite *MiddlewareTestSuite) TestMiddleware_AuthenticationFailure_NoHandler
 	req := httptest.NewRequest(http.MethodDelete, "/api/applications", nil)
 	w := httptest.NewRecorder()
 
-	suite.mockService.EXPECT().Process(req).Return(context.TODO(), errNoHandlerFound)
+	suite.mockService.EXPECT().Process(req).Return(context.Background(), errNoHandlerFound)
 
 	handler := suite.middleware(suite.testHandler)
 	handler.ServeHTTP(w, req)
@@ -154,7 +154,7 @@ func (suite *MiddlewareTestSuite) TestMiddleware_AuthorizationFailure_Forbidden(
 	req := httptest.NewRequest(http.MethodGet, "/admin/users", nil)
 	w := httptest.NewRecorder()
 
-	suite.mockService.EXPECT().Process(req).Return(context.TODO(), errForbidden)
+	suite.mockService.EXPECT().Process(req).Return(context.Background(), errForbidden)
 
 	handler := suite.middleware(suite.testHandler)
 	handler.ServeHTTP(w, req)
@@ -168,7 +168,7 @@ func (suite *MiddlewareTestSuite) TestMiddleware_AuthorizationFailure_Insufficie
 	req := httptest.NewRequest(http.MethodPost, "/admin/settings", nil)
 	w := httptest.NewRecorder()
 
-	suite.mockService.EXPECT().Process(req).Return(context.TODO(), errInsufficientPermissions)
+	suite.mockService.EXPECT().Process(req).Return(context.Background(), errInsufficientPermissions)
 
 	handler := suite.middleware(suite.testHandler)
 	handler.ServeHTTP(w, req)
@@ -183,7 +183,7 @@ func (suite *MiddlewareTestSuite) TestMiddleware_UnknownError() {
 	w := httptest.NewRecorder()
 
 	unknownErr := errors.New("some unexpected error")
-	suite.mockService.EXPECT().Process(req).Return(context.TODO(), unknownErr)
+	suite.mockService.EXPECT().Process(req).Return(context.Background(), unknownErr)
 
 	handler := suite.middleware(suite.testHandler)
 	handler.ServeHTTP(w, req)

--- a/backend/tests/mocks/authn/authnmock/AuthenticationServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/authnmock/AuthenticationServiceInterface_mock.go
@@ -131,8 +131,8 @@ func (_c *AuthenticationServiceInterfaceMock_AuthenticateWithCredentials_Call) R
 }
 
 // FinishIDPAuthentication provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) FinishIDPAuthentication(requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+func (_mock *AuthenticationServiceInterfaceMock) FinishIDPAuthentication(ctx context.Context, requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FinishIDPAuthentication")
@@ -140,18 +140,18 @@ func (_mock *AuthenticationServiceInterfaceMock) FinishIDPAuthentication(request
 
 	var r0 *common.AuthenticationResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string, bool, string, string) (*common.AuthenticationResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 	}
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string, bool, string, string) *common.AuthenticationResponse); ok {
-		r0 = returnFunc(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string, bool, string, string) *common.AuthenticationResponse); ok {
+		r0 = returnFunc(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthenticationResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(idp.IDPType, string, bool, string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(requestedType, sessionToken, skipAssertion, existingAssertion, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, idp.IDPType, string, bool, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -166,36 +166,41 @@ type AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call struct {
 }
 
 // FinishIDPAuthentication is a helper method to define mock.On call
+//   - ctx context.Context
 //   - requestedType idp.IDPType
 //   - sessionToken string
 //   - skipAssertion bool
 //   - existingAssertion string
 //   - code string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) FinishIDPAuthentication(requestedType interface{}, sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, code interface{}) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
-	return &AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call{Call: _e.mock.On("FinishIDPAuthentication", requestedType, sessionToken, skipAssertion, existingAssertion, code)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) FinishIDPAuthentication(ctx interface{}, requestedType interface{}, sessionToken interface{}, skipAssertion interface{}, existingAssertion interface{}, code interface{}) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
+	return &AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call{Call: _e.mock.On("FinishIDPAuthentication", ctx, requestedType, sessionToken, skipAssertion, existingAssertion, code)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Run(run func(requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Run(run func(ctx context.Context, requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 idp.IDPType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(idp.IDPType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 idp.IDPType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(idp.IDPType)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
 		}
-		var arg3 string
+		var arg3 bool
 		if args[3] != nil {
-			arg3 = args[3].(string)
+			arg3 = args[3].(bool)
 		}
 		var arg4 string
 		if args[4] != nil {
 			arg4 = args[4].(string)
+		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
 		}
 		run(
 			arg0,
@@ -203,6 +208,7 @@ func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Run(r
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -213,7 +219,7 @@ func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) Retur
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) RunAndReturn(run func(requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call) RunAndReturn(run func(ctx context.Context, requestedType idp.IDPType, sessionToken string, skipAssertion bool, existingAssertion string, code string) (*common.AuthenticationResponse, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_FinishIDPAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -481,8 +487,8 @@ func (_c *AuthenticationServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func
 }
 
 // StartIDPAuthentication provides a mock function for the type AuthenticationServiceInterfaceMock
-func (_mock *AuthenticationServiceInterfaceMock) StartIDPAuthentication(requestedType idp.IDPType, idpID string) (*authn.IDPAuthInitData, *serviceerror.ServiceError) {
-	ret := _mock.Called(requestedType, idpID)
+func (_mock *AuthenticationServiceInterfaceMock) StartIDPAuthentication(ctx context.Context, requestedType idp.IDPType, idpID string) (*authn.IDPAuthInitData, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, requestedType, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartIDPAuthentication")
@@ -490,18 +496,18 @@ func (_mock *AuthenticationServiceInterfaceMock) StartIDPAuthentication(requeste
 
 	var r0 *authn.IDPAuthInitData
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string) (*authn.IDPAuthInitData, *serviceerror.ServiceError)); ok {
-		return returnFunc(requestedType, idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string) (*authn.IDPAuthInitData, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, requestedType, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(idp.IDPType, string) *authn.IDPAuthInitData); ok {
-		r0 = returnFunc(requestedType, idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, idp.IDPType, string) *authn.IDPAuthInitData); ok {
+		r0 = returnFunc(ctx, requestedType, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*authn.IDPAuthInitData)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(idp.IDPType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(requestedType, idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, idp.IDPType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, requestedType, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -516,25 +522,31 @@ type AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call struct {
 }
 
 // StartIDPAuthentication is a helper method to define mock.On call
+//   - ctx context.Context
 //   - requestedType idp.IDPType
 //   - idpID string
-func (_e *AuthenticationServiceInterfaceMock_Expecter) StartIDPAuthentication(requestedType interface{}, idpID interface{}) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
-	return &AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call{Call: _e.mock.On("StartIDPAuthentication", requestedType, idpID)}
+func (_e *AuthenticationServiceInterfaceMock_Expecter) StartIDPAuthentication(ctx interface{}, requestedType interface{}, idpID interface{}) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
+	return &AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call{Call: _e.mock.On("StartIDPAuthentication", ctx, requestedType, idpID)}
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) Run(run func(requestedType idp.IDPType, idpID string)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) Run(run func(ctx context.Context, requestedType idp.IDPType, idpID string)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 idp.IDPType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(idp.IDPType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 idp.IDPType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(idp.IDPType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -545,7 +557,7 @@ func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) Return
 	return _c
 }
 
-func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) RunAndReturn(run func(requestedType idp.IDPType, idpID string) (*authn.IDPAuthInitData, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
+func (_c *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call) RunAndReturn(run func(ctx context.Context, requestedType idp.IDPType, idpID string) (*authn.IDPAuthInitData, *serviceerror.ServiceError)) *AuthenticationServiceInterfaceMock_StartIDPAuthentication_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package githubmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
@@ -39,8 +41,8 @@ func (_m *GithubOAuthAuthnServiceInterfaceMock) EXPECT() *GithubOAuthAuthnServic
 }
 
 // BuildAuthorizeURL provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
-func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeURL")
@@ -48,16 +50,16 @@ func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID strin
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call struct {
 }
 
 // BuildAuthorizeURL is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(idpID interface{}) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	return &GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", idpID)}
+func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(ctx interface{}, idpID interface{}) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	return &GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", ctx, idpID)}
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(idpID string)) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ctx context.Context, idpID string)) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,14 +103,14 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s 
 	return _c
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(idpID string) (string, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ExchangeCodeForToken provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
-func (_mock *GithubOAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, code, validateResponse)
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code, validateResponse)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExchangeCodeForToken")
@@ -110,18 +118,18 @@ func (_mock *GithubOAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID st
 
 	var r0 *oauth.TokenResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code, validateResponse)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) *oauth.TokenResponse); ok {
-		r0 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) *oauth.TokenResponse); ok {
+		r0 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.TokenResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -136,31 +144,37 @@ type GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call struct {
 }
 
 // ExchangeCodeForToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - code string
 //   - validateResponse bool
-func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(idpID interface{}, code interface{}, validateResponse interface{}) *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
-	return &GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", idpID, code, validateResponse)}
+func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, idpID interface{}, code interface{}, validateResponse interface{}) *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+	return &GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, idpID, code, validateResponse)}
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(idpID string, code string, validateResponse bool)) *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx context.Context, idpID string, code string, validateResponse bool)) *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -171,14 +185,14 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Return
 	return _c
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // FetchUserInfo provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
-func (_mock *GithubOAuthAuthnServiceInterfaceMock) FetchUserInfo(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, accessToken)
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) FetchUserInfo(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, accessToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchUserInfo")
@@ -186,18 +200,18 @@ func (_mock *GithubOAuthAuthnServiceInterfaceMock) FetchUserInfo(idpID string, a
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, accessToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]interface{}); ok {
-		r0 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -212,25 +226,31 @@ type GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call struct {
 }
 
 // FetchUserInfo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - accessToken string
-func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) FetchUserInfo(idpID interface{}, accessToken interface{}) *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
-	return &GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", idpID, accessToken)}
+func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) FetchUserInfo(ctx interface{}, idpID interface{}, accessToken interface{}) *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
+	return &GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", ctx, idpID, accessToken)}
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(idpID string, accessToken string)) *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(ctx context.Context, idpID string, accessToken string)) *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -241,7 +261,7 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) Return(string
 	return _c
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -311,8 +331,8 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_GetInternalUser_Call) RunAndRetur
 }
 
 // GetOAuthClientConfig provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
-func (_mock *GithubOAuthAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) GetOAuthClientConfig(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOAuthClientConfig")
@@ -320,18 +340,18 @@ func (_mock *GithubOAuthAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID st
 
 	var r0 *oauth.OAuthClientConfig
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *oauth.OAuthClientConfig); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *oauth.OAuthClientConfig); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.OAuthClientConfig)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -346,19 +366,25 @@ type GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call struct {
 }
 
 // GetOAuthClientConfig is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(idpID interface{}) *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
-	return &GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", idpID)}
+func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(ctx interface{}, idpID interface{}) *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+	return &GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", ctx, idpID)}
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(idpID string)) *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(ctx context.Context, idpID string)) *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -369,7 +395,7 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Return
 	return _c
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package googlemock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
@@ -39,8 +41,8 @@ func (_m *GoogleOIDCAuthnServiceInterfaceMock) EXPECT() *GoogleOIDCAuthnServiceI
 }
 
 // BuildAuthorizeURL provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeURL")
@@ -48,16 +50,16 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID string
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call struct {
 }
 
 // BuildAuthorizeURL is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(idpID interface{}) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	return &GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", idpID)}
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(ctx interface{}, idpID interface{}) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", ctx, idpID)}
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(idpID string)) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ctx context.Context, idpID string)) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,14 +103,14 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s s
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(idpID string) (string, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ExchangeCodeForToken provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, code, validateResponse)
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code, validateResponse)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExchangeCodeForToken")
@@ -110,18 +118,18 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID str
 
 	var r0 *oauth.TokenResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code, validateResponse)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) *oauth.TokenResponse); ok {
-		r0 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) *oauth.TokenResponse); ok {
+		r0 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.TokenResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -136,31 +144,37 @@ type GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call struct {
 }
 
 // ExchangeCodeForToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - code string
 //   - validateResponse bool
-func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(idpID interface{}, code interface{}, validateResponse interface{}) *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
-	return &GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", idpID, code, validateResponse)}
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, idpID interface{}, code interface{}, validateResponse interface{}) *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, idpID, code, validateResponse)}
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(idpID string, code string, validateResponse bool)) *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx context.Context, idpID string, code string, validateResponse bool)) *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -171,14 +185,14 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Return(
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // FetchUserInfo provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) FetchUserInfo(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, accessToken)
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) FetchUserInfo(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, accessToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchUserInfo")
@@ -186,18 +200,18 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) FetchUserInfo(idpID string, ac
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, accessToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]interface{}); ok {
-		r0 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -212,25 +226,31 @@ type GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call struct {
 }
 
 // FetchUserInfo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - accessToken string
-func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) FetchUserInfo(idpID interface{}, accessToken interface{}) *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
-	return &GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", idpID, accessToken)}
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) FetchUserInfo(ctx interface{}, idpID interface{}, accessToken interface{}) *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", ctx, idpID, accessToken)}
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(idpID string, accessToken string)) *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(ctx context.Context, idpID string, accessToken string)) *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -241,7 +261,7 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) Return(stringT
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -375,8 +395,8 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetInternalUser_Call) RunAndReturn
 }
 
 // GetOAuthClientConfig provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) GetOAuthClientConfig(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOAuthClientConfig")
@@ -384,18 +404,18 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID str
 
 	var r0 *oauth.OAuthClientConfig
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *oauth.OAuthClientConfig); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *oauth.OAuthClientConfig); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.OAuthClientConfig)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -410,19 +430,25 @@ type GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call struct {
 }
 
 // GetOAuthClientConfig is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(idpID interface{}) *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
-	return &GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", idpID)}
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(ctx interface{}, idpID interface{}) *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", ctx, idpID)}
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(idpID string)) *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(ctx context.Context, idpID string)) *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -433,22 +459,22 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Return(
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateIDToken provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) ValidateIDToken(idpID string, idToken string) *serviceerror.ServiceError {
-	ret := _mock.Called(idpID, idToken)
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) ValidateIDToken(ctx context.Context, idpID string, idToken string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, idpID, idToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateIDToken")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(idpID, idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, idpID, idToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -463,25 +489,31 @@ type GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call struct {
 }
 
 // ValidateIDToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - idToken string
-func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) ValidateIDToken(idpID interface{}, idToken interface{}) *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
-	return &GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call{Call: _e.mock.On("ValidateIDToken", idpID, idToken)}
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) ValidateIDToken(ctx interface{}, idpID interface{}, idToken interface{}) *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call{Call: _e.mock.On("ValidateIDToken", ctx, idpID, idToken)}
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) Run(run func(idpID string, idToken string)) *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) Run(run func(ctx context.Context, idpID string, idToken string)) *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -492,7 +524,7 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) Return(servi
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) RunAndReturn(run func(idpID string, idToken string) *serviceerror.ServiceError) *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, idToken string) *serviceerror.ServiceError) *GoogleOIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package oauthmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
@@ -39,8 +41,8 @@ func (_m *OAuthAuthnCoreServiceInterfaceMock) EXPECT() *OAuthAuthnCoreServiceInt
 }
 
 // BuildAuthorizeURL provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
-func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeURL")
@@ -48,16 +50,16 @@ func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(idpID string)
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call struct {
 }
 
 // BuildAuthorizeURL is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) BuildAuthorizeURL(idpID interface{}) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
-	return &OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", idpID)}
+func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) BuildAuthorizeURL(ctx interface{}, idpID interface{}) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+	return &OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", ctx, idpID)}
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(idpID string)) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ctx context.Context, idpID string)) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,14 +103,14 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s st
 	return _c
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(idpID string) (string, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ExchangeCodeForToken provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
-func (_mock *OAuthAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, code, validateResponse)
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code, validateResponse)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExchangeCodeForToken")
@@ -110,18 +118,18 @@ func (_mock *OAuthAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(idpID stri
 
 	var r0 *oauth.TokenResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code, validateResponse)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) *oauth.TokenResponse); ok {
-		r0 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) *oauth.TokenResponse); ok {
+		r0 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.TokenResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -136,31 +144,37 @@ type OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call struct {
 }
 
 // ExchangeCodeForToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - code string
 //   - validateResponse bool
-func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) ExchangeCodeForToken(idpID interface{}, code interface{}, validateResponse interface{}) *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
-	return &OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", idpID, code, validateResponse)}
+func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, idpID interface{}, code interface{}, validateResponse interface{}) *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
+	return &OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, idpID, code, validateResponse)}
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(idpID string, code string, validateResponse bool)) *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx context.Context, idpID string, code string, validateResponse bool)) *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -171,14 +185,14 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) Return(t
 	return _c
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // FetchUserInfo provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
-func (_mock *OAuthAuthnCoreServiceInterfaceMock) FetchUserInfo(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, accessToken)
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) FetchUserInfo(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, accessToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchUserInfo")
@@ -186,18 +200,18 @@ func (_mock *OAuthAuthnCoreServiceInterfaceMock) FetchUserInfo(idpID string, acc
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, accessToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]interface{}); ok {
-		r0 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -212,25 +226,31 @@ type OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call struct {
 }
 
 // FetchUserInfo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - accessToken string
-func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) FetchUserInfo(idpID interface{}, accessToken interface{}) *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
-	return &OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", idpID, accessToken)}
+func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) FetchUserInfo(ctx interface{}, idpID interface{}, accessToken interface{}) *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
+	return &OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", ctx, idpID, accessToken)}
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) Run(run func(idpID string, accessToken string)) *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) Run(run func(ctx context.Context, idpID string, accessToken string)) *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -241,7 +261,7 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) Return(stringTo
 	return _c
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -311,8 +331,8 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_GetInternalUser_Call) RunAndReturn(
 }
 
 // GetOAuthClientConfig provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
-func (_mock *OAuthAuthnCoreServiceInterfaceMock) GetOAuthClientConfig(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) GetOAuthClientConfig(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOAuthClientConfig")
@@ -320,18 +340,18 @@ func (_mock *OAuthAuthnCoreServiceInterfaceMock) GetOAuthClientConfig(idpID stri
 
 	var r0 *oauth.OAuthClientConfig
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *oauth.OAuthClientConfig); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *oauth.OAuthClientConfig); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.OAuthClientConfig)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -346,19 +366,25 @@ type OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call struct {
 }
 
 // GetOAuthClientConfig is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) GetOAuthClientConfig(idpID interface{}) *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
-	return &OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", idpID)}
+func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) GetOAuthClientConfig(ctx interface{}, idpID interface{}) *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
+	return &OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", ctx, idpID)}
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(idpID string)) *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(ctx context.Context, idpID string)) *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -369,7 +395,7 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) Return(o
 	return _c
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package oauthmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
@@ -39,8 +41,8 @@ func (_m *OAuthAuthnServiceInterfaceMock) EXPECT() *OAuthAuthnServiceInterfaceMo
 }
 
 // BuildAuthorizeURL provides a mock function for the type OAuthAuthnServiceInterfaceMock
-func (_mock *OAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeURL")
@@ -48,16 +50,16 @@ func (_mock *OAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID string) (st
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call struct {
 }
 
 // BuildAuthorizeURL is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OAuthAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(idpID interface{}) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	return &OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", idpID)}
+func (_e *OAuthAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(ctx interface{}, idpID interface{}) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	return &OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", ctx, idpID)}
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(idpID string)) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ctx context.Context, idpID string)) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,14 +103,14 @@ func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string
 	return _c
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(idpID string) (string, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ExchangeCodeForToken provides a mock function for the type OAuthAuthnServiceInterfaceMock
-func (_mock *OAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, code, validateResponse)
+func (_mock *OAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code, validateResponse)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExchangeCodeForToken")
@@ -110,18 +118,18 @@ func (_mock *OAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID string, 
 
 	var r0 *oauth.TokenResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code, validateResponse)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) *oauth.TokenResponse); ok {
-		r0 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) *oauth.TokenResponse); ok {
+		r0 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.TokenResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -136,31 +144,37 @@ type OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call struct {
 }
 
 // ExchangeCodeForToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - code string
 //   - validateResponse bool
-func (_e *OAuthAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(idpID interface{}, code interface{}, validateResponse interface{}) *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
-	return &OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", idpID, code, validateResponse)}
+func (_e *OAuthAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, idpID interface{}, code interface{}, validateResponse interface{}) *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+	return &OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, idpID, code, validateResponse)}
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(idpID string, code string, validateResponse bool)) *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx context.Context, idpID string, code string, validateResponse bool)) *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -171,14 +185,14 @@ func (_c *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Return(token
 	return _c
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // FetchUserInfo provides a mock function for the type OAuthAuthnServiceInterfaceMock
-func (_mock *OAuthAuthnServiceInterfaceMock) FetchUserInfo(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, accessToken)
+func (_mock *OAuthAuthnServiceInterfaceMock) FetchUserInfo(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, accessToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchUserInfo")
@@ -186,18 +200,18 @@ func (_mock *OAuthAuthnServiceInterfaceMock) FetchUserInfo(idpID string, accessT
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, accessToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]interface{}); ok {
-		r0 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -212,25 +226,31 @@ type OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call struct {
 }
 
 // FetchUserInfo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - accessToken string
-func (_e *OAuthAuthnServiceInterfaceMock_Expecter) FetchUserInfo(idpID interface{}, accessToken interface{}) *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
-	return &OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", idpID, accessToken)}
+func (_e *OAuthAuthnServiceInterfaceMock_Expecter) FetchUserInfo(ctx interface{}, idpID interface{}, accessToken interface{}) *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
+	return &OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", ctx, idpID, accessToken)}
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(idpID string, accessToken string)) *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(ctx context.Context, idpID string, accessToken string)) *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -241,7 +261,7 @@ func (_c *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) Return(stringToIfac
 	return _c
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -381,8 +401,8 @@ func (_c *OAuthAuthnServiceInterfaceMock_GetInternalUser_Call) RunAndReturn(run 
 }
 
 // GetOAuthClientConfig provides a mock function for the type OAuthAuthnServiceInterfaceMock
-func (_mock *OAuthAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OAuthAuthnServiceInterfaceMock) GetOAuthClientConfig(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOAuthClientConfig")
@@ -390,18 +410,18 @@ func (_mock *OAuthAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID string) 
 
 	var r0 *oauth.OAuthClientConfig
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *oauth.OAuthClientConfig); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *oauth.OAuthClientConfig); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.OAuthClientConfig)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -416,19 +436,25 @@ type OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call struct {
 }
 
 // GetOAuthClientConfig is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OAuthAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(idpID interface{}) *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
-	return &OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", idpID)}
+func (_e *OAuthAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(ctx interface{}, idpID interface{}) *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+	return &OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", ctx, idpID)}
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(idpID string)) *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(ctx context.Context, idpID string)) *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -439,7 +465,7 @@ func (_c *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Return(oAuth
 	return _c
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OAuthAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package oidcmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
@@ -39,8 +41,8 @@ func (_m *OIDCAuthnCoreServiceInterfaceMock) EXPECT() *OIDCAuthnCoreServiceInter
 }
 
 // BuildAuthorizeURL provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeURL")
@@ -48,16 +50,16 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(idpID string) 
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call struct {
 }
 
 // BuildAuthorizeURL is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) BuildAuthorizeURL(idpID interface{}) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
-	return &OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", idpID)}
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) BuildAuthorizeURL(ctx interface{}, idpID interface{}) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", ctx, idpID)}
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(idpID string)) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ctx context.Context, idpID string)) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,14 +103,14 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s str
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(idpID string) (string, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ExchangeCodeForToken provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, code, validateResponse)
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code, validateResponse)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExchangeCodeForToken")
@@ -110,18 +118,18 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(idpID strin
 
 	var r0 *oauth.TokenResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code, validateResponse)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) *oauth.TokenResponse); ok {
-		r0 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) *oauth.TokenResponse); ok {
+		r0 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.TokenResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -136,31 +144,37 @@ type OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call struct {
 }
 
 // ExchangeCodeForToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - code string
 //   - validateResponse bool
-func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) ExchangeCodeForToken(idpID interface{}, code interface{}, validateResponse interface{}) *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
-	return &OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", idpID, code, validateResponse)}
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, idpID interface{}, code interface{}, validateResponse interface{}) *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, idpID, code, validateResponse)}
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(idpID string, code string, validateResponse bool)) *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx context.Context, idpID string, code string, validateResponse bool)) *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -171,14 +185,14 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) Return(to
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // FetchUserInfo provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) FetchUserInfo(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, accessToken)
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) FetchUserInfo(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, accessToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchUserInfo")
@@ -186,18 +200,18 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) FetchUserInfo(idpID string, acce
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, accessToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]interface{}); ok {
-		r0 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -212,25 +226,31 @@ type OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call struct {
 }
 
 // FetchUserInfo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - accessToken string
-func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) FetchUserInfo(idpID interface{}, accessToken interface{}) *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
-	return &OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", idpID, accessToken)}
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) FetchUserInfo(ctx interface{}, idpID interface{}, accessToken interface{}) *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", ctx, idpID, accessToken)}
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) Run(run func(idpID string, accessToken string)) *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) Run(run func(ctx context.Context, idpID string, accessToken string)) *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -241,7 +261,7 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) Return(stringToI
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -375,8 +395,8 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_GetInternalUser_Call) RunAndReturn(r
 }
 
 // GetOAuthClientConfig provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) GetOAuthClientConfig(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) GetOAuthClientConfig(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOAuthClientConfig")
@@ -384,18 +404,18 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) GetOAuthClientConfig(idpID strin
 
 	var r0 *oauth.OAuthClientConfig
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *oauth.OAuthClientConfig); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *oauth.OAuthClientConfig); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.OAuthClientConfig)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -410,19 +430,25 @@ type OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call struct {
 }
 
 // GetOAuthClientConfig is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) GetOAuthClientConfig(idpID interface{}) *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
-	return &OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", idpID)}
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) GetOAuthClientConfig(ctx interface{}, idpID interface{}) *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", ctx, idpID)}
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(idpID string)) *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(ctx context.Context, idpID string)) *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -433,22 +459,22 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) Return(oA
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateIDToken provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) ValidateIDToken(idpID string, idToken string) *serviceerror.ServiceError {
-	ret := _mock.Called(idpID, idToken)
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) ValidateIDToken(ctx context.Context, idpID string, idToken string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, idpID, idToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateIDToken")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(idpID, idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, idpID, idToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -463,25 +489,31 @@ type OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call struct {
 }
 
 // ValidateIDToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - idToken string
-func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) ValidateIDToken(idpID interface{}, idToken interface{}) *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call {
-	return &OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call{Call: _e.mock.On("ValidateIDToken", idpID, idToken)}
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) ValidateIDToken(ctx interface{}, idpID interface{}, idToken interface{}) *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call{Call: _e.mock.On("ValidateIDToken", ctx, idpID, idToken)}
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call) Run(run func(idpID string, idToken string)) *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call) Run(run func(ctx context.Context, idpID string, idToken string)) *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -492,7 +524,7 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call) Return(service
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call) RunAndReturn(run func(idpID string, idToken string) *serviceerror.ServiceError) *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, idToken string) *serviceerror.ServiceError) *OIDCAuthnCoreServiceInterfaceMock_ValidateIDToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package oidcmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authn/oauth"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userprovider"
@@ -39,8 +41,8 @@ func (_m *OIDCAuthnServiceInterfaceMock) EXPECT() *OIDCAuthnServiceInterfaceMock
 }
 
 // BuildAuthorizeURL provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID string) (string, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeURL")
@@ -48,16 +50,16 @@ func (_mock *OIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(idpID string) (str
 
 	var r0 string
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (string, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,19 +74,25 @@ type OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call struct {
 }
 
 // BuildAuthorizeURL is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(idpID interface{}) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	return &OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", idpID)}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) BuildAuthorizeURL(ctx interface{}, idpID interface{}) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	return &OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call{Call: _e.mock.On("BuildAuthorizeURL", ctx, idpID)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(idpID string)) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ctx context.Context, idpID string)) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -95,14 +103,14 @@ func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string,
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(idpID string) (string, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ExchangeCodeForToken provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, code, validateResponse)
+func (_mock *OIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, code, validateResponse)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExchangeCodeForToken")
@@ -110,18 +118,18 @@ func (_mock *OIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(idpID string, c
 
 	var r0 *oauth.TokenResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) (*oauth.TokenResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, code, validateResponse)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, bool) *oauth.TokenResponse); ok {
-		r0 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) *oauth.TokenResponse); ok {
+		r0 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.TokenResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, bool) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, code, validateResponse)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, code, validateResponse)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -136,31 +144,37 @@ type OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call struct {
 }
 
 // ExchangeCodeForToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - code string
 //   - validateResponse bool
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(idpID interface{}, code interface{}, validateResponse interface{}) *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
-	return &OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", idpID, code, validateResponse)}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) ExchangeCodeForToken(ctx interface{}, idpID interface{}, code interface{}, validateResponse interface{}) *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+	return &OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call{Call: _e.mock.On("ExchangeCodeForToken", ctx, idpID, code, validateResponse)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(idpID string, code string, validateResponse bool)) *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Run(run func(ctx context.Context, idpID string, code string, validateResponse bool)) *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 bool
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(string)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -171,14 +185,14 @@ func (_c *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) Return(tokenR
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_ExchangeCodeForToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // FetchUserInfo provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) FetchUserInfo(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID, accessToken)
+func (_mock *OIDCAuthnServiceInterfaceMock) FetchUserInfo(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID, accessToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchUserInfo")
@@ -186,18 +200,18 @@ func (_mock *OIDCAuthnServiceInterfaceMock) FetchUserInfo(idpID string, accessTo
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID, accessToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) map[string]interface{}); ok {
-		r0 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID, accessToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, accessToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -212,25 +226,31 @@ type OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call struct {
 }
 
 // FetchUserInfo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - accessToken string
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) FetchUserInfo(idpID interface{}, accessToken interface{}) *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
-	return &OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", idpID, accessToken)}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) FetchUserInfo(ctx interface{}, idpID interface{}, accessToken interface{}) *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
+	return &OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call{Call: _e.mock.On("FetchUserInfo", ctx, idpID, accessToken)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(idpID string, accessToken string)) *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) Run(run func(ctx context.Context, idpID string, accessToken string)) *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -241,7 +261,7 @@ func (_c *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) Return(stringToIface
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run func(ctx context.Context, idpID string, accessToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -375,8 +395,8 @@ func (_c *OIDCAuthnServiceInterfaceMock_GetInternalUser_Call) RunAndReturn(run f
 }
 
 // GetOAuthClientConfig provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
-	ret := _mock.Called(idpID)
+func (_mock *OIDCAuthnServiceInterfaceMock) GetOAuthClientConfig(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOAuthClientConfig")
@@ -384,18 +404,18 @@ func (_mock *OIDCAuthnServiceInterfaceMock) GetOAuthClientConfig(idpID string) (
 
 	var r0 *oauth.OAuthClientConfig
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
-		return returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *oauth.OAuthClientConfig); ok {
-		r0 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *oauth.OAuthClientConfig); ok {
+		r0 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth.OAuthClientConfig)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idpID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -410,19 +430,25 @@ type OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call struct {
 }
 
 // GetOAuthClientConfig is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(idpID interface{}) *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
-	return &OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", idpID)}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) GetOAuthClientConfig(ctx interface{}, idpID interface{}) *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+	return &OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call{Call: _e.mock.On("GetOAuthClientConfig", ctx, idpID)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(idpID string)) *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Run(run func(ctx context.Context, idpID string)) *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -433,22 +459,22 @@ func (_c *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) Return(oAuthC
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*oauth.OAuthClientConfig, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_GetOAuthClientConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateIDToken provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) ValidateIDToken(idpID string, idToken string) *serviceerror.ServiceError {
-	ret := _mock.Called(idpID, idToken)
+func (_mock *OIDCAuthnServiceInterfaceMock) ValidateIDToken(ctx context.Context, idpID string, idToken string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, idpID, idToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateIDToken")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(idpID, idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, idpID, idToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -463,25 +489,31 @@ type OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call struct {
 }
 
 // ValidateIDToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - idToken string
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) ValidateIDToken(idpID interface{}, idToken interface{}) *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
-	return &OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call{Call: _e.mock.On("ValidateIDToken", idpID, idToken)}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) ValidateIDToken(ctx interface{}, idpID interface{}, idToken interface{}) *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
+	return &OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call{Call: _e.mock.On("ValidateIDToken", ctx, idpID, idToken)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) Run(run func(idpID string, idToken string)) *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) Run(run func(ctx context.Context, idpID string, idToken string)) *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -492,22 +524,22 @@ func (_c *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) Return(serviceErro
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) RunAndReturn(run func(idpID string, idToken string) *serviceerror.ServiceError) *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call) RunAndReturn(run func(ctx context.Context, idpID string, idToken string) *serviceerror.ServiceError) *OIDCAuthnServiceInterfaceMock_ValidateIDToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ValidateTokenResponse provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) ValidateTokenResponse(idpID string, tokenResp *oauth.TokenResponse, validateIDToken bool) *serviceerror.ServiceError {
-	ret := _mock.Called(idpID, tokenResp, validateIDToken)
+func (_mock *OIDCAuthnServiceInterfaceMock) ValidateTokenResponse(ctx context.Context, idpID string, tokenResp *oauth.TokenResponse, validateIDToken bool) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, idpID, tokenResp, validateIDToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateTokenResponse")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, *oauth.TokenResponse, bool) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(idpID, tokenResp, validateIDToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *oauth.TokenResponse, bool) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, idpID, tokenResp, validateIDToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -522,31 +554,37 @@ type OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call struct {
 }
 
 // ValidateTokenResponse is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idpID string
 //   - tokenResp *oauth.TokenResponse
 //   - validateIDToken bool
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) ValidateTokenResponse(idpID interface{}, tokenResp interface{}, validateIDToken interface{}) *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call {
-	return &OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call{Call: _e.mock.On("ValidateTokenResponse", idpID, tokenResp, validateIDToken)}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) ValidateTokenResponse(ctx interface{}, idpID interface{}, tokenResp interface{}, validateIDToken interface{}) *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call {
+	return &OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call{Call: _e.mock.On("ValidateTokenResponse", ctx, idpID, tokenResp, validateIDToken)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call) Run(run func(idpID string, tokenResp *oauth.TokenResponse, validateIDToken bool)) *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call) Run(run func(ctx context.Context, idpID string, tokenResp *oauth.TokenResponse, validateIDToken bool)) *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 *oauth.TokenResponse
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*oauth.TokenResponse)
+			arg1 = args[1].(string)
 		}
-		var arg2 bool
+		var arg2 *oauth.TokenResponse
 		if args[2] != nil {
-			arg2 = args[2].(bool)
+			arg2 = args[2].(*oauth.TokenResponse)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -557,7 +595,7 @@ func (_c *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call) Return(servi
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call) RunAndReturn(run func(idpID string, tokenResp *oauth.TokenResponse, validateIDToken bool) *serviceerror.ServiceError) *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call) RunAndReturn(run func(ctx context.Context, idpID string, tokenResp *oauth.TokenResponse, validateIDToken bool) *serviceerror.ServiceError) *OIDCAuthnServiceInterfaceMock_ValidateTokenResponse_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authz/engine/AuthorizationEngine_mock.go
+++ b/backend/tests/mocks/authz/engine/AuthorizationEngine_mock.go
@@ -5,6 +5,8 @@
 package enginemock
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,8 +38,8 @@ func (_m *AuthorizationEngineMock) EXPECT() *AuthorizationEngineMock_Expecter {
 }
 
 // GetAuthorizedPermissions provides a mock function for the type AuthorizationEngineMock
-func (_mock *AuthorizationEngineMock) GetAuthorizedPermissions(userID string, groupIDs []string, requestedPermissions []string) ([]string, error) {
-	ret := _mock.Called(userID, groupIDs, requestedPermissions)
+func (_mock *AuthorizationEngineMock) GetAuthorizedPermissions(ctx context.Context, userID string, groupIDs []string, requestedPermissions []string) ([]string, error) {
+	ret := _mock.Called(ctx, userID, groupIDs, requestedPermissions)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAuthorizedPermissions")
@@ -45,18 +47,18 @@ func (_mock *AuthorizationEngineMock) GetAuthorizedPermissions(userID string, gr
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, []string, []string) ([]string, error)); ok {
-		return returnFunc(userID, groupIDs, requestedPermissions)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, []string) ([]string, error)); ok {
+		return returnFunc(ctx, userID, groupIDs, requestedPermissions)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, []string, []string) []string); ok {
-		r0 = returnFunc(userID, groupIDs, requestedPermissions)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, []string) []string); ok {
+		r0 = returnFunc(ctx, userID, groupIDs, requestedPermissions)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, []string, []string) error); ok {
-		r1 = returnFunc(userID, groupIDs, requestedPermissions)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string, []string) error); ok {
+		r1 = returnFunc(ctx, userID, groupIDs, requestedPermissions)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -69,31 +71,37 @@ type AuthorizationEngineMock_GetAuthorizedPermissions_Call struct {
 }
 
 // GetAuthorizedPermissions is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userID string
 //   - groupIDs []string
 //   - requestedPermissions []string
-func (_e *AuthorizationEngineMock_Expecter) GetAuthorizedPermissions(userID interface{}, groupIDs interface{}, requestedPermissions interface{}) *AuthorizationEngineMock_GetAuthorizedPermissions_Call {
-	return &AuthorizationEngineMock_GetAuthorizedPermissions_Call{Call: _e.mock.On("GetAuthorizedPermissions", userID, groupIDs, requestedPermissions)}
+func (_e *AuthorizationEngineMock_Expecter) GetAuthorizedPermissions(ctx interface{}, userID interface{}, groupIDs interface{}, requestedPermissions interface{}) *AuthorizationEngineMock_GetAuthorizedPermissions_Call {
+	return &AuthorizationEngineMock_GetAuthorizedPermissions_Call{Call: _e.mock.On("GetAuthorizedPermissions", ctx, userID, groupIDs, requestedPermissions)}
 }
 
-func (_c *AuthorizationEngineMock_GetAuthorizedPermissions_Call) Run(run func(userID string, groupIDs []string, requestedPermissions []string)) *AuthorizationEngineMock_GetAuthorizedPermissions_Call {
+func (_c *AuthorizationEngineMock_GetAuthorizedPermissions_Call) Run(run func(ctx context.Context, userID string, groupIDs []string, requestedPermissions []string)) *AuthorizationEngineMock_GetAuthorizedPermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []string
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]string)
+			arg1 = args[1].(string)
 		}
 		var arg2 []string
 		if args[2] != nil {
 			arg2 = args[2].([]string)
 		}
+		var arg3 []string
+		if args[3] != nil {
+			arg3 = args[3].([]string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -104,7 +112,7 @@ func (_c *AuthorizationEngineMock_GetAuthorizedPermissions_Call) Return(strings 
 	return _c
 }
 
-func (_c *AuthorizationEngineMock_GetAuthorizedPermissions_Call) RunAndReturn(run func(userID string, groupIDs []string, requestedPermissions []string) ([]string, error)) *AuthorizationEngineMock_GetAuthorizedPermissions_Call {
+func (_c *AuthorizationEngineMock_GetAuthorizedPermissions_Call) RunAndReturn(run func(ctx context.Context, userID string, groupIDs []string, requestedPermissions []string) ([]string, error)) *AuthorizationEngineMock_GetAuthorizedPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authzmock/AuthorizationServiceInterface_mock.go
+++ b/backend/tests/mocks/authzmock/AuthorizationServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package authzmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/authz"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *AuthorizationServiceInterfaceMock) EXPECT() *AuthorizationServiceInter
 }
 
 // GetAuthorizedPermissions provides a mock function for the type AuthorizationServiceInterfaceMock
-func (_mock *AuthorizationServiceInterfaceMock) GetAuthorizedPermissions(request authz.GetAuthorizedPermissionsRequest) (*authz.GetAuthorizedPermissionsResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(request)
+func (_mock *AuthorizationServiceInterfaceMock) GetAuthorizedPermissions(ctx context.Context, request authz.GetAuthorizedPermissionsRequest) (*authz.GetAuthorizedPermissionsResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAuthorizedPermissions")
@@ -47,18 +49,18 @@ func (_mock *AuthorizationServiceInterfaceMock) GetAuthorizedPermissions(request
 
 	var r0 *authz.GetAuthorizedPermissionsResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(authz.GetAuthorizedPermissionsRequest) (*authz.GetAuthorizedPermissionsResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, authz.GetAuthorizedPermissionsRequest) (*authz.GetAuthorizedPermissionsResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(authz.GetAuthorizedPermissionsRequest) *authz.GetAuthorizedPermissionsResponse); ok {
-		r0 = returnFunc(request)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, authz.GetAuthorizedPermissionsRequest) *authz.GetAuthorizedPermissionsResponse); ok {
+		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*authz.GetAuthorizedPermissionsResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(authz.GetAuthorizedPermissionsRequest) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(request)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, authz.GetAuthorizedPermissionsRequest) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,19 +75,25 @@ type AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call struct {
 }
 
 // GetAuthorizedPermissions is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request authz.GetAuthorizedPermissionsRequest
-func (_e *AuthorizationServiceInterfaceMock_Expecter) GetAuthorizedPermissions(request interface{}) *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call {
-	return &AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call{Call: _e.mock.On("GetAuthorizedPermissions", request)}
+func (_e *AuthorizationServiceInterfaceMock_Expecter) GetAuthorizedPermissions(ctx interface{}, request interface{}) *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call {
+	return &AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call{Call: _e.mock.On("GetAuthorizedPermissions", ctx, request)}
 }
 
-func (_c *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call) Run(run func(request authz.GetAuthorizedPermissionsRequest)) *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call {
+func (_c *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call) Run(run func(ctx context.Context, request authz.GetAuthorizedPermissionsRequest)) *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 authz.GetAuthorizedPermissionsRequest
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(authz.GetAuthorizedPermissionsRequest)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 authz.GetAuthorizedPermissionsRequest
+		if args[1] != nil {
+			arg1 = args[1].(authz.GetAuthorizedPermissionsRequest)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -96,7 +104,7 @@ func (_c *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call) Retur
 	return _c
 }
 
-func (_c *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call) RunAndReturn(run func(request authz.GetAuthorizedPermissionsRequest) (*authz.GetAuthorizedPermissionsResponse, *serviceerror.ServiceError)) *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call {
+func (_c *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call) RunAndReturn(run func(ctx context.Context, request authz.GetAuthorizedPermissionsRequest) (*authz.GetAuthorizedPermissionsResponse, *serviceerror.ServiceError)) *AuthorizationServiceInterfaceMock_GetAuthorizedPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/design/resolvemock/DesignResolveServiceInterface_mock.go
+++ b/backend/tests/mocks/design/resolvemock/DesignResolveServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package resolvemock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/design/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
@@ -38,8 +40,8 @@ func (_m *DesignResolveServiceInterfaceMock) EXPECT() *DesignResolveServiceInter
 }
 
 // ResolveDesign provides a mock function for the type DesignResolveServiceInterfaceMock
-func (_mock *DesignResolveServiceInterfaceMock) ResolveDesign(resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(resolveType, id)
+func (_mock *DesignResolveServiceInterfaceMock) ResolveDesign(ctx context.Context, resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, resolveType, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResolveDesign")
@@ -47,18 +49,18 @@ func (_mock *DesignResolveServiceInterfaceMock) ResolveDesign(resolveType common
 
 	var r0 *common.DesignResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(common.DesignResolveType, string) (*common.DesignResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(resolveType, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.DesignResolveType, string) (*common.DesignResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, resolveType, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(common.DesignResolveType, string) *common.DesignResponse); ok {
-		r0 = returnFunc(resolveType, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.DesignResolveType, string) *common.DesignResponse); ok {
+		r0 = returnFunc(ctx, resolveType, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.DesignResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(common.DesignResolveType, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(resolveType, id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.DesignResolveType, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, resolveType, id)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -73,25 +75,31 @@ type DesignResolveServiceInterfaceMock_ResolveDesign_Call struct {
 }
 
 // ResolveDesign is a helper method to define mock.On call
+//   - ctx context.Context
 //   - resolveType common.DesignResolveType
 //   - id string
-func (_e *DesignResolveServiceInterfaceMock_Expecter) ResolveDesign(resolveType interface{}, id interface{}) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
-	return &DesignResolveServiceInterfaceMock_ResolveDesign_Call{Call: _e.mock.On("ResolveDesign", resolveType, id)}
+func (_e *DesignResolveServiceInterfaceMock_Expecter) ResolveDesign(ctx interface{}, resolveType interface{}, id interface{}) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
+	return &DesignResolveServiceInterfaceMock_ResolveDesign_Call{Call: _e.mock.On("ResolveDesign", ctx, resolveType, id)}
 }
 
-func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) Run(run func(resolveType common.DesignResolveType, id string)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
+func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) Run(run func(ctx context.Context, resolveType common.DesignResolveType, id string)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 common.DesignResolveType
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(common.DesignResolveType)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 common.DesignResolveType
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(common.DesignResolveType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -102,7 +110,7 @@ func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) Return(designRes
 	return _c
 }
 
-func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) RunAndReturn(run func(resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
+func (_c *DesignResolveServiceInterfaceMock_ResolveDesign_Call) RunAndReturn(run func(ctx context.Context, resolveType common.DesignResolveType, id string) (*common.DesignResponse, *serviceerror.ServiceError)) *DesignResolveServiceInterfaceMock_ResolveDesign_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

We are currently there are multiple usages of context.TODO  which is being updated to either, context.Background or to pass down the actual request context. 

Issue : https://github.com/asgardeo/thunder/issues/1817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Broadened context propagation across authentication, OAuth/OIDC, authorization, design-resolve, and flow execution paths to improve request lifecycle handling and cancellation support.

* **Tests**
  * Updated test suites and mocks to be context-aware, relaxing/aligning expectations to match the new signatures.

---

Note: No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->