### PR TITLE
Fix consent executor to include special attributes

### DIFF
--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -48,8 +48,9 @@ import (
 )
 
 const (
-	testEmail     = "test@example.com"
-	testNameValue = "Test"
+	testEmail      = "test@example.com"
+	testNameValue  = "Test"
+	testAssertOUID = "ou-789"
 )
 
 type AuthAssertExecutorTestSuite struct {
@@ -580,7 +581,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:    true,
 			UserID:             "user-123",
-			OrganizationUnitID: "ou-789",
+			OrganizationUnitID: testAssertOUID,
 		},
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Application: appmodel.Application{
@@ -590,15 +591,15 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 		},
 	}
 
-	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-789").Return(ou.OrganizationUnit{
-		ID:     "ou-789",
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAssertOUID).Return(ou.OrganizationUnit{
+		ID:     testAssertOUID,
 		Name:   "Engineering",
 		Handle: "eng",
 	}, nil)
 
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
-			return claims[oauth2const.ClaimOUID] == "ou-789" &&
+			return claims[oauth2const.ClaimOUID] == testAssertOUID &&
 				claims[oauth2const.ClaimOUName] == "Engineering" &&
 				claims[oauth2const.ClaimOUHandle] == "eng"
 		}), mock.Anything).Return("jwt-token", int64(3600), nil)

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -28,9 +28,11 @@ import (
 	"time"
 
 	consentauthn "github.com/asgardeo/thunder/internal/authn/consent"
+	"github.com/asgardeo/thunder/internal/authnprovider"
 	"github.com/asgardeo/thunder/internal/consent"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
@@ -124,11 +126,11 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 	logger.Debug("Checking if user consent is required")
 
 	essentialAttributes, optionalAttributes := e.getRequiredAttributes(ctx)
+	availableAttributes := buildAugmentedAvailableAttributes(ctx)
 
 	// Resolve consent to determine if any required consents are missing and need to be prompted
 	promptData, svcErr := e.consentEnforcer.ResolveConsent(
-		ctx.Context, ouID, appID, userID, essentialAttributes, optionalAttributes,
-		ctx.AuthenticatedUser.AvailableAttributes)
+		ctx.Context, ouID, appID, userID, essentialAttributes, optionalAttributes, availableAttributes)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			logger.Debug("Client error while resolving user consent", log.Any("error", svcErr))
@@ -293,6 +295,47 @@ func (e *consentExecutor) getRequiredAttributes(ctx *core.NodeContext) (
 	}
 
 	return essentialAttributes, optionalAttributes
+}
+
+// buildAugmentedAvailableAttributes returns an AvailableAttributes value augmented with
+// special attribute keys (groups, userType, ouId, ouName, ouHandle) that are present by
+// construction in the authenticated user context but are never included in AvailableAttributes
+// by authentication providers.
+func buildAugmentedAvailableAttributes(ctx *core.NodeContext) *authnprovider.AvailableAttributes {
+	base := ctx.AuthenticatedUser.AvailableAttributes
+
+	var baseAttrs map[string]*authnprovider.AttributeMetadataResponse
+	var baseVerifications map[string]*authnprovider.VerificationResponse
+	if base != nil {
+		baseAttrs = base.Attributes
+		baseVerifications = base.Verifications
+	}
+
+	// Shallow-copy existing entries so we never mutate the original
+	augmented := make(map[string]*authnprovider.AttributeMetadataResponse, len(baseAttrs))
+	for k, v := range baseAttrs {
+		augmented[k] = v
+	}
+
+	// Inject special attribute keys.
+	// Value is set to empty since the consent enforcer only checks for presence of the key, and the actual values
+	// can be obtained from the authenticated user context if needed
+	if ctx.AuthenticatedUser.UserType != "" {
+		augmented[oauth2const.ClaimUserType] = &authnprovider.AttributeMetadataResponse{}
+	}
+	if ctx.AuthenticatedUser.OrganizationUnitID != "" {
+		augmented[oauth2const.ClaimOUID] = &authnprovider.AttributeMetadataResponse{}
+		augmented[oauth2const.ClaimOUName] = &authnprovider.AttributeMetadataResponse{}
+		augmented[oauth2const.ClaimOUHandle] = &authnprovider.AttributeMetadataResponse{}
+	}
+	if ctx.AuthenticatedUser.UserID != "" {
+		augmented[oauth2const.UserAttributeGroups] = &authnprovider.AttributeMetadataResponse{}
+	}
+
+	return &authnprovider.AvailableAttributes{
+		Attributes:    augmented,
+		Verifications: baseVerifications,
+	}
 }
 
 // collectConsentedAttributes extracts all approved attribute names from a consent record.

--- a/backend/internal/flow/executor/consent_executor_test.go
+++ b/backend/internal/flow/executor/consent_executor_test.go
@@ -42,6 +42,10 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 )
 
+const (
+	testUserTypeInternal = "internal"
+)
+
 type ConsentExecutorTestSuite struct {
 	suite.Suite
 	mockConsentEnforcer *consentenforcermock.ConsentEnforcerServiceInterfaceMock
@@ -163,7 +167,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AllConsentsActive() 
 
 	// ResolveConsent returns nil = all consents active
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "user-123",
-		[]string{}, []string{"email", "phone"}, ctx.AuthenticatedUser.AvailableAttributes).
+		[]string{}, []string{"email", "phone"}, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -184,7 +188,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_RequiredAttributesFr
 
 	// ResolveConsent should receive attributes from RuntimeData, not from Application config
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "user-123",
-		[]string{}, []string{"email", "name"}, ctx.AuthenticatedUser.AvailableAttributes).
+		[]string{}, []string{"email", "name"}, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -204,7 +208,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_RequiredEssentialAnd
 		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "user-123",
-		[]string{"email"}, []string{"name"}, ctx.AuthenticatedUser.AvailableAttributes).
+		[]string{"email"}, []string{"name"}, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -224,7 +228,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_NilAssertionConfig()
 
 	// Attributes should be nil when no RuntimeData and no Assertion config
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "user-123",
-		[]string{}, []string{}, ctx.AuthenticatedUser.AvailableAttributes).
+		[]string{}, []string{}, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -247,7 +251,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_ExplicitEmptyRuntime
 
 	// Expect empty slices — NOT the Application.Assertion.UserAttributes (["email","phone"])
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "user-123",
-		[]string{}, []string{}, ctx.AuthenticatedUser.AvailableAttributes).
+		[]string{}, []string{}, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -924,6 +928,119 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_NoConsentedElements
 		"Consented attributes should be empty when no elements are approved")
 }
 
+// ----- Execute: with augmented attributes tests -----
+
+func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_GroupsInjected() {
+	ctx := buildConsentNodeContext()
+	// UserID is set (from buildConsentNodeContext: testUserID="user-123"), so "groups" must be injected
+	// into the available attributes passed to ResolveConsent
+
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(true)
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
+
+	suite.mockConsentEnforcer.On("ResolveConsent",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything,
+		mock.MatchedBy(func(aa *authnprovider.AvailableAttributes) bool {
+			if aa == nil || len(aa.Attributes) == 0 {
+				return false
+			}
+			groupsMeta, hasGroups := aa.Attributes["groups"]
+			return hasGroups && groupsMeta != nil
+		})).
+		Return(nil, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_OUClaimsInjected() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.OrganizationUnitID = "ou-999"
+
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(true)
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
+
+	suite.mockConsentEnforcer.On("ResolveConsent",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything,
+		mock.MatchedBy(func(aa *authnprovider.AvailableAttributes) bool {
+			if aa == nil {
+				return false
+			}
+			_, hasOUID := aa.Attributes["ouId"]
+			_, hasOUName := aa.Attributes["ouName"]
+			_, hasOUHandle := aa.Attributes["ouHandle"]
+			return hasOUID && hasOUName && hasOUHandle
+		})).
+		Return(nil, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_UserTypeInjected() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.UserType = "customer"
+
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(true)
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
+
+	suite.mockConsentEnforcer.On("ResolveConsent",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything,
+		mock.MatchedBy(func(aa *authnprovider.AvailableAttributes) bool {
+			return aa != nil && func() bool { _, ok := aa.Attributes["userType"]; return ok }()
+		})).
+		Return(nil, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_NilBaseWithSpecialClaims() {
+	// Even with a nil AvailableAttributes base, special claim keys from the authenticated
+	// user context must be injected and forwarded to ResolveConsent.
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.AvailableAttributes = nil
+	ctx.AuthenticatedUser.UserType = testUserTypeInternal
+
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(true)
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
+
+	suite.mockConsentEnforcer.On("ResolveConsent",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything,
+		mock.MatchedBy(func(aa *authnprovider.AvailableAttributes) bool {
+			if aa == nil {
+				return false
+			}
+			_, hasUserType := aa.Attributes["userType"]
+			_, hasGroups := aa.Attributes["groups"]
+			return hasUserType && hasGroups
+		})).
+		Return(nil, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
 // ----- collectConsentedAttributes Tests -----
 
 func (suite *ConsentExecutorTestSuite) TestCollectConsentedAttributes_MixedApprovals() {
@@ -1031,4 +1148,208 @@ func (suite *ConsentExecutorTestSuite) TestCollectConsentedAttributes_AllApprove
 	assert.Contains(suite.T(), attrs, "email")
 	assert.Contains(suite.T(), attrs, "phone")
 	assert.Contains(suite.T(), attrs, "name")
+}
+
+// ----- buildAugmentedAvailableAttributes Tests -----
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_NilBase() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.AvailableAttributes = nil
+	ctx.AuthenticatedUser.UserType = testUserTypeInternal
+	ctx.AuthenticatedUser.OrganizationUnitID = "ou-123"
+
+	result := buildAugmentedAvailableAttributes(ctx)
+
+	// Even with a nil base we should still inject the special claim keys that are known
+	// to be present from the authenticated user context.
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), result.Attributes, "userType")
+	assert.Contains(suite.T(), result.Attributes, "ouId")
+	assert.Contains(suite.T(), result.Attributes, "ouName")
+	assert.Contains(suite.T(), result.Attributes, "ouHandle")
+	assert.Contains(suite.T(), result.Attributes, "groups")
+	assert.Len(suite.T(), result.Attributes, 5)
+	assert.Nil(suite.T(), result.Verifications)
+}
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_EmptyAttributes() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.AvailableAttributes = &authnprovider.AvailableAttributes{
+		Attributes: map[string]*authnprovider.AttributeMetadataResponse{},
+	}
+	ctx.AuthenticatedUser.UserType = testUserTypeInternal
+	ctx.AuthenticatedUser.OrganizationUnitID = "ou-123"
+
+	result := buildAugmentedAvailableAttributes(ctx)
+
+	// Even with an empty base we should inject special claim keys so they survive the
+	// consent profile-presence filter.
+	assert.NotNil(suite.T(), result)
+	assert.NotEqual(suite.T(), ctx.AuthenticatedUser.AvailableAttributes, result)
+	assert.Contains(suite.T(), result.Attributes, "userType")
+	assert.Contains(suite.T(), result.Attributes, "ouId")
+	assert.Contains(suite.T(), result.Attributes, "ouName")
+	assert.Contains(suite.T(), result.Attributes, "ouHandle")
+	assert.Contains(suite.T(), result.Attributes, "groups")
+	assert.Len(suite.T(), result.Attributes, 5)
+}
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_NoSpecialContext() {
+	ctx := buildConsentNodeContext()
+	// UserType, OrganizationUnitID, UserID are all empty
+	ctx.AuthenticatedUser.UserType = ""
+	ctx.AuthenticatedUser.OrganizationUnitID = ""
+	ctx.AuthenticatedUser.UserID = ""
+	ctx.AuthenticatedUser.AvailableAttributes = &authnprovider.AvailableAttributes{
+		Attributes: map[string]*authnprovider.AttributeMetadataResponse{
+			"email": nil,
+			"phone": nil,
+		},
+	}
+
+	result := buildAugmentedAvailableAttributes(ctx)
+
+	assert.NotNil(suite.T(), result)
+	// No special keys should be added; only original keys remain
+	assert.Len(suite.T(), result.Attributes, 2)
+	assert.True(suite.T(), result.Attributes["email"] == nil)
+	assert.True(suite.T(), result.Attributes["phone"] == nil)
+	assert.NotContains(suite.T(), result.Attributes, "userType")
+	assert.NotContains(suite.T(), result.Attributes, "groups")
+	assert.NotContains(suite.T(), result.Attributes, "ouId")
+}
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_WithSingleSpecialField() {
+	type testCase struct {
+		name             string
+		userType         string
+		ouID             string
+		userID           string
+		expectedContains []string
+		expectedAbsent   []string
+	}
+
+	cases := []testCase{
+		{
+			name:             "UserType only",
+			userType:         testUserTypeInternal,
+			expectedContains: []string{"userType", "email"},
+			expectedAbsent:   []string{"ouId", "ouName", "ouHandle", "groups"},
+		},
+		{
+			name:             "OrganizationUnitID only",
+			ouID:             "ou-456",
+			expectedContains: []string{"ouId", "ouName", "ouHandle", "email"},
+			expectedAbsent:   []string{"userType", "groups"},
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			ctx := buildConsentNodeContext()
+			ctx.AuthenticatedUser.UserType = tc.userType
+			ctx.AuthenticatedUser.OrganizationUnitID = tc.ouID
+			ctx.AuthenticatedUser.UserID = tc.userID
+			ctx.AuthenticatedUser.AvailableAttributes = &authnprovider.AvailableAttributes{
+				Attributes: map[string]*authnprovider.AttributeMetadataResponse{
+					"email": nil,
+				},
+			}
+
+			result := buildAugmentedAvailableAttributes(ctx)
+
+			assert.NotNil(suite.T(), result)
+			for _, key := range tc.expectedContains {
+				assert.Contains(suite.T(), result.Attributes, key)
+			}
+			for _, key := range tc.expectedAbsent {
+				assert.NotContains(suite.T(), result.Attributes, key)
+			}
+		})
+	}
+}
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_WithGroups() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.UserType = ""
+	ctx.AuthenticatedUser.OrganizationUnitID = ""
+	ctx.AuthenticatedUser.UserID = "user-abc"
+	ctx.AuthenticatedUser.AvailableAttributes = &authnprovider.AvailableAttributes{
+		Attributes: map[string]*authnprovider.AttributeMetadataResponse{
+			"email": nil,
+		},
+	}
+
+	result := buildAugmentedAvailableAttributes(ctx)
+
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), result.Attributes, "groups")
+	assert.NotContains(suite.T(), result.Attributes, "userType")
+	assert.NotContains(suite.T(), result.Attributes, "ouId")
+	assert.Contains(suite.T(), result.Attributes, "email")
+}
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_AllSpecialFields() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.UserType = testUserTypeInternal
+	ctx.AuthenticatedUser.OrganizationUnitID = "ou-789"
+	ctx.AuthenticatedUser.UserID = "user-xyz"
+	ctx.AuthenticatedUser.AvailableAttributes = &authnprovider.AvailableAttributes{
+		Attributes: map[string]*authnprovider.AttributeMetadataResponse{
+			"email": nil,
+		},
+	}
+
+	result := buildAugmentedAvailableAttributes(ctx)
+
+	assert.NotNil(suite.T(), result)
+	assert.Contains(suite.T(), result.Attributes, "email")
+	assert.Contains(suite.T(), result.Attributes, "userType")
+	assert.Contains(suite.T(), result.Attributes, "ouId")
+	assert.Contains(suite.T(), result.Attributes, "ouName")
+	assert.Contains(suite.T(), result.Attributes, "ouHandle")
+	assert.Contains(suite.T(), result.Attributes, "groups")
+	// Total: 1 original + 5 special
+	assert.Len(suite.T(), result.Attributes, 6)
+}
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_DoesNotMutateOriginal() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.UserType = testUserTypeInternal
+	ctx.AuthenticatedUser.OrganizationUnitID = "ou-789"
+	ctx.AuthenticatedUser.UserID = "user-xyz"
+	ctx.AuthenticatedUser.AvailableAttributes = &authnprovider.AvailableAttributes{
+		Attributes: map[string]*authnprovider.AttributeMetadataResponse{
+			"email": nil,
+			"phone": nil,
+		},
+	}
+
+	originalLen := len(ctx.AuthenticatedUser.AvailableAttributes.Attributes)
+	_ = buildAugmentedAvailableAttributes(ctx)
+
+	// The original map must not have been modified
+	assert.Len(suite.T(), ctx.AuthenticatedUser.AvailableAttributes.Attributes, originalLen)
+	assert.NotContains(suite.T(), ctx.AuthenticatedUser.AvailableAttributes.Attributes, "userType")
+	assert.NotContains(suite.T(), ctx.AuthenticatedUser.AvailableAttributes.Attributes, "groups")
+	assert.NotContains(suite.T(), ctx.AuthenticatedUser.AvailableAttributes.Attributes, "ouId")
+}
+
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_PreservesVerifications() {
+	ctx := buildConsentNodeContext()
+	ctx.AuthenticatedUser.UserType = testUserTypeInternal
+	ctx.AuthenticatedUser.AvailableAttributes = &authnprovider.AvailableAttributes{
+		Attributes: map[string]*authnprovider.AttributeMetadataResponse{
+			"email": nil,
+		},
+		Verifications: map[string]*authnprovider.VerificationResponse{
+			"v-1": {},
+		},
+	}
+
+	result := buildAugmentedAvailableAttributes(ctx)
+
+	assert.NotNil(suite.T(), result)
+	// Verifications reference is preserved (shallow copy)
+	assert.Equal(suite.T(), ctx.AuthenticatedUser.AvailableAttributes.Verifications, result.Verifications)
 }


### PR DESCRIPTION
### Purpose
This pull request introduces a new augmentation mechanism for available user attributes in the consent flow, ensuring that special attribute keys (such as `groups`, `userType`, `ouId`, `ouName`, and `ouHandle`) are always included when checking user consent. If requested, now the consent will also be collected for these special attributes and included in the tokens accordingly.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/1833

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced consent flow with improved attribute handling, now including support for injecting user type, organization unit identifiers, and group information into the consent resolution process.

* **Tests**
  * Expanded test coverage with comprehensive test cases for augmented attributes composition across various scenarios and contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->