### PR TITLE
Add support to get unique schema attributes

### DIFF
--- a/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
+++ b/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
@@ -308,6 +308,76 @@ func (_c *UserSchemaServiceInterfaceMock_GetDisplayAttributesByNames_Call) RunAn
 	return _c
 }
 
+// GetUniqueAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetUniqueAttributes(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUniqueAttributes")
+	}
+
+	var r0 []string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUniqueAttributes'
+type UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call struct {
+	*mock.Call
+}
+
+// GetUniqueAttributes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userType string
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUniqueAttributes(ctx interface{}, userType interface{}) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	return &UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call{Call: _e.mock.On("GetUniqueAttributes", ctx, userType)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call) Run(run func(ctx context.Context, userType string)) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call) Return(strings []string, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	_c.Call.Return(strings, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call) RunAndReturn(run func(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(ctx context.Context, schemaID string) (*UserSchema, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, schemaID)

--- a/backend/internal/userschema/model/array.go
+++ b/backend/internal/userschema/model/array.go
@@ -44,6 +44,10 @@ func (p *array) isDisplayable() bool {
 	return false
 }
 
+func (p *array) isUnique() bool {
+	return false
+}
+
 func (p *array) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	arrayValue, ok := value.([]interface{})
 	if !ok {

--- a/backend/internal/userschema/model/boolean.go
+++ b/backend/internal/userschema/model/boolean.go
@@ -43,6 +43,10 @@ func (p *boolean) isDisplayable() bool {
 	return false
 }
 
+func (p *boolean) isUnique() bool {
+	return false
+}
+
 func (p *boolean) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	_, ok := value.(bool)
 	if !ok {

--- a/backend/internal/userschema/model/number.go
+++ b/backend/internal/userschema/model/number.go
@@ -33,6 +33,10 @@ type number struct {
 	enum        map[float64]struct{}
 }
 
+func (p *number) isUnique() bool {
+	return p.unique
+}
+
 func (p *number) isRequired() bool {
 	return p.required
 }

--- a/backend/internal/userschema/model/object.go
+++ b/backend/internal/userschema/model/object.go
@@ -43,6 +43,10 @@ func (p *object) isDisplayable() bool {
 	return false
 }
 
+func (p *object) isUnique() bool {
+	return false
+}
+
 func (p *object) validateValue(value interface{}, path string, logger *log.Logger) (bool, error) {
 	valueMap, ok := value.(map[string]interface{})
 	if !ok {

--- a/backend/internal/userschema/model/schema.go
+++ b/backend/internal/userschema/model/schema.go
@@ -44,6 +44,7 @@ type property interface {
 	isRequired() bool
 	isCredential() bool
 	isDisplayable() bool
+	isUnique() bool
 	validateValue(value interface{}, path string, logger *log.Logger) (bool, error)
 	validateUniqueness(value interface{}, path string,
 		identifyUser func(map[string]interface{}) (*string, error), logger *log.Logger) (bool, error)
@@ -116,6 +117,18 @@ func (cs *Schema) GetCredentialAttributes() []string {
 	var fields []string
 	for name, prop := range cs.properties {
 		if prop.isCredential() {
+			fields = append(fields, name)
+		}
+	}
+
+	return fields
+}
+
+// GetUniqueAttributes returns the names of top-level properties marked as unique.
+func (cs *Schema) GetUniqueAttributes() []string {
+	var fields []string
+	for name, prop := range cs.properties {
+		if prop.isUnique() {
 			fields = append(fields, name)
 		}
 	}

--- a/backend/internal/userschema/model/string.go
+++ b/backend/internal/userschema/model/string.go
@@ -35,6 +35,10 @@ type str struct {
 	pattern     *regexp.Regexp
 }
 
+func (p *str) isUnique() bool {
+	return p.unique
+}
+
 func (p *str) isRequired() bool {
 	return p.required
 }

--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -64,6 +64,9 @@ type UserSchemaServiceInterface interface {
 	GetCredentialAttributes(
 		ctx context.Context, userType string,
 	) ([]string, *serviceerror.ServiceError)
+	GetUniqueAttributes(
+		ctx context.Context, userType string,
+	) ([]string, *serviceerror.ServiceError)
 	GetDisplayAttributesByNames(
 		ctx context.Context, names []string,
 	) (map[string]string, *serviceerror.ServiceError)
@@ -558,6 +561,23 @@ func (us *userSchemaService) GetCredentialAttributes(
 	}
 
 	return compiledSchema.GetCredentialAttributes(), nil
+}
+
+// GetUniqueAttributes returns the names of schema properties marked as unique for a given user type.
+func (us *userSchemaService) GetUniqueAttributes(
+	ctx context.Context, userType string,
+) ([]string, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaLoggerComponentName))
+
+	compiledSchema, err := us.getCompiledSchemaForUserType(ctx, userType, logger)
+	if err != nil {
+		if errors.Is(err, ErrUserSchemaNotFound) {
+			return nil, &ErrorUserSchemaNotFound
+		}
+		return nil, logAndReturnServerError(logger, "Failed to load user schema for unique attributes", err)
+	}
+
+	return compiledSchema.GetUniqueAttributes(), nil
 }
 
 // GetDisplayAttributesByNames returns display attributes for multiple user schemas by name.

--- a/backend/internal/userschema/service_test.go
+++ b/backend/internal/userschema/service_test.go
@@ -869,6 +869,93 @@ func (s *GetCredentialAttributesTestSuite) TestStoreError_ReturnsInternalError()
 	s.Require().Equal(ErrorInternalServerError, *svcErr)
 }
 
+type GetUniqueAttributesTestSuite struct {
+	suite.Suite
+}
+
+func TestGetUniqueAttributesTestSuite(t *testing.T) {
+	suite.Run(t, new(GetUniqueAttributesTestSuite))
+}
+
+func (s *GetUniqueAttributesTestSuite) TestReturnsUniqueFieldNames() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "customer").
+		Return(UserSchema{
+			Schema: json.RawMessage(
+				`{"email":{"type":"string","unique":true},` +
+					`"username":{"type":"string","unique":true},` +
+					`"given_name":{"type":"string"}}`,
+			),
+		}, nil).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	fields, svcErr := service.GetUniqueAttributes(context.Background(), "customer")
+
+	s.Require().Nil(svcErr)
+	sort.Strings(fields)
+	s.Require().Equal([]string{"email", "username"}, fields)
+}
+
+func (s *GetUniqueAttributesTestSuite) TestNoUniqueAttributes_ReturnsEmpty() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "customer").
+		Return(UserSchema{
+			Schema: json.RawMessage(`{"given_name":{"type":"string"},"age":{"type":"number"}}`),
+		}, nil).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	fields, svcErr := service.GetUniqueAttributes(context.Background(), "customer")
+
+	s.Require().Nil(svcErr)
+	s.Require().Empty(fields)
+}
+
+func (s *GetUniqueAttributesTestSuite) TestSchemaNotFound_ReturnsError() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetUserSchemaByName", context.Background(), "unknown").
+		Return(UserSchema{}, ErrUserSchemaNotFound).
+		Once()
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	fields, svcErr := service.GetUniqueAttributes(context.Background(), "unknown")
+
+	s.Require().Nil(fields)
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(ErrorUserSchemaNotFound, *svcErr)
+}
+
+func (s *GetUniqueAttributesTestSuite) TestEmptyUserType_ReturnsError() {
+	storeMock := newUserSchemaStoreInterfaceMock(s.T())
+
+	service := &userSchemaService{
+		userSchemaStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	fields, svcErr := service.GetUniqueAttributes(context.Background(), "")
+
+	s.Require().Nil(fields)
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(ErrorUserSchemaNotFound, *svcErr)
+}
+
 // ----- DeleteUserSchema Tests -----
 
 func TestDeleteUserSchema(t *testing.T) {

--- a/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
@@ -309,6 +309,76 @@ func (_c *UserSchemaServiceInterfaceMock_GetDisplayAttributesByNames_Call) RunAn
 	return _c
 }
 
+// GetUniqueAttributes provides a mock function for the type UserSchemaServiceInterfaceMock
+func (_mock *UserSchemaServiceInterfaceMock) GetUniqueAttributes(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUniqueAttributes")
+	}
+
+	var r0 []string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUniqueAttributes'
+type UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call struct {
+	*mock.Call
+}
+
+// GetUniqueAttributes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userType string
+func (_e *UserSchemaServiceInterfaceMock_Expecter) GetUniqueAttributes(ctx interface{}, userType interface{}) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	return &UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call{Call: _e.mock.On("GetUniqueAttributes", ctx, userType)}
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call) Run(run func(ctx context.Context, userType string)) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call) Return(strings []string, serviceError *serviceerror.ServiceError) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	_c.Call.Return(strings, serviceError)
+	return _c
+}
+
+func (_c *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call) RunAndReturn(run func(ctx context.Context, userType string) ([]string, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_GetUniqueAttributes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserSchema provides a mock function for the type UserSchemaServiceInterfaceMock
 func (_mock *UserSchemaServiceInterfaceMock) GetUserSchema(ctx context.Context, schemaID string) (*userschema.UserSchema, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, schemaID)


### PR DESCRIPTION
This pull request introduces support for retrieving unique attributes from user schemas, enhancing the schema service with a new method and interface contract. The main changes include the addition of the `GetUniqueAttributes` method, updates to the schema property interface and types to support uniqueness checks, and comprehensive unit tests to verify the new functionality.

Enhancements to user schema uniqueness support:

* Added `GetUniqueAttributes` method to the `UserSchemaServiceInterface` and implemented it in `userSchemaService`, allowing retrieval of unique attribute names for a given user type. [[1]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaR67-R69) [[2]](diffhunk://#diff-f76269c20c4a1b476ed025214f934af9bc7cf6a79bed8bbe99a09eb4c506cedaR566-R582)
* Introduced `isUnique()` to the `property` interface and implemented it for all property types (`string`, `number`, `array`, `boolean`, `object`), enabling schema properties to specify uniqueness. [[1]](diffhunk://#diff-f5f09d406cb757c788849aa66806f00db452399b22918c1d6000c5ca69476ef0R47) [[2]](diffhunk://#diff-0de0c8cdc4da84f3dbd952c15fba59f8abb0af0c4b9422fb47d4a8c8fe9acb45R38-R41) [[3]](diffhunk://#diff-4818559bf72a626d7d38f08a819042fa4eee3ea9d6a51eb279e1b59f173c9d33R36-R39) [[4]](diffhunk://#diff-d5461f917076db6e798b20492cf73e9a5d30d66e932523962a230d23f71a7f9fR47-R50) [[5]](diffhunk://#diff-0d72bba972237a85ef9ec9348f0ef2749ceeb2251bc6e873a6de44861ea1645cR46-R49) [[6]](diffhunk://#diff-1c5cfba20aa31e726f71789c0027ac3a224330236f0c83bad03a447e999fa0b3R46-R49)
* Added `GetUniqueAttributes` method to the `Schema` type, which collects and returns the names of unique top-level properties.

Testing and mock updates:

* Implemented a new test suite `GetUniqueAttributesTestSuite` in `service_test.go` to verify correct behavior for schemas with unique properties, schemas without unique properties, missing schemas, and empty user types.
* Updated mocks in both `UserSchemaServiceInterface_mock_test.go` and `UserSchemaServiceInterface_mock.go` to support the new `GetUniqueAttributes` method for testing and integration purposes. [[1]](diffhunk://#diff-a264bec873f31743442f8c69b583dccde043290911601e9a43e6cdebaa140cddR756-R818) [[2]](diffhunk://#diff-a59769f21442894c7970531390081af7a9635bf3243e49ca1ca67575b3b9c300R242-R308)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve unique schema attributes for a given user type.
  * Returns a list of property names marked as unique within a schema.

* **Tests**
  * Added tests covering successful retrieval, no-unique-results, missing schema, and invalid input error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related issue:
https://github.com/asgardeo/thunder/issues/1820