### PR TITLE
Enhance release version handling in workflow with improved input validation

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., v1.0.0). Leave empty to use version.txt'
+        description: 'Release version (e.g., X for v0.X.0, X.Y for v0.X.Y, or X.Y.Z for v0.Y.Z). Leave empty to use version.txt'
         required: false
         type: string
       prerelease:
@@ -33,6 +33,7 @@ permissions:
 
 env:
   GOFLAGS: "-mod=readonly"
+  RELEASE_MAJOR_VERSION: 0
 
 jobs:
   build-thunder:
@@ -51,11 +52,38 @@ jobs:
       - name: 📝 Determine Release Version
         id: get_version
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
-            # Use manually provided version
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            # Manual trigger - always use input values for flags
             PRERELEASE="${{ github.event.inputs.prerelease }}"
             RUN_PERF_TEST="${{ github.event.inputs.run_performance_test }}"
+            INPUT_VERSION="${{ github.event.inputs.version }}"
+            MAJOR="${{ env.RELEASE_MAJOR_VERSION }}"
+
+            if [ -n "$INPUT_VERSION" ]; then
+              # Handle manually provided version
+              if [[ $INPUT_VERSION =~ ^v?[0-9]+\.([0-9]+)\.([0-9]+) ]]; then
+                # Full format (vX.Y.Z) -> Parse and use MAJOR
+                MINOR="${BASH_REMATCH[1]}"
+                PATCH="${BASH_REMATCH[2]}"
+                VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+              elif [[ $INPUT_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+                # minor.patch format (X.Y) -> v0.X.Y
+                VERSION="v${MAJOR}.${INPUT_VERSION}"
+              elif [[ $INPUT_VERSION =~ ^[0-9]+$ ]]; then
+                # minor format (X) -> v0.X.0
+                VERSION="v${MAJOR}.${INPUT_VERSION}.0"
+              else
+                echo "❌ Error: Invalid version format '$INPUT_VERSION'. Use 'X', 'X.Y', or 'vX.Y.Z'"
+                exit 1
+              fi
+            else
+              # Manual run without version - read from version.txt
+              if [ ! -f version.txt ] || [ -z "$(cat version.txt | tr -d '[:space:]')" ]; then
+                echo "❌ Error: version.txt not found or empty"
+                exit 1
+              fi
+              VERSION=$(tr -d '[:space:]' < version.txt)
+            fi
           else
             # Scheduled run or manual run without version - read from version.txt
             if [ ! -f version.txt ] || [ -z "$(cat version.txt | tr -d '[:space:]')" ]; then
@@ -69,7 +97,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
           echo "run_performance_test=$RUN_PERF_TEST" >> $GITHUB_OUTPUT
-          echo "✅ Using version: $VERSION"
+          echo "✅ Using version: $VERSION (Prerelease: $PRERELEASE, Perf Test: $RUN_PERF_TEST)"
 
       - name: ✅ Validate Release Version
         run: |
@@ -415,18 +443,19 @@ jobs:
           # Parse version components (handle both X.Y and X.Y.Z formats)
           if [[ $RELEASE_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             # X.Y.Z format
-            MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="${BASH_REMATCH[3]}"
           elif [[ $RELEASE_VERSION =~ ^([0-9]+)\.([0-9]+) ]]; then
             # X.Y format
-            MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="0"
           else
             echo "❌ Error: Unable to parse version format: $RELEASE_VERSION"
             exit 1
           fi
+          
+          # Use fixed major version
+          MAJOR="${{ env.RELEASE_MAJOR_VERSION }}"
           
           # Bump minor version
           NEXT_MINOR=$((MINOR + 1))


### PR DESCRIPTION
### Purpose
This pull request updates the `release-builder.yml` GitHub Actions workflow to improve how release versions are handled, especially for manual releases. The changes introduce more flexible version input parsing, set a fixed major version via an environment variable, and clarify the workflow's output messaging.

**Release version handling improvements:**

* Enhanced the `version` input description to clarify acceptable formats (X, X.Y, or X.Y.Z), making it easier for users to know how to specify a release version.
* Updated the version determination logic to accept and normalize various input formats (single number, X.Y, or vX.Y.Z), always using a fixed major version (`RELEASE_MAJOR_VERSION`), and added error handling for invalid formats.
* Set a new environment variable `RELEASE_MAJOR_VERSION` (default: 0) to control the major version used in release tags, ensuring consistency across releases.
* Adjusted version parsing and bumping logic to always use the fixed major version, regardless of the input, to prevent accidental major version changes.

**Workflow output improvements:**

* Improved output messaging to include prerelease and performance test flag values, making workflow runs more transparent.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to let manual release input be authoritative and accept multiple version formats (vX.Y.Z, X.Y, X).
  * Added a RELEASE_MAJOR_VERSION setting to fix the major version used in releases and next development version computation.
  * Falls back to version.txt when no input provided; invalid inputs now fail fast.
  * Improved logging to show prerelease and performance-test flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->