### PR TITLE
Use attribute cache for generating tokens and userinfo response

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -244,8 +244,8 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	}
 
 	// Initialize OAuth services.
-	err = oauth.Initialize(mux, applicationService, userService, jwtService, flowExecService, observabilitySvc,
-		pkiService, ouService)
+	err = oauth.Initialize(mux, applicationService, jwtService, flowExecService, observabilitySvc,
+		pkiService, ouService, attributeCacheService)
 	if err != nil {
 		logger.Fatal("Failed to initialize OAuth services", log.Error(err))
 	}

--- a/backend/internal/attributecache/store.go
+++ b/backend/internal/attributecache/store.go
@@ -159,9 +159,14 @@ func (s *attributeCacheStore) buildAttributeCacheFromResultRow(row map[string]in
 		return AttributeCache{}, errors.New("failed to parse id as string")
 	}
 
-	attributesStr, ok := row["attributes"].(string)
-	if !ok {
-		return AttributeCache{}, errors.New("failed to parse attributes as string")
+	var attributesStr string
+	switch v := row["attributes"].(type) {
+	case string:
+		attributesStr = v
+	case []byte:
+		attributesStr = string(v)
+	default:
+		return AttributeCache{}, errors.New("failed to parse attributes: expected string or []byte")
 	}
 
 	var attributes map[string]interface{}

--- a/backend/internal/attributecache/store_test.go
+++ b/backend/internal/attributecache/store_test.go
@@ -142,6 +142,27 @@ func (suite *AttributeCacheStoreTestSuite) TestGetAttributeCache_Success() {
 	assert.Less(suite.T(), result.TTLSeconds, 3700)
 }
 
+func (suite *AttributeCacheStoreTestSuite) TestGetAttributeCache_SuccessWithBytesAttributes() {
+	resultRow := map[string]interface{}{
+		"id":          suite.testCache.ID,
+		"attributes":  []byte(`{"key":"value"}`),
+		"expiry_time": suite.futureTime,
+	}
+
+	suite.mockDBProvider.On("GetRuntimeDBClient").Return(suite.mockDBClient, nil).Once()
+	suite.mockDBClient.On("QueryContext", suite.ctx, queryGetAttributeCache,
+		suite.testCache.ID, suite.testDeploymentID).
+		Return([]map[string]interface{}{resultRow}, nil).Once()
+
+	result, err := suite.store.GetAttributeCache(suite.ctx, suite.testCache.ID)
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), suite.testCache.ID, result.ID)
+	assert.Equal(suite.T(), suite.testCache.Attributes, result.Attributes)
+	assert.Greater(suite.T(), result.TTLSeconds, 3500)
+	assert.Less(suite.T(), result.TTLSeconds, 3700)
+}
+
 func (suite *AttributeCacheStoreTestSuite) TestGetAttributeCache_DBProviderError() {
 	suite.mockDBProvider.On("GetRuntimeDBClient").Return(nil, errors.New("db provider error")).Once()
 
@@ -236,7 +257,7 @@ func (suite *AttributeCacheStoreTestSuite) TestGetAttributeCache_InvalidAttribut
 	result, err := suite.store.GetAttributeCache(suite.ctx, suite.testCache.ID)
 
 	assert.NotNil(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "failed to parse attributes as string")
+	assert.Contains(suite.T(), err.Error(), "failed to parse attributes: expected string or []byte")
 	assert.Equal(suite.T(), AttributeCache{}, result)
 }
 
@@ -375,6 +396,22 @@ func (suite *AttributeCacheStoreTestSuite) TestBuildAttributeCacheFromResultRow_
 	assert.Equal(suite.T(), suite.testCache.ID, result.ID)
 	assert.Equal(suite.T(), suite.testCache.Attributes, result.Attributes)
 	// TTL should be approximately 3600 seconds (allowing for small time differences)
+	assert.Greater(suite.T(), result.TTLSeconds, 3500)
+	assert.Less(suite.T(), result.TTLSeconds, 3700)
+}
+
+func (suite *AttributeCacheStoreTestSuite) TestBuildAttributeCacheFromResultRow_AttributesAsBytes() {
+	resultRow := map[string]interface{}{
+		"id":          suite.testCache.ID,
+		"attributes":  []byte(`{"key":"value"}`),
+		"expiry_time": suite.futureTime,
+	}
+
+	result, err := suite.store.buildAttributeCacheFromResultRow(resultRow)
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), suite.testCache.ID, result.ID)
+	assert.Equal(suite.T(), suite.testCache.Attributes, result.Attributes)
 	assert.Greater(suite.T(), result.TTLSeconds, 3500)
 	assert.Less(suite.T(), result.TTLSeconds, 3700)
 }

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -172,6 +172,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 	}
 
 	if ttlSecondsStr, exists := ctx.RuntimeData[common.RuntimeKeyUserAttributesCacheTTLSeconds]; exists {
+		// We are not in an App Native flow, so we need to cache the user attributes
 		if len(resolvedAttributes) > 0 {
 			ttlSeconds, err := strconv.Atoi(ttlSecondsStr)
 			if err != nil {
@@ -191,34 +192,12 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 					log.String("error", creationErr.ErrorDescription.DefaultValue))
 				return "", errors.New("failed to create attribute cache")
 			}
-			jwtClaims["attribute_cache_id"] = result.ID
+			jwtClaims["aci"] = result.ID
 		}
 	} else {
+		// We are in an App Native flow, so we need to add user attributes to the assertion
 		for attrKey, attrVal := range resolvedAttributes {
 			jwtClaims[attrKey] = attrVal
-		}
-	}
-
-	// Handle groups if configured in user attributes
-	if slices.Contains(requiredAttributes, oauth2const.UserAttributeGroups) && ctx.AuthenticatedUser.UserID != "" {
-		if err := a.appendGroupsToClaims(ctx.AuthenticatedUser.UserID, jwtClaims); err != nil {
-			return "", err
-		}
-	}
-
-	// Add user type to the claims
-	if slices.Contains(requiredAttributes, oauth2const.ClaimUserType) && ctx.AuthenticatedUser.UserType != "" {
-		jwtClaims[oauth2const.ClaimUserType] = ctx.AuthenticatedUser.UserType
-	}
-
-	// Add OU details to the claims
-	ouAttributesConfigured := slices.Contains(requiredAttributes, oauth2const.ClaimOUID) ||
-		slices.Contains(requiredAttributes, oauth2const.ClaimOUName) ||
-		slices.Contains(requiredAttributes, oauth2const.ClaimOUHandle)
-	if ouAttributesConfigured && ctx.AuthenticatedUser.OUID != "" {
-		if err := a.appendOUDetailsToClaims(
-			ctx.Context, ctx.AuthenticatedUser.OUID, jwtClaims, requiredAttributes); err != nil {
-			return "", err
 		}
 	}
 
@@ -390,6 +369,29 @@ func (a *authAssertExecutor) resolveUserAttributes(ctx *core.NodeContext, reques
 				attributes[attr] = val
 				continue
 			}
+		}
+	}
+
+	// Handle groups if configured in user attributes
+	if slices.Contains(requestedAttributes, oauth2const.UserAttributeGroups) && ctx.AuthenticatedUser.UserID != "" {
+		if err := a.appendGroupsToClaims(ctx.AuthenticatedUser.UserID, attributes); err != nil {
+			return nil, err
+		}
+	}
+
+	// Add user type to the claims
+	if slices.Contains(requestedAttributes, oauth2const.ClaimUserType) && ctx.AuthenticatedUser.UserType != "" {
+		attributes[oauth2const.ClaimUserType] = ctx.AuthenticatedUser.UserType
+	}
+
+	// Add OU details to the claims
+	ouAttributesConfigured := slices.Contains(requestedAttributes, oauth2const.ClaimOUID) ||
+		slices.Contains(requestedAttributes, oauth2const.ClaimOUName) ||
+		slices.Contains(requestedAttributes, oauth2const.ClaimOUHandle)
+	if ouAttributesConfigured && ctx.AuthenticatedUser.OUID != "" {
+		if err := a.appendOUDetailsToClaims(
+			ctx.Context, ctx.AuthenticatedUser.OUID, attributes, requestedAttributes); err != nil {
+			return nil, err
 		}
 	}
 

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	authnassert "github.com/asgardeo/thunder/internal/authn/assert"
 	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/authnprovider"
@@ -50,6 +51,7 @@ import (
 const (
 	testEmail      = "test@example.com"
 	testNameValue  = "Test"
+	testAuthOUID   = "ou-123"
 	testAssertOUID = "ou-789"
 )
 
@@ -126,7 +128,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
-			OUID:            "ou-123",
+			OUID:            testAuthOUID,
 			UserType:        "INTERNAL",
 		},
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{
@@ -154,8 +156,8 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return("jwt-token", int64(3600), nil)
 
-	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-123").
-		Return(ou.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAuthOUID).
+		Return(ou.OrganizationUnit{ID: testAuthOUID}, nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -689,7 +691,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendOUDetailsToClaimsFai
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
-			OUID:            "ou-123",
+			OUID:            testAuthOUID,
 		},
 		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
 		Application: appmodel.Application{
@@ -699,7 +701,7 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendOUDetailsToClaimsFai
 		},
 	}
 
-	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-123").
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAuthOUID).
 		Return(ou.OrganizationUnit{}, &serviceerror.ServiceError{
 			Error:            "ou_not_found",
 			ErrorDescription: "organization unit not found",
@@ -1298,6 +1300,524 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithoutConsentedAttributes
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+// ----- Execute with Attribute Cache TTL in RuntimeData -----
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_AttrsStoredInCacheNotJWT() {
+	attrs := map[string]interface{}{"email": testEmail, "phone": "1234567890"}
+	attrsJSON, _ := json.Marshal(attrs)
+
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		AppID:   "app-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserAttributesCacheTTLSeconds: "300",
+		},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Application: appmodel.Application{
+			Assertion: &appmodel.AssertionConfig{
+				UserAttributes: []string{"email", "phone"},
+			},
+		},
+	}
+
+	existingUser := &userprovider.User{
+		UserID:     "user-123",
+		Attributes: attrsJSON,
+	}
+
+	suite.mockUserProvider.On("GetUser", "user-123").Return(existingUser, nil)
+	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything,
+		mock.MatchedBy(func(cache *attributecache.AttributeCache) bool {
+			return cache.TTLSeconds == 300 &&
+				cache.Attributes["email"] == testEmail &&
+				cache.Attributes["phone"] == "1234567890"
+		})).Return(&attributecache.AttributeCache{ID: "cache-abc"}, nil)
+	// In the OAuth cache path, only aci goes into the JWT; individual attrs go to cache.
+	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasEmail := claims["email"]
+			_, hasPhone := claims["phone"]
+			return claims["aci"] == "cache-abc" && !hasEmail && !hasPhone
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	suite.mockUserProvider.AssertExpectations(suite.T())
+	suite.mockAttributeCacheSvc.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilUserAttributes_NoAttrsCopied() {
+	// Use runtime essential attributes so resolvedAttributes is non-empty and cache is created,
+	// but Assertion.UserAttributes is nil so no individual attrs should be copied to JWT.
+	attrs := map[string]interface{}{"email": testEmail}
+	attrsJSON, _ := json.Marshal(attrs)
+
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		AppID:   "app-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserAttributesCacheTTLSeconds: "300",
+			common.RuntimeKeyRequiredEssentialAttributes:   "email",
+		},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Application: appmodel.Application{
+			Assertion: &appmodel.AssertionConfig{
+				UserAttributes: nil,
+			},
+		},
+	}
+
+	existingUser := &userprovider.User{
+		UserID:     "user-123",
+		Attributes: attrsJSON,
+	}
+
+	suite.mockUserProvider.On("GetUser", "user-123").Return(existingUser, nil)
+	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything, mock.Anything).
+		Return(&attributecache.AttributeCache{ID: "cache-xyz"}, nil)
+	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			// aci present, but no individual attribute claims
+			_, hasEmail := claims["email"]
+			return claims["aci"] == "cache-xyz" && !hasEmail
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	suite.mockAttributeCacheSvc.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OnlyResolvedAttrsStoredInCache() {
+	// resolved attributes only contain "email"; "phone" is configured but not found in user store
+	attrs := map[string]interface{}{"email": testEmail}
+	attrsJSON, _ := json.Marshal(attrs)
+
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		AppID:   "app-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserAttributesCacheTTLSeconds: "600",
+		},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Application: appmodel.Application{
+			Assertion: &appmodel.AssertionConfig{
+				UserAttributes: []string{"email", "phone"},
+			},
+		},
+	}
+
+	existingUser := &userprovider.User{
+		UserID:     "user-123",
+		Attributes: attrsJSON,
+	}
+
+	suite.mockUserProvider.On("GetUser", "user-123").Return(existingUser, nil)
+	// Cache should only contain resolved attrs (email, not phone)
+	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything,
+		mock.MatchedBy(func(cache *attributecache.AttributeCache) bool {
+			_, hasPhone := cache.Attributes["phone"]
+			return cache.Attributes["email"] == testEmail && !hasPhone
+		})).Return(&attributecache.AttributeCache{ID: "cache-def"}, nil)
+	// JWT should only contain aci, not individual attrs
+	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasEmail := claims["email"]
+			_, hasPhone := claims["phone"]
+			return claims["aci"] == "cache-def" && !hasEmail && !hasPhone
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	suite.mockAttributeCacheSvc.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilAssertion_NoAttrsCopied() {
+	// Use runtime essential attributes so resolvedAttributes is non-empty and cache is created,
+	// but Assertion is nil so no individual attrs should be copied to JWT.
+	attrs := map[string]interface{}{"email": testEmail}
+	attrsJSON, _ := json.Marshal(attrs)
+
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		AppID:   "app-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserAttributesCacheTTLSeconds: "300",
+			common.RuntimeKeyRequiredEssentialAttributes:   "email",
+		},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Application: appmodel.Application{
+			Assertion: nil,
+		},
+	}
+
+	existingUser := &userprovider.User{
+		UserID:     "user-123",
+		Attributes: attrsJSON,
+	}
+
+	suite.mockUserProvider.On("GetUser", "user-123").Return(existingUser, nil)
+	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything, mock.Anything).
+		Return(&attributecache.AttributeCache{ID: "cache-nil"}, nil)
+	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasEmail := claims["email"]
+			return claims["aci"] == "cache-nil" && !hasEmail
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	suite.mockAttributeCacheSvc.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// ----- resolveUserAttributes: groups, userType, OU handling -----
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID: "user-123",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	userGroups := &userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{
+			{Name: "admin"},
+			{Name: "developer"},
+		},
+	}
+
+	suite.mockUserProvider.On("GetUserGroups", "user-123", oauth2const.DefaultGroupListLimit, 0).
+		Return(userGroups, nil)
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, []string{oauth2const.UserAttributeGroups})
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), attrs)
+	groups, ok := attrs[oauth2const.UserAttributeGroups].([]string)
+	assert.True(suite.T(), ok)
+	assert.Equal(suite.T(), []string{"admin", "developer"}, groups)
+	suite.mockUserProvider.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups_FetchError() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID: "user-123",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	suite.mockUserProvider.On("GetUserGroups", "user-123", oauth2const.DefaultGroupListLimit, 0).
+		Return(nil, &userprovider.UserProviderError{Message: "groups_fetch_failed", Description: "database error"})
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, []string{oauth2const.UserAttributeGroups})
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), attrs)
+	assert.Contains(suite.T(), err.Error(), "something went wrong while fetching user groups")
+	suite.mockUserProvider.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups_EmptyUserID_GroupsSkipped() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID: "",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, []string{oauth2const.UserAttributeGroups})
+
+	assert.NoError(suite.T(), err)
+	// Groups attribute should not be present when UserID is empty
+	_, hasGroups := attrs[oauth2const.UserAttributeGroups]
+	assert.False(suite.T(), hasGroups)
+	suite.mockUserProvider.AssertNotCalled(suite.T(), "GetUserGroups")
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithUserType() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID:   "user-123",
+			UserType: "INTERNAL",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, []string{oauth2const.ClaimUserType})
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), attrs)
+	assert.Equal(suite.T(), "INTERNAL", attrs[oauth2const.ClaimUserType])
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithEmptyUserType_NotAdded() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID:   "user-123",
+			UserType: "",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, []string{oauth2const.ClaimUserType})
+
+	assert.NoError(suite.T(), err)
+	_, hasUserType := attrs[oauth2const.ClaimUserType]
+	assert.False(suite.T(), hasUserType)
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetails() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID: "user-123",
+			OUID:   testAuthOUID,
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAuthOUID).
+		Return(ou.OrganizationUnit{ID: testAuthOUID, Name: "Engineering", Handle: "eng"}, nil)
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx,
+		[]string{oauth2const.ClaimOUID, oauth2const.ClaimOUName, oauth2const.ClaimOUHandle})
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), attrs)
+	assert.Equal(suite.T(), testAuthOUID, attrs[oauth2const.ClaimOUID])
+	assert.Equal(suite.T(), "Engineering", attrs[oauth2const.ClaimOUName])
+	assert.Equal(suite.T(), "eng", attrs[oauth2const.ClaimOUHandle])
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetails_FetchError() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID: "user-123",
+			OUID:   "ou-invalid",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-invalid").
+		Return(ou.OrganizationUnit{}, &serviceerror.ServiceError{
+			Error:            "ou_not_found",
+			ErrorDescription: "organization unit not found",
+		})
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, []string{oauth2const.ClaimOUID})
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), attrs)
+	assert.Contains(suite.T(), err.Error(), "something went wrong while fetching organization unit")
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetails_EmptyOUID_OUDetailsSkipped() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			UserID: "user-123",
+			OUID:   "",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, []string{oauth2const.ClaimOUID})
+
+	assert.NoError(suite.T(), err)
+	_, hasOUID := attrs[oauth2const.ClaimOUID]
+	assert.False(suite.T(), hasOUID)
+	suite.mockOUService.AssertNotCalled(suite.T(), "GetOrganizationUnit")
+}
+
+// ----- Execute with Attribute Cache: groups/userType/OU now go into cache -----
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_GroupsIncludedInCache() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		AppID:   "app-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserAttributesCacheTTLSeconds: "300",
+		},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Application: appmodel.Application{
+			Assertion: &appmodel.AssertionConfig{
+				UserAttributes: []string{oauth2const.UserAttributeGroups},
+			},
+		},
+	}
+
+	userGroups := &userprovider.UserGroupListResponse{
+		Groups: []userprovider.UserGroup{
+			{Name: "admin"},
+			{Name: "developer"},
+		},
+	}
+
+	suite.mockUserProvider.On("GetUserGroups", "user-123", oauth2const.DefaultGroupListLimit, 0).
+		Return(userGroups, nil)
+	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything,
+		mock.MatchedBy(func(cache *attributecache.AttributeCache) bool {
+			groups, ok := cache.Attributes[oauth2const.UserAttributeGroups].([]string)
+			return ok && len(groups) == 2
+		})).Return(&attributecache.AttributeCache{ID: "cache-groups"}, nil)
+	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasGroups := claims[oauth2const.UserAttributeGroups]
+			return claims["aci"] == "cache-groups" && !hasGroups
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	suite.mockUserProvider.AssertExpectations(suite.T())
+	suite.mockAttributeCacheSvc.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_UserTypeIncludedInCache() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		AppID:   "app-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-123",
+			UserType:        "EXTERNAL",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserAttributesCacheTTLSeconds: "300",
+		},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Application: appmodel.Application{
+			Assertion: &appmodel.AssertionConfig{
+				UserAttributes: []string{oauth2const.ClaimUserType},
+			},
+		},
+	}
+
+	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything,
+		mock.MatchedBy(func(cache *attributecache.AttributeCache) bool {
+			return cache.Attributes[oauth2const.ClaimUserType] == "EXTERNAL"
+		})).Return(&attributecache.AttributeCache{ID: "cache-usertype"}, nil)
+	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasUserType := claims[oauth2const.ClaimUserType]
+			return claims["aci"] == "cache-usertype" && !hasUserType
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	suite.mockAttributeCacheSvc.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OUDetailsIncludedInCache() {
+	ctx := &core.NodeContext{
+		FlowID:  "flow-123",
+		AppID:   "app-123",
+		Context: context.Background(),
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-123",
+			OUID:            testAuthOUID,
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserAttributesCacheTTLSeconds: "300",
+		},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Application: appmodel.Application{
+			Assertion: &appmodel.AssertionConfig{
+				UserAttributes: []string{oauth2const.ClaimOUID, oauth2const.ClaimOUName},
+			},
+		},
+	}
+
+	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, testAuthOUID).
+		Return(ou.OrganizationUnit{ID: testAuthOUID, Name: "Engineering"}, nil)
+	suite.mockAttributeCacheSvc.On("CreateAttributeCache", mock.Anything,
+		mock.MatchedBy(func(cache *attributecache.AttributeCache) bool {
+			return cache.Attributes[oauth2const.ClaimOUID] == testAuthOUID &&
+				cache.Attributes[oauth2const.ClaimOUName] == "Engineering"
+		})).Return(&attributecache.AttributeCache{ID: "cache-ou"}, nil)
+	suite.mockJWTService.On("GenerateJWT", "user-123", "app-123", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasOUID := claims[oauth2const.ClaimOUID]
+			return claims["aci"] == "cache-ou" && !hasOUID
+		}), mock.Anything).Return("jwt-token", int64(3600), nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	suite.mockOUService.AssertExpectations(suite.T())
+	suite.mockAttributeCacheSvc.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithRuntimeRequiredEssentialAndOptionalAttributes() {

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/application"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
 	"github.com/asgardeo/thunder/internal/oauth/jwks"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/dcr"
@@ -38,19 +39,18 @@ import (
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/observability"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 // Initialize initializes all OAuth-related services and registers their routes.
 func Initialize(
 	mux *http.ServeMux,
 	applicationService application.ApplicationServiceInterface,
-	userService user.UserServiceInterface,
 	jwtService jwt.JWTServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 	observabilitySvc observability.ObservabilityServiceInterface,
 	pkiService pki.PKIServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
+	attributeCacheSvc attributecache.AttributeCacheServiceInterface,
 ) error {
 	// Fetch runtime transactioner for OAuth services.
 	transactioner, err := provider.GetDBProvider().GetRuntimeDBTransactioner()
@@ -61,7 +61,8 @@ func Initialize(
 	jwks.Initialize(mux, pkiService)
 	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService)
 	grantHandlerProvider, err := granthandlers.Initialize(
-		mux, jwtService, userService, applicationService, flowExecService, tokenBuilder, tokenValidator)
+		mux, jwtService, applicationService, flowExecService, tokenBuilder, tokenValidator,
+		attributeCacheSvc)
 	if err != nil {
 		return err
 	}
@@ -70,9 +71,8 @@ func Initialize(
 	token.Initialize(mux, jwtService, applicationService, grantHandlerProvider,
 		scopeValidator, observabilitySvc, discoveryService, transactioner)
 	introspect.Initialize(mux, jwtService, applicationService, discoveryService)
-	userinfo.Initialize(
-		mux, jwtService, tokenValidator, applicationService, userService, ouService, transactioner,
-	)
+	userinfo.Initialize(mux, jwtService, tokenValidator, applicationService, ouService, attributeCacheSvc,
+		transactioner)
 	dcr.Initialize(mux, applicationService, transactioner)
 	return nil
 }

--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -44,7 +44,7 @@ const (
 	jsonDataKeyCodeChallenge       = "code_challenge"
 	jsonDataKeyCodeChallengeMethod = "code_challenge_method"
 	jsonDataKeyResource            = "resource"
-	jsonDataKeyUserAttributes      = "user_attributes"
+	jsonDataKeyAttributeCacheID    = "attribute_cache_id"
 	jsonDataKeyClaimsRequest       = "claims_request"
 	jsonDataKeyClaimsLocales       = "claims_locales"
 	jsonDataKeyNonce               = "nonce"
@@ -147,8 +147,8 @@ func (acs *authorizationCodeStore) getJSONDataBytes(authzCode AuthorizationCode)
 	}
 
 	// Include user attributes if present
-	if len(authzCode.UserAttributes) > 0 {
-		jsonData[jsonDataKeyUserAttributes] = authzCode.UserAttributes
+	if len(authzCode.AttributeCacheID) > 0 {
+		jsonData[jsonDataKeyAttributeCacheID] = authzCode.AttributeCacheID
 	}
 
 	// Include claims request if present
@@ -261,9 +261,8 @@ func appendAuthzDataJSON(row map[string]interface{}, authzCode *AuthorizationCod
 	if nonce, ok := authzData[jsonDataKeyNonce].(string); ok {
 		authzCode.Nonce = nonce
 	}
-
-	if userAttrs, ok := authzData[jsonDataKeyUserAttributes].(map[string]interface{}); ok && userAttrs != nil {
-		authzCode.UserAttributes = userAttrs
+	if attributeCacheID, ok := authzData[jsonDataKeyAttributeCacheID].(string); ok {
+		authzCode.AttributeCacheID = attributeCacheID
 	}
 
 	if claimsData, ok := authzData[jsonDataKeyClaimsRequest]; ok && claimsData != nil {

--- a/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store_test.go
@@ -149,12 +149,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_Success()
 		"code_challenge":        "abc123",
 		"code_challenge_method": "s256",
 		"resource":              "",
-		"user_attributes": map[string]interface{}{
-			"userType": "person",
-			"ouId":     "550e8400-e29b-41d4-a716-446655440000",
-			"ouName":   "Default OU",
-			"ouHandle": "default",
-		},
+		"attribute_cache_id":    "test-cache-id",
 	}
 	authzDataJSON, _ := json.Marshal(authzData)
 
@@ -181,11 +176,7 @@ func (suite *AuthorizationCodeStoreTestSuite) TestGetAuthorizationCode_Success()
 	assert.Equal(suite.T(), "test-user-id", result.AuthorizedUserID)
 	assert.Equal(suite.T(), "abc123", result.CodeChallenge)
 	assert.Equal(suite.T(), "s256", result.CodeChallengeMethod)
-	assert.NotNil(suite.T(), result.UserAttributes)
-	assert.Equal(suite.T(), "person", result.UserAttributes["userType"])
-	assert.Equal(suite.T(), "550e8400-e29b-41d4-a716-446655440000", result.UserAttributes["ouId"])
-	assert.Equal(suite.T(), "Default OU", result.UserAttributes["ouName"])
-	assert.Equal(suite.T(), "default", result.UserAttributes["ouHandle"])
+	assert.Equal(suite.T(), "test-cache-id", result.AttributeCacheID)
 	assert.NotZero(suite.T(), result.TimeCreated)
 	assert.NotZero(suite.T(), result.ExpiryTime)
 	assert.Equal(suite.T(), "read write", result.Scopes)

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -621,14 +621,7 @@ func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_Succes
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "test-user", clms.userID)
-	assert.Equal(suite.T(), "local", clms.userAttributes["userType"])
-	assert.Equal(suite.T(), "ou123", clms.userAttributes["ouId"])
-	assert.Equal(suite.T(), "Organization", clms.userAttributes["ouName"])
-	assert.Equal(suite.T(), "org-handle", clms.userAttributes["ouHandle"])
-	assert.Equal(suite.T(), "testuser", clms.userAttributes["username"])
-	assert.Equal(suite.T(), "test@example.com", clms.userAttributes["email"])
-	assert.Equal(suite.T(), "Test", clms.userAttributes["given_name"])
-	assert.Equal(suite.T(), "User", clms.userAttributes["family_name"])
+	assert.Equal(suite.T(), "", clms.attributeCacheID)
 	assert.Equal(suite.T(), "read write", clms.authorizedPermissions)
 }
 
@@ -664,10 +657,6 @@ func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_NonStr
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "test-user", clms.userID)
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["username"])
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["email"])
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["given_name"])
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["family_name"])
 	// Non-string authorized_permissions is ignored
 	assert.Equal(suite.T(), "", clms.authorizedPermissions)
 }
@@ -680,7 +669,6 @@ func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_UserTy
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "test-user", clms.userID)
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["userType"])
 }
 
 func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_OUClaimsInUserAttributes() {
@@ -692,9 +680,30 @@ func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_OUClai
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "test-user", clms.userID)
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["ouId"])
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["ouName"])
-	assert.Equal(suite.T(), float64(12345), clms.userAttributes["ouHandle"])
+}
+
+func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_WithAttributeCacheID() {
+	// JWT payload: {"sub":"test-user","aci":"cache-abc-123","authorized_permissions":"read write"}
+	jwtToken := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJhY2kiOiJjYWNoZS1hYmMtMTIzIiwiYXV0aG9yaXplZF9wZXJtaXNzaW9ucyI6InJlYWQgd3JpdGUifQ."
+
+	clms, _, err := decodeAttributesFromAssertion(jwtToken)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "test-user", clms.userID)
+	assert.Equal(suite.T(), "cache-abc-123", clms.attributeCacheID)
+	assert.Equal(suite.T(), "read write", clms.authorizedPermissions)
+}
+
+func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_NonStringAttributeCacheID() {
+	// JWT payload: {"sub":"test-user","aci":12345}
+	jwtToken := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJhY2kiOjEyMzQ1fQ."
+
+	_, _, err := decodeAttributesFromAssertion(jwtToken)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "JWT 'aci' claim is not a string")
 }
 
 func (suite *AuthorizeHandlerTestSuite) TestValidateSubClaimConstraint() {

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -39,7 +39,7 @@ type AuthorizationCode struct {
 	ClientID            string
 	RedirectURI         string
 	AuthorizedUserID    string
-	UserAttributes      map[string]interface{}
+	AttributeCacheID    string
 	TimeCreated         time.Time
 	ExpiryTime          time.Time
 	Scopes              string
@@ -81,5 +81,5 @@ type AuthorizationError struct {
 type assertionClaims struct {
 	userID                string
 	authorizedPermissions string
-	userAttributes        map[string]interface{}
+	attributeCacheID      string
 }

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -34,6 +34,7 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
 	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	oauth2model "github.com/asgardeo/thunder/internal/oauth/oauth2/model"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	oauth2utils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/database/transaction"
@@ -245,10 +246,11 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 
 	// Initiate flow with OAuth context.
 	runtimeData := map[string]string{
-		flowcm.RuntimeKeyRequestedPermissions:        utils.StringifyStringArray(nonOidcScopes, " "),
-		flowcm.RuntimeKeyRequiredEssentialAttributes: essentialAttributes,
-		flowcm.RuntimeKeyRequiredOptionalAttributes:  optionalAttributes,
-		flowcm.RuntimeKeyRequiredLocales:             claimsLocales,
+		flowcm.RuntimeKeyRequestedPermissions:          utils.StringifyStringArray(nonOidcScopes, " "),
+		flowcm.RuntimeKeyRequiredEssentialAttributes:   essentialAttributes,
+		flowcm.RuntimeKeyRequiredOptionalAttributes:    optionalAttributes,
+		flowcm.RuntimeKeyRequiredLocales:               claimsLocales,
+		flowcm.RuntimeKeyUserAttributesCacheTTLSeconds: fmt.Sprintf("%d", resolveUserAttributesCacheTTL(app)),
 	}
 	flowInitCtx := &flowexec.FlowInitContext{
 		ApplicationID: app.AppID,
@@ -509,9 +511,7 @@ func (as *authorizeService) verifyAssertion(assertion string) error {
 
 // decodeAttributesFromAssertion decodes user attributes from the flow assertion JWT.
 func decodeAttributesFromAssertion(assertion string) (assertionClaims, time.Time, error) {
-	claims := assertionClaims{
-		userAttributes: make(map[string]interface{}),
-	}
+	claims := assertionClaims{}
 
 	_, jwtPayload, err := jwt.DecodeJWT(assertion)
 	if err != nil {
@@ -533,14 +533,6 @@ func decodeAttributesFromAssertion(assertion string) (assertionClaims, time.Time
 		}
 	}
 
-	// Standard JWT claims that should not be treated as user attributes.
-	standardClaims := map[string]bool{
-		"iss": true, "sub": true, "aud": true, "exp": true, "nbf": true, "iat": true, "jti": true,
-		"assurance":              true,
-		"authorized_permissions": true,
-	}
-
-	userAttributes := make(map[string]interface{})
 	for key, value := range jwtPayload {
 		// Extract sub claim.
 		if key == oauth2const.ClaimSub {
@@ -560,15 +552,15 @@ func decodeAttributesFromAssertion(assertion string) (assertionClaims, time.Time
 			continue
 		}
 
-		// Skip standard JWT claims.
-		if standardClaims[key] {
+		if key == "aci" {
+			strValue, ok := value.(string)
+			if !ok {
+				return claims, time.Time{}, errors.New("JWT 'aci' claim is not a string")
+			}
+			claims.attributeCacheID = strValue
 			continue
 		}
-
-		// All other claims are treated as user attributes.
-		userAttributes[key] = value
 	}
-	claims.userAttributes = userAttributes
 
 	return claims, authTime, nil
 }
@@ -621,7 +613,7 @@ func createAuthorizationCode(
 		ClientID:            clientID,
 		RedirectURI:         redirectURI,
 		AuthorizedUserID:    claims.userID,
-		UserAttributes:      claims.userAttributes,
+		AttributeCacheID:    claims.attributeCacheID,
 		TimeCreated:         authTime,
 		ExpiryTime:          expiryTime,
 		Scopes:              utils.StringifyStringArray(allScopes, " "),
@@ -829,4 +821,22 @@ func validateSubClaimConstraint(claimsRequest *oauth2model.ClaimsRequest, actual
 	}
 
 	return nil
+}
+
+// resolveUserAttributesCacheTTL determines the TTL for caching user attributes based on the
+// token validity configuration. The largest of the access and refresh token (if allowed) validity
+// periods is taken as the base, then the authorization code validity period is added to cover
+// the window between code issuance and token exchange.
+// A fixed buffer of attributeCacheTTLBufferSeconds is added to cover the window between
+// authentication completion and token issuance.
+func resolveUserAttributesCacheTTL(app *appmodel.OAuthAppConfigProcessedDTO) int64 {
+	maxTTL := tokenservice.ResolveTokenConfig(app, tokenservice.TokenTypeAccess).ValidityPeriod
+	if app.IsAllowedGrantType(oauth2const.GrantTypeRefreshToken) {
+		refreshTTL := tokenservice.ResolveTokenConfig(app, tokenservice.TokenTypeRefresh).ValidityPeriod
+		if refreshTTL > maxTTL {
+			maxTTL = refreshTTL
+		}
+	}
+	authCodeTTL := config.GetThunderRuntime().Config.OAuth.AuthorizationCode.ValidityPeriod
+	return maxTTL + authCodeTTL + oauth2const.AttributeCacheTTLBufferSeconds
 }

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -1498,6 +1498,145 @@ func (suite *AuthorizeServiceTestSuite) TestResolveScopeAttributes_UnknownScope(
 	assert.Nil(suite.T(), result)
 }
 
+func (suite *AuthorizeServiceTestSuite) TestResolveAttrCacheTTL_RefreshAllowed_UsesMaxOfRefreshAndAccessValidity() {
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("test", &config.Config{
+		JWT: config.JWTConfig{ValidityPeriod: 900},
+		OAuth: config.OAuthConfig{
+			RefreshToken:      config.RefreshTokenConfig{ValidityPeriod: 7200},
+			AuthorizationCode: config.AuthorizationCodeConfig{ValidityPeriod: 600},
+		},
+	})
+
+	app := &appmodel.OAuthAppConfigProcessedDTO{
+		GrantTypes: []oauth2const.GrantType{
+			oauth2const.GrantTypeAuthorizationCode,
+			oauth2const.GrantTypeRefreshToken,
+		},
+		Token: &appmodel.OAuthTokenConfig{
+			AccessToken: &appmodel.AccessTokenConfig{ValidityPeriod: 3600},
+		},
+	}
+
+	// Refresh token validity (7200) > access token validity (3600) → max(7200) + authCode(600) + buffer(60) = 7860.
+	assert.Equal(suite.T(), int64(7860), resolveUserAttributesCacheTTL(app))
+}
+
+func (suite *AuthorizeServiceTestSuite) TestResolveAttrCacheTTL_RefreshTokenAllowed_UsesAccessTokenWhenLonger() {
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("test", &config.Config{
+		JWT: config.JWTConfig{ValidityPeriod: 900},
+		OAuth: config.OAuthConfig{
+			RefreshToken:      config.RefreshTokenConfig{ValidityPeriod: 1800},
+			AuthorizationCode: config.AuthorizationCodeConfig{ValidityPeriod: 600},
+		},
+	})
+
+	app := &appmodel.OAuthAppConfigProcessedDTO{
+		GrantTypes: []oauth2const.GrantType{
+			oauth2const.GrantTypeAuthorizationCode,
+			oauth2const.GrantTypeRefreshToken,
+		},
+		Token: &appmodel.OAuthTokenConfig{
+			AccessToken: &appmodel.AccessTokenConfig{ValidityPeriod: 7200},
+		},
+	}
+
+	// Access token validity (7200) > refresh token validity (1800) → max(7200) + authCode(600) + buffer(60) = 7860.
+	assert.Equal(suite.T(), int64(7860), resolveUserAttributesCacheTTL(app))
+}
+
+func (suite *AuthorizeServiceTestSuite) TestResolveUserAttributesCacheTTL_RefreshTokenAllowed_FallsBackToGlobalJWT() {
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("test", &config.Config{
+		JWT: config.JWTConfig{ValidityPeriod: 900},
+		OAuth: config.OAuthConfig{
+			// RefreshToken.ValidityPeriod is 0 → ResolveTokenConfig falls back to global JWT validity.
+			RefreshToken:      config.RefreshTokenConfig{ValidityPeriod: 0},
+			AuthorizationCode: config.AuthorizationCodeConfig{ValidityPeriod: 600},
+		},
+	})
+
+	app := &appmodel.OAuthAppConfigProcessedDTO{
+		GrantTypes: []oauth2const.GrantType{
+			oauth2const.GrantTypeAuthorizationCode,
+			oauth2const.GrantTypeRefreshToken,
+		},
+	}
+
+	// JWT fallback (900) + authCode(600) + buffer(60) = 1560.
+	assert.Equal(suite.T(), int64(1560), resolveUserAttributesCacheTTL(app))
+}
+
+func (suite *AuthorizeServiceTestSuite) TestResolveAttrCacheTTL_RefreshTokenNotAllowed_UsesAccessTokenValidity() {
+	app := &appmodel.OAuthAppConfigProcessedDTO{
+		GrantTypes: []oauth2const.GrantType{oauth2const.GrantTypeAuthorizationCode},
+		Token: &appmodel.OAuthTokenConfig{
+			AccessToken: &appmodel.AccessTokenConfig{ValidityPeriod: 3600},
+		},
+	}
+
+	// Access token validity (3600) + authCode(600) + buffer(60) = 4260.
+	assert.Equal(suite.T(), int64(4260), resolveUserAttributesCacheTTL(app))
+}
+
+func (suite *AuthorizeServiceTestSuite) TestResolveAttrCacheTTL_NoRefreshToken_ZeroAccessTTL_FallsBackToGlobalJWT() {
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("test", &config.Config{
+		JWT: config.JWTConfig{ValidityPeriod: 900},
+		OAuth: config.OAuthConfig{
+			AuthorizationCode: config.AuthorizationCodeConfig{ValidityPeriod: 600},
+		},
+	})
+
+	app := &appmodel.OAuthAppConfigProcessedDTO{
+		GrantTypes: []oauth2const.GrantType{oauth2const.GrantTypeAuthorizationCode},
+		Token: &appmodel.OAuthTokenConfig{
+			// ValidityPeriod 0 is treated as unset by ResolveTokenConfig → falls back to global JWT validity.
+			AccessToken: &appmodel.AccessTokenConfig{ValidityPeriod: 0},
+		},
+	}
+
+	// JWT fallback (900) + authCode(600) + buffer(60) = 1560.
+	assert.Equal(suite.T(), int64(1560), resolveUserAttributesCacheTTL(app))
+}
+
+func (suite *AuthorizeServiceTestSuite) TestResolveAttrCacheTTL_NoRefreshToken_NilToken_FallsBackToGlobalJWT() {
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("test", &config.Config{
+		JWT: config.JWTConfig{ValidityPeriod: 900},
+		OAuth: config.OAuthConfig{
+			AuthorizationCode: config.AuthorizationCodeConfig{ValidityPeriod: 600},
+		},
+	})
+
+	app := &appmodel.OAuthAppConfigProcessedDTO{
+		GrantTypes: []oauth2const.GrantType{oauth2const.GrantTypeAuthorizationCode},
+		Token:      nil,
+	}
+
+	// JWT fallback (900) + authCode(600) + buffer(60) = 1560.
+	assert.Equal(suite.T(), int64(1560), resolveUserAttributesCacheTTL(app))
+}
+
+func (suite *AuthorizeServiceTestSuite) TestResolveAttrCacheTTL_NoRefreshToken_NilAccessToken_FallsBackToGlobalJWT() {
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("test", &config.Config{
+		JWT: config.JWTConfig{ValidityPeriod: 900},
+		OAuth: config.OAuthConfig{
+			AuthorizationCode: config.AuthorizationCodeConfig{ValidityPeriod: 600},
+		},
+	})
+
+	app := &appmodel.OAuthAppConfigProcessedDTO{
+		GrantTypes: []oauth2const.GrantType{oauth2const.GrantTypeAuthorizationCode},
+		Token:      &appmodel.OAuthTokenConfig{AccessToken: nil},
+	}
+
+	// JWT fallback (900) + authCode(600) + buffer(60) = 1560.
+	assert.Equal(suite.T(), int64(1560), resolveUserAttributesCacheTTL(app))
+}
+
 // determineClaimsForTokens is a test helper retained to keep existing token-claim tests readable.
 // It mirrors the token-specific split (access_token / id_token / userinfo) on top of current helper functions.
 func determineClaimsForTokens(oidcScopes []string, claimsRequest *oauth2model.ClaimsRequest,

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -339,6 +339,12 @@ const (
 	SupportedClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 )
 
+const (
+	// AttributeCacheTTLBufferSeconds is a fixed buffer added to attribute cache TTL values to
+	// account for the gap between cache entry creation (end of authentication) and token issuance.
+	AttributeCacheTTLBufferSeconds = 60
+)
+
 // GetSupportedResponseTypes returns all supported OAuth2 response types.
 func GetSupportedResponseTypes() []string {
 	result := make([]string, len(supportedResponseTypes))

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/authz"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
@@ -32,26 +33,25 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 // authorizationCodeGrantHandler handles the authorization code grant type.
 type authorizationCodeGrantHandler struct {
-	authzService authz.AuthorizeServiceInterface
-	userService  user.UserServiceInterface
-	tokenBuilder tokenservice.TokenBuilderInterface
+	authzService   authz.AuthorizeServiceInterface
+	tokenBuilder   tokenservice.TokenBuilderInterface
+	attributeCache attributecache.AttributeCacheServiceInterface
 }
 
 // newAuthorizationCodeGrantHandler creates a new instance of AuthorizationCodeGrantHandler.
 func newAuthorizationCodeGrantHandler(
-	userService user.UserServiceInterface,
 	authzService authz.AuthorizeServiceInterface,
 	tokenBuilder tokenservice.TokenBuilderInterface,
+	attributeCache attributecache.AttributeCacheServiceInterface,
 ) GrantHandlerInterface {
 	return &authorizationCodeGrantHandler{
-		authzService: authzService,
-		userService:  userService,
-		tokenBuilder: tokenBuilder,
+		authzService:   authzService,
+		tokenBuilder:   tokenBuilder,
+		attributeCache: attributeCache,
 	}
 }
 
@@ -127,25 +127,34 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	// Parse authorized scopes
 	authorizedScopes := tokenservice.ParseScopes(authCode.Scopes)
 
-	// Use user attributes from the authorization code
-	attrs := authCode.UserAttributes
-	if attrs == nil {
-		attrs = make(map[string]interface{})
+	// Get user attributes from attribute cache
+	attrs := make(map[string]interface{})
+	if authCode.AttributeCacheID != "" {
+		userAttributes, err := h.attributeCache.GetAttributeCache(ctx, authCode.AttributeCacheID)
+		if err != nil {
+			logger.Error("Failed to get user attributes from attribute cache. " + err.ErrorDescription.DefaultValue)
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorServerError,
+				ErrorDescription: "Failed to get user attributes from attribute cache",
+			}
+		}
+		attrs = userAttributes.Attributes
 	}
 
 	audience := tokenservice.DetermineAudience("", authCode.Resource, "", authCode.ClientID)
 
 	// Generate access token using tokenBuilder (attributes will be filtered in BuildAccessToken)
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
-		Subject:        authCode.AuthorizedUserID,
-		Audience:       audience,
-		ClientID:       tokenRequest.ClientID,
-		Scopes:         authorizedScopes,
-		UserAttributes: attrs,
-		GrantType:      string(constants.GrantTypeAuthorizationCode),
-		OAuthApp:       oauthApp,
-		ClaimsRequest:  authCode.ClaimsRequest,
-		ClaimsLocales:  authCode.ClaimsLocales,
+		Subject:          authCode.AuthorizedUserID,
+		Audience:         audience,
+		ClientID:         tokenRequest.ClientID,
+		Scopes:           authorizedScopes,
+		UserAttributes:   attrs,
+		AttributeCacheID: authCode.AttributeCacheID,
+		GrantType:        string(constants.GrantTypeAuthorizationCode),
+		OAuthApp:         oauthApp,
+		ClaimsRequest:    authCode.ClaimsRequest,
+		ClaimsLocales:    authCode.ClaimsLocales,
 	})
 	if err != nil {
 		return nil, &model.ErrorResponse{

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -29,16 +29,18 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/authz"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/system/config"
-	"github.com/asgardeo/thunder/internal/user"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/i18n/core"
+	"github.com/asgardeo/thunder/tests/mocks/attributecachemock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/authzmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
-	usersvcmock "github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
 const (
@@ -46,6 +48,7 @@ const (
 	testCodeChallenge           = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 	testCodeChallengeMethodS256 = "S256"
 	testClientCallbackURL       = "https://client.example.com/callback"
+	testCacheID                 = "test-cache-id"
 )
 
 // convertToStringSlice converts groups from various formats to []string for testing.
@@ -71,14 +74,14 @@ func convertToStringSlice(groups interface{}) []string {
 
 type AuthorizationCodeGrantHandlerTestSuite struct {
 	suite.Suite
-	handler          *authorizationCodeGrantHandler
-	mockJWTService   *jwtmock.JWTServiceInterfaceMock
-	mockTokenBuilder *tokenservicemock.TokenBuilderInterfaceMock
-	mockAuthzService *authzmock.AuthorizeServiceInterfaceMock
-	mockUserService  *usersvcmock.UserServiceInterfaceMock
-	oauthApp         *appmodel.OAuthAppConfigProcessedDTO
-	testAuthzCode    authz.AuthorizationCode
-	testTokenReq     *model.TokenRequest
+	handler              *authorizationCodeGrantHandler
+	mockJWTService       *jwtmock.JWTServiceInterfaceMock
+	mockTokenBuilder     *tokenservicemock.TokenBuilderInterfaceMock
+	mockAuthzService     *authzmock.AuthorizeServiceInterfaceMock
+	mockAttrCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
+	oauthApp             *appmodel.OAuthAppConfigProcessedDTO
+	testAuthzCode        authz.AuthorizationCode
+	testTokenReq         *model.TokenRequest
 }
 
 func TestAuthorizationCodeGrantHandlerSuite(t *testing.T) {
@@ -97,12 +100,12 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockAuthzService = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
-	suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
+	suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
 	suite.handler = &authorizationCodeGrantHandler{
-		tokenBuilder: suite.mockTokenBuilder,
-		authzService: suite.mockAuthzService,
-		userService:  suite.mockUserService,
+		tokenBuilder:   suite.mockTokenBuilder,
+		authzService:   suite.mockAuthzService,
+		attributeCache: suite.mockAttrCacheService,
 	}
 
 	suite.oauthApp = &appmodel.OAuthAppConfigProcessedDTO{
@@ -132,20 +135,17 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) SetupTest() {
 		ClientID:         testClientID,
 		RedirectURI:      "https://client.example.com/callback",
 		AuthorizedUserID: testUserID,
-		UserAttributes: map[string]interface{}{
-			"email":    "test@example.com",
-			"username": "testuser",
-		},
-		TimeCreated: time.Now().Add(-5 * time.Minute),
-		ExpiryTime:  time.Now().Add(5 * time.Minute),
-		Scopes:      "read write",
-		State:       authz.AuthCodeStateActive,
+		AttributeCacheID: "",
+		TimeCreated:      time.Now().Add(-5 * time.Minute),
+		ExpiryTime:       time.Now().Add(5 * time.Minute),
+		Scopes:           "read write",
+		State:            authz.AuthCodeStateActive,
 	}
 }
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestNewAuthorizationCodeGrantHandler() {
-	handler := newAuthorizationCodeGrantHandler(suite.mockUserService,
-		suite.mockAuthzService, suite.mockTokenBuilder)
+	handler := newAuthorizationCodeGrantHandler(
+		suite.mockAuthzService, suite.mockTokenBuilder, suite.mockAttrCacheService)
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }
@@ -434,7 +434,6 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 		includeOpenIDScope   bool
 		scopeClaimsForGroups bool
 		expectedGroups       []string
-		mockGroups           []user.UserGroup
 		description          string
 	}{
 		{
@@ -444,10 +443,6 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 			includeOpenIDScope:   false,
 			scopeClaimsForGroups: false,
 			expectedGroups:       []string{"Admin", "Users"},
-			mockGroups: []user.UserGroup{
-				{ID: "group1", Name: "Admin"},
-				{ID: "group2", Name: "Users"},
-			},
 			description: "Should include groups in access token when configured (IDToken config " +
 				"present but openid scope not requested)",
 		},
@@ -458,11 +453,8 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 			includeOpenIDScope:   true,
 			scopeClaimsForGroups: true,
 			expectedGroups:       []string{"Admin", "Users"},
-			mockGroups: []user.UserGroup{
-				{ID: "group1", Name: "Admin"},
-				{ID: "group2", Name: "Users"},
-			},
-			description: "Should include groups in both tokens when configured with openid scope and scope claims",
+			description: "Should include groups in both tokens when configured with openid scope and scope" +
+				"claims",
 		},
 	}
 
@@ -470,13 +462,13 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 		suite.Run(tc.name, func() {
 			// Reset mocks for each test case
 			suite.mockAuthzService = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
-			suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
 			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 			suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
+			suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 			suite.handler = &authorizationCodeGrantHandler{
-				tokenBuilder: suite.mockTokenBuilder,
-				authzService: suite.mockAuthzService,
-				userService:  suite.mockUserService,
+				tokenBuilder:   suite.mockTokenBuilder,
+				authzService:   suite.mockAuthzService,
+				attributeCache: suite.mockAttrCacheService,
 			}
 
 			accessTokenAttrs := []string{"email", "username"}
@@ -522,18 +514,20 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 				authzCode.Scopes = oidcReadWriteScopes
 			}
 
-			// Add user attributes to authz code (including groups from assertion)
-			userGroups := make([]string, 0, len(tc.mockGroups))
-			for _, group := range tc.mockGroups {
-				userGroups = append(userGroups, group.Name)
-			}
-			authzCode.UserAttributes = map[string]interface{}{
+			// Add user attributes to authz code via attribute cache
+			authzCode.AttributeCacheID = testCacheID
+			expectedAttrs := map[string]interface{}{
 				"email":    "test@example.com",
 				"username": "testuser",
 			}
-			if len(userGroups) > 0 {
-				authzCode.UserAttributes[constants.UserAttributeGroups] = userGroups
+			if len(tc.expectedGroups) > 0 {
+				expectedAttrs[constants.UserAttributeGroups] = tc.expectedGroups
 			}
+			suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+				Return(&attributecache.AttributeCache{
+					ID:         testCacheID,
+					Attributes: expectedAttrs,
+				}, (*serviceerror.I18nServiceError)(nil)).Once()
 
 			suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 				Return(&authzCode, nil)
@@ -626,7 +620,6 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 			}
 
 			suite.mockAuthzService.AssertExpectations(suite.T())
-			suite.mockUserService.AssertExpectations(suite.T())
 			suite.mockTokenBuilder.AssertExpectations(suite.T())
 		})
 	}
@@ -662,13 +655,13 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			suite.mockAuthzService = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
-			suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
 			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 			suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
+			suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 			suite.handler = &authorizationCodeGrantHandler{
-				tokenBuilder: suite.mockTokenBuilder,
-				authzService: suite.mockAuthzService,
-				userService:  suite.mockUserService,
+				tokenBuilder:   suite.mockTokenBuilder,
+				authzService:   suite.mockAuthzService,
+				attributeCache: suite.mockAttrCacheService,
 			}
 
 			accessTokenAttrs := []string{"email", "username"}
@@ -713,12 +706,17 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 				authzCode.Scopes = oidcReadWriteScopes
 			}
 
-			// Add user attributes to authz code (groups will be empty array or not present)
-			authzCode.UserAttributes = map[string]interface{}{
-				"email":    "test@example.com",
-				"username": "testuser",
-			}
-			// Empty groups - not added to UserAttributes (user has no groups)
+			// Add user attributes to authz code via attribute cache (groups will be empty/not present)
+			authzCode.AttributeCacheID = testCacheID
+			suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+				Return(&attributecache.AttributeCache{
+					ID: testCacheID,
+					Attributes: map[string]interface{}{
+						"email":    "test@example.com",
+						"username": "testuser",
+					},
+				}, (*serviceerror.I18nServiceError)(nil)).Once()
+			// Empty groups - not added to Attributes (user has no groups)
 
 			suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 				Return(&authzCode, nil)
@@ -791,7 +789,6 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 			}
 
 			suite.mockAuthzService.AssertExpectations(suite.T())
-			suite.mockUserService.AssertExpectations(suite.T())
 			suite.mockTokenBuilder.AssertExpectations(suite.T())
 		})
 	}
@@ -917,7 +914,6 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_IDTokenGene
 	assert.Equal(suite.T(), "Failed to generate token", err.ErrorDescription)
 
 	suite.mockAuthzService.AssertExpectations(suite.T())
-	suite.mockUserService.AssertExpectations(suite.T())
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
 }
 
@@ -969,13 +965,18 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_FetchUserGr
 		},
 	}
 
-	// Add groups to auth code (from assertion)
+	// Add groups to auth code via attribute cache (from assertion)
 	authzCodeWithGroups := suite.testAuthzCode
-	authzCodeWithGroups.UserAttributes = map[string]interface{}{
-		"email":    "test@example.com",
-		"username": "testuser",
-		"groups":   []string{"Admin", "Users"},
-	}
+	authzCodeWithGroups.AttributeCacheID = testCacheID
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return(&attributecache.AttributeCache{
+			ID: testCacheID,
+			Attributes: map[string]interface{}{
+				"email":    "test@example.com",
+				"username": "testuser",
+				"groups":   []string{"Admin", "Users"},
+			},
+		}, (*serviceerror.I18nServiceError)(nil))
 
 	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 		Return(&authzCodeWithGroups, nil)
@@ -1009,8 +1010,26 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_FetchUserGr
 
 	suite.mockAuthzService.AssertExpectations(suite.T())
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
-	// Verify GetUserGroups was NOT called
-	suite.mockUserService.AssertNotCalled(suite.T(), "GetUserGroups")
+}
+
+func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_AttributeCacheFetchError() {
+	authzCodeWithCacheID := suite.testAuthzCode
+	authzCodeWithCacheID.AttributeCacheID = testCacheID
+
+	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
+		Return(&authzCodeWithCacheID, nil)
+
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return((*attributecache.AttributeCache)(nil), &serviceerror.I18nServiceError{
+			Type:  serviceerror.ServerErrorType,
+			Error: core.I18nMessage{DefaultValue: "cache error"},
+		})
+
+	result, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
 }
 
 // createPKCEApp creates a test OAuth app with PKCE required
@@ -1104,7 +1123,6 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestRetrieveAndValidateAuth
 	assert.NotNil(suite.T(), result)
 
 	suite.mockAuthzService.AssertExpectations(suite.T())
-	suite.mockUserService.AssertExpectations(suite.T())
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
 }
 

--- a/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
+++ b/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
@@ -48,5 +48,6 @@ type RefreshTokenGrantHandlerInterface interface {
 		scopes []string,
 		claimsRequest *model.ClaimsRequest,
 		claimsLocales string,
+		attributeCacheID string,
 	) *model.ErrorResponse
 }

--- a/backend/internal/oauth/oauth2/granthandlers/init.go
+++ b/backend/internal/oauth/oauth2/granthandlers/init.go
@@ -22,28 +22,28 @@ import (
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/application"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/authz"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 // Initialize initializes the grant handler provider with the given services.
 func Initialize(
 	mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface,
-	userService user.UserServiceInterface,
 	applicationService application.ApplicationServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
+	attrCacheService attributecache.AttributeCacheServiceInterface,
 ) (GrantHandlerProviderInterface, error) {
 	authzService, err := authz.Initialize(mux, applicationService, jwtService, flowExecService)
 	if err != nil {
 		return nil, err
 	}
 	grantHandlerProvider := newGrantHandlerProvider(
-		jwtService, userService, authzService, tokenBuilder, tokenValidator)
+		jwtService, authzService, tokenBuilder, tokenValidator, attrCacheService)
 	return grantHandlerProvider, nil
 }

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -19,11 +19,11 @@
 package granthandlers
 
 import (
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/authz"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 // GrantHandlerProviderInterface defines the interface for the grant handler provider.
@@ -42,17 +42,17 @@ type GrantHandlerProvider struct {
 // newGrantHandlerProvider creates a new instance of GrantHandlerProvider.
 func newGrantHandlerProvider(
 	jwtService jwt.JWTServiceInterface,
-	userService user.UserServiceInterface,
 	authzService authz.AuthorizeServiceInterface,
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
+	attrCacheService attributecache.AttributeCacheServiceInterface,
 ) GrantHandlerProviderInterface {
 	return &GrantHandlerProvider{
 		clientCredentialsGrantHandler: newClientCredentialsGrantHandler(tokenBuilder),
 		authorizationCodeGrantHandler: newAuthorizationCodeGrantHandler(
-			userService, authzService, tokenBuilder),
+			authzService, tokenBuilder, attrCacheService),
 		refreshTokenGrantHandler: newRefreshTokenGrantHandler(
-			jwtService, userService, tokenBuilder, tokenValidator),
+			jwtService, tokenBuilder, tokenValidator, attrCacheService),
 		tokenExchangeGrantHandler: newTokenExchangeGrantHandler(tokenBuilder, tokenValidator),
 	}
 }

--- a/backend/internal/oauth/oauth2/granthandlers/provider_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider_test.go
@@ -25,20 +25,20 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	"github.com/asgardeo/thunder/tests/mocks/attributecachemock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/authzmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
-	usersvcmock "github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
 type GrantHandlerProviderTestSuite struct {
 	suite.Suite
-	provider           GrantHandlerProviderInterface
-	mockJWTService     *jwtmock.JWTServiceInterfaceMock
-	mockUserService    *usersvcmock.UserServiceInterfaceMock
-	authzService       *authzmock.AuthorizeServiceInterfaceMock
-	mockTokenBuilder   *tokenservicemock.TokenBuilderInterfaceMock
-	mockTokenValidator *tokenservicemock.TokenValidatorInterfaceMock
+	provider             GrantHandlerProviderInterface
+	mockJWTService       *jwtmock.JWTServiceInterfaceMock
+	authzService         *authzmock.AuthorizeServiceInterfaceMock
+	mockTokenBuilder     *tokenservicemock.TokenBuilderInterfaceMock
+	mockTokenValidator   *tokenservicemock.TokenValidatorInterfaceMock
+	mockAttrCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
 }
 
 func TestGrantHandlerProviderSuite(t *testing.T) {
@@ -47,26 +47,26 @@ func TestGrantHandlerProviderSuite(t *testing.T) {
 
 func (suite *GrantHandlerProviderTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
-	suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
 	suite.authzService = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
+	suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 	suite.provider = newGrantHandlerProvider(
 		suite.mockJWTService,
-		suite.mockUserService,
 		suite.authzService,
 		suite.mockTokenBuilder,
 		suite.mockTokenValidator,
+		suite.mockAttrCacheService,
 	)
 }
 
 func (suite *GrantHandlerProviderTestSuite) TestNewGrantHandlerProvider() {
 	provider := newGrantHandlerProvider(
 		suite.mockJWTService,
-		suite.mockUserService,
 		suite.authzService,
 		suite.mockTokenBuilder,
 		suite.mockTokenValidator,
+		suite.mockAttrCacheService,
 	)
 	assert.NotNil(suite.T(), provider)
 	assert.Implements(suite.T(), (*GrantHandlerProviderInterface)(nil), provider)

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -20,39 +20,41 @@ package granthandlers
 
 import (
 	"slices"
+	"time"
 
 	"context"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 // refreshTokenGrantHandler handles the refresh token grant type.
 type refreshTokenGrantHandler struct {
-	jwtService     jwt.JWTServiceInterface
-	userService    user.UserServiceInterface
-	tokenBuilder   tokenservice.TokenBuilderInterface
-	tokenValidator tokenservice.TokenValidatorInterface
+	jwtService       jwt.JWTServiceInterface
+	tokenBuilder     tokenservice.TokenBuilderInterface
+	tokenValidator   tokenservice.TokenValidatorInterface
+	attrCacheService attributecache.AttributeCacheServiceInterface
 }
 
 // newRefreshTokenGrantHandler creates a new instance of RefreshTokenGrantHandler.
 func newRefreshTokenGrantHandler(
 	jwtService jwt.JWTServiceInterface,
-	userService user.UserServiceInterface,
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
+	attrCacheService attributecache.AttributeCacheServiceInterface,
 ) RefreshTokenGrantHandlerInterface {
 	return &refreshTokenGrantHandler{
-		jwtService:     jwtService,
-		userService:    userService,
-		tokenBuilder:   tokenBuilder,
-		tokenValidator: tokenValidator,
+		jwtService:       jwtService,
+		tokenBuilder:     tokenBuilder,
+		tokenValidator:   tokenValidator,
+		attrCacheService: attrCacheService,
 	}
 }
 
@@ -102,16 +104,43 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 		return nil, scopeErr
 	}
 
+	// Get user attributes from attribute cache.
+	// cacheEntry is kept so its current TTLSeconds can be compared later.
+	attrs := make(map[string]interface{})
+	var cacheEntry *attributecache.AttributeCache
+	var fetchErr *serviceerror.I18nServiceError
+	if refreshTokenClaims.AttributeCacheID != "" {
+		cacheEntry, fetchErr = h.attrCacheService.GetAttributeCache(ctx, refreshTokenClaims.AttributeCacheID)
+		if fetchErr != nil {
+			logger.Error("Failed to get user attributes from attribute cache",
+				log.String("error", fetchErr.ErrorDescription.DefaultValue))
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorServerError,
+				ErrorDescription: "Failed to get user attributes from attribute cache",
+			}
+		}
+		if cacheEntry == nil {
+			logger.Error("Attribute cache entry not found for cache ID",
+				log.String("cache_id", refreshTokenClaims.AttributeCacheID))
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorServerError,
+				ErrorDescription: "Failed to get user attributes from attribute cache",
+			}
+		}
+		attrs = cacheEntry.Attributes
+	}
+
 	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
-		Subject:        refreshTokenClaims.Sub,
-		Audience:       refreshTokenClaims.Aud,
-		ClientID:       tokenRequest.ClientID,
-		Scopes:         newTokenScopes,
-		UserAttributes: refreshTokenClaims.UserAttributes,
-		GrantType:      refreshTokenClaims.GrantType,
-		OAuthApp:       oauthApp,
-		ClaimsRequest:  refreshTokenClaims.ClaimsRequest,
-		ClaimsLocales:  refreshTokenClaims.ClaimsLocales,
+		Subject:          refreshTokenClaims.Sub,
+		Audience:         refreshTokenClaims.Aud,
+		ClientID:         tokenRequest.ClientID,
+		Scopes:           newTokenScopes,
+		UserAttributes:   attrs,
+		AttributeCacheID: refreshTokenClaims.AttributeCacheID,
+		GrantType:        refreshTokenClaims.GrantType,
+		OAuthApp:         oauthApp,
+		ClaimsRequest:    refreshTokenClaims.ClaimsRequest,
+		ClaimsLocales:    refreshTokenClaims.ClaimsLocales,
 	})
 	if err != nil {
 		logger.Error("Failed to generate access token", log.Error(err))
@@ -132,7 +161,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 			Subject:        refreshTokenClaims.Sub,
 			Audience:       tokenRequest.ClientID,
 			Scopes:         newTokenScopes,
-			UserAttributes: refreshTokenClaims.UserAttributes,
+			UserAttributes: attrs,
 			OAuthApp:       oauthApp,
 			ClaimsRequest:  refreshTokenClaims.ClaimsRequest,
 		})
@@ -150,24 +179,28 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	conf := config.GetThunderRuntime().Config
 	renewRefreshToken := conf.OAuth.RefreshToken.RenewOnGrant
 
-	// Issue a new refresh token if renew_on_grant is enabled
+	// Issue a new refresh token if renew_on_grant is enabled; otherwise reuse the existing one.
 	if renewRefreshToken {
 		logger.Debug("Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
 		errResp := h.IssueRefreshToken(ctx, tokenResponse, oauthApp, refreshTokenClaims.Sub, refreshTokenClaims.Aud,
 			refreshTokenClaims.GrantType, newTokenScopes, refreshTokenClaims.ClaimsRequest,
-			refreshTokenClaims.ClaimsLocales)
+			refreshTokenClaims.ClaimsLocales, refreshTokenClaims.AttributeCacheID)
 		if errResp != nil && errResp.Error != "" {
 			logger.Error("Failed to issue refresh token", log.String("error", errResp.Error))
 			return nil, errResp
 		}
 	} else {
-		// Return the existing refresh token
 		tokenResponse.RefreshToken = model.TokenDTO{
 			Token:    tokenRequest.RefreshToken,
 			IssuedAt: refreshTokenClaims.Iat,
 			Scopes:   refreshTokenClaims.Scopes,
 			ClientID: tokenRequest.ClientID,
 		}
+	}
+
+	if errResp := h.extendCacheTTL(ctx, cacheEntry, oauthApp, refreshTokenClaims.Iat,
+		accessToken.ExpiresIn, renewRefreshToken, refreshTokenClaims.AttributeCacheID, logger); errResp != nil {
+		return nil, errResp
 	}
 
 	return tokenResponse, nil
@@ -182,17 +215,18 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	scopes []string,
 	claimsRequest *model.ClaimsRequest,
 	claimsLocales string,
+	attributeCacheID string,
 ) *model.ErrorResponse {
 	tokenCtx := &tokenservice.RefreshTokenBuildContext{
-		ClientID:             oauthApp.ClientID,
-		Scopes:               scopes,
-		GrantType:            grantType,
-		AccessTokenSubject:   subject,
-		AccessTokenAudience:  audience,
-		AccessTokenUserAttrs: tokenResponse.AccessToken.UserAttributes,
-		OAuthApp:             oauthApp,
-		ClaimsRequest:        claimsRequest,
-		ClaimsLocales:        claimsLocales,
+		ClientID:            oauthApp.ClientID,
+		Scopes:              scopes,
+		GrantType:           grantType,
+		AccessTokenSubject:  subject,
+		AccessTokenAudience: audience,
+		AttributeCacheID:    attributeCacheID,
+		OAuthApp:            oauthApp,
+		ClaimsRequest:       claimsRequest,
+		ClaimsLocales:       claimsLocales,
 	}
 
 	// Build refresh token using token builder
@@ -208,6 +242,51 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 		tokenResponse = &model.TokenResponseDTO{}
 	}
 	tokenResponse.RefreshToken = *refreshToken
+	return nil
+}
+
+// extendCacheTTL extends the attribute cache TTL when the desired lifetime exceeds what is already
+// stored. The desired TTL is the larger of:
+//   - the refresh token's actual expiry (iat + validity; for a renewed token, iat = now)
+//   - the newly issued access token's expiry (now + ExpiresIn)
+//
+// This ensures the cache outlives whichever token lives longest without needlessly
+// re-writing an already-sufficient entry.
+func (h *refreshTokenGrantHandler) extendCacheTTL(
+	ctx context.Context,
+	cacheEntry *attributecache.AttributeCache,
+	oauthApp *appmodel.OAuthAppConfigProcessedDTO,
+	refreshIat, accessExpiresIn int64,
+	renewRefreshToken bool,
+	cacheID string,
+	logger *log.Logger,
+) *model.ErrorResponse {
+	if cacheEntry == nil {
+		return nil
+	}
+	now := time.Now().Unix()
+	refreshValidity := tokenservice.ResolveTokenConfig(oauthApp, tokenservice.TokenTypeRefresh).ValidityPeriod
+	if renewRefreshToken {
+		refreshIat = now // newly issued token starts from now
+	}
+	refreshExpiry := refreshIat + refreshValidity
+	accessExpiry := now + accessExpiresIn
+	maxExpiry := refreshExpiry
+	if accessExpiry > maxExpiry {
+		maxExpiry = accessExpiry
+	}
+	desiredTTL := int(maxExpiry-now) + constants.AttributeCacheTTLBufferSeconds
+	if desiredTTL > cacheEntry.TTLSeconds {
+		if extErr := h.attrCacheService.ExtendAttributeCacheTTL(ctx, cacheID, desiredTTL); extErr != nil {
+			logger.Error("Failed to extend attribute cache TTL",
+				log.String("cache_id", cacheID),
+				log.String("error", extErr.Error.String()))
+			return &model.ErrorResponse{
+				Error:            constants.ErrorServerError,
+				ErrorDescription: "Failed to extend attribute cache TTL",
+			}
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -29,14 +29,17 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/i18n/core"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/tests/mocks/attributecachemock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
-	usersvcmock "github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
 // testUserID and testAudience are declared in tokenexchange_test.go
@@ -46,15 +49,15 @@ const testRefreshTokenClientID = "test-client-id"
 
 type RefreshTokenGrantHandlerTestSuite struct {
 	suite.Suite
-	handler            *refreshTokenGrantHandler
-	mockJWTService     *jwtmock.JWTServiceInterfaceMock
-	mockUserService    *usersvcmock.UserServiceInterfaceMock
-	mockTokenBuilder   *tokenservicemock.TokenBuilderInterfaceMock
-	mockTokenValidator *tokenservicemock.TokenValidatorInterfaceMock
-	oauthApp           *appmodel.OAuthAppConfigProcessedDTO
-	validRefreshToken  string
-	validClaims        map[string]interface{}
-	testTokenReq       *model.TokenRequest
+	handler              *refreshTokenGrantHandler
+	mockJWTService       *jwtmock.JWTServiceInterfaceMock
+	mockTokenBuilder     *tokenservicemock.TokenBuilderInterfaceMock
+	mockTokenValidator   *tokenservicemock.TokenValidatorInterfaceMock
+	mockAttrCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
+	oauthApp             *appmodel.OAuthAppConfigProcessedDTO
+	validRefreshToken    string
+	validClaims          map[string]interface{}
+	testTokenReq         *model.TokenRequest
 }
 
 func TestRefreshTokenGrantHandlerSuite(t *testing.T) {
@@ -80,15 +83,15 @@ func (suite *RefreshTokenGrantHandlerTestSuite) SetupTest() {
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
-	suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
+	suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
 	suite.handler = &refreshTokenGrantHandler{
-		jwtService:     suite.mockJWTService,
-		userService:    suite.mockUserService,
-		tokenBuilder:   suite.mockTokenBuilder,
-		tokenValidator: suite.mockTokenValidator,
+		jwtService:       suite.mockJWTService,
+		tokenBuilder:     suite.mockTokenBuilder,
+		tokenValidator:   suite.mockTokenValidator,
+		attrCacheService: suite.mockAttrCacheService,
 	}
 
 	suite.oauthApp = &appmodel.OAuthAppConfigProcessedDTO{
@@ -130,9 +133,9 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TearDownTest() {
 func (suite *RefreshTokenGrantHandlerTestSuite) TestNewRefreshTokenGrantHandler() {
 	handler := newRefreshTokenGrantHandler(
 		suite.mockJWTService,
-		suite.mockUserService,
 		suite.mockTokenBuilder,
 		suite.mockTokenValidator,
+		suite.mockAttrCacheService,
 	)
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*RefreshTokenGrantHandlerInterface)(nil), handler)
@@ -214,7 +217,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() 
 
 	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp,
 		testRefreshTokenUserID, testRefreshTokenAudience,
-		"authorization_code", []string{"read", "write"}, nil, "")
+		"authorization_code", []string{"read", "write"}, nil, "", "")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), tokenResponse.RefreshToken)
@@ -234,7 +237,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_JWTGenerat
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp, "", "",
-		"authorization_code", []string{"read"}, nil, "")
+		"authorization_code", []string{"read"}, nil, "", "")
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
@@ -254,7 +257,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyT
 	tokenResponse := &model.TokenResponseDTO{}
 
 	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp, "", "",
-		"authorization_code", []string{"read"}, nil, "")
+		"authorization_code", []string{"read"}, nil, "", "")
 
 	assert.Nil(suite.T(), err)
 }
@@ -279,7 +282,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithClaims
 
 	err := suite.handler.IssueRefreshToken(context.Background(), tokenResponse, suite.oauthApp,
 		testRefreshTokenUserID, testRefreshTokenAudience,
-		"authorization_code", []string{"read"}, nil, "en-US fr-CA ja")
+		"authorization_code", []string{"read"}, nil, "en-US fr-CA ja", "")
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), tokenResponse.RefreshToken)
@@ -290,12 +293,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	// Mock successful refresh token validation
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"read", "write"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{"email": "test@example.com"},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock successful access token generation
@@ -327,12 +330,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	// Mock successful refresh token validation
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"read", "write"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{"email": "test@example.com"},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock successful access token generation
@@ -364,16 +367,46 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	assert.Equal(suite.T(), "new.refresh.token", response.RefreshToken.Token)
 }
 
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_GetAttributeCacheError() {
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: testCacheID,
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	cacheErr := &serviceerror.I18nServiceError{
+		Type: serviceerror.ServerErrorType,
+		Code: "ACS-2001",
+		Error: core.I18nMessage{
+			Key:          "error.attributecache.internal_server_error",
+			DefaultValue: "Internal server error",
+		},
+	}
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return((*attributecache.AttributeCache)(nil), cacheErr).Once()
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+	assert.Equal(suite.T(), "Failed to get user attributes from attribute cache", err.ErrorDescription)
+}
+
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_BuildAccessTokenError() {
 	// Mock successful refresh token validation
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"read"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock failed access token generation
@@ -395,12 +428,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IssueRefreshToke
 	// Mock successful refresh token validation
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"read"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock successful access token generation
@@ -489,12 +522,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerated
 	// Mock successful refresh token validation with openid scope
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"openid", "read"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{"email": "test@example.com"},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"openid", "read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock successful access token generation
@@ -542,12 +575,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoIDToken_WhenOp
 	// Mock successful refresh token validation without openid scope
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"read", "write"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{"email": "test@example.com"},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock successful access token generation
@@ -576,12 +609,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGeneratio
 	// Mock successful refresh token validation with openid scope
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"openid", "read"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"openid", "read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock successful access token generation
@@ -611,6 +644,360 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGeneratio
 	assert.Equal(suite.T(), "Failed to generate token", err.ErrorDescription)
 }
 
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_ReusesExistingRefreshToken() {
+	// RenewOnGrant is false by default in SetupTest.
+	// iat = now-3600, refreshValidity = 86400 → refresh remaining ≈ 82800 s.
+	// Access token ExpiresIn is 0 (< 82800), so the cache is extended to the refresh
+	// token's remaining lifetime (~82800 s).
+
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: testCacheID,
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
+			(*serviceerror.I18nServiceError)(nil)).Once()
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+		Token:    "new.access.token",
+		IssuedAt: time.Now().Unix(),
+		Scopes:   []string{"read"},
+	}, nil)
+
+	// TTL ≈ 82800 + buffer(60) = 82860; allow ±2 s for execution time between test setup and handler call.
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID,
+		mock.MatchedBy(func(ttl int) bool { return ttl >= 82858 && ttl <= 82862 })).
+		Return((*serviceerror.I18nServiceError)(nil))
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	assert.Equal(suite.T(), suite.validRefreshToken, response.RefreshToken.Token)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ExtendsCache_WhenAccessTokenOutlivesRefreshToken() {
+	// iat = now-83000, refreshValidity = 86400 → refresh remaining = 3400 s.
+	// Access token ExpiresIn = 7200 > 3400, so the cache must be extended to 7200 s.
+
+	now := time.Now().Unix()
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: testCacheID,
+			Iat:              now - 83000,
+		}, nil)
+
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
+			(*serviceerror.I18nServiceError)(nil)).Once()
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	// Access token expiry (now+7200) > refresh token expiry (now+3400) → TTL = 7200 + buffer(60) = 7260.
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID, 7260).
+		Return((*serviceerror.I18nServiceError)(nil))
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	assert.Equal(suite.T(), suite.validRefreshToken, response.RefreshToken.Token)
+	suite.mockAttrCacheService.AssertCalled(suite.T(), "ExtendAttributeCacheTTL", mock.Anything, testCacheID, 7260)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_ExtendCacheTTLError() {
+	// Same near-expiry scenario: access token outlives the refresh token, but
+	// ExtendAttributeCacheTTL fails → handler returns a server error.
+
+	now := time.Now().Unix()
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: testCacheID,
+			Iat:              now - 83000,
+		}, nil)
+
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
+			(*serviceerror.I18nServiceError)(nil)).Once()
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	extendErr := &serviceerror.I18nServiceError{
+		Type: serviceerror.ServerErrorType,
+		Code: "ACS-2001",
+		Error: core.I18nMessage{
+			Key:          "error.attributecache.internal_server_error",
+			DefaultValue: "Internal server error",
+		},
+	}
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID, 7260).
+		Return(extendErr)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+	assert.Equal(suite.T(), "Failed to extend attribute cache TTL", err.ErrorDescription)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_ExtendsAttributeCacheTTL() {
+	config.GetThunderRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
+
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: testCacheID,
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
+			(*serviceerror.I18nServiceError)(nil)).Once()
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+		Token:          "new.access.token",
+		IssuedAt:       time.Now().Unix(),
+		ExpiresIn:      3600,
+		Scopes:         []string{"read"},
+		UserAttributes: map[string]interface{}{"aci": testCacheID},
+	}, nil)
+
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything).Return(&model.TokenDTO{
+		Token:     "new.refresh.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 86400,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	// Expect TTL to be extended to the refresh token validity period (86400 from config) + buffer(60) = 86460.
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID, 86460).
+		Return((*serviceerror.I18nServiceError)(nil))
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	assert.Equal(suite.T(), "new.access.token", response.AccessToken.Token)
+	assert.Equal(suite.T(), "new.refresh.token", response.RefreshToken.Token)
+	suite.mockAttrCacheService.AssertCalled(suite.T(), "ExtendAttributeCacheTTL", mock.Anything, testCacheID, 86460)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_ExtendAttributeCacheTTLError() {
+	config.GetThunderRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
+
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: testCacheID,
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
+			(*serviceerror.I18nServiceError)(nil)).Once()
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+		Token:          "new.access.token",
+		IssuedAt:       time.Now().Unix(),
+		ExpiresIn:      3600,
+		Scopes:         []string{"read"},
+		UserAttributes: map[string]interface{}{"aci": testCacheID},
+	}, nil)
+
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything).Return(&model.TokenDTO{
+		Token:     "new.refresh.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 86400,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	extendErr := &serviceerror.I18nServiceError{
+		Type: serviceerror.ServerErrorType,
+		Code: "ACS-2001",
+		Error: core.I18nMessage{
+			Key:          "error.attributecache.internal_server_error",
+			DefaultValue: "Internal server error",
+		},
+	}
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID, 86460).
+		Return(extendErr)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+	assert.Equal(suite.T(), "Failed to extend attribute cache TTL", err.ErrorDescription)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SkipsCacheExtend_WhenCurrentTTLAlreadySufficient() {
+	// cacheEntry.TTLSeconds (100000) already exceeds the computed desiredTTL
+	// (max of refresh remaining ≈ 82800 and access ExpiresIn 3600, plus buffer 60 = ≈ 82860), so
+	// ExtendAttributeCacheTTL must not be called.
+
+	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"read", "write"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: testCacheID,
+			Iat:              int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockAttrCacheService.On("GetAttributeCache", mock.Anything, testCacheID).
+		Return(&attributecache.AttributeCache{
+			ID:         testCacheID,
+			Attributes: map[string]interface{}{},
+			TTLSeconds: 100000,
+		}, (*serviceerror.I18nServiceError)(nil)).Once()
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+		Token:     "new.access.token",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+	}, nil)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	suite.mockAttrCacheService.AssertNotCalled(suite.T(), "ExtendAttributeCacheTTL")
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestExtendCacheTTL_NilCacheEntry_NoOp() {
+	result := suite.handler.extendCacheTTL(
+		context.Background(), nil, suite.oauthApp,
+		time.Now().Unix()-3600, 3600, false, testCacheID, log.GetLogger(),
+	)
+
+	assert.Nil(suite.T(), result)
+	suite.mockAttrCacheService.AssertNotCalled(suite.T(), "ExtendAttributeCacheTTL")
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestExtendCacheTTL_CurrentTTLSufficient_NoExtension() {
+	// TTLSeconds (200000) > computed desiredTTL (≈82860) → no extend call.
+	cacheEntry := &attributecache.AttributeCache{ID: testCacheID, TTLSeconds: 200000}
+
+	result := suite.handler.extendCacheTTL(
+		context.Background(), cacheEntry, suite.oauthApp,
+		time.Now().Unix()-3600, 3600, false, testCacheID, log.GetLogger(),
+	)
+
+	assert.Nil(suite.T(), result)
+	suite.mockAttrCacheService.AssertNotCalled(suite.T(), "ExtendAttributeCacheTTL")
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestExtendCacheTTL_RefreshOutlivesAccess_ExtendsToRefreshExpiry() {
+	// iat=now-3600, validity=86400 → remaining≈82800. accessExpiresIn=3600 < 82800.
+	// desiredTTL ≈ 82800 + 60 = 82860 (±1 for clock drift).
+	cacheEntry := &attributecache.AttributeCache{ID: testCacheID, TTLSeconds: 0}
+
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID,
+		mock.MatchedBy(func(ttl int) bool { return ttl >= 82858 && ttl <= 82862 })).
+		Return((*serviceerror.I18nServiceError)(nil))
+
+	result := suite.handler.extendCacheTTL(
+		context.Background(), cacheEntry, suite.oauthApp,
+		time.Now().Unix()-3600, 3600, false, testCacheID, log.GetLogger(),
+	)
+
+	assert.Nil(suite.T(), result)
+	suite.mockAttrCacheService.AssertCalled(suite.T(), "ExtendAttributeCacheTTL", mock.Anything, testCacheID,
+		mock.MatchedBy(func(ttl int) bool { return ttl >= 82858 && ttl <= 82862 }))
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestExtendCacheTTL_AccessOutlivesRefresh_ExtendsToAccessExpiry() {
+	// iat=now-83000, validity=86400 → refresh remaining=3400. accessExpiresIn=7200 > 3400.
+	// desiredTTL = 7200 + 60 = 7260.
+	cacheEntry := &attributecache.AttributeCache{ID: testCacheID, TTLSeconds: 0}
+
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID, 7260).
+		Return((*serviceerror.I18nServiceError)(nil))
+
+	result := suite.handler.extendCacheTTL(
+		context.Background(), cacheEntry, suite.oauthApp,
+		time.Now().Unix()-83000, 7200, false, testCacheID, log.GetLogger(),
+	)
+
+	assert.Nil(suite.T(), result)
+	suite.mockAttrCacheService.AssertCalled(suite.T(), "ExtendAttributeCacheTTL", mock.Anything, testCacheID, 7260)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestExtendCacheTTL_RenewOnGrant_UsesNowAsRefreshIat() {
+	// renewRefreshToken=true → refreshIat overridden to now.
+	// refreshValidity=86400, accessExpiresIn=3600 < 86400 → desiredTTL = 86400 + 60 = 86460.
+	cacheEntry := &attributecache.AttributeCache{ID: testCacheID, TTLSeconds: 0}
+
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID, 86460).
+		Return((*serviceerror.I18nServiceError)(nil))
+
+	result := suite.handler.extendCacheTTL(
+		context.Background(), cacheEntry, suite.oauthApp,
+		time.Now().Unix()-3600, // stale iat — ignored when renewRefreshToken=true
+		3600, true, testCacheID, log.GetLogger(),
+	)
+
+	assert.Nil(suite.T(), result)
+	suite.mockAttrCacheService.AssertCalled(suite.T(), "ExtendAttributeCacheTTL", mock.Anything, testCacheID, 86460)
+}
+
+func (suite *RefreshTokenGrantHandlerTestSuite) TestExtendCacheTTL_ExtendFails_ReturnsServerError() {
+	cacheEntry := &attributecache.AttributeCache{ID: testCacheID, TTLSeconds: 0}
+
+	extendErr := &serviceerror.I18nServiceError{
+		Type: serviceerror.ServerErrorType,
+		Code: "ACS-2001",
+		Error: core.I18nMessage{
+			Key:          "error.attributecache.internal_server_error",
+			DefaultValue: "Internal server error",
+		},
+	}
+	suite.mockAttrCacheService.On("ExtendAttributeCacheTTL", mock.Anything, testCacheID, mock.Anything).
+		Return(extendErr)
+
+	result := suite.handler.extendCacheTTL(
+		context.Background(), cacheEntry, suite.oauthApp,
+		time.Now().Unix()-83000, 7200, false, testCacheID, log.GetLogger(),
+	)
+
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), constants.ErrorServerError, result.Error)
+	assert.Equal(suite.T(), "Failed to extend attribute cache TTL", result.ErrorDescription)
+}
+
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenewOnGrant() {
 	// Enable RenewOnGrant in config
 	config.GetThunderRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
@@ -618,12 +1005,12 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenew
 	// Mock successful refresh token validation with openid scope
 	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
-			Sub:            testRefreshTokenUserID,
-			Aud:            testRefreshTokenAudience,
-			Scopes:         []string{"openid", "read"},
-			GrantType:      "authorization_code",
-			UserAttributes: map[string]interface{}{"email": "test@example.com"},
-			Iat:            int64(suite.validClaims["iat"].(float64)),
+			Sub:              testRefreshTokenUserID,
+			Aud:              testRefreshTokenAudience,
+			Scopes:           []string{"openid", "read"},
+			GrantType:        "authorization_code",
+			AttributeCacheID: "",
+			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
 	// Mock successful access token generation

--- a/backend/internal/oauth/oauth2/model/token.go
+++ b/backend/internal/oauth/oauth2/model/token.go
@@ -53,17 +53,18 @@ type TokenResponse struct {
 
 // TokenDTO represents the data transfer object for tokens.
 type TokenDTO struct {
-	Token          string
-	TokenType      string
-	IssuedAt       int64
-	ExpiresIn      int64
-	Scopes         []string
-	ClientID       string
-	UserAttributes map[string]interface{}
-	Subject        string
-	Audience       string
-	ClaimsRequest  *ClaimsRequest
-	ClaimsLocales  string
+	Token            string
+	TokenType        string
+	IssuedAt         int64
+	ExpiresIn        int64
+	Scopes           []string
+	ClientID         string
+	UserAttributes   map[string]interface{}
+	AttributeCacheID string
+	Subject          string
+	Audience         string
+	ClaimsRequest    *ClaimsRequest
+	ClaimsLocales    string
 }
 
 // TokenResponseDTO represents the data transfer object for token responses.

--- a/backend/internal/oauth/oauth2/token/service.go
+++ b/backend/internal/oauth/oauth2/token/service.go
@@ -214,7 +214,7 @@ func (ts *tokenService) ProcessTokenRequest(
 			tokenRespDTO, oauthApp,
 			tokenRespDTO.AccessToken.Subject, tokenRespDTO.AccessToken.Audience,
 			grantTypeStr, tokenRespDTO.AccessToken.Scopes, tokenRespDTO.AccessToken.ClaimsRequest,
-			tokenRespDTO.AccessToken.ClaimsLocales,
+			tokenRespDTO.AccessToken.ClaimsLocales, tokenRespDTO.AccessToken.AttributeCacheID,
 		)
 		if refreshTokenError != nil && refreshTokenError.Error != "" {
 			publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,

--- a/backend/internal/oauth/oauth2/token/service_test.go
+++ b/backend/internal/oauth/oauth2/token/service_test.go
@@ -379,7 +379,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_WithRefreshToken() {
 
 	mockRefreshHandler.
 		On("IssueRefreshToken", mock.Anything, tokenRespDTO, app, "user123", "test-audience",
-			"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "").
+			"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "", "").
 		Return(nil)
 
 	svc := suite.newService()
@@ -434,7 +434,7 @@ func (suite *TokenServiceTestSuite) TestProcessTokenRequest_RefreshTokenIssuance
 
 	mockRefreshHandler.
 		On("IssueRefreshToken", mock.Anything, tokenRespDTO, app, "user123", "test-audience",
-			"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "").
+			"authorization_code", []string{"openid"}, (*model.ClaimsRequest)(nil), "", "").
 		Return(&model.ErrorResponse{
 			Error:            "server_error",
 			ErrorDescription: "Failed to issue refresh token",

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -53,7 +53,7 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 		return nil, fmt.Errorf("build context cannot be nil")
 	}
 
-	tokenConfig := resolveTokenConfig(ctx.OAuthApp, TokenTypeAccess)
+	tokenConfig := ResolveTokenConfig(ctx.OAuthApp, TokenTypeAccess)
 
 	userAttributes := tb.buildAccessTokenUserAttributes(ctx.UserAttributes, ctx.OAuthApp)
 	jwtClaims, claimsErr := tb.buildAccessTokenClaims(ctx, userAttributes)
@@ -62,15 +62,16 @@ func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2m
 	}
 
 	tokenDTO := &oauth2model.TokenDTO{
-		TokenType:      constants.TokenTypeBearer,
-		ExpiresIn:      tokenConfig.ValidityPeriod,
-		Scopes:         ctx.Scopes,
-		ClientID:       ctx.ClientID,
-		UserAttributes: userAttributes,
-		Subject:        ctx.Subject,
-		Audience:       ctx.Audience,
-		ClaimsRequest:  ctx.ClaimsRequest,
-		ClaimsLocales:  ctx.ClaimsLocales,
+		TokenType:        constants.TokenTypeBearer,
+		ExpiresIn:        tokenConfig.ValidityPeriod,
+		Scopes:           ctx.Scopes,
+		ClientID:         ctx.ClientID,
+		UserAttributes:   userAttributes,
+		AttributeCacheID: ctx.AttributeCacheID,
+		Subject:          ctx.Subject,
+		Audience:         ctx.Audience,
+		ClaimsRequest:    ctx.ClaimsRequest,
+		ClaimsLocales:    ctx.ClaimsLocales,
 	}
 
 	token, iat, err := tb.jwtService.GenerateJWT(
@@ -114,6 +115,11 @@ func (tb *tokenBuilder) buildAccessTokenClaims(
 	// Add filtered user attributes to claims
 	for key, value := range filteredAttributes {
 		claims[key] = value
+	}
+
+	// Set after merging user attributes to prevent user attributes from overwriting this system claim.
+	if ctx.AttributeCacheID != "" {
+		claims["aci"] = ctx.AttributeCacheID
 	}
 
 	if ctx.ActorClaims != nil {
@@ -160,6 +166,10 @@ func (tb *tokenBuilder) buildAccessTokenUserAttributes(
 		accessTokenUserAttributes = oauthApp.Token.AccessToken.UserAttributes
 	}
 
+	if accessTokenUserAttributes == nil {
+		accessTokenUserAttributes = []string{}
+	}
+
 	// If app config specifies which attributes to include, filter them
 	if len(accessTokenUserAttributes) > 0 {
 		for _, attr := range accessTokenUserAttributes {
@@ -196,7 +206,7 @@ func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth
 		return nil, fmt.Errorf("build context cannot be nil")
 	}
 
-	tokenConfig := resolveTokenConfig(ctx.OAuthApp, TokenTypeRefresh)
+	tokenConfig := ResolveTokenConfig(ctx.OAuthApp, TokenTypeRefresh)
 
 	claims, claimsErr := tb.buildRefreshTokenClaims(ctx)
 	if claimsErr != nil {
@@ -243,12 +253,8 @@ func (tb *tokenBuilder) buildRefreshTokenClaims(ctx *RefreshTokenBuildContext) (
 	claims["access_token_aud"] = ctx.AccessTokenAudience
 	claims["grant_type"] = ctx.GrantType
 
-	if ctx.OAuthApp != nil &&
-		ctx.OAuthApp.Token != nil &&
-		ctx.OAuthApp.Token.AccessToken != nil &&
-		len(ctx.OAuthApp.Token.AccessToken.UserAttributes) > 0 &&
-		len(ctx.AccessTokenUserAttrs) > 0 {
-		claims["access_token_user_attributes"] = ctx.AccessTokenUserAttrs
+	if ctx.AttributeCacheID != "" {
+		claims["aci"] = ctx.AttributeCacheID
 	}
 
 	// Include claims request if present
@@ -276,7 +282,7 @@ func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.Tok
 		return nil, fmt.Errorf("build context cannot be nil")
 	}
 
-	tokenConfig := resolveTokenConfig(ctx.OAuthApp, TokenTypeID)
+	tokenConfig := ResolveTokenConfig(ctx.OAuthApp, TokenTypeID)
 
 	jwtClaims := tb.buildIDTokenClaims(ctx)
 

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -39,6 +39,7 @@ const (
 	testIDToken      = "test-id-token"      //nolint:gosec // Test token, not a real credential
 	testUserName     = "John Doe"
 	testAppID        = "app123"
+	testCacheID      = "test-cache-id"
 )
 
 type TokenBuilderTestSuite struct {
@@ -437,13 +438,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 	}
 
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{"read", "write"},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{"name": testUserName},
-		OAuthApp:             oauthAppWithUserAttrs,
+		ClientID:            "test-client",
+		Scopes:              []string{"read", "write"},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    testCacheID,
+		OAuthApp:            oauthAppWithUserAttrs,
 	}
 
 	expectedToken := testRefreshToken
@@ -459,7 +460,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 				claims["access_token_sub"] == "user123" &&
 				claims["access_token_aud"] == testAppID &&
 				claims["grant_type"] == string(constants.GrantTypeAuthorizationCode) &&
-				claims["access_token_user_attributes"].(map[string]interface{})["name"] == testUserName
+				claims["aci"] == testCacheID
 		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
@@ -478,13 +479,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAttributes() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{"read"},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{},
-		OAuthApp:             suite.oauthApp,
+		ClientID:            "test-client",
+		Scopes:              []string{"read"},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    "",
+		OAuthApp:            suite.oauthApp,
 	}
 
 	expectedToken := testRefreshToken
@@ -496,8 +497,8 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
-			_, hasUserAttrs := claims["access_token_user_attributes"]
-			return !hasUserAttrs
+			_, hasAttrCacheID := claims["aci"]
+			return !hasAttrCacheID
 		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
@@ -510,13 +511,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthApp() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{"read"},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{"name": testUserName},
-		OAuthApp:             nil,
+		ClientID:            "test-client",
+		Scopes:              []string{"read"},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    testCacheID,
+		OAuthApp:            nil,
 	}
 
 	expectedToken := testRefreshToken
@@ -528,8 +529,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
-			_, hasUserAttrs := claims["access_token_user_attributes"]
-			return !hasUserAttrs // Should not include user attrs when OAuthApp is nil
+			return claims["aci"] == testCacheID
 		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
@@ -542,13 +542,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{},
-		OAuthApp:             suite.oauthApp,
+		ClientID:            "test-client",
+		Scopes:              []string{},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    "",
+		OAuthApp:            suite.oauthApp,
 	}
 
 	expectedToken := testRefreshToken
@@ -581,13 +581,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithTokenConfi
 	}
 
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{"read"},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{},
-		OAuthApp:             customOAuthApp,
+		ClientID:            "test-client",
+		Scopes:              []string{"read"},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    "",
+		OAuthApp:            customOAuthApp,
 	}
 
 	expectedToken := testRefreshToken
@@ -618,13 +618,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 	}
 
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{"read"},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{"name": testUserName},
-		OAuthApp:             oauthAppWithNilAccessToken,
+		ClientID:            "test-client",
+		Scopes:              []string{"read"},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    testCacheID,
+		OAuthApp:            oauthAppWithNilAccessToken,
 	}
 
 	expectedToken := testRefreshToken
@@ -636,8 +636,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 		"https://thunder.io",
 		int64(3600),
 		mock.MatchedBy(func(claims map[string]interface{}) bool {
-			_, hasUserAttrs := claims["access_token_user_attributes"]
-			return !hasUserAttrs // Should not include user attrs when AccessToken is nil
+			return claims["aci"] == testCacheID
 		}), mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
@@ -658,13 +657,13 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_NilContext() {
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFailed() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{"read"},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{},
-		OAuthApp:             suite.oauthApp,
+		ClientID:            "test-client",
+		Scopes:              []string{"read"},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    "",
+		OAuthApp:            suite.oauthApp,
 	}
 
 	suite.mockJWTService.On("GenerateJWT",
@@ -690,14 +689,14 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFai
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithClaimsLocales() {
 	ctx := &RefreshTokenBuildContext{
-		ClientID:             "test-client",
-		Scopes:               []string{"openid", "profile"},
-		GrantType:            string(constants.GrantTypeAuthorizationCode),
-		AccessTokenSubject:   "user123",
-		AccessTokenAudience:  "app123",
-		AccessTokenUserAttrs: map[string]interface{}{"name": testUserName},
-		OAuthApp:             suite.oauthApp,
-		ClaimsLocales:        "en-US fr-CA ja",
+		ClientID:            "test-client",
+		Scopes:              []string{"openid", "profile"},
+		GrantType:           string(constants.GrantTypeAuthorizationCode),
+		AccessTokenSubject:  "user123",
+		AccessTokenAudience: "app123",
+		AttributeCacheID:    "",
+		OAuthApp:            suite.oauthApp,
+		ClaimsLocales:       "en-US fr-CA ja",
 	}
 
 	expectedToken := testRefreshToken

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -44,29 +44,30 @@ type TokenConfig struct {
 
 // AccessTokenBuildContext contains all the information needed to build an access token.
 type AccessTokenBuildContext struct {
-	Subject        string
-	Audience       string
-	ClientID       string
-	Scopes         []string
-	UserAttributes map[string]interface{}
-	GrantType      string
-	OAuthApp       *appmodel.OAuthAppConfigProcessedDTO
-	ActorClaims    *SubjectTokenClaims
-	ClaimsRequest  *oauth2model.ClaimsRequest
-	ClaimsLocales  string
+	Subject          string
+	Audience         string
+	ClientID         string
+	Scopes           []string
+	UserAttributes   map[string]interface{}
+	AttributeCacheID string
+	GrantType        string
+	OAuthApp         *appmodel.OAuthAppConfigProcessedDTO
+	ActorClaims      *SubjectTokenClaims
+	ClaimsRequest    *oauth2model.ClaimsRequest
+	ClaimsLocales    string
 }
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
 type RefreshTokenBuildContext struct {
-	ClientID             string
-	Scopes               []string
-	GrantType            string
-	AccessTokenSubject   string
-	AccessTokenAudience  string
-	AccessTokenUserAttrs map[string]interface{}
-	OAuthApp             *appmodel.OAuthAppConfigProcessedDTO
-	ClaimsRequest        *oauth2model.ClaimsRequest
-	ClaimsLocales        string
+	ClientID            string
+	Scopes              []string
+	GrantType           string
+	AccessTokenSubject  string
+	AccessTokenAudience string
+	AttributeCacheID    string
+	OAuthApp            *appmodel.OAuthAppConfigProcessedDTO
+	ClaimsRequest       *oauth2model.ClaimsRequest
+	ClaimsLocales       string
 }
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
@@ -83,14 +84,14 @@ type IDTokenBuildContext struct {
 
 // RefreshTokenClaims represents the validated claims from a refresh token.
 type RefreshTokenClaims struct {
-	Sub            string
-	Aud            string
-	GrantType      string
-	Scopes         []string
-	UserAttributes map[string]interface{}
-	Iat            int64
-	ClaimsRequest  *oauth2model.ClaimsRequest
-	ClaimsLocales  string
+	Sub              string
+	Aud              string
+	GrantType        string
+	Scopes           []string
+	AttributeCacheID string
+	Iat              int64
+	ClaimsRequest    *oauth2model.ClaimsRequest
+	ClaimsLocales    string
 }
 
 // SubjectTokenClaims represents the validated claims from a subject token (for token exchange).

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -20,17 +20,15 @@ package tokenservice
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
-	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/config"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 // ParseScopes parses a space-separated scope string into a slice of scope strings.
@@ -56,8 +54,8 @@ func JoinScopes(scopes []string) string {
 	return strings.Join(scopes, " ")
 }
 
-// resolveTokenConfig resolves the token configuration from the OAuth app or falls back to global config.
-func resolveTokenConfig(oauthApp *appmodel.OAuthAppConfigProcessedDTO, tokenType TokenType) *TokenConfig {
+// ResolveTokenConfig resolves the token configuration from the OAuth app or falls back to global config.
+func ResolveTokenConfig(oauthApp *appmodel.OAuthAppConfigProcessedDTO, tokenType TokenType) *TokenConfig {
 	conf := config.GetThunderRuntime().Config
 
 	tokenConfig := &TokenConfig{
@@ -199,7 +197,7 @@ func ExtractUserAttributes(claims map[string]interface{}) map[string]interface{}
 func getValidIssuers(oauthApp *appmodel.OAuthAppConfigProcessedDTO) map[string]bool {
 	validIssuers := make(map[string]bool)
 
-	tokenConfig := resolveTokenConfig(oauthApp, TokenTypeAccess)
+	tokenConfig := ResolveTokenConfig(oauthApp, TokenTypeAccess)
 	validIssuers[tokenConfig.Issuer] = true
 
 	// TODO: Add support for external issuers
@@ -219,26 +217,11 @@ func validateIssuer(issuer string, oauthApp *appmodel.OAuthAppConfigProcessedDTO
 // Callers should log errors with their own context.
 func FetchUserAttributes(
 	ctx context.Context,
-	userService user.UserServiceInterface,
-	ouService ou.OrganizationUnitServiceInterface,
-	userID string,
+	attrCacheService attributecache.AttributeCacheServiceInterface,
 	allowedClaims []string,
+	attributeCacheKey string,
 ) (map[string]interface{}, error) {
-	userData, svcErr := userService.GetUser(ctx, userID)
-	if svcErr != nil {
-		return nil, fmt.Errorf("failed to fetch user: %s", svcErr.Error)
-	}
-
-	// Parse user attributes from JSON
-	var attrs map[string]interface{}
-	if userData.Attributes != nil {
-		if err := json.Unmarshal(userData.Attributes, &attrs); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal user attributes: %w", err)
-		}
-	}
-	if attrs == nil {
-		attrs = make(map[string]interface{})
-	}
+	attrs := make(map[string]interface{})
 
 	// Helper to check if a claim should be included
 	shouldInclude := func(claimName string) bool {
@@ -248,46 +231,18 @@ func FetchUserAttributes(
 		return slices.Contains(allowedClaims, claimName)
 	}
 
-	// Add default claim - user type
-	if userData.Type != "" && shouldInclude(constants.ClaimUserType) {
-		attrs[constants.ClaimUserType] = userData.Type
-	}
-
-	if userData.OUID != "" {
-		// Add default claim - ouId
-		if shouldInclude(constants.ClaimOUID) {
-			attrs[constants.ClaimOUID] = userData.OUID
+	if attributeCacheKey != "" {
+		attrCache, err := attrCacheService.GetAttributeCache(ctx, attributeCacheKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch attribute cache: %s", err.Error)
 		}
-
-		// Only fetch OU details if ouHandle or ouName are requested
-		needsOUDetails := shouldInclude(constants.ClaimOUHandle) || shouldInclude(constants.ClaimOUName)
-		if needsOUDetails && ouService != nil {
-			ouDetails, ouErr := ouService.GetOrganizationUnit(ctx, userData.OUID)
-			if ouErr != nil {
-				return nil, fmt.Errorf("failed to fetch organization unit details: %s", ouErr.Error)
-			}
-
-			if shouldInclude(constants.ClaimOUHandle) {
-				attrs[constants.ClaimOUHandle] = ouDetails.Handle
-			}
-			if shouldInclude(constants.ClaimOUName) {
-				attrs[constants.ClaimOUName] = ouDetails.Name
-			}
+		if attrCache == nil || attrCache.Attributes == nil {
+			return nil, fmt.Errorf("attribute cache not found for key: %s", attributeCacheKey)
 		}
-	}
-
-	// Fetch and add groups if requested
-	if shouldInclude(constants.UserAttributeGroups) {
-		groups, svcErr := userService.GetUserGroups(ctx, userID, constants.DefaultGroupListLimit, 0)
-		if svcErr != nil {
-			return nil, fmt.Errorf("failed to fetch user groups: %s", svcErr.Error)
-		}
-		if len(groups.Groups) > 0 {
-			groupNames := make([]string, 0, len(groups.Groups))
-			for _, group := range groups.Groups {
-				groupNames = append(groupNames, group.Name)
+		for key, value := range attrCache.Attributes {
+			if shouldInclude(key) {
+				attrs[key] = value
 			}
-			attrs[constants.UserAttributeGroups] = groupNames
 		}
 	}
 

--- a/backend/internal/oauth/oauth2/tokenservice/utils_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils_test.go
@@ -20,7 +20,6 @@ package tokenservice
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,13 +27,12 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
-	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/user"
-	"github.com/asgardeo/thunder/tests/mocks/oumock"
-	"github.com/asgardeo/thunder/tests/mocks/usermock"
+	"github.com/asgardeo/thunder/internal/system/i18n/core"
+	"github.com/asgardeo/thunder/tests/mocks/attributecachemock"
 )
 
 type UtilsTestSuite struct {
@@ -618,467 +616,174 @@ func (suite *UtilsTestSuite) TestextractScopesFromClaims_ScopeTakesPriorityOverA
 	assert.Equal(suite.T(), []string{"openid", "profile"}, result)
 }
 
-func (suite *UtilsTestSuite) TestFetchUserAttributes_GetUserError() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
+func (suite *UtilsTestSuite) TestFetchUserAttributes_GetAttributeCacheError() {
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
-	// Mock GetUser to return error
-	serverErr := &serviceerror.ServiceError{
-		Type:             serviceerror.ServerErrorType,
-		Code:             "USER_NOT_FOUND",
-		ErrorDescription: "user not found",
+	// Mock GetAttributeCache to return error
+	serverErr := &serviceerror.I18nServiceError{
+		Type: serviceerror.ServerErrorType,
+		Code: "CACHE_NOT_FOUND",
+		Error: core.I18nMessage{
+			Key:          "cache_not_found",
+			DefaultValue: "Cache not found",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "cache_not_found_desc",
+			DefaultValue: "cache not found",
+		},
 	}
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(nil, serverErr)
+	mockAttrCacheService.On("GetAttributeCache", mock.Anything, "cache-key-123").
+		Return(nil, serverErr)
 
-	_, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", nil)
-
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "failed to fetch user")
-
-	mockUserService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_UnmarshalError() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return user with invalid JSON in attributes
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{invalid json}`), // Invalid JSON
-		Type:       "local",
-	}, nil)
-
-	_, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", nil)
+	_, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		[]string{constants.ClaimUserType}, "cache-key-123")
 
 	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "failed to unmarshal user attributes")
+	assert.Contains(suite.T(), err.Error(), "failed to fetch attribute cache")
 
-	mockUserService.AssertExpectations(suite.T())
+	mockAttrCacheService.AssertExpectations(suite.T())
 }
 
-func (suite *UtilsTestSuite) TestFetchUserAttributes_NilAttributes() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
+func (suite *UtilsTestSuite) TestFetchUserAttributes_EmptyCacheKey() {
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
-	// Mock GetUser to return user with nil attributes
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: nil,
-		Type:       "local",
-	}, nil)
-
-	allowedClaims := []string{constants.ClaimUserType}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
+	// When cache key is empty, no cache lookup should happen
+	attrs, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		[]string{constants.ClaimUserType}, "")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), attrs)
-	assert.Equal(suite.T(), "local", attrs[constants.ClaimUserType])
+	assert.Empty(suite.T(), attrs) // No attributes when cache key is empty and no claims allowed
 
-	mockUserService.AssertExpectations(suite.T())
+	// Verify GetAttributeCache was NOT called
+	mockAttrCacheService.AssertNotCalled(suite.T(), "GetAttributeCache", mock.Anything, mock.Anything)
+}
+
+func (suite *UtilsTestSuite) TestFetchUserAttributes_NilCacheAttributes() {
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
+
+	// Mock GetAttributeCache to return cache with nil attributes — must be treated as an error
+	mockAttrCacheService.On("GetAttributeCache", mock.Anything, "cache-key-123").
+		Return(&attributecache.AttributeCache{
+			ID:         "cache-key-123",
+			Attributes: nil,
+		}, nil)
+
+	allowedClaims := []string{constants.ClaimUserType}
+	_, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		allowedClaims, "cache-key-123")
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "attribute cache not found for key")
+
+	mockAttrCacheService.AssertExpectations(suite.T())
 }
 
 func (suite *UtilsTestSuite) TestFetchUserAttributes_EmptyAllowedClaims() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
-	// Mock GetUser to return user with full data
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-		OUID:       "ou-123",
-	}, nil)
+	// Mock GetAttributeCache to return cached attributes
+	mockAttrCacheService.On("GetAttributeCache", mock.Anything, "cache-key-123").
+		Return(&attributecache.AttributeCache{
+			ID: "cache-key-123",
+			Attributes: map[string]interface{}{
+				"email":                 "test@example.com",
+				constants.ClaimUserType: "local",
+				constants.ClaimOUID:     "ou-123",
+			},
+		}, nil)
 
-	// Empty allowedClaims - no special claims should be added
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", []string{})
+	// Empty allowedClaims - no claims should be returned
+	attrs, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		[]string{}, "cache-key-123")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), attrs)
-	// Only user attributes should be present, not default claims
-	assert.Equal(suite.T(), "test@example.com", attrs["email"])
-	assert.Nil(suite.T(), attrs[constants.ClaimUserType])
-	assert.Nil(suite.T(), attrs[constants.ClaimOUID])
-	assert.Nil(suite.T(), attrs[constants.UserAttributeGroups])
+	// No attributes should be present when allowedClaims is empty
+	assert.Empty(suite.T(), attrs)
 
-	mockUserService.AssertExpectations(suite.T())
+	mockAttrCacheService.AssertExpectations(suite.T())
 }
 
 func (suite *UtilsTestSuite) TestFetchUserAttributes_NilAllowedClaims() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
-	// Mock GetUser to return user with full data
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-		OUID:       "ou-123",
-	}, nil)
+	// Mock GetAttributeCache to return cached attributes
+	mockAttrCacheService.On("GetAttributeCache", mock.Anything, "cache-key-123").
+		Return(&attributecache.AttributeCache{
+			ID: "cache-key-123",
+			Attributes: map[string]interface{}{
+				"email":                 "test@example.com",
+				constants.ClaimUserType: "local",
+				constants.ClaimOUID:     "ou-123",
+			},
+		}, nil)
 
-	// Nil allowedClaims - no special claims should be added
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", nil)
+	// Nil allowedClaims - no claims should be returned
+	attrs, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		nil, "cache-key-123")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), attrs)
-	// Only user attributes should be present
-	assert.Equal(suite.T(), "test@example.com", attrs["email"])
-	assert.Nil(suite.T(), attrs[constants.ClaimUserType])
-	assert.Nil(suite.T(), attrs[constants.ClaimOUID])
+	// No attributes should be present when allowedClaims is nil
+	assert.Empty(suite.T(), attrs)
 
-	mockUserService.AssertExpectations(suite.T())
+	mockAttrCacheService.AssertExpectations(suite.T())
 }
 
-func (suite *UtilsTestSuite) TestFetchUserAttributes_UserWithNoType() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
+func (suite *UtilsTestSuite) TestFetchUserAttributes_CacheWithoutUserType() {
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
-	// Mock GetUser to return user without type
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "", // Empty type
-		OUID:       "ou-123",
-	}, nil)
+	// Mock GetAttributeCache to return cache without userType
+	mockAttrCacheService.On("GetAttributeCache", mock.Anything, "cache-key-123").
+		Return(&attributecache.AttributeCache{
+			ID: "cache-key-123",
+			Attributes: map[string]interface{}{
+				"email":             "test@example.com",
+				constants.ClaimOUID: "ou-123",
+			},
+		}, nil)
 
 	allowedClaims := []string{constants.ClaimUserType, constants.ClaimOUID}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
+	attrs, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		allowedClaims, "cache-key-123")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), attrs)
-	// userType should not be present since it's empty
+	// userType should not be present since it's not in cache
 	assert.Nil(suite.T(), attrs[constants.ClaimUserType])
-	// ouId should still be present
+	// ouId should be present
 	assert.Equal(suite.T(), "ou-123", attrs[constants.ClaimOUID])
 
-	mockUserService.AssertExpectations(suite.T())
+	mockAttrCacheService.AssertExpectations(suite.T())
 }
 
-func (suite *UtilsTestSuite) TestFetchUserAttributes_UserWithNoOrganizationUnit() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
+//nolint:dupl // Similar test structure but different scenario (cache without OUID)
+func (suite *UtilsTestSuite) TestFetchUserAttributes_CacheWithoutOUID() {
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 
-	// Mock GetUser to return user without organization unit
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-		OUID:       "", // Empty OU
-	}, nil)
+	// Mock GetAttributeCache to return cache without OUID
+	mockAttrCacheService.On("GetAttributeCache", mock.Anything, "cache-key-123").
+		Return(&attributecache.AttributeCache{
+			ID: "cache-key-123",
+			Attributes: map[string]interface{}{
+				"email":                 "test@example.com",
+				constants.ClaimUserType: "local",
+			},
+		}, nil)
 
 	allowedClaims := []string{constants.ClaimUserType, constants.ClaimOUID}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
+	attrs, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		allowedClaims, "cache-key-123")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), attrs)
 	// userType should be present
 	assert.Equal(suite.T(), "local", attrs[constants.ClaimUserType])
-	// ouId should not be present since OU is empty
+	// ouId should not be present since it's not in cache
 	assert.Nil(suite.T(), attrs[constants.ClaimOUID])
 
-	mockUserService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_WithOUServiceSuccess() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user with OU
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-		OUID:       "ou-123",
-	}, nil)
-
-	// Mock GetOrganizationUnit to return OU details
-	mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-123").Return(ou.OrganizationUnit{
-		ID:     "ou-123",
-		Handle: "test-org",
-		Name:   "Test Organization",
-	}, nil)
-
-	// Request all OU-related claims
-	allowedClaims := []string{constants.ClaimOUID, constants.ClaimOUHandle, constants.ClaimOUName}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, mockOUService, "test-user", allowedClaims)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), attrs)
-	assert.Equal(suite.T(), "ou-123", attrs[constants.ClaimOUID])
-	assert.Equal(suite.T(), "test-org", attrs[constants.ClaimOUHandle])
-	assert.Equal(suite.T(), "Test Organization", attrs[constants.ClaimOUName])
-
-	mockUserService.AssertExpectations(suite.T())
-	mockOUService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_WithOUServiceError() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user with OU
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-		OUID:       "ou-123",
-	}, nil)
-
-	// Mock GetOrganizationUnit to return error
-	mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-123").
-		Return(ou.OrganizationUnit{}, &serviceerror.ServiceError{
-			Type:             serviceerror.ServerErrorType,
-			Code:             "OU_NOT_FOUND",
-			ErrorDescription: "organization unit not found",
-		})
-
-	// Request ouHandle which requires OU service
-	allowedClaims := []string{constants.ClaimOUHandle}
-	_, err := FetchUserAttributes(context.Background(), mockUserService, mockOUService, "test-user", allowedClaims)
-
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "failed to fetch organization unit details")
-
-	mockUserService.AssertExpectations(suite.T())
-	mockOUService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_OUDetailsNotRequestedSkipsOUService() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user with OU
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-		OUID:       "ou-123",
-	}, nil)
-
-	// No mock for GetOrganizationUnit - it should NOT be called
-
-	// Request only ouId (not ouHandle or ouName)
-	allowedClaims := []string{constants.ClaimOUID}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, mockOUService, "test-user", allowedClaims)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), attrs)
-	assert.Equal(suite.T(), "ou-123", attrs[constants.ClaimOUID])
-	// ouHandle and ouName should not be present
-	assert.Nil(suite.T(), attrs[constants.ClaimOUHandle])
-	assert.Nil(suite.T(), attrs[constants.ClaimOUName])
-
-	// Verify GetOrganizationUnit was NOT called
-	mockOUService.AssertNotCalled(suite.T(), "GetOrganizationUnit", mock.Anything)
-	mockUserService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_NilOUServiceSkipsOUDetails() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user with OU
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-		OUID:       "ou-123",
-	}, nil)
-
-	// Request ouHandle but pass nil ouService
-	allowedClaims := []string{constants.ClaimOUID, constants.ClaimOUHandle}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), attrs)
-	// ouId should be present
-	assert.Equal(suite.T(), "ou-123", attrs[constants.ClaimOUID])
-	// ouHandle should NOT be present since ouService is nil
-	assert.Nil(suite.T(), attrs[constants.ClaimOUHandle])
-
-	mockUserService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_WithGroups() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com","username":"testuser"}`),
-		Type:       "local",
-		OUID:       "ou-123",
-	}, nil)
-
-	// Mock GetUserGroups to return groups
-	mockGroups := &user.UserGroupListResponse{
-		TotalResults: 2,
-		StartIndex:   0,
-		Count:        2,
-		Groups: []user.UserGroup{
-			{ID: "group1", Name: "Admin"},
-			{ID: "group2", Name: "Users"},
-		},
-	}
-	mockUserService.On("GetUserGroups", mock.Anything, "test-user", constants.DefaultGroupListLimit, 0).
-		Return(mockGroups, nil)
-
-	// Include default claims and groups in allowed list
-	allowedClaims := []string{
-		"email",
-		"username",
-		constants.ClaimUserType,
-		constants.ClaimOUID,
-		constants.UserAttributeGroups,
-	}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), attrs)
-	assert.Equal(suite.T(), "test@example.com", attrs["email"])
-	assert.Equal(suite.T(), "testuser", attrs["username"])
-	// Verify groups are merged into attrs
-	assert.Equal(suite.T(), []string{"Admin", "Users"}, attrs[constants.UserAttributeGroups])
-	// Verify default claims are merged into attrs
-	assert.Equal(suite.T(), "local", attrs[constants.ClaimUserType])
-	assert.Equal(suite.T(), "ou-123", attrs[constants.ClaimOUID])
-
-	mockUserService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_WithEmptyGroups() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-	}, nil)
-
-	// Mock GetUserGroups to return empty groups
-	mockGroups := &user.UserGroupListResponse{
-		TotalResults: 0,
-		StartIndex:   0,
-		Count:        0,
-		Groups:       []user.UserGroup{},
-	}
-	mockUserService.On("GetUserGroups", mock.Anything, "test-user", constants.DefaultGroupListLimit, 0).
-		Return(mockGroups, nil)
-
-	// Request groups
-	allowedClaims := []string{constants.UserAttributeGroups}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), attrs)
-	// Groups should not be added when empty
-	assert.Nil(suite.T(), attrs[constants.UserAttributeGroups])
-
-	mockUserService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_GetUserGroupsError() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-	}, nil)
-
-	// Mock GetUserGroups to return error
-	serverErr := &serviceerror.ServiceError{
-		Type:             serviceerror.ServerErrorType,
-		Code:             "INTERNAL_ERROR",
-		ErrorDescription: "failed to fetch groups",
-	}
-	mockUserService.On("GetUserGroups", mock.Anything, "test-user", constants.DefaultGroupListLimit, 0).
-		Return(nil, serverErr)
-
-	// Request groups in allowed claims to trigger the error
-	allowedClaims := []string{constants.UserAttributeGroups}
-	_, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
-
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "failed to fetch user groups")
-
-	mockUserService.AssertExpectations(suite.T())
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_WithoutGroups() {
-	mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-
-	// Mock GetUser to return valid user
-	mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-		ID:         "test-user",
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-		Type:       "local",
-	}, nil)
-
-	// Include userType but NOT groups - so GetUserGroups should not be called
-	allowedClaims := []string{"email", constants.ClaimUserType}
-	attrs, err := FetchUserAttributes(context.Background(), mockUserService, nil, "test-user", allowedClaims)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), attrs)
-	// Verify userType is in attrs
-	assert.Equal(suite.T(), "local", attrs[constants.ClaimUserType])
-	// Verify groups is not present
-	assert.Nil(suite.T(), attrs[constants.UserAttributeGroups])
-
-	// Verify GetUserGroups was NOT called
-	mockUserService.AssertNotCalled(
-		suite.T(), "GetUserGroups", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-}
-
-func (suite *UtilsTestSuite) TestFetchUserAttributes_SingleOUClaim() {
-	// Test cases for requesting only one OU claim at a time
-	testCases := []struct {
-		name          string
-		allowedClaims []string
-		expectedClaim string
-		expectedValue string
-		absentClaim   string
-	}{
-		{
-			name:          "OnlyOUHandle",
-			allowedClaims: []string{constants.ClaimOUHandle},
-			expectedClaim: constants.ClaimOUHandle,
-			expectedValue: "test-org",
-			absentClaim:   constants.ClaimOUName,
-		},
-		{
-			name:          "OnlyOUName",
-			allowedClaims: []string{constants.ClaimOUName},
-			expectedClaim: constants.ClaimOUName,
-			expectedValue: "Test Organization",
-			absentClaim:   constants.ClaimOUHandle,
-		},
-	}
-
-	for _, tc := range testCases {
-		suite.Run(tc.name, func() {
-			mockUserService := usermock.NewUserServiceInterfaceMock(suite.T())
-			mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
-
-			mockUserService.On("GetUser", mock.Anything, "test-user").Return(&user.User{
-				ID:         "test-user",
-				Attributes: json.RawMessage(`{"email":"test@example.com"}`),
-				OUID:       "ou-123",
-			}, nil)
-
-			mockOUService.On("GetOrganizationUnit", mock.Anything, "ou-123").Return(ou.OrganizationUnit{
-				ID:     "ou-123",
-				Handle: "test-org",
-				Name:   "Test Organization",
-			}, nil)
-
-			attrs, err := FetchUserAttributes(
-				context.Background(), mockUserService, mockOUService, "test-user", tc.allowedClaims)
-
-			assert.NoError(suite.T(), err)
-			assert.NotNil(suite.T(), attrs)
-			assert.Equal(suite.T(), tc.expectedValue, attrs[tc.expectedClaim])
-			assert.Nil(suite.T(), attrs[tc.absentClaim])
-
-			mockUserService.AssertExpectations(suite.T())
-			mockOUService.AssertExpectations(suite.T())
-		})
-	}
+	mockAttrCacheService.AssertExpectations(suite.T())
 }
 
 func (suite *UtilsTestSuite) TestResolveTokenConfig_RefreshToken_WithServerLevelConfig() {
@@ -1101,7 +806,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_RefreshToken_WithServerLevel
 		ClientID: "test-client",
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeRefresh)
+	result := ResolveTokenConfig(oauthApp, TokenTypeRefresh)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(86400), result.ValidityPeriod)
@@ -1128,7 +833,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_RefreshToken_WithoutServerLe
 		ClientID: "test-client",
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeRefresh)
+	result := ResolveTokenConfig(oauthApp, TokenTypeRefresh)
 
 	assert.NotNil(suite.T(), result)
 	// Should fallback to default JWT validity period
@@ -1152,7 +857,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_RefreshToken_WithNilOAuthApp
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
 	// oauthApp is nil
-	result := resolveTokenConfig(nil, TokenTypeRefresh)
+	result := ResolveTokenConfig(nil, TokenTypeRefresh)
 
 	assert.NotNil(suite.T(), result)
 	// Should still use server-level refresh token config
@@ -1181,7 +886,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_RefreshToken_WithTokenConfig
 		Token:    &appmodel.OAuthTokenConfig{},
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeRefresh)
+	result := ResolveTokenConfig(oauthApp, TokenTypeRefresh)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(86400), result.ValidityPeriod)
@@ -1199,7 +904,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_AccessToken_WithNilOAuthApp(
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
 	// oauthApp is nil - should use default config
-	result := resolveTokenConfig(nil, TokenTypeAccess)
+	result := ResolveTokenConfig(nil, TokenTypeAccess)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(3600), result.ValidityPeriod)
@@ -1222,7 +927,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_AccessToken_WithNilToken() {
 		Token:    nil,
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeAccess)
+	result := ResolveTokenConfig(oauthApp, TokenTypeAccess)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(3600), result.ValidityPeriod)
@@ -1248,7 +953,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_AccessToken_WithAppLevelConf
 		},
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeAccess)
+	result := ResolveTokenConfig(oauthApp, TokenTypeAccess)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(7200), result.ValidityPeriod)
@@ -1265,7 +970,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_IDToken_WithNilOAuthApp() {
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
 	// oauthApp is nil - should use default config
-	result := resolveTokenConfig(nil, TokenTypeID)
+	result := ResolveTokenConfig(nil, TokenTypeID)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(3600), result.ValidityPeriod)
@@ -1288,7 +993,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_IDToken_WithNilToken() {
 		Token:    nil,
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeID)
+	result := ResolveTokenConfig(oauthApp, TokenTypeID)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(3600), result.ValidityPeriod)
@@ -1314,7 +1019,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_IDToken_WithAppLevelConfig()
 		},
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeID)
+	result := ResolveTokenConfig(oauthApp, TokenTypeID)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), int64(1800), result.ValidityPeriod)
@@ -1331,7 +1036,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_WithCustomIssuer_NilOAuthApp
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
 	// With nil oauthApp, should use default issuer
-	result := resolveTokenConfig(nil, TokenTypeAccess)
+	result := ResolveTokenConfig(nil, TokenTypeAccess)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "https://thunder.io", result.Issuer)
@@ -1353,7 +1058,7 @@ func (suite *UtilsTestSuite) TestResolveTokenConfig_WithTokenConfig_UsesThunderI
 		Token:    &appmodel.OAuthTokenConfig{},
 	}
 
-	result := resolveTokenConfig(oauthApp, TokenTypeAccess)
+	result := ResolveTokenConfig(oauthApp, TokenTypeAccess)
 
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "https://thunder.io", result.Issuer)

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -127,12 +127,7 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 	grantType, _ := extractStringClaim(claims, "grant_type")
 	iat, _ := extractInt64Claim(claims, "iat")
 	scopes := extractScopesFromClaims(claims, false)
-
-	// Extract user attributes if present
-	var userAttributes map[string]interface{}
-	if userAttrs, ok := claims["access_token_user_attributes"].(map[string]interface{}); ok {
-		userAttributes = userAttrs
-	}
+	attributeCacheID, _ := extractStringClaim(claims, "aci")
 
 	// Extract claims request if present
 	var claimsRequest *oauth2model.ClaimsRequest
@@ -150,14 +145,14 @@ func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*
 
 	// Extract user type and organizational unit details if present
 	return &RefreshTokenClaims{
-		Sub:            sub,
-		Aud:            aud,
-		GrantType:      grantType,
-		Scopes:         scopes,
-		UserAttributes: userAttributes,
-		Iat:            iat,
-		ClaimsRequest:  claimsRequest,
-		ClaimsLocales:  claimsLocales,
+		Sub:              sub,
+		Aud:              aud,
+		GrantType:        grantType,
+		Scopes:           scopes,
+		AttributeCacheID: attributeCacheID,
+		Iat:              iat,
+		ClaimsRequest:    claimsRequest,
+		ClaimsLocales:    claimsLocales,
 	}, nil
 }
 

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -599,16 +599,16 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_EdgeCase_VeryLong
 func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_Basic() {
 	now := time.Now().Unix()
 	claims := map[string]interface{}{
-		"sub":                          "test-client",
-		"iss":                          "https://thunder.io",
-		"aud":                          "test-client",
-		"exp":                          float64(now + 3600),
-		"iat":                          float64(now),
-		"scope":                        "read write",
-		"access_token_sub":             "user123",
-		"access_token_aud":             testAppID,
-		"grant_type":                   "authorization_code",
-		"access_token_user_attributes": map[string]interface{}{"name": "John Doe"},
+		"sub":              "test-client",
+		"iss":              "https://thunder.io",
+		"aud":              "test-client",
+		"exp":              float64(now + 3600),
+		"iat":              float64(now),
+		"scope":            "read write",
+		"access_token_sub": "user123",
+		"access_token_aud": testAppID,
+		"grant_type":       "authorization_code",
+		"aci":              "test-cache-id",
 	}
 	token := suite.createTestJWT(claims)
 
@@ -622,7 +622,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_Basic() {
 	assert.Equal(suite.T(), testAppID, result.Aud)
 	assert.Equal(suite.T(), "authorization_code", result.GrantType)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
-	assert.Equal(suite.T(), map[string]interface{}{"name": "John Doe"}, result.UserAttributes)
+	assert.Equal(suite.T(), "test-cache-id", result.AttributeCacheID)
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
@@ -647,7 +647,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithoutUs
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
-	assert.Nil(suite.T(), result.UserAttributes)
+	assert.Equal(suite.T(), "", result.AttributeCacheID)
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
@@ -951,17 +951,17 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_MissingGran
 func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithClaimsLocales() {
 	now := time.Now().Unix()
 	claims := map[string]interface{}{
-		"sub":                          "test-client",
-		"iss":                          "https://thunder.io",
-		"aud":                          "test-client",
-		"exp":                          float64(now + 3600),
-		"iat":                          float64(now),
-		"scope":                        "read write",
-		"access_token_sub":             "user123",
-		"access_token_aud":             testAppID,
-		"grant_type":                   "authorization_code",
-		"access_token_user_attributes": map[string]interface{}{"name": "John Doe"},
-		"access_token_claims_locales":  "en-US fr-CA ja",
+		"sub":                         "test-client",
+		"iss":                         "https://thunder.io",
+		"aud":                         "test-client",
+		"exp":                         float64(now + 3600),
+		"iat":                         float64(now),
+		"scope":                       "read write",
+		"access_token_sub":            "user123",
+		"access_token_aud":            testAppID,
+		"grant_type":                  "authorization_code",
+		"aci":                         "test-cache-id",
+		"access_token_claims_locales": "en-US fr-CA ja",
 	}
 	token := suite.createTestJWT(claims)
 
@@ -975,7 +975,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithClaim
 	assert.Equal(suite.T(), testAppID, result.Aud)
 	assert.Equal(suite.T(), "authorization_code", result.GrantType)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
-	assert.Equal(suite.T(), map[string]interface{}{"name": "John Doe"}, result.UserAttributes)
+	assert.Equal(suite.T(), "test-cache-id", result.AttributeCacheID)
 	assert.Equal(suite.T(), "en-US fr-CA ja", result.ClaimsLocales)
 	suite.mockJWTService.AssertExpectations(suite.T())
 }

--- a/backend/internal/oauth/oauth2/userinfo/init.go
+++ b/backend/internal/oauth/oauth2/userinfo/init.go
@@ -22,13 +22,13 @@ import (
 	"net/http"
 
 	"github.com/asgardeo/thunder/internal/application"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/database/transaction"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 // Initialize initializes the userinfo handler and registers its routes.
@@ -37,13 +37,12 @@ func Initialize(
 	jwtService jwt.JWTServiceInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
 	applicationService application.ApplicationServiceInterface,
-	userService user.UserServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
+	attributeCacheSvc attributecache.AttributeCacheServiceInterface,
 	transactioner transaction.Transactioner,
 ) userInfoServiceInterface {
-	userInfoService := newUserInfoService(
-		jwtService, tokenValidator, applicationService, userService, ouService, transactioner,
-	)
+	userInfoService := newUserInfoService(jwtService, tokenValidator, applicationService, ouService,
+		attributeCacheSvc, transactioner)
 	userInfoHandler := newUserInfoHandler(userInfoService)
 	registerRoutes(mux, userInfoHandler)
 	return userInfoService

--- a/backend/internal/oauth/oauth2/userinfo/init_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/init_test.go
@@ -27,20 +27,20 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
+	"github.com/asgardeo/thunder/tests/mocks/attributecachemock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
-	usersvcmock "github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
 type InitTestSuite struct {
 	suite.Suite
-	mockJWTService     *jwtmock.JWTServiceInterfaceMock
-	mockTokenValidator *tokenservicemock.TokenValidatorInterfaceMock
-	mockAppService     *applicationmock.ApplicationServiceInterfaceMock
-	mockUserService    *usersvcmock.UserServiceInterfaceMock
-	mockOUService      *oumock.OrganizationUnitServiceInterfaceMock
-	mockTransactioner  *MockTransactioner
+	mockJWTService            *jwtmock.JWTServiceInterfaceMock
+	mockTokenValidator        *tokenservicemock.TokenValidatorInterfaceMock
+	mockAppService            *applicationmock.ApplicationServiceInterfaceMock
+	mockOUService             *oumock.OrganizationUnitServiceInterfaceMock
+	mockAttributeCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
+	mockTransactioner         *MockTransactioner
 }
 
 func TestInitTestSuite(t *testing.T) {
@@ -51,8 +51,8 @@ func (suite *InitTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
 	suite.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(suite.T())
-	suite.mockUserService = usersvcmock.NewUserServiceInterfaceMock(suite.T())
 	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	suite.mockAttributeCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 	suite.mockTransactioner = &MockTransactioner{}
 }
 
@@ -61,7 +61,7 @@ func (suite *InitTestSuite) TestInitialize() {
 
 	service := Initialize(mux, suite.mockJWTService,
 		suite.mockTokenValidator, suite.mockAppService,
-		suite.mockUserService, suite.mockOUService, suite.mockTransactioner)
+		suite.mockOUService, suite.mockAttributeCacheService, suite.mockTransactioner)
 
 	assert.NotNil(suite.T(), service)
 }
@@ -71,7 +71,7 @@ func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 
 	Initialize(mux, suite.mockJWTService,
 		suite.mockTokenValidator, suite.mockAppService,
-		suite.mockUserService, suite.mockOUService, suite.mockTransactioner)
+		suite.mockOUService, suite.mockAttributeCacheService, suite.mockTransactioner)
 
 	// Verify that the routes are registered by attempting to get a handler for them.
 	// The pattern includes the method because of CORS middleware wrapping.

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
@@ -35,7 +36,6 @@ import (
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
-	"github.com/asgardeo/thunder/internal/user"
 )
 
 const serviceLoggerComponentName = "UserInfoService"
@@ -50,8 +50,8 @@ type userInfoService struct {
 	jwtService         jwt.JWTServiceInterface
 	tokenValidator     tokenservice.TokenValidatorInterface
 	applicationService application.ApplicationServiceInterface
-	userService        user.UserServiceInterface
 	ouService          ou.OrganizationUnitServiceInterface
+	attributeCacheSvc  attributecache.AttributeCacheServiceInterface
 	transactioner      transaction.Transactioner
 	logger             *log.Logger
 }
@@ -61,16 +61,16 @@ func newUserInfoService(
 	jwtService jwt.JWTServiceInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
 	applicationService application.ApplicationServiceInterface,
-	userService user.UserServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
+	attributeCacheSvc attributecache.AttributeCacheServiceInterface,
 	transactioner transaction.Transactioner,
 ) userInfoServiceInterface {
 	return &userInfoService{
 		jwtService:         jwtService,
 		tokenValidator:     tokenValidator,
 		applicationService: applicationService,
-		userService:        userService,
 		ouService:          ouService,
+		attributeCacheSvc:  attributeCacheSvc,
 		transactioner:      transactioner,
 		logger:             log.GetLogger().With(log.String(log.LoggerKeyComponentName, serviceLoggerComponentName)),
 	}
@@ -111,9 +111,14 @@ func (s *userInfoService) GetUserInfo(
 		allowedUserAttributes = oauthApp.UserInfo.UserAttributes
 	}
 
+	attributeCacheID := ""
+	if val, ok := tokenClaims["aci"].(string); ok {
+		attributeCacheID = val
+	}
+
 	// Fetch user attributes with groups and default claims
-	userAttributes, err := tokenservice.FetchUserAttributes(ctx, s.userService, s.ouService,
-		sub, allowedUserAttributes)
+	userAttributes, err := tokenservice.FetchUserAttributes(ctx, s.attributeCacheSvc,
+		allowedUserAttributes, attributeCacheID)
 	if err != nil {
 		s.logger.Error("Failed to fetch user attributes", log.String("userID", sub), log.Error(err))
 		return nil, &serviceerror.InternalServerError

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -35,28 +35,28 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	"github.com/asgardeo/thunder/internal/attributecache"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/tokenservice"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
-	"github.com/asgardeo/thunder/internal/user"
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
+	"github.com/asgardeo/thunder/tests/mocks/attributecachemock"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
-	"github.com/asgardeo/thunder/tests/mocks/usermock"
 )
 
 type UserInfoServiceTestSuite struct {
 	suite.Suite
-	mockJWTService     *jwtmock.JWTServiceInterfaceMock
-	mockTokenValidator *tokenservicemock.TokenValidatorInterfaceMock
-	mockAppService     *applicationmock.ApplicationServiceInterfaceMock
-	mockUserService    *usermock.UserServiceInterfaceMock
-	mockOUService      *oumock.OrganizationUnitServiceInterfaceMock
-	mockTransactioner  *MockTransactioner
-	userInfoService    userInfoServiceInterface
-	privateKey         *rsa.PrivateKey
+	mockJWTService            *jwtmock.JWTServiceInterfaceMock
+	mockTokenValidator        *tokenservicemock.TokenValidatorInterfaceMock
+	mockAppService            *applicationmock.ApplicationServiceInterfaceMock
+	mockOUService             *oumock.OrganizationUnitServiceInterfaceMock
+	mockAttributeCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
+	mockTransactioner         *MockTransactioner
+	userInfoService           userInfoServiceInterface
+	privateKey                *rsa.PrivateKey
 }
 
 // MockTransactioner is a simple implementation of Transactioner for testing.
@@ -74,12 +74,13 @@ func (s *UserInfoServiceTestSuite) SetupTest() {
 	s.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(s.T())
 	s.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(s.T())
 	s.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(s.T())
-	s.mockUserService = usermock.NewUserServiceInterfaceMock(s.T())
 	s.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(s.T())
+	s.mockAttributeCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(s.T())
 	s.mockTransactioner = &MockTransactioner{}
 	s.userInfoService = newUserInfoService(
 		s.mockJWTService, s.mockTokenValidator,
-		s.mockAppService, s.mockUserService, s.mockOUService, s.mockTransactioner)
+		s.mockAppService, s.mockOUService,
+		s.mockAttributeCacheService, s.mockTransactioner)
 
 	// Initialize Thunder runtime for tests
 	config.ResetThunderRuntime()
@@ -206,25 +207,24 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ErrorFetchingUserAttributes()
 		"nbf":   float64(time.Now().Add(-time.Minute).Unix()),
 		"sub":   "user123",
 		"scope": "openid profile",
+		"aci":   "cache-err-123",
 	}
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(nil, &serviceerror.ServiceError{
-		Code:  "USER_NOT_FOUND",
-		Error: "User not found",
-	})
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-err-123").Return(
+		nil, &serviceerror.InternalServerErrorWithI18n)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
 	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
 	assert.Nil(s.T(), response)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 }
 
-// TestGetUserInfo_ErrorFetchingGroups tests error when fetching groups fails
+// TestGetUserInfo_ErrorFetchingGroups tests error when the attribute cache (which contains groups) cannot be fetched
 func (s *UserInfoServiceTestSuite) TestGetUserInfo_ErrorFetchingGroups() {
 	claims := map[string]interface{}{
 		"exp":       float64(time.Now().Add(time.Hour).Unix()),
@@ -232,41 +232,28 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ErrorFetchingGroups() {
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-groups-123",
 	}
 	token := s.createToken(claims)
 
-	userAttrs := map[string]interface{}{
-		"name":  "John Doe",
-		"email": "john@example.com",
-	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
-
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
-	// This test verifies error handling when groups are needed but fetching fails
-	// So we need an OAuth app with groups in UserAttributes
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		UserInfo: &appmodel.UserInfoConfig{
 			UserAttributes: []string{"name", constants.UserAttributeGroups},
 		},
 	}
+	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-groups-123").Return(
+		nil, &serviceerror.InternalServerErrorWithI18n)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
-	s.mockUserService.On("GetUserGroups", mock.Anything, "user123",
-		constants.DefaultGroupListLimit, 0).Return(nil, &serviceerror.ServiceError{
-		Code:  "INTERNAL_ERROR",
-		Error: "Failed to fetch groups",
-	})
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
 	assert.Equal(s.T(), serviceerror.InternalServerError.Code, svcErr.Code)
 	assert.Nil(s.T(), response)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
+	s.mockAppService.AssertExpectations(s.T())
 }
 
 // TestGetUserInfo_Success_StandardScopes tests successful response with standard OIDC scopes
@@ -277,6 +264,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_StandardScopes() {
 		"sub":       "user123",
 		"scope":     "openid profile email",
 		"client_id": "client123",
+		"aci":       "cache-std-123",
 	}
 	token := s.createToken(claims)
 
@@ -284,7 +272,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_StandardScopes() {
 		"name":  "John Doe",
 		"email": "john@example.com",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{
@@ -299,10 +286,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_StandardScopes() {
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-std-123").Return(
+		&attributecache.AttributeCache{ID: "cache-std-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -313,7 +298,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_StandardScopes() {
 	assert.Equal(s.T(), "John Doe", response.JSONBody["name"])
 	assert.Equal(s.T(), "john@example.com", response.JSONBody["email"])
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -325,13 +310,14 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithGroups() {
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-grp-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
-		"name": "John Doe",
+		"name":                        "John Doe",
+		constants.UserAttributeGroups: []interface{}{"admin", "users"},
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{
@@ -349,17 +335,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithGroups() {
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
-	s.mockUserService.On("GetUserGroups", mock.Anything, "user123",
-		constants.DefaultGroupListLimit, 0).Return(&user.UserGroupListResponse{
-		Groups: []user.UserGroup{
-			{Name: "admin"},
-			{Name: "users"},
-		},
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-grp-123").Return(
+		&attributecache.AttributeCache{ID: "cache-grp-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -370,27 +347,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithGroups() {
 	assert.Equal(s.T(), "John Doe", response.JSONBody["name"])
 	groupsValue := response.JSONBody[constants.UserAttributeGroups]
 	assert.NotNil(s.T(), groupsValue, "groups should be present")
-	// Groups can be []string or []interface{} depending on JSON unmarshaling
-	var groups []string
-	switch v := groupsValue.(type) {
-	case []string:
-		groups = v
-	case []interface{}:
-		groups = make([]string, 0, len(v))
-		for _, item := range v {
-			if str, ok := item.(string); ok {
-				groups = append(groups, str)
-			}
-		}
-	default:
-		s.T().Fatalf("groups should be []string or []interface{}, got %T", v)
-	}
+	groups, ok := groupsValue.([]interface{})
+	assert.True(s.T(), ok, "groups should be []interface{}")
 	assert.Len(s.T(), groups, 2)
 	assert.Contains(s.T(), groups, "admin")
 	assert.Contains(s.T(), groups, "users")
-	assert.Equal(s.T(), []string{"admin", "users"}, groups)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -402,6 +365,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithScopeClaimsMappin
 		"sub":       "user123",
 		"scope":     "openid custom_scope",
 		"client_id": "client123",
+		"aci":       "cache-scope-123",
 	}
 	token := s.createToken(claims)
 
@@ -410,7 +374,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithScopeClaimsMappin
 		"email": "john@example.com",
 		"phone": "1234567890",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{
@@ -428,10 +391,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithScopeClaimsMappin
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-scope-123").Return(
+		&attributecache.AttributeCache{ID: "cache-scope-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -443,7 +404,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithScopeClaimsMappin
 	assert.Equal(s.T(), "1234567890", response.JSONBody["phone"])
 	assert.NotContains(s.T(), response.JSONBody, "email") // email not in custom_scope mapping
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -454,6 +415,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_NoAppConfig() {
 		"nbf":   float64(time.Now().Add(-time.Minute).Unix()),
 		"sub":   "user123",
 		"scope": "openid profile",
+		"aci":   "cache-noapp-123",
 		// No client_id
 	}
 	token := s.createToken(claims)
@@ -462,14 +424,11 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_NoAppConfig() {
 		"name":  "John Doe",
 		"email": "john@example.com",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-noapp-123").Return(
+		&attributecache.AttributeCache{ID: "cache-noapp-123", Attributes: userAttrs}, nil)
 
 	// When no app config, BuildClaims returns empty (no allowedUserAttributes)
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -480,7 +439,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_NoAppConfig() {
 	// No other claims because allowedUserAttributes is empty
 	assert.Len(s.T(), response.JSONBody, 1)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 }
 
 // TestGetUserInfo_Success_AppNotFound tests successful response when app is not found
@@ -491,20 +450,18 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_AppNotFound() {
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-anf-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-anf-123").Return(
+		&attributecache.AttributeCache{ID: "cache-anf-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(nil, &serviceerror.ServiceError{
 		Code:  "APP_NOT_FOUND",
 		Error: "App not found",
@@ -519,7 +476,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_AppNotFound() {
 	// No other claims because allowedUserAttributes is empty
 	assert.Len(s.T(), response.JSONBody, 1)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -531,13 +488,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_GroupsNotInAllowedAtt
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-gnaa-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{
@@ -552,10 +509,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_GroupsNotInAllowedAtt
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-gnaa-123").Return(
+		&attributecache.AttributeCache{ID: "cache-gnaa-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -566,11 +521,12 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_GroupsNotInAllowedAtt
 	assert.Equal(s.T(), "John Doe", response.JSONBody["name"])
 	assert.NotContains(s.T(), response.JSONBody, constants.UserAttributeGroups) // groups not included
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
-// TestGetUserInfo_Success_EmptyUserAttributes tests successful response with empty user attributes
+// TestGetUserInfo_Success_EmptyUserAttributes tests successful response when no attribute cache key is present,
+// meaning the user has no cached attributes.
 func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_EmptyUserAttributes() {
 	claims := map[string]interface{}{
 		"exp":       float64(time.Now().Add(time.Hour).Unix()),
@@ -578,6 +534,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_EmptyUserAttributes()
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		// No "aci" claim — user has no cached attributes
 	}
 	token := s.createToken(claims)
 
@@ -594,10 +551,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_EmptyUserAttributes()
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: nil, // No attributes
-	}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -605,10 +558,10 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_EmptyUserAttributes()
 	assert.NotNil(s.T(), response)
 	assert.Equal(s.T(), appmodel.UserInfoResponseTypeJSON, response.Type)
 	assert.Equal(s.T(), "user123", response.JSONBody["sub"])
-	// No other claims because user has no attributes
+	// No other claims because user has no cached attributes
 	assert.Len(s.T(), response.JSONBody, 1)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -660,20 +613,18 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoInvalidClientID(clientIDValue 
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": clientIDValue,
+		"aci":       "cache-inv-cid-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-inv-cid-123").Return(
+		&attributecache.AttributeCache{ID: "cache-inv-cid-123", Attributes: userAttrs}, nil)
 
 	// When client_id is invalid, app lookup is skipped
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -684,7 +635,7 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoInvalidClientID(clientIDValue 
 	// No other claims because allowedUserAttributes is empty
 	assert.Len(s.T(), response.JSONBody, 1, description)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 }
 
 // TestGetUserInfo_ClientIDNotString tests when client_id exists but is not a string
@@ -704,6 +655,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilOAuthApp() {
 		"nbf":   float64(time.Now().Add(-time.Minute).Unix()),
 		"sub":   "user123",
 		"scope": "openid profile",
+		"aci":   "cache-nil-app-123",
 		// No client_id
 	}
 	token := s.createToken(claims)
@@ -711,14 +663,11 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilOAuthApp() {
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-app-123").Return(
+		&attributecache.AttributeCache{ID: "cache-nil-app-123", Attributes: userAttrs}, nil)
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.Nil(s.T(), svcErr)
 	assert.NotNil(s.T(), response)
@@ -727,7 +676,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilOAuthApp() {
 	// Groups not included because oauthApp is nil
 	assert.NotContains(s.T(), response.JSONBody, constants.UserAttributeGroups)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 }
 
 // TestGetUserInfo_GroupsWithNilToken tests groups when Token is nil
@@ -738,13 +687,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilToken() {
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-nil-tok-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: nil, // Token is nil
@@ -752,10 +701,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilToken() {
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-tok-123").Return(
+		&attributecache.AttributeCache{ID: "cache-nil-tok-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	// When Token is nil, groups are not added
@@ -767,7 +714,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilToken() {
 	// Groups not included because Token is nil
 	assert.NotContains(s.T(), response.JSONBody, constants.UserAttributeGroups)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -779,13 +726,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilIDToken() {
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-nil-idt-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{
@@ -795,10 +742,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilIDToken() {
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-idt-123").Return(
+		&attributecache.AttributeCache{ID: "cache-nil-idt-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	// When IDToken is nil, groups are not added
@@ -810,7 +755,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilIDToken() {
 	// Groups not included because IDToken is nil
 	assert.NotContains(s.T(), response.JSONBody, constants.UserAttributeGroups)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -822,13 +767,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithEmptyGroups() {
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-eg-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{
@@ -846,27 +791,21 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithEmptyGroups() {
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
-	s.mockUserService.On("GetUserGroups", mock.Anything, "user123",
-		constants.DefaultGroupListLimit, 0).Return(&user.UserGroupListResponse{
-		Groups: []user.UserGroup{}, // Empty groups
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-eg-123").Return(
+		&attributecache.AttributeCache{ID: "cache-eg-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
-	// When groups is empty, groups are not added to userAttributes
+	// When the cache has no groups key, groups are not added to userAttributes
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.Nil(s.T(), svcErr)
 	assert.NotNil(s.T(), response)
 	assert.Equal(s.T(), appmodel.UserInfoResponseTypeJSON, response.Type)
 	assert.Equal(s.T(), "user123", response.JSONBody["sub"])
 	assert.Equal(s.T(), "John Doe", response.JSONBody["name"])
-	// Groups not included because len(userGroups) == 0
+	// Groups not included because the attribute cache has no groups entry
 	assert.NotContains(s.T(), response.JSONBody, constants.UserAttributeGroups)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -891,8 +830,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ClientCredentialsGrant_Reject
 	assert.Equal(s.T(), errorClientCredentialsNotSupported.ErrorDescription, svcErr.ErrorDescription)
 	assert.Nil(s.T(), response)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	// Verify that user service is not called
-	s.mockUserService.AssertNotCalled(s.T(), "GetUser", mock.Anything)
 }
 
 // testGetUserInfoAllowedGrantType is a helper function for testing allowed grant types
@@ -903,6 +840,7 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoAllowedGrantType(grantTypeValu
 		"sub":       "user123",
 		"scope":     "openid profile",
 		"client_id": "client123",
+		"aci":       "cache-agt-123",
 	}
 	if grantTypeValue != nil {
 		claims["grant_type"] = grantTypeValue
@@ -912,7 +850,6 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoAllowedGrantType(grantTypeValu
 	userAttrs := map[string]interface{}{
 		"name": "John Doe",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{
@@ -927,10 +864,8 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoAllowedGrantType(grantTypeValu
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-agt-123").Return(
+		&attributecache.AttributeCache{ID: "cache-agt-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -940,7 +875,7 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoAllowedGrantType(grantTypeValu
 	assert.Equal(s.T(), "user123", response.JSONBody["sub"], description)
 	assert.Equal(s.T(), "John Doe", response.JSONBody["name"], description)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -990,8 +925,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_MissingOpenIDScope_WithOtherS
 	assert.Contains(s.T(), svcErr.ErrorDescription, "openid")
 	assert.Nil(s.T(), response)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	// Verify that user service is NOT called (fail fast)
-	s.mockUserService.AssertNotCalled(s.T(), "GetUser")
 }
 
 // TestGetUserInfo_OpenIDScope_CaseSensitive tests that scope matching is case-sensitive
@@ -1021,18 +954,14 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OnlyOpenIDScope_Success() {
 		"nbf":   float64(time.Now().Add(-time.Minute).Unix()),
 		"sub":   "user123",
 		"scope": "openid", // Only openid scope
+		"aci":   "cache-oid-only-123",
 	}
 	token := s.createToken(claims)
 
-	userAttrs := map[string]interface{}{}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
-
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-oid-only-123").Return(
+		&attributecache.AttributeCache{ID: "cache-oid-only-123", Attributes: map[string]interface{}{}}, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.Nil(s.T(), svcErr)
@@ -1042,7 +971,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OnlyOpenIDScope_Success() {
 	// Only sub claim should be present
 	assert.Len(s.T(), response.JSONBody, 1)
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 }
 
 // TestGetUserInfo_OpenIDScope_InMiddleOfScopeString tests openid scope in middle position
@@ -1053,6 +982,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_InMiddleOfScopeSt
 		"sub":       "user123",
 		"scope":     "profile openid email", // openid in middle
 		"client_id": "client123",
+		"aci":       "cache-mid-123",
 	}
 	token := s.createToken(claims)
 
@@ -1060,7 +990,6 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_InMiddleOfScopeSt
 		"name":  "John Doe",
 		"email": "john@example.com",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		UserInfo: &appmodel.UserInfoConfig{
@@ -1070,10 +999,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_InMiddleOfScopeSt
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-mid-123").Return(
+		&attributecache.AttributeCache{ID: "cache-mid-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -1084,7 +1011,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_InMiddleOfScopeSt
 	assert.Equal(s.T(), "John Doe", response.JSONBody["name"])
 	assert.Equal(s.T(), "john@example.com", response.JSONBody["email"])
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -1096,13 +1023,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_AtEnd() {
 		"sub":       "user123",
 		"scope":     "profile email openid", // openid at end
 		"client_id": "client123",
+		"aci":       "cache-end-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"email": "john@example.com",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		UserInfo: &appmodel.UserInfoConfig{
@@ -1112,10 +1039,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_AtEnd() {
 
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-end-123").Return(
+		&attributecache.AttributeCache{ID: "cache-end-123", Attributes: userAttrs}, nil)
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -1126,7 +1051,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_AtEnd() {
 	assert.Equal(s.T(), "user123", response.JSONBody["sub"])
 	assert.Equal(s.T(), "john@example.com", response.JSONBody["email"])
 	s.mockTokenValidator.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -1140,13 +1065,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 		"sub":       "user123",
 		"scope":     "openid email",
 		"client_id": "client123",
+		"aci":       "cache-jws-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"email": "john@example.com",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{},
@@ -1162,11 +1087,9 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
-	// User fetch
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	// Attribute cache fetch
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-jws-123").Return(
+		&attributecache.AttributeCache{ID: "cache-jws-123", Attributes: userAttrs}, nil)
 
 	// App fetch
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
@@ -1192,7 +1115,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 
 	s.mockTokenValidator.AssertExpectations(s.T())
 	s.mockJWTService.AssertExpectations(s.T())
-	s.mockUserService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 	s.mockAppService.AssertExpectations(s.T())
 }
 
@@ -1205,13 +1128,13 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 		"sub":       "user123",
 		"scope":     "openid email",
 		"client_id": "client123",
+		"aci":       "cache-jws-fail-123",
 	}
 	token := s.createToken(claims)
 
 	userAttrs := map[string]interface{}{
 		"email": "john@example.com",
 	}
-	userAttrsJSON, _ := json.Marshal(userAttrs)
 
 	oauthApp := &appmodel.OAuthAppConfigProcessedDTO{
 		Token: &appmodel.OAuthTokenConfig{},
@@ -1225,10 +1148,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
-	s.mockUserService.On("GetUser", mock.Anything, "user123").Return(&user.User{
-		ID:         "user123",
-		Attributes: userAttrsJSON,
-	}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-jws-fail-123").Return(
+		&attributecache.AttributeCache{ID: "cache-jws-fail-123", Attributes: userAttrs}, nil)
 
 	s.mockAppService.On("GetOAuthApplication", mock.Anything, "client123").Return(oauthApp, nil)
 
@@ -1257,4 +1178,5 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 
 	s.mockTokenValidator.AssertExpectations(s.T())
 	s.mockJWTService.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
 }

--- a/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/granthandlersmock/RefreshTokenGrantHandlerInterface_mock.go
@@ -116,16 +116,16 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_HandleGrant_Call) RunAndReturn(r
 }
 
 // IssueRefreshToken provides a mock function for the type RefreshTokenGrantHandlerInterfaceMock
-func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string) *model.ErrorResponse {
-	ret := _mock.Called(ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales)
+func (_mock *RefreshTokenGrantHandlerInterfaceMock) IssueRefreshToken(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string) *model.ErrorResponse {
+	ret := _mock.Called(ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IssueRefreshToken")
 	}
 
 	var r0 *model.ErrorResponse
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string, *model.ClaimsRequest, string) *model.ErrorResponse); ok {
-		r0 = returnFunc(ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.TokenResponseDTO, *model0.OAuthAppConfigProcessedDTO, string, string, string, []string, *model.ClaimsRequest, string, string) *model.ErrorResponse); ok {
+		r0 = returnFunc(ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ErrorResponse)
@@ -149,11 +149,12 @@ type RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call struct {
 //   - scopes []string
 //   - claimsRequest *model.ClaimsRequest
 //   - claimsLocales string
-func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(ctx interface{}, tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}, claimsRequest interface{}, claimsLocales interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
-	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales)}
+//   - attributeCacheID string
+func (_e *RefreshTokenGrantHandlerInterfaceMock_Expecter) IssueRefreshToken(ctx interface{}, tokenResponse interface{}, oauthApp interface{}, subject interface{}, audience interface{}, grantType interface{}, scopes interface{}, claimsRequest interface{}, claimsLocales interface{}, attributeCacheID interface{}) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+	return &RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call{Call: _e.mock.On("IssueRefreshToken", ctx, tokenResponse, oauthApp, subject, audience, grantType, scopes, claimsRequest, claimsLocales, attributeCacheID)}
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string)) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -191,6 +192,10 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 		if args[8] != nil {
 			arg8 = args[8].(string)
 		}
+		var arg9 string
+		if args[9] != nil {
+			arg9 = args[9].(string)
+		}
 		run(
 			arg0,
 			arg1,
@@ -201,6 +206,7 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Run(run 
 			arg6,
 			arg7,
 			arg8,
+			arg9,
 		)
 	})
 	return _c
@@ -211,7 +217,7 @@ func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) Return(e
 	return _c
 }
 
-func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
+func (_c *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call) RunAndReturn(run func(ctx context.Context, tokenResponse *model.TokenResponseDTO, oauthApp *model0.OAuthAppConfigProcessedDTO, subject string, audience string, grantType string, scopes []string, claimsRequest *model.ClaimsRequest, claimsLocales string, attributeCacheID string) *model.ErrorResponse) *RefreshTokenGrantHandlerInterfaceMock_IssueRefreshToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -640,37 +640,73 @@ func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithRequiredAttributes() 
 	ts.Require().NoError(err, "Failed to execute authentication flow")
 	ts.Require().NotEmpty(flowStep.Assertion, "Assertion should be generated")
 
-	// Step 3: Verify assertion contains only required attributes
-	// Expected: sub (from openid), name (from profile scope, filtered by IDToken.UserAttributes),
-	// email (from email scope, filtered by IDToken.UserAttributes), groups, roles (from AccessToken.UserAttributes)
-	// Should NOT contain: phone, customAttr, email_verified (not in IDToken.UserAttributes)
+	// Step 3: Verify assertion structure for OAuth flow.
+	// In OAuth flows, user attributes are stored in the attribute cache and not embedded
+	// directly in the assertion JWT. Only the aci is included in the JWT claims.
 
 	// Decode JWT to verify claims
 	jwtClaims, err := testutils.DecodeJWT(flowStep.Assertion)
 	ts.Require().NoError(err, "Failed to decode JWT assertion")
 	claims := jwtClaims.Additional
 
-	// Verify required attributes are present
+	// Verify sub is present (standard JWT subject claim)
 	ts.Assert().NotNil(claims["sub"], "sub claim should be present")
 	ts.Assert().Equal(userID, claims["sub"], "sub should match user ID")
-	ts.Assert().NotNil(claims["name"], "name claim should be present (from profile scope)")
-	ts.Assert().Equal("Required Attrs", claims["name"], "name should match user attribute")
-	ts.Assert().NotNil(claims["email"], "email claim should be present (from email scope)")
-	ts.Assert().Equal("requiredattrs@test.com", claims["email"], "email should match user attribute")
-	ts.Assert().NotNil(claims["roles"], "roles claim should be present (from access token config)")
-	rolesValue, ok := claims["roles"].([]interface{})
-	ts.Assert().True(ok, "roles should be an array")
-	ts.Assert().Equal([]interface{}{"developer"}, rolesValue, "roles should match user attribute")
-	if claims["groups"] != nil {
-		groupsValue, ok := claims["groups"].([]interface{})
-		ts.Assert().True(ok, "groups should be an array if present")
-		ts.Assert().NotEmpty(groupsValue, "groups array should not be empty if present")
-	}
 
-	// Verify non-required attributes are NOT present
-	ts.Assert().Nil(claims["phone"], "phone should NOT be present (not in required attributes)")
-	ts.Assert().Nil(claims["customAttr"], "customAttr should NOT be present (not in required attributes)")
-	ts.Assert().Nil(claims["email_verified"], "email_verified should NOT be present (not in IDToken.UserAttributes)")
-	ts.Assert().Nil(claims["given_name"], "given_name should NOT be present (not in required attributes)")
-	ts.Assert().Nil(claims["family_name"], "family_name should NOT be present (not in required attributes)")
+	// Verify aci is present and is a non-empty string (OAuth flow caches user attributes)
+	ts.Assert().NotNil(claims["aci"], "aci should be present in OAuth assertion")
+	cacheID, ok := claims["aci"].(string)
+	ts.Require().True(ok, "aci should be a string")
+	ts.Assert().NotEmpty(cacheID, "aci should not be empty")
+
+	// Verify user attributes are NOT directly embedded in the assertion (they are in the cache)
+	ts.Assert().Nil(claims["name"], "name should NOT be directly in assertion (stored in attribute cache)")
+	ts.Assert().Nil(claims["email"], "email should NOT be directly in assertion (stored in attribute cache)")
+	ts.Assert().Nil(claims["roles"], "roles should NOT be directly in assertion (stored in attribute cache)")
+	ts.Assert().Nil(claims["groups"], "groups should NOT be directly in assertion (stored in attribute cache)")
+	ts.Assert().Nil(claims["phone"], "phone should NOT be present in assertion")
+	ts.Assert().Nil(claims["customAttr"], "customAttr should NOT be present in assertion")
+	ts.Assert().Nil(claims["email_verified"], "email_verified should NOT be present in assertion")
+	ts.Assert().Nil(claims["given_name"], "given_name should NOT be present in assertion")
+	ts.Assert().Nil(claims["family_name"], "family_name should NOT be present in assertion")
+
+	// Step 4: Complete the authorization flow and verify the attribute cache content via the access token.
+	// The access token is built directly from the attribute cache, so its claims reflect the filtered set of
+	// resolved attributes. This downstream check confirms that required-attribute filtering was applied.
+	authzResp, err := testutils.CompleteAuthorization(authId, flowStep.Assertion)
+	ts.Require().NoError(err, "Failed to complete authorization")
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err, "Failed to extract authorization code")
+	ts.Require().NotEmpty(code, "Authorization code should not be empty")
+
+	tokenResult, err := testutils.RequestToken(
+		"required_attrs_test_client", "required_attrs_test_secret",
+		code, scopeTestRedirectURI, "authorization_code",
+	)
+	ts.Require().NoError(err, "Failed to request access token")
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, "Token request should succeed")
+	ts.Require().NotNil(tokenResult.Token, "Token response should not be nil")
+
+	// Decode the access token JWT to inspect its resolved claims
+	accessTokenJWT, err := testutils.DecodeJWT(tokenResult.Token.AccessToken)
+	ts.Require().NoError(err, "Failed to decode access token")
+	atClaims := accessTokenJWT.Additional
+
+	// The access token must carry the same aci, confirming the cache ID is propagated
+	// from the assertion JWT through the authorization code to the issued token
+	ts.Assert().Equal(cacheID, atClaims["aci"],
+		"Access token aci must match the one from the assertion JWT")
+
+	// Required attribute (roles) must be resolved and present — it was included in access_token.user_attributes
+	ts.Assert().NotNil(atClaims["roles"], "roles should be present in access token (required access_token attribute)")
+
+	// Excluded attributes must NOT appear — they were never added to the attribute cache
+	ts.Assert().Nil(atClaims["name"], "name should NOT be in access token (not an access_token attribute)")
+	ts.Assert().Nil(atClaims["email"], "email should NOT be in access token (not an access_token attribute)")
+	ts.Assert().Nil(atClaims["phone"], "phone should NOT be in access token (excluded attribute)")
+	ts.Assert().Nil(atClaims["customAttr"], "customAttr should NOT be in access token (excluded attribute)")
+	ts.Assert().Nil(atClaims["email_verified"], "email_verified should NOT be in access token (excluded attribute)")
+	ts.Assert().Nil(atClaims["given_name"], "given_name should NOT be in access token (excluded attribute)")
+	ts.Assert().Nil(atClaims["family_name"], "family_name should NOT be in access token (excluded attribute)")
 }


### PR DESCRIPTION
### Purpose

This pull request introduces a significant refactor in how user attributes are handled in OAuth authorization flows. Instead of directly storing user attributes in the authorization code, the system now uses an attribute cache and stores only the cache ID. This change improves security and scalability, and is reflected throughout the backend, including initialization, service registration, model definitions, and related tests.

### Approach

### Attribute Cache Integration

* Replaced direct storage of user attributes in the `AuthorizationCode` struct with an `AttributeCacheID`, updating serialization/deserialization logic and tests to match. (`backend/internal/oauth/oauth2/authz/model.go`, `auth_code_store.go`, `auth_code_store_test.go`, `handler_test.go`) [[1]](diffhunk://#diff-bf9f63eff78affd59ca6a5c5131797e45001fb0fc37c73745d68a04cb8df0ebdL42-R42) [[2]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL47-R47) [[3]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL150-R151) [[4]](diffhunk://#diff-42f5b7dfbd3f1429ce49d1e421d92d13cd9ee036165c5838db0ce1f550c1b37aL264-R265) [[5]](diffhunk://#diff-4505abf3272b6504ef692bf20b049aeb554ecbdb84a5b966bb587577e5d69772L152-R152) [[6]](diffhunk://#diff-4505abf3272b6504ef692bf20b049aeb554ecbdb84a5b966bb587577e5d69772L184-R179) [[7]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cL624-R624) [[8]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cL667-L670) [[9]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cL683) [[10]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cL695-R696)

* Updated the assertion claims structure and related decoding logic to use `attributeCacheID` instead of `userAttributes`, including new test cases for JWTs containing the cache ID. (`model.go`, `handler_test.go`) [[1]](diffhunk://#diff-bf9f63eff78affd59ca6a5c5131797e45001fb0fc37c73745d68a04cb8df0ebdL84-R84) [[2]](diffhunk://#diff-ac3333d7ed31dfa0ac060343f3911e42cf2df252a9b1f14b1fccf9b621d9ce6cL695-R696)

### Service Initialization and Registration

* Modified OAuth service initialization and registration to pass the `attributeCacheService` wherever required, ensuring the attribute cache is available throughout the OAuth flow. (`servicemanager.go`, `init.go`) [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L248-R248) [[2]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4R26) [[3]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4R55) [[4]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4L64-R67) [[5]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4L73-R77)

### Authorization Flow Logic

* Updated the authorization flow to add the attribute cache TTL to runtime data and to store only the cache ID in JWT claims, copying configured user attributes from the cache to the JWT only if specified in the application assertion config. (`auth_assert_executor.go`, `auth_assert_executor_test.go`, `authz/service.go`) [[1]](diffhunk://#diff-491fe16254a1b16f0310628b4961c9808c86dae266ea9797505cf7e4de29c83fR195-R203) [[2]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R1303-R1500) [[3]](diffhunk://#diff-a19169f208c81ae739b01ba45fef130d1026b848dbede951786de661df44d32eR254)

### Test Enhancements

* Added and updated tests to cover scenarios involving the attribute cache, including cases where attributes are copied to JWT claims, omitted, or only existing attributes are added. (`auth_assert_executor_test.go`)

### Dependency Updates

* Updated imports across files to include the new `attributecache` package and related services. (`auth_assert_executor_test.go`, `init.go`, `service.go`) [[1]](diffhunk://#diff-411f9f7d2be1c3a24a3c77262b3ae14d10295229cfe765afb5ff139629aaae85R31) [[2]](diffhunk://#diff-d447f0c87f48eb8cbf2a41c3692c43520fef6554b2ad56382110de6085cd31e4R26) [[3]](diffhunk://#diff-a19169f208c81ae739b01ba45fef130d1026b848dbede951786de661df44d32eR37)

### Related Issues
- https://github.com/asgardeo/thunder/issues/1752

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribute caching for user attributes; tokens and authorization codes now reference cached attributes via an attribute-cache identifier (aci).

* **Improvements**
  * Authorization, token refresh, userinfo and token issuance flows source attributes from the cache, reducing token payloads.
  * Cache TTL is computed from token settings and can be extended on refresh when needed.

* **Bug Fixes**
  * More robust parsing/handling of cached attribute data formats and clearer error paths.

* **Tests**
  * Expanded coverage for cache interactions, TTL resolution, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->