### PR TITLE
Add isReadOnly attribute for list response

### DIFF
--- a/api/design.yaml
+++ b/api/design.yaml
@@ -798,6 +798,10 @@ components:
           format: date-time
           description: Timestamp when the layout was last updated (ISO 8601 format)
           example: "2024-01-20T14:45:00Z"
+        isReadOnly:
+          type: boolean
+          description: Indicates whether the layout is read-only (declarative)
+          example: false
 
     LayoutListItem:
       type: object
@@ -825,6 +829,10 @@ components:
           format: date-time
           description: Timestamp when the layout was last updated (ISO 8601 format)
           example: "2024-01-20T14:45:00Z"
+        isReadOnly:
+          type: boolean
+          description: Indicates whether the layout is read-only (declarative)
+          example: false
 
     LayoutListResponse:
       type: object

--- a/backend/internal/application/model/application.go
+++ b/backend/internal/application/model/application.go
@@ -263,7 +263,7 @@ type BasicApplicationResponse struct {
 	ThemeID                   string `json:"themeId,omitempty" jsonschema:"Theme ID."`
 	LayoutID                  string `json:"layoutId,omitempty" jsonschema:"Layout ID."`
 	Template                  string `json:"template,omitempty" jsonschema:"Application Template."`
-	IsReadOnly                bool   `json:"isReadOnly,omitempty" jsonschema:"Indicates if the application is read-only (declarative/immutable)."`
+	IsReadOnly                bool   `json:"isReadOnly" jsonschema:"Indicates if the application is read-only (declarative/immutable)."`
 }
 
 // ApplicationListResponse represents the response structure for listing applications.

--- a/backend/internal/design/layout/mgt/composite_store.go
+++ b/backend/internal/design/layout/mgt/composite_store.go
@@ -83,8 +83,22 @@ func (c *compositeLayoutStore) CreateLayout(id string, layout CreateLayoutReques
 // Checks database store first, then falls back to file store (declarative).
 func (c *compositeLayoutStore) GetLayout(id string) (Layout, error) {
 	layout, err := declarativeresource.CompositeGetHelper(
-		func() (Layout, error) { return c.dbStore.GetLayout(id) },
-		func() (Layout, error) { return c.fileStore.GetLayout(id) },
+		func() (Layout, error) {
+			layout, err := c.dbStore.GetLayout(id)
+			if err != nil {
+				return Layout{}, err
+			}
+			layout.IsReadOnly = false
+			return layout, nil
+		},
+		func() (Layout, error) {
+			layout, err := c.fileStore.GetLayout(id)
+			if err != nil {
+				return Layout{}, err
+			}
+			layout.IsReadOnly = true
+			return layout, nil
+		},
 		errLayoutNotFound,
 	)
 	return layout, err
@@ -162,18 +176,20 @@ func mergeAndDeduplicateLayouts(dbLayouts, fileLayouts []Layout) []Layout {
 	merged := make([]Layout, 0, len(dbLayouts)+len(fileLayouts))
 
 	// Add file-based (declarative) layouts first (they take precedence)
-	for _, layout := range fileLayouts {
-		if !seen[layout.ID] {
-			merged = append(merged, layout)
-			seen[layout.ID] = true
+	for i := range fileLayouts {
+		if !seen[fileLayouts[i].ID] {
+			fileLayouts[i].IsReadOnly = true
+			merged = append(merged, fileLayouts[i])
+			seen[fileLayouts[i].ID] = true
 		}
 	}
 
 	// Add database layouts (skip if already added from file store)
-	for _, layout := range dbLayouts {
-		if !seen[layout.ID] {
-			merged = append(merged, layout)
-			seen[layout.ID] = true
+	for i := range dbLayouts {
+		if !seen[dbLayouts[i].ID] {
+			dbLayouts[i].IsReadOnly = false
+			merged = append(merged, dbLayouts[i])
+			seen[dbLayouts[i].ID] = true
 		}
 	}
 

--- a/backend/internal/design/layout/mgt/composite_store_test.go
+++ b/backend/internal/design/layout/mgt/composite_store_test.go
@@ -205,7 +205,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromDBStore() {
 	layout, err := suite.store.GetLayout("layout1")
 
 	suite.NoError(err)
-	suite.Equal(expectedLayout, layout)
+	suite.Equal(expectedLayout.ID, layout.ID)
+	suite.Equal(expectedLayout.DisplayName, layout.DisplayName)
+	suite.False(layout.IsReadOnly)
 }
 
 // Test GetLayout - From file store (fallback when not in DB store)
@@ -217,7 +219,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromFileStore() {
 	layout, err := suite.store.GetLayout("layout1")
 
 	suite.NoError(err)
-	suite.Equal(expectedLayout, layout)
+	suite.Equal(expectedLayout.ID, layout.ID)
+	suite.Equal(expectedLayout.DisplayName, layout.DisplayName)
+	suite.True(layout.IsReadOnly)
 }
 
 // Test GetLayout - Not found in either store

--- a/backend/internal/design/layout/mgt/handler.go
+++ b/backend/internal/design/layout/mgt/handler.go
@@ -70,6 +70,7 @@ func (lh *layoutMgtHandler) HandleLayoutListRequest(w http.ResponseWriter, r *ht
 			Description: layout.Description,
 			CreatedAt:   layout.CreatedAt,
 			UpdatedAt:   layout.UpdatedAt,
+			IsReadOnly:  layout.IsReadOnly,
 		})
 	}
 
@@ -111,6 +112,7 @@ func (lh *layoutMgtHandler) HandleLayoutPostRequest(w http.ResponseWriter, r *ht
 		Layout:      createdLayout.Layout,
 		CreatedAt:   createdLayout.CreatedAt,
 		UpdatedAt:   createdLayout.UpdatedAt,
+		IsReadOnly:  createdLayout.IsReadOnly,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, layoutResponse)
@@ -135,6 +137,7 @@ func (lh *layoutMgtHandler) HandleLayoutGetRequest(w http.ResponseWriter, r *htt
 		Layout:      layout.Layout,
 		CreatedAt:   layout.CreatedAt,
 		UpdatedAt:   layout.UpdatedAt,
+		IsReadOnly:  layout.IsReadOnly,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)
@@ -165,6 +168,7 @@ func (lh *layoutMgtHandler) HandleLayoutPutRequest(w http.ResponseWriter, r *htt
 		Layout:      updatedLayout.Layout,
 		CreatedAt:   updatedLayout.CreatedAt,
 		UpdatedAt:   updatedLayout.UpdatedAt,
+		IsReadOnly:  updatedLayout.IsReadOnly,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)

--- a/backend/internal/design/layout/mgt/handler_test.go
+++ b/backend/internal/design/layout/mgt/handler_test.go
@@ -155,6 +155,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutPostRequest_Success() {
 		DisplayName: "New Layout",
 		Description: "A new layout",
 		Layout:      json.RawMessage(`{"structure": "grid"}`),
+		IsReadOnly:  true,
 	}
 
 	mockSvc := &mockLayoutService{
@@ -181,6 +182,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutPostRequest_Success() {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "layout-new", response.ID)
+	assert.True(suite.T(), response.IsReadOnly)
 }
 
 // Test HandleLayoutPostRequest - Invalid JSON body
@@ -224,6 +226,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutGetRequest_Success() {
 		DisplayName: "Test Layout",
 		Description: "A test layout",
 		Layout:      json.RawMessage(`{"structure": "centered"}`),
+		IsReadOnly:  true,
 	}
 
 	mockSvc := &mockLayoutService{
@@ -246,6 +249,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutGetRequest_Success() {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "layout-123", response.ID)
+	assert.True(suite.T(), response.IsReadOnly)
 }
 
 // Test HandleLayoutGetRequest - Not found
@@ -274,6 +278,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutPutRequest_Success() {
 		DisplayName: "Updated Layout",
 		Description: "Updated desc",
 		Layout:      json.RawMessage(`{"structure": "flex"}`),
+		IsReadOnly:  true,
 	}
 
 	mockSvc := &mockLayoutService{
@@ -297,6 +302,11 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutPutRequest_Success() {
 	mux.ServeHTTP(w, req)
 
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var response Layout
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(suite.T(), err)
+	assert.True(suite.T(), response.IsReadOnly)
 }
 
 // Test HandleLayoutPutRequest - Invalid JSON

--- a/backend/internal/design/layout/mgt/model.go
+++ b/backend/internal/design/layout/mgt/model.go
@@ -29,6 +29,7 @@ type Layout struct {
 	Layout      json.RawMessage `json:"layout" yaml:"layout"`
 	CreatedAt   string          `json:"createdAt" yaml:"createdAt,omitempty"`
 	UpdatedAt   string          `json:"updatedAt" yaml:"updatedAt,omitempty"`
+	IsReadOnly  bool            `json:"isReadOnly" yaml:"isReadOnly"`
 }
 
 // LayoutListItem represents a layout item in the list response.
@@ -39,6 +40,7 @@ type LayoutListItem struct {
 	Description string `json:"description,omitempty"`
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
+	IsReadOnly  bool   `json:"isReadOnly"`
 }
 
 // CreateLayoutRequest represents the request body for creating a layout configuration.

--- a/backend/internal/design/theme/mgt/composite_store.go
+++ b/backend/internal/design/theme/mgt/composite_store.go
@@ -83,8 +83,22 @@ func (c *compositeThemeStore) CreateTheme(id string, theme CreateThemeRequest) e
 // Checks database store first, then falls back to file store (declarative).
 func (c *compositeThemeStore) GetTheme(id string) (Theme, error) {
 	theme, err := declarativeresource.CompositeGetHelper(
-		func() (Theme, error) { return c.dbStore.GetTheme(id) },
-		func() (Theme, error) { return c.fileStore.GetTheme(id) },
+		func() (Theme, error) {
+			theme, err := c.dbStore.GetTheme(id)
+			if err != nil {
+				return Theme{}, err
+			}
+			theme.IsReadOnly = false
+			return theme, nil
+		},
+		func() (Theme, error) {
+			theme, err := c.fileStore.GetTheme(id)
+			if err != nil {
+				return Theme{}, err
+			}
+			theme.IsReadOnly = true
+			return theme, nil
+		},
 		errThemeNotFound,
 	)
 	return theme, err
@@ -162,18 +176,20 @@ func mergeAndDeduplicateThemes(dbThemes, fileThemes []Theme) []Theme {
 	merged := make([]Theme, 0, len(dbThemes)+len(fileThemes))
 
 	// Add file-based (declarative) themes first (they take precedence)
-	for _, theme := range fileThemes {
-		if !seen[theme.ID] {
-			merged = append(merged, theme)
-			seen[theme.ID] = true
+	for i := range fileThemes {
+		if !seen[fileThemes[i].ID] {
+			fileThemes[i].IsReadOnly = true
+			merged = append(merged, fileThemes[i])
+			seen[fileThemes[i].ID] = true
 		}
 	}
 
 	// Add database themes (skip if already added from file store)
-	for _, theme := range dbThemes {
-		if !seen[theme.ID] {
-			merged = append(merged, theme)
-			seen[theme.ID] = true
+	for i := range dbThemes {
+		if !seen[dbThemes[i].ID] {
+			dbThemes[i].IsReadOnly = false
+			merged = append(merged, dbThemes[i])
+			seen[dbThemes[i].ID] = true
 		}
 	}
 

--- a/backend/internal/design/theme/mgt/composite_store_test.go
+++ b/backend/internal/design/theme/mgt/composite_store_test.go
@@ -205,7 +205,9 @@ func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromDBStore() {
 	theme, err := suite.store.GetTheme("theme1")
 
 	suite.NoError(err)
-	suite.Equal(expectedTheme, theme)
+	suite.Equal(expectedTheme.ID, theme.ID)
+	suite.Equal(expectedTheme.DisplayName, theme.DisplayName)
+	suite.False(theme.IsReadOnly)
 }
 
 // Test GetTheme - From file store (fallback when not in DB store)
@@ -217,7 +219,9 @@ func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromFileStore() {
 	theme, err := suite.store.GetTheme("theme1")
 
 	suite.NoError(err)
-	suite.Equal(expectedTheme, theme)
+	suite.Equal(expectedTheme.ID, theme.ID)
+	suite.Equal(expectedTheme.DisplayName, theme.DisplayName)
+	suite.True(theme.IsReadOnly)
 }
 
 // Test GetTheme - Not found in either store

--- a/backend/internal/design/theme/mgt/handler.go
+++ b/backend/internal/design/theme/mgt/handler.go
@@ -73,6 +73,7 @@ func (th *themeMgtHandler) HandleThemeListRequest(w http.ResponseWriter, r *http
 			PrimaryColor:       primaryColor,
 			CreatedAt:          theme.CreatedAt,
 			UpdatedAt:          theme.UpdatedAt,
+			IsReadOnly:         theme.IsReadOnly,
 		})
 	}
 

--- a/backend/internal/design/theme/mgt/model.go
+++ b/backend/internal/design/theme/mgt/model.go
@@ -29,6 +29,7 @@ type Theme struct {
 	Theme       json.RawMessage `json:"theme" yaml:"theme"`
 	CreatedAt   string          `json:"createdAt" yaml:"createdAt,omitempty"`
 	UpdatedAt   string          `json:"updatedAt" yaml:"updatedAt,omitempty"`
+	IsReadOnly  bool            `json:"isReadOnly" yaml:"isReadOnly"`
 }
 
 // ThemeListItem represents a theme item in the list response.
@@ -41,6 +42,7 @@ type ThemeListItem struct {
 	PrimaryColor       string `json:"primaryColor"`
 	CreatedAt          string `json:"createdAt"`
 	UpdatedAt          string `json:"updatedAt"`
+	IsReadOnly         bool   `json:"isReadOnly"`
 }
 
 // themeColorSchemeInfo is a minimal struct for extracting color info from theme JSON.

--- a/backend/internal/flow/mgt/model.go
+++ b/backend/internal/flow/mgt/model.go
@@ -48,7 +48,7 @@ type CompleteFlowDefinition struct {
 	Nodes         []NodeDefinition `json:"nodes,omitempty" yaml:"nodes" jsonschema:"List of nodes defining the flow logic."`
 	CreatedAt     string           `json:"createdAt,omitempty" yaml:"createdAt" jsonschema:"Timestamp when the flow was created."`
 	UpdatedAt     string           `json:"updatedAt,omitempty" yaml:"updatedAt" jsonschema:"Timestamp when the flow was last updated."`
-	IsReadOnly    bool             `json:"isReadOnly,omitempty" yaml:"isReadOnly" jsonschema:"Whether the flow is immutable (declarative)."`
+	IsReadOnly    bool             `json:"isReadOnly" yaml:"isReadOnly" jsonschema:"Whether the flow is immutable (declarative)."`
 }
 
 // BasicFlowDefinition represents basic information about a flow definition.

--- a/backend/internal/idp/model.go
+++ b/backend/internal/idp/model.go
@@ -61,7 +61,7 @@ type basicIDPResponse struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Type        string `json:"type"`
-	IsReadOnly  bool   `json:"isReadOnly,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly"`
 }
 
 // idpRequestWithID represents the request payload for creating an identity provider from file-based config.

--- a/backend/internal/ou/model.go
+++ b/backend/internal/ou/model.go
@@ -31,7 +31,7 @@ type OrganizationUnitBasic struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	LogoURL     string `json:"logoUrl,omitempty"`
-	IsReadOnly  bool   `json:"isReadOnly,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly"`
 }
 
 // OrganizationUnit represents an organization unit.

--- a/backend/internal/resource/model.go
+++ b/backend/internal/resource/model.go
@@ -28,7 +28,7 @@ type ResourceServerResponse struct {
 	Identifier  string `json:"identifier,omitempty"`
 	OUID        string `json:"ouId"`
 	Delimiter   string `json:"delimiter"`
-	IsReadOnly  bool   `json:"isReadOnly,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly"`
 }
 
 // ResourceResponse represents a resource.

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -281,17 +281,19 @@ func mergeRoles(dbRoles, fileRoles []Role) []Role {
 	seen := make(map[string]bool)
 	result := make([]Role, 0, len(dbRoles)+len(fileRoles))
 
-	// Add database roles first (they take precedence)
-	for _, role := range dbRoles {
-		result = append(result, role)
-		seen[role.ID] = true
+	// Add database roles first (they take precedence) - mark as mutable (IsReadOnly=false)
+	for i := range dbRoles {
+		dbRoles[i].IsReadOnly = false
+		result = append(result, dbRoles[i])
+		seen[dbRoles[i].ID] = true
 	}
 
-	// Add file-based roles only if not already seen
-	for _, role := range fileRoles {
-		if !seen[role.ID] {
-			result = append(result, role)
-			seen[role.ID] = true
+	// Add file-based roles only if not already seen - mark as immutable (IsReadOnly=true)
+	for i := range fileRoles {
+		if !seen[fileRoles[i].ID] {
+			fileRoles[i].IsReadOnly = true
+			result = append(result, fileRoles[i])
+			seen[fileRoles[i].ID] = true
 		}
 	}
 

--- a/backend/internal/role/model.go
+++ b/backend/internal/role/model.go
@@ -49,6 +49,7 @@ type RoleSummaryResponse struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	OUID        string `json:"ouId"`
+	IsReadOnly  bool   `json:"isReadOnly"`
 }
 
 // RoleResponse represents a complete role with permissions.
@@ -156,6 +157,7 @@ type Role struct {
 	Name        string
 	Description string
 	OUID        string
+	IsReadOnly  bool
 }
 
 // RoleWithPermissions represents complete role details used internally by the service layer.

--- a/backend/internal/system/declarative_resource/entity/entity_store.go
+++ b/backend/internal/system/declarative_resource/entity/entity_store.go
@@ -21,6 +21,7 @@ package entity
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -238,6 +239,10 @@ func (s *Store) ListByType(keyType KeyType) ([]*Entity, error) {
 			entities = append(entities, entity)
 		}
 	}
+
+	sort.Slice(entities, func(i, j int) bool {
+		return entities[i].ID.ID < entities[j].ID.ID
+	})
 
 	return entities, nil
 }

--- a/backend/internal/system/declarative_resource/entity/entity_store_test.go
+++ b/backend/internal/system/declarative_resource/entity/entity_store_test.go
@@ -125,6 +125,42 @@ func TestStoreStringConvenienceMethods(t *testing.T) {
 	}
 }
 
+func TestListByType_SortsByEntityID(t *testing.T) {
+	store := NewStore()
+
+	err := store.Set(NewCompositeKey("id-2", KeyTypeNotification), TestNotification{Sender: "s2"})
+	if err != nil {
+		t.Fatalf("Failed to set id-2 entity: %v", err)
+	}
+
+	err = store.Set(NewCompositeKey("id-1", KeyTypeNotification), TestNotification{Sender: "s1"})
+	if err != nil {
+		t.Fatalf("Failed to set id-1 entity: %v", err)
+	}
+
+	err = store.Set(NewCompositeKey("id-3", KeyTypeApplication), map[string]string{"name": "app"})
+	if err != nil {
+		t.Fatalf("Failed to set non-notification entity: %v", err)
+	}
+
+	entities, err := store.ListByType(KeyTypeNotification)
+	if err != nil {
+		t.Fatalf("Failed to list by type: %v", err)
+	}
+
+	if len(entities) != 2 {
+		t.Fatalf("Expected 2 entities, got %d", len(entities))
+	}
+
+	if entities[0].ID.ID != "id-1" {
+		t.Fatalf("Expected first entity ID id-1, got %s", entities[0].ID.ID)
+	}
+
+	if entities[1].ID.ID != "id-2" {
+		t.Fatalf("Expected second entity ID id-2, got %s", entities[1].ID.ID)
+	}
+}
+
 func TestKeyTypeValidation(t *testing.T) {
 	// Test valid KeyTypes
 	validTypes := []KeyType{

--- a/backend/internal/user/composite_store.go
+++ b/backend/internal/user/composite_store.go
@@ -21,7 +21,6 @@ package user
 import (
 	"context"
 	"errors"
-	"sort"
 	"strings"
 
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
@@ -330,27 +329,23 @@ func (c *compositeUserStore) ValidateUserIDsInOUs(
 // mergeAndDeduplicateUsers merges and deduplicates users from two lists.
 // Database users take precedence over file-based users when IDs conflict.
 func mergeAndDeduplicateUsers(dbUsers, fileUsers []User) []User {
-	userMap := make(map[string]User)
+	seen := make(map[string]bool)
+	result := make([]User, 0, len(dbUsers)+len(fileUsers))
 
-	// Add file users first
-	for _, user := range fileUsers {
-		userMap[user.ID] = user
+	// Add database users first (they take precedence) - mark as mutable (IsReadOnly=false)
+	for i := range dbUsers {
+		dbUsers[i].IsReadOnly = false
+		result = append(result, dbUsers[i])
+		seen[dbUsers[i].ID] = true
 	}
 
-	// Add/overwrite with db users (db takes precedence)
-	for _, user := range dbUsers {
-		userMap[user.ID] = user
-	}
-
-	ids := make([]string, 0, len(userMap))
-	for id := range userMap {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-
-	result := make([]User, 0, len(ids))
-	for _, id := range ids {
-		result = append(result, userMap[id])
+	// Add file-based users only if not already seen - mark as immutable (IsReadOnly=true)
+	for i := range fileUsers {
+		if !seen[fileUsers[i].ID] {
+			fileUsers[i].IsReadOnly = true
+			result = append(result, fileUsers[i])
+			seen[fileUsers[i].ID] = true
+		}
 	}
 
 	return result

--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -32,6 +32,7 @@ type User struct {
 	Type       string          `json:"type,omitempty"`
 	Attributes json.RawMessage `json:"attributes,omitempty"`
 	Display    string          `json:"display,omitempty"`
+	IsReadOnly bool            `json:"isReadOnly"`
 }
 
 // Credential represents the credentials of a user.

--- a/backend/internal/userschema/model.go
+++ b/backend/internal/userschema/model.go
@@ -49,7 +49,7 @@ type UserSchemaListItem struct {
 	OUID                  string            `json:"ouId"`
 	AllowSelfRegistration bool              `json:"allowSelfRegistration"`
 	SystemAttributes      *SystemAttributes `json:"systemAttributes,omitempty"`
-	IsReadOnly            bool              `json:"isReadOnly,omitempty"`
+	IsReadOnly            bool              `json:"isReadOnly"`
 }
 
 // Link represents a hypermedia link in the API response.

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -10015,6 +10015,10 @@ components:
           format: date-time
           description: Timestamp when the layout was last updated (ISO 8601 format)
           example: 2024-01-20T14:45:00Z
+        isReadOnly:
+          type: boolean
+          description: Indicates whether the layout is read-only (declarative)
+          example: false
     LayoutListItem:
       type: object
       properties:
@@ -10041,6 +10045,10 @@ components:
           format: date-time
           description: Timestamp when the layout was last updated (ISO 8601 format)
           example: 2024-01-20T14:45:00Z
+        isReadOnly:
+          type: boolean
+          description: Indicates whether the layout is read-only (declarative)
+          example: false
     LayoutListResponse:
       type: object
       properties:


### PR DESCRIPTION
### Purpose
Add isReadOnly attribute for list response

### Approach
This pull request introduces a consistent approach to marking configuration entities as read-only or mutable, based on their source (file-based/declarative vs. database). It adds the `IsReadOnly` field to several models and ensures that when merging entities from different sources, file-based entities are marked as immutable (`IsReadOnly=true`) and database entities as mutable (`IsReadOnly=false`). This helps clarify which entities can be edited and which are managed declaratively. The changes also update API responses to include the `IsReadOnly` attribute.

**Read-only flag propagation and merging logic:**

* Updated merge logic in `composite_store.go` for layouts, themes, roles, and users to set `IsReadOnly` based on source: file-based entities are marked immutable, database entities are mutable. [[1]](diffhunk://#diff-c3aaebaa7d8295e1e4a402573602e6771087d9f7b59a84bfa769e8d162980309L151-R164) [[2]](diffhunk://#diff-1b43879aa566016ce68c8fa138a95ba3e45a0aabbfeb2281a86d6d8870a0f284L151-R164) [[3]](diffhunk://#diff-c59b5410cc89d068dd3d08818644443065d3a8d5beb4579f2f0b3afb9ec18bfeL287-R299) [[4]](diffhunk://#diff-89f6fcb384f1133f0268a4b33525b3ec936dd193f8391ec5b23094019feb987dL333-L353)
* Removed the `omitempty` tag from `IsReadOnly` in various struct definitions to ensure the flag is always present in API responses. [[1]](diffhunk://#diff-d1cd71be17c228f8921a9c01b0bc932b322aaceb1ffb935fd602efb2ff0b5dd4L266-R266) [[2]](diffhunk://#diff-f4257b466148a833738b9bd7a0701e29b1d0ec6a076281549d8fe8210c25cfe2L51-R51) [[3]](diffhunk://#diff-a77102b18d2a039ef88d4d0e49dd7b41cd58e3920b8cabcacb64b2548638990fL64-R64) [[4]](diffhunk://#diff-7ef1cb84103f219b6908c4ab5fd587e1d538da44f67d08b7c355b5a41602195eL34-R34) [[5]](diffhunk://#diff-d0c70e6df38f463d237abb208d80a4a04ce463e875b36cb84a37ffb88c8d42c4L31-R31) [[6]](diffhunk://#diff-33ca3b723cad6a6023a7ccf97157881fe04084388cdcff959931b794a33c00e0L52-R52)

**Model and API response enhancements:**

* Added `IsReadOnly` field to the `Layout`, `Theme`, `Role`, and `User` models and their respective list item structs, so clients can distinguish between mutable and immutable entities. [[1]](diffhunk://#diff-5e089ea50d7d427d79d4fa95737b90b6a5a594d526094d4a9c9086865cad2329R31) [[2]](diffhunk://#diff-5e089ea50d7d427d79d4fa95737b90b6a5a594d526094d4a9c9086865cad2329R41) [[3]](diffhunk://#diff-4b4ff8770e4a9c5630eca13709a4e23f2b78621d0aa99a9c66c9030ddc2e149eR31) [[4]](diffhunk://#diff-4b4ff8770e4a9c5630eca13709a4e23f2b78621d0aa99a9c66c9030ddc2e149eR41) [[5]](diffhunk://#diff-16af70d007c6432ad6ea6c88e0a3d906fbf0b3a2564cc6555778201d8a2c9bcfR160) [[6]](diffhunk://#diff-16af70d007c6432ad6ea6c88e0a3d906fbf0b3a2564cc6555778201d8a2c9bcfR52) [[7]](diffhunk://#diff-b6dc1e9146cbd706b1737da259b451880c34dcbc1bb90d70c88184cc05cb450bR35)
* Updated API handlers for layout and theme listing to include the `IsReadOnly` field in responses. [[1]](diffhunk://#diff-3d655f2161082ed379b35fb9fe349f22c540e4f2a060dfcc854e3ed353127447R70) [[2]](diffhunk://#diff-130018ffc44d2df1ea68352d4638657ff7046abc79770f73f1679b9370d8c07bR70)

**Code cleanup:**

* Removed unnecessary `sort` import and sorting logic from the user merging function, simplifying the code. [[1]](diffhunk://#diff-89f6fcb384f1133f0268a4b33525b3ec936dd193f8391ec5b23094019feb987dL24) [[2]](diffhunk://#diff-89f6fcb384f1133f0268a4b33525b3ec936dd193f8391ec5b23094019feb987dL333-L353)

These changes provide clear visibility into which entities are managed declaratively and which can be edited, improving API clarity and maintainability.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses now always include a persistent isReadOnly flag for layouts, themes, flows, roles, users, schemas and other config items; merged results mark file-sourced items read-only and DB items editable.
* **Tests**
  * Updated handler/store tests to assert the read-only flag; added a test verifying deterministic ordering when listing declarative entities.
* **Documentation**
  * OpenAPI and generated docs updated to expose the new isReadOnly property for layout responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->