### PR TITLE
Fix composite get and uuid validation

### DIFF
--- a/backend/internal/design/layout/mgt/composite_store.go
+++ b/backend/internal/design/layout/mgt/composite_store.go
@@ -80,11 +80,11 @@ func (c *compositeLayoutStore) CreateLayout(id string, layout CreateLayoutReques
 }
 
 // GetLayout retrieves a layout by ID from either store.
-// Checks file store (declarative) first to maintain precedence, then falls back to database store.
+// Checks database store first, then falls back to file store (declarative).
 func (c *compositeLayoutStore) GetLayout(id string) (Layout, error) {
 	layout, err := declarativeresource.CompositeGetHelper(
-		func() (Layout, error) { return c.fileStore.GetLayout(id) },
 		func() (Layout, error) { return c.dbStore.GetLayout(id) },
+		func() (Layout, error) { return c.fileStore.GetLayout(id) },
 		errLayoutNotFound,
 	)
 	return layout, err

--- a/backend/internal/design/layout/mgt/composite_store_test.go
+++ b/backend/internal/design/layout/mgt/composite_store_test.go
@@ -197,10 +197,9 @@ func (suite *CompositeLayoutStoreTestSuite) TestCreateLayout_DBStoreError() {
 	suite.Equal(testErr, err)
 }
 
-// Test GetLayout - From DB store (fallback when not in file store)
+// Test GetLayout - From DB store (DB takes precedence)
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromDBStore() {
 	expectedLayout := Layout{ID: "layout1", DisplayName: "DB Layout"}
-	suite.mockFileStore.On("GetLayout", "layout1").Return(Layout{}, errLayoutNotFound)
 	suite.mockDBStore.On("GetLayout", "layout1").Return(expectedLayout, nil)
 
 	layout, err := suite.store.GetLayout("layout1")
@@ -209,9 +208,10 @@ func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromDBStore() {
 	suite.Equal(expectedLayout, layout)
 }
 
-// Test GetLayout - From file store (takes precedence)
+// Test GetLayout - From file store (fallback when not in DB store)
 func (suite *CompositeLayoutStoreTestSuite) TestGetLayout_FromFileStore() {
 	expectedLayout := Layout{ID: "layout1", DisplayName: "File Layout"}
+	suite.mockDBStore.On("GetLayout", "layout1").Return(Layout{}, errLayoutNotFound)
 	suite.mockFileStore.On("GetLayout", "layout1").Return(expectedLayout, nil)
 
 	layout, err := suite.store.GetLayout("layout1")

--- a/backend/internal/design/layout/mgt/file_based_store.go
+++ b/backend/internal/design/layout/mgt/file_based_store.go
@@ -66,7 +66,7 @@ func (f *layoutFileBasedStore) DeleteLayout(id string) error {
 func (f *layoutFileBasedStore) GetLayout(id string) (Layout, error) {
 	data, err := f.GenericFileBasedStore.Get(id)
 	if err != nil {
-		return Layout{}, err
+		return Layout{}, errLayoutNotFound
 	}
 	layout, ok := data.(*Layout)
 	if !ok {

--- a/backend/internal/design/theme/mgt/composite_store.go
+++ b/backend/internal/design/theme/mgt/composite_store.go
@@ -80,11 +80,11 @@ func (c *compositeThemeStore) CreateTheme(id string, theme CreateThemeRequest) e
 }
 
 // GetTheme retrieves a theme by ID from either store.
-// Checks file store (declarative) first to maintain precedence, then falls back to database store.
+// Checks database store first, then falls back to file store (declarative).
 func (c *compositeThemeStore) GetTheme(id string) (Theme, error) {
 	theme, err := declarativeresource.CompositeGetHelper(
-		func() (Theme, error) { return c.fileStore.GetTheme(id) },
 		func() (Theme, error) { return c.dbStore.GetTheme(id) },
+		func() (Theme, error) { return c.fileStore.GetTheme(id) },
 		errThemeNotFound,
 	)
 	return theme, err

--- a/backend/internal/design/theme/mgt/composite_store_test.go
+++ b/backend/internal/design/theme/mgt/composite_store_test.go
@@ -197,10 +197,9 @@ func (suite *CompositeThemeStoreTestSuite) TestCreateTheme_DBStoreError() {
 	suite.Equal(testErr, err)
 }
 
-// Test GetTheme - From DB store (fallback when not in file store)
+// Test GetTheme - From DB store (DB takes precedence)
 func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromDBStore() {
 	expectedTheme := Theme{ID: "theme1", DisplayName: "DB Theme"}
-	suite.mockFileStore.On("GetTheme", "theme1").Return(Theme{}, errThemeNotFound)
 	suite.mockDBStore.On("GetTheme", "theme1").Return(expectedTheme, nil)
 
 	theme, err := suite.store.GetTheme("theme1")
@@ -209,9 +208,10 @@ func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromDBStore() {
 	suite.Equal(expectedTheme, theme)
 }
 
-// Test GetTheme - From file store (takes precedence)
+// Test GetTheme - From file store (fallback when not in DB store)
 func (suite *CompositeThemeStoreTestSuite) TestGetTheme_FromFileStore() {
 	expectedTheme := Theme{ID: "theme1", DisplayName: "File Theme"}
+	suite.mockDBStore.On("GetTheme", "theme1").Return(Theme{}, errThemeNotFound)
 	suite.mockFileStore.On("GetTheme", "theme1").Return(expectedTheme, nil)
 
 	theme, err := suite.store.GetTheme("theme1")

--- a/backend/internal/design/theme/mgt/file_based_store.go
+++ b/backend/internal/design/theme/mgt/file_based_store.go
@@ -66,7 +66,7 @@ func (f *themeFileBasedStore) DeleteTheme(id string) error {
 func (f *themeFileBasedStore) GetTheme(id string) (Theme, error) {
 	data, err := f.GenericFileBasedStore.Get(id)
 	if err != nil {
-		return Theme{}, err
+		return Theme{}, errThemeNotFound
 	}
 	theme, ok := data.(*Theme)
 	if !ok {

--- a/backend/internal/userschema/init_test.go
+++ b/backend/internal/userschema/init_test.go
@@ -847,15 +847,14 @@ func TestValidateUserSchemaWithOUCheck(t *testing.T) {
 			errorContains: "organization unit id must not be empty",
 		},
 		{
-			name: "Invalid schema - malformed OU ID",
+			name: "Valid schema - non-UUID OU ID",
 			schema: UserSchema{
 				ID:     "invalid-003",
 				Name:   "Test Schema",
 				OUID:   "not-a-valid-uuid",
 				Schema: []byte(`{"email":{"type":"string"}}`),
 			},
-			shouldBeValid: false,
-			errorContains: "organization unit id is not a valid UUID",
+			shouldBeValid: true,
 		},
 		{
 			name: "Invalid schema - empty schema definition",

--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -757,12 +757,6 @@ func validateUserSchemaDefinition(schema UserSchema) *serviceerror.ServiceError 
 		return invalidSchemaRequestError("organization unit id must not be empty")
 	}
 
-	if !utils.IsValidUUID(schema.OUID) {
-		logger.Debug("User schema validation failed: invalid organization unit ID format",
-			log.String("ouId", schema.OUID))
-		return invalidSchemaRequestError("organization unit id is not a valid UUID")
-	}
-
 	if len(schema.Schema) == 0 {
 		logger.Debug("User schema validation failed: schema definition is empty")
 		return invalidSchemaRequestError("schema definition must not be empty")

--- a/backend/internal/userschema/service_test.go
+++ b/backend/internal/userschema/service_test.go
@@ -466,7 +466,7 @@ func TestValidateUserSchemaDefinitionReturnsErrorWhenOUIDIsEmpty(t *testing.T) {
 	require.Contains(t, err.ErrorDescription, "organization unit id must not be empty")
 }
 
-func TestValidateUserSchemaDefinitionReturnsErrorWhenOUIDIsNotUUID(t *testing.T) {
+func TestValidateUserSchemaDefinitionAllowsNonUUIDOUID(t *testing.T) {
 	validSchema := json.RawMessage(`{"email":{"type":"string"}}`)
 
 	schema := UserSchema{
@@ -477,9 +477,7 @@ func TestValidateUserSchemaDefinitionReturnsErrorWhenOUIDIsNotUUID(t *testing.T)
 
 	err := validateUserSchemaDefinition(schema)
 
-	require.NotNil(t, err)
-	require.Equal(t, ErrorInvalidUserSchemaRequest.Code, err.Code)
-	require.Contains(t, err.ErrorDescription, "organization unit id is not a valid UUID")
+	require.Nil(t, err)
 }
 
 func TestValidateUserSchemaDefinitionReturnsErrorWhenSchemaIsEmpty(t *testing.T) {
@@ -654,13 +652,13 @@ func TestValidateUserSchemaDefinitionWithMultipleValidationErrors(t *testing.T) 
 			expectedError: "user schema name must not be empty",
 		},
 		{
-			name: "Valid name but invalid OU ID format",
+			name: "Non-UUID OU ID still validates schema payload",
 			schema: UserSchema{
 				Name:   "test",
 				OUID:   "123",
-				Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+				Schema: json.RawMessage{},
 			},
-			expectedError: "organization unit id is not a valid UUID",
+			expectedError: "schema definition must not be empty",
 		},
 		{
 			name: "Valid OU ID but empty schema",


### PR DESCRIPTION
### Purpose
1. Fix the Get method order in getting layouts and themes in Composite store.
2. Remove UUID validation of OU ID when creating user schema

### Approach
This pull request updates the logic around how layouts and themes are retrieved from storage backends, and relaxes validation requirements for organization unit IDs (OU IDs) in user schema definitions. The most significant changes are the switch in precedence for storage lookup (now checking the database before file store), and the removal of the UUID format requirement for OU IDs in user schemas. Related tests and documentation are updated accordingly.

**Storage retrieval precedence changes:**

* The `GetLayout` and `GetTheme` methods in `compositeLayoutStore` and `compositeThemeStore` now check the database store first before falling back to the file (declarative) store, reversing the previous order. This affects both the implementation and the method documentation. [[1]](diffhunk://#diff-c3aaebaa7d8295e1e4a402573602e6771087d9f7b59a84bfa769e8d162980309L83-R87) [[2]](diffhunk://#diff-1b43879aa566016ce68c8fa138a95ba3e45a0aabbfeb2281a86d6d8870a0f284L83-R87)

**User schema validation changes:**

* The validation logic for user schema definitions no longer requires the `OUID` field to be a valid UUID—any non-empty string is now accepted. The UUID check and related error messages have been removed from `validateUserSchemaDefinition`.

**Test updates:**

* Tests for user schema validation have been updated to reflect the relaxed OU ID requirement. Test names and assertions now expect non-UUID OU IDs to be valid, and error checks for invalid UUIDs have been removed. [[1]](diffhunk://#diff-bc0a6abe8eaa76a93787275b0ef7ce252542b5e40ff27cd0a3c15ce497ff18f8L850-R857) [[2]](diffhunk://#diff-5050f57d6c0630bc371cb7293fa07f13f8f5bb26f280d049652544127d83a3b3L469-R469) [[3]](diffhunk://#diff-5050f57d6c0630bc371cb7293fa07f13f8f5bb26f280d049652544127d83a3b3L480-R480) [[4]](diffhunk://#diff-5050f57d6c0630bc371cb7293fa07f13f8f5bb26f280d049652544127d83a3b3L657-R661)


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Storage lookup now prefers database entries first, falling back to file-based declarations for layouts and themes.
  * UUID-format validation for organization unit identifiers removed; non-UUID identifiers are now accepted.

* **Bug Fix**
  * File-backed reads now surface consistent "not found" responses when items are missing.

* **Tests**
  * Unit tests updated to reflect DB-first lookup and relaxed OU ID validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->