### PR TITLE
Add include=display query param int GET users/{userId} endpoint

### DIFF
--- a/backend/internal/authn/passkey/service.go
+++ b/backend/internal/authn/passkey/service.go
@@ -99,7 +99,7 @@ func (w *passkeyService) StartRegistration(
 	}
 
 	// Retrieve core user
-	coreUser, svcErr := w.userService.GetUser(ctx, req.UserID)
+	coreUser, svcErr := w.userService.GetUser(ctx, req.UserID, false)
 	if svcErr != nil {
 		return nil, handleUserRetrievalError(svcErr, req.UserID, logger)
 	}
@@ -225,7 +225,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 	}
 
 	// Get core user
-	coreUser, svcErr := w.userService.GetUser(ctx, userID)
+	coreUser, svcErr := w.userService.GetUser(ctx, userID, false)
 	if svcErr != nil {
 		logger.Error("Failed to retrieve user", log.String("error", svcErr.Error))
 		return nil, &serviceerror.InternalServerError
@@ -334,7 +334,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 	} else {
 		// Username-based flow: Retrieve user and credentials
 		// Retrieve user by userID to verify user exists
-		coreUser, svcErr := w.userService.GetUser(ctx, req.UserID)
+		coreUser, svcErr := w.userService.GetUser(ctx, req.UserID, false)
 		if svcErr != nil {
 			return nil, handleUserRetrievalError(svcErr, req.UserID, logger)
 		}
@@ -443,7 +443,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	}
 
 	// Get core user
-	coreUser, svcErr := w.userService.GetUser(ctx, userID)
+	coreUser, svcErr := w.userService.GetUser(ctx, userID, false)
 	if svcErr != nil {
 		logger.Error("Failed to retrieve user", log.String("error", svcErr.Error))
 		return nil, &serviceerror.InternalServerError

--- a/backend/internal/authn/passkey/service_test.go
+++ b/backend/internal/authn/passkey/service_test.go
@@ -122,7 +122,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_UserNotFound() {
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(
 		nil,
 		&serviceerror.ServiceError{
 			Type: serviceerror.ClientErrorType,
@@ -143,7 +143,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_UserServiceServerEr
 		RelyingPartyID: testRelyingPartyID,
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(
 		nil,
 		&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
@@ -170,7 +170,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_GetCredentialsError
 		OUID: "org123",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").Return(
 		nil,
 		&serviceerror.ServiceError{
@@ -294,7 +294,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_EmptyRelyingParty
 }
 
 func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_UserNotFound() {
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(
 		nil,
 		&serviceerror.ServiceError{
 			Type: serviceerror.ClientErrorType,
@@ -314,7 +314,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_UserNotFound() {
 }
 
 func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_UserServiceServerError() {
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(
 		nil,
 		&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
@@ -340,7 +340,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_GetCredentialsErr
 		OUID: "org123",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").Return(
 		nil,
 		&serviceerror.ServiceError{
@@ -369,7 +369,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_NoCredentialsFoun
 
 	emptyCredentials := []user.Credential{}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").Return(
 		emptyCredentials,
 		nil,
@@ -908,7 +908,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_StoreSessionError()
 		OUID: "org123",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{}, nil).Once()
 
@@ -996,7 +996,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_GetUserError() {
 		Error: "User retrieval error",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(nil, svcErr).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(nil, svcErr).Once()
 
 	req := &PasskeyAuthenticationFinishRequest{
 		CredentialID:      testCredentialID,
@@ -1028,7 +1028,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_GetCredentialsEr
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 
 	credErr := &serviceerror.ServiceError{
 		Type:  serviceerror.ServerErrorType,
@@ -1069,7 +1069,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_NoCredentialsErr
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{}, nil).Once()
 
@@ -1115,7 +1115,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_InvalidAssertion
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -1476,7 +1476,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_CredentialsValida
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -1521,7 +1521,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_CredentialWithZer
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -1570,7 +1570,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_WithExistingValidCr
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -1619,7 +1619,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_UpdateCredential
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -1663,7 +1663,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_SkipAssertion() 
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -1878,7 +1878,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_WithMultipleCrede
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -2001,7 +2001,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_ValidateLoginFai
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -2045,7 +2045,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_ClearSessionAfte
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 
@@ -2092,7 +2092,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_BuildAuthRespons
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 
@@ -2138,7 +2138,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_UpdateCredential
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 
@@ -2181,7 +2181,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_InitializeWebAut
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, "invalid-rp-id", nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 
@@ -2215,7 +2215,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_GetWebAuthnCredenti
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 
 	// Mock credential retrieval failure
 	credErr := &serviceerror.ServiceError{
@@ -2259,7 +2259,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_BeginRegistrationEr
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{}, nil).Once()
 
@@ -2337,7 +2337,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_GetWebAuthnCreden
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 
 	credErr := &serviceerror.ServiceError{
 		Type:  serviceerror.ServerErrorType,
@@ -2382,7 +2382,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_BeginLoginError()
 	}
 	credJSON, _ := json.Marshal(mockCredential)
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credJSON)}}, nil).Once()
 
@@ -2423,7 +2423,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_GetWebAuthnCrede
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 
 	credErr := &serviceerror.ServiceError{
 		Type:  serviceerror.ServerErrorType,
@@ -2470,7 +2470,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_ParseAssertionRe
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credJSON)}}, nil).Once()
 
@@ -2511,7 +2511,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_ValidateLoginErr
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credJSON)}}, nil).Once()
 
@@ -2598,7 +2598,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_WithRelyingPartyNam
 		OUID: "org123",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{}, nil).Once()
 
@@ -2643,7 +2643,7 @@ func (suite *WebAuthnServiceTestSuite) TestStartRegistration_WithExistingCredent
 		Type: "person",
 	}
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -2760,7 +2760,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_Usernameless_Suc
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, "", testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return(mockUserCreds, nil).Once()
 
@@ -2858,7 +2858,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_Usernameless_Use
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, "", testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, "nonexistent-user").Return(
+	suite.mockUserService.On("GetUser", mock.Anything, "nonexistent-user", false).Return(
 		nil,
 		&serviceerror.ServiceError{
 			Type: serviceerror.ClientErrorType,
@@ -2903,7 +2903,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_Usernameless_Get
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, "", testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 
 	credErr := &serviceerror.ServiceError{
 		Type:  serviceerror.ServerErrorType,
@@ -2950,7 +2950,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_Usernameless_NoC
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, "", testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{}, nil).Once()
 
@@ -3000,7 +3000,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_Usernameless_Wit
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, "", testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 
@@ -3054,7 +3054,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_UsernameBasedFlo
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 
@@ -3109,7 +3109,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_ValidatePasskeyL
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, "", testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 
@@ -3160,7 +3160,7 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_ValidateLogin_Re
 	suite.mockSessionStore.On("retrieveSession", testSessionToken).
 		Return(sessionData, testUserID, testRelyingPartyID, nil).Once()
 
-	suite.mockUserService.On("GetUser", mock.Anything, testUserID).Return(testUser, nil).Once()
+	suite.mockUserService.On("GetUser", mock.Anything, testUserID, false).Return(testUser, nil).Once()
 	suite.mockUserService.On("GetUserCredentialsByType", mock.Anything, testUserID, "passkey").
 		Return([]user.Credential{{Value: string(credentialJSON)}}, nil).Once()
 

--- a/backend/internal/authnprovider/default_authn_provider.go
+++ b/backend/internal/authnprovider/default_authn_provider.go
@@ -55,7 +55,7 @@ func (p *defaultAuthnProvider) Authenticate(
 		return nil, NewError(ErrorCodeSystemError, authErr.Error, authErr.ErrorDescription)
 	}
 
-	userResult, getUserErr := p.userSvc.GetUser(ctx, authResponse.ID)
+	userResult, getUserErr := p.userSvc.GetUser(ctx, authResponse.ID, false)
 	if getUserErr != nil {
 		if getUserErr.Code == user.ErrorUserNotFound.Code {
 			return nil, NewError(ErrorCodeUserNotFound, getUserErr.Error, getUserErr.ErrorDescription)
@@ -101,7 +101,7 @@ func (p *defaultAuthnProvider) GetAttributes(
 ) (*GetAttributesResult, *AuthnProviderError) {
 	userID := token
 
-	userResult, authErr := p.userSvc.GetUser(ctx, userID)
+	userResult, authErr := p.userSvc.GetUser(ctx, userID, false)
 	if authErr != nil {
 		if authErr.Type == serviceerror.ClientErrorType {
 			return nil, NewError(ErrorCodeInvalidToken, authErr.Error, authErr.ErrorDescription)

--- a/backend/internal/authnprovider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/default_authn_provider_test.go
@@ -67,7 +67,8 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Success() {
 	suite.mockService.On("AuthenticateUser", mock.Anything, identifiers, credentials).
 		Return(authResp, (*serviceerror.ServiceError)(nil)).Once()
 	// Expect GetUser call
-	suite.mockService.On("GetUser", mock.Anything, "user123").Return(userObj, (*serviceerror.ServiceError)(nil)).Once()
+	suite.mockService.On("GetUser", mock.Anything, "user123", false).
+		Return(userObj, (*serviceerror.ServiceError)(nil)).Once()
 
 	result, err := suite.provider.Authenticate(context.Background(), identifiers, credentials, nil)
 
@@ -136,7 +137,8 @@ func (suite *DefaultAuthnProviderTestSuite) TestGetAttributes_Success_All() {
 		Attributes: json.RawMessage(`{"email":"test@example.com", "age": 30}`),
 	}
 
-	suite.mockService.On("GetUser", mock.Anything, token).Return(userObj, (*serviceerror.ServiceError)(nil)).Once()
+	suite.mockService.On("GetUser", mock.Anything, token, false).
+		Return(userObj, (*serviceerror.ServiceError)(nil)).Once()
 
 	result, err := suite.provider.GetAttributes(context.Background(), token, nil, nil)
 
@@ -156,7 +158,8 @@ func (suite *DefaultAuthnProviderTestSuite) TestGetAttributes_Success_Filtered()
 		Attributes: json.RawMessage(`{"email":"test@example.com", "age": 30}`),
 	}
 
-	suite.mockService.On("GetUser", mock.Anything, token).Return(userObj, (*serviceerror.ServiceError)(nil)).Once()
+	suite.mockService.On("GetUser", mock.Anything, token, false).
+		Return(userObj, (*serviceerror.ServiceError)(nil)).Once()
 
 	reqAttrs := &RequestedAttributes{
 		Attributes: map[string]*AttributeMetadataRequest{
@@ -176,7 +179,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestGetAttributes_InvalidToken() {
 	token := "invalid"
 	notFoundErr := &user.ErrorUserNotFound
 
-	suite.mockService.On("GetUser", mock.Anything, token).Return(nil, notFoundErr).Once()
+	suite.mockService.On("GetUser", mock.Anything, token, false).Return(nil, notFoundErr).Once()
 
 	result, err := suite.provider.GetAttributes(context.Background(), token, nil, nil)
 
@@ -201,7 +204,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_GetUserNotFound() {
 
 	// Expect GetUser call - Fail with UserNotFound
 	userNotFoundErr := &user.ErrorUserNotFound
-	suite.mockService.On("GetUser", mock.Anything, "user123").Return(nil, userNotFoundErr).Once()
+	suite.mockService.On("GetUser", mock.Anything, "user123", false).Return(nil, userNotFoundErr).Once()
 
 	result, err := suite.provider.Authenticate(context.Background(), identifiers, credentials, nil)
 

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -321,8 +321,8 @@ func (_c *UserServiceInterfaceMock_DeleteUser_Call) RunAndReturn(run func(ctx co
 }
 
 // GetUser provides a mock function for the type UserServiceInterfaceMock
-func (_mock *UserServiceInterfaceMock) GetUser(ctx context.Context, userID string) (*User, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, userID)
+func (_mock *UserServiceInterfaceMock) GetUser(ctx context.Context, userID string, includeDisplay bool) (*User, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userID, includeDisplay)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUser")
@@ -330,18 +330,18 @@ func (_mock *UserServiceInterfaceMock) GetUser(ctx context.Context, userID strin
 
 	var r0 *User
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*User, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, userID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) (*User, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userID, includeDisplay)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *User); ok {
-		r0 = returnFunc(ctx, userID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) *User); ok {
+		r0 = returnFunc(ctx, userID, includeDisplay)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, userID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userID, includeDisplay)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -358,11 +358,12 @@ type UserServiceInterfaceMock_GetUser_Call struct {
 // GetUser is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userID string
-func (_e *UserServiceInterfaceMock_Expecter) GetUser(ctx interface{}, userID interface{}) *UserServiceInterfaceMock_GetUser_Call {
-	return &UserServiceInterfaceMock_GetUser_Call{Call: _e.mock.On("GetUser", ctx, userID)}
+//   - includeDisplay bool
+func (_e *UserServiceInterfaceMock_Expecter) GetUser(ctx interface{}, userID interface{}, includeDisplay interface{}) *UserServiceInterfaceMock_GetUser_Call {
+	return &UserServiceInterfaceMock_GetUser_Call{Call: _e.mock.On("GetUser", ctx, userID, includeDisplay)}
 }
 
-func (_c *UserServiceInterfaceMock_GetUser_Call) Run(run func(ctx context.Context, userID string)) *UserServiceInterfaceMock_GetUser_Call {
+func (_c *UserServiceInterfaceMock_GetUser_Call) Run(run func(ctx context.Context, userID string, includeDisplay bool)) *UserServiceInterfaceMock_GetUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -372,9 +373,14 @@ func (_c *UserServiceInterfaceMock_GetUser_Call) Run(run func(ctx context.Contex
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -385,7 +391,7 @@ func (_c *UserServiceInterfaceMock_GetUser_Call) Return(user *User, serviceError
 	return _c
 }
 
-func (_c *UserServiceInterfaceMock_GetUser_Call) RunAndReturn(run func(ctx context.Context, userID string) (*User, *serviceerror.ServiceError)) *UserServiceInterfaceMock_GetUser_Call {
+func (_c *UserServiceInterfaceMock_GetUser_Call) RunAndReturn(run func(ctx context.Context, userID string, includeDisplay bool) (*User, *serviceerror.ServiceError)) *UserServiceInterfaceMock_GetUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -95,7 +95,7 @@ func (e *userExporter) GetAllResourceIDs(ctx context.Context) ([]string, *servic
 // GetResourceByID retrieves a user by its ID.
 func (e *userExporter) GetResourceByID(
 	ctx context.Context, id string) (interface{}, string, *serviceerror.ServiceError) {
-	user, err := e.service.GetUser(ctx, id)
+	user, err := e.service.GetUser(ctx, id, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/backend/internal/user/declarative_resource_test.go
+++ b/backend/internal/user/declarative_resource_test.go
@@ -181,7 +181,7 @@ func (suite *DeclarativeResourceTestSuite) TestUserExporter_GetResourceByID() {
 	exporter := newUserExporter(mockSvc)
 
 	attrs := json.RawMessage(`{"username":"alice"}`)
-	mockSvc.On("GetUser", context.Background(), "user-1").
+	mockSvc.On("GetUser", context.Background(), "user-1", false).
 		Return(&User{ID: "user-1", Type: "person", OUID: "ou-1", Attributes: attrs}, nil)
 
 	resource, name, err := exporter.GetResourceByID(context.Background(), "user-1")

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -133,8 +133,11 @@ func (uh *userHandler) HandleUserGetRequest(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Parse include parameter to check if display name should be included.
+	includeDisplay := r.URL.Query().Get(sysutils.QueryParamInclude) == sysutils.IncludeValueDisplay
+
 	// Get the user using the user service.
-	user, svcErr := uh.userService.GetUser(ctx, id)
+	user, svcErr := uh.userService.GetUser(ctx, id, includeDisplay)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return
@@ -338,7 +341,10 @@ func (uh *userHandler) HandleSelfUserGetRequest(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	user, svcErr := uh.userService.GetUser(ctx, userID)
+	// Parse include parameter to check if display name should be included.
+	includeDisplay := r.URL.Query().Get(sysutils.QueryParamInclude) == sysutils.IncludeValueDisplay
+
+	user, svcErr := uh.userService.GetUser(ctx, userID, includeDisplay)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -48,7 +48,7 @@ func TestHandleSelfUserGetRequest_Success(t *testing.T) {
 		ID:         userID,
 		Attributes: json.RawMessage(`{"username":"alice"}`),
 	}
-	mockSvc.On("GetUser", mock.Anything, userID).Return(expectedUser, nil)
+	mockSvc.On("GetUser", mock.Anything, userID, false).Return(expectedUser, nil)
 
 	handler := newUserHandler(mockSvc)
 	req := httptest.NewRequest(http.MethodGet, "/users/me", nil)
@@ -64,6 +64,25 @@ func TestHandleSelfUserGetRequest_Success(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&respUser))
 	require.Equal(t, expectedUser.ID, respUser.ID)
 	require.JSONEq(t, string(expectedUser.Attributes), string(respUser.Attributes))
+}
+
+func TestHandleSelfUserGetRequest_IncludeDisplay(t *testing.T) {
+	userID := testUserID123
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	expectedUser := &User{ID: userID}
+	mockSvc.On("GetUser", mock.Anything, userID, true).Return(expectedUser, nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/me?include=display", nil)
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserGetRequest(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	mockSvc.AssertExpectations(t)
 }
 
 func TestHandleSelfUserGetRequest_Unauthorized(t *testing.T) {
@@ -358,7 +377,7 @@ func TestHandleUserGetRequest_Success(t *testing.T) {
 	mockSvc := NewUserServiceInterfaceMock(t)
 	userID := testUserID123
 	expectedUser := &User{ID: userID}
-	mockSvc.On("GetUser", mock.Anything, userID).Return(expectedUser, nil)
+	mockSvc.On("GetUser", mock.Anything, userID, false).Return(expectedUser, nil)
 
 	handler := newUserHandler(mockSvc)
 	req := httptest.NewRequest(http.MethodGet, "/users/"+userID, nil)
@@ -372,6 +391,23 @@ func TestHandleUserGetRequest_Success(t *testing.T) {
 	var resp User
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Equal(t, userID, resp.ID)
+}
+
+func TestHandleUserGetRequest_IncludeDisplay(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	userID := testUserID123
+	expectedUser := &User{ID: userID}
+	mockSvc.On("GetUser", mock.Anything, userID, true).Return(expectedUser, nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/"+userID+"?include=display", nil)
+	req.SetPathValue("id", userID)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserGetRequest(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	mockSvc.AssertExpectations(t)
 }
 
 func TestHandleUserPutRequest_Success(t *testing.T) {
@@ -577,7 +613,7 @@ func TestHandleUserGetRequest_ErrorCases(t *testing.T) {
 	})
 
 	t.Run("ServiceError", func(t *testing.T) {
-		mockSvc.On("GetUser", mock.Anything, userID).Return(nil, &ErrorUserNotFound).Once()
+		mockSvc.On("GetUser", mock.Anything, userID, false).Return(nil, &ErrorUserNotFound).Once()
 		req := httptest.NewRequest(http.MethodGet, "/users/"+userID, nil)
 		req.SetPathValue("id", userID)
 		rr := httptest.NewRecorder()
@@ -665,7 +701,7 @@ func TestHandleError_ErrorUnauthorized_Returns403(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockSvc.On("GetUser", mock.Anything, userID).Return(nil, tc.svcErr).Once()
+			mockSvc.On("GetUser", mock.Anything, userID, false).Return(nil, tc.svcErr).Once()
 			req := httptest.NewRequest(http.MethodGet, "/users/"+userID, nil)
 			req.SetPathValue("id", userID)
 			rr := httptest.NewRecorder()

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -50,7 +50,7 @@ type UserServiceInterface interface {
 	CreateUser(ctx context.Context, user *User) (*User, *serviceerror.ServiceError)
 	CreateUserByPath(ctx context.Context, handlePath string,
 		request CreateUserByPathRequest) (*User, *serviceerror.ServiceError)
-	GetUser(ctx context.Context, userID string) (*User, *serviceerror.ServiceError)
+	GetUser(ctx context.Context, userID string, includeDisplay bool) (*User, *serviceerror.ServiceError)
 	GetUserGroups(ctx context.Context, userID string,
 		limit, offset int) (*UserGroupListResponse, *serviceerror.ServiceError)
 	UpdateUser(ctx context.Context, userID string, user *User) (*User, *serviceerror.ServiceError)
@@ -478,7 +478,9 @@ func (us *userService) extractCredentials(user *User, schemaCredentialAttributes
 }
 
 // GetUser retrieves a user by ID.
-func (us *userService) GetUser(ctx context.Context, userID string) (*User, *serviceerror.ServiceError) {
+func (us *userService) GetUser(
+	ctx context.Context, userID string, includeDisplay bool,
+) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug("Retrieving user", log.String("id", userID))
 
@@ -498,6 +500,13 @@ func (us *userService) GetUser(ctx context.Context, userID string) (*User, *serv
 	// Check authz using the user's OU ID (fetched from store).
 	if svcErr := us.checkUserAccess(ctx, security.ActionReadUser, user.OUID, userID); svcErr != nil {
 		return nil, svcErr
+	}
+
+	if includeDisplay {
+		displayAttrPaths := ResolveDisplayAttributePaths(
+			ctx, []string{user.Type}, us.userSchemaService, logger)
+		user.Display = utils.ResolveDisplay(
+			user.ID, user.Type, user.Attributes, displayAttrPaths)
 	}
 
 	logger.Debug("Successfully retrieved user", log.String("id", userID))

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -1705,9 +1705,37 @@ func TestUserService_GetUser_ReturnsUser(t *testing.T) {
 		authzService: newAllowAllAuthz(t),
 	}
 
-	user, err := service.GetUser(context.Background(), userID)
+	user, err := service.GetUser(context.Background(), userID, false)
 	require.Nil(t, err)
 	require.Equal(t, expectedUser, *user)
+}
+
+func TestUserService_GetUser_WithIncludeDisplay(t *testing.T) {
+	userID := svcTestUserID1
+	expectedUser := User{
+		ID:         userID,
+		OUID:       testOrgID,
+		Type:       "employee",
+		Attributes: json.RawMessage(`{"email":"alice@example.com"}`),
+	}
+
+	storeMock := newUserStoreInterfaceMock(t)
+	storeMock.On("IsUserDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetUser", mock.Anything, userID).Return(expectedUser, nil).Once()
+
+	mockSchema := userschemamock.NewUserSchemaServiceInterfaceMock(t)
+	mockSchema.On("GetDisplayAttributesByNames", mock.Anything, []string{"employee"}).
+		Return(map[string]string{"employee": "email"}, nil).Once()
+
+	service := &userService{
+		userStore:         storeMock,
+		authzService:      newAllowAllAuthz(t),
+		userSchemaService: mockSchema,
+	}
+
+	user, err := service.GetUser(context.Background(), userID, true)
+	require.Nil(t, err)
+	require.Equal(t, "alice@example.com", user.Display)
 }
 
 func TestUserService_DeleteUser(t *testing.T) {
@@ -3022,14 +3050,14 @@ func TestUserService_CRUD_ErrorCases(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("GetUser_MissingID", func(t *testing.T) {
-		_, err := service.GetUser(ctx, "")
+		_, err := service.GetUser(ctx, "", false)
 		require.NotNil(t, err)
 		require.Equal(t, ErrorMissingUserID.Code, err.Code)
 	})
 
 	t.Run("GetUser_NotFound", func(t *testing.T) {
 		mockStore.On("GetUser", mock.Anything, "u1").Return(User{}, ErrUserNotFound).Once()
-		_, err := service.GetUser(ctx, "u1")
+		_, err := service.GetUser(ctx, "u1", false)
 		require.NotNil(t, err)
 		require.Equal(t, ErrorUserNotFound.Code, err.Code)
 	})
@@ -4199,7 +4227,7 @@ func TestUserService_GetUser_ErrorCases(t *testing.T) {
 			if tc.name == "MissingUserID_ReturnsMissingUserIDError" {
 				id = ""
 			}
-			user, err := svc.GetUser(context.Background(), id)
+			user, err := svc.GetUser(context.Background(), id, false)
 			require.Nil(t, user)
 			require.NotNil(t, err)
 			require.Equal(t, tc.wantErrCode, err.Code)

--- a/backend/internal/userprovider/default_user_provider.go
+++ b/backend/internal/userprovider/default_user_provider.go
@@ -53,7 +53,7 @@ func (p *defaultUserProvider) IdentifyUser(filters map[string]interface{}) (*str
 
 // GetUser retrieves a user based on the given user ID.
 func (p *defaultUserProvider) GetUser(userID string) (*User, *UserProviderError) {
-	userResult, err := p.userSvc.GetUser(security.WithRuntimeContext(context.Background()), userID)
+	userResult, err := p.userSvc.GetUser(security.WithRuntimeContext(context.Background()), userID, false)
 	if err != nil {
 		if err.Code == user.ErrorUserNotFound.Code {
 			return nil, NewUserProviderError(ErrorCodeUserNotFound, err.Error, err.ErrorDescription)

--- a/backend/internal/userprovider/default_user_provider_test.go
+++ b/backend/internal/userprovider/default_user_provider_test.go
@@ -88,8 +88,8 @@ func (suite *DefaultUserProviderTestSuite) TestGetUser() {
 	}
 
 	// Test Success
-	suite.mockService.On("GetUser", mock.Anything, userID).Return(expectedUser, (*serviceerror.ServiceError)(nil)).
-		Once()
+	suite.mockService.On("GetUser", mock.Anything, userID, false).
+		Return(expectedUser, (*serviceerror.ServiceError)(nil)).Once()
 
 	u, err := suite.provider.GetUser(userID)
 	suite.Nil(err)
@@ -98,7 +98,7 @@ func (suite *DefaultUserProviderTestSuite) TestGetUser() {
 	suite.Equal("ou1", u.OUID)
 
 	// Test Not Found
-	suite.mockService.On("GetUser", mock.Anything, userID).Return(nil, &user.ErrorUserNotFound).
+	suite.mockService.On("GetUser", mock.Anything, userID, false).Return(nil, &user.ErrorUserNotFound).
 		Once()
 
 	u, err = suite.provider.GetUser(userID)

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -322,8 +322,8 @@ func (_c *UserServiceInterfaceMock_DeleteUser_Call) RunAndReturn(run func(ctx co
 }
 
 // GetUser provides a mock function for the type UserServiceInterfaceMock
-func (_mock *UserServiceInterfaceMock) GetUser(ctx context.Context, userID string) (*user.User, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, userID)
+func (_mock *UserServiceInterfaceMock) GetUser(ctx context.Context, userID string, includeDisplay bool) (*user.User, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userID, includeDisplay)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUser")
@@ -331,18 +331,18 @@ func (_mock *UserServiceInterfaceMock) GetUser(ctx context.Context, userID strin
 
 	var r0 *user.User
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*user.User, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, userID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) (*user.User, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userID, includeDisplay)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *user.User); ok {
-		r0 = returnFunc(ctx, userID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) *user.User); ok {
+		r0 = returnFunc(ctx, userID, includeDisplay)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*user.User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, userID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userID, includeDisplay)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -359,11 +359,12 @@ type UserServiceInterfaceMock_GetUser_Call struct {
 // GetUser is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userID string
-func (_e *UserServiceInterfaceMock_Expecter) GetUser(ctx interface{}, userID interface{}) *UserServiceInterfaceMock_GetUser_Call {
-	return &UserServiceInterfaceMock_GetUser_Call{Call: _e.mock.On("GetUser", ctx, userID)}
+//   - includeDisplay bool
+func (_e *UserServiceInterfaceMock_Expecter) GetUser(ctx interface{}, userID interface{}, includeDisplay interface{}) *UserServiceInterfaceMock_GetUser_Call {
+	return &UserServiceInterfaceMock_GetUser_Call{Call: _e.mock.On("GetUser", ctx, userID, includeDisplay)}
 }
 
-func (_c *UserServiceInterfaceMock_GetUser_Call) Run(run func(ctx context.Context, userID string)) *UserServiceInterfaceMock_GetUser_Call {
+func (_c *UserServiceInterfaceMock_GetUser_Call) Run(run func(ctx context.Context, userID string, includeDisplay bool)) *UserServiceInterfaceMock_GetUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -373,9 +374,14 @@ func (_c *UserServiceInterfaceMock_GetUser_Call) Run(run func(ctx context.Contex
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -386,7 +392,7 @@ func (_c *UserServiceInterfaceMock_GetUser_Call) Return(user1 *user.User, servic
 	return _c
 }
 
-func (_c *UserServiceInterfaceMock_GetUser_Call) RunAndReturn(run func(ctx context.Context, userID string) (*user.User, *serviceerror.ServiceError)) *UserServiceInterfaceMock_GetUser_Call {
+func (_c *UserServiceInterfaceMock_GetUser_Call) RunAndReturn(run func(ctx context.Context, userID string, includeDisplay bool) (*user.User, *serviceerror.ServiceError)) *UserServiceInterfaceMock_GetUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/frontend/apps/thunder-console/src/features/users/api/__tests__/useGetUser.test.ts
+++ b/frontend/apps/thunder-console/src/features/users/api/__tests__/useGetUser.test.ts
@@ -109,7 +109,7 @@ describe('useGetUser', () => {
 
     expect(mockHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: `https://api.test.com/users/${userId}`,
+        url: `https://api.test.com/users/${userId}?include=display`,
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/thunder-console/src/features/users/api/useGetUser.ts
+++ b/frontend/apps/thunder-console/src/features/users/api/useGetUser.ts
@@ -40,7 +40,7 @@ export default function useGetUser(userId: string | undefined): UseQueryResult<A
       const response: {
         data: ApiUser;
       } = await http.request({
-        url: `${serverUrl}/users/${userId}`,
+        url: `${serverUrl}/users/${userId}?include=display`,
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
### Purpose
This pull request updates the `GetUser` method calls throughout the passkey authentication service and its tests to include an additional boolean argument. This change ensures consistency between the service implementation and its test mocks, likely reflecting an updated method signature for `GetUser`.

Updates to service logic:

* All calls to `userService.GetUser` in `backend/internal/authn/passkey/service.go` now include a third argument (`false`), aligning with the updated method signature. [[1]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL102-R102) [[2]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL228-R228) [[3]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL337-R337) [[4]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL446-R446)

Updates to test code:

* All test mocks for `GetUser` in `backend/internal/authn/passkey/service_test.go` are updated to include the new argument, ensuring test compatibility with the updated service logic. [[1]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L125-R125) [[2]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L146-R146) [[3]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L173-R173) [[4]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L297-R297) [[5]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L317-R317) [[6]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L343-R343) [[7]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L372-R372) [[8]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L911-R911) [[9]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L999-R999) [[10]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1031-R1031) [[11]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1072-R1072) [[12]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1118-R1118) [[13]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1479-R1479) [[14]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1524-R1524) [[15]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1573-R1573) [[16]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1622-R1622) [[17]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1666-R1666) [[18]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L1881-R1881) [[19]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2004-R2004) [[20]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2048-R2048) [[21]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2095-R2095) [[22]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2141-R2141) [[23]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2184-R2184) [[24]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2218-R2218) [[25]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2262-R2262) [[26]](diffhunk://#diff-af49522615608bd1b9809c9a9c9ee66b43f9767e5de287e22d05b2009f002e07L2340-R2340)

### Related Issues
- https://github.com/asgardeo/thunder/issues/1890

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profiles now include display attributes by default when retrieved.
  * Added support for controlling display attribute inclusion via optional query parameters on user endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->