### PR TITLE
fix(docs): resolve duplicate Docusaurus sidebar translation key errors

### DIFF
--- a/docs/content/guides/key-concepts/authentication/overview.mdx
+++ b/docs/content/guides/key-concepts/authentication/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Authentication
 sidebar_position: 1
+sidebar_label: Overview
 ---
 
 # 🚧 WIP

--- a/docs/content/guides/key-concepts/authentication/passwordless/overview.mdx
+++ b/docs/content/guides/key-concepts/authentication/passwordless/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Passwordless
 sidebar_position: 2
+sidebar_label: Overview
 ---
 
 # 🚧 WIP

--- a/docs/content/sdks/react/guides/protecting-routes/overview.mdx
+++ b/docs/content/sdks/react/guides/protecting-routes/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Protecting Routes
+sidebar_label: Overview
 description: Choose your routing library to secure routes in your React application
 hide_table_of_contents: true
 hide_title: true

--- a/docs/content/sdks/react/overview.mdx
+++ b/docs/content/sdks/react/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: React SDK Overview
 sidebar_position: 1
+sidebar_label: Overview
 description: Asgardeo React SDK for seamless authentication integration
 ---
 

--- a/docs/content/sdks/react/sidebar.ts
+++ b/docs/content/sdks/react/sidebar.ts
@@ -23,7 +23,6 @@ const sidebar: SidebarsConfig = {
     {
       type: 'doc',
       id: 'sdks/react/overview',
-      label: 'Overview',
     },
     {
       type: 'category',
@@ -174,7 +173,6 @@ const sidebar: SidebarsConfig = {
             {
               type: 'doc',
               id: 'sdks/react/guides/protecting-routes/overview',
-              label: 'Overview',
             },
             {
               type: 'doc',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -226,7 +226,6 @@ const sidebars: SidebarsConfig = {
             {
               type: 'doc',
               id: 'guides/key-concepts/authentication/overview',
-              label: 'Overview',
             },
             {
               type: 'category',
@@ -236,7 +235,6 @@ const sidebars: SidebarsConfig = {
                 {
                   type: 'doc',
                   id: 'guides/key-concepts/authentication/passwordless/overview',
-                  label: 'Overview',
                 },
                 {
                   type: 'doc',


### PR DESCRIPTION
### **Description**

#### **What does this PR do?**
Resolves a critical build-blocking issue (`Multiple docs sidebar items produce the same translation key: 'Overview'`) that occurs when internationalization (i18n) is enabled. 

#### **Why is this necessary?**
Docusaurus attempts to generate global translation keys using explicit sidebar labels (e.g., `sidebar.docsSidebar.doc.Overview`). Since we previously had multiple separate items hardcoded generic `label: 'Overview'` properties in the same sidebar configurations, Docusaurus threw a duplicate ID error during translation extraction. This was currently blocking the community PR that attempts to introduce official i18n configurations. 

#### **How was this fixed?**
1. Removed all explicitly mapped `label: 'Overview'` lines from `docs/sidebars.ts` and `docs/content/sdks/react/sidebar.ts`.
2. Re-injected `sidebar_label: Overview` directly into the Front Matter of the corresponding `.mdx` files (like `content/guides/key-concepts/authentication/overview.mdx`, `content/sdks/react/overview.mdx`, etc.).

By delegating the label mapping to the document's Front Matter, Docusaurus safely scopes the translation ID natively to the document's physical path. The UI remains visually identical, but all duplicate sidebar ID conflicts are officially resolved!

#### **Tested Changes**
- [x] Tested locally via `npm run docusaurus write-translations`
- [x] Tested locally via `npm run build`
- [x] Verified sidebar UI still accurately renders "Overview" for the targeted modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Sidebar labels now come from each page's metadata (added "Overview" label to several overview pages).
  * Removed hardcoded "Overview" overrides in sidebar configuration so displayed labels reflect document frontmatter.
  * Result: sidebar labels are more consistent and easier to maintain; no content or page layout changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->