### PR TITLE
Fix `Invite` flows to support `i18n` translations via Thunder Console

### DIFF
--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -36,16 +36,6 @@
             "meta": {
                 "components": [
                     {
-                        "alt": "{{ t(signup:images.app_logo.alt) }}",
-                        "category": "DISPLAY",
-                        "height": "60",
-                        "id": "image",
-                        "resourceType": "ELEMENT",
-                        "src": "{{ meta(application.logo_url) }}",
-                        "type": "IMAGE",
-                        "width": ""
-                    },
-                    {
                         "align": "center",
                         "type": "TEXT",
                         "id": "heading_usertype",
@@ -98,16 +88,6 @@
             "type": "PROMPT",
             "meta": {
                 "components": [
-                    {
-                        "alt": "{{ t(signup:images.app_logo.alt) }}",
-                        "category": "DISPLAY",
-                        "height": "60",
-                        "id": "image",
-                        "resourceType": "ELEMENT",
-                        "src": "{{ meta(application.logo_url) }}",
-                        "type": "IMAGE",
-                        "width": ""
-                    },
                     {
                         "align": "center",
                         "type": "TEXT",
@@ -207,16 +187,6 @@
             "type": "PROMPT",
             "meta": {
                 "components": [
-                    {
-                        "alt": "{{ t(signup:images.app_logo.alt) }}",
-                        "category": "DISPLAY",
-                        "height": "60",
-                        "id": "image",
-                        "resourceType": "ELEMENT",
-                        "src": "{{ meta(application.logo_url) }}",
-                        "type": "IMAGE",
-                        "width": ""
-                    },
                     {
                         "align": "center",
                         "type": "TEXT",

--- a/backend/internal/design/layout/mgt/handler.go
+++ b/backend/internal/design/layout/mgt/handler.go
@@ -109,6 +109,8 @@ func (lh *layoutMgtHandler) HandleLayoutPostRequest(w http.ResponseWriter, r *ht
 		DisplayName: createdLayout.DisplayName,
 		Description: createdLayout.Description,
 		Layout:      createdLayout.Layout,
+		CreatedAt:   createdLayout.CreatedAt,
+		UpdatedAt:   createdLayout.UpdatedAt,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, layoutResponse)
@@ -131,6 +133,8 @@ func (lh *layoutMgtHandler) HandleLayoutGetRequest(w http.ResponseWriter, r *htt
 		DisplayName: layout.DisplayName,
 		Description: layout.Description,
 		Layout:      layout.Layout,
+		CreatedAt:   layout.CreatedAt,
+		UpdatedAt:   layout.UpdatedAt,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)
@@ -159,6 +163,8 @@ func (lh *layoutMgtHandler) HandleLayoutPutRequest(w http.ResponseWriter, r *htt
 		DisplayName: updatedLayout.DisplayName,
 		Description: updatedLayout.Description,
 		Layout:      updatedLayout.Layout,
+		CreatedAt:   updatedLayout.CreatedAt,
+		UpdatedAt:   updatedLayout.UpdatedAt,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)

--- a/backend/internal/design/theme/mgt/handler.go
+++ b/backend/internal/design/theme/mgt/handler.go
@@ -109,6 +109,8 @@ func (th *themeMgtHandler) HandleThemePostRequest(w http.ResponseWriter, r *http
 		DisplayName: createdTheme.DisplayName,
 		Description: createdTheme.Description,
 		Theme:       createdTheme.Theme,
+		CreatedAt:   createdTheme.CreatedAt,
+		UpdatedAt:   createdTheme.UpdatedAt,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, themeResponse)
@@ -131,6 +133,8 @@ func (th *themeMgtHandler) HandleThemeGetRequest(w http.ResponseWriter, r *http.
 		DisplayName: theme.DisplayName,
 		Description: theme.Description,
 		Theme:       theme.Theme,
+		CreatedAt:   theme.CreatedAt,
+		UpdatedAt:   theme.UpdatedAt,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, themeResponse)
@@ -159,6 +163,8 @@ func (th *themeMgtHandler) HandleThemePutRequest(w http.ResponseWriter, r *http.
 		DisplayName: updatedTheme.DisplayName,
 		Description: updatedTheme.Description,
 		Theme:       updatedTheme.Theme,
+		CreatedAt:   updatedTheme.CreatedAt,
+		UpdatedAt:   updatedTheme.UpdatedAt,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, themeResponse)

--- a/backend/internal/flow/flowmeta/handler.go
+++ b/backend/internal/flow/flowmeta/handler.go
@@ -44,8 +44,8 @@ func newFlowMetaHandler(flowMetaService FlowMetaServiceInterface) *flowMetaHandl
 // HandleGetFlowMetadata handles the GET /flow/meta endpoint.
 func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.Request) {
 	// Get query parameters
-	metaType := r.URL.Query().Get("type")
-	id := r.URL.Query().Get("id")
+	metaType := sysutils.SanitizeString(r.URL.Query().Get("type"))
+	id := sysutils.SanitizeString(r.URL.Query().Get("id"))
 
 	var language *string
 	var namespace *string
@@ -58,20 +58,16 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 		namespace = &ns
 	}
 
-	// Validate required parameters
-	if metaType == "" {
+	// Validate parameter combinations: id requires type, and type requires id
+	if id != "" && metaType == "" {
 		handleServiceError(w, &ErrorMissingType)
 		return
 	}
 
-	if id == "" {
+	if metaType != "" && id == "" {
 		handleServiceError(w, &ErrorMissingID)
 		return
 	}
-
-	// Sanitize inputs
-	metaType = sysutils.SanitizeString(metaType)
-	id = sysutils.SanitizeString(id)
 	if language != nil {
 		lang := sysutils.SanitizeString(*language)
 		language = &lang

--- a/backend/internal/flow/flowmeta/handler_test.go
+++ b/backend/internal/flow/flowmeta/handler_test.go
@@ -180,9 +180,47 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_Success_OUType(
 	assert.Equal(suite.T(), expectedResponse.OU.Handle, response.OU.Handle)
 }
 
-func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_MissingType() {
-	// Arrange
-	req := httptest.NewRequest(http.MethodGet, "/flow/meta?id=some-id", nil)
+func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_SystemFlow_NoParams() {
+	// Arrange: no type or id — system flow, returns i18n only
+	expectedResponse := &FlowMetadataResponse{
+		IsRegistrationFlowEnabled: false,
+		Design: DesignMetadata{
+			Theme:  json.RawMessage(`{}`),
+			Layout: json.RawMessage(`{}`),
+		},
+		I18n: I18nMetadata{
+			Languages:    []string{"en-US"},
+			Language:     "en-US",
+			TotalResults: 5,
+			Translations: map[string]map[string]string{
+				"system": {"key": "value"},
+			},
+		},
+	}
+
+	suite.mockService.On("GetFlowMetadata", mock.Anything, MetaType(""), "", (*string)(nil), (*string)(nil)).
+		Return(expectedResponse, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/flow/meta", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	suite.handler.HandleGetFlowMetadata(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var response FlowMetadataResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(suite.T(), err)
+	assert.False(suite.T(), response.IsRegistrationFlowEnabled)
+	assert.Nil(suite.T(), response.Application)
+	assert.Nil(suite.T(), response.OU)
+}
+
+func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_MissingID_WhenTypeProvided() {
+	// Arrange: type is provided but id is missing — id is required when type is set
+	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP", nil)
 	w := httptest.NewRecorder()
 
 	// Act
@@ -192,9 +230,9 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_MissingType() {
 	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
 }
 
-func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_MissingID() {
-	// Arrange
-	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP", nil)
+func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_MissingType_WhenIDProvided() {
+	// Arrange: id is provided but type is missing — type is required when id is set
+	req := httptest.NewRequest(http.MethodGet, "/flow/meta?id=some-id", nil)
 	w := httptest.NewRecorder()
 
 	// Act
@@ -202,6 +240,11 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_MissingID() {
 
 	// Assert
 	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+
+	var errorResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &errorResp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), ErrorMissingType.Code, errorResp["code"])
 }
 
 func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_InvalidType() {

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -93,13 +93,41 @@ func (fms *flowMetaService) GetFlowMetadata(
 	language *string,
 	namespace *string,
 ) (*FlowMetadataResponse, *serviceerror.ServiceError) {
-	// Validate type parameter
+	response := newFlowMetadataResponse()
+	lang, ns := resolveLanguageAndNamespace(language, namespace)
+
+	if metaType == "" {
+		fms.populateI18nMetadata(response, lang, ns)
+		return response, nil
+	}
+
 	if !metaType.IsValid() {
 		return nil, &ErrorInvalidType
 	}
 
+	ouID, svcErr := fms.populateTypeMetadata(ctx, metaType, id, response)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	if svcErr := fms.populateOUMetadata(ctx, ouID, response); svcErr != nil {
+		return nil, svcErr
+	}
+
+	fms.populateDesignMetadata(ctx, metaType, id, ouID, response)
+	fms.populateI18nMetadata(response, lang, ns)
+
+	fms.logger.Debug("Successfully retrieved flow metadata",
+		log.String("type", string(metaType)),
+		log.String("id", id))
+
+	return response, nil
+}
+
+func newFlowMetadataResponse() *FlowMetadataResponse {
 	emptyJSON, _ := json.Marshal(map[string]interface{}{})
-	response := &FlowMetadataResponse{
+
+	return &FlowMetadataResponse{
 		Design: DesignMetadata{
 			Theme:  json.RawMessage(emptyJSON),
 			Layout: json.RawMessage(emptyJSON),
@@ -108,109 +136,10 @@ func (fms *flowMetaService) GetFlowMetadata(
 			Translations: make(map[string]map[string]string),
 		},
 	}
+}
 
-	var ouID string
-
-	// Get application or OU details based on type
-	if metaType == MetaTypeAPP {
-		app, svcErr := fms.applicationService.GetApplication(ctx, id)
-		if svcErr != nil {
-			if svcErr.Code == application.ErrorApplicationNotFound.Code {
-				return nil, &ErrorApplicationNotFound
-			}
-
-			fms.logger.Error("Failed to get application",
-				log.String("appID", id),
-				log.String("error", svcErr.Error),
-				log.String("code", svcErr.Code))
-			return nil, &ErrorApplicationFetchFailed
-		}
-
-		response.IsRegistrationFlowEnabled = app.IsRegistrationFlowEnabled
-		response.Application = &ApplicationMetadata{
-			ID:        app.ID,
-			Name:      app.Name,
-			LogoURL:   app.LogoURL,
-			URL:       app.URL,
-			TosURI:    app.TosURI,
-			PolicyURI: app.PolicyURI,
-		}
-
-		// Get the root OU for the deployment since applications are scoped to the deployment.
-		// Only populate OU metadata if there is exactly one OU in the deployment.
-		ouList, ouErr := fms.ouService.GetOrganizationUnitList(ctx, 1, 0)
-		if ouErr != nil {
-			if ouErr.Code == ou.ErrorOrganizationUnitNotFound.Code {
-				return nil, &ErrorOUNotFound
-			}
-
-			fms.logger.Error("Failed to get root organization unit",
-				log.String("error", ouErr.Error),
-				log.String("code", ouErr.Code))
-			return nil, &ErrorOUFetchFailed
-		}
-		if ouList != nil && ouList.TotalResults == 1 && len(ouList.OrganizationUnits) > 0 {
-			ouID = ouList.OrganizationUnits[0].ID
-		}
-	} else {
-		// For OU type, use the provided ID as the OU ID
-		ouID = id
-		response.IsRegistrationFlowEnabled = false
-	}
-
-	// Get OU details
-	if ouID != "" {
-		orgUnit, svcErr := fms.ouService.GetOrganizationUnit(ctx, ouID)
-		if svcErr != nil {
-			if svcErr.Code == ou.ErrorOrganizationUnitNotFound.Code {
-				return nil, &ErrorOUNotFound
-			}
-
-			fms.logger.Error("Failed to get organization unit",
-				log.String("ouID", ouID),
-				log.String("error", svcErr.Error),
-				log.String("code", svcErr.Code))
-			return nil, &ErrorOUFetchFailed
-		}
-
-		response.OU = &OUMetadata{
-			ID:              orgUnit.ID,
-			Handle:          orgUnit.Handle,
-			Name:            orgUnit.Name,
-			Description:     orgUnit.Description,
-			LogoURL:         orgUnit.LogoURL,
-			TosURI:          orgUnit.TosURI,
-			PolicyURI:       orgUnit.PolicyURI,
-			CookiePolicyURI: orgUnit.CookiePolicyURI,
-		}
-	}
-
-	// Get design configuration (theme and layout)
-	designType := common.DesignResolveTypeAPP
-	designID := id
-	if metaType == MetaTypeOU {
-		designType = common.DesignResolveTypeOU
-		designID = ouID
-	}
-
-	designResp, svcErr := fms.designResolve.ResolveDesign(ctx, designType, designID)
-	if svcErr != nil {
-		// Design is optional, log and continue with empty design
-		fms.logger.Debug("Failed to get design configuration",
-			log.String("type", string(designType)),
-			log.String("id", designID),
-			log.String("error", svcErr.Error))
-	} else if designResp != nil {
-		if designResp.Theme != nil {
-			response.Design.Theme = designResp.Theme
-		}
-		if designResp.Layout != nil {
-			response.Design.Layout = designResp.Layout
-		}
-	}
-
-	// Get i18n translations
-	lang := "en-US"
+func resolveLanguageAndNamespace(language *string, namespace *string) (string, string) {
+	lang := i18nmgt.SystemLanguage
 	if language != nil && *language != "" {
 		lang = *language
 	}
@@ -220,9 +149,136 @@ func (fms *flowMetaService) GetFlowMetadata(
 		ns = *namespace
 	}
 
+	return lang, ns
+}
+
+func (fms *flowMetaService) populateTypeMetadata(
+	ctx context.Context,
+	metaType MetaType,
+	id string,
+	response *FlowMetadataResponse,
+) (string, *serviceerror.ServiceError) {
+	if metaType == MetaTypeOU {
+		response.IsRegistrationFlowEnabled = false
+		return id, nil
+	}
+
+	app, svcErr := fms.applicationService.GetApplication(ctx, id)
+	if svcErr != nil {
+		if svcErr.Code == application.ErrorApplicationNotFound.Code {
+			return "", &ErrorApplicationNotFound
+		}
+
+		fms.logger.Error("Failed to get application",
+			log.String("appID", id),
+			log.String("error", svcErr.Error),
+			log.String("code", svcErr.Code))
+		return "", &ErrorApplicationFetchFailed
+	}
+
+	response.IsRegistrationFlowEnabled = app.IsRegistrationFlowEnabled
+	response.Application = &ApplicationMetadata{
+		ID:        app.ID,
+		Name:      app.Name,
+		LogoURL:   app.LogoURL,
+		URL:       app.URL,
+		TosURI:    app.TosURI,
+		PolicyURI: app.PolicyURI,
+	}
+
+	ouList, ouErr := fms.ouService.GetOrganizationUnitList(ctx, 1, 0)
+	if ouErr != nil {
+		if ouErr.Code == ou.ErrorOrganizationUnitNotFound.Code {
+			return "", &ErrorOUNotFound
+		}
+
+		fms.logger.Error("Failed to get root organization unit",
+			log.String("error", ouErr.Error),
+			log.String("code", ouErr.Code))
+		return "", &ErrorOUFetchFailed
+	}
+
+	if ouList != nil && ouList.TotalResults == 1 && len(ouList.OrganizationUnits) > 0 {
+		return ouList.OrganizationUnits[0].ID, nil
+	}
+
+	return "", nil
+}
+
+func (fms *flowMetaService) populateOUMetadata(
+	ctx context.Context,
+	ouID string,
+	response *FlowMetadataResponse,
+) *serviceerror.ServiceError {
+	if ouID == "" {
+		return nil
+	}
+
+	orgUnit, svcErr := fms.ouService.GetOrganizationUnit(ctx, ouID)
+	if svcErr != nil {
+		if svcErr.Code == ou.ErrorOrganizationUnitNotFound.Code {
+			return &ErrorOUNotFound
+		}
+
+		fms.logger.Error("Failed to get organization unit",
+			log.String("ouID", ouID),
+			log.String("error", svcErr.Error),
+			log.String("code", svcErr.Code))
+		return &ErrorOUFetchFailed
+	}
+
+	response.OU = &OUMetadata{
+		ID:              orgUnit.ID,
+		Handle:          orgUnit.Handle,
+		Name:            orgUnit.Name,
+		Description:     orgUnit.Description,
+		LogoURL:         orgUnit.LogoURL,
+		TosURI:          orgUnit.TosURI,
+		PolicyURI:       orgUnit.PolicyURI,
+		CookiePolicyURI: orgUnit.CookiePolicyURI,
+	}
+
+	return nil
+}
+
+func (fms *flowMetaService) populateDesignMetadata(
+	ctx context.Context,
+	metaType MetaType,
+	id string,
+	ouID string,
+	response *FlowMetadataResponse,
+) {
+	designType := common.DesignResolveTypeAPP
+	designID := id
+	if metaType == MetaTypeOU {
+		designType = common.DesignResolveTypeOU
+		designID = ouID
+	}
+
+	designResp, svcErr := fms.designResolve.ResolveDesign(ctx, designType, designID)
+	if svcErr != nil {
+		fms.logger.Debug("Failed to get design configuration",
+			log.String("type", string(designType)),
+			log.String("id", designID),
+			log.String("error", svcErr.Error))
+		return
+	}
+
+	if designResp == nil {
+		return
+	}
+
+	if designResp.Theme != nil {
+		response.Design.Theme = designResp.Theme
+	}
+	if designResp.Layout != nil {
+		response.Design.Layout = designResp.Layout
+	}
+}
+
+func (fms *flowMetaService) populateI18nMetadata(response *FlowMetadataResponse, lang string, ns string) {
 	i18nResp, i18nErr := fms.i18nService.ResolveTranslations(lang, ns)
 	if i18nErr != nil {
-		// i18n is optional, log and continue with empty translations
 		fms.logger.Debug("Failed to get i18n translations",
 			log.String("language", lang),
 			log.String("namespace", ns),
@@ -233,20 +289,13 @@ func (fms *flowMetaService) GetFlowMetadata(
 		response.I18n.Translations = i18nResp.Translations
 	}
 
-	// Get list of available languages
 	languages, i18nErr := fms.i18nService.ListLanguages()
 	if i18nErr != nil {
 		fms.logger.Debug("Failed to list languages",
 			log.String("error", i18nErr.Error.DefaultValue))
-
-		response.I18n.Languages = []string{"en"}
-	} else {
-		response.I18n.Languages = languages
+		response.I18n.Languages = []string{i18nmgt.SystemLanguage}
+		return
 	}
 
-	fms.logger.Debug("Successfully retrieved flow metadata",
-		log.String("type", string(metaType)),
-		log.String("id", id))
-
-	return response, nil
+	response.I18n.Languages = languages
 }

--- a/backend/internal/flow/flowmeta/service_test.go
+++ b/backend/internal/flow/flowmeta/service_test.go
@@ -320,3 +320,31 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_I18nError_ContinuesWi
 	assert.NotNil(suite.T(), result.I18n.Translations)
 	assert.Equal(suite.T(), 0, len(result.I18n.Translations))
 }
+
+func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_SystemFlow_NoTypeOrID() {
+	// Arrange: no type or id — system flow returns i18n only, skips app/OU/design
+	mockTranslations := &i18nmgt.LanguageTranslationsResponse{
+		Language:     "en-US",
+		TotalResults: 3,
+		Translations: map[string]map[string]string{
+			"system": {"error.internal": "Internal error"},
+		},
+	}
+
+	suite.mockI18nService.On("ResolveTranslations", "en-US", "").Return(mockTranslations, nil)
+	suite.mockI18nService.On("ListLanguages").Return([]string{"en-US"}, nil)
+
+	// Act
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, MetaType(""), "", nil, nil)
+
+	// Assert
+	assert.Nil(suite.T(), svcErr)
+	assert.NotNil(suite.T(), result)
+	assert.False(suite.T(), result.IsRegistrationFlowEnabled)
+	assert.Nil(suite.T(), result.Application)
+	assert.Nil(suite.T(), result.OU)
+	assert.Equal(suite.T(), "en-US", result.I18n.Language)
+	assert.Equal(suite.T(), 3, result.I18n.TotalResults)
+	assert.Equal(suite.T(), []string{"en-US"}, result.I18n.Languages)
+	assert.Contains(suite.T(), result.I18n.Translations, "system")
+}

--- a/frontend/apps/thunder-gate/src/components/AcceptInvite/AcceptInviteBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/AcceptInvite/AcceptInviteBox.tsx
@@ -35,11 +35,10 @@ import {
   ColorSchemeImage,
   CircularProgress,
 } from '@wso2/oxygen-ui';
-import {AcceptInvite, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {AcceptInvite, useAsgardeo, type EmbeddedFlowComponent} from '@asgardeo/react';
 import {useNavigate} from 'react-router';
 import {useTranslation} from 'react-i18next';
 import {useConfig} from '@thunder/shared-contexts';
-import {useTemplateLiteralResolver} from '@thunder/shared-hooks';
 import ROUTES from '../../constants/routes';
 import FlowComponentRenderer from '../flow/FlowComponentRenderer';
 
@@ -57,7 +56,7 @@ const StyledPaper = styled(Paper)(({theme}) => ({
 
 export default function AcceptInviteBox(): JSX.Element {
   const navigate = useNavigate();
-  const {resolve} = useTemplateLiteralResolver();
+  const {resolveFlowTemplateLiterals} = useAsgardeo();
   const {t} = useTranslation();
   const {getServerUrl} = useConfig();
   const [flowError, setFlowError] = useState<string | null>(null);
@@ -168,7 +167,7 @@ export default function AcceptInviteBox(): JSX.Element {
                         touched={touched}
                         fieldErrors={fieldErrors}
                         isLoading={isLoading}
-                        resolve={resolve}
+                        resolve={resolveFlowTemplateLiterals}
                         onInputChange={handleInputChange}
                         onSubmit={(action, inputs) => {
                           handleSubmit(action, inputs).catch(() => {});

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -1376,32 +1376,6 @@ const translations = {
     'errors.passkey.failed': 'Failed to create passkey. Please try again.',
   },
 
-  // This should be resolved from backend in future efforts
-  // ISSUE: https://github.com/asgardeo/thunder/issues/1724
-  // ============================================================================
-  // Onboarding namespace - User onboarding flow translation
-  // ============================================================================
-  onboarding: {
-    'forms.email.title': 'User Email',
-    'forms.email.fields.email.label': 'Email',
-    'forms.email.fields.email.placeholder': 'Enter email',
-    'forms.email.actions.next.label': 'Next',
-    'forms.user_details.title': 'User Details',
-    'forms.user_details.fields.username.label': 'Username',
-    'forms.user_details.fields.username.placeholder': 'Enter username',
-    'forms.user_details.fields.first_name.label': 'First Name',
-    'forms.user_details.fields.first_name.placeholder': 'Enter first name',
-    'forms.user_details.fields.last_name.label': 'Last Name',
-    'forms.user_details.fields.last_name.placeholder': 'Enter last name',
-    'forms.user_details.fields.phone_number.label': 'Phone Number',
-    'forms.user_details.fields.phone_number.placeholder': 'Enter phone number',
-    'forms.user_details.actions.next.label': 'Next',
-    'forms.credential.title': 'Set Password',
-    'forms.credential.fields.password.label': 'Password',
-    'forms.credential.fields.password.placeholder': 'Enter password',
-    'forms.credential.actions.submit.label': 'Set Password',
-  },
-
   // ============================================================================
   // Invite namespace - Invite acceptance feature translations (for Thunder Gate)
   // ============================================================================

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.15.4
-      version: 0.15.4
+      specifier: 0.16.0
+      version: 0.16.0
     '@asgardeo/react-router':
       specifier: 2.0.0
       version: 2.0.0
@@ -257,10 +257,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
+        version: 0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/abstract':
         specifier: 0.1.21
         version: 0.1.21
@@ -471,10 +471,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
+        version: 0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -732,7 +732,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
+        version: 0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -910,7 +910,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
+        version: 0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1310,14 +1310,14 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@asgardeo/browser@0.5.5':
-    resolution: {integrity: sha512-UrrUkBAHIrYBpTUlNI4Ed4CSreQEnzMBPi8zuQkwBz3VbTuV5uKFqQKVJU1VPewIUqxMnMtG9NjwE7bCxIq2WA==}
+  '@asgardeo/browser@0.5.6':
+    resolution: {integrity: sha512-kEJbflcIjV+DX3g6/EOnTRcltZfZ/2oA4OwB1D4LZThymx9FkcB5qdmsA+uvLtRqYL0q+4EVKVQc4FOc3ro9pQ==}
 
   '@asgardeo/i18n@0.4.4':
     resolution: {integrity: sha512-ZbaMDgN3TBg1B8+76xWXnsTwnqrsSSuy4vf6Cqrf/i7ecAqykHmaEtzY5A+piI3F4V4kPWMdU+hs1N3JYOC8FQ==}
 
-  '@asgardeo/javascript@0.10.1':
-    resolution: {integrity: sha512-NQWYGpMwtcxMg5+a2s+45hofb/7NluA3WbzOmQwA7YBUJl6NUvaYflF2HyZ5Jw2HRu9jzWs8iB2yFUy6DKFMdQ==}
+  '@asgardeo/javascript@0.10.2':
+    resolution: {integrity: sha512-32/w0jDBgCiXTksDEpyIErH0+tatDP0LfNC5QwcreojcjoO5x/8u/tbFbbcwnzJlKMrjLWM7jzpHZRATzYI21w==}
 
   '@asgardeo/react-router@2.0.0':
     resolution: {integrity: sha512-RvHol3VgjV466y7RhpmPosER89Yz1prREvjWjhu95X9e4l761+3n8bRSQR5lpP1tasAVKtVH6RzWvWoPST7+Zg==}
@@ -1326,8 +1326,8 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@asgardeo/react@0.15.4':
-    resolution: {integrity: sha512-rmmqc9oxcS6DPBKH6mO4j3j37h+h5qwjKy0su+ZCpN6FxUwKfkjwEcc13Rc4y+CIWtyrYCd9YcOBmI/ukNECLA==}
+  '@asgardeo/react@0.16.0':
+    resolution: {integrity: sha512-dC4013jWfxaiSHuGmky/Wa9WW30TmaQLBJaN+0F5c1Dc8v/Gj/D8oNFRU7+gBncqZ1+JgJ5dYkQ7sMLcqcn5Og==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -11575,9 +11575,9 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@asgardeo/browser@0.5.5(esbuild@0.25.9)':
+  '@asgardeo/browser@0.5.6(esbuild@0.25.9)':
     dependencies:
-      '@asgardeo/javascript': 0.10.1
+      '@asgardeo/javascript': 0.10.2
       axios: 1.13.5
       base64url: 3.0.1
       buffer: 6.0.3
@@ -11598,22 +11598,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@asgardeo/javascript@0.10.1':
+  '@asgardeo/javascript@0.10.2':
     dependencies:
       '@asgardeo/i18n': 0.4.4
       jose: 5.10.0
       tslib: 2.8.1
 
-  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@asgardeo/react': 0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
+      '@asgardeo/react': 0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)
       react: 19.2.3
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.15.4(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)':
+  '@asgardeo/react@0.16.0(@types/react@19.2.7)(esbuild@0.25.9)(react@19.2.3)':
     dependencies:
-      '@asgardeo/browser': 0.5.5(esbuild@0.25.9)
+      '@asgardeo/browser': 0.5.6(esbuild@0.25.9)
       '@asgardeo/i18n': 0.4.4
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.4(react@19.2.3))(react@19.2.3)

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - ../docs
 
 catalog:
-  '@asgardeo/react': 0.15.4
+  '@asgardeo/react': 0.16.0
   '@asgardeo/react-router': 2.0.0
   '@hookform/resolvers': 5.2.2
   '@tanstack/react-query': 5.90.5

--- a/tests/integration/flow/flowmeta/flowmeta_api_test.go
+++ b/tests/integration/flow/flowmeta/flowmeta_api_test.go
@@ -276,7 +276,8 @@ func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataMissingID() {
 	suite.Equal("Missing required parameter", errorResp.Message)
 }
 
-// TestGetFlowMetadataMissingBothParams tests GET /flow/meta without any parameters
+// TestGetFlowMetadataMissingBothParams tests GET /flow/meta without any parameters.
+// When neither type nor id is provided, the endpoint returns i18n metadata only (system flow).
 func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataMissingBothParams() {
 	client := testutils.GetHTTPClient()
 
@@ -288,17 +289,20 @@ func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataMissingBothParams() {
 	suite.Require().NoError(err)
 	defer resp.Body.Close()
 
-	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+	suite.Equal(http.StatusOK, resp.StatusCode)
 
 	body, err := io.ReadAll(resp.Body)
 	suite.Require().NoError(err)
 
-	var errorResp ErrorResponse
-	err = json.Unmarshal(body, &errorResp)
+	var metadata FlowMetadataResponse
+	err = json.Unmarshal(body, &metadata)
 	suite.Require().NoError(err)
 
-	// Missing type is checked first
-	suite.Equal("FM-1004", errorResp.Code)
+	// No type/id means system flow: only i18n metadata is returned
+	suite.Nil(metadata.Application)
+	suite.Nil(metadata.OU)
+	suite.NotNil(metadata.I18n.Languages)
+	suite.NotEmpty(metadata.I18n.Languages)
 }
 
 // TestGetFlowMetadataInvalidType tests GET /flow/meta with invalid type parameter


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request introduces several improvements and refactors to both the backend and frontend, primarily focused on user onboarding flow, internationalization (i18n) handling, and dependency upgrades. The most significant updates are a backend API change to support a "system flow" mode for onboarding metadata (returning only i18n when no type/id is provided), removal of hardcoded onboarding translations from the frontend, and an upgrade to the `@asgardeo/react` package with related code adjustments.

**Backend: User onboarding flow and metadata API enhancements**

* Added support for a "system flow" mode in the `GetFlowMetadata` backend API: when no type or id is provided, the endpoint now returns only i18n metadata and skips application/OU/design, with corresponding service and handler logic updates. [[1]](diffhunk://#diff-ed5708e09c73de04b55f559b5137e5aa013f8f8a23c02490d44419e7d430c82dR107-R148) [[2]](diffhunk://#diff-efeca919b5a5228ada943d7093ca0f6313824aeac8f5603b3dd012d262b144eeL61-R62) [[3]](diffhunk://#diff-ed5708e09c73de04b55f559b5137e5aa013f8f8a23c02490d44419e7d430c82dL96-L100) [[4]](diffhunk://#diff-c90505b092e6daf68c09890ccde66aad958d98ab69da3e4eada3beebe4f59af3R323-R350) [[5]](diffhunk://#diff-806a966379711cf062358d5309af89fb8caaaccedd0859a79056acaf37c9439dL183-R222)
* Removed display of the application logo image from multiple onboarding flow steps in `user_onboarding_flow.json`. [[1]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL38-L47) [[2]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL101-L110) [[3]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL210-L219)

**Frontend: Internationalization and dependency management**

* Removed hardcoded onboarding translations from the frontend i18n bundle, as these are now resolved from the backend.
* Upgraded `@asgardeo/react` and related packages to version 0.16.0, updating lockfiles and workspace configuration accordingly. [[1]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L10-R11) [[2]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L260-R263) [[3]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L474-R477) [[4]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L735-R735) [[5]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L913-R913) [[6]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L1310-R1317) [[7]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L1326-R1327) [[8]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L11580-R11582) [[9]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8L11603-R11618) [[10]](diffhunk://#diff-f60c0ec3013027a039a8555f62dcdd071cf966ee68edeb1d64cf20267dba3411L7-R7)
* Refactored `AcceptInviteBox` to use the new `useAsgardeo().resolveFlowTemplateLiterals` hook instead of the old `useTemplateLiteralResolver`. [[1]](diffhunk://#diff-db951b8d012b7b5c00bac9e31aacb1e38d22c5ffa4b2339637f004993a203dd3L38-L42) [[2]](diffhunk://#diff-db951b8d012b7b5c00bac9e31aacb1e38d22c5ffa4b2339637f004993a203dd3L60-R59) [[3]](diffhunk://#diff-db951b8d012b7b5c00bac9e31aacb1e38d22c5ffa4b2339637f004993a203dd3L171-R170)
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

<img width="1105" height="962" alt="Screenshot 2026-03-20 at 13 45 44" src="https://github.com/user-attachments/assets/e534553f-f85a-444a-8b6b-768c3986e783" />

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/1724

### Related PRs
- https://github.com/asgardeo/javascript/pull/418

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System flow metadata: endpoint returns i18n/system metadata when type and ID are omitted.

* **Bug Fixes**
  * Validation tightened for flow metadata: type and ID are now cross-validated to surface specific errors.

* **Improvements**
  * Layout and Theme responses now include created/updated timestamps.
  * Invite rendering uses updated template resolver for flow templates.

* **Removals**
  * Onboarding translation namespace and onboarding screen logo component removed.

* **Tests**
  * Updated/added tests covering system-flow behavior and revised validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->