### PR TITLE
Remove logo from accept invite

### DIFF
--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -277,16 +277,6 @@
             "meta": {
                 "components": [
                     {
-                        "alt": "{{ t(signup:images.app_logo.alt) }}",
-                        "category": "DISPLAY",
-                        "height": "60",
-                        "id": "image",
-                        "resourceType": "ELEMENT",
-                        "src": "{{ meta(application.logo_url) }}",
-                        "type": "IMAGE",
-                        "width": ""
-                    },
-                    {
                         "align": "center",
                         "type": "TEXT",
                         "id": "text_header_pwd",


### PR DESCRIPTION
This pull request makes a small update to the user onboarding flow by removing the display of the application logo from the prompt components.

* Removed the `IMAGE` component that displayed the application logo from the prompt in `user_onboarding_flow.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed logo display from two onboarding screens in the user registration flow. All other functionality and user interactions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->