### PR TITLE
Remove version input from improvement template

### DIFF
--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -17,10 +17,3 @@ body:
       description: Describe the improvement you suggest.
     validations:
       required: true
-  - type: input
-    id: version
-    attributes:
-      label: Version
-      description: Enter product version or commit.
-    validations:
-      required: false


### PR DESCRIPTION
Removed the version input field from the improvement issue template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the GitHub issue template by removing an optional version field from improvement reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->