### PR TITLE
Refactor i18n POST request

### DIFF
--- a/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/__tests__/I18nConfigurationCard.test.tsx
+++ b/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/__tests__/I18nConfigurationCard.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@thunder/shared-contexts', () => ({
 const mockMutate = vi.fn();
 vi.mock('@thunder/i18n', () => ({
   NamespaceConstants: {CUSTOM_NAMESPACE: 'custom'},
+  I18nDefaultConstants: {FALLBACK_LANGUAGE: 'en-US'},
   useUpdateTranslation: () => ({
     mutate: mockMutate,
     isPending: false,

--- a/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/__tests__/TextPropertyField.test.tsx
+++ b/frontend/apps/thunder-console/src/features/flows/components/resource-property-panel/__tests__/TextPropertyField.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@thunder/shared-contexts', () => ({
 // Mock the API hooks used by I18nConfigurationCard from @thunder/i18n
 vi.mock('@thunder/i18n', () => ({
   NamespaceConstants: {CUSTOM_NAMESPACE: 'custom'},
+  I18nDefaultConstants: {FALLBACK_LANGUAGE: 'en-US'},
   useUpdateTranslation: () => ({
     mutate: vi.fn(),
     isPending: false,

--- a/frontend/apps/thunder-console/src/features/flows/constants/FlowI18nConstants.ts
+++ b/frontend/apps/thunder-console/src/features/flows/constants/FlowI18nConstants.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {NamespaceConstants} from '@thunder/i18n';
+import {I18nDefaultConstants, NamespaceConstants} from '@thunder/i18n';
 
 /**
  * i18n namespace constants for flow feature translations.
@@ -43,7 +43,7 @@ const FlowI18nConstants = {
   /**
    * Namespace for default flow translations (e.g., built-in or system flows)
    */
-  DEFAULT_LANGUAGE: 'en-US',
+  DEFAULT_LANGUAGE: I18nDefaultConstants.FALLBACK_LANGUAGE,
 } as const;
 
 export default FlowI18nConstants;

--- a/frontend/apps/thunder-console/src/features/flows/context/FlowBuilderCoreProvider.tsx
+++ b/frontend/apps/thunder-console/src/features/flows/context/FlowBuilderCoreProvider.tsx
@@ -33,6 +33,7 @@ import {
 } from 'react';
 import {Stack, Typography} from '@wso2/oxygen-ui';
 import {Settings} from '@wso2/oxygen-ui-icons-react';
+import {I18nDefaultConstants} from '@thunder/i18n';
 import ValidationProvider from './ValidationProvider';
 import FlowBuilderCoreContext from './FlowBuilderCoreContext';
 import type {FlowCompletionConfigsInterface} from '../models/flows';
@@ -115,7 +116,7 @@ function FlowContextWrapper({
   const [lastInteractedElementInternal, setLastInteractedElementInternal] = useState<Resource>();
   const [lastInteractedStepId, setLastInteractedStepId] = useState<string>('');
   const [selectedAttributes, setSelectedAttributes] = useState<Record<string, Claim[]>>({});
-  const [language, setLanguage] = useState<string>('en-US');
+  const [language, setLanguage] = useState<string>(I18nDefaultConstants.FALLBACK_LANGUAGE);
   const [flowCompletionConfigs, setFlowCompletionConfigs] = useState<FlowCompletionConfigsInterface>({});
   const [flowNodeTypes, setFlowNodeTypes] = useState<NodeTypes>({});
   const [flowEdgeTypes, setFlowEdgeTypes] = useState<EdgeTypes>({});
@@ -124,7 +125,9 @@ function FlowContextWrapper({
 
   const setResourcePropertiesPanelHeadingRef = useRef(setResourcePropertiesPanelHeading);
   const setLastInteractedElementInternalRef = useRef(setLastInteractedElementInternal);
-  const setIsOpenResourcePropertiesPanelRef = useRef<Dispatch<SetStateAction<boolean>>>(setIsOpenResourcePropertiesPanel);
+  const setIsOpenResourcePropertiesPanelRef = useRef<Dispatch<SetStateAction<boolean>>>(
+    setIsOpenResourcePropertiesPanel,
+  );
   const setLastInteractedStepIdRef = useRef(setLastInteractedStepId);
 
   // Ref to store the callback to close the validation panel (for mutual exclusion)

--- a/frontend/apps/thunder-console/src/features/translations/components/edit-translation/TranslationEditorHeader.tsx
+++ b/frontend/apps/thunder-console/src/features/translations/components/edit-translation/TranslationEditorHeader.tsx
@@ -36,8 +36,8 @@ export interface TranslationEditorHeaderProps {
   dirtyCount: number;
   /** Whether a save or reset operation is in progress. */
   isSaving: boolean;
-  /** Whether the selected language is English (disables Reset to Default). */
-  isEnglish: boolean;
+  /** Whether the selected language is the fallback language (disables Reset to Default). */
+  isFallbackLanguage: boolean;
   /** Whether a namespace is selected (required to enable Reset to Default). */
   hasNamespace: boolean;
   /** Called when the user clicks the back button. */
@@ -66,7 +66,7 @@ export default function TranslationEditorHeader({
   hasDirtyChanges,
   dirtyCount,
   isSaving,
-  isEnglish,
+  isFallbackLanguage,
   hasNamespace,
   onBack,
   onDiscard,
@@ -104,7 +104,7 @@ export default function TranslationEditorHeader({
           <Button size="small" onClick={onDiscard} disabled={!hasDirtyChanges || isSaving}>
             {t('actions.discardChanges')}
           </Button>
-          {!isEnglish && (
+          {!isFallbackLanguage && (
             <Button size="small" onClick={onResetToDefault} disabled={!hasNamespace || isSaving}>
               {t('actions.resetToDefault')}
             </Button>

--- a/frontend/apps/thunder-console/src/features/translations/components/edit-translation/__tests__/TranslationEditorHeader.test.tsx
+++ b/frontend/apps/thunder-console/src/features/translations/components/edit-translation/__tests__/TranslationEditorHeader.test.tsx
@@ -39,7 +39,7 @@ const defaultProps = {
   hasDirtyChanges: false,
   dirtyCount: 0,
   isSaving: false,
-  isEnglish: false,
+  isFallbackLanguage: false,
   hasNamespace: true,
   onBack: vi.fn(),
   onDiscard: vi.fn(),
@@ -67,21 +67,21 @@ describe('TranslationEditorHeader', () => {
     });
 
     it('renders discard, save, and reset-to-default action buttons', () => {
-      render(<TranslationEditorHeader {...defaultProps} isEnglish={false} />);
+      render(<TranslationEditorHeader {...defaultProps} isFallbackLanguage={false} />);
 
       expect(screen.getByText('actions.discardChanges')).toBeInTheDocument();
       expect(screen.getByText('actions.resetToDefault')).toBeInTheDocument();
       expect(screen.getByText('actions.saveChanges')).toBeInTheDocument();
     });
 
-    it('hides Reset to Default button when isEnglish is true', () => {
-      render(<TranslationEditorHeader {...defaultProps} isEnglish />);
+    it('hides Reset to Default button when isFallbackLanguage is true', () => {
+      render(<TranslationEditorHeader {...defaultProps} isFallbackLanguage />);
 
       expect(screen.queryByText('actions.resetToDefault')).not.toBeInTheDocument();
     });
 
-    it('shows Reset to Default button when isEnglish is false', () => {
-      render(<TranslationEditorHeader {...defaultProps} isEnglish={false} />);
+    it('shows Reset to Default button when isFallbackLanguage is false', () => {
+      render(<TranslationEditorHeader {...defaultProps} isFallbackLanguage={false} />);
 
       expect(screen.getByText('actions.resetToDefault')).toBeInTheDocument();
     });
@@ -134,13 +134,13 @@ describe('TranslationEditorHeader', () => {
     });
 
     it('disables Reset to Default when hasNamespace is false', () => {
-      render(<TranslationEditorHeader {...defaultProps} isEnglish={false} hasNamespace={false} />);
+      render(<TranslationEditorHeader {...defaultProps} isFallbackLanguage={false} hasNamespace={false} />);
 
       expect(screen.getByText('actions.resetToDefault').closest('button')).toBeDisabled();
     });
 
     it('enables Reset to Default when hasNamespace is true and not saving', () => {
-      render(<TranslationEditorHeader {...defaultProps} isEnglish={false} hasNamespace isSaving={false} />);
+      render(<TranslationEditorHeader {...defaultProps} isFallbackLanguage={false} hasNamespace isSaving={false} />);
 
       expect(screen.getByText('actions.resetToDefault').closest('button')).not.toBeDisabled();
     });
@@ -188,7 +188,7 @@ describe('TranslationEditorHeader', () => {
       render(
         <TranslationEditorHeader
           {...defaultProps}
-          isEnglish={false}
+          isFallbackLanguage={false}
           hasNamespace
           onResetToDefault={onResetToDefault}
         />,

--- a/frontend/apps/thunder-console/src/features/translations/pages/TranslationCreatePage.tsx
+++ b/frontend/apps/thunder-console/src/features/translations/pages/TranslationCreatePage.tsx
@@ -18,10 +18,7 @@
 
 import {Alert, Box, Breadcrumbs, Button, IconButton, LinearProgress, Typography} from '@wso2/oxygen-ui';
 import {ChevronRight, X} from '@wso2/oxygen-ui-icons-react';
-import {useAsgardeo} from '@asgardeo/react';
-import {useQueryClient} from '@tanstack/react-query';
-import {I18nQueryKeys, useGetTranslations} from '@thunder/i18n';
-import {useConfig} from '@thunder/shared-contexts';
+import {useGetTranslations, useCreateTranslations, I18nDefaultConstants} from '@thunder/i18n';
 import {useLogger} from '@thunder/logger/react';
 import {useCallback, useEffect, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -64,12 +61,13 @@ const STEPS: TranslationCreateFlowStep[] = [
  */
 export default function TranslationCreatePage(): JSX.Element {
   const {t} = useTranslation('translations');
-  const {getServerUrl} = useConfig();
-  const serverUrl = getServerUrl();
   const navigate = useNavigate();
   const logger = useLogger('TranslationCreatePage');
-  const queryClient = useQueryClient();
-  const {refetch: fetchEnTranslations} = useGetTranslations({language: 'en-US', enabled: false});
+  const {refetch: fetchEnTranslations} = useGetTranslations({
+    language: I18nDefaultConstants.FALLBACK_LANGUAGE,
+    enabled: false,
+  });
+  const createTranslations = useCreateTranslations();
 
   const {
     currentStep,
@@ -90,17 +88,6 @@ export default function TranslationCreatePage(): JSX.Element {
     error,
     setError,
   } = useTranslationCreate();
-
-  const {http} = useAsgardeo() as unknown as {
-    http: {
-      request: (config: {
-        url: string;
-        method: string;
-        headers?: Record<string, string>;
-        data?: string;
-      }) => Promise<{data: unknown}>;
-    };
-  };
 
   const [stepReady, setStepReady] = useState<Record<TranslationCreateFlowStep, boolean>>({
     COUNTRY: false,
@@ -159,40 +146,29 @@ export default function TranslationCreatePage(): JSX.Element {
       setIsCreating(false);
       return;
     }
-    const enTranslations = enData.translations;
 
-    const entries: {namespace: string; key: string; value: string}[] = [];
-    Object.entries(enTranslations).forEach(([ns, nsValues]) => {
+    const translations: Record<string, Record<string, string>> = {};
+    Object.entries(enData.translations).forEach(([ns, nsValues]) => {
+      translations[ns] = {};
       Object.entries(nsValues).forEach(([key, val]) => {
-        entries.push({namespace: ns, key, value: populateFromEnglish ? val : ''});
+        translations[ns][key] = populateFromEnglish ? val : '';
       });
     });
 
-    let completed = 0;
-    const total = entries.length;
-
-    await Promise.allSettled(
-      entries.map(async ({namespace, key, value}) => {
-        try {
-          await (http as {request: (config: unknown) => Promise<unknown>}).request({
-            url: `${serverUrl}/i18n/languages/${localeCode}/translations/ns/${namespace}/keys/${key}`,
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            data: JSON.stringify({value}),
-          });
-        } finally {
-          completed += 1;
-          setProgress(Math.round((completed / total) * 100));
-        }
-      }),
-    );
+    try {
+      await createTranslations.mutateAsync({language: localeCode, translations});
+      setProgress(100);
+    } catch (_err: unknown) {
+      logger.error('Failed to create translations', {error: _err});
+      setError(t('language.add.error'));
+      setIsCreating(false);
+      return;
+    }
 
     try {
-      await queryClient.invalidateQueries({queryKey: [I18nQueryKeys.TRANSLATIONS]});
-      await queryClient.invalidateQueries({queryKey: [I18nQueryKeys.LANGUAGES]});
       await navigate(`/translations/${localeCode}`);
-    } catch {
-      setError(t('language.add.error'));
+    } catch (_err: unknown) {
+      logger.error('Translations created but navigation failed', {error: _err, localeCode});
       setIsCreating(false);
     }
   };

--- a/frontend/apps/thunder-console/src/features/translations/pages/TranslationsEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/translations/pages/TranslationsEditPage.tsx
@@ -17,7 +17,7 @@
  */
 
 import {Alert, PageContent, Snackbar, useColorScheme} from '@wso2/oxygen-ui';
-import {useGetTranslations, useUpdateTranslation, NamespaceConstants} from '@thunder/i18n';
+import {useGetTranslations, useUpdateTranslation, NamespaceConstants, I18nDefaultConstants} from '@thunder/i18n';
 import {useCallback, useEffect, useMemo, useState, type JSX, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate, useParams} from 'react-router';
@@ -87,6 +87,10 @@ export default function TranslationsEditPage(): JSX.Element {
   const updateTranslation = useUpdateTranslation();
 
   const namespaces = useMemo(() => {
+    if (!translationsData?.translations) {
+      return [];
+    }
+
     const ns = Object.keys(translationsData?.translations ?? {});
     return ns.includes(NamespaceConstants.CUSTOM_NAMESPACE) ? ns : [...ns, NamespaceConstants.CUSTOM_NAMESPACE];
   }, [translationsData]);
@@ -217,7 +221,6 @@ export default function TranslationsEditPage(): JSX.Element {
   };
 
   const isLoading = !!selectedLanguage && translationsLoading;
-  const isEnglish = selectedLanguage === 'en' || selectedLanguage === 'en-US';
   const isCustomNamespace = selectedNamespace === NamespaceConstants.CUSTOM_NAMESPACE;
 
   return (
@@ -227,7 +230,7 @@ export default function TranslationsEditPage(): JSX.Element {
         hasDirtyChanges={hasDirtyChanges}
         dirtyCount={dirtyKeys.length}
         isSaving={isSaving}
-        isEnglish={isEnglish}
+        isFallbackLanguage={selectedLanguage === I18nDefaultConstants.FALLBACK_LANGUAGE}
         hasNamespace={!!selectedNamespace}
         onBack={handleBack}
         onDiscard={handleDiscard}

--- a/frontend/apps/thunder-console/src/features/translations/pages/__tests__/TranslationCreatePage.test.tsx
+++ b/frontend/apps/thunder-console/src/features/translations/pages/__tests__/TranslationCreatePage.test.tsx
@@ -40,30 +40,17 @@ vi.mock('react-router', async () => {
   };
 });
 
-const mockHttpRequest = vi.fn().mockResolvedValue({data: {}});
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
-    http: {
-      request: mockHttpRequest,
-    },
-  }),
+const {mockRefetch, mockCreateTranslationsMutateAsync} = vi.hoisted(() => ({
+  mockRefetch: vi.fn(),
+  mockCreateTranslationsMutateAsync: vi.fn().mockResolvedValue({}),
 }));
 
-vi.mock('@tanstack/react-query', async () => {
-  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
-  return {
-    ...actual,
-    useQueryClient: () => ({
-      invalidateQueries: vi.fn().mockResolvedValue(undefined),
-    }),
-  };
-});
-
-const mockRefetch = vi.hoisted(() => vi.fn());
-
 vi.mock('@thunder/i18n', () => ({
-  I18nQueryKeys: {TRANSLATIONS: 'translations', LANGUAGES: 'languages'},
   useGetTranslations: vi.fn().mockReturnValue({data: undefined, isLoading: false, refetch: mockRefetch}),
+  useCreateTranslations: vi.fn().mockReturnValue({mutateAsync: mockCreateTranslationsMutateAsync}),
+  I18nDefaultConstants: {
+    FALLBACK_LANGUAGE: 'en-US',
+  },
   enUS: {},
 }));
 
@@ -384,7 +371,12 @@ describe('TranslationCreatePage', () => {
 
       // Wait for async create to complete
       await vi.waitFor(() => {
-        expect(mockHttpRequest).toHaveBeenCalled();
+        expect(mockCreateTranslationsMutateAsync).toHaveBeenCalledWith({
+          language: 'fr-FR',
+          translations: {
+            common: {'actions.save': 'Save'},
+          },
+        });
       });
     });
 
@@ -396,6 +388,40 @@ describe('TranslationCreatePage', () => {
         data: null,
         error: new Error('Fetch failed'),
       });
+
+      mockUseTranslationCreate.mockReturnValue({
+        ...baseContext,
+        currentStep: TranslationCreateFlowStep.INITIALIZE,
+        localeCode: 'fr-FR',
+        setError,
+        setIsCreating,
+        setProgress: vi.fn(),
+      });
+
+      const user = userEvent.setup();
+      render(<TranslationCreatePage />);
+
+      await user.click(screen.getByText('language.create.createButton'));
+
+      await vi.waitFor(() => {
+        expect(setError).toHaveBeenCalledWith('language.add.error');
+        expect(setIsCreating).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('sets error when creating translations fails after fetching defaults', async () => {
+      const setError = vi.fn();
+      const setIsCreating = vi.fn();
+
+      mockRefetch.mockResolvedValue({
+        data: {
+          translations: {
+            common: {'actions.save': 'Save'},
+          },
+        },
+        error: null,
+      });
+      mockCreateTranslationsMutateAsync.mockRejectedValueOnce(new Error('Create failed'));
 
       mockUseTranslationCreate.mockReturnValue({
         ...baseContext,

--- a/frontend/apps/thunder-console/src/features/translations/pages/__tests__/TranslationsEditPage.test.tsx
+++ b/frontend/apps/thunder-console/src/features/translations/pages/__tests__/TranslationsEditPage.test.tsx
@@ -57,9 +57,13 @@ vi.mock('@thunder/i18n', () => ({
   useGetTranslations: mockUseGetTranslations,
   useUpdateTranslation: mockUseUpdateTranslation,
   NamespaceConstants: {
+    CUSTOM_NAMESPACE: 'custom',
     COMMON: 'common',
     AUTH: 'auth',
     LOGIN_FLOW: 'loginFlow',
+  },
+  I18nDefaultConstants: {
+    FALLBACK_LANGUAGE: 'en-US',
   },
 }));
 
@@ -81,7 +85,7 @@ vi.mock('../../components/edit-translation/TranslationEditorHeader', () => ({
     hasDirtyChanges: boolean;
     isSaving: boolean;
     selectedLanguage: string | null;
-    isEnglish: boolean;
+    isFallbackLanguage: boolean;
     hasNamespace: boolean;
     dirtyCount: number;
   }) => {
@@ -102,7 +106,7 @@ vi.mock('../../components/edit-translation/TranslationEditorHeader', () => ({
         </button>
         <span data-testid="header-language">{props.selectedLanguage}</span>
         <span data-testid="header-dirty-count">{props.dirtyCount}</span>
-        <span data-testid="header-is-english">{String(props.isEnglish)}</span>
+        <span data-testid="header-is-english">{String(props.isFallbackLanguage)}</span>
       </div>
     );
   },
@@ -113,7 +117,7 @@ vi.mock('../../components/edit-translation/NamespaceSelector', () => ({
     mockNamespaceSelector(props);
     return (
       <div data-testid="namespace-selector">
-        <button type="button" onClick={() => props.onChange('loginFlow')}>
+        <button type="button" onClick={() => props.onChange('auth')}>
           select namespace
         </button>
         <span data-testid="ns-value">{props.value ?? ''}</span>
@@ -200,6 +204,32 @@ describe('TranslationsEditPage', () => {
 
     it('initializes with the first namespace from the translation data', () => {
       render(<TranslationsEditPage />);
+
+      expect(screen.getByTestId('ns-value')).toHaveTextContent('common');
+    });
+
+    it('switches from no namespace to the first loaded namespace', () => {
+      let isLoaded = false;
+      mockUseGetTranslations.mockImplementation(({language}: {language: string}) => {
+        if (language === 'fr-FR') {
+          return {
+            data: isLoaded ? sampleTranslations : undefined,
+            isLoading: !isLoaded,
+          };
+        }
+
+        return {
+          data: undefined,
+          isLoading: false,
+        };
+      });
+
+      const {rerender} = render(<TranslationsEditPage />);
+
+      expect(screen.getByTestId('ns-value')).toHaveTextContent('');
+
+      isLoaded = true;
+      rerender(<TranslationsEditPage />);
 
       expect(screen.getByTestId('ns-value')).toHaveTextContent('common');
     });
@@ -321,7 +351,7 @@ describe('TranslationsEditPage', () => {
 
       await user.click(screen.getByText('select namespace'));
 
-      expect(screen.getByTestId('ns-value')).toHaveTextContent('loginFlow');
+      expect(screen.getByTestId('ns-value')).toHaveTextContent('auth');
     });
 
     it('resets dirty changes when the namespace changes', async () => {

--- a/frontend/apps/thunder-console/src/features/user-types/components/create-user-type/I18nTextInput.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/components/create-user-type/I18nTextInput.tsx
@@ -39,12 +39,16 @@ import {
   Typography,
 } from '@wso2/oxygen-ui';
 import {PlusIcon, SquareFunction, XIcon} from '@wso2/oxygen-ui-icons-react';
-import {useGetLanguages, useGetTranslations, useUpdateTranslation, NamespaceConstants} from '@thunder/i18n';
+import {
+  useGetLanguages,
+  useGetTranslations,
+  useUpdateTranslation,
+  NamespaceConstants,
+  I18nDefaultConstants,
+} from '@thunder/i18n';
 import {isI18nTemplatePattern, I18N_KEY_PATTERN} from '@thunder/utils';
 import {useTemplateLiteralResolver} from '@thunder/shared-hooks';
 import {invalidateI18nCache} from '../../../../i18n/invalidate-i18n-cache';
-
-const DEFAULT_LANGUAGE = 'en-US';
 
 /**
  * Sanitizes a string for use as a translation key.
@@ -84,11 +88,18 @@ interface I18nContentProps {
 /**
  * Content component for the i18n popover with select and create modes.
  */
-function I18nContent({i18nKey, isActive, isCreateMode, onChange, onCreateModeChange, defaultNewKey = undefined}: I18nContentProps): ReactElement {
+function I18nContent({
+  i18nKey,
+  isActive,
+  isCreateMode,
+  onChange,
+  onCreateModeChange,
+  defaultNewKey = undefined,
+}: I18nContentProps): ReactElement {
   const {t, i18n} = useTranslation();
   const {data: languagesData} = useGetLanguages();
   const {data: translationsData, isLoading} = useGetTranslations({
-    language: DEFAULT_LANGUAGE,
+    language: I18nDefaultConstants.FALLBACK_LANGUAGE,
     namespace: NamespaceConstants.CUSTOM_NAMESPACE,
     enabled: isActive,
   });
@@ -101,7 +112,7 @@ function I18nContent({i18nKey, isActive, isCreateMode, onChange, onCreateModeCha
   const sanitizedDefaultKey = defaultNewKey ? sanitizeTranslationKey(defaultNewKey) : '';
   const [newKey, setNewKey] = useState(sanitizedDefaultKey);
   const [newValue, setNewValue] = useState('');
-  const [selectedLanguage, setSelectedLanguage] = useState(DEFAULT_LANGUAGE);
+  const [selectedLanguage, setSelectedLanguage] = useState(I18nDefaultConstants.FALLBACK_LANGUAGE as string);
   const [error, setError] = useState<string | null>(null);
 
   const availableKeys = useMemo(() => {
@@ -143,13 +154,13 @@ function I18nContent({i18nKey, isActive, isCreateMode, onChange, onCreateModeCha
     if (languagesData?.languages && languagesData.languages.length > 0) {
       return languagesData.languages;
     }
-    return [DEFAULT_LANGUAGE];
+    return [I18nDefaultConstants.FALLBACK_LANGUAGE];
   }, [languagesData]);
 
   const resetCreateForm = useCallback(() => {
     setNewKey(sanitizedDefaultKey);
     setNewValue('');
-    setSelectedLanguage(DEFAULT_LANGUAGE);
+    setSelectedLanguage(I18nDefaultConstants.FALLBACK_LANGUAGE as string);
     setError(null);
   }, [sanitizedDefaultKey]);
 
@@ -163,7 +174,12 @@ function I18nContent({i18nKey, isActive, isCreateMode, onChange, onCreateModeCha
       return;
     }
     if (!/^[a-zA-Z0-9._-]+$/.test(newKey)) {
-      setError(t('userTypes:displayNameI18n.invalidKeyFormat', 'Key may only contain letters, numbers, dots, hyphens, and underscores'));
+      setError(
+        t(
+          'userTypes:displayNameI18n.invalidKeyFormat',
+          'Key may only contain letters, numbers, dots, hyphens, and underscores',
+        ),
+      );
       return;
     }
 
@@ -220,7 +236,7 @@ function I18nContent({i18nKey, isActive, isCreateMode, onChange, onCreateModeCha
             options={availableLanguages}
             value={selectedLanguage}
             onChange={(_e: SyntheticEvent, newLang: string | null) =>
-              setSelectedLanguage(newLang ?? DEFAULT_LANGUAGE)
+              setSelectedLanguage(newLang ?? I18nDefaultConstants.FALLBACK_LANGUAGE)
             }
             renderInput={(params: AutocompleteRenderInputParams) => <TextField {...params} size="small" />}
             disableClearable
@@ -352,7 +368,14 @@ interface I18nPopoverProps {
 /**
  * Popover with i18n key selection and creation UI.
  */
-function I18nPopover({open, anchorEl, onClose, value, onChange, defaultNewKey = undefined}: I18nPopoverProps): ReactElement {
+function I18nPopover({
+  open,
+  anchorEl,
+  onClose,
+  value,
+  onChange,
+  defaultNewKey = undefined,
+}: I18nPopoverProps): ReactElement {
   const {t} = useTranslation();
   const [isCreateMode, setIsCreateMode] = useState(false);
 
@@ -411,14 +434,20 @@ function I18nPopover({open, anchorEl, onClose, value, onChange, defaultNewKey = 
  * or creating translation keys. Similar to the flow builder's TextPropertyField
  * but standalone (no flow builder context dependency).
  */
-export default function I18nTextInput({label, value, onChange, placeholder = undefined, defaultNewKey = undefined}: I18nTextInputProps): ReactElement {
+export default function I18nTextInput({
+  label,
+  value,
+  onChange,
+  placeholder = undefined,
+  defaultNewKey = undefined,
+}: I18nTextInputProps): ReactElement {
   const {t} = useTranslation();
   const {resolve} = useTemplateLiteralResolver();
   const iconButtonRef = useRef<HTMLButtonElement>(null);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const isDynamic = isI18nTemplatePattern(value);
-  const resolvedValue = isDynamic ? resolve(value, {t}) ?? '' : '';
+  const resolvedValue = isDynamic ? (resolve(value, {t}) ?? '') : '';
 
   return (
     <FormControl fullWidth>

--- a/frontend/apps/thunder-console/src/features/user-types/components/create-user-type/__tests__/I18nTextInput.test.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/components/create-user-type/__tests__/I18nTextInput.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {render, screen, userEvent, waitFor} from '@thunder/test-utils';
+import I18nTextInput from '../I18nTextInput';
+
+const {mockResolve, mockMutate, mockAddResourceBundle, mockInvalidateI18nCache, mockLanguages, mockTranslations} =
+  vi.hoisted(() => ({
+    mockResolve: vi.fn<(value: string) => string | null>(),
+    mockMutate: vi.fn(),
+    mockAddResourceBundle: vi.fn(),
+    mockInvalidateI18nCache: vi.fn(),
+    mockLanguages: {value: {languages: ['en-US', 'fr-FR']} as {languages: string[]} | undefined},
+    mockTranslations: {
+      value: {
+        translations: {
+          custom: {
+            display_name: 'Display Name',
+            first_name: 'First Name',
+          },
+        },
+      },
+    },
+  }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      addResourceBundle: mockAddResourceBundle,
+    },
+  }),
+}));
+
+vi.mock('@thunder/shared-hooks', () => ({
+  useTemplateLiteralResolver: () => ({
+    resolve: mockResolve,
+  }),
+}));
+
+vi.mock('@thunder/i18n', () => ({
+  NamespaceConstants: {
+    CUSTOM_NAMESPACE: 'custom',
+  },
+  I18nDefaultConstants: {
+    FALLBACK_LANGUAGE: 'en-US',
+  },
+  useGetLanguages: () => ({
+    data: mockLanguages.value,
+  }),
+  useGetTranslations: () => ({
+    data: mockTranslations.value,
+    isLoading: false,
+  }),
+  useUpdateTranslation: () => ({
+    mutate: mockMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock('../../../../i18n/invalidate-i18n-cache', () => ({
+  invalidateI18nCache: mockInvalidateI18nCache,
+}));
+
+describe('I18nTextInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolve.mockReturnValue('Resolved Display');
+    mockLanguages.value = {languages: ['en-US', 'fr-FR']};
+    mockTranslations.value = {
+      translations: {
+        custom: {
+          display_name: 'Display Name',
+          first_name: 'First Name',
+        },
+      },
+    };
+  });
+
+  it('shows resolved value when input has an i18n template', () => {
+    render(
+      <I18nTextInput
+        label="Display Name"
+        value="{{t(custom:display_name)}}"
+        onChange={vi.fn()}
+        placeholder="Type a value"
+      />,
+    );
+
+    expect(screen.getByText('userTypes:displayNameI18n.resolvedValue')).toBeInTheDocument();
+    expect(screen.getByText('Resolved Display')).toBeInTheDocument();
+  });
+
+  it('opens popover and enters create mode', async () => {
+    const user = userEvent.setup();
+    const {container} = render(
+      <I18nTextInput label="Display Name" value="" onChange={vi.fn()} defaultNewKey="Display Name" />,
+    );
+
+    const configureButton = container.querySelector('button');
+    expect(configureButton).not.toBeNull();
+
+    await user.click(configureButton!);
+    await user.click(screen.getByText('userTypes:displayNameI18n.createTitle'));
+
+    expect(screen.getByDisplayValue('display_name')).toBeInTheDocument();
+    expect(screen.getByText('common:create')).toBeInTheDocument();
+    expect(screen.getByText('common:cancel')).toBeInTheDocument();
+  });
+
+  it('creates a translation with fallback language and emits template value', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    mockLanguages.value = undefined;
+    mockMutate.mockImplementation(
+      (
+        _payload: unknown,
+        callbacks?: {
+          onSuccess?: () => void;
+        },
+      ) => {
+        callbacks?.onSuccess?.();
+      },
+    );
+
+    const {container} = render(
+      <I18nTextInput label="Display Name" value="" onChange={onChange} defaultNewKey="Display Name" />,
+    );
+
+    const configureButton = container.querySelector('button');
+    expect(configureButton).not.toBeNull();
+
+    await user.click(configureButton!);
+    await user.click(screen.getByText('userTypes:displayNameI18n.createTitle'));
+
+    await user.type(screen.getByPlaceholderText('e.g., First Name'), 'Shown Display Name');
+    await user.click(screen.getByText('common:create'));
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+
+    expect(mockMutate.mock.calls[0][0]).toEqual({
+      language: 'en-US',
+      namespace: 'custom',
+      key: 'display_name',
+      value: 'Shown Display Name',
+    });
+
+    expect(mockAddResourceBundle).toHaveBeenCalledWith(
+      'en-US',
+      'custom',
+      {display_name: 'Shown Display Name'},
+      true,
+      true,
+    );
+    expect(onChange).toHaveBeenCalledWith('{{t(custom:display_name)}}');
+  });
+});

--- a/frontend/apps/thunder-console/src/hocs/withI18n.tsx
+++ b/frontend/apps/thunder-console/src/hocs/withI18n.tsx
@@ -20,14 +20,15 @@ import type {JSX, ComponentType} from 'react';
 import i18next from 'i18next';
 import {initReactI18next} from 'react-i18next';
 import enUS from '@thunder/i18n/locales/en-US';
+import {I18nDefaultConstants} from '@thunder/i18n';
 import I18nProvider from '../i18n/I18nProvider';
 
 await i18next.use(initReactI18next).init({
   resources: {
-    'en-US': enUS,
+    [I18nDefaultConstants.FALLBACK_LANGUAGE]: enUS,
   },
-  lng: 'en-US',
-  fallbackLng: 'en-US',
+  lng: I18nDefaultConstants.FALLBACK_LANGUAGE,
+  fallbackLng: I18nDefaultConstants.FALLBACK_LANGUAGE,
   defaultNS: 'common',
   interpolation: {
     escapeValue: false,

--- a/frontend/apps/thunder-gate/src/hocs/withI18n.tsx
+++ b/frontend/apps/thunder-gate/src/hocs/withI18n.tsx
@@ -22,6 +22,7 @@ import {useAsgardeo} from '@asgardeo/react';
 import i18next from 'i18next';
 import {initReactI18next, useTranslation} from 'react-i18next';
 import enUS from '@thunder/i18n/locales/en-US';
+import {I18nDefaultConstants} from '@thunder/i18n';
 
 interface I18nMeta {
   i18n?: {
@@ -32,10 +33,10 @@ interface I18nMeta {
 
 await i18next.use(initReactI18next).init({
   resources: {
-    'en-US': enUS,
+    [I18nDefaultConstants.FALLBACK_LANGUAGE]: enUS,
   },
-  lng: 'en-US',
-  fallbackLng: 'en-US',
+  lng: I18nDefaultConstants.FALLBACK_LANGUAGE,
+  fallbackLng: I18nDefaultConstants.FALLBACK_LANGUAGE,
   defaultNS: 'common',
   interpolation: {
     escapeValue: false,

--- a/frontend/packages/thunder-i18n/src/api/useCreateTranslations.ts
+++ b/frontend/packages/thunder-i18n/src/api/useCreateTranslations.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
+import {useConfig} from '@thunder/shared-contexts';
+import {useAsgardeo} from '@asgardeo/react';
+import type {TranslationsResponse} from '../models/responses';
+import type {CreateTranslationsVariables} from '../models/requests';
+import I18nQueryKeys from '../constants/i18n-query-keys';
+
+/**
+ * Custom hook to bulk-create translations for a new language.
+ *
+ * Sends a single POST request with the full translations bundle to
+ * `POST /i18n/languages/{language}/translations`.
+ *
+ * @returns TanStack Query mutation object for creating translations
+ *
+ * @example
+ * ```tsx
+ * function CreateLanguagePage() {
+ *   const createTranslations = useCreateTranslations();
+ *
+ *   const handleCreate = () => {
+ *     createTranslations.mutate(
+ *       {language: 'fr-FR', translations: {'common': {'hello': 'Bonjour'}}},
+ *       {
+ *         onSuccess: () => navigate('/translations/fr-FR'),
+ *         onError: (error) => console.error('Failed to create:', error),
+ *       },
+ *     );
+ *   };
+ * }
+ * ```
+ */
+export default function useCreateTranslations(): UseMutationResult<
+  TranslationsResponse,
+  Error,
+  CreateTranslationsVariables
+> {
+  const {http} = useAsgardeo();
+  const {getServerUrl} = useConfig();
+  const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+
+  return useMutation<TranslationsResponse, Error, CreateTranslationsVariables>({
+    mutationFn: async ({language, translations}: CreateTranslationsVariables): Promise<TranslationsResponse> => {
+      const serverUrl: string = getServerUrl();
+      const response: {data: TranslationsResponse} = await http.request({
+        url: `${serverUrl}/i18n/languages/${language}/translations`,
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        data: JSON.stringify({translations}),
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return response.data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({queryKey: [I18nQueryKeys.TRANSLATIONS]}).catch(() => {});
+      queryClient.invalidateQueries({queryKey: [I18nQueryKeys.TRANSLATIONS, variables.language]}).catch(() => {});
+      queryClient.invalidateQueries({queryKey: [I18nQueryKeys.LANGUAGES]}).catch(() => {});
+    },
+  });
+}

--- a/frontend/packages/thunder-i18n/src/constants/I18nDefaultConstants.ts
+++ b/frontend/packages/thunder-i18n/src/constants/I18nDefaultConstants.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The BCP 47 locale code used as the fallback language across all Thunder applications.
+ */
+const I18nDefaultConstants = {
+  /**
+   * The default fallback language for Thunder i18n translations. This is used when a translation
+   */
+  FALLBACK_LANGUAGE: 'en-US',
+} as const;
+
+export default I18nDefaultConstants;

--- a/frontend/packages/thunder-i18n/src/index.ts
+++ b/frontend/packages/thunder-i18n/src/index.ts
@@ -82,6 +82,8 @@ export type {UseGetLanguagesOptions} from './api/useGetLanguages';
 export {default as useUpdateTranslation} from './api/useUpdateTranslation';
 export type {UseUpdateTranslationOptions} from './api/useUpdateTranslation';
 
+export {default as useCreateTranslations} from './api/useCreateTranslations';
+
 export {default as useDeleteTranslations} from './api/useDeleteTranslations';
 
 export {default as useLanguage} from './api/useLanguage';
@@ -90,6 +92,7 @@ export type {UseLanguageReturn} from './api/useLanguage';
 // Export constants
 export {default as I18nQueryKeys} from './constants/i18n-query-keys';
 export {default as NamespaceConstants} from './constants/NamespaceConstants';
+export {default as I18nDefaultConstants} from './constants/I18nDefaultConstants';
 
 // Export models
 export * from './models/requests';

--- a/frontend/packages/thunder-i18n/src/models/requests.ts
+++ b/frontend/packages/thunder-i18n/src/models/requests.ts
@@ -17,6 +17,20 @@
  */
 
 /**
+ * Variables for the bulk create translations mutation.
+ */
+export interface CreateTranslationsVariables {
+  /**
+   * The language code to create translations for (e.g., "fr-FR").
+   */
+  language: string;
+  /**
+   * Translations bundle: { namespace: { key: value } }.
+   */
+  translations: Record<string, Record<string, string>>;
+}
+
+/**
  * Variables for the update translation mutation.
  */
 export interface UpdateTranslationVariables {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request standardizes the usage of the fallback language constant for i18n functionality across both frontend and backend code, replacing hardcoded language values (like 'en-US' and 'en') with a single source of truth. It also refactors translation creation and editing logic to use new API hooks, simplifies related tests, and improves clarity in component and prop naming.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

**Fallback Language Standardization**
- Replaced hardcoded fallback language strings (e.g., `'en-US'`, `'en'`) with `I18nDefaultConstants.FALLBACK_LANGUAGE` across frontend components, context providers, and constants to ensure consistency and easier maintenance. [[1]](diffhunk://#diff-13729979bd3764101e39568fbe968d4d99fb99b557b898cd7dacf752c259a487L19-R19) [[2]](diffhunk://#diff-13729979bd3764101e39568fbe968d4d99fb99b557b898cd7dacf752c259a487L46-R46) [[3]](diffhunk://#diff-2ac3e52874bc2f09ed8768d47a2d2615016d29f00fa6b6e81ccf784c912faa82R36) [[4]](diffhunk://#diff-2ac3e52874bc2f09ed8768d47a2d2615016d29f00fa6b6e81ccf784c912faa82L118-R119) [[5]](diffhunk://#diff-eb96ec566f53a1425deb874bd68a5ca12a3bb8fad4c91ff9a9077274defae7ffL42-L48) [[6]](diffhunk://#diff-0ee83b2ac83f23b7e14a320a641f6a3f8657bfafe798c1b50ce2dcce75e1b08aL20-R20) [[7]](diffhunk://#diff-0ee83b2ac83f23b7e14a320a641f6a3f8657bfafe798c1b50ce2dcce75e1b08aL230-R233) [[8]](diffhunk://#diff-4fe74863c80e71a65bda4843eb443dcbfc23529f121ad0c95924e96b32ff0729L39-R40) [[9]](diffhunk://#diff-4fe74863c80e71a65bda4843eb443dcbfc23529f121ad0c95924e96b32ff0729L69-R69) [[10]](diffhunk://#diff-4fe74863c80e71a65bda4843eb443dcbfc23529f121ad0c95924e96b32ff0729L107-R107) [[11]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7R60-R67) [[12]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L84-R88) [[13]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L105-R109)

**Translation Creation & Editing Refactor**
- Updated translation creation logic to use the `useCreateTranslations` hook, replacing manual HTTP requests and query invalidation with a single mutation call, and restructured translation data handling for efficiency. [[1]](diffhunk://#diff-1eadb483f09bce9e1d94f71c10484540c1f05552baff52a76b1cd8daefbdf8e3L21-R21) [[2]](diffhunk://#diff-1eadb483f09bce9e1d94f71c10484540c1f05552baff52a76b1cd8daefbdf8e3L67-R70) [[3]](diffhunk://#diff-1eadb483f09bce9e1d94f71c10484540c1f05552baff52a76b1cd8daefbdf8e3L94-L104) [[4]](diffhunk://#diff-1eadb483f09bce9e1d94f71c10484540c1f05552baff52a76b1cd8daefbdf8e3L162-R163)
- Improved the logic for determining the fallback language in translation editing and header components, renaming related props and checks from `isEnglish` to `isFallbackLanguage` for clarity. [[1]](diffhunk://#diff-0ee83b2ac83f23b7e14a320a641f6a3f8657bfafe798c1b50ce2dcce75e1b08aL220) [[2]](diffhunk://#diff-4fe74863c80e71a65bda4843eb443dcbfc23529f121ad0c95924e96b32ff0729L39-R40) [[3]](diffhunk://#diff-4fe74863c80e71a65bda4843eb443dcbfc23529f121ad0c95924e96b32ff0729L69-R69) [[4]](diffhunk://#diff-4fe74863c80e71a65bda4843eb443dcbfc23529f121ad0c95924e96b32ff0729L107-R107)

**Test Updates and Simplification**
- Refactored tests to mock new translation hooks, update assertions to match the refactored translation logic, and use the fallback language constant in test data and checks. [[1]](diffhunk://#diff-43593dd983c48f5d895f56775793b34ee181afd916f2797b704118da50eb30fdL43-R53) [[2]](diffhunk://#diff-43593dd983c48f5d895f56775793b34ee181afd916f2797b704118da50eb30fdL387-R379) [[3]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7R60-R67) [[4]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L84-R88) [[5]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L105-R109) [[6]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L116-R120) [[7]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7R211-R236) [[8]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L324-R354)

**Backend Consistency**
- Updated backend i18n metadata population to set both `Languages` and `Language` fields using the system fallback language for improved API consistency.

**Minor Improvements**
- Fixed a minor formatting issue in a React ref initialization for better readability.
- Improved namespace handling logic in translation editing to ensure custom namespaces are always included. [[1]](diffhunk://#diff-0ee83b2ac83f23b7e14a320a641f6a3f8657bfafe798c1b50ce2dcce75e1b08aR90-R93) [[2]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L116-R120) [[3]](diffhunk://#diff-b9549d9e1dd345714f5c7adf0dae48762251a398cd0eaa02c0dfaaed6fe25bd7L324-R354)
### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk translation creation for efficient multi-language updates.

* **Refactor**
  * Centralized the default/fallback language into a shared constant.
  * Reworked translation creation to use a single batched flow.
  * Clarified language state/props by adopting "fallback language" terminology.

* **Tests**
  * Updated and added tests to reflect the new creation flow and fallback-language behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->