### PR TITLE
Pack consent server with thunder distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 FROM golang:1.26-alpine3.23 AS builder
 
 # Install build dependencies including Node.js and npm
-RUN apk add --no-cache git make bash sqlite openssl zip nodejs npm
+RUN apk add --no-cache git make bash sqlite openssl zip nodejs npm curl
 
 # Set environment variables for CI build
 ENV CI=true
@@ -104,6 +104,7 @@ RUN cd /tmp/dist && \
 # Set ownership and permissions
 RUN chown -R thunder:thunder /opt/thunder && \
     chmod +x thunder start.sh setup.sh scripts/init_script.sh && \
+    (find consent -name "consent-server" -o -name "start.sh" 2>/dev/null | xargs -r chmod +x) && \
     (find bootstrap -name "*.sh" -type f -exec chmod +x {} \; 2>/dev/null || true)
 
 # Expose the default port
@@ -114,6 +115,7 @@ USER thunder
 
 # Set environment variables
 ENV BACKEND_PORT=8090
+ENV WITH_CONSENT=true
 
 # Start the application
 CMD ["./start.sh"]

--- a/backend/cmd/server/repository/conf/deployment.yaml
+++ b/backend/cmd/server/repository/conf/deployment.yaml
@@ -50,3 +50,7 @@ cors:
 passkey:
   allowed_origins:
     - "https://localhost:8090"
+
+consent:
+  enabled: true
+  base_url: "http://localhost:9090/api/v1"

--- a/build.ps1
+++ b/build.ps1
@@ -202,6 +202,7 @@ function Read-Config {
         $script:PORT = 8090
         $script:HTTP_ONLY = "false"
         $script:PUBLIC_HOSTNAME = ""
+        $script:CONSENT_ENABLED = $true
     }
     else {
         # Try yq first (YAML parser)
@@ -210,6 +211,8 @@ function Read-Config {
             $script:PORT = & yq eval '.server.port // 8090' $CONFIG_FILE 2>$null
             $script:HTTP_ONLY = & yq eval '.server.http_only // false' $CONFIG_FILE 2>$null
             $script:PUBLIC_HOSTNAME = & yq eval '.server.public_hostname // ""' $CONFIG_FILE 2>$null
+            $consentEnabled = & yq eval '.consent.enabled // true' $CONFIG_FILE 2>$null
+            $script:CONSENT_ENABLED = ($consentEnabled -eq "true")
         }
         else {
             # Fallback: basic parsing with regex
@@ -245,6 +248,14 @@ function Read-Config {
             }
             else {
                 $script:PUBLIC_HOSTNAME = ""
+            }
+
+            # Try to extract consent.enabled
+            if ($content -match 'consent:[\s\S]*?enabled:\s*(true|false)') {
+                $script:CONSENT_ENABLED = ($matches[1] -eq "true")
+            }
+            else {
+                $script:CONSENT_ENABLED = $true
             }
         }
     }
@@ -604,6 +615,14 @@ function Package {
         Write-Host "Including Unix scripts (start.sh, setup.sh)..."
         Copy-Item -Path "start.sh" -Destination $package_folder -Force
         Copy-Item -Path "setup.sh" -Destination $package_folder -Force
+    }
+
+    Write-Host "Packaging consent server..."
+    $packageFolderAbs = (Resolve-Path -Path $package_folder).Path
+    & (Join-Path $SCRIPT_DIR "scripts/package-consent-server.ps1") `
+        -GoOS $GO_OS -GoArch $GO_ARCH -DistOutputPath $packageFolderAbs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Consent server packaging failed with exit code $LASTEXITCODE"
     }
 
     Write-Host "Creating zip file..."
@@ -1460,8 +1479,31 @@ function Ensure-Crypto-File {
 }
 
 function Run {
+    function Cleanup-Servers {
+        Write-Host ""
+        Write-Host "🛑 Shutting down servers..."
+        if ($script:FRONTEND_PID) { 
+            Stop-Process -Id $script:FRONTEND_PID -Force -ErrorAction SilentlyContinue
+        }
+        Get-Process -Name "*pnpm*" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        Get-Process -Name "node" -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -like "*vite*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+        if ($script:BACKEND_PID) { 
+            Stop-Process -Id $script:BACKEND_PID -Force -ErrorAction SilentlyContinue
+        }
+        if ($script:CONSENT_PROCESS -and -not $script:CONSENT_PROCESS.HasExited) {
+            Stop-Process -Id $script:CONSENT_PROCESS.Id -Force -ErrorAction SilentlyContinue
+        }
+        Start-Sleep -Seconds 1
+        Write-Host "✅ All servers stopped successfully."
+    }
+
     Write-Host "Running frontend apps..."
     Run-Frontend
+
+    if ($script:CONSENT_ENABLED) {
+        Write-Host "Running consent server..."
+        Run-Consent
+    }
 
     # Save original THUNDER_SKIP_SECURITY value and temporarily set to true
     $script:ORIGINAL_THUNDER_SKIP_SECURITY = $env:THUNDER_SKIP_SECURITY
@@ -1543,28 +1585,6 @@ function Run {
 
     Write-Host "Press Ctrl+C to stop."
 
-    function Cleanup-Servers {
-        Write-Host ""
-        Write-Host "🛑 Shutting down servers..."
-        # Kill frontend processes using multiple approaches
-        if ($script:FRONTEND_PID) { 
-            Stop-Process -Id $script:FRONTEND_PID -Force -ErrorAction SilentlyContinue
-        }
-        # Kill all pnpm dev processes
-        Get-Process -Name "*pnpm*" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-        # Kill all node processes running vite
-        Get-Process -Name "node" -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -like "*vite*" } | Stop-Process -Force -ErrorAction SilentlyContinue
-        # Kill backend process
-        if ($script:BACKEND_PID) { 
-            Stop-Process -Id $script:BACKEND_PID -Force -ErrorAction SilentlyContinue
-        }
-
-        # Wait a moment for processes to exit gracefully
-        Start-Sleep -Seconds 1
-
-        Write-Host "✅ All servers stopped successfully."
-    }
-    
     # Set up Ctrl+C handler
     [Console]::TreatControlCAsInput = $false
     
@@ -1720,6 +1740,52 @@ function Run-Docs {
     }
     
     Write-Host "================================================================"
+}
+
+function Run-Consent {
+    $consentDir = Join-Path $TARGET_DIR "consent"
+    $consentBinary = Join-Path $consentDir "consent-server.exe"
+    if ($GO_OS -ne "windows") {
+        $consentBinary = Join-Path $consentDir "consent-server"
+    }
+
+    if (-not (Test-Path $consentBinary)) {
+        Write-Host "=== Downloading consent server ==="
+        & .\scripts\package-consent-server.ps1 -GoOS $GO_OS -GoArch $GO_ARCH -DistOutputPath $TARGET_DIR
+        if ($LASTEXITCODE -ne 0) { throw "Failed to package consent server" }
+    }
+
+    if (-not (Test-Path $consentBinary)) {
+        Write-Host "Error: Consent server binary not found at $consentBinary"
+        exit 1
+    }
+
+    Write-Host "=== Starting consent server ==="
+    $consentPort = if ($env:CONSENT_SERVER_PORT) { $env:CONSENT_SERVER_PORT } else { "9090" }
+    $script:CONSENT_PROCESS = Start-Process -FilePath $consentBinary -WorkingDirectory $consentDir -PassThru -NoNewWindow
+    $consentTimeout = 30
+    $consentElapsed = 0
+    while ($consentElapsed -lt $consentTimeout) {
+        if ($script:CONSENT_PROCESS.HasExited) {
+            Write-Host "Error: Consent server process exited unexpectedly"
+            exit 1
+        }
+        try {
+            $resp = Invoke-WebRequest -Uri "http://localhost:${consentPort}/health/readiness" -UseBasicParsing -ErrorAction Stop
+            if ($resp.StatusCode -eq 200) {
+                Write-Host "Consent server is ready"
+                break
+            }
+        } catch { }
+        Start-Sleep -Seconds 1
+        $consentElapsed++
+    }
+    if ($consentElapsed -ge $consentTimeout) {
+        Write-Host "Error: Consent server failed to become ready within ${consentTimeout}s"
+        exit 1
+    }
+
+    Write-Host "Consent server started (PID: $($script:CONSENT_PROCESS.Id))"
 }
 
 # Main script logic

--- a/build.sh
+++ b/build.sh
@@ -154,6 +154,7 @@ read_config() {
         PORT=8090
         HTTP_ONLY="false"
         PUBLIC_HOSTNAME=""
+        CONSENT_ENABLED="true"
     else
         # Try yq first (YAML parser)
         if command -v yq >/dev/null 2>&1; then
@@ -161,6 +162,7 @@ read_config() {
             PORT=$(yq eval '.server.port // 8090' "$config_file" 2>/dev/null)
             HTTP_ONLY=$(yq eval '.server.http_only // false' "$config_file" 2>/dev/null)
             PUBLIC_HOSTNAME=$(yq eval '.server.public_hostname // ""' "$config_file" 2>/dev/null)
+            CONSENT_ENABLED=$(yq eval '.consent.enabled // true' "$config_file" 2>/dev/null)
         else
             # Fallback: basic parsing with grep/awk
             HOSTNAME=$(grep -E '^\s*hostname:' "$config_file" | awk -F':' '{gsub(/[[:space:]"'\'']/,"",$2); print $2}' | head -1)
@@ -172,6 +174,13 @@ read_config() {
                 HTTP_ONLY="true"
             else
                 HTTP_ONLY="false"
+            fi
+
+            # Check for consent.enabled (default: true)
+            if grep -A1 '^consent:' "$config_file" 2>/dev/null | grep -q 'enabled.*false'; then
+                CONSENT_ENABLED="false"
+            else
+                CONSENT_ENABLED="true"
             fi
 
             # Use defaults if not found
@@ -464,6 +473,10 @@ function package() {
         chmod +x "$DIST_DIR/$PRODUCT_FOLDER/start.sh"
         chmod +x "$DIST_DIR/$PRODUCT_FOLDER/setup.sh"
     fi
+
+    echo "Packaging consent server..."
+    bash "$SCRIPT_DIR/scripts/package-consent-server.sh" \
+            "$GO_OS" "$GO_ARCH" "$(cd "$DIST_DIR/$PRODUCT_FOLDER" && pwd)"
 
     echo "Creating zip file..."
     (cd "$DIST_DIR" && zip -r "$PRODUCT_FOLDER.zip" "$PRODUCT_FOLDER")
@@ -930,8 +943,31 @@ function ensure_crypto_file() {
 }
 
 function run() {
+    cleanup_servers() {
+        echo -e "\n🛑 Shutting down servers..."
+        if [ ! -z "$FRONTEND_PID" ]; then 
+            kill $FRONTEND_PID 2>/dev/null
+        fi
+        pkill -f "pnpm.*dev" 2>/dev/null
+        pkill -f "vite" 2>/dev/null
+        if [ ! -z "$BACKEND_PID" ]; then 
+            kill $BACKEND_PID 2>/dev/null
+        fi
+        if [ ! -z "$CONSENT_PID" ]; then 
+            kill $CONSENT_PID 2>/dev/null
+        fi
+        sleep 1
+        echo "✅ All servers stopped successfully."
+    }
+    trap cleanup_servers EXIT INT TERM
+
     echo "Running frontend apps..."
     run_frontend
+
+    if [ "$CONSENT_ENABLED" = "true" ]; then
+        echo "Running consent server..."
+        run_consent
+    fi
 
     # Save original THUNDER_SKIP_SECURITY value and temporarily set to true
     ORIGINAL_THUNDER_SKIP_SECURITY="${THUNDER_SKIP_SECURITY:-}"
@@ -997,30 +1033,6 @@ function run() {
     echo ""
 
     echo "Press Ctrl+C to stop."
-
-    cleanup_servers() {
-        echo -e "\n🛑 Shutting down servers..."
-        # Kill frontend processes using multiple approaches
-        if [ ! -z "$FRONTEND_PID" ]; then 
-            kill $FRONTEND_PID 2>/dev/null
-        fi
-        # Kill all pnpm dev processes
-        pkill -f "pnpm.*dev" 2>/dev/null
-        # Kill all vite processes
-        pkill -f "vite" 2>/dev/null
-        # Kill backend process
-        if [ ! -z "$BACKEND_PID" ]; then 
-            kill $BACKEND_PID 2>/dev/null
-        fi
-
-        # Wait a moment for processes to exit gracefully
-        sleep 1
-
-        echo "✅ All servers stopped successfully."
-        exit 0
-    }
-    
-    trap cleanup_servers SIGINT
 
     wait $BACKEND_PID 2>/dev/null
 }
@@ -1140,6 +1152,45 @@ function run_docs() {
     # Return to script directory
     cd "$SCRIPT_DIR" || exit 1
     echo "================================================================"
+}
+
+function run_consent() {
+    local consent_dir="$TARGET_DIR/consent"
+    local consent_port="${CONSENT_SERVER_PORT:-9090}"
+
+    if [ ! -f "$consent_dir/consent-server" ]; then
+        echo "=== Downloading consent server ==="
+        ./scripts/package-consent-server.sh "$GO_OS" "$GO_ARCH" "$TARGET_DIR"
+    fi
+
+    if [ ! -f "$consent_dir/consent-server" ]; then
+        echo "Error: Consent server binary not found at $consent_dir/consent-server"
+        exit 1
+    fi
+
+    echo "=== Starting consent server ==="
+    (cd "$consent_dir" && ./consent-server) &
+    CONSENT_PID=$!
+    CONSENT_TIMEOUT=30
+    CONSENT_ELAPSED=0
+    while [ $CONSENT_ELAPSED -lt $CONSENT_TIMEOUT ]; do
+        if ! kill -0 "$CONSENT_PID" 2>/dev/null; then
+            echo "Error: Consent server process exited unexpectedly"
+            exit 1
+        fi
+        if curl -s -f "http://localhost:${consent_port}/health/readiness" > /dev/null 2>&1; then
+            echo "Consent server is ready"
+            break
+        fi
+        sleep 1
+        CONSENT_ELAPSED=$((CONSENT_ELAPSED + 1))
+    done
+    if [ $CONSENT_ELAPSED -ge $CONSENT_TIMEOUT ]; then
+        echo "Error: Consent server failed to become ready within ${CONSENT_TIMEOUT}s"
+        exit 1
+    fi
+    
+    echo "Consent server started (PID: $CONSENT_PID)"
 }
 
 case "$1" in

--- a/install/helm/conf/consent-deployment.yaml
+++ b/install/helm/conf/consent-deployment.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+server:
+  hostname: {{ .Values.configuration.consent.server.hostname | quote }}
+  port: {{ .Values.configuration.consent.server.port }}
+  readTimeout: 30s
+  writeTimeout: 30s
+  idleTimeout: 120s
+
+database:
+  consent:
+    type: {{ .Values.configuration.consent.database.type | quote }}
+    {{- if eq .Values.configuration.consent.database.type "sqlite" }}
+    path: {{ .Values.configuration.consent.database.sqlitePath | quote }}
+    options: {{ .Values.configuration.consent.database.sqliteOptions | quote }}
+    {{- else }}
+    hostname: {{ .Values.configuration.consent.database.host | quote }}
+    port: {{ .Values.configuration.consent.database.port }}
+    database: {{ .Values.configuration.consent.database.name | quote }}
+    user: {{ .Values.configuration.consent.database.username | quote }}
+    password: {{ "${DB_CONSENT_PASSWORD}" | quote }}
+    sslmode: {{ .Values.configuration.consent.database.sslmode | quote }}
+    max_open_conns: {{ .Values.configuration.consent.database.max_open_conns }}
+    max_idle_conns: {{ .Values.configuration.consent.database.max_idle_conns }}
+    conn_max_lifetime: {{ .Values.configuration.consent.database.conn_max_lifetime | quote }}
+    {{- end }}
+
+logging:
+  level: info
+
+consent:
+  status_mappings:
+    active_status: ACTIVE
+    expired_status: EXPIRED
+    revoked_status: REVOKED
+    created_status: CREATED
+    rejected_status: REJECTED
+  auth_status_mappings:
+    approved_state: APPROVED
+    rejected_state: REJECTED
+    created_state: CREATED
+    system_expired_state: SYS_EXPIRED
+    system_revoked_state: SYS_REVOKED

--- a/install/helm/templates/_helpers.tpl
+++ b/install/helm/templates/_helpers.tpl
@@ -91,7 +91,9 @@ This is used to trigger pod restarts when auto-generated Secrets change.
 {{- $config := default dict $database.config -}}
 {{- $runtime := default dict $database.runtime -}}
 {{- $user := default dict $database.user -}}
-{{- if or (and $config.password (not (default dict $config.passwordRef).key)) (and $runtime.password (not (default dict $runtime.passwordRef).key)) (and $user.password (not (default dict $user.passwordRef).key)) }}true{{- end }}
+{{- $consent := default dict $configuration.consent -}}
+{{- $consentDb := default dict $consent.database -}}
+{{- if or (and $config.password (not (default dict $config.passwordRef).key)) (and $runtime.password (not (default dict $runtime.passwordRef).key)) (and $user.password (not (default dict $user.passwordRef).key)) (and $consent.enabled $consentDb.password (not (default dict $consentDb.passwordRef).key)) }}true{{- end }}
 {{- end }}
 
 {{/*
@@ -105,9 +107,12 @@ Injects DB_CONFIG_PASSWORD, DB_RUNTIME_PASSWORD, and DB_USER_PASSWORD from eithe
 {{- $config := default dict $database.config -}}
 {{- $runtime := default dict $database.runtime -}}
 {{- $user := default dict $database.user -}}
+{{- $consent := default dict $configuration.consent -}}
+{{- $consentDb := default dict $consent.database -}}
 {{- $configPasswordRef := default dict $config.passwordRef -}}
 {{- $runtimePasswordRef := default dict $runtime.passwordRef -}}
 {{- $userPasswordRef := default dict $user.passwordRef -}}
+{{- $consentPasswordRef := default dict $consentDb.passwordRef -}}
 {{- if or $config.password $configPasswordRef.key }}
 - name: DB_CONFIG_PASSWORD
   valueFrom:
@@ -128,5 +133,12 @@ Injects DB_CONFIG_PASSWORD, DB_RUNTIME_PASSWORD, and DB_USER_PASSWORD from eithe
     secretKeyRef:
       name: {{ if $userPasswordRef.key }}{{ $userPasswordRef.name | default $defaultDbSecretName }}{{ else }}{{ $defaultDbSecretName }}{{ end }}
       key: {{ $userPasswordRef.key | default "user-db-password" }}
+{{- end }}
+{{- if and $consent.enabled (or $consentDb.password $consentPasswordRef.key) }}
+- name: DB_CONSENT_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ if $consentPasswordRef.key }}{{ $consentPasswordRef.name | default $defaultDbSecretName }}{{ else }}{{ $defaultDbSecretName }}{{ end }}
+      key: {{ $consentPasswordRef.key | default "consent-db-password" }}
 {{- end }}
 {{- end }}

--- a/install/helm/templates/config-map.yaml
+++ b/install/helm/templates/config-map.yaml
@@ -25,3 +25,6 @@ data:
   deployment.yaml: {{ tpl (.Files.Get "conf/deployment.yaml") . | quote }}
   gate-config.js: {{ tpl (.Files.Get "conf/apps/gate/config.js") . | quote }}
   console-config.js: {{ tpl (.Files.Get "conf/apps/console/config.js") . | quote }}
+  {{- if .Values.configuration.consent.enabled }}
+  consent-deployment.yaml: {{ tpl (.Files.Get "conf/consent-deployment.yaml") . | quote }}
+  {{- end }}

--- a/install/helm/templates/secret.yaml
+++ b/install/helm/templates/secret.yaml
@@ -19,10 +19,13 @@
 {{- $config := default dict $database.config -}}
 {{- $runtime := default dict $database.runtime -}}
 {{- $user := default dict $database.user -}}
+{{- $consent := default dict $configuration.consent -}}
+{{- $consentDb := default dict $consent.database -}}
 
 {{- $configPassword := "" }}
 {{- $runtimePassword := "" }}
 {{- $userPassword := "" }}
+{{- $consentPassword := "" }}
 
 {{- if and $config.password (not (default dict $config.passwordRef).key) }}
   {{- $configPassword = $config.password }}
@@ -33,8 +36,11 @@
 {{- if and $user.password (not (default dict $user.passwordRef).key) }}
   {{- $userPassword = $user.password }}
 {{- end }}
+{{- if and $consent.enabled $consentDb.password (not (default dict $consentDb.passwordRef).key) }}
+  {{- $consentPassword = $consentDb.password }}
+{{- end }}
 
-{{- $createSecret := or $configPassword $runtimePassword $userPassword }}
+{{- $createSecret := or $configPassword $runtimePassword $userPassword $consentPassword }}
 
 {{- if $createSecret }}
 apiVersion: v1
@@ -61,5 +67,8 @@ data:
   {{- end }}
   {{- if $userPassword }}
   user-db-password: {{ $userPassword | b64enc | quote }}
+  {{- end }}
+  {{- if $consentPassword }}
+  consent-db-password: {{ $consentPassword | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/install/helm/templates/setup-config-map.yaml
+++ b/install/helm/templates/setup-config-map.yaml
@@ -28,4 +28,7 @@ metadata:
     "helm.sh/hook-weight": "-10"
 data:
   deployment.yaml: {{ tpl (.Files.Get "conf/deployment.yaml") . | quote }}
+  {{- if .Values.configuration.consent.enabled }}
+  consent-deployment.yaml: {{ tpl (.Files.Get "conf/consent-deployment.yaml") . | quote }}
+  {{- end }}
 {{- end }}

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -15,7 +15,7 @@
 # under the License.
 
 {{- if .Values.setup.enabled }}
-{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
+{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") (and .Values.configuration.consent.enabled (eq .Values.configuration.consent.database.type "sqlite")) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -98,6 +98,21 @@ spec:
               else
                 echo "Database already initialized"
               fi
+              {{- if and .Values.configuration.consent.enabled (eq .Values.configuration.consent.database.type "sqlite") }}
+              if [ ! -f /data/consent/consentdb.db ]; then
+                echo "Copying consent database from image..."
+                mkdir -p /data/consent
+                if [ -d /opt/thunder/consent/repository/database ]; then
+                  cp -r /opt/thunder/consent/repository/database/* /data/consent/
+                  echo "Consent database initialization complete"
+                else
+                  echo "Error: consent database source directory not found" >&2
+                  exit 1
+                fi
+              else
+                echo "Consent database already initialized"
+              fi
+              {{- end }}
           volumeMounts:
             - name: database-storage
               mountPath: /data
@@ -119,6 +134,13 @@ spec:
             {{- if .Values.setup.debug }}
             - name: DEBUG
               value: "true"
+            {{- end }}
+            {{- if .Values.configuration.consent.enabled }}
+            - name: WITH_CONSENT
+              value: "true"
+            {{- else }}
+            - name: WITH_CONSENT
+              value: "false"
             {{- end }}
             {{- include "thunder.databasePasswordEnvVars" . | nindent 12 }}
             {{- if .Values.setup.env }}
@@ -146,9 +168,19 @@ spec:
             - name: database-storage
               mountPath: /opt/thunder/repository/database
             {{- end }}
+            {{- if and .Values.configuration.consent.enabled (eq .Values.configuration.consent.database.type "sqlite") }}
+            - name: database-storage
+              mountPath: /opt/thunder/consent/repository/database
+              subPath: consent
+            {{- end }}
             - name: deployment-yaml-volume
               mountPath: /opt/thunder/repository/conf/deployment.yaml
               subPath: deployment.yaml
+            {{- if .Values.configuration.consent.enabled }}
+            - name: deployment-yaml-volume
+              mountPath: /opt/thunder/consent/repository/conf/deployment.yaml
+              subPath: consent-deployment.yaml
+            {{- end }}
             {{- /* Validate bootstrap configuration - patterns are mutually exclusive */ -}}
             {{- if and .Values.bootstrap.scripts .Values.bootstrap.configMap.name }}
             {{- fail "\n\n❌ ERROR: Invalid bootstrap configuration detected!\n\nYou cannot use both 'bootstrap.scripts' and 'bootstrap.configMap' at the same time." }}

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -14,7 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
+{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") (and .Values.configuration.consent.enabled (eq .Values.configuration.consent.database.type "sqlite")) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -89,6 +89,13 @@ spec:
           env:
             - name: THUNDER_SKIP_SECURITY
               value: {{ .Values.deployment.skipSecurity | quote }}
+            {{- if .Values.configuration.consent.enabled }}
+            - name: WITH_CONSENT
+              value: "true"
+            {{- else }}
+            - name: WITH_CONSENT
+              value: "false"
+            {{- end }}
             {{- include "thunder.databasePasswordEnvVars" . | nindent 12 }}
           startupProbe:
             exec:
@@ -137,6 +144,11 @@ spec:
             - name: database-storage
               mountPath: /opt/thunder/repository/database
             {{- end }}
+            {{- if and .Values.configuration.consent.enabled (eq .Values.configuration.consent.database.type "sqlite") }}
+            - name: database-storage
+              mountPath: /opt/thunder/consent/repository/database
+              subPath: consent
+            {{- end }}
             - name: deployment-yaml-volume
               mountPath: /opt/thunder/repository/conf/deployment.yaml
               subPath: deployment.yaml
@@ -146,6 +158,11 @@ spec:
             - name: console-config-volume
               mountPath: /opt/thunder/apps/console/config.js
               subPath: console-config.js
+            {{- if .Values.configuration.consent.enabled }}
+            - name: consent-deployment-yaml-volume
+              mountPath: /opt/thunder/consent/repository/conf/deployment.yaml
+              subPath: consent-deployment.yaml
+            {{- end }}
       volumes:
         {{- if or .Values.persistence.enabled $usingSqlite }}
         - name: database-storage
@@ -161,3 +178,8 @@ spec:
         - name: console-config-volume
           configMap:
             name: {{ include "thunder.fullname" . }}-config-map
+        {{- if .Values.configuration.consent.enabled }}
+        - name: consent-deployment-yaml-volume
+          configMap:
+            name: {{ include "thunder.fullname" . }}-config-map
+        {{- end }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -271,10 +271,29 @@ configuration:
 
   # Consent configuration
   consent:
-    enabled: false
-    baseUrl: ""
+    enabled: true
+    baseUrl: "http://localhost:9090/api/v1"
     timeout: 5
     maxRetries: 3
+    server:
+      port: 9090
+      hostname: "localhost"
+    database:
+      # WARNING: Use sqlite only if you are running a single pod.
+      type: "postgres" # postgres or sqlite
+      # Below two parameters are only required for sqlite
+      sqlitePath: "repository/database/consentdb.db" # Only required for sqlite
+      sqliteOptions: "_pragma=journal_mode(WAL)&_pragma=cache_size(-16000)" # Only required for sqlite
+      # Below parameters are only required for Postgres
+      name: "consentdb"
+      host: "localhost"
+      port: "5432"
+      username: "asgthunder"
+      password: "asgthunder"
+      sslmode: "require"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: "3600s"
 
 # Persistence configuration for SQLite databases
 # Only relevant when using SQLite as the database type

--- a/install/openchoreo/helm/templates/thunder-component.yaml
+++ b/install/openchoreo/helm/templates/thunder-component.yaml
@@ -110,7 +110,65 @@ spec:
             {{- range .Values.cors.allowed_origins }}
               - "{{ . }}"
             {{- end }}
+
+          consent:
+            enabled: ${THUNDER_CONSENT_ENABLED}
+            base_url: "${THUNDER_CONSENT_BASE_URL}"
           EOF
+
+          {{- if .Values.consent.enabled }}
+          # Generate consent server configuration
+          cat > /opt/thunder/consent/repository/conf/deployment.yaml << EOF
+          server:
+            hostname: "${CONSENT_SERVER_HOSTNAME}"
+            port: ${CONSENT_SERVER_PORT}
+            readTimeout: 30s
+            writeTimeout: 30s
+            idleTimeout: 120s
+
+          database:
+            consent:
+              type: "${CONSENT_DB_TYPE}"
+              hostname: "${DATABASE_HOST}"
+              port: ${DATABASE_PORT}
+              database: "${CONSENT_DB_DATABASE}"
+              user: "${CONSENT_DB_USERNAME}"
+              password: "${CONSENT_DB_PASSWORD}"
+              sslmode: "${CONSENT_DB_SSL_MODE}"
+
+          logging:
+            level: info
+
+          consent:
+            status_mappings:
+              active_status: ACTIVE
+              expired_status: EXPIRED
+              revoked_status: REVOKED
+              created_status: CREATED
+              rejected_status: REJECTED
+            auth_status_mappings:
+              approved_state: APPROVED
+              rejected_state: REJECTED
+              created_state: CREATED
+              system_expired_state: SYS_EXPIRED
+              system_revoked_state: SYS_REVOKED
+          EOF
+
+          echo "Starting consent server..."
+          if [ ! -x /opt/thunder/consent/start.sh ]; then
+            echo "Error: consent/start.sh is missing or not executable"
+            exit 1
+          fi
+          (cd /opt/thunder/consent && ./start.sh) &
+          CONSENT_PID=$!
+          sleep 1
+          if ! kill -0 "$CONSENT_PID" 2>/dev/null; then
+            echo "Error: Consent server failed to start"
+            exit 1
+          fi
+          echo "Consent server started successfully (PID: $CONSENT_PID)"
+
+          {{- end }}
           echo "Starting Thunder with PostgreSQL configuration..."
           exec /opt/thunder/thunder
       env:
@@ -162,6 +220,26 @@ spec:
           value: "{{ .Values.oauth.refresh_token_validity }}"
         - key: THUNDER_CRYPTO_ENCRYPTION_KEY
           value: "{{ .Values.crypto.encryption.key }}"
+        - key: THUNDER_CONSENT_ENABLED
+          value: "{{ .Values.consent.enabled }}"
+        - key: THUNDER_CONSENT_BASE_URL
+          value: "{{ .Values.consent.baseUrl }}"
+        {{- if .Values.consent.enabled }}
+        - key: CONSENT_SERVER_HOSTNAME
+          value: "{{ .Values.consent.server.hostname }}"
+        - key: CONSENT_SERVER_PORT
+          value: "{{ .Values.consent.server.port }}"
+        - key: CONSENT_DB_TYPE
+          value: "{{ .Values.consent.database.type }}"
+        - key: CONSENT_DB_DATABASE
+          value: "{{ .Values.consent.database.database }}"
+        - key: CONSENT_DB_USERNAME
+          value: "{{ .Values.consent.database.username }}"
+        - key: CONSENT_DB_PASSWORD
+          value: "{{ .Values.consent.database.password }}"
+        - key: CONSENT_DB_SSL_MODE
+          value: "{{ .Values.consent.database.sslmode }}"
+        {{- end }}
 
   endpoints:
     identity-api:

--- a/install/openchoreo/helm/values.yaml
+++ b/install/openchoreo/helm/values.yaml
@@ -85,6 +85,20 @@ gateway:
   dnsPrefixStaging: staging # DNS prefix for staging environment
   dnsPrefixProd: prod      # DNS prefix for production environment
 
+# Consent server configuration
+consent:
+  enabled: true
+  baseUrl: "http://localhost:9090/api/v1"
+  server:
+    port: 9090
+    hostname: "localhost"
+  database:
+    database: consentdb       # Consent database name
+    username: <DB_USERNAME>   # Required: Database username for consent DB
+    password: <DB_PASSWORD>   # Required: Database password for consent DB
+    type: postgres            # Database type (currently only postgres is supported)
+    sslmode: disable          # SSL mode: disable, require, verify-ca, verify-full
+
 serviceClass:
   name: default
   # Whether to create the ServiceClass resource

--- a/install/quick-start/docker-compose.yml
+++ b/install/quick-start/docker-compose.yml
@@ -18,9 +18,10 @@ services:
   # Initialize database from the image
   thunder-db-init:
     image: ghcr.io/asgardeo/thunder:latest
-    command: sh -c "cp -r /opt/thunder/repository/database/* /data/"
+    command: sh -c "cp -r /opt/thunder/repository/database/* /data/ && (cp -r /opt/thunder/consent/repository/database/* /consent-data/ 2>/dev/null || true)"
     volumes:
       - thunder-db:/data
+      - consent-db:/consent-data
     restart: "no"
 
   # Run setup once with the shared database
@@ -29,6 +30,7 @@ services:
     command: ./setup.sh
     volumes:
       - thunder-db:/opt/thunder/repository/database
+      - consent-db:/opt/thunder/consent/repository/database
     depends_on:
       thunder-db-init:
         condition: service_completed_successfully
@@ -44,7 +46,10 @@ services:
       - "8090:8090"
     volumes:
       - thunder-db:/opt/thunder/repository/database
+      - consent-db:/opt/thunder/consent/repository/database
 
 volumes:
   thunder-db:
+    driver: local
+  consent-db:
     driver: local

--- a/scripts/package-consent-server.ps1
+++ b/scripts/package-consent-server.ps1
@@ -1,0 +1,176 @@
+#!/usr/bin/env pwsh
+
+# ----------------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# package-consent-server.ps1
+# Download, configure, and stage the default consent server into thunder distribution.
+#
+# Usage: .\scripts\package-consent-server.ps1 -GoOS <os> -GoArch <arch> -DistOutputPath <path>
+#
+# Arguments:
+#   GoOS           - Target OS in Go env format (linux, darwin, windows)
+#   GoArch         - Target architecture in Go env format (amd64, arm64)
+#   DistOutputPath - Absolute path to the distribution product folder
+#                    (a 'consent' subdirectory will be created inside this)
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string]$GoOS,
+    [Parameter(Mandatory = $true)] [string]$GoArch,
+    [Parameter(Mandatory = $true)] [string]$DistOutputPath
+)
+
+$ErrorActionPreference = "Stop"
+
+# Consent server release coordinates
+$CONSENT_SERVER_VERSION = "0.2.0"
+$CONSENT_SERVER_DOWNLOAD_URL = "https://github.com/wso2/openfgc/releases/download"
+$CONSENT_SERVER_PORT = 9090
+
+# Map Go env OS/ARCH names to release artifact naming
+$PACKAGE_OS = $GoOS
+$PACKAGE_ARCH = $GoArch
+
+if ($GoOS -eq "darwin") {
+    $PACKAGE_OS = "macos"
+}
+elseif ($GoOS -eq "windows") {
+    $PACKAGE_OS = "win"
+}
+
+if ($GoArch -eq "amd64") {
+    $PACKAGE_ARCH = "x64"
+}
+
+$ARCHIVE_NAME = "consent-server-${CONSENT_SERVER_VERSION}-${PACKAGE_OS}-${PACKAGE_ARCH}.zip"
+$ARCHIVE_URL = "${CONSENT_SERVER_DOWNLOAD_URL}/v${CONSENT_SERVER_VERSION}/${ARCHIVE_NAME}"
+$EXTRACTED_FOLDER = "consent-server-${CONSENT_SERVER_VERSION}-${PACKAGE_OS}-${PACKAGE_ARCH}"
+
+$TMP_DIR = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -Path $TMP_DIR -ItemType Directory -Force | Out-Null
+
+try {
+    Write-Host "================================================================"
+    Write-Host "Packaging consent server ${CONSENT_SERVER_VERSION} for ${PACKAGE_OS}/${PACKAGE_ARCH}..."
+    Write-Host "Downloading from: $ARCHIVE_URL"
+    Write-Host "================================================================"
+
+    $archivePath = Join-Path $TMP_DIR $ARCHIVE_NAME
+    try {
+        Invoke-WebRequest -Uri $ARCHIVE_URL -OutFile $archivePath -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Error: Failed to download consent server from $ARCHIVE_URL"
+        Write-Host $_.Exception.Message
+        exit 1
+    }
+
+    # Verify archive integrity using SHA256 checksum if available
+    $checksumUrl = "${ARCHIVE_URL}.sha256"
+    $checksumPath = Join-Path $TMP_DIR "${ARCHIVE_NAME}.sha256"
+    try {
+        Invoke-WebRequest -Uri $checksumUrl -OutFile $checksumPath -ErrorAction Stop
+        Write-Host "Verifying archive checksum..."
+        $expectedHash = (Get-Content $checksumPath -Raw).Trim().Split()[0]
+        $actualHash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
+        if ($expectedHash -ne $actualHash) {
+            Write-Host "Error: Checksum verification failed for $ARCHIVE_NAME"
+            Write-Host "  Expected: $expectedHash"
+            Write-Host "  Actual:   $actualHash"
+            exit 1
+        }
+        Write-Host "Checksum verification passed."
+    }
+    catch {
+        Write-Host "Warning: No .sha256 checksum file found for $ARCHIVE_NAME, skipping verification."
+    }
+
+    Write-Host "Extracting consent server archive..."
+    Expand-Archive -Path $archivePath -DestinationPath $TMP_DIR -Force
+
+    $WORK_DIR = Join-Path $TMP_DIR $EXTRACTED_FOLDER
+    if (-not (Test-Path $WORK_DIR)) {
+        Write-Host "Error: Expected extracted directory '$EXTRACTED_FOLDER' not found in archive."
+        exit 1
+    }
+
+    Write-Host "Initializing SQLite database..."
+    $dbDir = Join-Path $WORK_DIR "repository/database"
+    New-Item -Path $dbDir -ItemType Directory -Force | Out-Null
+    $dbPath = Join-Path $dbDir "consentdb.db"
+    $sqlScriptPath = Join-Path $WORK_DIR "dbscripts/db_schema_sqlite.sql"
+
+    if (-not (Get-Command sqlite3 -ErrorAction SilentlyContinue)) {
+        Write-Host "Error: 'sqlite3' CLI not found. Install sqlite3 and re-run the build."
+        exit 1
+    }
+
+    & sqlite3 $dbPath ".read `"$sqlScriptPath`""
+    if ($LASTEXITCODE -ne 0) { throw "Failed to initialize consent DB with exit code $LASTEXITCODE" }
+
+    & sqlite3 $dbPath "PRAGMA journal_mode=WAL;"
+    if ($LASTEXITCODE -ne 0) { throw "Failed to enable WAL mode for consent DB with exit code $LASTEXITCODE" }
+
+    Write-Host "Writing SQLite deployment configuration..."
+    $confPath = Join-Path $WORK_DIR "repository/conf/deployment.yaml"
+    $deploymentYaml = @"
+server:
+  hostname: localhost
+  port: $CONSENT_SERVER_PORT
+  readTimeout: 30s
+  writeTimeout: 30s
+  idleTimeout: 120s
+
+database:
+  consent:
+    type: sqlite
+    path: repository/database/consentdb.db
+    options: "_pragma=journal_mode(WAL)&_pragma=cache_size(-16000)"
+
+logging:
+  level: info
+
+consent:
+  status_mappings:
+    active_status: ACTIVE
+    expired_status: EXPIRED
+    revoked_status: REVOKED
+    created_status: CREATED
+    rejected_status: REJECTED
+  auth_status_mappings:
+    approved_state: APPROVED
+    rejected_state: REJECTED
+    created_state: CREATED
+    system_expired_state: SYS_EXPIRED
+    system_revoked_state: SYS_REVOKED
+"@
+    Set-Content -Path $confPath -Value $deploymentYaml -Encoding Ascii
+
+    Write-Host "Staging consent server into distribution..."
+    $consentDest = Join-Path $DistOutputPath "consent"
+    New-Item -Path $consentDest -ItemType Directory -Force | Out-Null
+    Copy-Item -Path (Join-Path $WORK_DIR "*") -Destination $consentDest -Recurse -Force
+
+    Write-Host "================================================================"
+    Write-Host "Consent server packaged successfully at: $consentDest"
+    Write-Host "================================================================"
+}
+finally {
+    Remove-Item -Path $TMP_DIR -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/package-consent-server.sh
+++ b/scripts/package-consent-server.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# package-consent-server.sh
+# Download, configure, and stage the default consent server into thunder distribution.
+#
+# Usage: ./scripts/package-consent-server.sh <GO_OS> <GO_ARCH> <DIST_OUTPUT_PATH>
+#
+# Arguments:
+#   GO_OS            - Target OS in Go env format (linux, darwin, windows)
+#   GO_ARCH          - Target architecture in Go env format (amd64, arm64)
+#   DIST_OUTPUT_PATH - Absolute path to the distribution product folder
+#                      (a 'consent' subdirectory will be created inside this)
+#
+# Exit codes:
+#   0 - Success
+#   1 - Failure
+
+set -e
+
+# Consent server release coordinates
+CONSENT_SERVER_VERSION="0.2.0"
+CONSENT_SERVER_DOWNLOAD_URL="https://github.com/wso2/openfgc/releases/download"
+CONSENT_SERVER_PORT=9090
+
+GO_OS="${1}"
+GO_ARCH="${2}"
+DIST_OUTPUT_PATH="${3}"
+
+if [ -z "$GO_OS" ] || [ -z "$GO_ARCH" ] || [ -z "$DIST_OUTPUT_PATH" ]; then
+    echo "Error: Missing required arguments."
+    echo "Usage: $0 <GO_OS> <GO_ARCH> <DIST_OUTPUT_PATH>"
+    exit 1
+fi
+
+# Map Go env OS/ARCH names to release artifact naming
+PACKAGE_OS="$GO_OS"
+PACKAGE_ARCH="$GO_ARCH"
+
+if [ "$GO_OS" = "darwin" ]; then
+    PACKAGE_OS="macos"
+elif [ "$GO_OS" = "windows" ]; then
+    PACKAGE_OS="win"
+fi
+
+if [ "$GO_ARCH" = "amd64" ]; then
+    PACKAGE_ARCH="x64"
+fi
+
+ARCHIVE_NAME="consent-server-${CONSENT_SERVER_VERSION}-${PACKAGE_OS}-${PACKAGE_ARCH}.zip"
+ARCHIVE_URL="${CONSENT_SERVER_DOWNLOAD_URL}/v${CONSENT_SERVER_VERSION}/${ARCHIVE_NAME}"
+EXTRACTED_FOLDER="consent-server-${CONSENT_SERVER_VERSION}-${PACKAGE_OS}-${PACKAGE_ARCH}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "================================================================"
+echo "Packaging consent server ${CONSENT_SERVER_VERSION} for ${PACKAGE_OS}/${PACKAGE_ARCH}..."
+echo "Downloading from: $ARCHIVE_URL"
+echo "================================================================"
+
+if ! curl -fsSL "$ARCHIVE_URL" -o "$TMP_DIR/$ARCHIVE_NAME"; then
+    echo "Error: Failed to download consent server from $ARCHIVE_URL"
+    exit 1
+fi
+
+# Verify archive integrity using SHA256 checksum if available
+CHECKSUM_URL="${ARCHIVE_URL}.sha256"
+if curl -fsSL "$CHECKSUM_URL" -o "$TMP_DIR/${ARCHIVE_NAME}.sha256" 2>/dev/null; then
+    echo "Verifying archive checksum..."
+    EXPECTED_HASH=$(awk '{print $1}' "$TMP_DIR/${ARCHIVE_NAME}.sha256")
+    ACTUAL_HASH=$(sha256sum "$TMP_DIR/$ARCHIVE_NAME" | awk '{print $1}')
+    if [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
+        echo "Error: Checksum verification failed for $ARCHIVE_NAME"
+        echo "  Expected: $EXPECTED_HASH"
+        echo "  Actual:   $ACTUAL_HASH"
+        exit 1
+    fi
+    echo "Checksum verification passed."
+else
+    echo "Warning: No .sha256 checksum file found for $ARCHIVE_NAME, skipping verification."
+fi
+
+echo "Extracting consent server archive..."
+(cd "$TMP_DIR" && unzip -q "$ARCHIVE_NAME")
+
+WORK_DIR="$TMP_DIR/$EXTRACTED_FOLDER"
+if [ ! -d "$WORK_DIR" ]; then
+    echo "Error: Expected extracted directory '$EXTRACTED_FOLDER' not found in archive."
+    exit 1
+fi
+
+echo "Initializing SQLite database..."
+mkdir -p "$WORK_DIR/repository/database"
+sqlite3 "$WORK_DIR/repository/database/consentdb.db" < "$WORK_DIR/dbscripts/db_schema_sqlite.sql"
+sqlite3 "$WORK_DIR/repository/database/consentdb.db" "PRAGMA journal_mode=WAL;"
+
+echo "Writing SQLite deployment configuration..."
+cat > "$WORK_DIR/repository/conf/deployment.yaml" << EOF
+server:
+  hostname: localhost
+  port: ${CONSENT_SERVER_PORT}
+  readTimeout: 30s
+  writeTimeout: 30s
+  idleTimeout: 120s
+
+database:
+  consent:
+    type: sqlite
+    path: repository/database/consentdb.db
+    options: "_pragma=journal_mode(WAL)&_pragma=cache_size(-16000)"
+
+logging:
+  level: info
+
+consent:
+  status_mappings:
+    active_status: ACTIVE
+    expired_status: EXPIRED
+    revoked_status: REVOKED
+    created_status: CREATED
+    rejected_status: REJECTED
+  auth_status_mappings:
+    approved_state: APPROVED
+    rejected_state: REJECTED
+    created_state: CREATED
+    system_expired_state: SYS_EXPIRED
+    system_revoked_state: SYS_REVOKED
+EOF
+
+echo "Staging consent server into distribution..."
+mkdir -p "$DIST_OUTPUT_PATH/consent"
+cp -r "$WORK_DIR/." "$DIST_OUTPUT_PATH/consent/"
+
+if [ "$GO_OS" != "windows" ]; then
+    chmod +x "$DIST_OUTPUT_PATH/consent/consent-server" 2>/dev/null || true
+    chmod +x "$DIST_OUTPUT_PATH/consent/start.sh" 2>/dev/null || true
+fi
+
+echo "================================================================"
+echo "Consent server packaged successfully at: $DIST_OUTPUT_PATH/consent"
+echo "================================================================"

--- a/setup.ps1
+++ b/setup.ps1
@@ -50,6 +50,7 @@ $BOOTSTRAP_FAIL_FAST = if ($env:BOOTSTRAP_FAIL_FAST -eq "false") { $false } else
 $BOOTSTRAP_SKIP_PATTERN = if ($env:BOOTSTRAP_SKIP_PATTERN) { $env:BOOTSTRAP_SKIP_PATTERN } else { "" }
 $BOOTSTRAP_ONLY_PATTERN = if ($env:BOOTSTRAP_ONLY_PATTERN) { $env:BOOTSTRAP_ONLY_PATTERN } else { "" }
 $BOOTSTRAP_DIR = if ($env:BOOTSTRAP_DIR) { $env:BOOTSTRAP_DIR } else { ".\bootstrap" }
+$WITH_CONSENT = if ($env:WITH_CONSENT -eq 'false') { $false } else { $true }
 
 # ============================================================================
 # Logging Functions
@@ -210,6 +211,7 @@ function Show-Help {
     Write-Host "Options:"
     Write-Host "  --debug                  Enable debug mode with remote debugging"
     Write-Host "  --debug-port PORT        Set debug port (default: 2345)"
+    Write-Host "  --without-consent        Disable the bundled consent server"
     Write-Host "  --help                   Show this help message"
     Write-Host ""
     Write-Host "Description:"
@@ -244,6 +246,11 @@ while ($i -lt $args.Count) {
                 Write-Host "Missing value for --debug-port" -ForegroundColor Red
                 exit 1
             }
+            break
+        }
+        '--without-consent' {
+            $WITH_CONSENT = $false
+            $i++
             break
         }
         '--help' {
@@ -449,6 +456,48 @@ if (-not $thunderPath) {
     $thunderPath = Join-Path $scriptDir 'thunder'
 }
 
+# Start Consent Server (if enabled)
+$consentProc = $null
+$consentDir = Join-Path $scriptDir 'consent'
+if ($WITH_CONSENT) {
+    if (-not (Test-Path $consentDir)) {
+        Log-Error "Consent server is enabled but consent directory not found: $consentDir"
+        exit 1
+    }
+    Write-Host "[INFO] Starting Consent Server..." -ForegroundColor Cyan
+    $consentPort = if ($env:CONSENT_SERVER_PORT) { $env:CONSENT_SERVER_PORT } else { "9090" }
+    $consentBinary = @(
+        (Join-Path $consentDir 'consent-server.exe'),
+        (Join-Path $consentDir 'consent-server')
+    ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if (-not $consentBinary) {
+        Log-Error "Consent server is enabled but consent-server binary not found in: $consentDir"
+        exit 1
+    }
+    $consentProc = Start-Process -FilePath $consentBinary -WorkingDirectory $consentDir -NoNewWindow -PassThru
+    $consentTimeout = 30
+    $consentElapsed = 0
+    while ($consentElapsed -lt $consentTimeout) {
+        if ($consentProc.HasExited) {
+            Log-Error "Consent server process exited unexpectedly (code $($consentProc.ExitCode))"
+            exit 1
+        }
+        try {
+            $resp = Invoke-WebRequest -Uri "http://localhost:${consentPort}/health/readiness" -UseBasicParsing -ErrorAction Stop
+            if ($resp.StatusCode -eq 200) {
+                Write-Host "[INFO] Consent server is ready" -ForegroundColor Cyan
+                break
+            }
+        } catch { }
+        Start-Sleep -Seconds 1
+        $consentElapsed++
+    }
+    if ($consentElapsed -ge $consentTimeout) {
+        Log-Error "Consent server failed to become ready within ${consentTimeout}s"
+        exit 1
+    }
+}
+
 $proc = $null
 try {
     if ($DEBUG_MODE) {
@@ -476,6 +525,11 @@ try {
         if ($proc -and -not $proc.HasExited) {
             try {
                 Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            } catch { }
+        }
+        if ($consentProc -and -not $consentProc.HasExited) {
+            try {
+                Stop-Process -Id $consentProc.Id -Force -ErrorAction SilentlyContinue
             } catch { }
         }
     }
@@ -712,6 +766,11 @@ finally {
     if ($proc -and -not $proc.HasExited) {
         try {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        } catch { }
+    }
+    if ($consentProc -and -not $consentProc.HasExited) {
+        try {
+            Stop-Process -Id $consentProc.Id -Force -ErrorAction SilentlyContinue
         } catch { }
     }
 

--- a/setup.sh
+++ b/setup.sh
@@ -44,6 +44,7 @@ BOOTSTRAP_FAIL_FAST=${BOOTSTRAP_FAIL_FAST:-true}
 BOOTSTRAP_SKIP_PATTERN="${BOOTSTRAP_SKIP_PATTERN:-}"
 BOOTSTRAP_ONLY_PATTERN="${BOOTSTRAP_ONLY_PATTERN:-}"
 BOOTSTRAP_DIR="${BOOTSTRAP_DIR:-./bootstrap}"
+WITH_CONSENT=${WITH_CONSENT:-true}
 
 # Color codes
 RED='\033[0;31m'
@@ -117,6 +118,7 @@ print_help() {
     echo "Options:"
     echo "  --debug                  Enable debug mode with remote debugging"
     echo "  --debug-port PORT        Set debug port (default: 2345)"
+    echo "  --without-consent        Disable the bundled consent server"
     echo "  --help                   Show this help message"
     echo ""
     echo "Description:"
@@ -142,6 +144,10 @@ while [[ $# -gt 0 ]]; do
         --debug-port)
             DEBUG_PORT="$2"
             shift 2
+            ;;
+        --without-consent)
+            WITH_CONSENT=false
+            shift
             ;;
         --help)
             print_help
@@ -274,6 +280,58 @@ if [ "$DEBUG_MODE" = "true" ] && ! command -v dlv &> /dev/null; then
 fi
 
 # ============================================================================
+# Start Consent Server (if enabled)
+# ============================================================================
+
+CONSENT_PID=""
+THUNDER_PID=""
+
+# Cleanup function
+cleanup() {
+    echo ""
+    echo -e "${CYAN}🛑 Stopping temporary server...${NC}"
+    if [ -n "$THUNDER_PID" ]; then
+        kill $THUNDER_PID 2>/dev/null || true
+        wait $THUNDER_PID 2>/dev/null || true
+    fi
+    if [ -n "$CONSENT_PID" ]; then
+        pkill -P $CONSENT_PID 2>/dev/null || true
+        kill $CONSENT_PID 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+CONSENT_SERVER_PORT="${CONSENT_SERVER_PORT:-9090}"
+if [ "$WITH_CONSENT" = "true" ]; then
+    CONSENT_SCRIPT="$(dirname "$0")/consent/start.sh"
+    if [ ! -x "$CONSENT_SCRIPT" ]; then
+        log_error "Consent server is enabled but consent/start.sh is missing or not executable"
+        exit 1
+    fi
+    echo -e "${CYAN}Starting Consent Server...${NC}"
+    (cd "$(dirname "$0")/consent" && ./start.sh) &
+    CONSENT_PID=$!
+    CONSENT_TIMEOUT=30
+    CONSENT_ELAPSED=0
+    while [ $CONSENT_ELAPSED -lt $CONSENT_TIMEOUT ]; do
+        if ! kill -0 "$CONSENT_PID" 2>/dev/null; then
+            log_error "Consent server process exited unexpectedly"
+            exit 1
+        fi
+        if curl -s -f "http://localhost:${CONSENT_SERVER_PORT}/health/readiness" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓ Consent server is ready${NC}"
+            break
+        fi
+        sleep 1
+        CONSENT_ELAPSED=$((CONSENT_ELAPSED + 1))
+    done
+    if [ $CONSENT_ELAPSED -ge $CONSENT_TIMEOUT ]; then
+        log_error "Consent server failed to become ready within ${CONSENT_TIMEOUT}s"
+        exit 1
+    fi
+fi
+
+# ============================================================================
 # Start Thunder Server with Security Disabled
 # ============================================================================
 
@@ -290,19 +348,6 @@ else
     ./thunder &
     THUNDER_PID=$!
 fi
-
-# Cleanup function
-cleanup() {
-    echo ""
-    echo -e "${CYAN}🛑 Stopping temporary server...${NC}"
-    if [ -n "$THUNDER_PID" ]; then
-        kill $THUNDER_PID 2>/dev/null || true
-        wait $THUNDER_PID 2>/dev/null || true
-    fi
-}
-
-# Register cleanup on exit
-trap cleanup EXIT INT TERM
 
 # ============================================================================
 # Wait for Server to be Ready

--- a/start.ps1
+++ b/start.ps1
@@ -36,6 +36,7 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
 $BACKEND_PORT = if ($env:BACKEND_PORT) { [int]$env:BACKEND_PORT } else { 8090 }
 $DEBUG_PORT = if ($env:DEBUG_PORT) { [int]$env:DEBUG_PORT } else { 2345 }
 $DEBUG_MODE = $false
+$WITH_CONSENT = if ($env:WITH_CONSENT -eq 'false') { $false } else { $true }
 
 # Parse command line arguments
 $i = 0
@@ -70,6 +71,11 @@ while ($i -lt $args.Count) {
             }
             break
         }
+        '--without-consent' {
+            $WITH_CONSENT = $false
+            $i++
+            break
+        }
         '--help' {
             Write-Host "Thunder Server Startup Script"
             Write-Host ""
@@ -79,6 +85,7 @@ while ($i -lt $args.Count) {
             Write-Host "  --debug              Enable debug mode with remote debugging"
             Write-Host "  --port PORT          Set application port (default: 8090)"
             Write-Host "  --debug-port PORT    Set debug port (default: 2345)"
+            Write-Host "  --without-consent    Disable the bundled consent server"
             Write-Host "  --help               Show this help message"
             Write-Host ""
             Write-Host "First-Time Setup:"
@@ -176,6 +183,48 @@ if (-not $thunderPath) {
 
 $proc = $null
 try {
+    # Start consent server if enabled
+    $consentProc = $null
+    if ($WITH_CONSENT) {
+        $consentDir = Join-Path $scriptDir "consent"
+        if (-not (Test-Path $consentDir)) {
+            Write-Host "[ERROR] Consent server is enabled but consent directory not found: $consentDir" -ForegroundColor Red
+            exit 1
+        }
+        $consentBinary = @(
+            (Join-Path $consentDir 'consent-server.exe'),
+            (Join-Path $consentDir 'consent-server')
+        ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $consentBinary) {
+            Write-Host "[ERROR] Consent server is enabled but consent-server binary not found in: $consentDir" -ForegroundColor Red
+            exit 1
+        }
+        Write-Host "[INFO] Starting Consent Server..."
+        $consentPort = if ($env:CONSENT_SERVER_PORT) { $env:CONSENT_SERVER_PORT } else { "9090" }
+        $consentProc = Start-Process -FilePath $consentBinary -WorkingDirectory $consentDir -NoNewWindow -PassThru
+        $consentTimeout = 30
+        $consentElapsed = 0
+        while ($consentElapsed -lt $consentTimeout) {
+            if ($consentProc.HasExited) {
+                Write-Host "[ERROR] Consent server process exited unexpectedly (code $($consentProc.ExitCode))" -ForegroundColor Red
+                exit 1
+            }
+            try {
+                $resp = Invoke-WebRequest -Uri "http://localhost:${consentPort}/health/readiness" -UseBasicParsing -ErrorAction Stop
+                if ($resp.StatusCode -eq 200) {
+                    Write-Host "[INFO] Consent server is ready"
+                    break
+                }
+            } catch { }
+            Start-Sleep -Seconds 1
+            $consentElapsed++
+        }
+        if ($consentElapsed -ge $consentTimeout) {
+            Write-Host "[ERROR] Consent server failed to become ready within ${consentTimeout}s" -ForegroundColor Red
+            exit 1
+        }
+    }
+
     if ($DEBUG_MODE) {
         Write-Host "[INFO] Starting Thunder Server in DEBUG mode..."
         Write-Host "[INFO] Application will run on: https://localhost:$BACKEND_PORT"
@@ -222,5 +271,13 @@ finally {
     Write-Host "`n[STOP] Stopping server..."
     if ($proc -and -not $proc.HasExited) {
         try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch { }
+    }
+    if ($consentProc -and -not $consentProc.HasExited) {
+        try {
+            # Stop child processes first (the consent-server binary started by start.ps1)
+            Get-CimInstance Win32_Process -Filter "ParentProcessId = $($consentProc.Id)" -ErrorAction SilentlyContinue |
+                ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+            Stop-Process -Id $consentProc.Id -Force -ErrorAction SilentlyContinue
+        } catch { }
     }
 }

--- a/start.sh
+++ b/start.sh
@@ -21,6 +21,7 @@
 BACKEND_PORT=${BACKEND_PORT:-8090}
 DEBUG_PORT=${DEBUG_PORT:-2345}
 DEBUG_MODE=${DEBUG_MODE:-false}
+WITH_CONSENT=${WITH_CONSENT:-true}
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -37,6 +38,10 @@ while [[ $# -gt 0 ]]; do
             BACKEND_PORT="$2"
             shift 2
             ;;
+        --without-consent)
+            WITH_CONSENT=false
+            shift
+            ;;
         --help)
             echo "Thunder Server Startup Script"
             echo ""
@@ -46,6 +51,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --debug              Enable debug mode with remote debugging"
             echo "  --port PORT          Set application port (default: 8090)"
             echo "  --debug-port PORT    Set debug port (default: 2345)"
+            echo "  --without-consent    Disable the bundled consent server"
             echo "  --help               Show this help message"
             echo ""
             echo "First-Time Setup:"
@@ -112,6 +118,52 @@ if [ "$DEBUG_MODE" = "true" ]; then
     fi
 fi
 
+# Cleanup function
+CONSENT_PID=""
+THUNDER_PID=""
+cleanup() {
+    echo -e "\n🛑 Stopping server..."
+    if [ -n "$THUNDER_PID" ]; then
+        kill $THUNDER_PID 2>/dev/null || true
+    fi
+    if [ -n "$CONSENT_PID" ]; then
+        pkill -P $CONSENT_PID 2>/dev/null || true
+        kill $CONSENT_PID 2>/dev/null || true
+    fi
+}
+trap cleanup SIGINT SIGTERM EXIT
+
+# Start consent server if enabled
+CONSENT_SERVER_PORT="${CONSENT_SERVER_PORT:-9090}"
+if [ "$WITH_CONSENT" = "true" ]; then
+    CONSENT_SCRIPT="$(dirname "$0")/consent/start.sh"
+    if [ ! -x "$CONSENT_SCRIPT" ]; then
+        echo "Error: Consent server is enabled but consent/start.sh is missing or not executable"
+        exit 1
+    fi
+    echo "Starting Consent Server..."
+    (cd "$(dirname "$0")/consent" && ./start.sh) &
+    CONSENT_PID=$!
+    CONSENT_TIMEOUT=30
+    CONSENT_ELAPSED=0
+    while [ $CONSENT_ELAPSED -lt $CONSENT_TIMEOUT ]; do
+        if ! kill -0 "$CONSENT_PID" 2>/dev/null; then
+            echo "Error: Consent server process exited unexpectedly"
+            exit 1
+        fi
+        if curl -s -f "http://localhost:${CONSENT_SERVER_PORT}/health/readiness" > /dev/null 2>&1; then
+            echo "Consent server is ready"
+            break
+        fi
+        sleep 1
+        CONSENT_ELAPSED=$((CONSENT_ELAPSED + 1))
+    done
+    if [ $CONSENT_ELAPSED -ge $CONSENT_TIMEOUT ]; then
+        echo "Error: Consent server failed to become ready within ${CONSENT_TIMEOUT}s"
+        exit 1
+    fi
+fi
+
 # Run thunder
 if [ "$DEBUG_MODE" = "true" ]; then
     echo "⚡ Starting Thunder Server in DEBUG mode..."
@@ -131,17 +183,6 @@ else
     BACKEND_PORT=$BACKEND_PORT ./thunder &
     THUNDER_PID=$!
 fi
-
-# Cleanup function
-cleanup() {
-    echo -e "\n🛑 Stopping server..."
-    if [ -n "$THUNDER_PID" ]; then
-        kill $THUNDER_PID 2>/dev/null || true
-    fi
-}
-
-# Cleanup on Ctrl+C or termination
-trap cleanup SIGINT SIGTERM EXIT
 
 # Status
 echo ""

--- a/tests/integration/testutils/test_utils.go
+++ b/tests/integration/testutils/test_utils.go
@@ -216,7 +216,11 @@ func extractFile(f *zip.File, dest string) error {
 	}
 
 	os.MkdirAll(filepath.Dir(path), os.ModePerm)
-	outFile, err := os.Create(path)
+	mode := f.Mode()
+	if mode == 0 {
+		mode = 0666
+	}
+	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Purpose
This pull request packs [openFGC](https://github.com/wso2/openfgc) consent server with the thunder distribution. It adds packaging and deployment logic for the consent server, integrates its configuration into Helm charts (including secret management and environment variables), and updates the default configuration to enable the consent server by default. The changes ensure the consent server can be properly built, configured, and deployed alongside the main application, with support for both PostgreSQL and SQLite databases.

### Approach
**Consent Server Integration**

* Added packaging steps for the consent server to both `build.sh` and `build.ps1`, ensuring it is included in distribution artifacts.
* Updated the `Dockerfile` to install `curl` (required for consent server scripts) and ensure executable permissions on consent server scripts.
* Added the `WITH_CONSENT` environment variable in both the Dockerfile and Helm deployment, enabling conditional consent server startup.

**Helm Chart and Kubernetes Support**

* Introduced a new `consent-deployment.yaml` Helm configuration file for consent server settings and database credentials, with templating for both SQLite and PostgreSQL.
* Modified Helm templates and values to support consent server configuration, including mounting config maps, handling SQLite database persistence, and injecting consent server environment variables.
* Updated secret management in Helm templates to support consent server database credentials, ensuring secure handling and injection of secrets.
* Enhanced deployment and setup jobs to support initializing and mounting consent server database files, especially for SQLite deployments.

**Configuration Defaults**

* Enabled the consent server by default and provided a full example configuration (including database settings) in `values.yaml`.
* Added consent server configuration to the main deployment YAML and OpenChoreo Helm templates.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1836

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Optional consent server component can be enabled; configurable API endpoint, server host/port, and DB backend (Postgres/SQLite). CLI flags and env var to control startup.

* **Deployment**
  - Charts and compose updated to include consent config, secrets, volumes, and conditional ConfigMap/volume mounts when enabled.

* **Packaging / Build**
  - Packaging and run tooling now include, verify, and start the consent server as part of package/run workflows.

* **Bug Fixes**
  - Preserve and apply executable permissions for bundled server files during packaging/extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->