### PR TITLE
Stop multiple PR builders running on the same PR on subsequent commits

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -10,6 +10,11 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Avoid running multiple PR builders for the same PR on subsequent pushes.
+concurrency:
+  group: pr-builder-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GOFLAGS: "-mod=readonly"
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request introduces a workflow improvement to the PR builder GitHub Actions configuration. The main change ensures that only one PR builder job runs per pull request at a time, automatically cancelling any in-progress jobs if a new commit is pushed to the same PR.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->


Workflow automation improvement:

* Added a `concurrency` group to `.github/workflows/pr-builder.yml` to prevent multiple PR builder jobs from running simultaneously for the same pull request, cancelling any in-progress jobs when new commits are pushed.


### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/1936

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
