### PR TITLE
Refactor executor handling in flow engine and task execution nodes

### DIFF
--- a/backend/internal/flow/core/factory_test.go
+++ b/backend/internal/flow/core/factory_test.go
@@ -450,12 +450,6 @@ func (f *fakeExecutorBackedNode) GetExecutorName() string {
 
 func (f *fakeExecutorBackedNode) SetExecutorName(name string) {}
 
-func (f *fakeExecutorBackedNode) GetExecutor() ExecutorInterface {
-	return nil
-}
-
-func (f *fakeExecutorBackedNode) SetExecutor(executor ExecutorInterface) {}
-
 func (f *fakeExecutorBackedNode) GetOnSuccess() string {
 	return ""
 }

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -44,6 +44,8 @@ type NodeContext struct {
 	RuntimeData    map[string]string
 	ForwardedData  map[string]interface{}
 
+	Executor ExecutorInterface
+
 	Application       appmodel.Application
 	AuthenticatedUser authncm.AuthenticatedUser
 	ExecutionHistory  map[string]*common.NodeExecutionRecord

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -30,8 +30,6 @@ type ExecutorBackedNodeInterface interface {
 	NodeInterface
 	GetExecutorName() string
 	SetExecutorName(name string)
-	GetExecutor() ExecutorInterface
-	SetExecutor(executor ExecutorInterface)
 	GetInputs() []common.Input
 	SetInputs(inputs []common.Input)
 	GetOnSuccess() string
@@ -48,7 +46,6 @@ type ExecutorBackedNodeInterface interface {
 type taskExecutionNode struct {
 	*node
 	executorName string
-	executor     ExecutorInterface
 	mode         string
 	inputs       []common.Input
 	onSuccess    string
@@ -74,7 +71,6 @@ func newTaskExecutionNode(id string, properties map[string]interface{}, isStartN
 			previousNodeList: []string{},
 		},
 		executorName: "",
-		executor:     nil,
 		inputs:       []common.Input{},
 		logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TaskExecutionNode"),
 			log.String(log.LoggerKeyNodeID, id)),
@@ -86,7 +82,7 @@ func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *se
 	logger := log.GetLogger().With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
 	logger.Debug("Executing task execution node")
 
-	if n.executor == nil {
+	if ctx.Executor == nil {
 		logger.Error("No executor configured for the node")
 		return nil, &serviceerror.InternalServerError
 	}
@@ -176,7 +172,7 @@ func (n *taskExecutionNode) enrichRuntimeData(ctx *NodeContext) {
 // triggerExecutor triggers the executor configured for the node.
 func (n *taskExecutionNode) triggerExecutor(ctx *NodeContext, logger *log.Logger) (
 	*common.ExecutorResponse, *serviceerror.ServiceError) {
-	execResp, err := n.executor.Execute(ctx)
+	execResp, err := ctx.Executor.Execute(ctx)
 	if err != nil {
 		logger.Error("Error executing node executor", log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -249,19 +245,6 @@ func (n *taskExecutionNode) GetExecutorName() string {
 // SetExecutorName sets the executor name for the task execution node
 func (n *taskExecutionNode) SetExecutorName(name string) {
 	n.executorName = name
-}
-
-// GetExecutor returns the executor instance associated with the task execution node
-func (n *taskExecutionNode) GetExecutor() ExecutorInterface {
-	return n.executor
-}
-
-// SetExecutor sets the executor instance for the task execution node
-func (n *taskExecutionNode) SetExecutor(executor ExecutorInterface) {
-	n.executor = executor
-	if executor != nil {
-		n.executorName = executor.GetName()
-	}
 }
 
 // GetOnSuccess returns the onSuccess node ID

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -58,15 +58,9 @@ func (s *TaskExecutionNodeTestSuite) TestExecutorMethods() {
 	s.True(ok)
 
 	s.Empty(execNode.GetExecutorName())
-	s.Nil(execNode.GetExecutor())
 
 	execNode.SetExecutorName("test-executor")
 	s.Equal("test-executor", execNode.GetExecutorName())
-
-	s.mockExecutor.On("GetName").Return("mock-executor")
-	execNode.SetExecutor(s.mockExecutor)
-	s.NotNil(execNode.GetExecutor())
-	s.Equal("mock-executor", execNode.GetExecutorName())
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteNoExecutor() {
@@ -89,7 +83,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 		{
 			name: "Complete execution",
 			setupMock: func(m *ExecutorInterfaceMock) {
-				m.On("GetName").Return("test-executor").Once()
 				m.On("Execute", mock.Anything).Return(
 					&common.ExecutorResponse{
 						Status:         common.ExecComplete,
@@ -107,7 +100,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 		{
 			name: "User input required",
 			setupMock: func(m *ExecutorInterfaceMock) {
-				m.On("GetName").Return("test-executor").Once()
 				m.On("Execute", mock.Anything).Return(
 					&common.ExecutorResponse{
 						Status: common.ExecUserInputRequired,
@@ -121,7 +113,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 		{
 			name: "External redirection",
 			setupMock: func(m *ExecutorInterfaceMock) {
-				m.On("GetName").Return("test-executor").Once()
 				m.On("Execute", mock.Anything).Return(
 					&common.ExecutorResponse{
 						Status:      common.ExecExternalRedirection,
@@ -135,7 +126,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 		{
 			name: "Retry execution",
 			setupMock: func(m *ExecutorInterfaceMock) {
-				m.On("GetName").Return("test-executor").Once()
 				m.On("Execute", mock.Anything).Return(
 					&common.ExecutorResponse{Status: common.ExecRetry},
 					nil,
@@ -150,11 +140,9 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 		s.Run(tt.name, func() {
 			mockExec := NewExecutorInterfaceMock(s.T())
 			node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
-			execNode, _ := node.(ExecutorBackedNodeInterface)
 			tt.setupMock(mockExec)
-			execNode.SetExecutor(mockExec)
 
-			ctx := &NodeContext{FlowID: "test-flow"}
+			ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 			resp, err := node.Execute(ctx)
 
 			s.Nil(err)
@@ -166,17 +154,14 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteFailure() {
-	s.mockExecutor.On("GetName").Return("test-executor").Once()
 	s.mockExecutor.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{Status: common.ExecFailure, FailureReason: "AUTH_FAILED"},
 		nil,
 	).Once()
 
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
-	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: s.mockExecutor}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -186,7 +171,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailure() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureHandler() {
-	s.mockExecutor.On("GetName").Return("test-executor").Once()
 	s.mockExecutor.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{Status: common.ExecFailure, FailureReason: "AUTH_FAILED"},
 		nil,
@@ -195,9 +179,8 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureHandler() {
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	execNode, _ := node.(ExecutorBackedNodeInterface)
 	execNode.SetOnFailure("error-prompt")
-	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: s.mockExecutor}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -210,14 +193,11 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureHandler() {
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteExecutorError() {
-	s.mockExecutor.On("GetName").Return("test-executor").Once()
 	s.mockExecutor.On("Execute", mock.Anything).Return(nil, assert.AnError).Once()
 
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
-	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: s.mockExecutor}
 	resp, err := node.Execute(ctx)
 
 	s.NotNil(err)
@@ -226,13 +206,10 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteExecutorError() {
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteNilExecutorResponse() {
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
 
-	s.mockExecutor.On("GetName").Return("test-executor").Once()
 	s.mockExecutor.On("Execute", mock.Anything).Return(nil, nil).Once()
-	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: s.mockExecutor}
 	resp, err := node.Execute(ctx)
 
 	s.NotNil(err)
@@ -244,16 +221,12 @@ func (s *TaskExecutionNodeTestSuite) TestExecutePopulatedNodeProperties() {
 
 	props := map[string]interface{}{"k": "v"}
 	node := newTaskExecutionNode("task-props", props, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{Status: common.ExecComplete}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -321,16 +294,13 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteWithMode() {
 	execNode.SetMode("send")
 
 	var capturedCtx *NodeContext
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
 		capturedCtx = args.Get(0).(*NodeContext)
 	}).Return(
 		&common.ExecutorResponse{Status: common.ExecComplete}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -346,22 +316,19 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteEnrichesRuntimeData() {
 		"senderId": "sender-456",
 	}
 	node := newTaskExecutionNode("task-1", props, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
 
 	var capturedCtx *NodeContext
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
 		capturedCtx = args.Get(0).(*NodeContext)
 	}).Return(
 		&common.ExecutorResponse{Status: common.ExecComplete}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
 	ctx := &NodeContext{
 		FlowID:      "test-flow",
 		AppID:       "app-789",
 		RuntimeData: map[string]string{"existing": "value"},
+		Executor:    mockExec,
 	}
 	resp, err := node.Execute(ctx)
 
@@ -417,14 +384,10 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteWithOnSuccess() {
 	// Set onSuccess handler
 	execNode.SetOnSuccess("success-node")
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{Status: common.ExecComplete}, nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -436,19 +399,14 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteWithOnSuccess() {
 func (s *TaskExecutionNodeTestSuite) TestExecuteWithEmptyNodeProperties() {
 	mockExec := NewExecutorInterfaceMock(s.T())
 	node := newTaskExecutionNode("task-1", nil, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
 
 	var capturedCtx *NodeContext
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
 		capturedCtx = args.Get(0).(*NodeContext)
 	}).Return(
 		&common.ExecutorResponse{Status: common.ExecComplete}, nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -461,17 +419,12 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteWithEmptyNodeProperties() {
 func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithoutOnFailureHandler() {
 	mockExec := NewExecutorInterfaceMock(s.T())
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{Status: common.ExecFailure, FailureReason: "AUTH_FAILED"},
 		nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -484,16 +437,11 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithoutOnFailureHandler()
 func (s *TaskExecutionNodeTestSuite) TestExecuteCompleteWithoutOnSuccess() {
 	mockExec := NewExecutorInterfaceMock(s.T())
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
-	execNode, _ := node.(ExecutorBackedNodeInterface)
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{Status: common.ExecComplete}, nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -564,7 +512,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureStoresFailur
 
 	execNode.SetOnFailure("error-handler")
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status:        common.ExecFailure,
@@ -573,10 +520,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureStoresFailur
 		},
 		nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -595,7 +539,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureInitializesR
 
 	execNode.SetOnFailure("error-handler")
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status:        common.ExecFailure,
@@ -604,10 +547,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureInitializesR
 		},
 		nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -626,7 +566,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithEmptyFailureReasonAnd
 
 	execNode.SetOnFailure("error-handler")
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status:        common.ExecFailure,
@@ -634,10 +573,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithEmptyFailureReasonAnd
 		},
 		nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -660,7 +596,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureClearsNodeIn
 	execNode.SetOnFailure("prompt-email")
 	execNode.(*taskExecutionNode).inputs = inputs
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status:        common.ExecFailure,
@@ -668,10 +603,9 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureClearsNodeIn
 		}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		FlowID:   "test-flow",
+		Executor: mockExec,
 		UserInputs: map[string]string{
 			"email": "existing@example.com",
 		},
@@ -695,7 +629,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureNoNodeInputs
 	execNode.SetOnFailure("error-handler")
 	// No inputs configured on the node
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status:        common.ExecFailure,
@@ -703,10 +636,9 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureNoNodeInputs
 		}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		FlowID:   "test-flow",
+		Executor: mockExec,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
@@ -745,17 +677,13 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteHandle
 
 	execNode.SetOnIncomplete("prompt-credentials")
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status: common.ExecUserInputRequired,
 			Inputs: []common.Input{{Identifier: "username", Required: true}},
 		}, nil,
 	).Once()
-
-	execNode.SetExecutor(mockExec)
-
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{FlowID: "test-flow", Executor: mockExec}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -778,7 +706,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteAndFai
 	execNode.SetOnIncomplete("prompt-credentials")
 	execNode.(*taskExecutionNode).inputs = inputs
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status:        common.ExecUserInputRequired,
@@ -788,10 +715,9 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteAndFai
 		}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		FlowID:   "test-flow",
+		Executor: mockExec,
 		UserInputs: map[string]string{
 			"username": "testuser",
 			"password": "wrongpassword",
@@ -826,7 +752,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteAndFai
 	execNode.SetOnIncomplete("prompt-credentials")
 	execNode.(*taskExecutionNode).inputs = inputs
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status:        common.ExecUserInputRequired,
@@ -836,10 +761,9 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteAndFai
 		}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		FlowID:   "test-flow",
+		Executor: mockExec,
 		UserInputs: map[string]string{
 			"username": "nonexistent",
 		},
@@ -866,7 +790,6 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteNoFail
 		{Identifier: "username", Required: true},
 	}
 
-	mockExec.On("GetName").Return("test-executor").Once()
 	mockExec.On("Execute", mock.Anything).Return(
 		&common.ExecutorResponse{
 			Status: common.ExecUserInputRequired,
@@ -875,10 +798,9 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteNoFail
 		}, nil,
 	).Once()
 
-	execNode.SetExecutor(mockExec)
-
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		FlowID:   "test-flow",
+		Executor: mockExec,
 		UserInputs: map[string]string{
 			"username": "testuser",
 		},

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -127,10 +127,12 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 			continue
 		}
 
-		svcErr := fe.setNodeExecutor(currentNode, logger)
+		svcErr := fe.setNodeExecutor(ctx, currentNode, logger)
 		if svcErr != nil {
 			return flowStep, svcErr
 		}
+
+		nodeCtx.Executor = ctx.CurrentExecutor
 
 		executionStartTime := time.Now().UnixMilli()
 
@@ -233,8 +235,9 @@ func getNodeInputs(node core.NodeInterface) []common.Input {
 	return nil
 }
 
-// setNodeExecutor sets the executor for the given node if it is not already set.
-func (fe *flowEngine) setNodeExecutor(node core.NodeInterface, logger *log.Logger) *serviceerror.ServiceError {
+// setNodeExecutor resolves the executor for the given node and stores it in ctx.CurrentExecutor.
+func (fe *flowEngine) setNodeExecutor(ctx *EngineContext, node core.NodeInterface, logger *log.Logger) *serviceerror.ServiceError {
+	ctx.CurrentExecutor = nil
 	if node.GetType() != common.NodeTypeTaskExecution {
 		return nil
 	}
@@ -245,12 +248,7 @@ func (fe *flowEngine) setNodeExecutor(node core.NodeInterface, logger *log.Logge
 		return &serviceerror.InternalServerError
 	}
 
-	// Return if executor is already set
-	if executableNode.GetExecutor() != nil {
-		return nil
-	}
-
-	logger.Debug("Executor not set for the node. Constructing executor.", log.String("nodeID", node.GetID()))
+	logger.Debug("Resolving executor for node.", log.String("nodeID", node.GetID()))
 
 	executorName := executableNode.GetExecutorName()
 	if executorName == "" {
@@ -265,7 +263,7 @@ func (fe *flowEngine) setNodeExecutor(node core.NodeInterface, logger *log.Logge
 		return &serviceerror.InternalServerError
 	}
 
-	executableNode.SetExecutor(executor)
+	ctx.CurrentExecutor = executor
 	return nil
 }
 
@@ -295,8 +293,8 @@ func (fe *flowEngine) clearSensitiveInputs(ctx *EngineContext, node core.NodeInt
 	// fall back to the executor's default inputs.
 	inputs := execNode.GetInputs()
 	if len(inputs) == 0 {
-		if executor := execNode.GetExecutor(); executor != nil {
-			inputs = executor.GetDefaultInputs()
+		if ctx.CurrentExecutor != nil {
+			inputs = ctx.CurrentExecutor.GetDefaultInputs()
 		}
 	}
 
@@ -390,11 +388,10 @@ func (fe *flowEngine) shouldUpdateAuthenticatedUser(engineCtx *EngineContext) bo
 		return false
 	}
 
-	executableNode, ok := currentNode.(core.ExecutorBackedNodeInterface)
-	if !ok {
+	if _, ok := currentNode.(core.ExecutorBackedNodeInterface); !ok {
 		return false
 	}
-	executorInst := executableNode.GetExecutor()
+	executorInst := engineCtx.CurrentExecutor
 	if executorInst == nil {
 		return false
 	}
@@ -675,7 +672,7 @@ func recordNodeExecution(ctx *EngineContext, node core.NodeInterface, nodeResp *
 	// Create new record if it does not exist
 	if record == nil {
 		nextStep := len(ctx.ExecutionHistory) + 1
-		newRecord := createExecutionRecord(node, nextStep)
+		newRecord := createExecutionRecord(node, nextStep, ctx.CurrentExecutor)
 		ctx.ExecutionHistory[nodeID] = &newRecord
 		record = &newRecord
 	}
@@ -688,7 +685,7 @@ func recordNodeExecution(ctx *EngineContext, node core.NodeInterface, nodeResp *
 }
 
 // createExecutionRecord creates a new node execution record.
-func createExecutionRecord(node core.NodeInterface, step int) common.NodeExecutionRecord {
+func createExecutionRecord(node core.NodeInterface, step int, executorInst core.ExecutorInterface) common.NodeExecutionRecord {
 	record := common.NodeExecutionRecord{
 		NodeID:     node.GetID(),
 		NodeType:   string(node.GetType()),
@@ -700,12 +697,11 @@ func createExecutionRecord(node core.NodeInterface, step int) common.NodeExecuti
 
 	// Set executor details if applicable (only for executor-backed nodes)
 	if node.GetType() == common.NodeTypeTaskExecution {
+		if executorInst != nil {
+			record.ExecutorName = executorInst.GetName()
+			record.ExecutorType = executorInst.GetType()
+		}
 		if executableNode, ok := node.(core.ExecutorBackedNodeInterface); ok {
-			executor := executableNode.GetExecutor()
-			if executor != nil {
-				record.ExecutorName = executor.GetName()
-				record.ExecutorType = executor.GetType()
-			}
 			record.ExecutorMode = executableNode.GetMode()
 		}
 	}

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -445,15 +445,15 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_AuthenticatedUserUpd
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 	}
 
 	nodeResp := &common.NodeResponse{
@@ -481,15 +481,15 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_MergesUserAttributes
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			Attributes: map[string]interface{}{
 				"existingAttr": "existingValue",
@@ -525,15 +525,15 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_PreservesExistingUse
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		RuntimeData: map[string]string{
 			"userID": "existing-user-id",
 		},
@@ -563,15 +563,15 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_PreviousAttrsNilNewA
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			Attributes: map[string]interface{}{
 				"prevAttr": "prevValue",
@@ -637,7 +637,6 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_NonExecutorBackedNod
 func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_NilExecutor() {
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(nil)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
@@ -656,12 +655,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_AuthFlowWithAuthExec
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 	}
 
 	result := fe.shouldUpdateAuthenticatedUser(ctx)
@@ -677,12 +676,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_AuthFlowWithProvisio
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		RuntimeData: map[string]string{
 			common.RuntimeKeyUserEligibleForProvisioning: "true",
 		},
@@ -700,12 +699,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_AuthFlowWithNonAuthE
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 	}
 
 	result := fe.shouldUpdateAuthenticatedUser(ctx)
@@ -720,12 +719,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_RegistrationFlowWith
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeRegistration,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeRegistration,
 	}
 
 	result := fe.shouldUpdateAuthenticatedUser(ctx)
@@ -740,12 +739,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_RegistrationFlowSkip
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeRegistration,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeRegistration,
 		RuntimeData: map[string]string{
 			common.RuntimeKeySkipProvisioning: "true",
 		},
@@ -929,12 +928,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_UserOnboardingFlowWi
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeUserOnboarding,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeUserOnboarding,
 	}
 
 	result := fe.shouldUpdateAuthenticatedUser(ctx)
@@ -950,12 +949,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_UserOnboardingFlowWi
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeUserOnboarding,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeUserOnboarding,
 	}
 
 	result := fe.shouldUpdateAuthenticatedUser(ctx)
@@ -971,12 +970,12 @@ func (s *EngineTestSuite) TestShouldUpdateAuthenticatedUser_UserOnboardingFlowWi
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeUserOnboarding,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeUserOnboarding,
 	}
 
 	result := fe.shouldUpdateAuthenticatedUser(ctx)
@@ -990,7 +989,6 @@ func (s *EngineTestSuite) TestClearSensitiveInputs_AuthFlowRemovesPassword() {
 		{Identifier: "username", Type: "TEXT_INPUT", Required: true},
 		{Identifier: "password", Type: common.InputTypePassword, Required: true},
 	})
-	mockNode.On("GetExecutor").Return(nil).Maybe()
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
@@ -1013,7 +1011,6 @@ func (s *EngineTestSuite) TestClearSensitiveInputs_AuthFlowRemovesOTP() {
 	mockNode.On("GetInputs").Return([]common.Input{
 		{Identifier: "otp", Type: common.InputTypeOTP, Required: true},
 	})
-	mockNode.On("GetExecutor").Return(nil).Maybe()
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
@@ -1070,7 +1067,6 @@ func (s *EngineTestSuite) TestClearSensitiveInputs_NonSensitiveInputsRetained() 
 	mockNode.On("GetInputs").Return([]common.Input{
 		{Identifier: "username", Type: "TEXT_INPUT", Required: true},
 	})
-	mockNode.On("GetExecutor").Return(nil).Maybe()
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
@@ -1095,11 +1091,11 @@ func (s *EngineTestSuite) TestClearSensitiveInputs_NoNodeInputsUsesExecutorDefau
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 	mockNode.On("GetInputs").Return([]common.Input{})
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		FlowType: common.FlowTypeAuthentication,
+		FlowType:        common.FlowTypeAuthentication,
+		CurrentExecutor: mockExecutor,
 		UserInputs: map[string]string{
 			"username": "testuser",
 			"password": "secret123",
@@ -1144,7 +1140,6 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_RetainsTokenAndAvail
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
@@ -1168,8 +1163,9 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_RetainsTokenAndAvail
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     true,
 			UserID:              "user-123",
@@ -1221,7 +1217,6 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_UpdatesTokenAndAvail
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
@@ -1257,8 +1252,9 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_UpdatesTokenAndAvail
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     true,
 			UserID:              "user-123",
@@ -1300,15 +1296,15 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_EmptyPreviousTokenAn
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     false,
 			Token:               "", // No previous token
@@ -1346,7 +1342,6 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_TokenSetButAvailable
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
-	mockNode.On("GetExecutor").Return(mockExecutor)
 
 	fe := &flowEngine{
 		observabilitySvc: mockObservability,
@@ -1364,8 +1359,9 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_TokenSetButAvailable
 	}
 
 	ctx := &EngineContext{
-		CurrentNode: mockNode,
-		FlowType:    common.FlowTypeAuthentication,
+		CurrentNode:     mockNode,
+		CurrentExecutor: mockExecutor,
+		FlowType:        common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     true,
 			Token:               "old-token",

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -47,6 +47,7 @@ type EngineContext struct {
 	TraceID        string
 
 	CurrentNode         core.NodeInterface
+	CurrentExecutor     core.ExecutorInterface
 	CurrentNodeResponse *common.NodeResponse
 	CurrentAction       string
 


### PR DESCRIPTION
### Purpose
This pull request refactors how executors are managed and injected into task execution nodes in the flow core. The main change is to move executor management out of the node itself and into the `NodeContext`, simplifying the node interface and making executor injection more explicit and testable. The test suite and related interfaces have been updated accordingly.

Key changes include:

### Executor Management Refactor

* Removed the `executor` field and all related getter/setter methods (`GetExecutor`, `SetExecutor`) from `taskExecutionNode` and `ExecutorBackedNodeInterface`. The node now relies on the executor provided in the `NodeContext` during execution. [[1]](diffhunk://#diff-eaa97885453e311e7f4624a45c7eaa7103568b52c9c7f1d4d7098be4e85fcfccL33-L34) [[2]](diffhunk://#diff-eaa97885453e311e7f4624a45c7eaa7103568b52c9c7f1d4d7098be4e85fcfccL51) [[3]](diffhunk://#diff-eaa97885453e311e7f4624a45c7eaa7103568b52c9c7f1d4d7098be4e85fcfccL77) [[4]](diffhunk://#diff-eaa97885453e311e7f4624a45c7eaa7103568b52c9c7f1d4d7098be4e85fcfccL254-L266) [[5]](diffhunk://#diff-43ae4188edb4c3ec7055b711c637c53a65b020d6983670af00693852932c0e2bL453-L458)
* Updated `NodeContext` to include a new `Executor` field of type `ExecutorInterface`, which is now used during node execution.

### Task Execution Logic Updates

* Modified the execution logic in `taskExecutionNode.Execute` and `triggerExecutor` to use the executor from the context (`ctx.Executor`) instead of a node field. [[1]](diffhunk://#diff-eaa97885453e311e7f4624a45c7eaa7103568b52c9c7f1d4d7098be4e85fcfccL89-R85) [[2]](diffhunk://#diff-eaa97885453e311e7f4624a45c7eaa7103568b52c9c7f1d4d7098be4e85fcfccL179-R175)

### Test Suite Refactor

* Refactored all relevant tests in `task_execution_node_test.go` to inject the executor via the `NodeContext` instead of setting it on the node. Removed all usages of `SetExecutor`, `GetExecutor`, and related mock expectations. [[1]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L61-L69) [[2]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L92) [[3]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L110) [[4]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L124) [[5]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L138) [[6]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L153-R145) [[7]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L169-R164) [[8]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L189) [[9]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L198-R183) [[10]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L213-R200) [[11]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L229-R212) [[12]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L247-R229) [[13]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L324-R303) [[14]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L349-R331) [[15]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L420-R390) [[16]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L439-R409) [[17]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L464-R427) [[18]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L487-R444) [[19]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L567) [[20]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L576-R523) [[21]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L598) [[22]](diffhunk://#diff-e5ea5791ff1e908c16415a07125e72ce28da106962d72f550c593a0c58ab0756L607-R550)

These changes make executor injection more flexible and decouple executor lifecycle management from the node, improving testability and maintainability.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal executor provisioning mechanism to use runtime context instead of node-level storage, improving execution flow architecture.

* **Tests**
  * Updated test suites to reflect changes in executor availability handling.

---

**Note:** This release contains internal architectural improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->