### PR TITLE
Fix duplicate consent element across purposes

### DIFF
--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -454,6 +454,10 @@ func buildPurposePrompts(purposes []consent.ConsentPurpose, essentialAttributes,
 	consentedElements map[string]bool, userAttributeSet map[string]bool) []ConsentPurposePrompt {
 	// For each purpose, determine which required elements still need consent
 	var promptPurposes []ConsentPurposePrompt
+	// Track elements already assigned to a prior purpose so the same element is never emitted
+	// in more than one purpose. The consent service rejects requests with duplicate elements
+	// across purposes (CS-4002).
+	globalSeen := make(map[string]bool)
 	for _, purpose := range purposes {
 		essential := []string{}
 		optional := []string{}
@@ -475,12 +479,18 @@ func buildPurposePrompts(purposes []consent.ConsentPurpose, essentialAttributes,
 				continue
 			}
 
+			// Skip elements already claimed by a previous purpose
+			if globalSeen[elem.Name] {
+				continue
+			}
+
 			// Classify the element as essential or optional for prompting
 			if slices.Contains(essentialAttributes, elem.Name) {
 				essential = append(essential, elem.Name)
 			} else {
 				optional = append(optional, elem.Name)
 			}
+			globalSeen[elem.Name] = true
 		}
 
 		if len(essential) > 0 || len(optional) > 0 {

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -1134,6 +1134,97 @@ func (s *ConsentEnforcerServiceTestSuite) TestBuildPurposePrompts_NoMatchingElem
 	s.Empty(result)
 }
 
+func (s *ConsentEnforcerServiceTestSuite) TestBuildPurposePrompts_SameElementInMultiplePurposes() {
+	// Same attribute 'givenName' is configured under two different purposes.
+	// It must only appear in the first purpose that claims it.
+	purposes := []consent.ConsentPurpose{
+		{
+			ID:   "p1",
+			Name: "purpose1",
+			Elements: []consent.PurposeElement{
+				{Name: "givenName"},
+				{Name: "lastName"},
+			},
+		},
+		{
+			ID:   "p2",
+			Name: "purpose2",
+			Elements: []consent.PurposeElement{
+				{Name: "givenName"}, // duplicate — must be dropped
+				{Name: "email"},
+			},
+		},
+	}
+
+	result := buildPurposePrompts(purposes, nil, nil, map[string]bool{}, nil)
+
+	s.Len(result, 2)
+
+	// givenName must appear in exactly one purpose across the entire result
+	givenNameCount := 0
+	for _, p := range result {
+		for _, e := range append(p.Essential, p.Optional...) {
+			if e == "givenName" {
+				givenNameCount++
+			}
+		}
+	}
+	s.Equal(1, givenNameCount, "givenName must not appear in more than one purpose")
+
+	// purpose1 gets givenName (first-wins), purpose2 keeps only email
+	s.Equal("purpose1", result[0].PurposeName)
+	s.Contains(result[0].Optional, "givenName")
+	s.Equal("purpose2", result[1].PurposeName)
+	s.Contains(result[1].Optional, "email")
+	s.NotContains(result[1].Optional, "givenName")
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestBuildPurposePrompts_EmptyNamedPurposeWithDuplicateElement() {
+	// Mirrors the exact issue scenario: purpose "" and "Brown Tools Write" both declare
+	// givenName. The consent service (CS-4002) rejects payloads with duplicate elements
+	// across purposes, so givenName must only be emitted once.
+	purposes := []consent.ConsentPurpose{
+		{
+			ID:   "p1",
+			Name: "",
+			Elements: []consent.PurposeElement{
+				{Name: "givenName"},
+				{Name: "lastName"},
+			},
+		},
+		{
+			ID:   "p2",
+			Name: "Brown Tools Write",
+			Elements: []consent.PurposeElement{
+				{Name: "givenName"},     // duplicate — must be dropped
+				{Name: "mobileNumber"},
+			},
+		},
+	}
+
+	result := buildPurposePrompts(purposes, nil, nil, map[string]bool{}, nil)
+
+	s.Len(result, 2)
+
+	givenNameCount := 0
+	for _, p := range result {
+		for _, e := range append(p.Essential, p.Optional...) {
+			if e == "givenName" {
+				givenNameCount++
+			}
+		}
+	}
+	s.Equal(1, givenNameCount, "givenName must not appear in more than one purpose")
+
+	// Empty-named purpose is first, so it claims givenName
+	s.Equal("", result[0].PurposeName)
+	s.ElementsMatch([]string{"givenName", "lastName"}, result[0].Optional)
+
+	// "Brown Tools Write" must only contain mobileNumber
+	s.Equal("Brown Tools Write", result[1].PurposeName)
+	s.Equal([]string{"mobileNumber"}, result[1].Optional)
+}
+
 // mergeConsentPurposes tests
 
 func (s *ConsentEnforcerServiceTestSuite) TestMergeConsentPurposes_NoExisting() {


### PR DESCRIPTION
## Summary

- `buildPurposePrompts` in `backend/internal/authn/consent/service.go` was emitting the same attribute in every consent purpose it was configured under, producing a consent request payload with duplicate elements across purposes.
- The external consent service rejects such payloads with `CS-4002` ("duplicate element validation failed"), blocking users from completing login on apps where attributes are shared across multiple purposes.
- Fix: add a `globalSeen` map inside `buildPurposePrompts` so each attribute is claimed by at most one purpose (first-wins order, matching the purpose list returned by the consent service).

## Test plan

- [ ] All pre-existing `TestBuildPurposePrompts_*` tests still pass
- [ ] New `TestBuildPurposePrompts_SameElementInMultiplePurposes` — generic two-purpose duplicate case passes
- [ ] New `TestBuildPurposePrompts_EmptyNamedPurposeWithDuplicateElement` — exact issue scenario (purpose `""` + `"Brown Tools Write"` both declaring `givenName`) passes
- [ ] `go test ./internal/authn/consent/... -v` reports all green

Fixes #1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate attributes appearing multiple times in consent prompts, ensuring each attribute displays only once across all consent purposes.

* **Tests**
  * Added comprehensive test coverage for duplicate attribute handling in consent purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->