### PR TITLE
Add OU selection backend support for invited users

### DIFF
--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -27,7 +27,7 @@
             "executor": {
                 "name": "UserTypeResolver"
             },
-            "onSuccess": "prompt_email",
+            "onSuccess": "ou_selection",
             "onIncomplete": "prompt_usertype"
         },
         {
@@ -39,8 +39,13 @@
                         "align": "center",
                         "type": "TEXT",
                         "id": "heading_usertype",
-                        "label": "{{ t(signup:forms.user_type.title) }}",
+                        "label": "{{ t(onboarding:forms.user_type.title) }}",
                         "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "TEXT",
+                        "id": "subtitle_usertype",
+                        "label": "{{ t(onboarding:forms.user_type.subtitle) }}"
                     },
                     {
                         "type": "BLOCK",
@@ -50,15 +55,15 @@
                                 "type": "SELECT",
                                 "id": "usertype_input",
                                 "ref": "userType",
-                                "label": "{{ t(signup:forms.user_type.fields.user_type.label) }}",
-                                "placeholder": "{{ t(signup:forms.user_type.fields.user_type.placeholder) }}",
+                                "label": "{{ t(onboarding:forms.user_type.fields.user_type.label) }}",
+                                "placeholder": "{{ t(onboarding:forms.user_type.fields.user_type.placeholder) }}",
                                 "required": true,
                                 "options": []
                             },
                             {
                                 "type": "ACTION",
                                 "id": "action_usertype",
-                                "label": "{{ t(signup:forms.user_type.actions.continue.label) }}",
+                                "label": "{{ t(onboarding:forms.user_type.actions.continue.label) }}",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
                             }
@@ -79,6 +84,74 @@
                     "action": {
                         "ref": "action_usertype",
                         "nextNode": "user_type_resolver"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "ou_selection",
+            "type": "TASK_EXECUTION",
+            "properties": {
+                "resolveFrom": "prompt"
+            },
+            "executor": {
+                "name": "OUResolverExecutor"
+            },
+            "onSuccess": "prompt_email",
+            "onIncomplete": "prompt_ou_selection"
+        },
+        {
+            "id": "prompt_ou_selection",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "heading_ou_selection",
+                        "label": "{{ t(onboarding:forms.ou_selection.title) }}",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "type": "TEXT",
+                        "id": "subtitle_ou_selection",
+                        "label": "{{ t(onboarding:forms.ou_selection.subtitle) }}"
+                    },
+                    {
+                        "type": "BLOCK",
+                        "id": "block_ou_selection",
+                        "components": [
+                            {
+                                "type": "OU_SELECT",
+                                "id": "ou_selection_input",
+                                "ref": "ouId",
+                                "label": "{{ t(onboarding:forms.ou_selection.fields.ou.label) }}",
+                                "required": true
+                            },
+                            {
+                                "type": "ACTION",
+                                "id": "action_ou_selection",
+                                "label": "{{ t(onboarding:forms.ou_selection.actions.continue.label) }}",
+                                "variant": "PRIMARY",
+                                "eventType": "SUBMIT"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "prompts": [
+                {
+                    "inputs": [
+                        {
+                            "ref": "ou_selection_input",
+                            "identifier": "ouId",
+                            "type": "OU_SELECT",
+                            "required": true
+                        }
+                    ],
+                    "action": {
+                        "ref": "action_ou_selection",
+                        "nextNode": "ou_selection"
                     }
                 }
             ]

--- a/backend/cmd/server/bootstrap/i18n/en-US.json
+++ b/backend/cmd/server/bootstrap/i18n/en-US.json
@@ -18,7 +18,16 @@
       "forms.credential.title": "Set Password",
       "forms.credential.fields.password.label": "Password",
       "forms.credential.fields.password.placeholder": "Enter password",
-      "forms.credential.actions.submit.label": "Set Password"
+      "forms.credential.actions.submit.label": "Set Password",
+      "forms.user_type.title": "Select a user type",
+      "forms.user_type.subtitle": "Choose a user type (schema) for the new user.",
+      "forms.user_type.fields.user_type.label": "User Type",
+      "forms.user_type.fields.user_type.placeholder": "Select a user type",
+      "forms.user_type.actions.continue.label": "Continue",
+      "forms.ou_selection.title": "Select an organization unit",
+      "forms.ou_selection.subtitle": "Choose which organization unit this user should belong to.",
+      "forms.ou_selection.fields.ou.label": "Organization Unit",
+      "forms.ou_selection.actions.continue.label": "Continue"
     },
     "signin": {
       "images.app_logo.alt": "Application logo",

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -135,6 +135,8 @@ const (
 	DataInviteLink = "inviteLink"
 	// DataEmailSent is the key used to indicate that an email was sent successfully in the flow response.
 	DataEmailSent = "emailSent"
+	// DataRootOUID is the key used to pass the root OU ID to the frontend for the OU tree picker.
+	DataRootOUID = "rootOuId"
 )
 
 // DefaultHTTPTimeout defines the default timeout duration for HTTP requests.

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -94,7 +94,7 @@ func Initialize(
 		"", []common.Input{{Identifier: userAttributeUsername, Type: "string", Required: true}}, []common.Input{},
 		flowFactory, userProvider))
 	reg.RegisterExecutor(ExecutorNameConsent, newConsentExecutor(flowFactory, authRegistry.ConsentEnforcerService))
-	reg.RegisterExecutor(ExecutorNameOUResolver, newOUResolverExecutor(flowFactory))
+	reg.RegisterExecutor(ExecutorNameOUResolver, newOUResolverExecutor(flowFactory, ouService))
 	reg.RegisterExecutor(ExecutorNameAttributeUniquenessValidator, newAttributeUniquenessValidator(
 		flowFactory, userSchemaService, userProvider))
 

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -19,8 +19,12 @@
 package executor
 
 import (
+	"errors"
+
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/security"
 )
@@ -29,32 +33,51 @@ import (
 const (
 	// ouResolveFromCaller indicates that the caller's OU should be used when creating the user.
 	ouResolveFromCaller = "caller"
+	// ouResolveFromPrompt indicates that the user should be prompted to select an OU.
+	ouResolveFromPrompt = "prompt"
 )
 
 // ouResolverExecutor resolves the organization unit for a user being onboarded.
 type ouResolverExecutor struct {
 	core.ExecutorInterface
-	logger *log.Logger
+	ouService ou.OrganizationUnitServiceInterface
+	logger    *log.Logger
 }
 
 // newOUResolverExecutor creates a new OU resolver executor.
-func newOUResolverExecutor(flowFactory core.FlowFactoryInterface) *ouResolverExecutor {
+func newOUResolverExecutor(
+	flowFactory core.FlowFactoryInterface,
+	ouService ou.OrganizationUnitServiceInterface,
+) *ouResolverExecutor {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "OUResolverExecutor"))
+
+	defaultInputs := []common.Input{
+		{
+			Ref:        "ou_selection_input",
+			Identifier: ouIDKey,
+			Type:       "OU_SELECT",
+			Required:   true,
+		},
+	}
+
 	base := flowFactory.CreateExecutor(
 		ExecutorNameOUResolver,
 		common.ExecutorTypeUtility,
-		[]common.Input{},
+		defaultInputs,
 		[]common.Input{},
 	)
 	return &ouResolverExecutor{
 		ExecutorInterface: base,
+		ouService:         ouService,
 		logger:            logger,
 	}
 }
 
 // Execute resolves the organization unit for the user being onboarded.
 // It reads the "resolveFrom" node property to determine the OU resolution strategy.
-// When set to "caller", it overrides the default OU with the caller's OU from the security context.
+// Supported strategies:
+//   - "caller": overrides the default OU with the caller's OU from the security context.
+//   - "prompt": checks for child OUs and prompts the user to select one if applicable.
 func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
 
@@ -72,6 +95,8 @@ func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 	switch resolveFrom {
 	case ouResolveFromCaller:
 		return e.resolveFromCaller(ctx, execResp, logger)
+	case ouResolveFromPrompt:
+		return e.resolveFromPrompt(ctx, logger)
 	default:
 		logger.Error("Unsupported resolveFrom value", log.String("resolveFrom", resolveFrom))
 		execResp.Status = common.ExecFailure
@@ -93,6 +118,84 @@ func (e *ouResolverExecutor) resolveFromCaller(ctx *core.NodeContext,
 
 	logger.Debug("Overriding user OU with caller's OU", log.String("callerOUID", callerOUID))
 	execResp.RuntimeData[ouIDKey] = callerOUID
+
+	return execResp, nil
+}
+
+// resolveFromPrompt checks whether the user type's OU has child OUs and,
+// if so, prompts the admin to select one during the onboarding flow.
+func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
+	logger *log.Logger) (*common.ExecutorResponse, error) {
+	execResp := &common.ExecutorResponse{
+		RuntimeData:    make(map[string]string),
+		AdditionalData: make(map[string]string),
+		ForwardedData:  make(map[string]interface{}),
+	}
+
+	// Read the default OU set by UserTypeResolver.
+	// The "prompt" strategy requires UserTypeResolver to have run first and set the defaultOUID.
+	parentOUID := ctx.RuntimeData[defaultOUIDKey]
+	if parentOUID == "" {
+		return nil, errors.New(
+			"no defaultOUID in runtime data; UserTypeResolver must run before OUResolver with prompt strategy",
+		)
+	}
+
+	// If the user already provided an OU selection, validate and accept it.
+	if selectedOUID, ok := ctx.UserInputs[ouIDKey]; ok && selectedOUID != "" {
+		// Validate that the selected OU belongs to the parent OU's subtree.
+		isDescendant, svcErr := e.ouService.IsParent(ctx.Context, parentOUID, selectedOUID)
+		if svcErr != nil {
+			if svcErr.Type == serviceerror.ClientErrorType {
+				execResp.Status = common.ExecFailure
+				execResp.FailureReason = "The selected organization unit is not valid."
+				return execResp, nil
+			}
+
+			return nil, errors.New("failed to validate selected organization unit: " + svcErr.Error)
+		}
+		if !isDescendant {
+			logger.Debug("Selected OU is not a descendant of the parent OU",
+				log.String(ouIDKey, selectedOUID),
+				log.String("parentOUID", parentOUID))
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "The selected organization unit is not valid for the chosen user type."
+			return execResp, nil
+		}
+
+		logger.Debug("OU selected by user", log.String(ouIDKey, selectedOUID))
+		execResp.RuntimeData[ouIDKey] = selectedOUID
+		execResp.Status = common.ExecComplete
+		return execResp, nil
+	}
+
+	// Check if the parent OU has child OUs.
+	children, svcErr := e.ouService.GetOrganizationUnitChildren(ctx.Context, parentOUID, 1, 0)
+	if svcErr != nil {
+		return nil, errors.New("failed to check child organization units: " + svcErr.Error)
+	}
+
+	if children.TotalResults == 0 {
+		logger.Debug("No child OUs found, skipping OU selection")
+		execResp.Status = common.ExecComplete
+		return execResp, nil
+	}
+
+	// Child OUs exist — prompt the user to select one.
+	logger.Debug("Child OUs found, requesting OU selection",
+		log.String("parentOUID", parentOUID),
+		log.Int("totalChildren", children.TotalResults))
+
+	execResp.Status = common.ExecUserInputRequired
+
+	inputs := e.GetDefaultInputs()
+	if len(inputs) > 0 {
+		input := inputs[0]
+		execResp.Inputs = []common.Input{input}
+		// Forward the root OU ID so the frontend knows where to start the tree picker.
+		execResp.AdditionalData[common.DataRootOUID] = parentOUID
+		execResp.ForwardedData[common.ForwardedDataKeyInputs] = execResp.Inputs
+	}
 
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/ou_resolver_executor_test.go
+++ b/backend/internal/flow/executor/ou_resolver_executor_test.go
@@ -23,32 +23,52 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/security"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/oumock"
 )
+
+const testParentOUID = "parent-ou-123"
+const testChildOUID = "child-ou-456"
 
 type OUResolverExecutorTestSuite struct {
 	suite.Suite
 	mockFlowFactory *coremock.FlowFactoryInterfaceMock
+	mockOUService   *oumock.OrganizationUnitServiceInterfaceMock
 	executor        *ouResolverExecutor
 }
 
 func (suite *OUResolverExecutorTestSuite) SetupTest() {
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
-	mockBaseExecutor := coremock.NewExecutorInterfaceMock(suite.T())
+	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+
+	defaultInputs := []common.Input{
+		{
+			Ref:        "ou_selection_input",
+			Identifier: ouIDKey,
+			Type:       "OU_SELECT",
+			Required:   true,
+		},
+	}
 
 	suite.mockFlowFactory.On("CreateExecutor",
 		ExecutorNameOUResolver,
 		common.ExecutorTypeUtility,
-		[]common.Input{},
-		[]common.Input{}).Return(mockBaseExecutor)
+		defaultInputs,
+		[]common.Input{}).Return(
+		newMockExecutor("OUResolverExecutor", common.ExecutorTypeUtility, defaultInputs, []common.Input{}))
 
-	suite.executor = newOUResolverExecutor(suite.mockFlowFactory)
+	suite.executor = newOUResolverExecutor(suite.mockFlowFactory, suite.mockOUService)
 }
+
+// --- Caller strategy tests ---
 
 func (suite *OUResolverExecutorTestSuite) TestExecute_ResolveFromCaller_Success() {
 	callerOUID := "caller-ou-123"
@@ -218,6 +238,232 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_NilContext() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
 	assert.Equal(suite.T(), "Unable to determine caller organization unit", resp.FailureReason)
+}
+
+// --- Prompt strategy tests ---
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_NoDefaultOUID_ReturnsError() {
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{},
+		UserInputs:  map[string]string{},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "no defaultOUID in runtime data")
+	suite.mockOUService.AssertNotCalled(
+		suite.T(), "GetOrganizationUnitChildren", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_Valid() {
+	parentOUID := testParentOUID
+	selectedOUID := testChildOUID
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{
+			ouIDKey: selectedOUID,
+		},
+	}
+
+	suite.mockOUService.On("IsParent", mock.Anything, parentOUID, selectedOUID).
+		Return(true, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), selectedOUID, result.RuntimeData[ouIDKey])
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_NotInSubtree() {
+	parentOUID := testParentOUID
+	selectedOUID := "unrelated-ou-789"
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{
+			ouIDKey: selectedOUID,
+		},
+	}
+
+	suite.mockOUService.On("IsParent", mock.Anything, parentOUID, selectedOUID).
+		Return(false, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Contains(suite.T(), result.FailureReason, "not valid for the chosen user type")
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_ServerError() {
+	parentOUID := testParentOUID
+	selectedOUID := testChildOUID
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{
+			ouIDKey: selectedOUID,
+		},
+	}
+
+	svcErr := &serviceerror.ServiceError{
+		Type:  serviceerror.ServerErrorType,
+		Code:  "OU-50001",
+		Error: "internal error",
+	}
+	suite.mockOUService.On("IsParent", mock.Anything, parentOUID, selectedOUID).
+		Return(false, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to validate selected organization unit")
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_ClientError() {
+	parentOUID := testParentOUID
+	selectedOUID := testChildOUID
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{
+			ouIDKey: selectedOUID,
+		},
+	}
+
+	svcErr := &serviceerror.ServiceError{
+		Type:  serviceerror.ClientErrorType,
+		Code:  "OU-40001",
+		Error: "not found",
+	}
+	suite.mockOUService.On("IsParent", mock.Anything, parentOUID, selectedOUID).
+		Return(false, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Contains(suite.T(), result.FailureReason, "not valid")
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_NoChildOUs_Skips() {
+	parentOUID := testParentOUID
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{},
+	}
+
+	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0).
+		Return(&ou.OrganizationUnitListResponse{TotalResults: 0}, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_HasChildOUs_RequestsInput() {
+	parentOUID := testParentOUID
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{},
+	}
+
+	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0).
+		Return(&ou.OrganizationUnitListResponse{TotalResults: 3}, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
+	assert.Equal(suite.T(), parentOUID, result.AdditionalData[common.DataRootOUID])
+	assert.NotEmpty(suite.T(), result.Inputs)
+	assert.Equal(suite.T(), ouIDKey, result.Inputs[0].Identifier)
+	assert.Equal(suite.T(), "OU_SELECT", result.Inputs[0].Type)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_GetChildrenError_ReturnsError() {
+	parentOUID := testParentOUID
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{},
+	}
+
+	svcErr := &serviceerror.ServiceError{
+		Type:  serviceerror.ServerErrorType,
+		Code:  "OU-50001",
+		Error: "internal error",
+	}
+	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0).
+		Return((*ou.OrganizationUnitListResponse)(nil), svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to check child organization units")
+	suite.mockOUService.AssertExpectations(suite.T())
 }
 
 func TestOUResolverExecutorSuite(t *testing.T) {

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -339,20 +339,18 @@ func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 }
 
 // getOUID retrieves the organization unit ID from runtime data.
+// Priority: RuntimeData["ouId"] (set by OUResolverExecutor) > RuntimeData["defaultOUID"] (set by UserTypeResolver).
 func (p *provisioningExecutor) getOUID(ctx *core.NodeContext) string {
-	ouID := ""
-	// Check for ouId in runtime data
+	// Check for ouId in runtime data (e.g. from OUResolverExecutor).
 	if val, ok := ctx.RuntimeData[ouIDKey]; ok && val != "" {
-		ouID = val
+		return val
 	}
-	// If not found, check for defaultOUID in runtime data
-	if ouID == "" {
-		if val, ok := ctx.RuntimeData[defaultOUIDKey]; ok && val != "" {
-			ouID = val
-		}
+	// Fallback: check for defaultOUID in runtime data (set by UserTypeResolver).
+	if val, ok := ctx.RuntimeData[defaultOUIDKey]; ok && val != "" {
+		return val
 	}
 
-	return ouID
+	return ""
 }
 
 // getUserType retrieves the user type from runtime data.

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -864,25 +864,29 @@ func (suite *ProvisioningExecutorTestSuite) TestGetOUID() {
 	tests := []struct {
 		name        string
 		runtimeData map[string]string
+		userInputs  map[string]string
 		expected    string
 	}{
 		{
-			name: "FromOUIDKey",
+			name: "RuntimeOUIDTakesPriority",
 			runtimeData: map[string]string{
-				ouIDKey:        "ou-from-ouIDKey",
-				defaultOUIDKey: "ou-from-defaultOUIDKey",
+				ouIDKey:        "ou-from-resolver",
+				defaultOUIDKey: "ou-from-usertype",
 			},
-			expected: "ou-from-ouIDKey",
+			userInputs: map[string]string{
+				ouIDKey: "ou-from-userinput",
+			},
+			expected: "ou-from-resolver",
 		},
 		{
-			name: "FromDefaultOUIDKey",
+			name: "DefaultOUIDWhenNoExplicitOUID",
 			runtimeData: map[string]string{
-				defaultOUIDKey: "ou-from-defaultOUIDKey",
+				defaultOUIDKey: "ou-from-usertype",
 			},
-			expected: "ou-from-defaultOUIDKey",
+			expected: "ou-from-usertype",
 		},
 		{
-			name:        "NotFound",
+			name:        "ReturnsEmptyWhenNotFound",
 			runtimeData: map[string]string{},
 			expected:    "",
 		},
@@ -892,6 +896,7 @@ func (suite *ProvisioningExecutorTestSuite) TestGetOUID() {
 		suite.Run(tt.name, func() {
 			ctx := &core.NodeContext{
 				RuntimeData: tt.runtimeData,
+				UserInputs:  tt.userInputs,
 			}
 
 			ouID := suite.executor.getOUID(ctx)


### PR DESCRIPTION
### Purpose
This pull request enhances the user onboarding flow by introducing a new step for organization unit (OU) selection, ensuring that users are assigned to the appropriate OU based on their user type. It adds a dedicated executor for OU selection, updates the onboarding flow to include this step, and improves internationalization support. Comprehensive unit tests are also provided to ensure correct behavior.

**User Onboarding Flow Enhancements:**

* Added a new OU selection step (`ou_selection`) to the onboarding flow, which prompts the admin to select a child organization unit if applicable. The flow now routes to OU selection after user type resolution and before prompting for email. [[1]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL30-R30) [[2]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aR91-R155)
* Updated prompt labels and added subtitles for user type and OU selection steps to use new i18n keys under the `onboarding` namespace, improving clarity and consistency. [[1]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL42-R49) [[2]](diffhunk://#diff-d48c1c0511028fcc9028691ce60290e9db73d16ebb03236c2b8404c699cfaa3aL53-R66) [[3]](diffhunk://#diff-7b28e27d921d46bd17e2898aa2a855953fff0d6c5bb14788e0a3706dd7b2f7e4L21-R30)

**Executor Implementation:**

* Introduced a new `OUSelectionExecutor` (`ou_selection_executor.go`) that checks if the selected user type's OU has child OUs and, if so, prompts for selection. It validates the selected OU and handles various edge cases (e.g., no children, invalid selection).
* Registered the new executor in the system and added its constant definition. [[1]](diffhunk://#diff-82a5330129814e06de3d54d982ddd0ee9e70262be578aa6dcfbe0babfa628d4fR47) [[2]](diffhunk://#diff-0fea251d329deae0b6b8ddab73d999044a47de1d1fc219263dcb7b1125885e06R98)

**Provisioning Logic Improvements:**

* Updated the provisioning executor's `getOUID` method to prioritize OU selection: user input (`UserInputs["ouId"]`) takes precedence over runtime data, ensuring the explicitly selected OU is used.

**Testing:**

* Added a comprehensive test suite for `OUSelectionExecutor`, covering all major code paths and validation scenarios.
* Enhanced tests for the provisioning executor to verify the new OU selection priority logic. [[1]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R867) [[2]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R885-R902) [[3]](diffhunk://#diff-d84c0e159faf5eec6aae87e46f1dc53d59ea89c0847571ef75b6d5e9b3f49d88R914)

### Related Issues
- resolves https://github.com/asgardeo/thunder/issues/1947

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive organization-unit (OU) selection step before the email step, including OU picker input, default/root suggestion, and validation of selections.
  * Introduced an explicit user-type selection step with updated title, subtitle, and continue action.

* **Documentation**
  * Added English localization strings for the new user-type and OU selection onboarding steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->