### PR TITLE
Add Self Registration Invite Flow

### DIFF
--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_invite.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_invite.json
@@ -1,0 +1,350 @@
+{
+  "name": "Default Self-Invite Registration Flow",
+  "handle": "default-self-invite-flow",
+  "flowType": "REGISTRATION",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "START",
+      "onSuccess": "user_type_resolver"
+    },
+    {
+      "id": "user_type_resolver",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "UserTypeResolver"
+      },
+      "onSuccess": "prompt_email",
+      "onIncomplete": "prompt_usertype"
+    },
+    {
+      "id": "prompt_usertype",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "alt": "{{ t(signup:images.app_logo.alt) }}",
+            "category": "DISPLAY",
+            "height": "60",
+            "id": "image",
+            "resourceType": "ELEMENT",
+            "src": "{{ meta(application.logoUrl) }}",
+            "type": "IMAGE",
+            "width": ""
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "heading_usertype",
+            "label": "{{ t(signup:forms.user_type.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_usertype",
+            "components": [
+              {
+                "type": "SELECT",
+                "id": "usertype_input",
+                "ref": "userType",
+                "label": "{{ t(signup:forms.user_type.fields.user_type.label) }}",
+                "placeholder": "{{ t(signup:forms.user_type.fields.user_type.placeholder) }}",
+                "required": true,
+                "options": []
+              },
+              {
+                "type": "ACTION",
+                "id": "action_usertype",
+                "label": "{{ t(signup:forms.user_type.actions.continue.label) }}",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "usertype_input",
+              "identifier": "userType",
+              "type": "SELECT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_usertype",
+            "nextNode": "user_type_resolver"
+          }
+        }
+      ]
+    },
+    {
+      "id": "prompt_email",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "alt": "{{ t(signup:images.app_logo.alt) }}",
+            "category": "DISPLAY",
+            "height": "60",
+            "id": "image",
+            "resourceType": "ELEMENT",
+            "src": "{{ meta(application.logoUrl) }}",
+            "type": "IMAGE",
+            "width": ""
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "text_header_email",
+            "label": "{{ t(signup:forms.email.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_email",
+            "components": [
+              {
+                "id": "input_prompt_email",
+                "ref": "email",
+                "type": "EMAIL_INPUT",
+                "label": "{{ t(signup:forms.email.fields.email.label) }}",
+                "required": true,
+                "placeholder": "{{ t(signup:forms.email.fields.email.placeholder) }}"
+              },
+              {
+                "type": "ACTION",
+                "id": "action_submit_email",
+                "label": "{{ t(signup:forms.email.actions.next.label) }}",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "input_prompt_email",
+              "identifier": "email",
+              "type": "EMAIL_INPUT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_submit_email",
+            "nextNode": "check_email_uniqueness"
+          }
+        }
+      ]
+    },
+    {
+      "id": "check_email_uniqueness",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "AttributeUniquenessValidator"
+      },
+      "onSuccess": "invite_generate",
+      "onIncomplete": "prompt_email"
+    },
+    {
+      "id": "invite_generate",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "InviteExecutor",
+        "mode": "generate"
+      },
+      "onSuccess": "send_registration_email"
+    },
+    {
+      "id": "send_registration_email",
+      "type": "TASK_EXECUTION",
+      "properties": {
+        "emailTemplate": "SELF_REGISTRATION"
+      },
+      "executor": {
+        "name": "EmailExecutor",
+        "mode": "send"
+      },
+      "onSuccess": "invite_verify"
+    },
+    {
+      "id": "invite_verify",
+      "type": "TASK_EXECUTION",
+      "inputs": [
+        {
+          "ref": "input_003",
+          "identifier": "inviteToken",
+          "type": "HIDDEN",
+          "required": true
+        }
+      ],
+      "executor": {
+        "name": "InviteExecutor",
+        "mode": "verify"
+      },
+      "onSuccess": "prompt_user_details"
+    },
+    {
+      "id": "prompt_user_details",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "alt": "{{ t(signup:images.app_logo.alt) }}",
+            "category": "DISPLAY",
+            "height": "60",
+            "id": "image",
+            "resourceType": "ELEMENT",
+            "src": "{{ meta(application.logoUrl) }}",
+            "type": "IMAGE",
+            "width": ""
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "text_header_details",
+            "label": "{{ t(signup:forms.user_details.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_user_details",
+            "components": [
+              {
+                "id": "input_prompt_username",
+                "ref": "username",
+                "type": "TEXT_INPUT",
+                "label": "{{ t(signup:forms.user_details.fields.username.label) }}",
+                "required": true,
+                "placeholder": "{{ t(signup:forms.user_details.fields.username.placeholder) }}"
+              },
+              {
+                "id": "input_prompt_given_name",
+                "ref": "given_name",
+                "type": "TEXT_INPUT",
+                "label": "{{ t(signup:forms.user_details.fields.first_name.label) }}",
+                "required": false,
+                "placeholder": "{{ t(signup:forms.user_details.fields.first_name.placeholder) }}"
+              },
+              {
+                "id": "input_prompt_family_name",
+                "ref": "family_name",
+                "type": "TEXT_INPUT",
+                "label": "{{ t(signup:forms.user_details.fields.last_name.label) }}",
+                "required": false,
+                "placeholder": "{{ t(signup:forms.user_details.fields.last_name.placeholder) }}"
+              },
+              {
+                "id": "input_prompt_password",
+                "ref": "password",
+                "type": "PASSWORD_INPUT",
+                "label": "{{ t(signup:forms.credential.fields.password.label) }}",
+                "required": true,
+                "placeholder": "{{ t(signup:forms.credential.fields.password.placeholder) }}"
+              },
+              {
+                "type": "ACTION",
+                "id": "action_submit_details",
+                "label": "{{ t(signup:forms.credential.actions.submit.label) }}",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "input_prompt_username",
+              "identifier": "username",
+              "type": "TEXT_INPUT",
+              "required": true
+            },
+            {
+              "ref": "input_prompt_given_name",
+              "identifier": "given_name",
+              "type": "TEXT_INPUT",
+              "required": false
+            },
+            {
+              "ref": "input_prompt_family_name",
+              "identifier": "family_name",
+              "type": "TEXT_INPUT",
+              "required": false
+            },
+            {
+              "ref": "input_prompt_password",
+              "identifier": "password",
+              "type": "PASSWORD_INPUT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_submit_details",
+            "nextNode": "check_user_details_uniqueness"
+          }
+        }
+      ]
+    },
+    {
+      "id": "check_user_details_uniqueness",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "AttributeUniquenessValidator"
+      },
+      "onSuccess": "provisioning",
+      "onIncomplete": "prompt_user_details"
+    },
+    {
+      "id": "provisioning",
+      "type": "TASK_EXECUTION",
+      "inputs": [
+        {
+          "ref": "input_email",
+          "identifier": "email",
+          "type": "EMAIL_INPUT",
+          "required": true
+        },
+        {
+          "ref": "input_username",
+          "identifier": "username",
+          "type": "TEXT_INPUT",
+          "required": true
+        },
+        {
+          "ref": "input_password",
+          "identifier": "password",
+          "type": "PASSWORD_INPUT",
+          "required": true
+        },
+        {
+          "ref": "input_given_name",
+          "identifier": "given_name",
+          "type": "TEXT_INPUT",
+          "required": false
+        },
+        {
+          "ref": "input_family_name",
+          "identifier": "family_name",
+          "type": "TEXT_INPUT",
+          "required": false
+        }
+      ],
+      "executor": {
+        "name": "ProvisioningExecutor"
+      },
+      "onSuccess": "end"
+    },
+    {
+      "id": "end",
+      "type": "END"
+    }
+  ]
+}

--- a/backend/cmd/server/bootstrap/i18n/en-US.json
+++ b/backend/cmd/server/bootstrap/i18n/en-US.json
@@ -29,6 +29,20 @@
       "forms.ou_selection.fields.ou.label": "Organization Unit",
       "forms.ou_selection.actions.continue.label": "Continue"
     },
+    "invite": {
+      "validating": "Validating your invite link...",
+      "complete.title": "Welcome Aboard!",
+      "complete.description": "Your account has been successfully set up. You can now sign in.",
+      "complete.description.withApp": "Your account has been successfully set up for {{appName}}. You can now sign in.",
+      "complete.backToApp": "Back to Application",
+      "complete.backToApp.withApp": "Back to {{appName}}",
+      "errors.invalid.title": "Unable to verify invite",
+      "errors.invalid.description": "This invite link is invalid or has expired.",
+      "errors.failed.title": "Error",
+      "errors.failed.description": "An error occurred. Please try again.",
+      "goToSignIn": "Go to Sign In",
+      "signIn": "Sign In"
+    },
     "signin": {
       "images.app_logo.alt": "Application logo",
       "forms.credentials.title": "Sign In",
@@ -145,7 +159,23 @@
       "forms.collect_user_info.fields.username.placeholder": "Enter your username",
       "forms.collect_user_info.fields.email.label": "Email",
       "forms.collect_user_info.fields.email.placeholder": "Enter your email",
-      "forms.collect_user_info.actions.submit.label": "Sign Up"
+      "forms.collect_user_info.actions.submit.label": "Sign Up",
+      "forms.email.title": "Sign Up",
+      "forms.email.fields.email.label": "Email",
+      "forms.email.fields.email.placeholder": "Enter your email",
+      "forms.email.actions.next.label": "Next",
+      "forms.user_details.title": "Sign Up",
+      "forms.user_details.fields.username.label": "Username",
+      "forms.user_details.fields.username.placeholder": "Enter your username",
+      "forms.user_details.fields.first_name.label": "First Name",
+      "forms.user_details.fields.first_name.placeholder": "Enter your first name",
+      "forms.user_details.fields.last_name.label": "Last Name",
+      "forms.user_details.fields.last_name.placeholder": "Enter your last name",
+      "forms.user_details.actions.next.label": "Next",
+      "forms.credential.title": "Create Password",
+      "forms.credential.fields.password.label": "Password",
+      "forms.credential.fields.password.placeholder": "Enter your password",
+      "forms.credential.actions.submit.label": "Sign Up"
     }
   }
 }

--- a/backend/cmd/server/repository/resources/templates/registration_invite.yaml
+++ b/backend/cmd/server/repository/resources/templates/registration_invite.yaml
@@ -1,0 +1,20 @@
+id: "self-registration-invite"
+displayName: "Self Registration Invite Email"
+scenario: "SELF_REGISTRATION"
+type: "email"
+subject: "Complete Your Registration for {{ctx(appName)}}"
+contentType: "text/html"
+body: |
+  <!DOCTYPE html>
+  <html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+  	<h2>Complete Your Registration for {{ctx(appName)}}</h2>
+  	<p>You recently started the registration process for <strong>{{ctx(appName)}}</strong>. Click the link below to complete your account setup:</p>
+  	<p><a href="{{ctx(inviteLink)}}" style="display: inline-block; padding: 10px 20px;
+  		background-color: #ff7300; color: #fff; text-decoration: none;
+  		border-radius: 4px;">Complete Registration</a></p>
+  	<p>If the button above doesn't work, copy and paste the following link into your browser:</p>
+  	<p><a href="{{ctx(inviteLink)}}">{{ctx(inviteLink)}}</a></p>
+  	<p>If you did not initiate this request, you can safely ignore this email.</p>
+  </body>
+  </html>

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -77,7 +77,8 @@ const (
 	defaultOUIDKey = "defaultOUID"
 	userTypeKey    = "userType"
 
-	dataValueTrue = "true"
+	dataValueTrue  = "true"
+	dataValueFalse = "false"
 )
 
 // Executor property keys

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -19,7 +19,6 @@
 package executor
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -31,8 +30,7 @@ import (
 )
 
 // emailExecutor sends emails based on the configured email template and runtime context data.
-// When email is not configured (emailClient is nil), the executor completes as a no-op
-// without setting the emailSent flag, allowing the SDK to fall back to displaying the invite link.
+// When email is not configured (emailClient is nil), it completes as a no-op with emailSent=false.
 type emailExecutor struct {
 	core.ExecutorInterface
 	logger          *log.Logger
@@ -41,7 +39,7 @@ type emailExecutor struct {
 }
 
 // newEmailExecutor creates a new instance of the email executor.
-// emailClient may be nil if SMTP is not configured; the executor will act as a no-op in that case.
+// emailClient may be nil if SMTP is not configured; the executor completes as a no-op in that case.
 func newEmailExecutor(flowFactory core.FlowFactoryInterface, emailClient email.EmailClientInterface,
 	templateService template.TemplateServiceInterface) *emailExecutor {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "EmailExecutor"))
@@ -83,8 +81,8 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 	}
 
 	// If email client is not configured, complete as a no-op.
-	// The emailSent flag will NOT be set, so the SDK can fall back to showing the invite link.
 	if e.emailClient == nil {
+		execResp.AdditionalData[common.DataEmailSent] = dataValueFalse
 		logger.Debug("Email client not configured, skipping email send")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
@@ -120,15 +118,16 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 	}
 
 	inviteLink := ctx.RuntimeData[common.RuntimeKeyInviteLink]
-	if scenario == template.ScenarioUserInvite && inviteLink == "" {
+	if (scenario == template.ScenarioUserInvite || scenario == template.ScenarioSelfRegistration) && inviteLink == "" {
 		return nil, errors.New("invite link not found in runtime data")
 	}
 
 	templateData := template.TemplateData{
 		"inviteLink": inviteLink,
+		"appName":    ctx.Application.Name,
 	}
 
-	rendered, svcErr := e.templateService.Render(context.Background(), scenario, templateData)
+	rendered, svcErr := e.templateService.Render(ctx.Context, scenario, templateData)
 	if svcErr != nil {
 		return nil, fmt.Errorf("failed to render email template: %s", svcErr.Code)
 	}

--- a/backend/internal/flow/executor/email_executor_test.go
+++ b/backend/internal/flow/executor/email_executor_test.go
@@ -63,6 +63,7 @@ func (suite *EmailExecutorTestSuite) SetupTest() {
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Success() {
 	ctx := &core.NodeContext{
 		FlowID:       "test-flow-id",
+		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -80,6 +81,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Suc
 		template.ScenarioUserInvite,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
 		Subject: "You're Invited to Register",
@@ -103,6 +105,46 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Suc
 	suite.Contains(sentEmail.Body, "Complete Registration")
 }
 
+func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_InviteLinkNotExposed() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		FlowType:     common.FlowTypeRegistration,
+		ExecutorMode: ExecutorModeSend,
+		UserInputs: map[string]string{
+			"email": "user@example.com",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+		},
+		NodeProperties: map[string]interface{}{
+			"emailTemplate": "SELF_REGISTRATION",
+		},
+	}
+
+	suite.mockTemplateService.On("Render",
+		mock.Anything,
+		template.ScenarioSelfRegistration,
+		template.TemplateData{
+			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"appName":    "",
+		},
+	).Return(&template.RenderedTemplate{
+		Subject: "Complete Your Registration",
+		Body:    "<html><body>Click to register</body></html>",
+		IsHTML:  true,
+	}, nil)
+
+	suite.mockEmailClient.On("Send", mock.Anything).Return(nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	suite.NoError(err)
+	suite.Equal(common.ExecComplete, resp.Status)
+	suite.Equal(dataValueTrue, resp.AdditionalData[common.DataEmailSent])
+	// For SELF_REGISTRATION, invite link must NOT be exposed in AdditionalData
+	suite.Empty(resp.AdditionalData[common.DataInviteLink])
+}
+
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRuntimeRecipient() {
 	ctx := &core.NodeContext{
 		FlowID:       "test-flow-id",
@@ -124,6 +166,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRunti
 		template.ScenarioUserInvite,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
 		Subject: "You're Invited to Register",
@@ -162,6 +205,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData()
 		template.ScenarioUserInvite,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
 		Subject: "You're Invited to Register",
@@ -223,6 +267,28 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingInviteLink() {
 	suite.mockEmailClient.AssertNotCalled(suite.T(), "Send", mock.Anything)
 }
 
+func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_MissingInviteLink() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		FlowType:     common.FlowTypeRegistration,
+		ExecutorMode: ExecutorModeSend,
+		UserInputs: map[string]string{
+			"email": "user@example.com",
+		},
+		RuntimeData: make(map[string]string),
+		NodeProperties: map[string]interface{}{
+			"emailTemplate": "SELF_REGISTRATION",
+		},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	suite.Error(err)
+	suite.Nil(resp)
+	suite.Contains(err.Error(), "invite link not found")
+	suite.mockEmailClient.AssertNotCalled(suite.T(), "Send", mock.Anything)
+}
+
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplateProperty_DefaultsToUserInvite() {
 	ctx := &core.NodeContext{
 		FlowID:       "test-flow-id",
@@ -242,6 +308,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplatePropert
 		template.ScenarioUserInvite,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
 		Subject: "You're Invited to Register",
@@ -281,6 +348,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmptyTemplateString_De
 		template.ScenarioUserInvite,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
 		Subject: "You're Invited to Register",
@@ -470,6 +538,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_NoOp() 
 
 	ctx := &core.NodeContext{
 		FlowID:       "test-flow-id",
+		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -486,8 +555,33 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_NoOp() 
 
 	suite.NoError(err)
 	suite.Equal(common.ExecComplete, resp.Status)
-	// emailSent should NOT be set when email client is not configured
-	suite.Empty(resp.AdditionalData[common.DataEmailSent])
+	suite.Equal(dataValueFalse, resp.AdditionalData[common.DataEmailSent])
+}
+
+func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_SelfRegistration_InviteLinkNotExposed() {
+	noEmailExecutor := newEmailExecutor(suite.mockFlowFactory, nil, suite.mockTemplateService)
+
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		FlowType:     common.FlowTypeRegistration,
+		ExecutorMode: ExecutorModeSend,
+		UserInputs: map[string]string{
+			"email": "user@example.com",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+		},
+		NodeProperties: map[string]interface{}{
+			"emailTemplate": "SELF_REGISTRATION",
+		},
+	}
+
+	resp, err := noEmailExecutor.Execute(ctx)
+
+	suite.NoError(err)
+	suite.Equal(common.ExecComplete, resp.Status)
+	suite.Equal(dataValueFalse, resp.AdditionalData[common.DataEmailSent])
+	suite.Empty(resp.AdditionalData[common.DataInviteLink])
 }
 
 func (suite *EmailExecutorTestSuite) TestExecute_InvalidMode() {

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -20,9 +20,11 @@ package executor
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/utils"
@@ -89,7 +91,10 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 
 	execResp.RuntimeData[common.RuntimeKeyStoredInviteToken] = inviteToken
 	execResp.RuntimeData[common.RuntimeKeyInviteLink] = inviteLink
-	execResp.AdditionalData[common.DataInviteLink] = inviteLink
+
+	if ctx.FlowType == common.FlowTypeUserOnboarding {
+		execResp.AdditionalData[common.DataInviteLink] = inviteLink
+	}
 
 	execResp.Status = common.ExecComplete
 	return execResp, nil
@@ -151,6 +156,14 @@ func (e *inviteExecutor) generateInviteLink(ctx *core.NodeContext, inviteToken s
 		gateConfig.Hostname,
 		gateConfig.Port,
 		gateConfig.Path)
+	queryParams := url.Values{
+		"flowId":      []string{ctx.FlowID},
+		"inviteToken": []string{inviteToken},
+	}
 
-	return fmt.Sprintf("%s/invite?flowId=%s&inviteToken=%s", gateAppURL, ctx.FlowID, inviteToken)
+	if ctx.AppID != "" {
+		queryParams.Set(oauth2const.AppID, ctx.AppID)
+	}
+
+	return fmt.Sprintf("%s/invite?%s", gateAppURL, queryParams.Encode())
 }

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -75,6 +75,7 @@ func (suite *InviteExecutorTestSuite) TearDownTest() {
 func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode() {
 	ctx := &core.NodeContext{
 		FlowID:       "test-flow-id",
+		AppID:        "test-app-id",
 		ExecutorMode: ExecutorModeGenerate,
 		UserInputs:   make(map[string]string),
 		RuntimeData:  make(map[string]string),
@@ -85,11 +86,29 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
 	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyStoredInviteToken])
-	assert.Contains(suite.T(), resp.AdditionalData[common.DataInviteLink], "inviteToken=")
-	assert.Contains(suite.T(), resp.AdditionalData[common.DataInviteLink], "flowId=test-flow-id")
-	// Verify invite link is stored in runtime data for downstream executors
 	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink])
-	assert.Equal(suite.T(), resp.AdditionalData[common.DataInviteLink], resp.RuntimeData[common.RuntimeKeyInviteLink])
+	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "inviteToken=")
+	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "flowId=test-flow-id")
+	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "applicationId=test-app-id")
+	assert.Empty(suite.T(), resp.AdditionalData[common.DataInviteLink])
+}
+
+func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_UserOnboarding_ExposesInviteLink() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		AppID:        "test-app-id",
+		FlowType:     common.FlowTypeUserOnboarding,
+		ExecutorMode: ExecutorModeGenerate,
+		UserInputs:   make(map[string]string),
+		RuntimeData:  make(map[string]string),
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink])
+	assert.Equal(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], resp.AdditionalData[common.DataInviteLink])
 }
 
 func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_Idempotency() {
@@ -108,7 +127,8 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_Idempotency() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
 	assert.Equal(suite.T(), existingToken, resp.RuntimeData[common.RuntimeKeyStoredInviteToken])
-	assert.Contains(suite.T(), resp.AdditionalData[common.DataInviteLink], existingToken)
+	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], existingToken)
+	assert.Empty(suite.T(), resp.AdditionalData[common.DataInviteLink])
 }
 
 func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_NoTokenProvided() {

--- a/backend/internal/system/template/model.go
+++ b/backend/internal/system/template/model.go
@@ -27,11 +27,14 @@ type ScenarioType string
 const (
 	// ScenarioUserInvite represents the user invitation scenario.
 	ScenarioUserInvite ScenarioType = "USER_INVITE"
+	// ScenarioSelfRegistration represents the self-registration via invite link scenario.
+	ScenarioSelfRegistration ScenarioType = "SELF_REGISTRATION"
 )
 
 // supportedScenarios contains all valid scenario types.
 var supportedScenarios = map[ScenarioType]bool{
-	ScenarioUserInvite: true,
+	ScenarioUserInvite:       true,
+	ScenarioSelfRegistration: true,
 }
 
 // IsValidScenario checks if the given scenario type is supported.

--- a/backend/internal/system/template/service.go
+++ b/backend/internal/system/template/service.go
@@ -70,26 +70,28 @@ func (s *templateService) Render(
 		return nil, svcErr
 	}
 
-	body := ctxPlaceholderRegex.ReplaceAllStringFunc(tmpl.Body, func(match string) string {
-		// Extract the key from {{ctx(key)}}
-		submatches := ctxPlaceholderRegex.FindStringSubmatch(match)
-		if len(submatches) < 2 {
+	replacePlaceholders := func(s string) string {
+		return ctxPlaceholderRegex.ReplaceAllStringFunc(s, func(match string) string {
+			// Extract the key from {{ctx(key)}}
+			submatches := ctxPlaceholderRegex.FindStringSubmatch(match)
+			if len(submatches) < 2 {
+				return match
+			}
+			key := submatches[1]
+			if val, ok := data[key]; ok {
+				return val
+			}
 			return match
-		}
-		key := submatches[1]
-		if val, ok := data[key]; ok {
-			return val
-		}
-		return match
-	})
+		})
+	}
 
 	s.logger.Debug("Template rendered successfully",
 		log.String("scenario", string(scenario)),
 		log.String("templateID", tmpl.ID))
 
 	return &RenderedTemplate{
-		Subject: tmpl.Subject,
-		Body:    body,
+		Subject: replacePlaceholders(tmpl.Subject),
+		Body:    replacePlaceholders(tmpl.Body),
 		IsHTML:  tmpl.ContentType == "text/html",
 	}, nil
 }

--- a/backend/internal/system/template/service_test.go
+++ b/backend/internal/system/template/service_test.go
@@ -104,3 +104,38 @@ func (suite *TemplateServiceTestSuite) TestRender_UnknownPlaceholder() {
 	suite.Nil(err)
 	suite.Equal("Unknown: {{ctx(unknownKey)}}", res.Body)
 }
+
+func (suite *TemplateServiceTestSuite) TestRender_SubjectPlaceholderReplaced() {
+	dto := &TemplateDTO{
+		ID:          "1",
+		Scenario:    ScenarioSelfRegistration,
+		Subject:     "Complete your registration for {{ctx(appName)}}",
+		ContentType: "text/html",
+		Body:        "Click here: {{ctx(inviteLink)}}",
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioSelfRegistration).Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioSelfRegistration,
+		TemplateData{"appName": "My App", "inviteLink": "https://example.com/invite"})
+	suite.Nil(err)
+	suite.Equal("Complete your registration for My App", res.Subject)
+	suite.Equal("Click here: https://example.com/invite", res.Body)
+}
+
+func (suite *TemplateServiceTestSuite) TestRender_SelfRegistrationScenario() {
+	dto := &TemplateDTO{
+		ID:          "2",
+		Scenario:    ScenarioSelfRegistration,
+		Subject:     "You're invited",
+		ContentType: "text/plain",
+		Body:        "Register at {{ctx(inviteLink)}}",
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioSelfRegistration).Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioSelfRegistration,
+		TemplateData{"inviteLink": "https://example.com/invite"})
+	suite.Nil(err)
+	suite.Equal("You're invited", res.Subject)
+	suite.Equal("Register at https://example.com/invite", res.Body)
+	suite.False(res.IsHTML)
+}

--- a/frontend/apps/thunder-gate/src/components/AcceptInvite/AcceptInviteBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/AcceptInvite/AcceptInviteBox.tsx
@@ -24,20 +24,24 @@
 
 import type {JSX} from 'react';
 import {useState} from 'react';
-import {Box, Alert, Typography, AlertTitle, CircularProgress} from '@wso2/oxygen-ui';
+import {Box, Alert, Typography, AlertTitle, CircularProgress, Link} from '@wso2/oxygen-ui';
 import {AcceptInvite, useAsgardeo, type EmbeddedFlowComponent} from '@asgardeo/react';
 import {useNavigate} from 'react-router';
 import {useTranslation} from 'react-i18next';
 import {useConfig} from '@thunder/shared-contexts';
-import {FlowComponentRenderer, AuthCardLayout} from '@thunder/shared-design';
+import {useDesign, FlowComponentRenderer, AuthCardLayout} from '@thunder/shared-design';
 import ROUTES from '../../constants/routes';
 
 export default function AcceptInviteBox(): JSX.Element {
   const navigate = useNavigate();
-  const {resolveFlowTemplateLiterals} = useAsgardeo();
+  const {resolveFlowTemplateLiterals, meta} = useAsgardeo();
   const {t} = useTranslation();
   const {getServerUrl} = useConfig();
+  const {isDesignEnabled} = useDesign();
   const [flowError, setFlowError] = useState<string | null>(null);
+
+  const appName = (meta as {application?: {name?: string}} | undefined)?.application?.name ?? null;
+  const appUrl = (meta as {application?: {url?: string}} | undefined)?.application?.url ?? null;
 
   const baseUrl = getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string);
 
@@ -57,6 +61,8 @@ export default function AcceptInviteBox(): JSX.Element {
         },
         alt: {light: '', dark: ''},
       }}
+      showLogo={!isDesignEnabled}
+      logoDisplay={!isDesignEnabled ? {xs: 'flex', md: 'none'} : {display: 'none'}}
     >
       <AcceptInvite
         baseUrl={baseUrl}
@@ -107,8 +113,25 @@ export default function AcceptInviteBox(): JSX.Element {
             return (
               <Box sx={{textAlign: 'center', py: 2}}>
                 <Alert severity="success">
-                  {t('invite:complete.description', 'Your account has been successfully set up.')}
+                  {appName
+                    ? t(
+                        'invite:complete.description.withApp',
+                        'Your account has been successfully set up for {{appName}}. You can now sign in.',
+                        {appName},
+                      )
+                    : t(
+                        'invite:complete.description',
+                        'Your account has been successfully set up. You can now sign in.',
+                      )}
                 </Alert>
+                {appUrl && (
+                  <Link href={appUrl} sx={{display: 'inline-flex', alignItems: 'center', gap: 0.5, mt: 2}}>
+                    &#8592;{' '}
+                    {appName
+                      ? t('invite:complete.backToApp.withApp', 'Back to {{appName}}', {appName})
+                      : t('invite:complete.backToApp', 'Back to Application')}
+                  </Link>
+                )}
               </Box>
             );
           }

--- a/frontend/apps/thunder-gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
@@ -127,11 +127,16 @@ let mockAcceptInviteRenderProps: MockAcceptInviteRenderProps = createMockAcceptI
 // Track props passed to AcceptInvite
 let capturedOnGoToSignIn: (() => void) | undefined;
 let capturedOnError: ((error: Error) => void) | undefined;
+const mockUseAsgardeo = vi.fn().mockReturnValue({
+  resolveFlowTemplateLiterals: (template: string) => template,
+  meta: undefined,
+});
 
 vi.mock('@asgardeo/react', async () => {
   const actual = await vi.importActual('@asgardeo/react');
   return {
     ...actual,
+    useAsgardeo: () => mockUseAsgardeo() as {resolveFlowTemplateLiterals: (t: string) => string; meta: unknown},
     AcceptInvite: ({
       children,
       onGoToSignIn = undefined,
@@ -140,6 +145,7 @@ vi.mock('@asgardeo/react', async () => {
       children: (props: typeof mockAcceptInviteRenderProps) => React.ReactNode;
       onGoToSignIn?: () => void;
       onError?: (error: Error) => void;
+      onFlowChange?: (response: {failureReason?: string}) => void;
     }) => {
       capturedOnGoToSignIn = onGoToSignIn;
       capturedOnError = onError;
@@ -162,6 +168,10 @@ vi.mock('@asgardeo/react', async () => {
 describe('AcceptInviteBox', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseAsgardeo.mockReturnValue({
+      resolveFlowTemplateLiterals: (template: string) => template,
+      meta: undefined,
+    });
     mockUseDesign.mockReturnValue({
       isDesignEnabled: false,
     });
@@ -205,6 +215,83 @@ describe('AcceptInviteBox', () => {
     });
     render(<AcceptInviteBox />);
     expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+  });
+
+  it('renders without error when sdk has not produced a branch yet', () => {
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({
+      isLoading: false,
+      components: [],
+      error: null,
+      isValidatingToken: false,
+      isTokenInvalid: false,
+      isComplete: false,
+    });
+    render(<AcceptInviteBox />);
+    expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+  });
+
+  it('shows success message when invite flow completes', () => {
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({
+      isComplete: true,
+    });
+
+    render(<AcceptInviteBox />);
+
+    expect(screen.getByText(/Your account has been successfully set up\. You can now sign in\./)).toBeInTheDocument();
+  });
+
+  it('shows success message with app name when meta has application name', () => {
+    mockUseAsgardeo.mockReturnValue({
+      resolveFlowTemplateLiterals: (template: string) => template,
+      meta: {application: {name: 'My Test App'}},
+    });
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({isComplete: true});
+
+    render(<AcceptInviteBox />);
+
+    expect(
+      screen.getByText(/Your account has been successfully set up for My Test App\. You can now sign in\./),
+    ).toBeInTheDocument();
+  });
+
+  it('shows back to app link with app name when meta has application name and url', () => {
+    mockUseAsgardeo.mockReturnValue({
+      resolveFlowTemplateLiterals: (template: string) => template,
+      meta: {application: {name: 'My Test App', url: 'https://myapp.example.com'}},
+    });
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({isComplete: true});
+
+    render(<AcceptInviteBox />);
+
+    const link = screen.getByRole('link', {name: /Back to My Test App/});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://myapp.example.com');
+  });
+
+  it('shows generic back to application link when meta has url but no application name', () => {
+    mockUseAsgardeo.mockReturnValue({
+      resolveFlowTemplateLiterals: (template: string) => template,
+      meta: {application: {url: 'https://myapp.example.com'}},
+    });
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({isComplete: true});
+
+    render(<AcceptInviteBox />);
+
+    const link = screen.getByRole('link', {name: /Back to Application/});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://myapp.example.com');
+  });
+
+  it('does not show back to app link when meta has no application url', () => {
+    mockUseAsgardeo.mockReturnValue({
+      resolveFlowTemplateLiterals: (template: string) => template,
+      meta: {application: {name: 'My Test App'}},
+    });
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({isComplete: true});
+
+    render(<AcceptInviteBox />);
+
+    expect(screen.queryByRole('link', {name: /Back to/})).not.toBeInTheDocument();
   });
 
   it('shows error alert when error is present', () => {

--- a/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/SignUpBox.tsx
@@ -22,22 +22,96 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
 import type {JSX} from 'react';
+import {useState} from 'react';
 import {Box, Button, Alert, Typography, AlertTitle, CircularProgress} from '@wso2/oxygen-ui';
-import {SignUp, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {SignUp, useAsgardeo, type EmbeddedFlowComponent} from '@asgardeo/react';
 import {useNavigate, useSearchParams} from 'react-router';
 import {Trans, useTranslation} from 'react-i18next';
-import {useTemplateLiteralResolver} from '@thunder/shared-hooks';
-import {FlowComponentRenderer, AuthCardLayout} from '@thunder/shared-design';
+import {useDesign, FlowComponentRenderer, AuthCardLayout} from '@thunder/shared-design';
 import ROUTES from '../../constants/routes';
 
 export default function SignUpBox(): JSX.Element {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const {resolve} = useTemplateLiteralResolver();
+  const {resolveFlowTemplateLiterals: resolve} = useAsgardeo();
   const {t} = useTranslation();
+  const {isDesignEnabled} = useDesign();
+  const [emailSent, setEmailSent] = useState<boolean | null>(null);
+  const [flowError, setFlowError] = useState<string | null>(null);
 
   const currentParams = searchParams.toString();
   const signInUrl = currentParams ? `${ROUTES.AUTH.SIGN_IN}?${currentParams}` : ROUTES.AUTH.SIGN_IN;
+
+  const renderFlowContent = (
+    components: EmbeddedFlowComponent[],
+    error: any,
+    isLoading: boolean,
+    values: any,
+    touched: any,
+    fieldErrors: any,
+    handleInputChange: any,
+    handleSubmit: any,
+  ): JSX.Element | null => {
+    if (components.length > 0) {
+      return (
+        <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
+          {isLoading && (
+            <Typography sx={{textAlign: 'center'}}>
+              {t('signup:create_account.loading', 'Creating account...')}
+            </Typography>
+          )}
+          {components.map((component, index) => (
+            <FlowComponentRenderer
+              key={component.id ?? index}
+              component={component}
+              index={index}
+              values={values ?? {}}
+              touched={touched}
+              fieldErrors={fieldErrors}
+              isLoading={isLoading}
+              resolve={resolve}
+              onInputChange={handleInputChange}
+              onSubmit={(action, inputs) => {
+                setFlowError(null);
+                void handleSubmit(action, inputs);
+              }}
+            />
+          ))}
+        </Box>
+      );
+    }
+    if (emailSent === true) {
+      return (
+        <Alert severity="info" sx={{mb: 2}}>
+          <AlertTitle>{t('signup:email.sent.title', 'Check your email')}</AlertTitle>
+          {t(
+            'signup:email.sent.description',
+            'We sent you an invitation link. Please check your inbox and click the link to continue.',
+          )}
+        </Alert>
+      );
+    }
+    if (emailSent === false) {
+      return (
+        <Alert severity="warning" sx={{mb: 2}}>
+          <AlertTitle>{t('signup:email.not.sent.title', 'Email service unavailable')}</AlertTitle>
+          {t(
+            'signup:email.not.sent.description',
+            'Your registration was received but the verification email could not be sent. Please contact your administrator.',
+          )}
+        </Alert>
+      );
+    }
+    if (!error) {
+      return (
+        <Alert severity="error" sx={{mb: 2}}>
+          <AlertTitle>{t("Oops, that didn't work")}</AlertTitle>
+          {t("We're sorry, we ran into a problem. Please try again!")}
+        </Alert>
+      );
+    }
+    return null;
+  };
 
   return (
     <AuthCardLayout
@@ -49,8 +123,25 @@ export default function SignUpBox(): JSX.Element {
         },
         alt: {light: '', dark: ''},
       }}
+      showLogo={!isDesignEnabled}
+      logoDisplay={!isDesignEnabled ? {xs: 'flex', md: 'none'} : {display: 'none'}}
     >
-      <SignUp afterSignUpUrl={signInUrl}>
+      <SignUp
+        afterSignUpUrl={signInUrl}
+        onFlowChange={(response: any) => {
+          const emailSentValue = response?.data?.additionalData?.emailSent;
+          if (emailSentValue === 'true') {
+            setEmailSent(true);
+          } else if (emailSentValue === 'false') {
+            setEmailSent(false);
+          }
+          if (response?.failureReason) {
+            setFlowError(response.failureReason as string);
+          } else {
+            setFlowError(null);
+          }
+        }}
+      >
         {({values, fieldErrors, error, touched, handleInputChange, handleSubmit, isLoading, components}: any) => (
           <>
             {!components ? (
@@ -65,63 +156,51 @@ export default function SignUpBox(): JSX.Element {
                     {error.message ?? t('signup:errors.signup.failed.description')}
                   </Alert>
                 )}
-
-                {components && components.length > 0 ? (
-                  <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
-                    {isLoading && (
-                      <Typography sx={{textAlign: 'center'}}>{t('signup:creating', 'Creating account...')}</Typography>
-                    )}
-                    {(components as EmbeddedFlowComponent[]).map((component, index) => (
-                      <FlowComponentRenderer
-                        key={component.id ?? index}
-                        component={component}
-                        index={index}
-                        values={values ?? {}}
-                        touched={touched}
-                        fieldErrors={fieldErrors}
-                        isLoading={isLoading}
-                        resolve={resolve}
-                        onInputChange={handleInputChange}
-                        onSubmit={(action, inputs) => {
-                          void handleSubmit(action, inputs);
-                        }}
-                      />
-                    ))}
-                  </Box>
-                ) : (
+                {flowError && (
                   <Alert severity="error" sx={{mb: 2}}>
-                    <AlertTitle>{t("Oops, that didn't work")}</AlertTitle>
-                    {t("We're sorry, we ran into a problem. Please try again!")}
+                    {flowError}
                   </Alert>
+                )}
+
+                {renderFlowContent(
+                  components as EmbeddedFlowComponent[],
+                  error,
+                  isLoading as boolean,
+                  values,
+                  touched,
+                  fieldErrors,
+                  handleInputChange,
+                  handleSubmit,
                 )}
               </>
             )}
 
-            <Typography sx={{textAlign: 'center', mt: 3}}>
-              <Trans i18nKey="signup:redirect.to.signin">
-                Already have an account?
-                <Button
-                  variant="text"
-                  onClick={() => {
-                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    navigate(signInUrl);
-                  }}
-                  sx={{
-                    p: 0,
-                    minWidth: 'auto',
-                    textTransform: 'none',
-                    color: 'primary.main',
-                    textDecoration: 'underline',
-                    '&:hover': {
+            {emailSent !== true && (
+              <Typography sx={{textAlign: 'center', mt: 3}}>
+                <Trans i18nKey="signup:redirect.to.signin">
+                  Already have an account?
+                  <Button
+                    variant="text"
+                    onClick={() => {
+                      void navigate(signInUrl);
+                    }}
+                    sx={{
+                      p: 0,
+                      minWidth: 'auto',
+                      textTransform: 'none',
+                      color: 'primary.main',
                       textDecoration: 'underline',
-                      backgroundColor: 'transparent',
-                    },
-                  }}
-                >
-                  Sign in
-                </Button>
-              </Trans>
-            </Typography>
+                      '&:hover': {
+                        textDecoration: 'underline',
+                        backgroundColor: 'transparent',
+                      },
+                    }}
+                  >
+                    Sign in
+                  </Button>
+                </Trans>
+              </Typography>
+            )}
           </>
         )}
       </SignUp>

--- a/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import {act} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render as testRender, screen, fireEvent, waitFor} from '@thunder/test-utils';
 import userEvent from '@testing-library/user-event';
@@ -107,14 +108,22 @@ const createMockSignUpRenderProps = (overrides: Partial<MockSignUpRenderProps> =
 });
 
 let mockSignUpRenderProps: MockSignUpRenderProps = createMockSignUpRenderProps();
+let capturedOnFlowChange: ((response: unknown) => void) | undefined;
 
 vi.mock('@asgardeo/react', async () => {
   const actual = await vi.importActual('@asgardeo/react');
   return {
     ...actual,
-    SignUp: ({children}: {children: (props: typeof mockSignUpRenderProps) => React.ReactNode}) => (
-      <div data-testid="asgardeo-signup">{children(mockSignUpRenderProps)}</div>
-    ),
+    SignUp: ({
+      children,
+      onFlowChange = undefined,
+    }: {
+      children: (props: typeof mockSignUpRenderProps) => React.ReactNode;
+      onFlowChange?: (response: unknown) => void;
+    }) => {
+      capturedOnFlowChange = onFlowChange;
+      return <div data-testid="asgardeo-signup">{children(mockSignUpRenderProps)}</div>;
+    },
     EmbeddedFlowComponentType: {
       Text: 'TEXT',
       Block: 'BLOCK',
@@ -136,6 +145,7 @@ describe('SignUpBox', () => {
       isDesignEnabled: false,
     });
     mockSignUpRenderProps = createMockSignUpRenderProps();
+    capturedOnFlowChange = undefined;
   });
 
   it('renders without crashing', () => {
@@ -160,12 +170,120 @@ describe('SignUpBox', () => {
     expect(screen.getByText('Registration failed')).toBeInTheDocument();
   });
 
-  it('shows fallback error when no components available', () => {
+  it('shows fallback error when no components available and emailSent is unknown', () => {
     mockSignUpRenderProps = createMockSignUpRenderProps({
       components: [],
     });
     render(<SignUpBox />);
     expect(screen.getByText("Oops, that didn't work")).toBeInTheDocument();
+  });
+
+  it('shows check your email alert when onFlowChange reports emailSent true', () => {
+    mockSignUpRenderProps = createMockSignUpRenderProps({components: []});
+    render(<SignUpBox />);
+
+    act(() => {
+      capturedOnFlowChange?.({data: {additionalData: {emailSent: 'true'}}});
+    });
+
+    expect(screen.getByText('Check your email')).toBeInTheDocument();
+    expect(screen.queryByText("Oops, that didn't work")).not.toBeInTheDocument();
+  });
+
+  it('hides sign-in link when emailSent is true', () => {
+    mockSignUpRenderProps = createMockSignUpRenderProps({components: []});
+    render(<SignUpBox />);
+
+    expect(screen.getByText(/Already have an account/)).toBeInTheDocument();
+
+    act(() => {
+      capturedOnFlowChange?.({data: {additionalData: {emailSent: 'true'}}});
+    });
+
+    expect(screen.queryByText(/Already have an account/)).not.toBeInTheDocument();
+  });
+
+  it('shows email service unavailable warning when onFlowChange reports emailSent false', () => {
+    mockSignUpRenderProps = createMockSignUpRenderProps({components: []});
+    render(<SignUpBox />);
+
+    act(() => {
+      capturedOnFlowChange?.({data: {additionalData: {emailSent: 'false'}}});
+    });
+
+    expect(screen.getByText('Email service unavailable')).toBeInTheDocument();
+    expect(screen.queryByText("Oops, that didn't work")).not.toBeInTheDocument();
+  });
+
+  it('does not update emailSent state when onFlowChange has no emailSent field', () => {
+    mockSignUpRenderProps = createMockSignUpRenderProps({components: []});
+    render(<SignUpBox />);
+
+    act(() => {
+      capturedOnFlowChange?.({data: {additionalData: {otherField: 'value'}}});
+    });
+
+    expect(screen.getByText("Oops, that didn't work")).toBeInTheDocument();
+    expect(screen.queryByText('Check your email')).not.toBeInTheDocument();
+    expect(screen.queryByText('Email service unavailable')).not.toBeInTheDocument();
+  });
+
+  it('shows flowError alert when onFlowChange reports failureReason', () => {
+    mockSignUpRenderProps = createMockSignUpRenderProps({
+      components: [{id: 'block', type: 'BLOCK', components: []}],
+    });
+    render(<SignUpBox />);
+
+    act(() => {
+      capturedOnFlowChange?.({
+        failureReason: 'A user with this email already exists. Please use a different value.',
+        data: {additionalData: {}},
+      });
+    });
+
+    expect(
+      screen.getByText('A user with this email already exists. Please use a different value.'),
+    ).toBeInTheDocument();
+  });
+
+  it('clears flowError when submit is triggered', async () => {
+    mockSignUpRenderProps = createMockSignUpRenderProps({
+      components: [
+        {
+          id: 'block-1',
+          type: 'BLOCK',
+          components: [
+            {
+              id: 'submit-btn',
+              type: 'ACTION',
+              eventType: 'SUBMIT',
+              label: 'Register',
+              variant: 'PRIMARY',
+            },
+          ],
+        },
+      ],
+    });
+    render(<SignUpBox />);
+
+    act(() => {
+      capturedOnFlowChange?.({
+        failureReason: 'A user with this email already exists. Please use a different value.',
+        data: {additionalData: {}},
+      });
+    });
+
+    expect(
+      screen.getByText('A user with this email already exists. Please use a different value.'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Register'));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('A user with this email already exists. Please use a different value.'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('renders TEXT component as heading', () => {

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -1388,6 +1388,7 @@ const translations = {
   // Sign Up - Sign Up page translations
   // ============================================================================
   signup: {
+    'create_account.loading': 'Creating account...',
     'errors.signup.failed.message': 'Error',
     'errors.signup.failed.description': 'We are sorry, but we were unable to create your account. Please try again.',
     'redirect.to.signin': 'Already have an account? <1>Sign in</1>',
@@ -1398,21 +1399,6 @@ const translations = {
     'passkey.button.create': 'Create Passkey',
     'passkey.registering': 'Creating passkey...',
     'errors.passkey.failed': 'Failed to create passkey. Please try again.',
-  },
-
-  // ============================================================================
-  // Invite namespace - Invite acceptance feature translations (for Thunder Gate)
-  // ============================================================================
-  invite: {
-    validating: 'Validating your invite link...',
-    'complete.title': 'Welcome Aboard!',
-    'complete.description': 'Your account has been successfully set up.',
-    'errors.invalid.title': 'Unable to verify invite',
-    'errors.invalid.description': 'This invite link is invalid or has expired.',
-    'errors.failed.title': 'Error',
-    'errors.failed.description': 'An error occurred. Please try again.',
-    goToSignIn: 'Go to Sign In',
-    signIn: 'Sign In',
   },
 
   // ============================================================================


### PR DESCRIPTION
### Purpose

This PR introduces self-registration via an invite link flow, allowing users to sign up for an application by providing their email address, receiving a registration link, and completing their profile setup through that link.

Key improvements included alongside the new flow:

- **Invite link security**: The invite link is no longer leaked to the browser in self-registration flows. It is stored server-side only and delivered exclusively via email, preventing bypass of the email verification step.
- **Email sent signalling**: The `emailSent` flag (`"true"` / `"false"`) is now always present in the flow response `additionalData`, giving frontend clients a reliable way to detect whether an email was dispatched.
- **Application logo fix**: All flow JSON templates were using `logo_url` (snake_case) to resolve the application logo, but the flow metadata response uses `logoUrl` (camelCase). This mismatch caused the application logo to never render in login and registration prompts. Fixed across all affected flows.
- **Prompt meta always included**: Flow prompt node meta (UI component definitions) was previously only included in the response when verbose mode was enabled. Since meta contains required UI data, it is now always included when present.

---

### Approach

**New self-registration flow (`registeration_flow_basic_invite.json`)**

The flow follows this sequence:
1. Resolve user type → prompt for email → validate email uniqueness
2. Generate invite token + link (stored server-side only)
3. Send registration email via `EmailExecutor` (with `SELF_REGISTRATION` template)
4. Await invite token verification (user clicks the link from the email)
5. Prompt for user details → validate uniqueness → prompt for password → provision user

**Invite link handling**

`InviteExecutor` now stores the invite link only in `RuntimeData` (server-side). `EmailExecutor` is responsible for deciding when to expose it in `AdditionalData`:
- `USER_ONBOARDING` flows: invite link exposed in `AdditionalData` as fallback for admin UIs (allows inline display when SMTP is not configured)
- `REGISTRATION` (self-registration) flows: invite link never exposed in `AdditionalData` regardless of SMTP status

**Email not configured behaviour**

When SMTP is not configured, `EmailExecutor` always completes as a no-op (`ExecComplete`) with `emailSent: "false"` for all flow types. The self-registration flow relies on `emailSent: "true"` in the frontend to show the "check your email" state.

**Frontend**

- `SignUpBox`: added `emailSent` state — shows a "Check your email" alert when `emailSent === "true"` in `additionalData`
- `AcceptInviteBox`: personalises the completion message with the application name when available; removed the hardcoded "Go to Sign In" navigation button
- `ImageAdapter`: added null guard for unresolvable `src` and resolves `alt` text through the template literal resolver


### Related Issues
- https://github.com/asgardeo/thunder/issues/1923
 

---

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-service multi-step registration flow (email, user details, invite, password, provisioning).
  * Added personalized self-registration email invites with app name and a “Complete Registration” link.
  * Signup and invite UIs now show application name in completion messages when available.

* **Localization**
  * Added signup localization keys for email, user-details, and credential screens.

* **Bug Fixes**
  * Email-sent indicator now set explicitly; invite link exposure limited to onboarding flows.

* **Tests**
  * Expanded tests for templates, email sending, invite generation, and UI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->