### PR TITLE
Improve `Theme` Thumbnail in Thunder Design

### DIFF
--- a/api/design.yaml
+++ b/api/design.yaml
@@ -674,6 +674,18 @@ components:
           type: string
           description: Display name for the theme
           example: "Corporate Theme"
+        description:
+          type: string
+          description: Description of the theme
+          example: "A timeless theme with warm accents."
+        defaultColorScheme:
+          type: string
+          description: The name of the default color scheme for this theme (e.g. "light" or "dark")
+          example: "light"
+        primaryColor:
+          type: string
+          description: The primary color hex value from the default color scheme's palette
+          example: "#ff7300"
         createdAt:
           type: string
           format: date-time

--- a/backend/cmd/server/bootstrap/themes/acrylic-orange.json
+++ b/backend/cmd/server/bootstrap/themes/acrylic-orange.json
@@ -3,7 +3,7 @@
   "displayName": "Acrylic Orange",
   "description": "A vibrant theme with warm orange accents and translucent acrylic surfaces.",
   "theme": {
-    "defaultColorScheme": "light",
+    "defaultColorScheme": "dark",
     "direction": "ltr",
     "shape": {
       "borderRadius": 12

--- a/backend/cmd/server/bootstrap/themes/acrylic-purple.json
+++ b/backend/cmd/server/bootstrap/themes/acrylic-purple.json
@@ -3,7 +3,7 @@
   "displayName": "Acrylic Purple",
   "description": "A modern theme with bold purple accents and translucent acrylic surfaces.",
   "theme": {
-    "defaultColorScheme": "light",
+    "defaultColorScheme": "dark",
     "direction": "ltr",
     "shape": {
       "borderRadius": 12

--- a/backend/cmd/server/bootstrap/themes/high-contrast.json
+++ b/backend/cmd/server/bootstrap/themes/high-contrast.json
@@ -3,7 +3,7 @@
   "displayName": "High Contrast",
   "description": "A high contrast theme optimized for accessibility with bold colors and maximum readability.",
   "theme": {
-    "defaultColorScheme": "light",
+    "defaultColorScheme": "dark",
     "direction": "ltr",
     "shape": {"borderRadius": 4},
     "typography": {

--- a/backend/internal/design/theme/mgt/handler.go
+++ b/backend/internal/design/theme/mgt/handler.go
@@ -63,13 +63,16 @@ func (th *themeMgtHandler) HandleThemeListRequest(w http.ResponseWriter, r *http
 
 	themes := make([]ThemeListItem, 0, len(themeList.Themes))
 	for _, theme := range themeList.Themes {
+		defaultColorScheme, primaryColor := extractThemeColorInfo(theme.Theme)
 		themes = append(themes, ThemeListItem{
-			ID:          theme.ID,
-			Handle:      theme.Handle,
-			DisplayName: theme.DisplayName,
-			Description: theme.Description,
-			CreatedAt:   theme.CreatedAt,
-			UpdatedAt:   theme.UpdatedAt,
+			ID:                 theme.ID,
+			Handle:             theme.Handle,
+			DisplayName:        theme.DisplayName,
+			Description:        theme.Description,
+			DefaultColorScheme: defaultColorScheme,
+			PrimaryColor:       primaryColor,
+			CreatedAt:          theme.CreatedAt,
+			UpdatedAt:          theme.UpdatedAt,
 		})
 	}
 

--- a/backend/internal/design/theme/mgt/handler_test.go
+++ b/backend/internal/design/theme/mgt/handler_test.go
@@ -109,6 +109,84 @@ func (suite *ThemeHandlerTestSuite) TestHandleThemeListRequest_Success() {
 	assert.Len(suite.T(), response.Themes, 2)
 }
 
+// Test HandleThemeListRequest - color fields are populated from theme JSON
+func (suite *ThemeHandlerTestSuite) TestHandleThemeListRequest_ColorFieldsPopulated() {
+	themeList := &ThemeList{
+		TotalResults: 1,
+		StartIndex:   1,
+		Count:        1,
+		Themes: []Theme{
+			{
+				ID:          "theme-1",
+				DisplayName: "Theme 1",
+				Description: "Desc 1",
+				Theme: json.RawMessage(`{
+					"defaultColorScheme": "light",
+					"colorSchemes": {
+						"light": {"palette": {"primary": {"main": "#ff7300"}}}
+					}
+				}`),
+			},
+		},
+		Links: []Link{},
+	}
+
+	mockSvc := &mockThemeService{
+		getThemeListFunc: func(limit, offset int) (*ThemeList, *serviceerror.ServiceError) {
+			return themeList, nil
+		},
+	}
+
+	handler := newThemeMgtHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/design/themes", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleThemeListRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var response ThemeListResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), response.Themes, 1)
+	assert.Equal(suite.T(), "light", response.Themes[0].DefaultColorScheme)
+	assert.Equal(suite.T(), "#ff7300", response.Themes[0].PrimaryColor)
+}
+
+// Test HandleThemeListRequest - color fields are empty when theme JSON is absent
+func (suite *ThemeHandlerTestSuite) TestHandleThemeListRequest_EmptyColorFieldsWhenNoThemeJSON() {
+	themeList := &ThemeList{
+		TotalResults: 1,
+		StartIndex:   1,
+		Count:        1,
+		Themes: []Theme{
+			{ID: "theme-1", DisplayName: "Theme 1", Description: "Desc 1"},
+		},
+		Links: []Link{},
+	}
+
+	mockSvc := &mockThemeService{
+		getThemeListFunc: func(limit, offset int) (*ThemeList, *serviceerror.ServiceError) {
+			return themeList, nil
+		},
+	}
+
+	handler := newThemeMgtHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/design/themes", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleThemeListRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var response ThemeListResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), response.Themes, 1)
+	assert.Equal(suite.T(), "", response.Themes[0].DefaultColorScheme)
+	assert.Equal(suite.T(), "", response.Themes[0].PrimaryColor)
+}
+
 // Test HandleThemeListRequest - Invalid pagination
 func (suite *ThemeHandlerTestSuite) TestHandleThemeListRequest_InvalidLimit() {
 	handler := newThemeMgtHandler(&mockThemeService{})

--- a/backend/internal/design/theme/mgt/model.go
+++ b/backend/internal/design/theme/mgt/model.go
@@ -33,12 +33,47 @@ type Theme struct {
 
 // ThemeListItem represents a theme item in the list response.
 type ThemeListItem struct {
-	ID          string `json:"id"`
-	Handle      string `json:"handle"`
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
-	CreatedAt   string `json:"createdAt"`
-	UpdatedAt   string `json:"updatedAt"`
+	ID                 string `json:"id"`
+	Handle             string `json:"handle"`
+	DisplayName        string `json:"displayName"`
+	Description        string `json:"description"`
+	DefaultColorScheme string `json:"defaultColorScheme"`
+	PrimaryColor       string `json:"primaryColor"`
+	CreatedAt          string `json:"createdAt"`
+	UpdatedAt          string `json:"updatedAt"`
+}
+
+// themeColorSchemeInfo is a minimal struct for extracting color info from theme JSON.
+type themeColorSchemeInfo struct {
+	DefaultColorScheme string `json:"defaultColorScheme"`
+	ColorSchemes       map[string]struct {
+		Palette struct {
+			Primary struct {
+				Main string `json:"main"`
+			} `json:"primary"`
+		} `json:"palette"`
+	} `json:"colorSchemes"`
+}
+
+// extractThemeColorInfo extracts the defaultColorScheme and primaryColor from a raw theme JSON blob.
+// Returns empty strings on any parse or navigation failure so the list response degrades gracefully.
+func extractThemeColorInfo(themeJSON json.RawMessage) (defaultColorScheme, primaryColor string) {
+	if len(themeJSON) == 0 {
+		return "", ""
+	}
+	var info themeColorSchemeInfo
+	if err := json.Unmarshal(themeJSON, &info); err != nil {
+		return "", ""
+	}
+	defaultColorScheme = info.DefaultColorScheme
+	if defaultColorScheme == "" {
+		return "", ""
+	}
+	scheme, ok := info.ColorSchemes[defaultColorScheme]
+	if !ok {
+		return defaultColorScheme, ""
+	}
+	return defaultColorScheme, scheme.Palette.Primary.Main
 }
 
 // CreateThemeRequest represents the request body for creating a theme configuration.

--- a/backend/internal/design/theme/mgt/model_test.go
+++ b/backend/internal/design/theme/mgt/model_test.go
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thememgt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ThemeModelTestSuite struct {
+	suite.Suite
+}
+
+func TestThemeModelTestSuite(t *testing.T) {
+	suite.Run(t, new(ThemeModelTestSuite))
+}
+
+// Test extractThemeColorInfo - valid light scheme
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_ValidLight() {
+	themeJSON := json.RawMessage(`{
+		"defaultColorScheme": "light",
+		"colorSchemes": {
+			"light": {"palette": {"primary": {"main": "#ff7300"}}}
+		}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "light", scheme)
+	assert.Equal(suite.T(), "#ff7300", color)
+}
+
+// Test extractThemeColorInfo - valid dark scheme
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_ValidDark() {
+	themeJSON := json.RawMessage(`{
+		"defaultColorScheme": "dark",
+		"colorSchemes": {
+			"dark": {"palette": {"primary": {"main": "#bb86fc"}}}
+		}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "dark", scheme)
+	assert.Equal(suite.T(), "#bb86fc", color)
+}
+
+// Test extractThemeColorInfo - picks the defaultColorScheme when multiple schemes exist
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_MultipleSchemes() {
+	themeJSON := json.RawMessage(`{
+		"defaultColorScheme": "dark",
+		"colorSchemes": {
+			"light": {"palette": {"primary": {"main": "#ff7300"}}},
+			"dark":  {"palette": {"primary": {"main": "#bb86fc"}}}
+		}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "dark", scheme)
+	assert.Equal(suite.T(), "#bb86fc", color)
+}
+
+// Test extractThemeColorInfo - nil input
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_NilInput() {
+	scheme, color := extractThemeColorInfo(nil)
+
+	assert.Equal(suite.T(), "", scheme)
+	assert.Equal(suite.T(), "", color)
+}
+
+// Test extractThemeColorInfo - empty input
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_EmptyInput() {
+	scheme, color := extractThemeColorInfo(json.RawMessage{})
+
+	assert.Equal(suite.T(), "", scheme)
+	assert.Equal(suite.T(), "", color)
+}
+
+// Test extractThemeColorInfo - invalid JSON
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_InvalidJSON() {
+	scheme, color := extractThemeColorInfo(json.RawMessage(`{invalid json}`))
+
+	assert.Equal(suite.T(), "", scheme)
+	assert.Equal(suite.T(), "", color)
+}
+
+// Test extractThemeColorInfo - missing defaultColorScheme field
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_MissingDefaultColorScheme() {
+	themeJSON := json.RawMessage(`{
+		"colorSchemes": {
+			"light": {"palette": {"primary": {"main": "#ff7300"}}}
+		}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "", scheme)
+	assert.Equal(suite.T(), "", color)
+}
+
+// Test extractThemeColorInfo - defaultColorScheme references a scheme that doesn't exist
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_SchemeNotInColorSchemes() {
+	themeJSON := json.RawMessage(`{
+		"defaultColorScheme": "ocean",
+		"colorSchemes": {
+			"light": {"palette": {"primary": {"main": "#ff7300"}}}
+		}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "ocean", scheme)
+	assert.Equal(suite.T(), "", color)
+}
+
+// Test extractThemeColorInfo - primary.main is empty string
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_EmptyPrimaryMain() {
+	themeJSON := json.RawMessage(`{
+		"defaultColorScheme": "light",
+		"colorSchemes": {
+			"light": {"palette": {"primary": {"main": ""}}}
+		}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "light", scheme)
+	assert.Equal(suite.T(), "", color)
+}
+
+// Test extractThemeColorInfo - colorSchemes is empty object
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_EmptyColorSchemes() {
+	themeJSON := json.RawMessage(`{
+		"defaultColorScheme": "light",
+		"colorSchemes": {}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "light", scheme)
+	assert.Equal(suite.T(), "", color)
+}
+
+// Test extractThemeColorInfo - extra fields in JSON are ignored
+func (suite *ThemeModelTestSuite) TestExtractThemeColorInfo_ExtraFieldsIgnored() {
+	themeJSON := json.RawMessage(`{
+		"defaultColorScheme": "light",
+		"direction": "ltr",
+		"shape": {"borderRadius": 4},
+		"colorSchemes": {
+			"light": {
+				"palette": {
+					"primary": {"main": "#ff7300", "light": "#ffa040", "dark": "#b35000"},
+					"secondary": {"main": "#9c27b0"},
+					"background": {"default": "#f5f5f5", "paper": "#ffffff"}
+				}
+			}
+		}
+	}`)
+
+	scheme, color := extractThemeColorInfo(themeJSON)
+
+	assert.Equal(suite.T(), "light", scheme)
+	assert.Equal(suite.T(), "#ff7300", color)
+}

--- a/backend/internal/design/theme/mgt/store.go
+++ b/backend/internal/design/theme/mgt/store.go
@@ -305,11 +305,22 @@ func (s *themeMgtStore) buildThemeListItemFromResultRow(row map[string]interface
 		return Theme{}, fmt.Errorf("failed to extract updated_at: %w", err)
 	}
 
+	var themeJSON json.RawMessage
+	if themeInterface, ok := row["theme"]; ok {
+		switch v := themeInterface.(type) {
+		case string:
+			themeJSON = json.RawMessage(v)
+		case []byte:
+			themeJSON = json.RawMessage(v)
+		}
+	}
+
 	return Theme{
 		ID:          id,
 		Handle:      handle,
 		DisplayName: displayName,
 		Description: description,
+		Theme:       themeJSON,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 	}, nil

--- a/backend/internal/design/theme/mgt/store_constants.go
+++ b/backend/internal/design/theme/mgt/store_constants.go
@@ -38,7 +38,7 @@ var (
 	// queryGetThemeList retrieves a list of theme configurations with pagination.
 	queryGetThemeList = dbmodel.DBQuery{
 		ID: "THQ-THEME_MGT-03",
-		Query: "SELECT ID, HANDLE, DISPLAY_NAME, DESCRIPTION, CREATED_AT, UPDATED_AT FROM THEME " +
+		Query: "SELECT ID, HANDLE, DISPLAY_NAME, DESCRIPTION, THEME, CREATED_AT, UPDATED_AT FROM THEME " +
 			"WHERE DEPLOYMENT_ID = $3 ORDER BY CREATED_AT DESC LIMIT $1 OFFSET $2",
 	}
 

--- a/backend/internal/design/theme/mgt/store_test.go
+++ b/backend/internal/design/theme/mgt/store_test.go
@@ -95,16 +95,20 @@ func (suite *ThemeStoreTestSuite) TestGetThemeList_Success() {
 			"handle":       "theme-one",
 			"display_name": "Theme 1",
 			"description":  "Description 1",
-			"created_at":   "2024-01-15T10:30:00Z",
-			"updated_at":   "2024-01-15T10:30:00Z",
+			"theme": `{"defaultColorScheme":"light",` +
+				`"colorSchemes":{"light":{"palette":{"primary":{"main":"#ff7300"}}}}}`,
+			"created_at": "2024-01-15T10:30:00Z",
+			"updated_at": "2024-01-15T10:30:00Z",
 		},
 		{
 			"id":           "theme-2",
 			"handle":       "theme-two",
 			"display_name": "Theme 2",
 			"description":  "Description 2",
-			"created_at":   "2024-01-15T10:30:00Z",
-			"updated_at":   "2024-01-15T10:30:00Z",
+			"theme": `{"defaultColorScheme":"dark",` +
+				`"colorSchemes":{"dark":{"palette":{"primary":{"main":"#bb86fc"}}}}}`,
+			"created_at": "2024-01-15T10:30:00Z",
+			"updated_at": "2024-01-15T10:30:00Z",
 		},
 	}
 	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
@@ -116,6 +120,7 @@ func (suite *ThemeStoreTestSuite) TestGetThemeList_Success() {
 	assert.Len(suite.T(), themes, 2)
 	assert.Equal(suite.T(), "theme-1", themes[0].ID)
 	assert.Equal(suite.T(), "Theme 1", themes[0].DisplayName)
+	assert.NotNil(suite.T(), themes[0].Theme)
 }
 
 // Test GetThemeList - DB client error
@@ -352,6 +357,74 @@ func (suite *ThemeStoreTestSuite) TestBuildThemeListItemFromResultRow_MissingDes
 
 	_, err := suite.store.buildThemeListItemFromResultRow(row)
 	assert.Error(suite.T(), err)
+}
+
+func (suite *ThemeStoreTestSuite) TestBuildThemeListItemFromResultRow_WithThemeString() {
+	row := map[string]interface{}{
+		"id":           "theme-1",
+		"handle":       "classic",
+		"display_name": "Test Theme",
+		"description":  "A description",
+		"theme": `{"defaultColorScheme":"light",` +
+			`"colorSchemes":{"light":{"palette":{"primary":{"main":"#ff7300"}}}}}`,
+		"created_at": "2024-01-15T10:30:00Z",
+		"updated_at": "2024-01-15T10:30:00Z",
+	}
+
+	theme, err := suite.store.buildThemeListItemFromResultRow(row)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), theme.Theme)
+}
+
+func (suite *ThemeStoreTestSuite) TestBuildThemeListItemFromResultRow_WithThemeBytes() {
+	row := map[string]interface{}{
+		"id":           "theme-1",
+		"handle":       "classic",
+		"display_name": "Test Theme",
+		"description":  "A description",
+		"theme":        []byte(`{"defaultColorScheme":"light"}`),
+		"created_at":   "2024-01-15T10:30:00Z",
+		"updated_at":   "2024-01-15T10:30:00Z",
+	}
+
+	theme, err := suite.store.buildThemeListItemFromResultRow(row)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), theme.Theme)
+}
+
+func (suite *ThemeStoreTestSuite) TestBuildThemeListItemFromResultRow_WithoutThemeColumn() {
+	row := map[string]interface{}{
+		"id":           "theme-1",
+		"handle":       "classic",
+		"display_name": "Test Theme",
+		"description":  "A description",
+		"created_at":   "2024-01-15T10:30:00Z",
+		"updated_at":   "2024-01-15T10:30:00Z",
+	}
+
+	theme, err := suite.store.buildThemeListItemFromResultRow(row)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), theme.Theme)
+}
+
+func (suite *ThemeStoreTestSuite) TestBuildThemeListItemFromResultRow_NullThemeColumn() {
+	row := map[string]interface{}{
+		"id":           "theme-1",
+		"handle":       "classic",
+		"display_name": "Test Theme",
+		"description":  "A description",
+		"theme":        nil,
+		"created_at":   "2024-01-15T10:30:00Z",
+		"updated_at":   "2024-01-15T10:30:00Z",
+	}
+
+	theme, err := suite.store.buildThemeListItemFromResultRow(row)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), theme.Theme)
 }
 
 // Test buildThemeFromResultRow helper

--- a/frontend/apps/thunder-console/src/features/design/components/themes/ThemeThumbnail.tsx
+++ b/frontend/apps/thunder-console/src/features/design/components/themes/ThemeThumbnail.tsx
@@ -17,7 +17,7 @@
  */
 
 import type {ThemeListItem} from '@thunder/shared-design';
-import {Box, useColorScheme} from '@wso2/oxygen-ui';
+import {Box} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 
 export interface ThemeThumbnailProps {
@@ -25,13 +25,12 @@ export interface ThemeThumbnailProps {
 }
 
 /**
- * Derives multiple independent values from a name string using two separate
- * hash functions (djb2 + LCG) so that similar names still produce visually
- * distinct results.
+ * Derives a deterministic primary color from a name string when no real
+ * primaryColor is available from the API.
  */
-function hashName(name: string): {h1: number; h2: number} {
-  let h1 = 5381; // djb2 seed
-  let h2 = 1779033703; // FNV-like seed
+function primaryFromName(name: string): string {
+  let h1 = 5381;
+  let h2 = 1779033703;
   for (let i = 0; i < name.length; i += 1) {
     const c = name.charCodeAt(i);
     // eslint-disable-next-line no-bitwise
@@ -39,229 +38,105 @@ function hashName(name: string): {h1: number; h2: number} {
     // eslint-disable-next-line no-bitwise
     h2 = Math.imul(h2 ^ c, 0x9e3779b9) >>> 0;
   }
-  return {h1, h2};
-}
-
-/** Fallback palette derived from a name hash when no real theme data is available. */
-function paletteFromName(name: string, dark: boolean) {
-  const {h1, h2} = hashName(name);
-
   const hue = h1 % 360;
   // eslint-disable-next-line no-bitwise
   const sat = 52 + ((h1 >> 4) % 20);
   // eslint-disable-next-line no-bitwise
   const lig = 40 + ((h2 >> 12) % 12);
-
-  if (dark) {
-    return {
-      primary: `hsl(${hue}, ${sat}%, ${lig + 10}%)`,
-      primaryLight: `hsl(${hue}, ${sat}%, ${lig + 30}%)`,
-      bg: `hsl(${hue}, ${Math.round(sat * 0.15)}%, 12%)`,
-      paper: `hsl(${hue}, ${Math.round(sat * 0.12)}%, 18%)`,
-      text: `hsl(${hue}, 10%, 92%)`,
-      textFaint: `hsl(${hue}, 8%, 55%)`,
-      inputBorder: `hsl(${hue}, ${Math.round(sat * 0.15)}%, 30%)`,
-      divider: `hsl(${hue}, ${Math.round(sat * 0.1)}%, 24%)`,
-    };
-  }
-
-  return {
-    primary: `hsl(${hue}, ${sat}%, ${lig}%)`,
-    primaryLight: `hsl(${hue}, ${sat}%, ${lig + 42}%)`,
-    bg: `hsl(${hue}, ${Math.round(sat * 0.22)}%, 93%)`,
-    paper: `hsl(${hue}, ${Math.round(sat * 0.08)}%, 99%)`,
-    text: `hsl(${hue}, 15%, 18%)`,
-    textFaint: `hsl(${hue}, 10%, 48%)`,
-    inputBorder: `hsl(${hue}, ${Math.round(sat * 0.22)}%, 80%)`,
-    divider: `hsl(${hue}, ${Math.round(sat * 0.15)}%, 86%)`,
-  };
-}
-
-/** Builds a palette from the theme's actual color scheme data. */
-function paletteFromTheme(item: ThemeListItem, colorMode: 'light' | 'dark') {
-  const colorSchemes = item.theme?.colorSchemes;
-  const colors = colorSchemes?.[colorMode]?.palette;
-  if (!colors) return paletteFromName(item.displayName ?? '', colorMode === 'dark');
-
-  const isDark = colorMode === 'dark';
-
-  return {
-    primary: colors.primary?.main ?? (isDark ? '#90caf9' : '#1976d2'),
-    primaryLight: colors.primary?.light ?? (isDark ? '#bbdefb' : '#42a5f5'),
-    bg: colors.background?.default ?? (isDark ? '#121212' : '#f5f5f5'),
-    paper: colors.background?.paper ?? (isDark ? '#1e1e1e' : '#ffffff'),
-    text: colors.text?.primary ?? (isDark ? '#ffffffde' : '#000000de'),
-    textFaint: colors.text?.secondary ?? (isDark ? '#ffffff99' : '#00000099'),
-    inputBorder: colors.divider ?? (isDark ? '#ffffff1f' : '#0000001f'),
-    divider: colors.divider ?? (isDark ? '#ffffff1f' : '#0000001f'),
-  };
-}
-
-/** Returns up to 2 uppercase initials from a display name. */
-function initials(name: string): string {
-  const words = name.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) return '?';
-  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
-  return (words[0][0] + words[1][0]).toUpperCase();
+  return `hsl(${hue}, ${sat}%, ${lig}%)`;
 }
 
 export default function ThemeThumbnail({theme}: ThemeThumbnailProps): JSX.Element {
-  const {mode, systemMode} = useColorScheme();
-  const colorMode: 'light' | 'dark' = (mode === 'system' ? systemMode : mode) === 'dark' ? 'dark' : 'light';
+  const isDark = theme.defaultColorScheme === 'dark';
+  const primary = theme.primaryColor ?? primaryFromName(theme.displayName ?? '');
 
-  const p = paletteFromTheme(theme, colorMode);
-  const abbr = initials(theme.displayName ?? '');
-
-  const radius = (() => {
-    const r = theme.theme?.shape?.borderRadius;
-    if (typeof r === 'number') return r;
-    if (typeof r === 'string') return parseInt(r, 10) || 8;
-    return 8;
-  })();
-  const rCard = Math.min(Math.max(radius * 0.6, 4), 10);
-  const rBtn = Math.min(Math.max(radius * 0.5, 3), 8);
-  const rInput = Math.min(Math.max(radius * 0.4, 2), 6);
+  const bg = isDark ? '#1e1e1e' : '#f0ede8';
+  const surface = isDark ? '#2a2a2a' : '#ffffff';
+  const line = isDark ? 'rgba(255,255,255,0.14)' : 'rgba(0,0,0,0.10)';
+  const lineShort = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+  const divider = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)';
 
   return (
     <Box
       sx={{
         width: '100%',
         height: '100%',
-        bgcolor: p.bg,
+        bgcolor: bg,
+        borderRadius: 'inherit',
+        overflow: 'hidden',
+        p: 1.75,
         display: 'flex',
         flexDirection: 'column',
-        overflow: 'hidden',
+        gap: 1.25,
+        boxSizing: 'border-box',
       }}
     >
-      <Box sx={{flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+      {/* Header: avatar + title lines */}
+      <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
         <Box
           sx={{
-            bgcolor: p.paper,
-            borderRadius: `${rCard}px`,
-            overflow: 'hidden',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            width: '60%',
-            px: 1.5,
-            py: 1.5,
-            gap: 0.6,
+            width: 18,
+            height: 18,
+            borderRadius: '50%',
+            bgcolor: primary,
+            flexShrink: 0,
           }}
-        >
-          {/* Logo avatar */}
+        />
+        <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.55, flex: 1}}>
+          <Box sx={{height: 4, width: '55%', bgcolor: line, borderRadius: 0.5}} />
+          <Box sx={{height: 3, width: '35%', bgcolor: lineShort, borderRadius: 0.5}} />
+        </Box>
+      </Box>
+
+      {/* Divider */}
+      <Box sx={{height: '1px', bgcolor: divider, mx: -1.75}} />
+
+      {/* Content lines */}
+      <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.65, flex: 1}}>
+        <Box sx={{height: 4, width: '80%', bgcolor: line, borderRadius: 0.5}} />
+        <Box sx={{height: 4, width: '65%', bgcolor: lineShort, borderRadius: 0.5}} />
+        <Box sx={{height: 4, width: '72%', bgcolor: lineShort, borderRadius: 0.5, opacity: 0.7}} />
+      </Box>
+
+      {/* Bottom: surface card with overlapping primary circles */}
+      <Box
+        sx={{
+          bgcolor: surface,
+          borderRadius: 1.5,
+          px: 1.25,
+          py: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        {/* Mini text lines inside the card */}
+        <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.5}}>
+          <Box sx={{height: 3, width: 32, bgcolor: line, borderRadius: 0.5}} />
+          <Box sx={{height: 3, width: 22, bgcolor: lineShort, borderRadius: 0.5}} />
+        </Box>
+
+        {/* Two overlapping primary-color circles */}
+        <Box sx={{display: 'flex', alignItems: 'center', flexShrink: 0}}>
           <Box
             sx={{
-              width: 20,
-              height: 20,
+              width: 22,
+              height: 22,
               borderRadius: '50%',
-              bgcolor: p.primary,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              mb: 0.25,
-              flexShrink: 0,
+              bgcolor: primary,
+              opacity: 0.65,
+              zIndex: 1,
             }}
-          >
-            <Box
-              sx={{
-                color: '#fff',
-                fontSize: '7px',
-                fontWeight: 700,
-                lineHeight: 1,
-                fontFamily: 'sans-serif',
-                letterSpacing: '-0.3px',
-              }}
-            >
-              {abbr}
-            </Box>
-          </Box>
-
-          {/* Input 1 — with inner label line */}
+          />
           <Box
             sx={{
-              width: '100%',
-              height: 9,
-              border: `1px solid ${p.inputBorder}`,
-              borderRadius: `${rInput}px`,
-              bgcolor: p.bg,
-              px: 0.75,
-              display: 'flex',
-              alignItems: 'center',
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              bgcolor: primary,
+              ml: '-9px',
+              zIndex: 2,
             }}
-          >
-            <Box sx={{height: 3, width: '45%', bgcolor: p.textFaint, borderRadius: 0.5, opacity: 0.6}} />
-          </Box>
-
-          {/* Input 2 */}
-          <Box
-            sx={{
-              width: '100%',
-              height: 9,
-              border: `1px solid ${p.inputBorder}`,
-              borderRadius: `${rInput}px`,
-              bgcolor: p.bg,
-              px: 0.75,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.5,
-            }}
-          >
-            <Box sx={{height: 3, width: '40%', bgcolor: p.textFaint, borderRadius: 0.5, opacity: 0.6}} />
-            {/* Lock icon dots */}
-            <Box sx={{display: 'flex', gap: 0.3, ml: 'auto'}}>
-              {[0, 1, 2, 3].map((i) => (
-                <Box key={i} sx={{width: 2, height: 2, borderRadius: '50%', bgcolor: p.textFaint, opacity: 0.5}} />
-              ))}
-            </Box>
-          </Box>
-
-          {/* Primary button — flat, no gradient */}
-          <Box
-            sx={{
-              width: '100%',
-              height: 9,
-              bgcolor: p.primary,
-              borderRadius: `${rBtn}px`,
-              mt: 0.25,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Box sx={{height: 3, width: '35%', bgcolor: '#fff', borderRadius: 0.5, opacity: 0.9}} />
-          </Box>
-
-          {/* Divider */}
-          <Box sx={{width: '100%', display: 'flex', alignItems: 'center', gap: 0.5, my: 0.1}}>
-            <Box sx={{flex: 1, height: '1px', bgcolor: p.divider}} />
-            <Box sx={{height: 3, width: 8, bgcolor: p.textFaint, borderRadius: 0.5, opacity: 0.4}} />
-            <Box sx={{flex: 1, height: '1px', bgcolor: p.divider}} />
-          </Box>
-
-          {/* Social login placeholders */}
-          <Box sx={{display: 'flex', gap: 0.75, justifyContent: 'center'}}>
-            {[0, 1, 2].map((i) => (
-              <Box
-                key={i}
-                sx={{
-                  width: 14,
-                  height: 9,
-                  border: `1px solid ${p.inputBorder}`,
-                  borderRadius: `${rInput}px`,
-                  bgcolor: p.paper,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Box sx={{width: 5, height: 5, borderRadius: '50%', bgcolor: p.primaryLight}} />
-              </Box>
-            ))}
-          </Box>
-
-          {/* Link */}
-          <Box
-            sx={{height: 3, width: '52%', bgcolor: p.primary, borderRadius: 0.5, opacity: 0.55, mx: 'auto', mt: 0.1}}
           />
         </Box>
       </Box>

--- a/frontend/apps/thunder-console/src/features/design/components/themes/__tests__/ThemeThumbnail.test.tsx
+++ b/frontend/apps/thunder-console/src/features/design/components/themes/__tests__/ThemeThumbnail.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {ThemeListItem} from '@thunder/shared-design';
+import {render} from '@thunder/test-utils';
+import {describe, it, expect} from 'vitest';
+import ThemeThumbnail from '../ThemeThumbnail';
+
+const baseTheme: ThemeListItem = {
+  id: 'theme-1',
+  handle: 'classic',
+  displayName: 'Classic',
+};
+
+describe('ThemeThumbnail', () => {
+  describe('Rendering without crashing', () => {
+    it('renders a light theme with primaryColor', () => {
+      const {container} = render(
+        <ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'light', primaryColor: '#ff7300'}} />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('renders a dark theme with primaryColor', () => {
+      const {container} = render(
+        <ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'dark', primaryColor: '#bb86fc'}} />,
+      );
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('renders when primaryColor is absent (uses name-based fallback)', () => {
+      const {container} = render(<ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'light'}} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('renders when defaultColorScheme is absent (defaults to light palette)', () => {
+      const {container} = render(<ThemeThumbnail theme={{...baseTheme, primaryColor: '#ff7300'}} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('renders with only the required id, handle, and displayName props', () => {
+      const {container} = render(<ThemeThumbnail theme={baseTheme} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('renders without crashing for an empty displayName', () => {
+      const {container} = render(<ThemeThumbnail theme={{...baseTheme, displayName: ''}} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe('Distinct rendering per color scheme', () => {
+    it('renders different DOM for light vs dark', () => {
+      const {container: light} = render(
+        <ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'light', primaryColor: '#ff7300'}} />,
+      );
+      const {container: dark} = render(
+        <ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'dark', primaryColor: '#ff7300'}} />,
+      );
+      expect(light.innerHTML).not.toBe(dark.innerHTML);
+    });
+
+    it('renders different DOM for different primary colors', () => {
+      const {container: orange} = render(
+        <ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'light', primaryColor: '#ff7300'}} />,
+      );
+      const {container: blue} = render(
+        <ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'light', primaryColor: '#007bff'}} />,
+      );
+      expect(orange.innerHTML).not.toBe(blue.innerHTML);
+    });
+  });
+
+  describe('Fallback color generation', () => {
+    it('generates consistent output for the same displayName across renders', () => {
+      const theme: ThemeListItem = {...baseTheme, displayName: 'Ocean Blue'};
+      const {container: first} = render(<ThemeThumbnail theme={theme} />);
+      const {container: second} = render(<ThemeThumbnail theme={theme} />);
+      expect(first.innerHTML).toBe(second.innerHTML);
+    });
+
+    it('generates different output for different displayNames', () => {
+      const {container: a} = render(<ThemeThumbnail theme={{...baseTheme, displayName: 'Ocean Blue'}} />);
+      const {container: b} = render(<ThemeThumbnail theme={{...baseTheme, displayName: 'Forest Green'}} />);
+      expect(a.innerHTML).not.toBe(b.innerHTML);
+    });
+  });
+
+  describe('Visual structure', () => {
+    it('renders child elements inside the root container', () => {
+      const {container} = render(
+        <ThemeThumbnail theme={{...baseTheme, defaultColorScheme: 'light', primaryColor: '#ff7300'}} />,
+      );
+      expect(container.firstElementChild?.childElementCount).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/packages/thunder-prettier-config/src/index.ts
+++ b/frontend/packages/thunder-prettier-config/src/index.ts
@@ -23,7 +23,7 @@ const config = {
   endOfLine: 'lf',
   htmlWhitespaceSensitivity: 'css',
   insertPragma: false,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
   jsxSingleQuote: false,
   printWidth: 120,
   proseWrap: 'always',
@@ -32,7 +32,6 @@ const config = {
   semi: true,
   singleQuote: true,
   tabWidth: 2,
-  insertFinalNewline: true,
   // Adds trailing commas at the end of all objects.
   // 1. Easier to add an item or re-order items.
   // 2. Removes the need to have one line item be special because it lacks the ,.

--- a/frontend/packages/thunder-shared-design/src/models/responses.ts
+++ b/frontend/packages/thunder-shared-design/src/models/responses.ts
@@ -20,14 +20,18 @@ import type {LayoutConfig} from './layout';
 import type {Theme} from './theme';
 
 /**
- * Theme item in list responses (theme data may be null in list view)
+ * Theme item in list responses.
+ * The full theme configuration is not included; only the metadata needed for display.
  */
 export interface ThemeListItem {
   id: string;
   handle: string;
   displayName: string;
   description?: string;
-  theme: Theme | null;
+  defaultColorScheme?: string;
+  primaryColor?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 /**


### PR DESCRIPTION
### Purpose

The theme listing page (`GET /design/themes`) previously returned only metadata (id, handle,
displayName, etc.) with no visual information, making it impossible to render meaningful
thumbnails without fetching each theme individually.

This PR adds `defaultColorScheme` and `primaryColor` fields to the theme list API response
and uses them to render a rich thumbnail for each theme card in the console UI.

**Before:** Theme cards showed a generic placeholder (or a name-hash-derived fallback color)
because no real color data was available in list responses.

**After:** Each theme card shows a styled card preview using the theme's actual primary color
and default color scheme.

**Theme Listing**

<img width="1444" height="764" alt="Screenshot 2026-03-27 at 01 14 45" src="https://github.com/user-attachments/assets/7cab69e3-5250-42d7-8aff-0007fbbe0f72" />

**Application Onboarding**

<img width="880" height="801" alt="Screenshot 2026-03-27 at 01 14 29" src="https://github.com/user-attachments/assets/9b89217b-3ec3-4e01-842b-0c4982762935" />

### Approach

**Backend (`GET /design/themes`)**
- Added `THEME` to the `queryGetThemeList` SQL `SELECT` so the full theme JSON is available
  during list queries.
- Updated `buildThemeListItemFromResultRow` in the DB store to extract the `THEME` column
  into `Theme.Theme` (`json.RawMessage`). Absence or `NULL` of the column is handled
  gracefully — color fields degrade to empty strings rather than erroring.
- Added `extractThemeColorInfo()` helper in `model.go` that unmarshals only the two fields
  needed (`defaultColorScheme` and `colorSchemes[defaultColorScheme].palette.primary.main`)
  using a minimal struct, avoiding a full theme parse.
- Extended `ThemeListItem` response model with `defaultColorScheme` and `primaryColor` string
  fields.
- Updated `HandleThemeListRequest` to call the helper and populate both fields per theme.
- The file-based (declarative) store required no changes — it already returns full `Theme`
  objects.

**Frontend**
- Removed `theme: Theme | null` from the `ThemeListItem` interface (full config is no longer
  returned in list responses) and replaced it with `defaultColorScheme?: string` and
  `primaryColor?: string`.
- Redesigned `ThemeThumbnail` to use these fields directly: `defaultColorScheme` drives the
  light/dark background palette; `primaryColor` is used for the accent. A name-hash fallback
  is retained for themes where color data isn't yet available.
- The new thumbnail renders a card-style preview — avatar + title lines at the top, a surface
  card at the bottom with two overlapping primary-color circles as the visual color indicator.

**Tests**
- New `model_test.go` with 10 cases covering all `extractThemeColorInfo` edge cases (valid
  light/dark, nil/empty/invalid input, missing scheme, scheme not in map, empty primary).
- Updated `store_test.go`: existing `TestGetThemeList_Success` rows now include the `theme`
  column; added 4 new `buildThemeListItemFromResultRow` cases (string, bytes, absent, and null
  theme column).
- Updated `handler_test.go`: added `TestHandleThemeListRequest_ColorFieldsPopulated` and
  `TestHandleThemeListRequest_EmptyColorFieldsWhenNoThemeJSON`.
- New `ThemeThumbnail.test.tsx` with 12 cases covering all render paths, distinct output per
  scheme/color, and deterministic fallback generation.

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/1764

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme metadata now includes default color scheme and primary color information in list responses
  * Theme thumbnails display with accurate color scheme preview based on theme configuration

* **Updates**
  * Multiple themes now default to dark color scheme

* **Tests**
  * Added comprehensive test coverage for theme color information extraction, handling, and display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->