### PR TITLE
Add description to ApplicationMetadata in flow/meta response

### DIFF
--- a/api/flow-meta.yaml
+++ b/api/flow-meta.yaml
@@ -85,6 +85,7 @@ paths:
                     application:
                       id: "60a9b38b-6eba-9f9e-55f9-267067de4680"
                       name: "My Web Application"
+                      description: "My web application for managing resources"
                       logoUrl: "https://myapp.example.com/logo.png"
                       url: "https://myapp.example.com"
                       tosUri: "https://myapp.example.com/terms"
@@ -181,6 +182,10 @@ components:
           type: string
           description: Application name
           example: "My Web Application"
+        description:
+          type: string
+          description: Application description
+          example: "My web application for managing resources"
         logoUrl:
           type: string
           format: uri

--- a/backend/internal/flow/flowmeta/model.go
+++ b/backend/internal/flow/flowmeta/model.go
@@ -31,12 +31,13 @@ type FlowMetadataResponse struct {
 
 // ApplicationMetadata represents application-specific metadata.
 type ApplicationMetadata struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	LogoURL   string `json:"logoUrl,omitempty"`
-	URL       string `json:"url,omitempty"`
-	TosURI    string `json:"tosUri,omitempty"`
-	PolicyURI string `json:"policyUri,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	LogoURL     string `json:"logoUrl,omitempty"`
+	URL         string `json:"url,omitempty"`
+	TosURI      string `json:"tosUri,omitempty"`
+	PolicyURI   string `json:"policyUri,omitempty"`
 }
 
 // OUMetadata represents organization unit metadata.

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -178,12 +178,13 @@ func (fms *flowMetaService) populateTypeMetadata(
 
 	response.IsRegistrationFlowEnabled = app.IsRegistrationFlowEnabled
 	response.Application = &ApplicationMetadata{
-		ID:        app.ID,
-		Name:      app.Name,
-		LogoURL:   app.LogoURL,
-		URL:       app.URL,
-		TosURI:    app.TosURI,
-		PolicyURI: app.PolicyURI,
+		ID:          app.ID,
+		Name:        app.Name,
+		Description: app.Description,
+		LogoURL:     app.LogoURL,
+		URL:         app.URL,
+		TosURI:      app.TosURI,
+		PolicyURI:   app.PolicyURI,
 	}
 
 	ouList, ouErr := fms.ouService.GetOrganizationUnitList(ctx, 1, 0)

--- a/tests/integration/flow/flowmeta/flowmeta_api_test.go
+++ b/tests/integration/flow/flowmeta/flowmeta_api_test.go
@@ -119,6 +119,7 @@ func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithAppType() {
 	suite.NotNil(metadata.Application)
 	suite.Equal(suite.appID, metadata.Application.ID)
 	suite.Equal(testApp.Name, metadata.Application.Name)
+	suite.Equal(testApp.Description, metadata.Application.Description)
 	suite.True(metadata.IsRegistrationFlowEnabled)
 
 	// Verify design metadata is present (even if empty)

--- a/tests/integration/flow/flowmeta/model.go
+++ b/tests/integration/flow/flowmeta/model.go
@@ -31,12 +31,13 @@ type FlowMetadataResponse struct {
 
 // ApplicationMetadata represents application-specific metadata.
 type ApplicationMetadata struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	LogoURL   string `json:"logoUrl,omitempty"`
-	URL       string `json:"url,omitempty"`
-	TosURI    string `json:"tosUri,omitempty"`
-	PolicyURI string `json:"policyUri,omitempty"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	LogoURL     string `json:"logoUrl,omitempty"`
+	URL         string `json:"url,omitempty"`
+	TosURI      string `json:"tosUri,omitempty"`
+	PolicyURI   string `json:"policyUri,omitempty"`
 }
 
 // OUMetadata represents organization unit metadata.


### PR DESCRIPTION
### Purpose
The `application.description` field was not included in the `/flow/meta` API response, causing `{{meta(application.description)}}` template variables to not resolve in the UI.

The description was already stored in the database and available in the application domain model, but was not mapped to the `ApplicationMetadata` response struct. The fix aligns application metadata with the existing `OUMetadata` pattern, which already includes a `description` field.

### Approach
Added the `Description` field to the `ApplicationMetadata` struct in the flow meta model and mapped it from the application domain object in the service layer. Also updated the OpenAPI spec (`api/flow-meta.yaml`) to document the new field.

No new API surface was introduced — this is a bug fix restoring data that was expected but missing.

### Related Issues
- Closes #1965

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application metadata responses now include an optional description field, enabling applications to communicate their purpose and functionality to end-users with additional contextual information.

* **Tests**
  * Integration tests have been enhanced to verify that application descriptions are properly captured and returned in metadata responses, ensuring data consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->