### PR TITLE
Add `clientId` to context runtime data and standardize `userId` usage

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -159,6 +159,8 @@ const (
 	RuntimeKeyUserEligibleForProvisioning = "userEligibleForProvisioning"
 	// RuntimeKeySkipProvisioning indicates whether to skip provisioning
 	RuntimeKeySkipProvisioning = "skipProvisioning"
+	// RuntimeKeyClientID holds the OAuth client ID for the current flow execution, if applicable.
+	RuntimeKeyClientID = "clientId"
 	// RuntimeKeyRequestedPermissions holds the space-separated permission scopes requested by the OAuth client.
 	RuntimeKeyRequestedPermissions = "requested_permissions"
 	// RuntimeKeyRequiredEssentialAttributes holds the space-separated essential user attributes required for the flow.

--- a/backend/internal/flow/core/utils.go
+++ b/backend/internal/flow/core/utils.go
@@ -42,12 +42,12 @@ func ResolvePlaceholder(ctx *NodeContext, value string) string {
 
 		key := submatches[1]
 
-		// Special handling for userID - only resolve from runtime data or authenticated user
-		if key == "userID" {
+		// Special handling for userId - only resolve from runtime data or authenticated user
+		if key == "userId" {
 			if ctx.AuthenticatedUser.UserID != "" {
 				return ctx.AuthenticatedUser.UserID
 			}
-			if runtimeValue, ok := ctx.RuntimeData["userID"]; ok && runtimeValue != "" {
+			if runtimeValue, ok := ctx.RuntimeData["userId"]; ok && runtimeValue != "" {
 				return runtimeValue
 			}
 			return match // Keep placeholder if not found

--- a/backend/internal/flow/core/utils_test.go
+++ b/backend/internal/flow/core/utils_test.go
@@ -117,45 +117,45 @@ func (s *UtilsTestSuite) TestResolvePlaceholderUserIDFromAuthenticatedUser() {
 		},
 	}
 
-	result := ResolvePlaceholder(ctx, "{{ context.userID }}")
+	result := ResolvePlaceholder(ctx, "{{ context.userId }}")
 	s.Equal("user-123", result)
 }
 
 func (s *UtilsTestSuite) TestResolvePlaceholderUserIDFromRuntimeData() {
 	ctx := &NodeContext{
-		RuntimeData: map[string]string{"userID": "runtime-user-456"},
+		RuntimeData: map[string]string{"userId": "runtime-user-456"},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "",
 		},
 	}
 
-	result := ResolvePlaceholder(ctx, "{{ context.userID }}")
+	result := ResolvePlaceholder(ctx, "{{ context.userId }}")
 	s.Equal("runtime-user-456", result)
 }
 
 func (s *UtilsTestSuite) TestResolvePlaceholderUserIDAuthenticatedUserTakesPrecedence() {
 	ctx := &NodeContext{
-		RuntimeData: map[string]string{"userID": "runtime-user-id"},
+		RuntimeData: map[string]string{"userId": "runtime-user-id"},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "auth-user-id",
 		},
 	}
 
-	result := ResolvePlaceholder(ctx, "{{ context.userID }}")
+	result := ResolvePlaceholder(ctx, "{{ context.userId }}")
 	s.Equal("auth-user-id", result, "AuthenticatedUser.UserID should take precedence over RuntimeData")
 }
 
 func (s *UtilsTestSuite) TestResolvePlaceholderUserIDNotFromUserInputs() {
 	ctx := &NodeContext{
-		UserInputs:  map[string]string{"userID": "input-user-id"},
+		UserInputs:  map[string]string{"userId": "input-user-id"},
 		RuntimeData: map[string]string{},
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "",
 		},
 	}
 
-	result := ResolvePlaceholder(ctx, "{{ context.userID }}")
-	s.Equal("{{ context.userID }}", result, "userID should NOT be resolved from UserInputs")
+	result := ResolvePlaceholder(ctx, "{{ context.userId }}")
+	s.Equal("{{ context.userId }}", result, "userId should NOT be resolved from UserInputs")
 }
 
 func (s *UtilsTestSuite) TestResolvePlaceholderKeyNotFound() {

--- a/backend/internal/flow/executor/http_request_executor_test.go
+++ b/backend/internal/flow/executor/http_request_executor_test.go
@@ -125,7 +125,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderUserIDSpecialHa
 	ctx := &core.NodeContext{
 		FlowID: "test-flow",
 		UserInputs: map[string]string{
-			"userID": "input-user-id", // This should NOT be used for userID
+			"userId": "input-user-id", // This should NOT be used for userId
 		},
 		RuntimeData: map[string]string{},
 		AuthenticatedUser: authncm.AuthenticatedUser{
@@ -135,7 +135,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderUserIDSpecialHa
 			"url":    suite.mockServer.URL + "/api/user",
 			"method": "POST",
 			"body": map[string]interface{}{
-				"userId": "{{ context.userID }}",
+				"userId": "{{ context.userId }}",
 			},
 		},
 	}
@@ -145,7 +145,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderUserIDSpecialHa
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
 
-	// userID should be resolved from AuthenticatedUser, not from UserInputs
+	// userId should be resolved from AuthenticatedUser, not from UserInputs
 	assert.Equal(suite.T(), "auth-user-456", receivedBody["userId"])
 }
 

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -246,6 +246,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 
 	// Initiate flow with OAuth context.
 	runtimeData := map[string]string{
+		flowcm.RuntimeKeyClientID:                      clientID,
 		flowcm.RuntimeKeyRequestedPermissions:          utils.StringifyStringArray(nonOidcScopes, " "),
 		flowcm.RuntimeKeyRequiredEssentialAttributes:   essentialAttributes,
 		flowcm.RuntimeKeyRequiredOptionalAttributes:    optionalAttributes,

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -376,6 +376,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Se
 		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
 			assert.Equal(suite.T(), "test-app-id", initContext.ApplicationID)
 			assert.Equal(suite.T(), string(flowcm.FlowTypeAuthentication), initContext.FlowType)
+			assert.Equal(suite.T(), "test-client-id", initContext.RuntimeData[flowcm.RuntimeKeyClientID])
 			assert.ElementsMatch(suite.T(), []string{"email"},
 				strings.Fields(initContext.RuntimeData[flowcm.RuntimeKeyRequiredEssentialAttributes]))
 			assert.ElementsMatch(suite.T(), []string{"user_id", "phone_number"},

--- a/tests/integration/flow/authentication/http_request_executor_test.go
+++ b/tests/integration/flow/authentication/http_request_executor_test.go
@@ -59,7 +59,7 @@ var (
 					"method": "POST",
 					"headers": "{\"Content-Type\": \"application/json\", " +
 						"\"X-Flow-Id\": \"{{ context.flowID }}\"}",
-					"body": "{\"userId\": \"{{ context.userID }}\", " +
+					"body": "{\"userId\": \"{{ context.userId }}\", " +
 						"\"username\": \"{{ context.username }}\", \"event\": " +
 						"\"user_authenticated\", \"unknownField\": \"{{ context.unknownPlaceholder }}\"}",
 					"responseMapping": "{\"notificationId\": \"id\", \"status\": \"status\"}",
@@ -110,7 +110,7 @@ var (
 					"url":           "http://localhost:9091/api/error",
 					"method":        "POST",
 					"headers":       "{\"Content-Type\": \"application/json\"}",
-					"body":          "{\"userId\": \"{{ context.userID }}\"}",
+					"body":          "{\"userId\": \"{{ context.userId }}\"}",
 					"errorHandling": "{\"failOnError\": false}",
 					"timeout":       "5",
 				},
@@ -159,7 +159,7 @@ var (
 					"url":           "http://localhost:9091/api/error",
 					"method":        "POST",
 					"headers":       "{\"Content-Type\": \"application/json\"}",
-					"body":          "{\"userId\": \"{{ context.userID }}\"}",
+					"body":          "{\"userId\": \"{{ context.userId }}\"}",
 					"errorHandling": "{\"failOnError\": true}",
 					"timeout":       "5",
 				},
@@ -209,7 +209,7 @@ var (
 				"type": "string",
 			},
 			"password": map[string]interface{}{
-				"type": "string",
+				"type":       "string",
 				"credential": true,
 			},
 			"email": map[string]interface{}{

--- a/tests/integration/flow/registration/http_request_executor_registration_test.go
+++ b/tests/integration/flow/registration/http_request_executor_registration_test.go
@@ -154,11 +154,11 @@ var (
 						"Authorization": "Bearer test-token",
 					},
 					"body": map[string]interface{}{
-						"externalId":   "{{ context.userID }}",
+						"externalId":   "{{ context.userId }}",
 						"username":     "{{ context.username }}",
 						"email":        "{{ context.email }}",
-						"given_name":    "{{ context.given_name }}",
-						"family_name":     "{{ context.family_name }}",
+						"given_name":   "{{ context.given_name }}",
+						"family_name":  "{{ context.family_name }}",
 						"unknownField": "{{ context.unknownPlaceholder }}",
 					},
 					"responseMapping": map[string]interface{}{
@@ -200,7 +200,7 @@ var (
 				"type": "string",
 			},
 			"password": map[string]interface{}{
-				"type": "string",
+				"type":       "string",
 				"credential": true,
 			},
 			"email": map[string]interface{}{
@@ -339,11 +339,11 @@ func (ts *HTTPRequestRegistrationFlowTestSuite) SetupTest() {
 
 func (ts *HTTPRequestRegistrationFlowTestSuite) TestHTTPRequestRegistrationFlow_Success() {
 	step1, err := common.InitiateRegistrationFlow(httpRequestRegTestAppID, false, map[string]string{
-		"username":  "newuser123",
-		"password":  "NewUserPass123!",
-		"email":     "newuser@test.com",
-		"given_name": "New",
-		"family_name":  "User",
+		"username":    "newuser123",
+		"password":    "NewUserPass123!",
+		"email":       "newuser@test.com",
+		"given_name":  "New",
+		"family_name": "User",
 	}, "")
 
 	ts.NoError(err, "Registration flow should complete without error")


### PR DESCRIPTION
### Purpose
This pull request introduces support for having OAuth client ID in the flow runtime data, making it available for the http request executor to be used in ctx variables.

Additionally this renames the previously available `userID` context property to `userId` to make it consistent with other context properties.

**Usage:**
- `{{ context.clientId }}`
- `{{ context.userId }}`

**Example:**
```json
{
    "id": "publish_user_login_event",
    "type": "TASK_EXECUTION",
    "properties": {
        "body": {
            "event": "USER_LOGIN",
            "clientId": "{{ context.clientId }}",
            "userId": "{{ context.userId }}",
            "username": "{{ context.username }}"
        },
        "headers": {
            "Content-Type": "application/json",
            "Custom-x-header-1": "client_id: {{ context.clientId }}",
            "Custom-x-header-2": "user_id: {{ context.userId }}"
        },
        "method": "POST",
        "timeout": 5,
        "url": "https://webhook.site/xxx"
    },
    "executor": {
        "name": "HTTPRequestExecutor"
    },
    "onSuccess": "ID_8xhc"
},
```

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
This renames the previous `userID` usage in `HTTPRequestExecutor` to `userId` to make it consistent with other fields.

#### 💥 Impact
Those who are using `{{ context.userID }}` in `HTTPRequestExecutor` properties

#### 🔄 Migration Guide
Rename `{{ context.userID }}` usages to `{{ context.userId }}`

---

### Approach
**OAuth Client ID Handling:**

* Added a new constant `RuntimeKeyClientID` in `constants.go` to represent the OAuth client ID in runtime data.
* Updated the authorization service to include the client ID in the `runtimeData` map when initiating an OAuth flow.

**Placeholder Resolution Consistency:**

* Changed placeholder resolution logic to use `userId` (camelCase) instead of `userID` (PascalCase), ensuring consistent key usage throughout the codebase.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1978

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
