### PR TITLE
Fix schema validation failing on user update when credentials are absent

### DIFF
--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -324,7 +324,7 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *serv
 		return nil, svcErr
 	}
 
-	if svcErr := us.validateUserAndUniqueness(ctx, user.Type, user.Attributes, logger, ""); svcErr != nil {
+	if svcErr := us.validateUserAndUniqueness(ctx, user.Type, user.Attributes, logger, "", false); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -626,11 +626,6 @@ func (us *userService) UpdateUser(ctx context.Context, userID string, user *User
 			fmt.Errorf("schema service error: %s", svcErr.ErrorDescription), log.String("id", userID))
 	}
 
-	credentials, err := us.extractCredentials(user, schemaCredentialAttributes)
-	if err != nil {
-		return nil, logErrorAndReturnServerError(logger, "Failed to extract credentials", err, log.String("id", userID))
-	}
-
 	var capturedSvcErr *serviceerror.ServiceError
 
 	err = us.transactioner.Transact(ctx, func(txCtx context.Context) error {
@@ -641,12 +636,22 @@ func (us *userService) UpdateUser(ctx context.Context, userID string, user *User
 			return errors.New("rollback for validation error")
 		}
 
-		if svcErr := us.validateUserAndUniqueness(txCtx, user.Type, user.Attributes, logger, user.ID); svcErr != nil {
+		// Validate before extracting credentials so that credential values (e.g. regex)
+		// are still checked when present. skipCredentialRequired is true because
+		// credentials are optional during updates.
+		if svcErr := us.validateUserAndUniqueness(
+			txCtx, user.Type, user.Attributes, logger, user.ID, true,
+		); svcErr != nil {
 			capturedSvcErr = svcErr
 			return errors.New("rollback for validation error")
 		}
 
-		err := us.userStore.UpdateUser(txCtx, user)
+		credentials, err := us.extractCredentials(user, schemaCredentialAttributes)
+		if err != nil {
+			return fmt.Errorf("failed to extract credentials: %w", err)
+		}
+
+		err = us.userStore.UpdateUser(txCtx, user)
 		if err != nil {
 			return err
 		}
@@ -747,7 +752,7 @@ func (us *userService) UpdateUserAttributes(
 		existingUser.Attributes = attributes
 
 		if svcErr := us.validateUserAndUniqueness(txCtx, existingUser.Type,
-			existingUser.Attributes, logger, userID); svcErr != nil {
+			existingUser.Attributes, logger, userID, true); svcErr != nil {
 			capturedSvcErr = svcErr
 			return errors.New("rollback for validation error")
 		}
@@ -1528,8 +1533,9 @@ func (us *userService) validateOrganizationUnitForUserType(
 // validateUserAndUniqueness validates the user schema and checks for uniqueness.
 func (us *userService) validateUserAndUniqueness(
 	ctx context.Context, userType string, attributes []byte, logger *log.Logger, excludeUserID string,
+	skipCredentialRequired bool,
 ) *serviceerror.ServiceError {
-	isValid, svcErr := us.userSchemaService.ValidateUser(ctx, userType, attributes)
+	isValid, svcErr := us.userSchemaService.ValidateUser(ctx, userType, attributes, skipCredentialRequired)
 	if svcErr != nil {
 		if svcErr.Code == userschema.ErrorUserSchemaNotFound.Code {
 			return &ErrorUserSchemaNotFound

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -89,7 +89,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(false, &serviceerror.ServiceError{
 						Code:  "USRS-5000",
 						Type:  serviceerror.ServerErrorType,
@@ -114,7 +114,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(false, &userschema.ErrorUserSchemaNotFound).
 					Once()
 
@@ -135,7 +135,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(false, &serviceerror.ServiceError{
 						Code:  "USRS-5000",
 						Type:  serviceerror.ServerErrorType,
@@ -160,7 +160,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(false, nil).
 					Once()
 
@@ -181,7 +181,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
@@ -208,7 +208,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			setup: func(t *testing.T) (*userService, testMocks) {
 				schemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
@@ -238,7 +238,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return(&existingUserID, nil).
 					Once()
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
@@ -279,7 +279,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return((*string)(nil), nil).
 					Once()
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
@@ -318,7 +318,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return((*string)(nil), errors.New("store failure")).
 					Once()
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
@@ -364,7 +364,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 					Return(&existingUserID, nil).
 					Once()
 				schemaMock.
-					On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+					On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, nil).
 					Once()
 				schemaMock.
@@ -400,7 +400,7 @@ func TestOUStore_ValidateUserAndUniqueness(t *testing.T) {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "UserServiceTest"))
 
 			err := service.validateUserAndUniqueness(context.Background(), testUserType, tc.payload, logger,
-				tc.excludeUserID)
+				tc.excludeUserID, false)
 			tc.assert(t, err, mocks)
 		})
 	}
@@ -752,7 +752,7 @@ func TestUserService_CreateUser_UsesTransactionAndStore(t *testing.T) {
 	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
@@ -813,7 +813,7 @@ func TestUserService_CreateUser_PropagatesStoreError(t *testing.T) {
 	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
@@ -864,7 +864,7 @@ func TestUserService_CreateUser_TransactionerError(t *testing.T) {
 	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
@@ -1622,7 +1622,7 @@ func TestUserService_UpdateUserAttributes_SchemaValidationFails(t *testing.T) {
 		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).
 		Once()
 	schemaMock.
-		On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+		On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(false, &userschema.ErrorUserSchemaNotFound).
 		Once()
 
@@ -1654,7 +1654,7 @@ func TestUserService_UpdateUserAttributes_Succeeds(t *testing.T) {
 		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).
 		Once()
 	schemaMock.
-		On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+		On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).
 		Once()
 	schemaMock.
@@ -1788,7 +1788,7 @@ func TestUserService_UpdateUser(t *testing.T) {
 	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).
 		Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
@@ -1849,7 +1849,7 @@ func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
 		Return([]string{"password"}, (*serviceerror.ServiceError)(nil)).Once()
 	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
@@ -1943,7 +1943,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{OUID: testOrgID},
 						(*serviceerror.ServiceError)(nil)).Maybe()
-				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
 				userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
@@ -1976,7 +1976,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{OUID: testOrgID},
 						(*serviceerror.ServiceError)(nil)).Maybe()
-				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
 				userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
@@ -2001,7 +2001,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{OUID: testOrgID},
 						(*serviceerror.ServiceError)(nil)).Once()
-				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Once()
 				userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Once()
@@ -2028,7 +2028,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{OUID: testOrgID},
 						(*serviceerror.ServiceError)(nil)).Maybe()
-				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(false, (*serviceerror.ServiceError)(nil)).Once()
 				storeMock.On("GetUser", mock.Anything, userID).
 					Return(User{ID: userID, OUID: testOrgID, Type: testUserType}, nil).Once()
@@ -2052,7 +2052,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{OUID: testOrgID},
 						(*serviceerror.ServiceError)(nil)).Maybe()
-				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
 				userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
@@ -2063,7 +2063,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 			},
 			expectedError: &ErrorInternalServerError,
 			checkTx: func(t *testing.T, txCalls int) {
-				require.Equal(t, 0, txCalls)
+				require.Equal(t, 1, txCalls)
 			},
 		},
 		{
@@ -2081,7 +2081,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{OUID: testOrgID},
 						(*serviceerror.ServiceError)(nil)).Maybe()
-				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
 				userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
@@ -2393,7 +2393,7 @@ func TestUserService_UpdateUser_AuthzBranches(t *testing.T) {
 				userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 					Return(&userschema.UserSchema{OUID: existingOU},
 						(*serviceerror.ServiceError)(nil)).Maybe()
-				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+				userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
 				userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 					Return(true, (*serviceerror.ServiceError)(nil)).Maybe()
@@ -2510,7 +2510,7 @@ func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
 			Name: testUserType,
 			OUID: testOU,
 		}, (*serviceerror.ServiceError)(nil)).Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
@@ -3331,7 +3331,7 @@ func TestUserService_MoreErrorCases(t *testing.T) {
 		userSchemaMock.On("GetUserSchemaByName", mock.Anything, mock.Anything).
 			Return(&userschema.UserSchema{}, nil).Maybe()
 		userSchemaMock.On(
-			"ValidateUser", mock.Anything, mock.Anything, mock.Anything,
+			"ValidateUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		).Return(true, nil).Maybe()
 		userSchemaMock.On(
 			"ValidateUserUniqueness", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
@@ -3674,7 +3674,7 @@ func TestUserService_CreateUser_SchemaNotFound(t *testing.T) {
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
@@ -3709,7 +3709,7 @@ func TestUserService_CreateUser_GetCredentialAttributesInternalError(t *testing.
 	userSchemaMock := userschemamock.NewUserSchemaServiceInterfaceMock(t)
 	userSchemaMock.On("GetUserSchemaByName", mock.Anything, testUserType).
 		Return(&userschema.UserSchema{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).Once()
-	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything).
+	userSchemaMock.On("ValidateUser", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()
 	userSchemaMock.On("ValidateUserUniqueness", mock.Anything, testUserType, mock.Anything, mock.Anything).
 		Return(true, (*serviceerror.ServiceError)(nil)).Once()

--- a/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
+++ b/backend/internal/userschema/UserSchemaServiceInterface_mock_test.go
@@ -671,8 +671,8 @@ func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) RunAndReturn(run
 }
 
 // ValidateUser provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, userType, userAttributes)
+func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, userType string, userAttributes json.RawMessage, skipCredentialRequired bool) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, userAttributes, skipCredentialRequired)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateUser")
@@ -680,16 +680,16 @@ func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, u
 
 	var r0 bool
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) (bool, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, bool) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, userAttributes, skipCredentialRequired)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) bool); ok {
-		r0 = returnFunc(ctx, userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, bool) bool); ok {
+		r0 = returnFunc(ctx, userType, userAttributes, skipCredentialRequired)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, userType, userAttributes)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, userAttributes, skipCredentialRequired)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -707,11 +707,12 @@ type UserSchemaServiceInterfaceMock_ValidateUser_Call struct {
 //   - ctx context.Context
 //   - userType string
 //   - userAttributes json.RawMessage
-func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(ctx interface{}, userType interface{}, userAttributes interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
-	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", ctx, userType, userAttributes)}
+//   - skipCredentialRequired bool
+func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(ctx interface{}, userType interface{}, userAttributes interface{}, skipCredentialRequired interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", ctx, userType, userAttributes, skipCredentialRequired)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage, skipCredentialRequired bool)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -725,10 +726,15 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx con
 		if args[2] != nil {
 			arg2 = args[2].(json.RawMessage)
 		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -739,7 +745,7 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Return(b bool, servi
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage, skipCredentialRequired bool) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/userschema/model/schema.go
+++ b/backend/internal/userschema/model/schema.go
@@ -137,7 +137,10 @@ func (cs *Schema) GetUniqueAttributes() []string {
 }
 
 // Validate validates the user attributes against the schema.
-func (cs *Schema) Validate(attributes json.RawMessage, logger *log.Logger) (bool, error) {
+// When skipCredentialRequired is true, missing credential properties do not fail
+// the required check. This is used during updates where credentials are not
+// included in the payload.
+func (cs *Schema) Validate(attributes json.RawMessage, logger *log.Logger, skipCredentialRequired bool) (bool, error) {
 	if len(attributes) == 0 {
 		logger.Debug("User has no attributes to validate")
 		return true, nil
@@ -155,7 +158,7 @@ func (cs *Schema) Validate(attributes json.RawMessage, logger *log.Logger) (bool
 	for propName, prop := range cs.properties {
 		value, exists := userAttrs[propName]
 		if !exists {
-			if prop.isRequired() {
+			if prop.isRequired() && !(skipCredentialRequired && prop.isCredential()) {
 				return false, nil
 			}
 			continue

--- a/backend/internal/userschema/model/schema_test.go
+++ b/backend/internal/userschema/model/schema_test.go
@@ -47,7 +47,7 @@ func (s *SchemaValidateTestSuite) TestValidAttributes_Pass() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{"email":"user@example.com","age":30}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{"email":"user@example.com","age":30}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }
@@ -58,7 +58,7 @@ func (s *SchemaValidateTestSuite) TestExtraTopLevelAttribute_Rejected() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{"email":"user@example.com","address":"123 Main St"}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{"email":"user@example.com","address":"123 Main St"}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().False(ok)
 }
@@ -74,7 +74,7 @@ func (s *SchemaValidateTestSuite) TestExtraNestedObjectAttribute_Rejected() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{"address":{"city":"NYC","zip":"10001"}}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{"address":{"city":"NYC","zip":"10001"}}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().False(ok)
 }
@@ -87,7 +87,7 @@ func (s *SchemaValidateTestSuite) TestValidOnlyDeclaredAttributes_Pass() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{"email":"a@b.com","age":25,"active":true}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{"email":"a@b.com","age":25,"active":true}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }
@@ -100,7 +100,7 @@ func (s *SchemaValidateTestSuite) TestSubsetOfDeclaredAttributes_Pass() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{"email":"a@b.com"}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{"email":"a@b.com"}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }
@@ -111,7 +111,7 @@ func (s *SchemaValidateTestSuite) TestMultipleExtraAttributes_Rejected() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{"email":"a@b.com","foo":"bar","baz":123}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{"email":"a@b.com","foo":"bar","baz":123}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().False(ok)
 }
@@ -139,7 +139,7 @@ func (s *SchemaValidateTestSuite) TestDeeplyNestedExtraAttribute_Rejected() {
 				"country": "US"
 			}
 		}
-	}`), s.logger)
+	}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().False(ok)
 }
@@ -150,7 +150,7 @@ func (s *SchemaValidateTestSuite) TestEmptyAttributes_Pass() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }
@@ -161,7 +161,7 @@ func (s *SchemaValidateTestSuite) TestNilAttributes_Pass() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(nil, s.logger)
+	ok, err := schema.Validate(nil, s.logger, false)
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }
@@ -178,7 +178,7 @@ func (s *SchemaValidateTestSuite) TestValidNestedObjectAttributes_Pass() {
 	}`))
 	s.Require().NoError(err)
 
-	ok, err := schema.Validate(json.RawMessage(`{"address":{"street":"123 Main","city":"NYC"}}`), s.logger)
+	ok, err := schema.Validate(json.RawMessage(`{"address":{"street":"123 Main","city":"NYC"}}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }
@@ -210,7 +210,7 @@ func (s *SchemaValidateTestSuite) TestDisplayNameOnAllPropertyTypes_CompileSucce
 		"active": true,
 		"address": {"city": "NYC"},
 		"tags": ["admin"]
-	}`), s.logger)
+	}`), s.logger, false)
 	s.Require().NoError(err)
 	s.Require().True(ok)
 }

--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -54,6 +54,7 @@ type UserSchemaServiceInterface interface {
 	DeleteUserSchema(ctx context.Context, schemaID string) *serviceerror.ServiceError
 	ValidateUser(
 		ctx context.Context, userType string, userAttributes json.RawMessage,
+		skipCredentialRequired bool,
 	) (bool, *serviceerror.ServiceError)
 	ValidateUserUniqueness(
 		ctx context.Context,
@@ -484,6 +485,7 @@ func (us *userSchemaService) DeleteUserSchema(ctx context.Context, schemaID stri
 func (us *userSchemaService) ValidateUser(
 	ctx context.Context,
 	userType string, userAttributes json.RawMessage,
+	skipCredentialRequired bool,
 ) (bool, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, userSchemaLoggerComponentName))
 
@@ -495,7 +497,7 @@ func (us *userSchemaService) ValidateUser(
 		return false, logAndReturnServerError(logger, "Failed to load user schema", err)
 	}
 
-	isValid, err := compiledSchema.Validate(userAttributes, logger)
+	isValid, err := compiledSchema.Validate(userAttributes, logger, skipCredentialRequired)
 	if err != nil {
 		return false, logAndReturnServerError(logger, "Failed to validate user attributes against schema", err)
 	}

--- a/backend/internal/userschema/service_test.go
+++ b/backend/internal/userschema/service_test.go
@@ -293,6 +293,7 @@ func TestValidateUserReturnsTrueWhenValidationPasses(t *testing.T) {
 		context.Background(),
 		"employee",
 		json.RawMessage(`{"email":"employee@example.com"}`),
+		false,
 	)
 
 	require.True(t, ok)
@@ -311,7 +312,7 @@ func TestValidateUserReturnsInternalErrorWhenSchemaLoadFails(t *testing.T) {
 		transactioner:   &mockTransactioner{},
 	}
 
-	ok, svcErr := service.ValidateUser(context.Background(), "employee", json.RawMessage(`{}`))
+	ok, svcErr := service.ValidateUser(context.Background(), "employee", json.RawMessage(`{}`), false)
 
 	require.False(t, ok)
 	require.NotNil(t, svcErr)
@@ -363,6 +364,7 @@ func TestValidateUserReturnsSchemaNotFoundWhenSchemaMissing(t *testing.T) {
 		context.Background(),
 		"employee",
 		json.RawMessage(`{"email":"employee@example.com"}`),
+		false,
 	)
 
 	require.False(t, ok)

--- a/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
+++ b/backend/tests/mocks/userschemamock/UserSchemaServiceInterface_mock.go
@@ -672,8 +672,8 @@ func (_c *UserSchemaServiceInterfaceMock_UpdateUserSchema_Call) RunAndReturn(run
 }
 
 // ValidateUser provides a mock function for the type UserSchemaServiceInterfaceMock
-func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, userType, userAttributes)
+func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, userType string, userAttributes json.RawMessage, skipCredentialRequired bool) (bool, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, userType, userAttributes, skipCredentialRequired)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateUser")
@@ -681,16 +681,16 @@ func (_mock *UserSchemaServiceInterfaceMock) ValidateUser(ctx context.Context, u
 
 	var r0 bool
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) (bool, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, bool) (bool, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, userType, userAttributes, skipCredentialRequired)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) bool); ok {
-		r0 = returnFunc(ctx, userType, userAttributes)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage, bool) bool); ok {
+		r0 = returnFunc(ctx, userType, userAttributes, skipCredentialRequired)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, userType, userAttributes)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage, bool) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, userType, userAttributes, skipCredentialRequired)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -708,11 +708,12 @@ type UserSchemaServiceInterfaceMock_ValidateUser_Call struct {
 //   - ctx context.Context
 //   - userType string
 //   - userAttributes json.RawMessage
-func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(ctx interface{}, userType interface{}, userAttributes interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
-	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", ctx, userType, userAttributes)}
+//   - skipCredentialRequired bool
+func (_e *UserSchemaServiceInterfaceMock_Expecter) ValidateUser(ctx interface{}, userType interface{}, userAttributes interface{}, skipCredentialRequired interface{}) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+	return &UserSchemaServiceInterfaceMock_ValidateUser_Call{Call: _e.mock.On("ValidateUser", ctx, userType, userAttributes, skipCredentialRequired)}
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx context.Context, userType string, userAttributes json.RawMessage, skipCredentialRequired bool)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -726,10 +727,15 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Run(run func(ctx con
 		if args[2] != nil {
 			arg2 = args[2].(json.RawMessage)
 		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -740,7 +746,7 @@ func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) Return(b bool, servi
 	return _c
 }
 
-func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
+func (_c *UserSchemaServiceInterfaceMock_ValidateUser_Call) RunAndReturn(run func(ctx context.Context, userType string, userAttributes json.RawMessage, skipCredentialRequired bool) (bool, *serviceerror.ServiceError)) *UserSchemaServiceInterfaceMock_ValidateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
- Schema validation was rejecting user updates because required credential fields (e.g. `password`) were missing from the payload — the UI doesn't send credentials during updates
- Added `skipCredentialRequired` parameter to `ValidateUser` so update flows skip the required check for credential properties while still enforcing it during creation
- Reordered `UpdateUser` to validate attributes **before** extracting credentials, so credential values (regex, type) are still validated when present

## Test plan

### Single credential schema (`password`: required, credential, regex `^[A-Za-z0-9@#$%^&+=!]{8,}$`)

**Create:**
- [x] Both required fields + valid password → success
- [x] Missing password → USR-1019
- [x] Empty string password → USR-1019 (fails regex)
- [x] Too-short password → USR-1019 (fails regex)
- [x] Password with invalid chars (spaces) → USR-1019
- [x] Password as number (wrong type) → USR-1019
- [x] Password as boolean (wrong type) → USR-1019
- [x] Password as null → USR-1019
- [x] Extra attribute not in schema → USR-1019

**Update (PUT):**
- [x] Without credentials → success
- [x] With valid password → success
- [x] Too-short password → USR-1019
- [x] Password with spaces → USR-1019
- [x] Password as number → USR-1019
- [x] Password as boolean → USR-1019
- [x] Password as null → USR-1019
- [x] Empty string password → USR-1019
- [x] Extra attribute not in schema → USR-1019
- [x] Missing required non-credential field → USR-1019
- [x] Empty attributes (missing all required) → USR-1019

### Multi-credential schema (`password` + `pin`: both required, credential, with regex)

**Create:**
- [x] Both credentials valid → success
- [x] Both missing → USR-1019
- [x] Only password, missing pin → USR-1019
- [x] Only pin, missing password → USR-1019
- [x] Valid password, invalid pin (too long) → USR-1019
- [x] Invalid password (short), valid pin → USR-1019
- [x] Both credentials invalid → USR-1019
- [x] Pin with letters (fails regex) → USR-1019

**Update (PUT):**
- [x] No credentials at all → success
- [x] Only valid password, no pin → success
- [x] Only valid pin, no password → success
- [x] Both credentials valid → success
- [x] Valid password, invalid pin → USR-1019
- [x] Invalid password, valid pin → USR-1019
- [x] Both credentials invalid → USR-1019
- [x] Only invalid password, no pin → USR-1019
- [x] Only invalid pin, no password → USR-1019

Closes #1991