### PR TITLE
Add allowed user schema support to node poperty 

### DIFF
--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -82,10 +82,11 @@ const (
 
 // Executor property keys
 const (
-	propertyKeyAssignGroup    = "assignGroup"
-	propertyKeyAssignRole     = "assignRole"
-	propertyKeyRequiredScopes = "requiredScopes"
-	propertyKeyEmailTemplate  = "emailTemplate"
+	propertyKeyAssignGroup      = "assignGroup"
+	propertyKeyAssignRole       = "assignRole"
+	propertyKeyRequiredScopes   = "requiredScopes"
+	propertyKeyEmailTemplate    = "emailTemplate"
+	propertyKeyAllowedUserTypes = "allowedUserTypes"
 )
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -138,6 +138,27 @@ func (u *userTypeResolver) handleRegistrationFlows(ctx *core.NodeContext, execRe
 		return execResp, nil
 	}
 
+	// If allowedUserTypes is configured in node properties, filter the application-level allowed list
+	nodeAllowedUserTypes := u.getAllowedUserTypesFromProperties(ctx)
+	if len(nodeAllowedUserTypes) > 0 {
+		filtered := make([]string, 0, len(allowed))
+		for _, userType := range allowed {
+			if slices.Contains(nodeAllowedUserTypes, userType) {
+				filtered = append(filtered, userType)
+			}
+		}
+
+		if len(filtered) == 0 {
+			logger.Debug("No valid user types after filtering with node allowedUserTypes",
+				log.Any("applicationAllowed", allowed), log.Any("nodeAllowed", nodeAllowedUserTypes))
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "No valid user types available for this flow"
+			return execResp, nil
+		}
+
+		allowed = filtered
+	}
+
 	// Check if userType is provided in inputs
 	if u.HasRequiredInputs(ctx, execResp) {
 		err := u.resolveUserTypeFromInput(reqCtx, execResp, ctx.UserInputs[userTypeKey], allowed)
@@ -161,8 +182,20 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
 
+	// Read optional allowedUserTypes from node properties
+	allowedUserTypes := u.getAllowedUserTypesFromProperties(ctx)
+
 	// If userType already provided, validate and set runtime data
 	if userType, ok := ctx.UserInputs[userTypeKey]; ok && userType != "" {
+		// If allowedUserTypes is configured, validate the input against it
+		if len(allowedUserTypes) > 0 && !slices.Contains(allowedUserTypes, userType) {
+			logger.Debug("User type not in allowed list", log.String(userTypeKey, userType),
+				log.Any("allowedUserTypes", allowedUserTypes))
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "User type not allowed for this flow"
+			return execResp, nil
+		}
+
 		userSchema, ouID, err := u.getUserSchemaAndOU(ctx.Context, userType)
 		if err != nil {
 			execResp.Status = common.ExecFailure
@@ -194,13 +227,87 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 		return execResp, nil
 	}
 
-	options := make([]string, 0, len(schemas.Schemas))
-	for _, schema := range schemas.Schemas {
+	// Build the list of available schema names, filtering by allowedUserTypes if configured
+	availableSchemas := u.filterSchemasByAllowedTypes(schemas.Schemas, allowedUserTypes)
+
+	if len(availableSchemas) == 0 {
+		logger.Debug("No valid user types found after filtering with allowedUserTypes",
+			log.Any("allowedUserTypes", allowedUserTypes))
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "No valid user types available for this flow"
+		return execResp, nil
+	}
+
+	// If only one user schema is available, select it automatically
+	if len(availableSchemas) == 1 {
+		schema := availableSchemas[0]
+		logger.Debug("User type auto-selected for user onboarding", log.String(userTypeKey, schema.Name),
+			log.String(ouIDKey, schema.OUID))
+
+		execResp.RuntimeData[userTypeKey] = schema.Name
+		execResp.RuntimeData[defaultOUIDKey] = schema.OUID
+		execResp.Status = common.ExecComplete
+		return execResp, nil
+	}
+
+	options := make([]string, 0, len(availableSchemas))
+	for _, schema := range availableSchemas {
 		options = append(options, schema.Name)
 	}
 
 	u.promptUserSelection(execResp, options)
 	return execResp, nil
+}
+
+// getAllowedUserTypesFromProperties reads the optional allowedUserTypes property from node properties.
+func (u *userTypeResolver) getAllowedUserTypesFromProperties(ctx *core.NodeContext) []string {
+	if ctx.NodeProperties == nil {
+		return nil
+	}
+
+	val, exists := ctx.NodeProperties[propertyKeyAllowedUserTypes]
+	if !exists {
+		return nil
+	}
+
+	items, ok := val.([]interface{})
+	if !ok {
+		u.logger.Debug("allowedUserTypes property is not a valid array")
+		return nil
+	}
+
+	userTypes := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok && s != "" {
+			userTypes = append(userTypes, s)
+		}
+	}
+
+	if len(userTypes) > 0 {
+		u.logger.Debug("Allowed user types configured from node properties",
+			log.Any("allowedUserTypes", userTypes))
+	}
+
+	return userTypes
+}
+
+// filterSchemasByAllowedTypes filters schemas by the allowedUserTypes list.
+// If allowedUserTypes is empty, all schemas are returned.
+func (u *userTypeResolver) filterSchemasByAllowedTypes(
+	schemas []userschema.UserSchemaListItem, allowedUserTypes []string,
+) []userschema.UserSchemaListItem {
+	if len(allowedUserTypes) == 0 {
+		return schemas
+	}
+
+	filtered := make([]userschema.UserSchemaListItem, 0, len(schemas))
+	for _, schema := range schemas {
+		if slices.Contains(allowedUserTypes, schema.Name) {
+			filtered = append(filtered, schema)
+		}
+	}
+
+	return filtered
 }
 
 // resolveUserTypeFromInput resolves the user type from input and updates the executor response.

--- a/backend/internal/flow/executor/user_type_resolver_test.go
+++ b/backend/internal/flow/executor/user_type_resolver_test.go
@@ -735,6 +735,115 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_Sch
 	suite.mockUserSchemaService.AssertExpectations(suite.T())
 }
 
+func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowedUserTypes_FiltersAppAllowed() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: common.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"employee", "customer"},
+		},
+	}
+
+	// Mock schemas for the two filtered user types
+	employeeSchema := &userschema.UserSchema{Name: "employee", OUID: "ou-123", AllowSelfRegistration: true}
+	customerSchema := &userschema.UserSchema{Name: "customer", OUID: "ou-456", AllowSelfRegistration: true}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", ctx.Context, "employee").Return(employeeSchema, nil)
+	suite.mockUserSchemaService.On("GetUserSchemaByName", ctx.Context, "customer").Return(customerSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
+	assert.Len(suite.T(), result.Inputs, 1)
+	assert.ElementsMatch(suite.T(), []string{"employee", "customer"}, result.Inputs[0].Options)
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowedUserTypes_SingleAutoSelect() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: common.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"employee"},
+		},
+	}
+
+	mockSchema := &userschema.UserSchema{Name: "employee", OUID: "ou-123", AllowSelfRegistration: true}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", ctx.Context, "employee").Return(mockSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "ou-123", result.RuntimeData[defaultOUIDKey])
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowedUserTypes_NoneMatchApp() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: common.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer"},
+		},
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"partner"},
+		},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "No valid user types available for this flow", result.FailureReason)
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowedUserTypes_InputValidation() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: common.FlowTypeRegistration,
+		Application: appmodel.Application{
+			AllowedUserTypes: []string{"employee", "customer", "partner"},
+		},
+		UserInputs:  map[string]string{userTypeKey: "partner"},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"employee", "customer"},
+		},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	// "partner" is in application allowed but NOT in node allowed, so resolveUserTypeFromInput
+	// won't find it in the filtered allowed list
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "Application does not allow registration for the user type", result.FailureReason)
+}
+
 func (suite *UserTypeResolverTestSuite) TestGetUserSchemaAndOU_Success() {
 	suite.SetupTest()
 
@@ -911,6 +1020,34 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 	assert.Equal(suite.T(), "Failed to retrieve user types", result.FailureReason)
 }
 
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserType_SingleSchema_AutoSelect() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:      "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+	}
+
+	// Mock GetUserSchemaList returning a single schema
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "ou-123"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0).
+		Return(schemaList, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "ou-123", result.RuntimeData[defaultOUIDKey])
+}
+
 func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserType_PromptUser() {
 	suite.SetupTest()
 
@@ -942,6 +1079,152 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 	requiredInput := result.Inputs[0]
 	assert.Equal(suite.T(), userTypeKey, requiredInput.Identifier)
 	assert.ElementsMatch(suite.T(), []string{"employee", "customer"}, requiredInput.Options)
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUserTypes_SingleAutoSelect() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:      "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"employee"},
+		},
+	}
+
+	// Mock GetUserSchemaList returning multiple schemas
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "ou-123"},
+			{Name: "customer", OUID: "ou-456"},
+			{Name: "partner", OUID: "ou-789"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0).
+		Return(schemaList, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "ou-123", result.RuntimeData[defaultOUIDKey])
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUserTypes_MultiplePrompt() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:      "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"employee", "customer"},
+		},
+	}
+
+	// Mock GetUserSchemaList returning multiple schemas including non-allowed ones
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "ou-123"},
+			{Name: "customer", OUID: "ou-456"},
+			{Name: "partner", OUID: "ou-789"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0).
+		Return(schemaList, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
+	assert.Len(suite.T(), result.Inputs, 1)
+
+	requiredInput := result.Inputs[0]
+	assert.ElementsMatch(suite.T(), []string{"employee", "customer"}, requiredInput.Options)
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUserTypes_NoneValidInSystem() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:      "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"nonexistent"},
+		},
+	}
+
+	// Mock GetUserSchemaList returning schemas that don't match the allowed list
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "ou-123"},
+			{Name: "customer", OUID: "ou-456"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0).
+		Return(schemaList, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "No valid user types available for this flow", result.FailureReason)
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUserTypes_InputNotInAllowed() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:      "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{userTypeKey: "partner"},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"employee", "customer"},
+		},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "User type not allowed for this flow", result.FailureReason)
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUserTypes_InputInAllowed() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:      "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{userTypeKey: "employee"},
+		RuntimeData: map[string]string{},
+		NodeProperties: map[string]interface{}{
+			propertyKeyAllowedUserTypes: []interface{}{"employee", "customer"},
+		},
+	}
+
+	mockSchema := &userschema.UserSchema{Name: "employee", OUID: "ou-123"}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", ctx.Context, "employee").
+		Return(mockSchema, nil)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "ou-123", result.RuntimeData[defaultOUIDKey])
 }
 
 func (suite *UserTypeResolverTestSuite) TestPromptUserSelection_ForwardsInputsInForwardedData() {


### PR DESCRIPTION
This pull request adds support for specifying an `allowedUserTypes` property at the node level in user registration and onboarding flows. This allows flows to further restrict which user types are available for selection or auto-selection, beyond the application-level allowed user types. The implementation includes filtering logic, validation, and comprehensive test coverage for these new behaviors.

**Feature: Node-level Allowed User Types**

* Added a new node property key, `allowedUserTypes`, to the constants in `constants.go` to support node-level user type restrictions.
* Implemented logic in `user_type_resolver.go` to:
  - Filter the list of allowed user types at the node level during registration and onboarding flows.
  - Validate user input against the node-level allowed list and return appropriate failure reasons if no valid user types are available.
  - Auto-select the user type if only one valid option remains after filtering. [[1]](diffhunk://#diff-d8781035d0c0c7f33924e03093b5921306623cdaaab0ed5709dc17836de00cb7R141-R161) [[2]](diffhunk://#diff-d8781035d0c0c7f33924e03093b5921306623cdaaab0ed5709dc17836de00cb7R185-R198) [[3]](diffhunk://#diff-d8781035d0c0c7f33924e03093b5921306623cdaaab0ed5709dc17836de00cb7L197-R312)

**Testing: Node-level Allowed User Types**

* Added comprehensive unit tests in `user_type_resolver_test.go` to cover:
  - Filtering of application-allowed user types by node-level restrictions.
  - Auto-selection when only one user type is allowed at the node level.
  - Prompting the user when multiple valid options exist.
  - Handling of invalid or mismatched allowed user types at the node level.
  - Validation of user input against the node-level allowed list for both registration and onboarding flows. [[1]](diffhunk://#diff-45787b2d1d1c67f5c397ac0d7e6e003982e616230047eb3c4031969df2598502R738-R846) [[2]](diffhunk://#diff-45787b2d1d1c67f5c397ac0d7e6e003982e616230047eb3c4031969df2598502R1023-R1050) [[3]](diffhunk://#diff-45787b2d1d1c67f5c397ac0d7e6e003982e616230047eb3c4031969df2598502R1084-R1229)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restricting allowed user types at the flow node level in registration and user onboarding workflows
  * Automatic filtering of available schemas and options based on configured user type restrictions
  * Enhanced validation with early error detection when no valid user types are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->