### PR TITLE
Refactor graph cache to use in-memory cache implementation and enhance logging

### DIFF
--- a/backend/internal/flow/core/graph_cache.go
+++ b/backend/internal/flow/core/graph_cache.go
@@ -37,10 +37,10 @@ type graphCache struct {
 	cache cache.CacheInterface[*graph]
 }
 
-// newGraphCache creates a new instance of graphCache.
+// newGraphCache creates a new in-memory cache instance of graphCache.
 func newGraphCache() GraphCacheInterface {
 	return &graphCache{
-		cache: cache.GetCache[*graph]("FlowGraphCache"),
+		cache: cache.GetInMemoryCache[*graph]("FlowGraphCache"),
 	}
 }
 

--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -97,7 +97,7 @@ func (cm *CacheManager) Init() {
 			cm.enabled = false
 			return
 		}
-		logger.Info("Connected to Redis successfully", log.String("address", cacheConfig.Redis.Address))
+		logger.Debug("Connected to Redis successfully", log.String("address", cacheConfig.Redis.Address))
 	} else {
 		cm.cleanupInterval = getCleanupInterval(cacheConfig)
 		cm.startCleanupRoutine()
@@ -279,6 +279,56 @@ func newCache[T any](cacheName string) CacheInterface[T] {
 	}
 
 	return cache
+}
+
+// GetInMemoryCache returns a singleton in-memory cache instance for the given type and cache name,
+func GetInMemoryCache[T any](cacheName string) CacheInterface[T] {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
+
+	cm := GetCacheManager()
+
+	var t T
+	typeName := reflect.TypeOf(t).String()
+	cacheKey := cacheName + ":" + typeName
+
+	cm.getMutex().RLock()
+	if cache, exists := cm.getCache(cacheKey); exists {
+		cm.getMutex().RUnlock()
+		if retCache, ok := cache.(CacheInterface[T]); ok {
+			return retCache
+		}
+	} else {
+		cm.getMutex().RUnlock()
+	}
+
+	cm.getMutex().Lock()
+	defer cm.getMutex().Unlock()
+
+	if cache, exists := cm.getCache(cacheKey); exists {
+		if retCache, ok := cache.(CacheInterface[T]); ok {
+			return retCache
+		}
+	}
+
+	logger.Debug("Creating new in-memory cache", log.String("cacheName", cacheName), log.String("type", typeName))
+
+	cacheConfig := config.GetThunderRuntime().Config.Cache
+	cacheProperty := getCacheProperty(cacheConfig, cacheName)
+
+	var internalCache CacheInterface[T]
+	if cacheConfig.Disabled || cacheProperty.Disabled {
+		internalCache = &inMemoryCache[T]{name: cacheName, enabled: false}
+	} else {
+		internalCache = newInMemoryCache[T](cacheName, true, cacheConfig, cacheProperty)
+	}
+
+	newCache := &Cache[T]{
+		enabled:   !cacheConfig.Disabled && !cacheProperty.Disabled,
+		cacheName: cacheName,
+		cacheImpl: internalCache,
+	}
+	cm.addCache(cacheKey, newCache)
+	return newCache
 }
 
 // GetCache returns a singleton cache instance for the given type and cache name.


### PR DESCRIPTION
### Purpose
This pull request introduces a new method for explicitly creating in-memory cache instances and updates the flow graph cache to use this method. It also makes a minor logging change to reduce log verbosity when connecting to Redis. The main focus is on improving cache management and clarity around in-memory versus other cache types.

**Cache management improvements:**

* Added a new `GetInMemoryCache` function in `manager.go` to provide a singleton in-memory cache instance for a given type and cache name, ensuring more explicit control over cache type selection.
* Updated the `newGraphCache` function in `graph_cache.go` to use `GetInMemoryCache` instead of `GetCache`, making it clear that the flow graph cache is always in-memory.

**Logging changes:**

* Changed the Redis connection log level from `Info` to `Debug` in `manager.go` to reduce unnecessary log noise.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1968

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal cache management for improved system performance
  * Reduced logging verbosity for Redis connection operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->