### PR TITLE
Hide edit button for user types with only credential fields

### DIFF
--- a/frontend/apps/thunder-console/src/features/users/pages/UserEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/users/pages/UserEditPage.tsx
@@ -109,6 +109,13 @@ export default function UserEditPage() {
 
   const {data: userSchema, isLoading: isSchemaLoading, error: schemaError} = useGetUserSchema(schemaId);
 
+  const hasEditableFields = useMemo(() => {
+    if (!userSchema?.schema) return false;
+    return Object.entries(userSchema.schema).some(
+      ([, fieldDef]) => !((fieldDef.type === 'string' || fieldDef.type === 'number') && fieldDef.credential),
+    );
+  }, [userSchema]);
+
   const displayName = user?.display ?? user?.id ?? '';
 
   const {
@@ -293,7 +300,7 @@ export default function UserEditPage() {
                 'View and manage user attribute values.',
               )}
               headerAction={
-                !isEditMode ? (
+                !isEditMode && hasEditableFields ? (
                   <Button variant="outlined" size="small" onClick={() => setIsEditMode(true)}>
                     {t('common:actions.edit', 'Edit')}
                   </Button>

--- a/frontend/apps/thunder-console/src/features/users/pages/__tests__/UserEditPage.test.tsx
+++ b/frontend/apps/thunder-console/src/features/users/pages/__tests__/UserEditPage.test.tsx
@@ -679,6 +679,62 @@ describe('UserEditPage', () => {
       });
     });
 
+    it('hides edit button when schema has only credential fields', () => {
+      const credentialOnlySchema: ApiUserSchema = {
+        id: 'credential-only',
+        name: 'CredentialOnly',
+        schema: {
+          password: {
+            type: 'string',
+            required: true,
+            credential: true,
+          },
+          pin: {
+            type: 'number',
+            credential: true,
+          },
+        },
+      };
+
+      mockUseGetUserSchema.mockReturnValue({
+        data: credentialOnlySchema,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<UserEditPage />);
+
+      expect(screen.queryByRole('button', {name: /edit/i})).not.toBeInTheDocument();
+    });
+
+    it('shows edit button when schema has at least one non-credential field', () => {
+      const mixedSchema: ApiUserSchema = {
+        id: 'mixed',
+        name: 'Mixed',
+        schema: {
+          password: {
+            type: 'string',
+            required: true,
+            credential: true,
+          },
+          email: {
+            type: 'string',
+            required: true,
+          },
+        },
+      };
+
+      mockUseGetUserSchema.mockReturnValue({
+        data: mixedSchema,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<UserEditPage />);
+
+      expect(screen.getByRole('button', {name: /edit/i})).toBeInTheDocument();
+    });
+
     it('populates form fields with current user data', async () => {
       const user = userEvent.setup();
       render(<UserEditPage />);
@@ -1171,8 +1227,7 @@ describe('UserEditPage', () => {
       expect(alert).toBeInTheDocument();
     });
 
-    it('displays "No schema available for editing" when schema is null in edit mode', async () => {
-      const user = userEvent.setup();
+    it('hides edit button when schema is null', () => {
       mockUseGetUserSchema.mockReturnValue({
         data: {
           id: 'employee',
@@ -1185,11 +1240,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
-
-      await waitFor(() => {
-        expect(screen.getByText('No schema available for editing')).toBeInTheDocument();
-      });
+      expect(screen.queryByRole('button', {name: /edit/i})).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
### Purpose

When a user type is created with only credential fields (no user attributes), the Edit button is displayed on the user view page, but there are no fields available to edit. Clicking the Save button in this empty edit form results in an error.

This fix hides the Edit button when the user schema contains no editable (non-credential) fields, preventing users from entering a broken edit state.

**Before fix:**

<img width="1212" alt="Edit button shown with no fields" src="https://github.com/user-attachments/assets/68b0ee4a-4c0e-45c9-99d4-769c6a9dffb5" />

### Approach

- Added a `hasEditableFields` memoized value in `ViewUserPage.tsx` that checks whether the schema contains at least one non-credential field.
- Changed the Edit button render condition from `!isEditMode` to `!isEditMode && hasEditableFields`.
- Updated tests to cover credential-only schemas, mixed schemas, and null schema cases.

### Related Issues
- Fixes #1959

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The edit button is now only available when a user profile contains at least one editable field, preventing users from attempting to edit restricted or credential-only profiles.

* **Tests**
  * Enhanced test coverage to verify edit button visibility based on schema field editability and handle edge cases where all fields are restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->