### PR TITLE
Add logoUrl field to organization units and update related resources

### DIFF
--- a/api/ou.yaml
+++ b/api/ou.yaml
@@ -49,10 +49,12 @@ paths:
                     handle: "engineering"
                     name: "Engineering"
                     description: "Engineering Unit"
+                    logoUrl: "https://example.com/logos/engineering.png"
                   - id: "b7c40de6-95cd-4c45-8725-9c7cb5b9cafd"
                     handle: "sales"
                     name: "Sales"
                     description: "Sales Unit"
+                    logoUrl: "https://example.com/logos/sales.png"
                 links:
                   - href: "organization-units?offset=2&limit=2"
                     rel: "next"
@@ -346,10 +348,12 @@ paths:
                     name: "Frontend Team"
                     handle: "frontend"
                     description: "Handles UI/UX work"
+                    logoUrl: "https://example.com/logos/frontend.png"
                   - id: "2a8f9e1c-4d7b-4c8a-9f3e-1b2c3d4e5f6g"
                     name: "Backend Team"
                     handle: "backend"
                     description: "Handles server-side development"
+                    logoUrl: null
                 links:
                   - href: "organization-units/afc77cfd-620b-4cf0-a31c-7377b0ea8902/ous?offset=2&limit=2"
                     rel: "next"
@@ -887,10 +891,12 @@ paths:
                     name: "Frontend Team"
                     handle: "frontend"
                     description: "Handles UI/UX work"
+                    logoUrl: "https://example.com/logos/frontend.png"
                   - id: "2a8f9e1c-4d7b-4c8a-9f3e-1b2c3d4e5f6g"
                     name: "Backend Team"
                     handle: "backend"
                     description: "Handles server-side development"
+                    logoUrl: null
                 links:
                   - href: "organization-units/tree/engineering/ous?offset=2&limit=2"
                     rel: "next"

--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -59,7 +59,8 @@ Log-Info "Creating default organization unit..."
 $response = Invoke-ThunderApi -Method POST -Endpoint "/organization-units" -Data '{
   "handle": "default",
   "name": "Default",
-  "description": "Default organization unit"
+  "description": "Default organization unit",
+  "logoUrl": "emoji:🏛️"
 }'
 
 if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -52,7 +52,8 @@ log_info "Creating default organization unit..."
 RESPONSE=$(thunder_api_call POST "/organization-units" '{
   "handle": "default",
   "name": "Default",
-  "description": "Default organization unit"
+  "description": "Default organization unit",
+  "logoUrl": "emoji:🏛️"
 }')
 
 HTTP_CODE="${RESPONSE: -3}"

--- a/backend/cmd/server/bootstrap/02-sample-resources.ps1
+++ b/backend/cmd/server/bootstrap/02-sample-resources.ps1
@@ -56,6 +56,7 @@ $customerOuData = @{
     handle = $customerOuHandle
     name = "Customers"
     description = "Organization unit for customer accounts"
+    logoUrl = "emoji:🏛️"
 } | ConvertTo-Json -Depth 5
 
 $response = Invoke-ThunderApi -Method POST -Endpoint "/organization-units" -Data $customerOuData

--- a/backend/cmd/server/bootstrap/02-sample-resources.sh
+++ b/backend/cmd/server/bootstrap/02-sample-resources.sh
@@ -41,7 +41,8 @@ read -r -d '' CUSTOMERS_OU_PAYLOAD <<JSON || true
 {
   "handle": "${CUSTOMER_OU_HANDLE}",
   "name": "Customers",
-  "description": "Organization unit for customer accounts"
+  "description": "Organization unit for customer accounts",
+  "logoUrl": "emoji:🏛️"
 }
 JSON
 

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -52,6 +52,8 @@ type organizationUnitStoreInterface interface {
 	GetOrganizationUnitChildrenList(ctx context.Context, id string, limit, offset int) ([]OrganizationUnitBasic, error)
 }
 
+var getDBProvider = provider.GetDBProvider
+
 // organizationUnitStore is the default implementation of organizationUnitStoreInterface.
 type organizationUnitStore struct {
 	dbProvider   provider.DBProviderInterface
@@ -60,7 +62,7 @@ type organizationUnitStore struct {
 
 // newOrganizationUnitStore creates a new instance of organizationUnitStore.
 func newOrganizationUnitStore() (organizationUnitStoreInterface, transaction.Transactioner, error) {
-	dbProvider := provider.GetDBProvider()
+	dbProvider := getDBProvider()
 	transactioner, err := dbProvider.GetUserDBTransactioner()
 	if err != nil {
 		return nil, nil, err
@@ -495,11 +497,14 @@ func buildOrganizationUnitBasicFromResultRow(
 		}
 	}
 
-	logoURL := ""
-	if v, ok := row["logo_url"]; ok && v != nil {
-		if s, ok := v.(string); ok {
-			logoURL = s
-		}
+	ouMetadataData, err := parseOUMetadata(row)
+	if err != nil {
+		return OrganizationUnitBasic{}, fmt.Errorf("failed to parse OU Metadata: %w", err)
+	}
+
+	logoURL, err := extractStringFromOUMetadata(ouMetadataData, "logo_url")
+	if err != nil {
+		return OrganizationUnitBasic{}, err
 	}
 
 	return OrganizationUnitBasic{

--- a/backend/internal/ou/store_constants.go
+++ b/backend/internal/ou/store_constants.go
@@ -35,7 +35,7 @@ var (
 	// queryGetRootOrganizationUnitList is the query to get organization units with pagination.
 	queryGetRootOrganizationUnitList = dbmodel.DBQuery{
 		ID: "OUQ-OU_MGT-02",
-		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, PARENT_ID FROM ORGANIZATION_UNIT ` +
+		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, PARENT_ID, METADATA FROM ORGANIZATION_UNIT ` +
 			`WHERE PARENT_ID IS NULL AND DEPLOYMENT_ID = $3 ORDER BY NAME LIMIT $1 OFFSET $2`,
 	}
 
@@ -101,7 +101,7 @@ var (
 	// queryGetOrganizationUnitChildrenList is the query to get child organization units with pagination.
 	queryGetOrganizationUnitChildrenList = dbmodel.DBQuery{
 		ID: "OUQ-OU_MGT-11",
-		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION FROM ORGANIZATION_UNIT ` +
+		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, METADATA FROM ORGANIZATION_UNIT ` +
 			`WHERE PARENT_ID = $1 AND DEPLOYMENT_ID = $4 ORDER BY NAME LIMIT $2 OFFSET $3`,
 	}
 
@@ -161,9 +161,9 @@ func buildGetOrganizationUnitsByIDsQuery(ids []string) dbmodel.DBQuery {
 
 	return dbmodel.DBQuery{
 		ID: "OUQ-OU_MGT-21",
-		PostgresQuery: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION FROM ORGANIZATION_UNIT ` +
+		PostgresQuery: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, METADATA FROM ORGANIZATION_UNIT ` +
 			`WHERE OU_ID IN (` + pgInClause + `) AND DEPLOYMENT_ID = ` + deploymentIDParam + ` ORDER BY NAME`,
-		SQLiteQuery: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION FROM ORGANIZATION_UNIT ` +
+		SQLiteQuery: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, METADATA FROM ORGANIZATION_UNIT ` +
 			`WHERE OU_ID IN (` + sqliteInClause + `) AND DEPLOYMENT_ID = ? ORDER BY NAME`,
 	}
 }

--- a/backend/internal/ou/store_test.go
+++ b/backend/internal/ou/store_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/asgardeo/thunder/internal/system/database/provider"
 	"github.com/asgardeo/thunder/tests/mocks/database/providermock"
 )
 
@@ -281,12 +282,21 @@ func makeOUResultRow(id, handle, name, description string, parent *string) map[s
 		"handle":      handle,
 		"name":        name,
 		"description": description,
+		"metadata":    nil,
 	}
 	if parent != nil {
 		row["parent_id"] = *parent
 	} else {
 		row["parent_id"] = nil
 	}
+	return row
+}
+
+func makeOUResultRowWithLogoURL(
+	id, handle, name, description string, parent *string, logoURL string,
+) map[string]interface{} {
+	row := makeOUResultRow(id, handle, name, description, parent)
+	row["metadata"] = `{"logo_url":"` + logoURL + `"}`
 	return row
 }
 
@@ -306,15 +316,13 @@ func TestBuildOrganizationUnitBasicFromResultRow(t *testing.T) {
 		require.Equal(t, "desc", ou.Description)
 	})
 
-	t.Run("success with design fields", func(t *testing.T) {
+	t.Run("success with logo url in metadata", func(t *testing.T) {
 		row := map[string]interface{}{
 			"ou_id":       "ou1",
 			"handle":      "root",
 			"name":        "Root",
 			"description": "desc",
-			"theme_id":    "theme-123",
-			"layout_id":   "layout-456",
-			"logo_url":    "https://example.com/logo.png",
+			"metadata":    `{"logo_url":"https://example.com/logo.png"}`,
 		}
 
 		ou, err := buildOrganizationUnitBasicFromResultRow(row)
@@ -324,15 +332,13 @@ func TestBuildOrganizationUnitBasicFromResultRow(t *testing.T) {
 		require.Equal(t, "https://example.com/logo.png", ou.LogoURL)
 	})
 
-	t.Run("success with nil design fields", func(t *testing.T) {
+	t.Run("success with nil metadata", func(t *testing.T) {
 		row := map[string]interface{}{
 			"ou_id":       "ou1",
 			"handle":      "root",
 			"name":        "Root",
 			"description": "desc",
-			"theme_id":    nil,
-			"layout_id":   nil,
-			"logo_url":    nil,
+			"metadata":    nil,
 		}
 
 		ou, err := buildOrganizationUnitBasicFromResultRow(row)
@@ -340,6 +346,20 @@ func TestBuildOrganizationUnitBasicFromResultRow(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "ou1", ou.ID)
 		require.Equal(t, "", ou.LogoURL)
+	})
+
+	t.Run("error on invalid metadata", func(t *testing.T) {
+		row := map[string]interface{}{
+			"ou_id":    "ou1",
+			"handle":   "root",
+			"name":     "Root",
+			"metadata": 12345,
+		}
+
+		_, err := buildOrganizationUnitBasicFromResultRow(row)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse OU Metadata")
 	})
 
 	tests := []struct {
@@ -1134,6 +1154,134 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnit() {
 	}
 }
 
+func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitByHandle() {
+	parentID := testParentID
+	tests := []struct {
+		name          string
+		handle        string
+		parent        *string
+		setup         func(handle string, parent *string)
+		assert        func(ou OrganizationUnit)
+		wantErr       error
+		wantErrString string
+	}{
+		{
+			name:   "success root ou (nil parent)",
+			handle: "root",
+			parent: nil,
+			setup: func(handle string, parent *string) {
+				row := makeOUResultRow("ou1", handle, "Root", "desc", nil)
+				suite.expectDBClient()
+				suite.dbClientMock.
+					On("QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle,
+						handle, testDeploymentID).
+					Return([]map[string]interface{}{row}, nil).
+					Once()
+			},
+			assert: func(ou OrganizationUnit) {
+				suite.Equal("ou1", ou.ID)
+				suite.Equal("root", ou.Handle)
+				suite.Nil(ou.Parent)
+			},
+		},
+		{
+			name:   "success child ou (non-nil parent)",
+			handle: "child",
+			parent: &parentID,
+			setup: func(handle string, parent *string) {
+				row := makeOUResultRow("ou2", handle, "Child", "desc", parent)
+				suite.expectDBClient()
+				suite.dbClientMock.
+					On("QueryContext", mock.Anything, queryGetOrganizationUnitByHandle,
+						handle, testParentID, testDeploymentID).
+					Return([]map[string]interface{}{row}, nil).
+					Once()
+			},
+			assert: func(ou OrganizationUnit) {
+				suite.Equal("ou2", ou.ID)
+				suite.Equal("child", ou.Handle)
+			},
+		},
+		{
+			name:   "not found",
+			handle: "missing",
+			parent: nil,
+			setup: func(handle string, parent *string) {
+				suite.expectDBClient()
+				suite.dbClientMock.
+					On("QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle,
+						handle, testDeploymentID).
+					Return([]map[string]interface{}{}, nil).
+					Once()
+			},
+			wantErr: ErrOrganizationUnitNotFound,
+		},
+		{
+			name:   "query error",
+			handle: "root",
+			parent: nil,
+			setup: func(handle string, parent *string) {
+				suite.expectDBClient()
+				suite.dbClientMock.
+					On("QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle,
+						handle, testDeploymentID).
+					Return(nil, errors.New("query err")).
+					Once()
+			},
+			wantErrString: "failed to execute query for handle",
+		},
+		{
+			name:   "builder error",
+			handle: "root",
+			parent: nil,
+			setup: func(handle string, parent *string) {
+				suite.expectDBClient()
+				suite.dbClientMock.
+					On("QueryContext", mock.Anything, queryGetRootOrganizationUnitByHandle,
+						handle, testDeploymentID).
+					Return([]map[string]interface{}{{"ou_id": 2}}, nil).
+					Once()
+			},
+			wantErrString: "failed to build organization unit for handle",
+		},
+		{
+			name:   "db client error",
+			handle: "root",
+			parent: nil,
+			setup: func(handle string, parent *string) {
+				suite.providerMock.
+					On("GetUserDBClient").
+					Return(nil, errors.New("db err")).
+					Once()
+			},
+			wantErrString: "failed to get database client",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			tc.setup(tc.handle, tc.parent)
+
+			ou, err := suite.store.GetOrganizationUnitByHandle(context.Background(), tc.handle, tc.parent)
+
+			switch {
+			case tc.wantErr != nil:
+				suite.Require().ErrorIs(err, tc.wantErr)
+			case tc.wantErrString != "":
+				suite.Require().Error(err)
+				suite.Contains(err.Error(), tc.wantErrString)
+			default:
+				suite.Require().NoError(err)
+				if tc.assert != nil {
+					tc.assert(ou)
+				}
+			}
+		})
+	}
+}
+
 func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CreateOrganizationUnit() {
 	tests := []struct {
 		name    string
@@ -1280,7 +1428,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			setup: func(limit, offset int) {
 				suite.expectDBClient()
 				rows := []map[string]interface{}{
-					makeOUResultRow("root", "root", "Root", "desc", nil),
+					makeOUResultRowWithLogoURL(
+						"root", "root", "Root", "desc", nil, "https://example.com/root-logo.png"),
 					makeOUResultRow("child", "child", "Child", "", nil),
 				}
 				suite.dbClientMock.
@@ -1293,7 +1442,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			assert: func(ous []OrganizationUnitBasic) {
 				suite.Len(ous, 2)
 				suite.Equal("root", ous[0].ID)
+				suite.Equal("https://example.com/root-logo.png", ous[0].LogoURL)
 				suite.Equal("child", ous[1].Handle)
+				suite.Equal("", ous[1].LogoURL)
 			},
 		},
 		{
@@ -1453,7 +1604,8 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitsByI
 			setup: func(ids []string) {
 				suite.expectDBClient()
 				rows := []map[string]interface{}{
-					makeOUResultRow("ou1", "root1", "Root1", "desc1", nil),
+					makeOUResultRowWithLogoURL(
+						"ou1", "root1", "Root1", "desc1", nil, "https://example.com/ou1-logo.png"),
 					makeOUResultRow("ou2", "root2", "Root2", "desc2", nil),
 				}
 				suite.dbClientMock.
@@ -1466,7 +1618,9 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitsByI
 			assert: func(ous []OrganizationUnitBasic) {
 				suite.Len(ous, 2)
 				suite.Equal("ou1", ous[0].ID)
+				suite.Equal("https://example.com/ou1-logo.png", ous[0].LogoURL)
 				suite.Equal("ou2", ous[1].ID)
+				suite.Equal("", ous[1].LogoURL)
 			},
 		},
 		{
@@ -1556,9 +1710,23 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_buildGetOrganizationUni
 		query := buildGetOrganizationUnitsByIDsQuery(ids)
 
 		suite.Require().Equal("OUQ-OU_MGT-21", query.ID)
+		suite.Require().Contains(query.PostgresQuery, "METADATA")
 		suite.Require().Contains(query.PostgresQuery, "$1, $2, $3")
 		suite.Require().Contains(query.PostgresQuery, "DEPLOYMENT_ID = $4")
+		suite.Require().Contains(query.SQLiteQuery, "METADATA")
 		suite.Require().Contains(query.SQLiteQuery, "?, ?, ?")
 		suite.Require().Contains(query.SQLiteQuery, "DEPLOYMENT_ID = ?")
 	})
+}
+
+func TestNewOrganizationUnitStore_TransactionerError(t *testing.T) {
+	mockProvider := providermock.NewDBProviderInterfaceMock(t)
+	mockProvider.On("GetUserDBTransactioner").Return(nil, errors.New("transactioner error"))
+
+	originalGetDBProvider := getDBProvider
+	getDBProvider = func() provider.DBProviderInterface { return mockProvider }
+	defer func() { getDBProvider = originalGetDBProvider }()
+
+	_, _, err := newOrganizationUnitStore()
+	require.Error(t, err)
 }

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -2286,6 +2286,7 @@ paths:
                     application:
                       id: 60a9b38b-6eba-9f9e-55f9-267067de4680
                       name: My Web Application
+                      description: My web application for managing resources
                       logoUrl: https://myapp.example.com/logo.png
                       url: https://myapp.example.com
                       tosUri: https://myapp.example.com/terms
@@ -3935,10 +3936,12 @@ paths:
                     handle: engineering
                     name: Engineering
                     description: Engineering Unit
+                    logoUrl: https://example.com/logos/engineering.png
                   - id: b7c40de6-95cd-4c45-8725-9c7cb5b9cafd
                     handle: sales
                     name: Sales
                     description: Sales Unit
+                    logoUrl: https://example.com/logos/sales.png
                 links:
                   - href: organization-units?offset=2&limit=2
                     rel: next
@@ -4231,10 +4234,12 @@ paths:
                     name: Frontend Team
                     handle: frontend
                     description: Handles UI/UX work
+                    logoUrl: https://example.com/logos/frontend.png
                   - id: 2a8f9e1c-4d7b-4c8a-9f3e-1b2c3d4e5f6g
                     name: Backend Team
                     handle: backend
                     description: Handles server-side development
+                    logoUrl: null
                 links:
                   - href: organization-units/afc77cfd-620b-4cf0-a31c-7377b0ea8902/ous?offset=2&limit=2
                     rel: next
@@ -4802,10 +4807,12 @@ paths:
                     name: Frontend Team
                     handle: frontend
                     description: Handles UI/UX work
+                    logoUrl: https://example.com/logos/frontend.png
                   - id: 2a8f9e1c-4d7b-4c8a-9f3e-1b2c3d4e5f6g
                     name: Backend Team
                     handle: backend
                     description: Handles server-side development
+                    logoUrl: null
                 links:
                   - href: organization-units/tree/engineering/ous?offset=2&limit=2
                     rel: next
@@ -11087,6 +11094,10 @@ components:
           type: string
           description: Application name
           example: My Web Application
+        description:
+          type: string
+          description: Application description
+          example: My web application for managing resources
         logoUrl:
           type: string
           format: uri

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -2046,9 +2046,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -52,6 +52,7 @@
     "dotenv": "17.2.3"
   },
   "overrides": {
-    "flatted": ">=3.4.2"
+    "flatted": ">=3.4.2",
+    "path-to-regexp": ">=8.4.0"
   }
 }

--- a/tests/integration/ou/ou_tree_api_test.go
+++ b/tests/integration/ou/ou_tree_api_test.go
@@ -298,6 +298,7 @@ func (suite *OUPathAPITestSuite) TestGetOrganizationUnitChildrenByPath() {
 		Handle:      "child-engineering",
 		Description: "Child of Engineering Unit",
 		Parent:      &pathTestOUID,
+		LogoURL:     "https://example.com/child-engineering-logo.png",
 	}
 
 	childID, err := createOUForPath(suite, childOU)
@@ -345,6 +346,7 @@ func (suite *OUPathAPITestSuite) TestGetOrganizationUnitChildrenByPath() {
 			suite.Equal(childOU.Name, ou.Name)
 			suite.Equal(childOU.Handle, ou.Handle)
 			suite.Equal(childOU.Description, ou.Description)
+			suite.Equal(childOU.LogoURL, ou.LogoURL)
 			break
 		}
 	}

--- a/tests/integration/ou/ouapi_test.go
+++ b/tests/integration/ou/ouapi_test.go
@@ -175,6 +175,7 @@ func (suite *OUAPITestSuite) TestListOrganizationUnits() {
 			foundParent = true
 			suite.Equal(ouToCreate.Name, ou.Name)
 			suite.Equal(ouToCreate.Description, ou.Description)
+			suite.Equal(ouToCreate.LogoURL, ou.LogoURL)
 		}
 	}
 	suite.True(foundParent, "Created parent OU should be in the list")
@@ -756,6 +757,7 @@ func (suite *OUAPITestSuite) TestGetOrganizationUnitChildren() {
 			foundChild = true
 			suite.Equal(childOUToCreate.Name, ou.Name)
 			suite.Equal(childOUToCreate.Description, ou.Description)
+			suite.Equal(childOUToCreate.LogoURL, ou.LogoURL)
 		}
 	}
 	suite.True(foundChild, "Created child OU should be in the children list")


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request introduces support for a `logoUrl` property on organization units (OUs), allowing each OU to have an associated logo image or emoji. The changes span the API specification, backend data model and queries, resource bootstrapping scripts, and both unit and integration tests to ensure the new property is correctly handled throughout the stack.

Key changes include:

**API and Data Model Updates:**
- Added the `logoUrl` property to OU objects in the OpenAPI spec (`api/ou.yaml`) to document and expose this new field in API responses. [[1]](diffhunk://#diff-d00c6a10ef313a9255dd26ef070f9f1be173103c9ac8eedfd4976f90e6e0b716R52-R57) [[2]](diffhunk://#diff-d00c6a10ef313a9255dd26ef070f9f1be173103c9ac8eedfd4976f90e6e0b716R351-R356) [[3]](diffhunk://#diff-d00c6a10ef313a9255dd26ef070f9f1be173103c9ac8eedfd4976f90e6e0b716R894-R899)
- Modified backend database queries and data mapping logic to handle the `logoUrl`, now stored in the `METADATA` column as part of OU records. [[1]](diffhunk://#diff-1e048244bfbb5df6db4a9846c8f0bbb9d710370808b724a3cfa7315d33cdfe4aL38-R38) [[2]](diffhunk://#diff-1e048244bfbb5df6db4a9846c8f0bbb9d710370808b724a3cfa7315d33cdfe4aL104-R104) [[3]](diffhunk://#diff-1e048244bfbb5df6db4a9846c8f0bbb9d710370808b724a3cfa7315d33cdfe4aL164-R166) [[4]](diffhunk://#diff-9392b6e938671f6fe97d8c57c16c9f3ad78fa7dd3e6e685de8ddd109b81c879aL498-R505)

**Resource Bootstrapping:**
- Updated both PowerShell and shell scripts for initial resource creation to include a default `logoUrl` (using an emoji) when creating organization units. [[1]](diffhunk://#diff-251727c4cd4b985ce306b3bceda1a46916f4559e9aa429037689e8271628e3ceL62-R63) [[2]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aL55-R56) [[3]](diffhunk://#diff-b53003e82020d98b48d08f74cda38038f9fbacc8a4695c82678e491edf8acb89R59) [[4]](diffhunk://#diff-4267f1936f31d2ac2d4b97cf4deaa14c18ca545683fdaa57101fd31ca5d0a929L44-R45)

**Testing Enhancements:**
- Extended unit tests to cover parsing and error handling for the `logoUrl` in OU metadata, including new test helpers and cases for valid, missing, and invalid metadata. [[1]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6R284) [[2]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6R294-R299) [[3]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6L309-R322) [[4]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6L327-R338) [[5]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6R348-R361) [[6]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6L1283-R1300) [[7]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6R1313-R1315) [[8]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6L1456-R1475) [[9]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6R1488-R1490) [[10]](diffhunk://#diff-ec8cf9fee7995407de1239d18b14cb54e2fb6c9e2f5ec797e357276a9fc22cb6R1580-R1583)
- Updated integration tests to verify that the `logoUrl` is correctly returned in API responses for both parent and child organization units. [[1]](diffhunk://#diff-f27be9986267c2558b9c5e36a4416642ca2c482e709255602e467edc95e0403bR301) [[2]](diffhunk://#diff-f27be9986267c2558b9c5e36a4416642ca2c482e709255602e467edc95e0403bR349) [[3]](diffhunk://#diff-ab32c886355428cccc8093b5d19b30908453d73927245406f683be77da4db60dR178) [[4]](diffhunk://#diff-ab32c886355428cccc8093b5d19b30908453d73927245406f683be77da4db60dR760)

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->


<img width="1538" height="628" alt="Screenshot 2026-03-29 at 10 34 27" src="https://github.com/user-attachments/assets/3e8e557b-1356-486b-bdeb-83257fa6cb50" />


### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/1993

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization units now include logoUrl support so OUs can display logos; default/sample OUs include example logos.

* **Documentation**
  * API examples updated to show logoUrl (including null where absent) and added an optional application description field in metadata examples.

* **Tests**
  * Integration and E2E tests updated to create and assert logoUrl values.

* **Chores**
  * Server bootstrap payloads updated to include logoUrl in default/sample creations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->