### PR TITLE
Add type filter for role assingment API

### DIFF
--- a/api/role.yaml
+++ b/api/role.yaml
@@ -443,7 +443,7 @@ paths:
       tags:
         - roles
       summary: Get role assignments
-      description: Returns all user and group assignments for the role. Use include=display to get display names.
+      description: Returns user and group assignments for the role. Use type to filter by assignee type and include=display to get display names.
       parameters:
         - in: path
           name: id
@@ -451,6 +451,7 @@ paths:
           schema:
             type: string
             format: uuid
+        - $ref: '#/components/parameters/assigneeTypeQueryParam'
         - $ref: '#/components/parameters/includeQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
@@ -499,6 +500,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
               examples:
+                invalid-type:
+                  summary: Invalid assignee type parameter
+                  value:
+                    code: "ROL-1017"
+                    message: "Invalid assignee type"
+                    description: "The type parameter must be either 'user' or 'group'"
                 invalid-limit:
                   summary: Invalid limit parameter
                   value:
@@ -706,6 +713,17 @@ components:
         type: integer
         minimum: 0
         default: 0
+    assigneeTypeQueryParam:
+      in: query
+      name: type
+      required: false
+      schema:
+        type: string
+        enum:
+          - user
+          - group
+      description: |
+        Filter assignments by assignee type. When omitted, assignments of all types are returned.
     includeQueryParam:
       in: query
       name: include

--- a/backend/internal/role/RoleServiceInterface_mock_test.go
+++ b/backend/internal/role/RoleServiceInterface_mock_test.go
@@ -402,6 +402,100 @@ func (_c *RoleServiceInterfaceMock_GetRoleAssignments_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetRoleAssignmentsByType provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) GetRoleAssignmentsByType(ctx context.Context, id string, limit int, offset int, includeDisplay bool, assigneeType string) (*AssignmentList, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, limit, offset, includeDisplay, assigneeType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoleAssignmentsByType")
+	}
+
+	var r0 *AssignmentList
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, bool, string) (*AssignmentList, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, limit, offset, includeDisplay, assigneeType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, bool, string) *AssignmentList); ok {
+		r0 = returnFunc(ctx, id, limit, offset, includeDisplay, assigneeType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*AssignmentList)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, bool, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, limit, offset, includeDisplay, assigneeType)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRoleAssignmentsByType'
+type RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call struct {
+	*mock.Call
+}
+
+// GetRoleAssignmentsByType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - limit int
+//   - offset int
+//   - includeDisplay bool
+//   - assigneeType string
+func (_e *RoleServiceInterfaceMock_Expecter) GetRoleAssignmentsByType(ctx interface{}, id interface{}, limit interface{}, offset interface{}, includeDisplay interface{}, assigneeType interface{}) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	return &RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call{Call: _e.mock.On("GetRoleAssignmentsByType", ctx, id, limit, offset, includeDisplay, assigneeType)}
+}
+
+func (_c *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call) Run(run func(ctx context.Context, id string, limit int, offset int, includeDisplay bool, assigneeType string)) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call) Return(assignmentList *AssignmentList, serviceError *serviceerror.ServiceError) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(assignmentList, serviceError)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, includeDisplay bool, assigneeType string) (*AssignmentList, *serviceerror.ServiceError)) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRoleList provides a mock function for the type RoleServiceInterfaceMock
 func (_mock *RoleServiceInterfaceMock) GetRoleList(ctx context.Context, limit int, offset int) (*RoleList, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, limit, offset)

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -143,6 +143,44 @@ func (c *compositeRoleStore) GetRoleAssignments(
 	id string,
 	limit, offset int,
 ) ([]RoleAssignment, error) {
+	return c.getCompositeAssignments(ctx, id, limit, offset,
+		c.dbStore.GetRoleAssignmentsCount, c.fileStore.GetRoleAssignmentsCount,
+		func(count int) ([]RoleAssignment, error) { return c.dbStore.GetRoleAssignments(ctx, id, count, 0) },
+		func(count int) ([]RoleAssignment, error) { return c.fileStore.GetRoleAssignments(ctx, id, count, 0) },
+	)
+}
+
+// GetRoleAssignmentsByType retrieves assignments filtered by assignee type across both stores.
+func (c *compositeRoleStore) GetRoleAssignmentsByType(
+	ctx context.Context,
+	id string,
+	limit, offset int,
+	assigneeType string,
+) ([]RoleAssignment, error) {
+	return c.getCompositeAssignments(ctx, id, limit, offset,
+		func(ctx context.Context, id string) (int, error) {
+			return c.dbStore.GetRoleAssignmentsCountByType(ctx, id, assigneeType)
+		},
+		func(ctx context.Context, id string) (int, error) {
+			return c.fileStore.GetRoleAssignmentsCountByType(ctx, id, assigneeType)
+		},
+		func(count int) ([]RoleAssignment, error) {
+			return c.dbStore.GetRoleAssignmentsByType(ctx, id, count, 0, assigneeType)
+		},
+		func(count int) ([]RoleAssignment, error) {
+			return c.fileStore.GetRoleAssignmentsByType(ctx, id, count, 0, assigneeType)
+		},
+	)
+}
+
+// getCompositeAssignments is the shared logic for merging assignments from both stores.
+func (c *compositeRoleStore) getCompositeAssignments(
+	ctx context.Context,
+	id string,
+	limit, offset int,
+	dbCountFn, fileCountFn func(context.Context, string) (int, error),
+	dbListFn, fileListFn func(int) ([]RoleAssignment, error),
+) ([]RoleAssignment, error) {
 	capCount := func(fn func(context.Context, string) (int, error)) func() (int, error) {
 		return func() (int, error) {
 			count, err := fn(ctx, id)
@@ -153,10 +191,10 @@ func (c *compositeRoleStore) GetRoleAssignments(
 		}
 	}
 	assignments, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		capCount(c.dbStore.GetRoleAssignmentsCount),
-		capCount(c.fileStore.GetRoleAssignmentsCount),
-		func(count int) ([]RoleAssignment, error) { return c.dbStore.GetRoleAssignments(ctx, id, count, 0) },
-		func(count int) ([]RoleAssignment, error) { return c.fileStore.GetRoleAssignments(ctx, id, count, 0) },
+		capCount(dbCountFn),
+		capCount(fileCountFn),
+		dbListFn,
+		fileListFn,
 		mergeAssignments,
 		limit,
 		offset,
@@ -173,6 +211,40 @@ func (c *compositeRoleStore) GetRoleAssignments(
 
 // GetRoleAssignmentsCount retrieves the count of unique role assignments across both stores.
 func (c *compositeRoleStore) GetRoleAssignmentsCount(ctx context.Context, id string) (int, error) {
+	return c.getCompositeAssignmentsCount(ctx, id,
+		c.dbStore.GetRoleAssignmentsCount, c.fileStore.GetRoleAssignmentsCount,
+		func(count int) ([]RoleAssignment, error) { return c.dbStore.GetRoleAssignments(ctx, id, count, 0) },
+		func(count int) ([]RoleAssignment, error) { return c.fileStore.GetRoleAssignments(ctx, id, count, 0) },
+	)
+}
+
+// GetRoleAssignmentsCountByType retrieves the count of unique role assignments filtered by type.
+func (c *compositeRoleStore) GetRoleAssignmentsCountByType(
+	ctx context.Context, id string, assigneeType string,
+) (int, error) {
+	return c.getCompositeAssignmentsCount(ctx, id,
+		func(ctx context.Context, id string) (int, error) {
+			return c.dbStore.GetRoleAssignmentsCountByType(ctx, id, assigneeType)
+		},
+		func(ctx context.Context, id string) (int, error) {
+			return c.fileStore.GetRoleAssignmentsCountByType(ctx, id, assigneeType)
+		},
+		func(count int) ([]RoleAssignment, error) {
+			return c.dbStore.GetRoleAssignmentsByType(ctx, id, count, 0, assigneeType)
+		},
+		func(count int) ([]RoleAssignment, error) {
+			return c.fileStore.GetRoleAssignmentsByType(ctx, id, count, 0, assigneeType)
+		},
+	)
+}
+
+// getCompositeAssignmentsCount is the shared logic for counting merged assignments.
+func (c *compositeRoleStore) getCompositeAssignmentsCount(
+	ctx context.Context,
+	id string,
+	dbCountFn, fileCountFn func(context.Context, string) (int, error),
+	dbListFn, fileListFn func(int) ([]RoleAssignment, error),
+) (int, error) {
 	capCount := func(fn func(context.Context, string) (int, error)) func() (int, error) {
 		return func() (int, error) {
 			count, err := fn(ctx, id)
@@ -183,10 +255,10 @@ func (c *compositeRoleStore) GetRoleAssignmentsCount(ctx context.Context, id str
 		}
 	}
 	assignments, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		capCount(c.dbStore.GetRoleAssignmentsCount),
-		capCount(c.fileStore.GetRoleAssignmentsCount),
-		func(count int) ([]RoleAssignment, error) { return c.dbStore.GetRoleAssignments(ctx, id, count, 0) },
-		func(count int) ([]RoleAssignment, error) { return c.fileStore.GetRoleAssignments(ctx, id, count, 0) },
+		capCount(dbCountFn),
+		capCount(fileCountFn),
+		dbListFn,
+		fileListFn,
 		mergeAssignments,
 		serverconst.MaxCompositeStoreRecords+1,
 		0,

--- a/backend/internal/role/error_constants.go
+++ b/backend/internal/role/error_constants.go
@@ -133,6 +133,13 @@ var (
 		ErrorDescription: "Role creation is not allowed when running in declarative-only mode. " +
 			"Roles must be defined in declarative configuration files",
 	}
+	// ErrorInvalidAssigneeType is the error returned when the assignee type query parameter is invalid.
+	ErrorInvalidAssigneeType = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "ROL-1017",
+		Error:            "Invalid assignee type",
+		ErrorDescription: "The type parameter must be either 'user' or 'group'",
+	}
 )
 
 // Server errors for role management operations.
@@ -148,7 +155,7 @@ var (
 	// the maximum limit in composite mode (combining database and declarative resources).
 	ResultLimitExceededInCompositeMode = serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
-		Code:             "ROL-1016",
+		Code:             "ROL-1017",
 		Error:            "Result limit exceeded in composite mode",
 		ErrorDescription: "The total number of records exceeds the maximum limit in composite mode",
 	}

--- a/backend/internal/role/file_based_store.go
+++ b/backend/internal/role/file_based_store.go
@@ -153,6 +153,16 @@ func (f *fileBasedStore) GetRoleAssignments(
 	id string,
 	limit, offset int,
 ) ([]RoleAssignment, error) {
+	return f.GetRoleAssignmentsByType(ctx, id, limit, offset, "")
+}
+
+// GetRoleAssignmentsByType returns assignments for a role filtered by assignee type.
+func (f *fileBasedStore) GetRoleAssignmentsByType(
+	ctx context.Context,
+	id string,
+	limit, offset int,
+	assigneeType string,
+) ([]RoleAssignment, error) {
 	if limit <= 0 {
 		return []RoleAssignment{}, nil
 	}
@@ -176,7 +186,7 @@ func (f *fileBasedStore) GetRoleAssignments(
 		return nil, err
 	}
 
-	assignments := roleData.Assignments
+	assignments := filterAssignmentsByType(roleData.Assignments, assigneeType)
 	start := offset
 	if start >= len(assignments) {
 		return []RoleAssignment{}, nil
@@ -191,6 +201,13 @@ func (f *fileBasedStore) GetRoleAssignments(
 
 // GetRoleAssignmentsCount returns the assignment count for a role in the file-based store.
 func (f *fileBasedStore) GetRoleAssignmentsCount(ctx context.Context, id string) (int, error) {
+	return f.GetRoleAssignmentsCountByType(ctx, id, "")
+}
+
+// GetRoleAssignmentsCountByType returns the assignment count for a role filtered by type.
+func (f *fileBasedStore) GetRoleAssignmentsCountByType(
+	ctx context.Context, id string, assigneeType string,
+) (int, error) {
 	data, err := f.GenericFileBasedStore.Get(id)
 	if err != nil {
 		// Distinguish "not found" from other storage errors
@@ -207,7 +224,21 @@ func (f *fileBasedStore) GetRoleAssignmentsCount(ctx context.Context, id string)
 		return 0, err
 	}
 
-	return len(roleData.Assignments), nil
+	return len(filterAssignmentsByType(roleData.Assignments, assigneeType)), nil
+}
+
+// filterAssignmentsByType filters assignments by assignee type. If assigneeType is empty, all assignments are returned.
+func filterAssignmentsByType(assignments []RoleAssignment, assigneeType string) []RoleAssignment {
+	if assigneeType == "" {
+		return assignments
+	}
+	filtered := make([]RoleAssignment, 0)
+	for _, a := range assignments {
+		if string(a.Type) == assigneeType {
+			filtered = append(filtered, a)
+		}
+	}
+	return filtered
 }
 
 // UpdateRole is not supported in file-based store.

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -195,7 +195,20 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 	// Parse include parameter to check if display names should be included
 	includeDisplay := r.URL.Query().Get(sysutils.QueryParamInclude) == sysutils.IncludeValueDisplay
 
-	serviceResponse, svcErr := rh.roleService.GetRoleAssignments(ctx, id, limit, offset, includeDisplay)
+	// Parse optional type parameter to filter assignments by assignee type.
+	assigneeType := r.URL.Query().Get("type")
+	if assigneeType != "" && assigneeType != string(AssigneeTypeUser) && assigneeType != string(AssigneeTypeGroup) {
+		handleError(w, &ErrorInvalidAssigneeType)
+		return
+	}
+
+	var serviceResponse *AssignmentList
+	if assigneeType != "" {
+		serviceResponse, svcErr = rh.roleService.GetRoleAssignmentsByType(
+			ctx, id, limit, offset, includeDisplay, assigneeType)
+	} else {
+		serviceResponse, svcErr = rh.roleService.GetRoleAssignments(ctx, id, limit, offset, includeDisplay)
+	}
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return
@@ -220,6 +233,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 	logger.Debug("Successfully retrieved role assignments", log.String("role id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Bool("includeDisplay", includeDisplay),
+		log.String("assigneeType", assigneeType),
 		log.Int("totalResults", assignmentListResponse.TotalResults),
 		log.Int("count", assignmentListResponse.Count))
 }

--- a/backend/internal/role/init.go
+++ b/backend/internal/role/init.go
@@ -150,6 +150,14 @@ func registerRoutes(mux *http.ServeMux, roleHandler *roleHandler) {
 	mux.HandleFunc(middleware.WithCORS("OPTIONS /roles/{id}", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}, opts2))
+	opts4 := middleware.CORSOptions{
+		AllowedMethods:   "GET",
+		AllowedHeaders:   "Content-Type, Authorization",
+		AllowCredentials: true,
+	}
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /roles/{id}/assignments", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}, opts4))
 
 	opts3 := middleware.CORSOptions{
 		AllowedMethods:   "POST",

--- a/backend/internal/role/roleStoreInterface_mock_test.go
+++ b/backend/internal/role/roleStoreInterface_mock_test.go
@@ -596,6 +596,92 @@ func (_c *roleStoreInterfaceMock_GetRoleAssignments_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetRoleAssignmentsByType provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetRoleAssignmentsByType(ctx context.Context, id string, limit int, offset int, assigneeType string) ([]RoleAssignment, error) {
+	ret := _mock.Called(ctx, id, limit, offset, assigneeType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoleAssignmentsByType")
+	}
+
+	var r0 []RoleAssignment
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, string) ([]RoleAssignment, error)); ok {
+		return returnFunc(ctx, id, limit, offset, assigneeType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, string) []RoleAssignment); ok {
+		r0 = returnFunc(ctx, id, limit, offset, assigneeType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]RoleAssignment)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, string) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset, assigneeType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetRoleAssignmentsByType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRoleAssignmentsByType'
+type roleStoreInterfaceMock_GetRoleAssignmentsByType_Call struct {
+	*mock.Call
+}
+
+// GetRoleAssignmentsByType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - limit int
+//   - offset int
+//   - assigneeType string
+func (_e *roleStoreInterfaceMock_Expecter) GetRoleAssignmentsByType(ctx interface{}, id interface{}, limit interface{}, offset interface{}, assigneeType interface{}) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	return &roleStoreInterfaceMock_GetRoleAssignmentsByType_Call{Call: _e.mock.On("GetRoleAssignmentsByType", ctx, id, limit, offset, assigneeType)}
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call) Run(run func(ctx context.Context, id string, limit int, offset int, assigneeType string)) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call) Return(roleAssignments []RoleAssignment, err error) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(roleAssignments, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, assigneeType string) ([]RoleAssignment, error)) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRoleAssignmentsCount provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetRoleAssignmentsCount(ctx context.Context, id string) (int, error) {
 	ret := _mock.Called(ctx, id)
@@ -658,6 +744,78 @@ func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCount_Call) Return(n int, err
 }
 
 func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *roleStoreInterfaceMock_GetRoleAssignmentsCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRoleAssignmentsCountByType provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetRoleAssignmentsCountByType(ctx context.Context, id string, assigneeType string) (int, error) {
+	ret := _mock.Called(ctx, id, assigneeType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoleAssignmentsCountByType")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, id, assigneeType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, id, assigneeType)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, id, assigneeType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRoleAssignmentsCountByType'
+type roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call struct {
+	*mock.Call
+}
+
+// GetRoleAssignmentsCountByType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - assigneeType string
+func (_e *roleStoreInterfaceMock_Expecter) GetRoleAssignmentsCountByType(ctx interface{}, id interface{}, assigneeType interface{}) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
+	return &roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call{Call: _e.mock.On("GetRoleAssignmentsCountByType", ctx, id, assigneeType)}
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call) Run(run func(ctx context.Context, id string, assigneeType string)) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call) Return(n int, err error) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call) RunAndReturn(run func(ctx context.Context, id string, assigneeType string) (int, error)) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -49,6 +49,8 @@ type RoleServiceInterface interface {
 	DeleteRole(ctx context.Context, id string) *serviceerror.ServiceError
 	GetRoleAssignments(ctx context.Context, id string, limit, offset int,
 		includeDisplay bool) (*AssignmentList, *serviceerror.ServiceError)
+	GetRoleAssignmentsByType(ctx context.Context, id string, limit, offset int,
+		includeDisplay bool, assigneeType string) (*AssignmentList, *serviceerror.ServiceError)
 	AddAssignments(ctx context.Context, id string, assignments []RoleAssignment) *serviceerror.ServiceError
 	RemoveAssignments(ctx context.Context, id string, assignments []RoleAssignment) *serviceerror.ServiceError
 	IsRoleDeclarative(ctx context.Context, id string) (bool, *serviceerror.ServiceError)
@@ -363,6 +365,12 @@ func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.
 // GetRoleAssignments retrieves assignments for a role with pagination.
 func (rs *roleService) GetRoleAssignments(ctx context.Context, id string, limit, offset int,
 	includeDisplay bool) (*AssignmentList, *serviceerror.ServiceError) {
+	return rs.GetRoleAssignmentsByType(ctx, id, limit, offset, includeDisplay, "")
+}
+
+// GetRoleAssignmentsByType retrieves assignments for a role filtered by assignee type with pagination.
+func (rs *roleService) GetRoleAssignmentsByType(ctx context.Context, id string, limit, offset int,
+	includeDisplay bool, assigneeType string) (*AssignmentList, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	if err := validatePaginationParams(limit, offset); err != nil {
@@ -383,7 +391,13 @@ func (rs *roleService) GetRoleAssignments(ctx context.Context, id string, limit,
 		return nil, &ErrorRoleNotFound
 	}
 
-	totalCount, err := rs.roleStore.GetRoleAssignmentsCount(ctx, id)
+	var totalCount int
+	var assignments []RoleAssignment
+	if assigneeType != "" {
+		totalCount, err = rs.roleStore.GetRoleAssignmentsCountByType(ctx, id, assigneeType)
+	} else {
+		totalCount, err = rs.roleStore.GetRoleAssignmentsCount(ctx, id)
+	}
 	if err != nil {
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
@@ -392,7 +406,11 @@ func (rs *roleService) GetRoleAssignments(ctx context.Context, id string, limit,
 		return nil, &ErrorInternalServerError
 	}
 
-	assignments, err := rs.roleStore.GetRoleAssignments(ctx, id, limit, offset)
+	if assigneeType != "" {
+		assignments, err = rs.roleStore.GetRoleAssignmentsByType(ctx, id, limit, offset, assigneeType)
+	} else {
+		assignments, err = rs.roleStore.GetRoleAssignments(ctx, id, limit, offset)
+	}
 	if err != nil {
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
@@ -413,7 +431,11 @@ func (rs *roleService) GetRoleAssignments(ctx context.Context, id string, limit,
 		}
 	}
 	baseURL := fmt.Sprintf("/roles/%s/assignments", id)
-	links := utils.BuildPaginationLinks(baseURL, limit, offset, totalCount, utils.DisplayQueryParam(includeDisplay))
+	extraQuery := utils.DisplayQueryParam(includeDisplay)
+	if assigneeType != "" {
+		extraQuery += "&type=" + assigneeType
+	}
+	links := utils.BuildPaginationLinks(baseURL, limit, offset, totalCount, extraQuery)
 
 	response := &AssignmentList{
 		TotalResults: totalCount,

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -41,7 +41,10 @@ type roleStoreInterface interface {
 	GetRole(ctx context.Context, id string) (RoleWithPermissions, error)
 	IsRoleExist(ctx context.Context, id string) (bool, error)
 	GetRoleAssignments(ctx context.Context, id string, limit, offset int) ([]RoleAssignment, error)
+	GetRoleAssignmentsByType(ctx context.Context, id string,
+		limit, offset int, assigneeType string) ([]RoleAssignment, error)
 	GetRoleAssignmentsCount(ctx context.Context, id string) (int, error)
+	GetRoleAssignmentsCountByType(ctx context.Context, id string, assigneeType string) (int, error)
 	UpdateRole(ctx context.Context, id string, role RoleUpdateDetail) error
 	DeleteRole(ctx context.Context, id string) error
 	AddAssignments(ctx context.Context, id string, assignments []RoleAssignment) error
@@ -212,6 +215,29 @@ func (s *roleStore) GetRoleAssignments(ctx context.Context, id string, limit, of
 		return nil, fmt.Errorf("failed to get role assignments: %w", err)
 	}
 
+	return parseAssignmentResults(results)
+}
+
+// GetRoleAssignmentsByType retrieves assignments for a role filtered by assignee type with pagination.
+func (s *roleStore) GetRoleAssignmentsByType(
+	ctx context.Context, id string, limit, offset int, assigneeType string,
+) ([]RoleAssignment, error) {
+	dbClient, err := s.getConfigDBClient()
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := dbClient.QueryContext(
+		ctx, queryGetRoleAssignmentsByType, id, limit, offset, s.deploymentID, assigneeType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role assignments: %w", err)
+	}
+
+	return parseAssignmentResults(results)
+}
+
+// parseAssignmentResults parses database query results into role assignments.
+func parseAssignmentResults(results []map[string]interface{}) ([]RoleAssignment, error) {
 	assignments := make([]RoleAssignment, 0)
 	for _, row := range results {
 		assigneeID, err := parseStringField(row, "assignee_id")
@@ -239,6 +265,22 @@ func (s *roleStore) GetRoleAssignmentsCount(ctx context.Context, id string) (int
 	}
 
 	countResults, err := dbClient.QueryContext(ctx, queryGetRoleAssignmentsCount, id, s.deploymentID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get role assignments count: %w", err)
+	}
+
+	return parseCountResult(countResults)
+}
+
+// GetRoleAssignmentsCountByType retrieves the total count of assignments for a role filtered by type.
+func (s *roleStore) GetRoleAssignmentsCountByType(ctx context.Context, id string, assigneeType string) (int, error) {
+	dbClient, err := s.getConfigDBClient()
+	if err != nil {
+		return 0, err
+	}
+
+	countResults, err := dbClient.QueryContext(
+		ctx, queryGetRoleAssignmentsCountByType, id, s.deploymentID, assigneeType)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get role assignments count: %w", err)
 	}

--- a/backend/internal/role/store_constants.go
+++ b/backend/internal/role/store_constants.go
@@ -130,6 +130,20 @@ var (
 		ID:    "RLQ-ROLE_MGT-16",
 		Query: `SELECT COUNT(*) as count FROM "ROLE" WHERE ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
+
+	// queryGetRoleAssignmentsByType retrieves assignments for a role filtered by assignee type with pagination.
+	queryGetRoleAssignmentsByType = dbmodel.DBQuery{
+		ID: "RLQ-ROLE_MGT-17",
+		Query: `SELECT ASSIGNEE_ID, ASSIGNEE_TYPE FROM ROLE_ASSIGNMENT
+			WHERE ROLE_ID = $1 AND ASSIGNEE_TYPE = $5 AND DEPLOYMENT_ID = $4 ORDER BY CREATED_AT LIMIT $2 OFFSET $3`,
+	}
+
+	// queryGetRoleAssignmentsCountByType retrieves the total count of assignments for a role filtered by type.
+	queryGetRoleAssignmentsCountByType = dbmodel.DBQuery{
+		ID: "RLQ-ROLE_MGT-18",
+		Query: `SELECT COUNT(*) as total FROM ROLE_ASSIGNMENT
+			WHERE ROLE_ID = $1 AND ASSIGNEE_TYPE = $3 AND DEPLOYMENT_ID = $2`,
+	}
 )
 
 // buildAuthorizedPermissionsQuery constructs a database-specific query to retrieve authorized permissions

--- a/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
+++ b/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
@@ -403,6 +403,100 @@ func (_c *RoleServiceInterfaceMock_GetRoleAssignments_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetRoleAssignmentsByType provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) GetRoleAssignmentsByType(ctx context.Context, id string, limit int, offset int, includeDisplay bool, assigneeType string) (*role.AssignmentList, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, limit, offset, includeDisplay, assigneeType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoleAssignmentsByType")
+	}
+
+	var r0 *role.AssignmentList
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, bool, string) (*role.AssignmentList, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, limit, offset, includeDisplay, assigneeType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, bool, string) *role.AssignmentList); ok {
+		r0 = returnFunc(ctx, id, limit, offset, includeDisplay, assigneeType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*role.AssignmentList)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, bool, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, limit, offset, includeDisplay, assigneeType)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRoleAssignmentsByType'
+type RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call struct {
+	*mock.Call
+}
+
+// GetRoleAssignmentsByType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - limit int
+//   - offset int
+//   - includeDisplay bool
+//   - assigneeType string
+func (_e *RoleServiceInterfaceMock_Expecter) GetRoleAssignmentsByType(ctx interface{}, id interface{}, limit interface{}, offset interface{}, includeDisplay interface{}, assigneeType interface{}) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	return &RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call{Call: _e.mock.On("GetRoleAssignmentsByType", ctx, id, limit, offset, includeDisplay, assigneeType)}
+}
+
+func (_c *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call) Run(run func(ctx context.Context, id string, limit int, offset int, includeDisplay bool, assigneeType string)) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call) Return(assignmentList *role.AssignmentList, serviceError *serviceerror.ServiceError) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(assignmentList, serviceError)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, includeDisplay bool, assigneeType string) (*role.AssignmentList, *serviceerror.ServiceError)) *RoleServiceInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRoleList provides a mock function for the type RoleServiceInterfaceMock
 func (_mock *RoleServiceInterfaceMock) GetRoleList(ctx context.Context, limit int, offset int) (*role.RoleList, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, limit, offset)

--- a/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
+++ b/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
@@ -597,6 +597,92 @@ func (_c *roleStoreInterfaceMock_GetRoleAssignments_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetRoleAssignmentsByType provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetRoleAssignmentsByType(ctx context.Context, id string, limit int, offset int, assigneeType string) ([]role.RoleAssignment, error) {
+	ret := _mock.Called(ctx, id, limit, offset, assigneeType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoleAssignmentsByType")
+	}
+
+	var r0 []role.RoleAssignment
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, string) ([]role.RoleAssignment, error)); ok {
+		return returnFunc(ctx, id, limit, offset, assigneeType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, string) []role.RoleAssignment); ok {
+		r0 = returnFunc(ctx, id, limit, offset, assigneeType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]role.RoleAssignment)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, string) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset, assigneeType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetRoleAssignmentsByType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRoleAssignmentsByType'
+type roleStoreInterfaceMock_GetRoleAssignmentsByType_Call struct {
+	*mock.Call
+}
+
+// GetRoleAssignmentsByType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - limit int
+//   - offset int
+//   - assigneeType string
+func (_e *roleStoreInterfaceMock_Expecter) GetRoleAssignmentsByType(ctx interface{}, id interface{}, limit interface{}, offset interface{}, assigneeType interface{}) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	return &roleStoreInterfaceMock_GetRoleAssignmentsByType_Call{Call: _e.mock.On("GetRoleAssignmentsByType", ctx, id, limit, offset, assigneeType)}
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call) Run(run func(ctx context.Context, id string, limit int, offset int, assigneeType string)) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call) Return(roleAssignments []role.RoleAssignment, err error) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(roleAssignments, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, assigneeType string) ([]role.RoleAssignment, error)) *roleStoreInterfaceMock_GetRoleAssignmentsByType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRoleAssignmentsCount provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetRoleAssignmentsCount(ctx context.Context, id string) (int, error) {
 	ret := _mock.Called(ctx, id)
@@ -659,6 +745,78 @@ func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCount_Call) Return(n int, err
 }
 
 func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *roleStoreInterfaceMock_GetRoleAssignmentsCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRoleAssignmentsCountByType provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetRoleAssignmentsCountByType(ctx context.Context, id string, assigneeType string) (int, error) {
+	ret := _mock.Called(ctx, id, assigneeType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoleAssignmentsCountByType")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, id, assigneeType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, id, assigneeType)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, id, assigneeType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRoleAssignmentsCountByType'
+type roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call struct {
+	*mock.Call
+}
+
+// GetRoleAssignmentsCountByType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - assigneeType string
+func (_e *roleStoreInterfaceMock_Expecter) GetRoleAssignmentsCountByType(ctx interface{}, id interface{}, assigneeType interface{}) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
+	return &roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call{Call: _e.mock.On("GetRoleAssignmentsCountByType", ctx, id, assigneeType)}
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call) Run(run func(ctx context.Context, id string, assigneeType string)) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call) Return(n int, err error) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call) RunAndReturn(run func(ctx context.Context, id string, assigneeType string) (int, error)) *roleStoreInterfaceMock_GetRoleAssignmentsCountByType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -7195,8 +7195,8 @@ paths:
       tags:
         - roles
       summary: Get role assignments
-      description: Returns all user and group assignments for the role. Use
-        include=display to get display names.
+      description: Returns user and group assignments for the role. Use type to filter
+        by assignee type and include=display to get display names.
       parameters:
         - in: path
           name: id
@@ -7204,6 +7204,7 @@ paths:
           schema:
             type: string
             format: uuid
+        - $ref: "#/components/parameters/assigneeTypeQueryParam"
         - $ref: "#/components/parameters/includeQueryParam"
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/offsetQueryParam"
@@ -7252,6 +7253,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
               examples:
+                invalid-type:
+                  summary: Invalid assignee type parameter
+                  value:
+                    code: ROL-1017
+                    message: Invalid assignee type
+                    description: The type parameter must be either 'user' or 'group'
                 invalid-limit:
                   summary: Invalid limit parameter
                   value:
@@ -13319,6 +13326,18 @@ components:
         minLength: 1
         maxLength: 256
         example: user.not_found
+    assigneeTypeQueryParam:
+      in: query
+      name: type
+      required: false
+      schema:
+        type: string
+        enum:
+          - user
+          - group
+      description: >
+        Filter assignments by assignee type. When omitted, assignments of all
+        types are returned.
     filterParam:
       in: query
       name: filter

--- a/tests/integration/role/roleapi_test.go
+++ b/tests/integration/role/roleapi_test.go
@@ -1128,6 +1128,121 @@ func (suite *RoleAPITestSuite) TestCreateRole_MissingResourceServerID() {
 	// May return ROL-1012 or ROL-1001 depending on validation
 }
 
+// Test 31: Get Role Assignments - Filter by Type
+func (suite *RoleAPITestSuite) TestGetRoleAssignments_FilterByType() {
+	// Create a role with both user and group assignments
+	roleRequest := CreateRoleRequest{
+		Name: "Test Role for Type Filtering",
+		OUID: testOUID,
+		Permissions: []ResourcePermissions{
+			{
+				ResourceServerID: testResourceServer1ID,
+				Permissions:      []string{testPermission1},
+			},
+		},
+		Assignments: []Assignment{
+			{ID: testUserID1, Type: AssigneeTypeUser},
+			{ID: testUserID2, Type: AssigneeTypeUser},
+			{ID: testGroupID, Type: AssigneeTypeGroup},
+		},
+	}
+	role, err := suite.createRole(roleRequest)
+	suite.Require().NoError(err)
+	defer suite.deleteRole(role.ID)
+
+	// Verify no filter returns all assignments
+	allAssignments, err := suite.getRoleAssignments(role.ID, 0, 30)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(allAssignments)
+	suite.Equal(3, allAssignments.TotalResults, "Should return all 3 assignments without type filter")
+	suite.Equal(3, allAssignments.Count)
+
+	// Filter by user type
+	userAssignments, err := suite.getRoleAssignmentsByType(role.ID, 0, 30, "user")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(userAssignments)
+	suite.Equal(2, userAssignments.TotalResults, "Should return 2 user assignments")
+	suite.Equal(2, userAssignments.Count)
+	for _, assignment := range userAssignments.Assignments {
+		suite.Equal(AssigneeTypeUser, assignment.Type, "All assignments should be of type 'user'")
+	}
+
+	// Filter by group type
+	groupAssignments, err := suite.getRoleAssignmentsByType(role.ID, 0, 30, "group")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(groupAssignments)
+	suite.Equal(1, groupAssignments.TotalResults, "Should return 1 group assignment")
+	suite.Equal(1, groupAssignments.Count)
+	for _, assignment := range groupAssignments.Assignments {
+		suite.Equal(AssigneeTypeGroup, assignment.Type, "All assignments should be of type 'group'")
+	}
+	suite.Equal(testGroupID, groupAssignments.Assignments[0].ID)
+}
+
+// Test 32: Get Role Assignments - Filter by Type with Pagination
+func (suite *RoleAPITestSuite) TestGetRoleAssignments_FilterByTypeWithPagination() {
+	// Interleave group between users so a "paginate-then-filter" bug is caught.
+	// Wrong impl: offset=1,limit=1 on the raw list [user1, group, user2] gives [group] → filter → []
+	// Correct impl: filter first → [user1, user2], then offset=1,limit=1 → [user2]
+	roleRequest := CreateRoleRequest{
+		Name: "Test Role for Type Filter Pagination",
+		OUID: testOUID,
+		Permissions: []ResourcePermissions{
+			{
+				ResourceServerID: testResourceServer1ID,
+				Permissions:      []string{testPermission1},
+			},
+		},
+		Assignments: []Assignment{
+			{ID: testUserID1, Type: AssigneeTypeUser},
+			{ID: testGroupID, Type: AssigneeTypeGroup},
+			{ID: testUserID2, Type: AssigneeTypeUser},
+		},
+	}
+	role, err := suite.createRole(roleRequest)
+	suite.Require().NoError(err)
+	defer suite.deleteRole(role.ID)
+
+	// Get first page of user assignments (limit=1)
+	page1, err := suite.getRoleAssignmentsByType(role.ID, 0, 1, "user")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(page1)
+	suite.Equal(2, page1.TotalResults, "TotalResults should reflect filtered count")
+	suite.Require().Equal(1, page1.Count, "Should return only 1 assignment per page")
+
+	// Get second page — must return a different user than page 1
+	page2, err := suite.getRoleAssignmentsByType(role.ID, 1, 1, "user")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(page2)
+	suite.Equal(2, page2.TotalResults, "TotalResults should still be 2")
+	suite.Require().Equal(1, page2.Count, "Should return 1 assignment on second page")
+	suite.NotEqual(page1.Assignments[0].ID, page2.Assignments[0].ID,
+		"Page 1 and page 2 must return different user assignments")
+}
+
+// Test 33: Get Role Assignments - Invalid Type Parameter
+func (suite *RoleAPITestSuite) TestGetRoleAssignments_InvalidType() {
+	// Create a role
+	roleRequest := CreateRoleRequest{
+		Name: "Test Role for Invalid Type",
+		OUID: testOUID,
+		Permissions: []ResourcePermissions{
+			{
+				ResourceServerID: testResourceServer1ID,
+				Permissions:      []string{testPermission1},
+			},
+		},
+	}
+	role, err := suite.createRole(roleRequest)
+	suite.Require().NoError(err)
+	defer suite.deleteRole(role.ID)
+
+	// Request with invalid type should return error
+	_, err = suite.getRoleAssignmentsByType(role.ID, 0, 30, "invalid")
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "ROL-1017", "Should return invalid assignee type error")
+}
+
 // Helper methods
 
 func (suite *RoleAPITestSuite) createRole(request CreateRoleRequest) (*Role, error) {
@@ -1342,9 +1457,22 @@ func (suite *RoleAPITestSuite) getRoleAssignments(roleID string, offset, limit i
 
 func (suite *RoleAPITestSuite) getRoleAssignmentsWithInclude(roleID string, offset, limit int,
 	include string) (*AssignmentListResponse, error) {
+	return suite.getRoleAssignmentsWithParams(roleID, offset, limit, include, "")
+}
+
+func (suite *RoleAPITestSuite) getRoleAssignmentsByType(roleID string, offset, limit int,
+	assigneeType string) (*AssignmentListResponse, error) {
+	return suite.getRoleAssignmentsWithParams(roleID, offset, limit, "", assigneeType)
+}
+
+func (suite *RoleAPITestSuite) getRoleAssignmentsWithParams(roleID string, offset, limit int,
+	include, assigneeType string) (*AssignmentListResponse, error) {
 	url := fmt.Sprintf("%s%s/%s/assignments?offset=%d&limit=%d", testServerURL, rolesBasePath, roleID, offset, limit)
 	if include != "" {
 		url = fmt.Sprintf("%s&include=%s", url, include)
+	}
+	if assigneeType != "" {
+		url = fmt.Sprintf("%s&type=%s", url, assigneeType)
 	}
 
 	req, err := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
### Purpose
Add 'type` filter for the role assingment GET endpoint

### Related Issue(s)
- https://github.com/asgardeo/thunder/issues/1935

### Related PR(s)
- https://github.com/asgardeo/thunder/pull/1938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional `type` query parameter for role assignment listings to filter by user or group; pagination, totals and links respect the filter
  * Dedicated CORS preflight (OPTIONS) support for the role assignments endpoint

* **Bug Fixes**
  * Invalid `type` values return a documented 400 error (example code ROL-1017)

* **Documentation**
  * API spec updated with the `type` parameter and error example

* **Tests**
  * Integration tests for type filtering, pagination, and invalid-type handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->