### PR TITLE
Add build option to skip packing consent server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,10 @@ RUN if [ -n "$CERT_FILE" ] && [ -n "$KEY_FILE" ] && [ -f "$CERT_FILE" ] && [ -f 
 
 # Build both frontend and backend for the target architecture
 ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+ARG WITH_CONSENT=true
+RUN WITHOUT_CONSENT=$([ "$WITH_CONSENT" = "false" ] && echo "true" || echo "false") && \
+    export WITHOUT_CONSENT && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
         ./build.sh build linux amd64; \
     else \
         ./build.sh build linux arm64; \
@@ -115,7 +118,8 @@ USER thunder
 
 # Set environment variables
 ENV BACKEND_PORT=8090
-ENV WITH_CONSENT=true
+ARG WITH_CONSENT=true
+ENV WITH_CONSENT=${WITH_CONSENT}
 
 # Start the application
 CMD ["./start.sh"]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ VERSION_FILE=version.txt
 VERSION=$(shell cat $(VERSION_FILE))
 BINARY_NAME=thunder
 
+export WITHOUT_CONSENT ?= false
+
 # Tools
 PROJECT_DIR := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))/backend
 PROJECT_BIN_DIR := $(PROJECT_DIR)/bin

--- a/build.ps1
+++ b/build.ps1
@@ -33,8 +33,29 @@ param(
     [string]$TestRun,
     
     [Parameter(Position = 4)]
-    [string]$TestPackage
+    [string]$TestPackage,
+
+    [switch]$WithoutConsent
 )
+
+# Accept --without-consent anywhere in positional arguments.
+$positionalArgs = @($Command, $GO_OS, $GO_ARCH, $TestRun, $TestPackage)
+$withoutConsentFromArgs = $false
+
+for ($i = 0; $i -lt $positionalArgs.Count; $i++) {
+    if ($positionalArgs[$i] -ceq "--without-consent") {
+        $withoutConsentFromArgs = $true
+        $positionalArgs[$i] = $null
+    }
+}
+
+$Command = $positionalArgs[0]
+$GO_OS = $positionalArgs[1]
+$GO_ARCH = $positionalArgs[2]
+$TestRun = $positionalArgs[3]
+$TestPackage = $positionalArgs[4]
+
+$skipConsent = $WithoutConsent.IsPresent -or $withoutConsentFromArgs -or ($env:WITHOUT_CONSENT -eq "true")
 
 # Check for PowerShell Version Compatibility
 if ($PSVersionTable.PSVersion.Major -lt 7) {
@@ -617,12 +638,54 @@ function Package {
         Copy-Item -Path "setup.sh" -Destination $package_folder -Force
     }
 
-    Write-Host "Packaging consent server..."
-    $packageFolderAbs = (Resolve-Path -Path $package_folder).Path
-    & (Join-Path $SCRIPT_DIR "scripts/package-consent-server.ps1") `
-        -GoOS $GO_OS -GoArch $GO_ARCH -DistOutputPath $packageFolderAbs
-    if ($LASTEXITCODE -ne 0) {
-        throw "Consent server packaging failed with exit code $LASTEXITCODE"
+    if (-not $skipConsent) {
+        Write-Host "Packaging consent server..."
+        $packageFolderAbs = (Resolve-Path -Path $package_folder).Path
+        & (Join-Path $SCRIPT_DIR "scripts/package-consent-server.ps1") `
+            -GoOS $GO_OS -GoArch $GO_ARCH -DistOutputPath $packageFolderAbs
+        if ($LASTEXITCODE -ne 0) {
+            throw "Consent server packaging failed with exit code $LASTEXITCODE"
+        }
+    } else {
+        Write-Host "Skipping consent server packaging (--without-consent)..."
+        $targetYaml = Join-Path $package_folder "repository/conf/deployment.yaml"
+        $yqPatched = $false
+        if (Get-Command yq -ErrorAction SilentlyContinue) {
+            & yq eval '.consent.enabled = false' -i $targetYaml
+            if ($LASTEXITCODE -eq 0) {
+                $yqPatched = $true
+            }
+        }
+        if (-not $yqPatched) {
+            $content = Get-Content $targetYaml
+            $inConsent = $false
+            for ($i = 0; $i -lt $content.Length; $i++) {
+                if ($content[$i] -match '^consent:') {
+                    $inConsent = $true
+                } elseif ($inConsent -and $content[$i] -match '^\s*enabled:\s*true') {
+                    $content[$i] = $content[$i] -replace 'enabled:\s*true', 'enabled: false'
+                    $inConsent = $false
+                } elseif ($inConsent -and $content[$i] -match '^\S') {
+                    $inConsent = $false
+                }
+            }
+            $content | Set-Content $targetYaml
+        }
+        $consentDisabled = $false
+        $inConsentBlock = $false
+        foreach ($line in (Get-Content $targetYaml)) {
+            if ($line -match '^consent:') {
+                $inConsentBlock = $true
+            } elseif ($inConsentBlock -and $line -match '^\s+enabled:\s*false') {
+                $consentDisabled = $true
+                break
+            } elseif ($inConsentBlock -and $line -match '^\S') {
+                break
+            }
+        }
+        if (-not $consentDisabled) {
+            throw "Failed to disable consent in '$targetYaml' — packaging cannot continue with consent still enabled."
+        }
     }
 
     Write-Host "Creating zip file..."
@@ -1500,7 +1563,7 @@ function Run {
     Write-Host "Running frontend apps..."
     Run-Frontend
 
-    if ($script:CONSENT_ENABLED) {
+    if ($script:CONSENT_ENABLED -and -not $skipConsent) {
         Write-Host "Running consent server..."
         Run-Consent
     }

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,18 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Check if --without-consent is passed and remove it from args
+WITHOUT_CONSENT=${WITHOUT_CONSENT:-false}
+NEW_ARGS=()
+for arg in "$@"; do
+    if [ "$arg" = "--without-consent" ]; then
+        WITHOUT_CONSENT="true"
+    else
+        NEW_ARGS+=("$arg")
+    fi
+done
+set -- "${NEW_ARGS[@]}"
+
 # --- Set Default OS and the architecture --- 
 # Auto-detect GO OS
 DEFAULT_OS=$(go env GOOS 2>/dev/null)
@@ -474,9 +486,20 @@ function package() {
         chmod +x "$DIST_DIR/$PRODUCT_FOLDER/setup.sh"
     fi
 
-    echo "Packaging consent server..."
-    bash "$SCRIPT_DIR/scripts/package-consent-server.sh" \
-            "$GO_OS" "$GO_ARCH" "$(cd "$DIST_DIR/$PRODUCT_FOLDER" && pwd)"
+    if [ "$WITHOUT_CONSENT" != "true" ]; then
+        echo "Packaging consent server..."
+        bash "$SCRIPT_DIR/scripts/package-consent-server.sh" \
+                "$GO_OS" "$GO_ARCH" "$(cd "$DIST_DIR/$PRODUCT_FOLDER" && pwd)"
+    else
+        echo "Skipping consent server packaging (--without-consent)..."
+        local target_yaml="$DIST_DIR/$PRODUCT_FOLDER/repository/conf/deployment.yaml"
+        if command -v yq >/dev/null 2>&1; then
+            yq eval '.consent.enabled = false' -i "$target_yaml" 2>/dev/null || sed -i.bak '/^consent:/ { n; s/enabled: true/enabled: false/; }' "$target_yaml" || true
+        else
+            sed -i.bak '/^consent:/ { n; s/enabled: true/enabled: false/; }' "$target_yaml" || true
+        fi
+        rm -f "${target_yaml}.bak" 2>/dev/null || true
+    fi
 
     echo "Creating zip file..."
     (cd "$DIST_DIR" && zip -r "$PRODUCT_FOLDER.zip" "$PRODUCT_FOLDER")
@@ -964,7 +987,7 @@ function run() {
     echo "Running frontend apps..."
     run_frontend
 
-    if [ "$CONSENT_ENABLED" = "true" ]; then
+    if [ "$CONSENT_ENABLED" = "true" ] && [ "$WITHOUT_CONSENT" != "true" ]; then
         echo "Running consent server..."
         run_consent
     fi
@@ -1267,6 +1290,8 @@ case "$1" in
         echo "  debug_backend            - Run the Thunder backend for development in debug mode"
         echo "  run_frontend             - Run the Thunder frontend for development"
         echo "  run_docs                 - Run the documentation development server with live reload"
+        echo ""
+        echo "  --without-consent        - Skip packaging/running the consent server"
         exit 1
         ;;
 esac

--- a/docs/content/community/contributing/contributing-code/development-pipeline.mdx
+++ b/docs/content/community/contributing/contributing-code/development-pipeline.mdx
@@ -9,7 +9,11 @@ hide_table_of_contents: false
 
 ## Useful Commands
 
-This section provides a reference for all available make commands.
+This section provides a reference for the standard development commands. While the examples below use `make` for cross-platform simplicity, all commands map directly to the underlying build scripts for your OS:
+
+- **Make (Cross-platform):** `make <target>`
+- **Bash (Linux/macOS):** `./build.sh <target>`
+- **PowerShell (Windows):** `.\build.ps1 <target>`
 
 ### Building
 
@@ -35,6 +39,58 @@ make build_with_coverage
 
 This will run unit tests, build with coverage flags, run integration tests, and generate a combined coverage report.
 
+### Building without Consent Server
+
+By default, the build process downloads and packages the default consent server. If you want to skip this step, use the `WITHOUT_CONSENT` flag:
+
+**Using Make (Cross-platform)**
+```bash
+# Build and test bypassing consent
+make build WITHOUT_CONSENT=true
+make test_integration WITHOUT_CONSENT=true
+```
+
+**Using Bash (Linux/macOS)**
+```bash
+./build.sh build --without-consent
+```
+
+**Using PowerShell (Windows)**
+```powershell
+.\build.ps1 build --without-consent
+```
+
+**Using Docker**
+```bash
+docker build --build-arg WITH_CONSENT=false -t thunder:latest .
+```
+
+:::note
+If you build without the consent server, you must also disable it when running setup and starting the server, as the scripts default to `WITH_CONSENT=true`. Run setup and start with the appropriate flag for your platform:
+
+**Bash (Linux/macOS)**
+```bash
+./setup.sh --without-consent
+./start.sh --without-consent
+```
+
+**PowerShell (Windows)**
+```powershell
+.\setup.ps1 --without-consent
+.\start.ps1 --without-consent
+```
+
+**Make**
+```bash
+make run WITHOUT_CONSENT=true
+```
+
+**Docker (environment variable)**
+```bash
+docker run -e WITH_CONSENT=false thunder:latest
+```
+:::
+
 ### Running
 
 **Run everything (backend + frontend):**
@@ -43,6 +99,11 @@ make run
 ```
 
 This automatically sets up the complete development environment with backend, frontend apps, and seed data.
+
+If you built the project without the consent server, you must also run it with the flag to avoid startup errors:
+```bash
+make run WITHOUT_CONSENT=true
+```
 
 **Run only the backend:**
 ```bash


### PR DESCRIPTION
### Purpose
This pull request introduces a new build flag to optionally skip packaging and running the consent server across the build system, with support in both shell and PowerShell scripts, Dockerfile, and documentation. The change is controlled via a `WITHOUT_CONSENT` flag, which can be set as an environment variable, command-line argument, or Docker build argument. This allows developers to build and run the project without the default consent server, improving flexibility for different environments and use cases.

#### Sample build commands

**Using Make (Cross-platform)**
```bash
make build WITHOUT_CONSENT=true
make test_integration WITHOUT_CONSENT=true
```

**Using Bash (Linux/macOS)**
```bash
./build.sh build --without-consent
```

**Using PowerShell (Windows)**
```powershell
.\build.ps1 build --without-consent
```

**Using Docker**
```bash
docker build --build-arg WITH_CONSENT=false -t thunder:latest .
```

#### Sample run commands

If you build without the consent server, you must also disable it when running setup and starting the server.


**Make**
```bash
make run WITHOUT_CONSENT=true
```

**Bash (Linux/macOS)**
```bash
./setup.sh --without-consent
./start.sh --without-consent
```

**PowerShell (Windows)**
```powershell
.\setup.ps1 --without-consent
.\start.ps1 --without-consent
```

**Docker (environment variable)**
```bash
docker run -e WITH_CONSENT=false thunder:latest
```

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/asgardeo/thunder/issues/1967

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to build and run the application without the consent module via a unified WITHOUT_CONSENT/WITH_CONSENT option across Make, Bash, PowerShell and Docker flows.

* **Documentation**
  * Updated development pipeline docs with cross-platform instructions and examples for building, running and starting projects when the consent module is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->