### PR TITLE
Handle runtime SMTP errors gracefully in email executor

### DIFF
--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -139,7 +139,8 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 	}
 
 	if err := e.emailClient.Send(emailData); err != nil {
-		if isEmailClientError(err) {
+		if isEmailError(err) {
+			logger.Error("Error sending mail : ", log.Error(err))
 			execResp.Status = common.ExecFailure
 			execResp.FailureReason = "Failed to send email"
 			return execResp, nil
@@ -166,13 +167,16 @@ func resolveRecipientEmail(ctx *core.NodeContext) string {
 	return ""
 }
 
-// isEmailClientError returns true if the error is a client-side validation error
-// (e.g., invalid recipient, invalid sender) rather than a server-side transport error.
-func isEmailClientError(err error) bool {
+// isEmailError returns true if the error originated from the email subsystem,
+// covering both client-side validation errors and server-side SMTP transport errors.
+func isEmailError(err error) bool {
 	return errors.Is(err, email.ErrorInvalidRecipient) ||
 		errors.Is(err, email.ErrorInvalidSender) ||
 		errors.Is(err, email.ErrorInvalidSubject) ||
 		errors.Is(err, email.ErrorInvalidHost) ||
 		errors.Is(err, email.ErrorInvalidPort) ||
-		errors.Is(err, email.ErrorInvalidCredentials)
+		errors.Is(err, email.ErrorInvalidCredentials) ||
+		errors.Is(err, email.ErrorSMTPConnection) ||
+		errors.Is(err, email.ErrorSMTPAuth) ||
+		errors.Is(err, email.ErrorEmailSendFailed)
 }

--- a/backend/internal/flow/executor/email_executor_test.go
+++ b/backend/internal/flow/executor/email_executor_test.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -496,7 +497,58 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ClientError() {
 	suite.Equal("Failed to send email", resp.FailureReason)
 }
 
-func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ServerError() {
+func (suite *EmailExecutorTestSuite) TestExecute_SendMode_KnownSMTPErrors() {
+	cases := []struct {
+		name    string
+		sendErr error
+	}{
+		{"SMTPConnectionError", email.ErrorSMTPConnection},
+		{"SMTPAuthError", email.ErrorSMTPAuth},
+		{"EmailSendFailedError", email.ErrorEmailSendFailed},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			ctx := &core.NodeContext{
+				ExecutionID:  "test-execution-id",
+				ExecutorMode: ExecutorModeSend,
+				UserInputs: map[string]string{
+					"email": "user@example.com",
+				},
+				RuntimeData: map[string]string{
+					common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
+				},
+				NodeProperties: map[string]interface{}{
+					"emailTemplate": "USER_INVITE",
+				},
+			}
+
+			suite.mockTemplateService.On("Render",
+				mock.Anything,
+				template.ScenarioUserInvite,
+				template.TemplateTypeEmail,
+				mock.Anything,
+			).Return(&template.RenderedTemplate{
+				Subject: "You're Invited to Register",
+				Body:    "<html><body>Complete Registration</body></html>",
+				IsHTML:  true,
+			}, nil)
+
+			suite.mockEmailClient.On("Send", mock.Anything).Return(tc.sendErr)
+
+			resp, err := suite.executor.Execute(ctx)
+
+			suite.NoError(err)
+			suite.Equal(common.ExecFailure, resp.Status)
+			suite.Equal("Failed to send email", resp.FailureReason)
+			suite.Empty(resp.AdditionalData[common.DataEmailSent])
+		})
+	}
+}
+
+func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UnexpectedError() {
 	ctx := &core.NodeContext{
 		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
@@ -522,7 +574,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ServerError() {
 		IsHTML:  true,
 	}, nil)
 
-	suite.mockEmailClient.On("Send", mock.Anything).Return(email.ErrorSMTPConnection)
+	suite.mockEmailClient.On("Send", mock.Anything).Return(fmt.Errorf("unexpected internal error"))
 
 	resp, err := suite.executor.Execute(ctx)
 


### PR DESCRIPTION
### Purpose

When the email client is configured with syntactically valid but semantically wrong SMTP values (e.g., unreachable host, wrong credentials), `Send()` returns runtime errors (`ErrorSMTPConnection`, `ErrorSMTPAuth`, `ErrorEmailSendFailed`) that were not recognized by `isEmailClientError()`. These errors propagated as hard failures, stopping flow execution entirely instead of allowing graceful degradation with `emailSent=false`.

### Approach

Added the three missing SMTP transport error types (`ErrorSMTPConnection`, `ErrorSMTPAuth`, `ErrorEmailSendFailed`) to the error check function. Renamed `isEmailClientError()` to `isEmailError()` since it now covers both client-side validation errors and server-side SMTP transport errors.

With this change, all email subsystem errors are treated as graceful failures: the executor returns `ExecFailure` with `emailSent=false`, allowing the flow to continue and the SDK to fall back to displaying the invite link.

### Related Issues
- Fixes #2066

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email delivery failures are now classified more broadly across validation and SMTP transport errors; failures produce consistent "Failed to send email" responses and improved error logging for easier diagnosis.
  * Unexpected internal send errors now surface as execution errors rather than being treated as known send failures.

* **Tests**
  * Expanded tests covering SMTP connection, authentication, send failures, and unexpected internal errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->