### PR TITLE
Add a rule for make lint and make test to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Clone the SDK repository only if you are developing or debugging the SDK itself,
 - Write tests for new features and bug fixes (target 80%+ coverage).
 - Ensure proper error handling and logging at appropriate layers — not everywhere, just where failures are expected and actionable.
 - Ensure all identity-related code aligns with relevant RFC specifications.
+- Use `make lint` and `make test` to verify code quality and correctness before committing.
 
 ## Git and PR Conventions
 


### PR DESCRIPTION
This pull request adds a helpful guideline to the `AGENTS.md` documentation, encouraging developers to run code quality and test checks before committing. This should help maintain code quality and prevent errors from being merged.

- Documentation improvements:
  * Added a recommendation to use `make lint` and `make test` before committing code, to verify code quality and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with instructions for code quality verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->