### PR TITLE
Add Redis support with Docker Compose configuration and update README

### DIFF
--- a/install/local-development/redis/docker-compose.yml
+++ b/install/local-development/redis/docker-compose.yml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+services:
+  redis:
+    image: redis:7-alpine
+    restart: always
+    environment:
+      REDIS_USERNAME: asgthunder
+      REDIS_PASSWORD: asgthunder
+    command: >
+      redis-server
+      --user default off
+      --user asgthunder on ">asgthunder" ~* &* +@all
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:

--- a/install/quick-start/README.md
+++ b/install/quick-start/README.md
@@ -189,6 +189,37 @@ Then replace `<your-host>` with `thunder.local` and `<your-port>` with `8090` (o
 
 ---
 
+## Running with Redis Cache
+
+By default, Thunder cache is disabled. To use Redis, start a Redis instance and configure Thunder to point to it.
+
+### Step 1: Start Redis
+
+From the repository root, use the Redis Docker Compose file provided under `install/local-development/redis`:
+
+```bash
+docker compose -f ./install/local-development/redis/docker-compose.yml up -d
+```
+
+This starts Redis with a persistent volume.
+
+### Step 2: Configure Thunder to Use Redis
+
+Add the following cache section to your `deployment.yaml` override file (see [Custom Host and Port](#custom-host-and-port) for how to create and mount it), then start Thunder with `docker compose up`.
+
+```yaml
+cache:
+  type: "redis"
+  redis:
+    address: "<your-redis-host>:<your-redis-port>"
+    username: "<your-redis-username>"
+    password: "<your-redis-password>"
+    db: <your-redis-db>
+    key_prefix: "thunder:"
+```
+
+---
+
 ## Troubleshooting
 
 **`yaml: unmarshal errors` on startup**


### PR DESCRIPTION
### Purpose
This pull request adds support and documentation for running Thunder with a Redis cache instead of the default in-memory cache. The main changes include adding a Docker Compose file for local Redis setup and updating the documentation to guide users through configuring Thunder to use Redis.

**Redis support and documentation:**

* Added a Docker Compose file at `install/local-development/redis/docker-compose.yml` to easily start a local Redis instance with persistent storage for development purposes.
* Updated `install/quick-start/README.md` with step-by-step instructions for running Thunder with Redis, including how to start Redis using Docker Compose and how to configure Thunder to connect to it via the `deployment.yaml` override file.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1876

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis caching support: local Redis stack and cache-enabled deployments for faster, persistent caching.

* **Documentation**
  * Added a step-by-step guide for running Redis locally and configuring the app’s cache (connection, credentials, DB, key prefix) in deployment overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->