### PR TITLE
Change log level from Info to Debug for user schema retrieval logging

### DIFF
--- a/backend/internal/userschema/service.go
+++ b/backend/internal/userschema/service.go
@@ -116,7 +116,7 @@ func (us *userSchemaService) GetUserSchemaList(ctx context.Context, limit, offse
 
 	// Unfiltered path: the caller can see all user schemas.
 	if accessible.AllAllowed {
-		logger.Info("Caller has access to all user schemas, retrieving without OU filtering")
+		logger.Debug("Caller has access to all user schemas, retrieving without OU filtering")
 		return us.listAllUserSchemas(ctx, limit, offset, logger)
 	}
 


### PR DESCRIPTION
### Purpose
This pull request makes a minor change to the logging level in the `GetUserSchemaList` method. The log message for when the caller has access to all user schemas is now logged at the debug level instead of info.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging levels for improved system diagnostics. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->