### PR TITLE
Add 'include=display' support for thunder-console

### DIFF
--- a/frontend/apps/thunder-console/src/features/groups/api/__tests__/useGetGroup.test.ts
+++ b/frontend/apps/thunder-console/src/features/groups/api/__tests__/useGetGroup.test.ts
@@ -67,7 +67,7 @@ describe('useGetGroup', () => {
 
     expect(mockHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://localhost:8090/groups/g1',
+        url: 'https://localhost:8090/groups/g1?include=display',
         method: 'GET',
       }),
     );

--- a/frontend/apps/thunder-console/src/features/groups/api/__tests__/useGetGroups.test.ts
+++ b/frontend/apps/thunder-console/src/features/groups/api/__tests__/useGetGroups.test.ts
@@ -69,7 +69,7 @@ describe('useGetGroups', () => {
 
     expect(mockHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://localhost:8090/groups?limit=30&offset=0',
+        url: 'https://localhost:8090/groups?limit=30&offset=0&include=display',
         method: 'GET',
       }),
     );
@@ -82,7 +82,7 @@ describe('useGetGroups', () => {
     await waitFor(() => {
       expect(mockHttpRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://localhost:8090/groups?limit=10&offset=20',
+          url: 'https://localhost:8090/groups?limit=10&offset=20&include=display',
         }),
       );
     });

--- a/frontend/apps/thunder-console/src/features/groups/api/useGetGroup.ts
+++ b/frontend/apps/thunder-console/src/features/groups/api/useGetGroup.ts
@@ -40,7 +40,7 @@ export default function useGetGroup(groupId: string): UseQueryResult<Group> {
       const response: {
         data: Group;
       } = await http.request({
-        url: `${serverUrl}/groups/${groupId}`,
+        url: `${serverUrl}/groups/${groupId}?include=display`,
         method: 'GET',
       } as unknown as Parameters<typeof http.request>[0]);
 

--- a/frontend/apps/thunder-console/src/features/groups/api/useGetGroups.ts
+++ b/frontend/apps/thunder-console/src/features/groups/api/useGetGroups.ts
@@ -41,6 +41,7 @@ export default function useGetGroups(params?: GroupListParams): UseQueryResult<G
       const queryParams: URLSearchParams = new URLSearchParams({
         limit: limit.toString(),
         offset: offset.toString(),
+        include: 'display',
       });
 
       const response: {

--- a/frontend/apps/thunder-console/src/features/groups/components/GroupsList.tsx
+++ b/frontend/apps/thunder-console/src/features/groups/components/GroupsList.tsx
@@ -86,13 +86,13 @@ export default function GroupsList(): JSX.Element {
         valueGetter: (_value, row): string => row.description ?? '-',
       },
       {
-        field: 'ouId',
-        headerName: t('groups:listing.columns.organizationUnit', 'Organization Unit ID'),
+        field: 'ouHandle',
+        headerName: t('groups:listing.columns.organizationUnit', 'Organization Unit'),
         flex: 1,
         minWidth: 200,
         renderCell: (params: DataGrid.GridRenderCellParams<GroupBasic>) => (
           <Typography variant="body2" sx={{fontFamily: 'monospace', fontSize: '0.875rem'}}>
-            {params.row.ouId ?? '-'}
+            {params.row.ouHandle ?? params.row.ouId ?? '-'}
           </Typography>
         ),
       },

--- a/frontend/apps/thunder-console/src/features/groups/components/edit-group/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/groups/components/edit-group/general-settings/EditGeneralSettings.tsx
@@ -64,44 +64,80 @@ export default function EditGeneralSettings({group, onDeleteClick}: EditGeneralS
         title={t('groups:edit.general.sections.organizationUnit.title')}
         description={t('groups:edit.general.sections.organizationUnit.description')}
       >
-        <TextField
-          label={t('groups:edit.general.sections.organizationUnit.title')}
-          value={group.ouId}
-          fullWidth
-          size="small"
-          slotProps={{
-            input: {
-              readOnly: true,
-              endAdornment: (
-                <InputAdornment position="end">
-                  <Tooltip
-                    title={
-                      copiedField === 'ouId'
-                        ? t('common:actions.copied')
-                        : t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')
-                    }
-                  >
-                    <IconButton
-                      aria-label={t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')}
-                      onClick={() => {
-                        handleCopyToClipboard(group.ouId, 'ouId').catch(() => null);
-                      }}
-                      edge="end"
+        <Stack spacing={2}>
+          <TextField
+            label={t('groups:edit.general.sections.organizationUnit.handleLabel', 'Handle')}
+            value={group.ouHandle ?? '-'}
+            fullWidth
+            size="small"
+            slotProps={{
+              input: {
+                readOnly: true,
+                endAdornment: group.ouHandle ? (
+                  <InputAdornment position="end">
+                    <Tooltip
+                      title={
+                        copiedField === 'ouHandle'
+                          ? t('common:actions.copied')
+                          : t(
+                              'groups:edit.general.sections.quickCopy.copyOrganizationUnitHandle',
+                              'Copy Organization Unit Handle',
+                            )
+                      }
                     >
-                      {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
-                    </IconButton>
-                  </Tooltip>
-                </InputAdornment>
-              ),
-            },
-          }}
-          sx={{
-            '& input': {
-              fontFamily: 'monospace',
-              fontSize: '0.875rem',
-            },
-          }}
-        />
+                      <IconButton
+                        aria-label={t(
+                          'groups:edit.general.sections.quickCopy.copyOrganizationUnitHandle',
+                          'Copy Organization Unit Handle',
+                        )}
+                        onClick={() => {
+                          handleCopyToClipboard(group.ouHandle!, 'ouHandle').catch(() => null);
+                        }}
+                        edge="end"
+                      >
+                        {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+          />
+          <TextField
+            label={t('groups:edit.general.sections.organizationUnit.idLabel', 'ID')}
+            value={group.ouId}
+            fullWidth
+            size="small"
+            slotProps={{
+              input: {
+                readOnly: true,
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Tooltip
+                      title={
+                        copiedField === 'ouId'
+                          ? t('common:actions.copied')
+                          : t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')
+                      }
+                    >
+                      <IconButton
+                        aria-label={t('groups:edit.general.sections.quickCopy.copyOrganizationUnitId')}
+                        onClick={() => {
+                          handleCopyToClipboard(group.ouId, 'ouId').catch(() => null);
+                        }}
+                        edge="end"
+                      >
+                        {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+          />
+        </Stack>
       </SettingsCard>
 
       {/* Danger Zone */}

--- a/frontend/apps/thunder-console/src/features/groups/models/group.ts
+++ b/frontend/apps/thunder-console/src/features/groups/models/group.ts
@@ -40,6 +40,8 @@ export interface GroupBasic {
   description?: string;
   /** ID of the organization unit this group belongs to */
   ouId: string;
+  /** Handle of the organization unit, populated when include=display is used */
+  ouHandle?: string;
 }
 
 /**

--- a/frontend/apps/thunder-console/src/features/roles/api/__tests__/useGetRole.test.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/api/__tests__/useGetRole.test.tsx
@@ -119,7 +119,7 @@ describe('useGetRole', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const callArgs = mockHttpRequest.mock.calls[0][0];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(callArgs.url).toBe('https://api.test.com/roles/role-1');
+    expect(callArgs.url).toBe('https://api.test.com/roles/role-1?include=display');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(callArgs.method).toBe('GET');
   });

--- a/frontend/apps/thunder-console/src/features/roles/api/useGetRole.ts
+++ b/frontend/apps/thunder-console/src/features/roles/api/useGetRole.ts
@@ -38,7 +38,7 @@ export default function useGetRole(roleId: string): UseQueryResult<Role> {
       const serverUrl: string = getServerUrl();
 
       const response: {data: Role} = await http.request({
-        url: `${serverUrl}/roles/${roleId}`,
+        url: `${serverUrl}/roles/${roleId}?include=display`,
         method: 'GET',
       } as unknown as Parameters<typeof http.request>[0]);
 

--- a/frontend/apps/thunder-console/src/features/roles/api/useGetRoles.ts
+++ b/frontend/apps/thunder-console/src/features/roles/api/useGetRoles.ts
@@ -41,6 +41,7 @@ export default function useGetRoles(params?: RoleListParams): UseQueryResult<Rol
       const queryParams: URLSearchParams = new URLSearchParams({
         limit: limit.toString(),
         offset: offset.toString(),
+        include: 'display',
       });
 
       const response: {data: RoleListResponse} = await http.request({

--- a/frontend/apps/thunder-console/src/features/roles/components/RolesList.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/RolesList.tsx
@@ -110,10 +110,15 @@ export default function RolesList(): JSX.Element {
         valueGetter: (_value, row): string => row.description ?? '-',
       },
       {
-        field: 'ouId',
+        field: 'ouHandle',
         headerName: t('roles:listing.columns.organizationUnit'),
         flex: 1,
         minWidth: 200,
+        renderCell: (params: DataGrid.GridRenderCellParams<RoleSummary>) => (
+          <Typography variant="body2" sx={{fontFamily: 'monospace', fontSize: '0.875rem'}}>
+            {params.row.ouHandle ?? params.row.ouId ?? '-'}
+          </Typography>
+        ),
       },
       {
         field: 'actions',

--- a/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
@@ -58,41 +58,84 @@ export default function EditGeneralSettings({role, onDeleteClick}: EditGeneralSe
         title={t('roles:edit.general.sections.organizationUnit.title')}
         description={t('roles:edit.general.sections.organizationUnit.description')}
       >
-        <TextField
-          label={t('roles:edit.general.sections.organizationUnit.title')}
-          value={role.ouId}
-          fullWidth
-          size="small"
-          slotProps={{
-            input: {
-              readOnly: true,
-              endAdornment: (
-                <InputAdornment position="end">
-                  <Tooltip
-                    title={
-                      copiedField === 'ouId'
-                        ? t('common:actions.copied')
-                        : t('roles:edit.general.sections.organizationUnit.copyId')
-                    }
-                  >
-                    <IconButton
-                      aria-label={t('roles:edit.general.sections.organizationUnit.copyId')}
-                      onClick={() => {
-                        handleCopyToClipboard(role.ouId, 'ouId').catch(() => {
-                          /* noop */
-                        });
-                      }}
-                      edge="end"
+        <Stack spacing={2}>
+          <TextField
+            label={t('roles:edit.general.sections.organizationUnit.handleLabel', 'Handle')}
+            value={role.ouHandle ?? '-'}
+            fullWidth
+            size="small"
+            slotProps={{
+              input: {
+                readOnly: true,
+                endAdornment: role.ouHandle ? (
+                  <InputAdornment position="end">
+                    <Tooltip
+                      title={
+                        copiedField === 'ouHandle'
+                          ? t('common:actions.copied')
+                          : t(
+                              'roles:edit.general.sections.organizationUnit.copyHandle',
+                              'Copy Organization Unit Handle',
+                            )
+                      }
                     >
-                      {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
-                    </IconButton>
-                  </Tooltip>
-                </InputAdornment>
-              ),
-            },
-          }}
-          sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
-        />
+                      <IconButton
+                        aria-label={t(
+                          'roles:edit.general.sections.organizationUnit.copyHandle',
+                          'Copy Organization Unit Handle',
+                        )}
+                        onClick={() => {
+                          handleCopyToClipboard(role.ouHandle!, 'ouHandle').catch(() => {
+                            /* noop */
+                          });
+                        }}
+                        edge="end"
+                      >
+                        {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+          />
+          <TextField
+            label={t('roles:edit.general.sections.organizationUnit.idLabel', 'ID')}
+            value={role.ouId}
+            fullWidth
+            size="small"
+            slotProps={{
+              input: {
+                readOnly: true,
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Tooltip
+                      title={
+                        copiedField === 'ouId'
+                          ? t('common:actions.copied')
+                          : t('roles:edit.general.sections.organizationUnit.copyId')
+                      }
+                    >
+                      <IconButton
+                        aria-label={t('roles:edit.general.sections.organizationUnit.copyId')}
+                        onClick={() => {
+                          handleCopyToClipboard(role.ouId, 'ouId').catch(() => {
+                            /* noop */
+                          });
+                        }}
+                        edge="end"
+                      >
+                        {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+          />
+        </Stack>
       </SettingsCard>
 
       {/* Danger Zone */}

--- a/frontend/apps/thunder-console/src/features/roles/models/role.ts
+++ b/frontend/apps/thunder-console/src/features/roles/models/role.ts
@@ -50,6 +50,8 @@ export interface RoleSummary {
   description?: string;
   /** ID of the organization unit this role belongs to */
   ouId: string;
+  /** Handle of the organization unit (resolved when include=display is used) */
+  ouHandle?: string;
 }
 
 /**

--- a/frontend/apps/thunder-console/src/features/user-types/api/__tests__/useGetUserType.test.ts
+++ b/frontend/apps/thunder-console/src/features/user-types/api/__tests__/useGetUserType.test.ts
@@ -141,7 +141,7 @@ describe('useGetUserType', () => {
 
     expect(mockHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://api.test.com/user-schemas/123',
+        url: 'https://api.test.com/user-schemas/123?include=display',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/thunder-console/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
+++ b/frontend/apps/thunder-console/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
@@ -113,7 +113,7 @@ describe('useGetUserTypes', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const callArgs = mockHttpRequest.mock.calls[0][0];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(callArgs.url).toBe('https://api.test.com/user-schemas');
+    expect(callArgs.url).toBe('https://api.test.com/user-schemas?include=display');
   });
 
   it('should build URL with limit parameter only', async () => {
@@ -130,7 +130,7 @@ describe('useGetUserTypes', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const callArgs = mockHttpRequest.mock.calls[0][0];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(callArgs.url).toBe('https://api.test.com/user-schemas?limit=10');
+    expect(callArgs.url).toBe('https://api.test.com/user-schemas?limit=10&include=display');
   });
 
   it('should build URL with offset parameter only', async () => {
@@ -147,7 +147,7 @@ describe('useGetUserTypes', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const callArgs = mockHttpRequest.mock.calls[0][0];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(callArgs.url).toBe('https://api.test.com/user-schemas?offset=5');
+    expect(callArgs.url).toBe('https://api.test.com/user-schemas?offset=5&include=display');
   });
 
   it('should build URL with both limit and offset parameters', async () => {

--- a/frontend/apps/thunder-console/src/features/user-types/api/useGetUserType.ts
+++ b/frontend/apps/thunder-console/src/features/user-types/api/useGetUserType.ts
@@ -40,7 +40,7 @@ export default function useGetUserType(id?: string): UseQueryResult<ApiUserSchem
       const response: {
         data: ApiUserSchema;
       } = await http.request({
-        url: `${serverUrl}/user-schemas/${id}`,
+        url: `${serverUrl}/user-schemas/${id}?include=display`,
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/thunder-console/src/features/user-types/api/useGetUserTypes.ts
+++ b/frontend/apps/thunder-console/src/features/user-types/api/useGetUserTypes.ts
@@ -47,6 +47,7 @@ export default function useGetUserTypes(params?: UserSchemaListParams): UseQuery
       if (offset !== undefined) {
         queryParams.append('offset', offset.toString());
       }
+      queryParams.append('include', 'display');
 
       const queryString: string = queryParams.toString();
       const url = `${serverUrl}/user-schemas${queryString ? `?${queryString}` : ''}`;

--- a/frontend/apps/thunder-console/src/features/user-types/components/UserTypesList.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/components/UserTypesList.tsx
@@ -18,7 +18,6 @@
 
 import {useLogger} from '@thunder/logger/react';
 import {
-  Box,
   Chip,
   IconButton,
   Tooltip,
@@ -39,7 +38,6 @@ import {useCallback, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import useDataGridLocaleText from '../../../hooks/useDataGridLocaleText';
-import useGetOrganizationUnits from '../../organization-units/api/useGetOrganizationUnits';
 import useDeleteUserType from '../api/useDeleteUserType';
 import useGetUserTypes from '../api/useGetUserTypes';
 import type {UserSchemaListItem} from '../types/user-types';
@@ -54,27 +52,10 @@ export default function UserTypesList() {
   const logger = useLogger('UserTypesList');
   const dataGridLocaleText = useDataGridLocaleText();
 
-  const {data: userTypesData, isLoading: isUserTypesRequestLoading, error: userTypesRequestError} = useGetUserTypes();
+  const {data: userTypesData, isLoading, error: userTypesRequestError} = useGetUserTypes();
   const deleteUserTypeMutation = useDeleteUserType();
-  const {
-    data: organizationUnitsResponse,
-    isLoading: organizationUnitsLoading,
-    error: organizationUnitsError,
-  } = useGetOrganizationUnits();
 
-  const error = userTypesRequestError ?? organizationUnitsError;
-  const isLoading = isUserTypesRequestLoading || organizationUnitsLoading;
-  const organizationUnits = useMemo(
-    () => organizationUnitsResponse?.organizationUnits ?? [],
-    [organizationUnitsResponse],
-  );
-  const organizationUnitMap = useMemo(() => {
-    const map = new Map<string, string>();
-    organizationUnits.forEach((unit) => {
-      map.set(unit.id, unit.name);
-    });
-    return map;
-  }, [organizationUnits]);
+  const error = userTypesRequestError;
 
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [selectedUserTypeId, setSelectedUserTypeId] = useState<string | null>(null);
@@ -146,37 +127,15 @@ export default function UserTypesList() {
         ),
       },
       {
-        field: 'ou',
+        field: 'ouHandle',
         headerName: t('userTypes:listing.columns.organizationUnit', 'Organization Unit'),
         flex: 1,
         minWidth: 220,
-        renderCell: (params: GridRenderCellParams<UserSchemaListItem>) => {
-          const resolvedUnitName = params.row.ouId ? organizationUnitMap.get(params.row.ouId) : undefined;
-          const content = (() => {
-            if (!params.row.ouId) {
-              return t('common:messages.noData');
-            }
-            if (!resolvedUnitName) {
-              return params.row.ouId;
-            }
-            return resolvedUnitName;
-          })();
-
-          return (
-            <Box sx={{display: 'flex', alignItems: 'center', width: '100%', height: '100%'}}>
-              <Typography
-                variant="body2"
-                sx={{
-                  fontFamily: !resolvedUnitName && params.row.ouId ? 'monospace' : undefined,
-                  fontSize: '0.875rem',
-                  width: '100%',
-                }}
-              >
-                {content}
-              </Typography>
-            </Box>
-          );
-        },
+        renderCell: (params: DataGrid.GridRenderCellParams<UserSchemaListItem>) => (
+          <Typography variant="body2" sx={{fontFamily: 'monospace', fontSize: '0.875rem'}}>
+            {params.row.ouHandle ?? params.row.ouId ?? t('common:messages.noData')}
+          </Typography>
+        ),
       },
       {
         field: 'allowSelfRegistration',
@@ -228,7 +187,7 @@ export default function UserTypesList() {
         ),
       },
     ],
-    [organizationUnitMap, t, handleDeleteClick, handleViewClick],
+    [t, handleDeleteClick, handleViewClick],
   );
 
   return (

--- a/frontend/apps/thunder-console/src/features/user-types/components/__tests__/UserTypesList.test.tsx
+++ b/frontend/apps/thunder-console/src/features/user-types/components/__tests__/UserTypesList.test.tsx
@@ -178,8 +178,8 @@ describe('UserTypesList', () => {
     startIndex: 1,
     count: 2,
     schemas: [
-      {id: 'schema1', name: 'Employee Schema', ouId: 'root-ou', allowSelfRegistration: false},
-      {id: 'schema2', name: 'Contractor Schema', ouId: 'child-ou', allowSelfRegistration: true},
+      {id: 'schema1', name: 'Employee Schema', ouId: 'root-ou', ouHandle: 'root', allowSelfRegistration: false},
+      {id: 'schema2', name: 'Contractor Schema', ouId: 'child-ou', ouHandle: 'child', allowSelfRegistration: true},
     ],
   };
 
@@ -224,17 +224,19 @@ describe('UserTypesList', () => {
   it('shows organization unit names when available', () => {
     render(<UserTypesList />);
 
-    expect(screen.getByText('Root Organization')).toBeInTheDocument();
-    expect(screen.getByText('Child Organization')).toBeInTheDocument();
+    expect(screen.getByText('root')).toBeInTheDocument();
+    expect(screen.getByText('child')).toBeInTheDocument();
   });
 
-  it('falls back to organization unit id when lookup is missing', () => {
-    mockUseGetOrganizationUnits.mockReturnValueOnce({
-      data: {...mockOrganizationUnitsResponse, organizationUnits: []},
+  it('falls back to organization unit id when ouHandle is missing', () => {
+    mockUseGetUserTypes.mockReturnValueOnce({
+      data: {
+        ...mockUserTypesData,
+        schemas: [{...mockUserTypesData.schemas[0], ouHandle: undefined}],
+      },
       isLoading: false,
       error: null,
-      refetch: mockRefetchOrganizationUnits,
-    });
+    } as unknown as ReturnType<typeof useGetUserTypesHook>);
 
     render(<UserTypesList />);
 
@@ -245,7 +247,7 @@ describe('UserTypesList', () => {
     mockUseGetUserTypes.mockReturnValueOnce({
       data: {
         ...mockUserTypesData,
-        schemas: [{...mockUserTypesData.schemas[0], ouId: ''}],
+        schemas: [{...mockUserTypesData.schemas[0], ouId: undefined, ouHandle: undefined}],
       },
       isLoading: false,
       error: null,
@@ -473,21 +475,6 @@ describe('UserTypesList', () => {
       expect(mockMutateAsync).toHaveBeenCalledWith('schema1');
       // Dialog stays open so user can see error and retry
       expect(screen.getByText('Delete User Type')).toBeInTheDocument();
-    });
-  });
-
-  it('displays error from organization units in snackbar', async () => {
-    mockUseGetOrganizationUnits.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Failed to load organization units'),
-      refetch: mockRefetchOrganizationUnits,
-    });
-
-    render(<UserTypesList />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Failed to load organization units')).toBeInTheDocument();
     });
   });
 

--- a/frontend/apps/thunder-console/src/features/user-types/types/user-types.ts
+++ b/frontend/apps/thunder-console/src/features/user-types/types/user-types.ts
@@ -113,6 +113,7 @@ export interface ApiUserSchema {
   id: string;
   name: string;
   ouId: string;
+  ouHandle?: string;
   allowSelfRegistration: boolean;
   systemAttributes?: SystemAttributes;
   schema: UserSchemaDefinition;
@@ -125,6 +126,7 @@ export interface UserSchemaListItem {
   id: string;
   name: string;
   ouId: string;
+  ouHandle?: string;
   allowSelfRegistration: boolean;
   systemAttributes?: SystemAttributes;
 }

--- a/frontend/apps/thunder-console/src/features/users/components/UsersList.tsx
+++ b/frontend/apps/thunder-console/src/features/users/components/UsersList.tsx
@@ -154,6 +154,17 @@ export default function UsersList() {
         ),
       },
       {
+        field: 'ouHandle',
+        headerName: t('users:listing.columns.organizationUnit', 'Organization Unit'),
+        flex: 0.5,
+        minWidth: 150,
+        renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => (
+          <Typography variant="body2" sx={{fontFamily: 'monospace', fontSize: '0.875rem'}}>
+            {params.row.ouHandle ?? params.row.ouId ?? '-'}
+          </Typography>
+        ),
+      },
+      {
         field: 'actions',
         headerName: t('users:listing.columns.actions', 'Actions'),
         width: 150,

--- a/frontend/apps/thunder-console/src/features/users/models/users.ts
+++ b/frontend/apps/thunder-console/src/features/users/models/users.ts
@@ -39,6 +39,7 @@ export interface ApiError {
 export interface ApiUser {
   id: string;
   ouId: string;
+  ouHandle?: string;
   type: string;
   attributes?: Record<string, unknown>;
   display?: string;

--- a/frontend/apps/thunder-console/src/features/users/pages/UserEditPage.tsx
+++ b/frontend/apps/thunder-console/src/features/users/pages/UserEditPage.tsx
@@ -28,11 +28,15 @@ import {
   Chip,
   Tabs,
   Tab,
+  TextField,
+  InputAdornment,
+  Tooltip,
+  IconButton,
   PageContent,
   PageTitle,
 } from '@wso2/oxygen-ui';
-import {ArrowLeft, Save, X} from '@wso2/oxygen-ui-icons-react';
-import {useState, useEffect, useMemo, type SyntheticEvent, type ReactNode, type JSX} from 'react';
+import {ArrowLeft, Save, X, Copy, Check} from '@wso2/oxygen-ui-icons-react';
+import {useState, useEffect, useMemo, useCallback, useRef, type SyntheticEvent, type ReactNode, type JSX} from 'react';
 import {useForm} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import {Link, useNavigate, useParams} from 'react-router';
@@ -80,6 +84,8 @@ export default function UserEditPage() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const {data: user, isLoading: isUserLoading, error: userError} = useGetUser(userId);
   const updateUserMutation = useUpdateUser();
@@ -121,6 +127,26 @@ export default function UserEditPage() {
       });
     }
   }, [user, userSchema, setValue]);
+
+  useEffect(
+    () => () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleCopyToClipboard = useCallback(async (text: string, fieldName: string): Promise<void> => {
+    await navigator.clipboard.writeText(text);
+    setCopiedField(fieldName);
+    if (copyTimeoutRef.current) {
+      clearTimeout(copyTimeoutRef.current);
+    }
+    copyTimeoutRef.current = setTimeout(() => {
+      setCopiedField(null);
+    }, 2000);
+  }, []);
 
   const handleTabChange = (_event: SyntheticEvent, newValue: number) => {
     setActiveTab(newValue);
@@ -365,6 +391,93 @@ export default function UserEditPage() {
                   </Stack>
                 </Box>
               )}
+            </SettingsCard>
+
+            {/* Organization Unit */}
+            <SettingsCard
+              title={t('users:manageUser.sections.organizationUnit.title', 'Organization Unit')}
+              description={t(
+                'users:manageUser.sections.organizationUnit.description',
+                'The organization unit this user belongs to.',
+              )}
+            >
+              <Stack spacing={2}>
+                <TextField
+                  label={t('users:manageUser.sections.organizationUnit.handleLabel', 'Handle')}
+                  value={user.ouHandle ?? '-'}
+                  fullWidth
+                  size="small"
+                  slotProps={{
+                    input: {
+                      readOnly: true,
+                      endAdornment: user.ouHandle ? (
+                        <InputAdornment position="end">
+                          <Tooltip
+                            title={
+                              copiedField === 'ouHandle'
+                                ? t('common:actions.copied')
+                                : t(
+                                    'users:manageUser.sections.organizationUnit.copyHandle',
+                                    'Copy Organization Unit Handle',
+                                  )
+                            }
+                          >
+                            <IconButton
+                              aria-label={t(
+                                'users:manageUser.sections.organizationUnit.copyHandle',
+                                'Copy Organization Unit Handle',
+                              )}
+                              onClick={() => {
+                                handleCopyToClipboard(user.ouHandle!, 'ouHandle').catch(() => null);
+                              }}
+                              edge="end"
+                            >
+                              {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
+                            </IconButton>
+                          </Tooltip>
+                        </InputAdornment>
+                      ) : undefined,
+                    },
+                  }}
+                  sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+                />
+                <TextField
+                  label={t('users:manageUser.sections.organizationUnit.idLabel', 'ID')}
+                  value={user.ouId}
+                  fullWidth
+                  size="small"
+                  slotProps={{
+                    input: {
+                      readOnly: true,
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <Tooltip
+                            title={
+                              copiedField === 'ouId'
+                                ? t('common:actions.copied')
+                                : t('users:manageUser.sections.organizationUnit.copyId', 'Copy Organization Unit ID')
+                            }
+                          >
+                            <IconButton
+                              aria-label={t(
+                                'users:manageUser.sections.organizationUnit.copyId',
+                                'Copy Organization Unit ID',
+                              )}
+                              onClick={() => {
+                                handleCopyToClipboard(user.ouId, 'ouId').catch(() => null);
+                              }}
+                              edge="end"
+                            >
+                              {copiedField === 'ouId' ? <Check size={16} /> : <Copy size={16} />}
+                            </IconButton>
+                          </Tooltip>
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
+                  sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+                />
+              </Stack>
             </SettingsCard>
 
             {/* Danger Zone */}

--- a/frontend/apps/thunder-console/src/features/users/pages/UserInvitePage.tsx
+++ b/frontend/apps/thunder-console/src/features/users/pages/UserInvitePage.tsx
@@ -456,7 +456,7 @@ function InviteUserStepContent({
   // Invite link generated but email not sent
   if (isInviteGenerated && inviteLink) {
     return (
-      <Stack alignItems="center" spacing={3} sx={{py: 2}}>
+      <Stack alignItems="center" spacing={3} sx={{py: 2, flex: 1, justifyContent: 'center'}}>
         <Box
           sx={{
             width: 64,
@@ -856,13 +856,14 @@ export default function UserInvitePage(): JSX.Element {
               py: 8,
               px: 20,
               mx: 'auto',
-              alignItems: 'flex-start',
+              alignItems: 'center',
             }}
           >
             <Box
               sx={{
                 width: '100%',
                 maxWidth: 800,
+                flex: 1,
                 display: 'flex',
                 flexDirection: 'column',
               }}

--- a/frontend/packages/thunder-i18n/src/locales/en-US.ts
+++ b/frontend/packages/thunder-i18n/src/locales/en-US.ts
@@ -653,7 +653,7 @@ const translations = {
     'listing.search.placeholder': 'Search groups...',
     'listing.columns.name': 'Name',
     'listing.columns.description': 'Description',
-    'listing.columns.organizationUnit': 'Organization Unit ID',
+    'listing.columns.organizationUnit': 'Organization Unit',
     'listing.columns.actions': 'Actions',
 
     // Create page


### PR DESCRIPTION
### Purpose
This pull request updates how organization unit (OU) information is handled and displayed for groups and user types in the Thunder Console frontend. The main improvements are to consistently use the OU handle (a more user-friendly identifier) instead of the OU ID, and to simplify the code by removing redundant data fetching and mapping logic. The API requests are also updated to always request display information for OUs.

**Key changes include:**

### Organization Unit Display Improvements

* Added the `ouHandle` property to the `GroupBasic`, `ApiUserSchema`, `UserSchemaListItem`, and `ApiUser` interfaces, allowing the frontend to display a human-readable organization unit handle when available. [[1]](diffhunk://#diff-66e9d8b661c37ab468a107ab97fec2d02480d1af6c084ed0b64660c9d18080cbR43-R44) [[2]](diffhunk://#diff-69dde6fe9d74ecefebb6e710ce868e3ff6ef8ca1533a096b370529ae391dd2c3R116) [[3]](diffhunk://#diff-69dde6fe9d74ecefebb6e710ce868e3ff6ef8ca1533a096b370529ae391dd2c3R129) [[4]](diffhunk://#diff-4a715aaf73c6de0645a7ba0f75a4124700fe4a57dda106c76d0c4bfe40c9cbe9R42)
* Updated the `GroupsList` and `UserTypesList` components to show `ouHandle` (falling back to `ouId` if not present) in the relevant columns, improving readability for users. [[1]](diffhunk://#diff-388b9d2ca123a565bcbfabf2d33831a3c7b5699955b55d6a6f5b1a9eb29ee0daL90-R94) [[2]](diffhunk://#diff-7b1020453e748c5dfbf7b3e31a4e64e6171e2afd4f9e1fdfef2b1e59ec4b473fL151-R136)

### API Query Parameter Updates

* Modified API requests for groups and user types to always include `include=display`, ensuring the backend returns display-friendly fields like `ouHandle`. [[1]](diffhunk://#diff-03d8527ac23fc84df9f901e5bab11ef2a832414b4de33712649589742efe06d6L43-R43) [[2]](diffhunk://#diff-3c5fa93bb46e20935dcea00181c7e60bbd2090cf7020e4cb3744af8223bfea90R44) [[3]](diffhunk://#diff-3e6c35465b5a0644030c65fc7c87781dd202a789d64f1f1aaca48ebcd5424d18L43-R43) [[4]](diffhunk://#diff-0b95a4f62bf8aeb4208d3a725f23b833292ed64cd576176015f1168c95f63a3bR50)

### Code Simplification

* Removed the extra fetching and mapping of organization units in `UserTypesList`, since `ouHandle` is now provided directly by the API. This reduces complexity and potential for errors. [[1]](diffhunk://#diff-7b1020453e748c5dfbf7b3e31a4e64e6171e2afd4f9e1fdfef2b1e59ec4b473fL43) [[2]](diffhunk://#diff-7b1020453e748c5dfbf7b3e31a4e64e6171e2afd4f9e1fdfef2b1e59ec4b473fL59-R60) [[3]](diffhunk://#diff-7b1020453e748c5dfbf7b3e31a4e64e6171e2afd4f9e1fdfef2b1e59ec4b473fL233-R188)

These changes make organization unit information more user-friendly and simplify the codebase by relying on the backend to provide display values directly.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1843

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization unit handles (when available) are now shown across lists, details, and edit pages; fall back to IDs and handles are copyable.

* **Refactor**
  * Server responses now include organization unit display data so UI shows handles without additional lookups.

* **Style**
  * Column header updated from “Organization Unit ID” to “Organization Unit”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->