### PR TITLE
[DOCs] Update cache configuration to support Redis-backed caching

### DIFF
--- a/.vale/styles/WSO2-IAM/TitleCaseTitles.yml
+++ b/.vale/styles/WSO2-IAM/TitleCaseTitles.yml
@@ -27,3 +27,4 @@ exceptions:
   - via
   - with
   - without
+  - Per-Cache

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -181,16 +181,85 @@ Stores user profiles and credentials.
 
 ## Cache Configuration
 
-Thunder includes an in-memory caching layer to improve performance.
+Thunder includes both in-memory and Redis-backed caching to improve performance.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `cache.disabled` | `false` | If `true`, disables caching entirely |
-| `cache.type` | `inmemory` | Cache type (currently only `inmemory` is supported) |
+| `cache.type` | `inmemory` | Cache type (`inmemory` or `redis`). When `cache.type` is `redis`, Thunder does not use the periodic cleanup routine. |
 | `cache.size` | `1000` | Maximum number of cache entries |
 | `cache.ttl` | `3600` | Default time-to-live for cache entries in seconds |
 | `cache.eviction_policy` | `LRU` | Cache eviction policy (`LRU` - Least Recently Used) |
-| `cache.cleanup_interval` | `300` | Interval in seconds to clean up expired entries |
+| `cache.cleanup_interval` | `300` | In-memory only. Interval in seconds to clean up expired entries. Not used when `cache.type` is `redis`. |
+| `cache.properties[]` | `[]` | Per-cache overrides for `name`, `disabled`, `size`, `ttl`, and `eviction_policy` |
+| `cache.redis.address` | `""` | Redis server address in `host:port` format |
+| `cache.redis.username` | `""` | Redis username |
+| `cache.redis.password` | `""` | Redis password |
+| `cache.redis.db` | `0` | Redis database index |
+| `cache.redis.key_prefix` | `thunder` | Prefix added to all Redis cache keys |
+
+### Cache Property Overrides
+
+Use `cache.properties` when you want to override cache behavior for a specific internal cache instead of changing the global cache settings for all caches.
+
+Each item in `cache.properties` supports these fields:
+
+| Field | Required | Description |
+|---------|---------|-------------|
+| `name` | Yes | Internal cache name to override. The value must match the cache name exactly. |
+| `disabled` | No | Disables only that cache when set to `true`. |
+| `size` | No | Maximum number of entries for that cache. This setting applies to in-memory caches only. |
+| `ttl` | No | Time-to-live for that cache in seconds. |
+| `eviction_policy` | No | Eviction policy for that cache. Supported values are `LRU` and `LFU`. This setting applies to in-memory caches only. |
+
+If you omit a field in a `cache.properties` entry, Thunder falls back to the corresponding global `cache.*` setting.
+
+That means you can override only the fields you need. Thunder continues to use the global cache settings for any fields you leave unset.
+
+Thunder currently uses cache names such as:
+
+- `ApplicationByIDCache`
+- `ApplicationByNameCache`
+- `OAuthAppCache`
+- `FlowByIDCache`
+- `FlowByHandleCache`
+- `CertificateByIDCache`
+- `CertificateByReferenceCache`
+- `UserSchemaByIDCache`
+- `UserSchemaByNameCache`
+- `FlowGraphCache`
+
+:::note
+`FlowGraphCache` is always in-memory. It caches process-local flow graph Go objects during flow execution, not shared system-level cache data.
+:::
+
+:::note
+When `cache.type` is `redis`, per-cache `ttl` and `disabled` remain useful. Per-cache `size` and `eviction_policy` do not affect Redis behavior because Redis manages memory and eviction independently.
+:::
+
+### Redis Cache Configuration
+
+Set `cache.type` to `redis` and configure `cache.redis.address` to enable Redis-backed cache storage.
+
+```yaml
+cache:
+  type: "redis"
+  ttl: 3600
+  redis:
+    address: "localhost:6379"
+    username: ""
+    password: ""
+    db: 0
+    key_prefix: "thunder"
+```
+
+:::note
+When Redis caching is enabled, Thunder expires keys automatically based on TTL.
+:::
+
+:::warning
+If Thunder cannot connect to Redis during startup, it disables the cache layer.
+:::
 
 ## JWT Configuration
 


### PR DESCRIPTION
### Purpose
This pull request updates the cache configuration documentation to include support for Redis-backed caching in addition to the existing in-memory cache. The documentation now explains how to configure Redis as the cache backend and details the relevant settings.

**Cache system enhancements:**

* Updated the cache configuration section to reflect support for both in-memory and Redis-backed caching, including new configuration options for Redis such as `address`, `username`, `password`, `db`, and `key_prefix`.
* Added a dedicated "Redis Cache Configuration" section with an example YAML configuration and important notes on TTL handling and startup behavior if Redis is unavailable.
### Related Issues
- https://github.com/asgardeo/thunder/issues/1920

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Redis as an alternative to the in-memory cache in configuration docs.
  * Documented Redis connection, authentication, DB selection, and key-prefix settings.
  * Added per-cache overrides (name, disabled, size, ttl, eviction policy) with clear fallback to global settings.
  * New “Redis Cache Configuration” section with YAML example, TTL/expiration notes, and startup behavior if Redis is unreachable.

* **Style**
  * Added an exception to title-case rules to improve heading capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->