### PR TITLE
Use label-based bypass for dependency guard on fork PRs

### DIFF
--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -1,10 +1,11 @@
 # Reusable supply chain protection workflow.
 # Blocks package installs when dependency files are modified.
 #
-# Controlled via repository variables:
+# For PRs: the guard is active by default. A maintainer can add the
+#   'dependencies-approved' label to bypass it after reviewing the changes.
+# For non-PR contexts (schedule, workflow_dispatch): controlled via repository variables:
 #   vars.JS_DEPENDENCY_GUARD  - set to 'false' to disable JS guard
 #   vars.GO_DEPENDENCY_GUARD  - set to 'false' to disable Go guard
-# Both guards are enabled by default when the variable is unset.
 
 name: 🛡️ Dependency Guard
 
@@ -21,7 +22,11 @@ on:
 jobs:
   js:
     name: 🛡️ JS Dependency Guard
-    if: ${{ vars.JS_DEPENDENCY_GUARD != 'false' }}
+    if: >-
+      ${{
+        (inputs.detection-mode == 'pr' && !contains(github.event.pull_request.labels.*.name, 'dependencies-approved'))
+        || (inputs.detection-mode == 'commit' && vars.JS_DEPENDENCY_GUARD != 'false')
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -64,13 +69,17 @@ jobs:
           echo "::error::Changes detected in package.json / pnpm-lock.yaml / package-lock.json / .npmrc / pnpm-workspace.yaml."
           echo "::error::To prevent supply chain attacks, this workflow will not run JS package installs."
           echo ""
-          echo "If these changes are intentional and trusted, a maintainer must review and approve"
-          echo "the dependency changes before re-running this workflow."
+          echo "If these changes are intentional and trusted, a maintainer must add the"
+          echo "'dependencies-approved' label to the PR and re-run this workflow."
           exit 1
 
   go:
     name: 🛡️ Go Dependency Guard
-    if: ${{ vars.GO_DEPENDENCY_GUARD != 'false' }}
+    if: >-
+      ${{
+        (inputs.detection-mode == 'pr' && !contains(github.event.pull_request.labels.*.name, 'dependencies-approved'))
+        || (inputs.detection-mode == 'commit' && vars.GO_DEPENDENCY_GUARD != 'false')
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -110,6 +119,6 @@ jobs:
           echo "::error::Changes detected in go.mod / go.sum."
           echo "::error::To prevent supply chain attacks, this workflow will not run Go module downloads."
           echo ""
-          echo "If these changes are intentional and trusted, a maintainer must review and approve"
-          echo "the dependency changes before re-running this workflow."
+          echo "If these changes are intentional and trusted, a maintainer must add the"
+          echo "'dependencies-approved' label to the PR and re-run this workflow."
           exit 1


### PR DESCRIPTION
## Summary
- The `vars` context is unavailable for workflows triggered by fork PRs, causing the dependency guard to always block builds regardless of repo variable settings.
- Switch PR-mode guard to check for a `dependencies-approved` label instead. Only users with write access can add labels, so the security model is preserved.
- Non-PR contexts (schedule, workflow_dispatch) continue using repo variables (`vars.JS_DEPENDENCY_GUARD`, `vars.GO_DEPENDENCY_GUARD`).

## Test plan
- [ ] Merge this PR, then re-run the dependabot fixes PR — guard should pass (no dependency files in this PR to trigger it)
- [ ] On a PR with dependency changes, verify the guard blocks without the label
- [ ] Add `dependencies-approved` label and re-run — verify the guard is skipped
- [ ] Create the `dependencies-approved` label on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency verification workflow to enforce label-based approval for pull requests, streamlining the dependency review process with clearer approval guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->