### PR TITLE
Use vars for merge queue in dependency guard

### DIFF
--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -3,7 +3,7 @@
 #
 # For PRs: the guard is active by default. A maintainer can add the
 #   'dependencies-approved' label to bypass it after reviewing the changes.
-# For non-PR contexts (schedule, workflow_dispatch): controlled via repository variables:
+# For merge queue and non-PR contexts: controlled via repository variables:
 #   vars.JS_DEPENDENCY_GUARD  - set to 'false' to disable JS guard
 #   vars.GO_DEPENDENCY_GUARD  - set to 'false' to disable Go guard
 
@@ -24,7 +24,12 @@ jobs:
     name: 🛡️ JS Dependency Guard
     if: >-
       ${{
-        (inputs.detection-mode == 'pr' && !contains(github.event.pull_request.labels.*.name, 'dependencies-approved'))
+        (inputs.detection-mode == 'pr'
+          && github.event_name == 'pull_request'
+          && !contains(github.event.pull_request.labels.*.name, 'dependencies-approved'))
+        || (inputs.detection-mode == 'pr'
+          && github.event_name == 'merge_group'
+          && vars.JS_DEPENDENCY_GUARD != 'false')
         || (inputs.detection-mode == 'commit' && vars.JS_DEPENDENCY_GUARD != 'false')
       }}
     runs-on: ubuntu-latest
@@ -77,7 +82,12 @@ jobs:
     name: 🛡️ Go Dependency Guard
     if: >-
       ${{
-        (inputs.detection-mode == 'pr' && !contains(github.event.pull_request.labels.*.name, 'dependencies-approved'))
+        (inputs.detection-mode == 'pr'
+          && github.event_name == 'pull_request'
+          && !contains(github.event.pull_request.labels.*.name, 'dependencies-approved'))
+        || (inputs.detection-mode == 'pr'
+          && github.event_name == 'merge_group'
+          && vars.GO_DEPENDENCY_GUARD != 'false')
         || (inputs.detection-mode == 'commit' && vars.GO_DEPENDENCY_GUARD != 'false')
       }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- For `pull_request` events (including forks): uses `dependencies-approved` label to bypass the guard
- For `merge_group` events: uses repository variables (`vars.JS_DEPENDENCY_GUARD` / `vars.GO_DEPENDENCY_GUARD`) since `vars` context is available in merge queue (runs on base repo)
- For non-PR contexts (schedule, workflow_dispatch): continues using repository variables

This fixes the merge queue failure where labels are not available but `vars` context is.

## Test plan
- [ ] Merge this PR, then re-queue the dependabot fixes PR — guard should be skipped (vars set to `false`)
- [ ] Verify PR builds still respect the `dependencies-approved` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)