### PR TITLE
Add support for organization unit selection in user type resolution in user invite flow

### DIFF
--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -85,7 +85,7 @@ func Initialize(
 		attributeCacheSvc))
 	reg.RegisterExecutor(ExecutorNameAuthorization, newAuthorizationExecutor(flowFactory, authZService, userProvider))
 	reg.RegisterExecutor(ExecutorNameHTTPRequest, newHTTPRequestExecutor(flowFactory))
-	reg.RegisterExecutor(ExecutorNameUserTypeResolver, newUserTypeResolver(flowFactory, userSchemaService))
+	reg.RegisterExecutor(ExecutorNameUserTypeResolver, newUserTypeResolver(flowFactory, userSchemaService, ouService))
 	reg.RegisterExecutor(ExecutorNameInviteExecutor, newInviteExecutor(flowFactory))
 	reg.RegisterExecutor(ExecutorNameEmailExecutor, newEmailExecutor(flowFactory, emailClient, templateService))
 	reg.RegisterExecutor(ExecutorNameCredentialSetter, newCredentialSetter(flowFactory, userProvider))

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -35,6 +35,8 @@ const (
 	ouResolveFromCaller = "caller"
 	// ouResolveFromPrompt indicates that the user should be prompted to select an OU.
 	ouResolveFromPrompt = "prompt"
+	// ouResolveFromPromptAll shows the full OU tree without depending on UserTypeResolver.
+	ouResolveFromPromptAll = "promptAll"
 )
 
 // ouResolverExecutor resolves the organization unit for a user being onboarded.
@@ -78,6 +80,7 @@ func newOUResolverExecutor(
 // Supported strategies:
 //   - "caller": overrides the default OU with the caller's OU from the security context.
 //   - "prompt": checks for child OUs and prompts the user to select one if applicable.
+//   - "promptAll": shows the full OU tree from root, independent of UserTypeResolver.
 func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
 
@@ -97,6 +100,8 @@ func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 		return e.resolveFromCaller(ctx, execResp, logger)
 	case ouResolveFromPrompt:
 		return e.resolveFromPrompt(ctx, logger)
+	case ouResolveFromPromptAll:
+		return e.resolveFromPromptAll(ctx, logger)
 	default:
 		logger.Error("Unsupported resolveFrom value", log.String("resolveFrom", resolveFrom))
 		execResp.Status = common.ExecFailure
@@ -194,6 +199,48 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 		execResp.Inputs = []common.Input{input}
 		// Forward the root OU ID so the frontend knows where to start the tree picker.
 		execResp.AdditionalData[common.DataRootOUID] = parentOUID
+		execResp.ForwardedData[common.ForwardedDataKeyInputs] = execResp.Inputs
+	}
+
+	return execResp, nil
+}
+
+// resolveFromPromptAll shows the full OU tree from root, allowing selection of any OU.
+// Unlike "prompt", this strategy does not depend on UserTypeResolver having run first.
+func (e *ouResolverExecutor) resolveFromPromptAll(ctx *core.NodeContext,
+	logger *log.Logger) (*common.ExecutorResponse, error) {
+	execResp := &common.ExecutorResponse{
+		RuntimeData:    make(map[string]string),
+		AdditionalData: make(map[string]string),
+		ForwardedData:  make(map[string]interface{}),
+	}
+
+	// If the user already provided an OU selection, validate and accept it.
+	if selectedOUID, ok := ctx.UserInputs[ouIDKey]; ok && selectedOUID != "" {
+		exists, svcErr := e.ouService.IsOrganizationUnitExists(ctx.Context, selectedOUID)
+		if svcErr != nil {
+			return nil, errors.New("failed to validate selected organization unit: " + svcErr.Error)
+		}
+		if !exists {
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "The selected organization unit does not exist."
+			return execResp, nil
+		}
+
+		logger.Debug("OU selected by user", log.String(ouIDKey, selectedOUID))
+		execResp.RuntimeData[ouIDKey] = selectedOUID
+		execResp.Status = common.ExecComplete
+		return execResp, nil
+	}
+
+	// No selection yet — prompt the user with the full OU tree.
+	logger.Debug("Requesting OU selection from full tree")
+	execResp.Status = common.ExecUserInputRequired
+
+	inputs := e.GetDefaultInputs()
+	if len(inputs) > 0 {
+		input := inputs[0]
+		execResp.Inputs = []common.Input{input}
 		execResp.ForwardedData[common.ForwardedDataKeyInputs] = execResp.Inputs
 	}
 

--- a/backend/internal/flow/executor/ou_resolver_executor_test.go
+++ b/backend/internal/flow/executor/ou_resolver_executor_test.go
@@ -466,6 +466,130 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_GetChildrenError_Re
 	suite.mockOUService.AssertExpectations(suite.T())
 }
 
+// --- PromptAll strategy tests ---
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_FirstInvocation_RequestsInput() {
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
+		},
+		RuntimeData: map[string]string{},
+		UserInputs:  map[string]string{},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
+	assert.NotEmpty(suite.T(), result.Inputs)
+	assert.Equal(suite.T(), ouIDKey, result.Inputs[0].Identifier)
+	assert.Equal(suite.T(), "OU_SELECT", result.Inputs[0].Type)
+	// PromptAll should NOT set DataRootOUID (frontend shows full tree)
+	assert.Empty(suite.T(), result.AdditionalData[common.DataRootOUID])
+	suite.mockOUService.AssertNotCalled(suite.T(), "IsOrganizationUnitExists", mock.Anything, mock.Anything)
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_ValidOUSelection() {
+	selectedOUID := "valid-ou-123"
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
+		},
+		RuntimeData: map[string]string{},
+		UserInputs: map[string]string{
+			ouIDKey: selectedOUID,
+		},
+	}
+
+	suite.mockOUService.On("IsOrganizationUnitExists", mock.Anything, selectedOUID).
+		Return(true, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), selectedOUID, result.RuntimeData[ouIDKey])
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_NonExistentOU() {
+	selectedOUID := "nonexistent-ou-999"
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
+		},
+		RuntimeData: map[string]string{},
+		UserInputs: map[string]string{
+			ouIDKey: selectedOUID,
+		},
+	}
+
+	suite.mockOUService.On("IsOrganizationUnitExists", mock.Anything, selectedOUID).
+		Return(false, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "The selected organization unit does not exist.", result.FailureReason)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_ServiceError() {
+	selectedOUID := "some-ou-123"
+
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
+		},
+		RuntimeData: map[string]string{},
+		UserInputs: map[string]string{
+			ouIDKey: selectedOUID,
+		},
+	}
+
+	svcErr := &serviceerror.ServiceError{
+		Type:  serviceerror.ServerErrorType,
+		Code:  "OU-50001",
+		Error: "internal error",
+	}
+	suite.mockOUService.On("IsOrganizationUnitExists", mock.Anything, selectedOUID).
+		Return(false, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to validate selected organization unit")
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_EmptyOUInput_RequestsInput() {
+	ctx := &core.NodeContext{
+		FlowID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
+		},
+		RuntimeData: map[string]string{},
+		UserInputs: map[string]string{
+			ouIDKey: "",
+		},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
+	assert.NotEmpty(suite.T(), result.Inputs)
+	suite.mockOUService.AssertNotCalled(suite.T(), "IsOrganizationUnitExists", mock.Anything, mock.Anything)
+}
+
 func TestOUResolverExecutorSuite(t *testing.T) {
 	suite.Run(t, new(OUResolverExecutorTestSuite))
 }

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
+	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/userschema"
 )
@@ -43,6 +44,7 @@ type schemaWithOU struct {
 type userTypeResolver struct {
 	core.ExecutorInterface
 	userSchemaService userschema.UserSchemaServiceInterface
+	ouService         ou.OrganizationUnitServiceInterface
 	logger            *log.Logger
 }
 
@@ -52,6 +54,7 @@ var _ core.ExecutorInterface = (*userTypeResolver)(nil)
 func newUserTypeResolver(
 	flowFactory core.FlowFactoryInterface,
 	userSchemaService userschema.UserSchemaServiceInterface,
+	ouService ou.OrganizationUnitServiceInterface,
 ) *userTypeResolver {
 	logger := log.GetLogger().With(
 		log.String(log.LoggerKeyComponentName, userTypeResolverLoggerComponentName),
@@ -72,6 +75,7 @@ func newUserTypeResolver(
 	return &userTypeResolver{
 		ExecutorInterface: base,
 		userSchemaService: userSchemaService,
+		ouService:         ouService,
 		logger:            logger,
 	}
 }
@@ -203,6 +207,24 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 			return execResp, nil
 		}
 
+		// If an OU was already selected (OU-first onboarding flow), validate the user type is valid for that OU.
+		if selectedOUID, exists := ctx.RuntimeData[ouIDKey]; exists && selectedOUID != "" {
+			isValid, svcErr := u.ouService.IsParent(ctx.Context, ouID, selectedOUID)
+			if svcErr != nil {
+				logger.Error("Failed to validate user type against selected OU",
+					log.String(userTypeKey, userType), log.String(ouIDKey, selectedOUID),
+					log.String("error", svcErr.Error))
+				return nil, fmt.Errorf("failed to validate user type against selected OU: %s", svcErr.Error)
+			}
+			if !isValid {
+				logger.Debug("User type not valid for selected OU",
+					log.String(userTypeKey, userType), log.String(ouIDKey, selectedOUID))
+				execResp.Status = common.ExecFailure
+				execResp.FailureReason = "User type is not valid for the selected organization unit"
+				return execResp, nil
+			}
+		}
+
 		execResp.RuntimeData[userTypeKey] = userType
 		execResp.RuntimeData[defaultOUIDKey] = ouID
 		logger.Debug("User type resolved for user onboarding", log.String(userTypeKey, userType),
@@ -230,8 +252,19 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	// Build the list of available schema names, filtering by allowedUserTypes if configured
 	availableSchemas := u.filterSchemasByAllowedTypes(schemas.Schemas, allowedUserTypes)
 
+	// If an OU was already selected (OU-first onboarding flow), filter schemas to those valid for that OU.
+	// This only applies to USER_ONBOARDING flows where OUResolver with "promptAll" runs first.
+	// Registration flows derive the OU from the user type's schema, so ouId is never in RuntimeData.
+	if selectedOUID, exists := ctx.RuntimeData[ouIDKey]; exists && selectedOUID != "" {
+		var err error
+		availableSchemas, err = u.filterSchemasByOU(ctx, availableSchemas, selectedOUID, logger)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if len(availableSchemas) == 0 {
-		logger.Debug("No valid user types found after filtering with allowedUserTypes",
+		logger.Debug("No valid user types found after filtering",
 			log.Any("allowedUserTypes", allowedUserTypes))
 		execResp.Status = common.ExecFailure
 		execResp.FailureReason = "No valid user types available for this flow"
@@ -308,6 +341,32 @@ func (u *userTypeResolver) filterSchemasByAllowedTypes(
 	}
 
 	return filtered
+}
+
+// filterSchemasByOU filters schemas to only those valid for the given OU.
+// A schema is valid if its OUID is an ancestor of (or equal to) the selected OU.
+func (u *userTypeResolver) filterSchemasByOU(ctx *core.NodeContext,
+	schemas []userschema.UserSchemaListItem, selectedOUID string, logger *log.Logger,
+) ([]userschema.UserSchemaListItem, error) {
+	filtered := make([]userschema.UserSchemaListItem, 0, len(schemas))
+	for _, schema := range schemas {
+		isValid, svcErr := u.ouService.IsParent(ctx.Context, schema.OUID, selectedOUID)
+		if svcErr != nil {
+			logger.Error("Failed to check OU ancestry for schema",
+				log.String("schema", schema.Name), log.String("error", svcErr.Error))
+			return nil, fmt.Errorf("failed to check OU ancestry for schema %s: %s", schema.Name, svcErr.Error)
+		}
+		if isValid {
+			filtered = append(filtered, schema)
+		}
+	}
+
+	logger.Debug("Filtered schemas by selected OU",
+		log.String(ouIDKey, selectedOUID),
+		log.Int("before", len(schemas)),
+		log.Int("after", len(filtered)))
+
+	return filtered, nil
 }
 
 // resolveUserTypeFromInput resolves the user type from input and updates the executor response.

--- a/backend/internal/flow/executor/user_type_resolver_test.go
+++ b/backend/internal/flow/executor/user_type_resolver_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/userschema"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
+	"github.com/asgardeo/thunder/tests/mocks/oumock"
 	"github.com/asgardeo/thunder/tests/mocks/userschemamock"
 )
 
@@ -39,6 +40,7 @@ type UserTypeResolverTestSuite struct {
 	suite.Suite
 	mockUserSchemaService *userschemamock.UserSchemaServiceInterfaceMock
 	mockFlowFactory       *coremock.FlowFactoryInterfaceMock
+	mockOUService         *oumock.OrganizationUnitServiceInterfaceMock
 	executor              *userTypeResolver
 }
 
@@ -64,7 +66,8 @@ func (suite *UserTypeResolverTestSuite) SetupTest() {
 		defaultInputs, []common.Input{}).
 		Return(createMockUserTypeResolverExecutor(suite.T()))
 
-	suite.executor = newUserTypeResolver(suite.mockFlowFactory, suite.mockUserSchemaService)
+	suite.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	suite.executor = newUserTypeResolver(suite.mockFlowFactory, suite.mockUserSchemaService, suite.mockOUService)
 }
 
 func createMockUserTypeResolverExecutor(t *testing.T) core.ExecutorInterface {
@@ -112,7 +115,8 @@ func (suite *UserTypeResolverTestSuite) TestNewUserTypeResolver() {
 		defaultInputs, []common.Input{}).
 		Return(createMockUserTypeResolverExecutor(suite.T()))
 
-	executor := newUserTypeResolver(mockFlowFactory, mockUserSchemaService)
+	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	executor := newUserTypeResolver(mockFlowFactory, mockUserSchemaService, mockOUService)
 
 	assert.NotNil(suite.T(), executor)
 	assert.Equal(suite.T(), ExecutorNameUserTypeResolver, executor.GetName())
@@ -1301,4 +1305,258 @@ func (suite *UserTypeResolverTestSuite) TestPromptUserSelection_PreservesExistin
 	forwardedInputs, ok := execResp.ForwardedData[common.ForwardedDataKeyInputs]
 	assert.True(suite.T(), ok)
 	assert.NotNil(suite.T(), forwardedInputs)
+}
+
+// --- OU-first flow tests (UserOnboarding with ouId in RuntimeData) ---
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_UserTypeValidForOU() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: common.FlowTypeUserOnboarding,
+		UserInputs: map[string]string{
+			userTypeKey: "employee",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey: "child-ou-456",
+		},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:   "schema-123",
+		Name: "employee",
+		OUID: "parent-ou-123",
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", ctx.Context, "employee").
+		Return(userSchema, nil)
+	suite.mockOUService.On("IsParent", mock.Anything, "parent-ou-123", "child-ou-456").
+		Return(true, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "parent-ou-123", result.RuntimeData[defaultOUIDKey])
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_UserTypeNotValidForOU() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: common.FlowTypeUserOnboarding,
+		UserInputs: map[string]string{
+			userTypeKey: "employee",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey: "unrelated-ou-789",
+		},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:   "schema-123",
+		Name: "employee",
+		OUID: "parent-ou-123",
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", ctx.Context, "employee").
+		Return(userSchema, nil)
+	suite.mockOUService.On("IsParent", mock.Anything, "parent-ou-123", "unrelated-ou-789").
+		Return(false, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "User type is not valid for the selected organization unit", result.FailureReason)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_IsParentServiceError() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:   "flow-123",
+		FlowType: common.FlowTypeUserOnboarding,
+		UserInputs: map[string]string{
+			userTypeKey: "employee",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey: "child-ou-456",
+		},
+	}
+
+	userSchema := &userschema.UserSchema{
+		ID:   "schema-123",
+		Name: "employee",
+		OUID: "parent-ou-123",
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaByName", ctx.Context, "employee").
+		Return(userSchema, nil)
+	svcErr := &serviceerror.ServiceError{
+		Type:  serviceerror.ServerErrorType,
+		Error: "internal error",
+	}
+	suite.mockOUService.On("IsParent", mock.Anything, "parent-ou-123", "child-ou-456").
+		Return(false, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to validate user type against selected OU")
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_FiltersSchemasByOU() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:     "flow-123",
+		FlowType:   common.FlowTypeUserOnboarding,
+		UserInputs: map[string]string{},
+		RuntimeData: map[string]string{
+			ouIDKey: "child-ou-456",
+		},
+	}
+
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "parent-ou-123"},
+			{Name: "customer", OUID: "other-ou-789"},
+			{Name: "partner", OUID: "parent-ou-123"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0, false).
+		Return(schemaList, nil)
+
+	// employee's OU is ancestor of selected OU
+	suite.mockOUService.On("IsParent", mock.Anything, "parent-ou-123", "child-ou-456").
+		Return(true, (*serviceerror.ServiceError)(nil))
+	// customer's OU is NOT ancestor of selected OU
+	suite.mockOUService.On("IsParent", mock.Anything, "other-ou-789", "child-ou-456").
+		Return(false, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
+	assert.Len(suite.T(), result.Inputs, 1)
+	// Only employee and partner should remain (both have parent-ou-123)
+	assert.ElementsMatch(suite.T(), []string{"employee", "partner"}, result.Inputs[0].Options)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_FiltersSchemasToSingle_AutoSelect() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:     "flow-123",
+		FlowType:   common.FlowTypeUserOnboarding,
+		UserInputs: map[string]string{},
+		RuntimeData: map[string]string{
+			ouIDKey: "child-ou-456",
+		},
+	}
+
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "parent-ou-123"},
+			{Name: "customer", OUID: "other-ou-789"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0, false).
+		Return(schemaList, nil)
+
+	suite.mockOUService.On("IsParent", mock.Anything, "parent-ou-123", "child-ou-456").
+		Return(true, (*serviceerror.ServiceError)(nil))
+	suite.mockOUService.On("IsParent", mock.Anything, "other-ou-789", "child-ou-456").
+		Return(false, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecComplete, result.Status)
+	assert.Equal(suite.T(), "employee", result.RuntimeData[userTypeKey])
+	assert.Equal(suite.T(), "parent-ou-123", result.RuntimeData[defaultOUIDKey])
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_AllSchemasFilteredOut() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:     "flow-123",
+		FlowType:   common.FlowTypeUserOnboarding,
+		UserInputs: map[string]string{},
+		RuntimeData: map[string]string{
+			ouIDKey: "unrelated-ou-999",
+		},
+	}
+
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "ou-123"},
+			{Name: "customer", OUID: "ou-456"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0, false).
+		Return(schemaList, nil)
+
+	suite.mockOUService.On("IsParent", mock.Anything, "ou-123", "unrelated-ou-999").
+		Return(false, (*serviceerror.ServiceError)(nil))
+	suite.mockOUService.On("IsParent", mock.Anything, "ou-456", "unrelated-ou-999").
+		Return(false, (*serviceerror.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), "No valid user types available for this flow", result.FailureReason)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_IsParentErrorAbortsFiltering() {
+	suite.SetupTest()
+
+	ctx := &core.NodeContext{
+		FlowID:     "flow-123",
+		FlowType:   common.FlowTypeUserOnboarding,
+		UserInputs: map[string]string{},
+		RuntimeData: map[string]string{
+			ouIDKey: "child-ou-456",
+		},
+	}
+
+	schemaList := &userschema.UserSchemaListResponse{
+		Schemas: []userschema.UserSchemaListItem{
+			{Name: "employee", OUID: "parent-ou-123"},
+			{Name: "customer", OUID: "error-ou"},
+		},
+	}
+	suite.mockUserSchemaService.On("GetUserSchemaList", ctx.Context, 100, 0, false).
+		Return(schemaList, nil)
+
+	suite.mockOUService.On("IsParent", mock.Anything, "parent-ou-123", "child-ou-456").
+		Return(true, (*serviceerror.ServiceError)(nil))
+	svcErr := &serviceerror.ServiceError{
+		Type:  serviceerror.ServerErrorType,
+		Error: "internal error",
+	}
+	suite.mockOUService.On("IsParent", mock.Anything, "error-ou", "child-ou-456").
+		Return(false, svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to check OU ancestry for schema customer")
+	suite.mockOUService.AssertExpectations(suite.T())
 }

--- a/docs/__backup__/flows/flow-creation-guide.md
+++ b/docs/__backup__/flows/flow-creation-guide.md
@@ -196,7 +196,8 @@ Executors perform backend logic in TASK_EXECUTION nodes.
 
 | Executor | Description | Properties | Required | Flow Types |
 |----------|-------------|------------|----------|------------|
-| UserTypeResolver | Resolves user type and OU for registration. **Must be placed after START node** in registration flows. | None | Yes | Registration |
+| UserTypeResolver | Resolves user type and OU for registration/onboarding. In OU-first flows (when `ouId` is already in runtime data), filters available user types to those valid for the selected OU. | `allowedUserTypes` (optional array) | Yes | Registration, UserOnboarding |
+| OUResolverExecutor | Resolves the organization unit for a user during onboarding. Supports multiple strategies via the `resolveFrom` property. | `resolveFrom` | No | UserOnboarding |
 | BasicAuthExecutor | Attribute + credential authentication. Use any identifying attribute (username, email, phone) plus a credential. | None | No | Authentication, Registration |
 | GoogleOIDCAuthExecutor | Google social login via OIDC. | `idpId` | No | Authentication, Registration |
 | GithubOAuthExecutor | GitHub social login via OAuth. | `idpId` | No | Authentication, Registration |
@@ -208,6 +209,30 @@ Executors perform backend logic in TASK_EXECUTION nodes.
 | AttributeCollector | Collects additional attributes and updates user profile after authentication. | None | No | Authentication |
 | ProvisioningExecutor | Creates new user account in the system. Required at the end of registration flows. | None | Yes | Registration |
 | OUExecutor | Optionally create organization units during registration flows. | None | No | Registration |
+
+### OUResolverExecutor Strategies
+
+The `OUResolverExecutor` uses the `resolveFrom` property to determine how the organization unit is resolved:
+
+| Strategy | Description | Depends on UserTypeResolver? |
+|----------|-------------|------------------------------|
+| `caller` | Uses the OU of the caller from the JWT security context. Useful for admin-initiated flows where the new user inherits the OU of the caller. | No |
+| `prompt` | Checks if the user type's OU has child OUs. If so, prompts the admin to select one within that OU hierarchy. Requires `defaultOUID` to be set in runtime data by UserTypeResolver. | Yes (must run before) |
+| `promptAll` | Shows the full OU tree from root, allowing selection of any OU. Does not depend on UserTypeResolver having run first. Used in **OU-first** flows where the OU is selected before the user type. | No |
+
+### Flow Ordering: UserType-First vs OU-First
+
+User onboarding flows support two ordering strategies for resolving user type and organization unit:
+
+**UserType-First (default):**
+`START → UserTypeResolver → OUResolver (prompt) → ... → END`
+
+The user selects a user type first. The `UserTypeResolver` sets `defaultOUID` from the schema, then `OUResolver` with `prompt` strategy uses that OU as the root of the hierarchy for optional child-OU selection.
+
+**OU-First:**
+`START → OUResolver (promptAll) → UserTypeResolver → ... → END`
+
+The user selects an OU first from the full tree. The `OUResolver` with `promptAll` sets `ouId` in runtime data, then `UserTypeResolver` filters available user types to only those whose schema OU is an ancestor of (or equal to) the selected OU.
 
 ### Executor Modes
 


### PR DESCRIPTION
### Purpose

Make `OUResolverExecutor` and `UserTypeResolver` order-independent so flow authors can configure either **UserType-first** or **OU-first** onboarding flows.

**UserType-first** (existing behavior, unchanged): Admin picks a user type → sees OU tree scoped to that user type's subtree.

**OU-first** (new): Admin sees the full OU tree, picks an OU → sees only user types valid for that OU.

### Approach

Three changes that enable both flow orderings from the same executor code:

1. **New `"promptAll"` strategy on `OUResolverExecutor`** — Shows the full OU tree without depending on `UserTypeResolver` having run first. Validates the selected OU exists. Does not set `rootOuId` in `AdditionalData`, signaling the frontend to render the full tree.

2. **OU-aware filtering in `UserTypeResolver`** — When `RuntimeData["ouId"]` is already set (OU was selected first), filters schemas to only those whose OU is an ancestor of the selected OU using `IsParent()`. When `ouId` is absent (UserType-first flow), the filter is skipped entirely — existing behavior is preserved.

3. **Input validation** — When a user type is submitted via input in an OU-first flow, it is validated against the selected OU before being accepted.

#### How to switch between strategies

**UserType-first** (default): In the onboarding flow JSON, route `permission_validator → user_type_resolver → ou_selection` with `"resolveFrom": "prompt"` on the OU node.

```json
{ "id": "permission_validator", "onSuccess": "user_type_resolver" },
{ "id": "user_type_resolver", "onSuccess": "ou_selection" },
{ "id": "ou_selection", "properties": { "resolveFrom": "prompt" }, "onSuccess": "prompt_email" }
```

**OU-first**: Reorder the nodes and change the strategy to `"promptAll"`:

```json
{ "id": "permission_validator", "onSuccess": "ou_selection" },
{ "id": "ou_selection", "properties": { "resolveFrom": "promptAll" }, "onSuccess": "user_type_resolver" },
{ "id": "user_type_resolver", "onSuccess": "prompt_email" }
```

No code changes needed to switch — it's purely a flow configuration change.

### Related Issues
- Resolves https://github.com/asgardeo/thunder/issues/2140

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full-hierarchy organization unit selection during user onboarding (first-run prompts when no OU chosen)
  * User type options are now filtered and validated against the selected organization unit to prevent invalid choices
  * Selections that reference nonexistent OUs produce a clear failure message

* **Tests**
  * Expanded test coverage for organization unit selection, validation, and filtering behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->