### PR TITLE
Update navigation path in `Create Application` button inside Thunder Home

### DIFF
--- a/frontend/apps/thunder-console/src/features/home/components/StartBuildingSection.tsx
+++ b/frontend/apps/thunder-console/src/features/home/components/StartBuildingSection.tsx
@@ -68,7 +68,7 @@ export default function StartBuildingSection(): JSX.Element {
                     variant="contained"
                     size="small"
                     onClick={() => {
-                      navigate('/applications')?.catch(() => undefined);
+                      navigate('/applications/create')?.catch(() => undefined);
                     }}
                     sx={{textTransform: 'none'}}
                   >

--- a/frontend/apps/thunder-console/src/features/home/components/__tests__/StartBuildingSection.test.tsx
+++ b/frontend/apps/thunder-console/src/features/home/components/__tests__/StartBuildingSection.test.tsx
@@ -97,7 +97,7 @@ describe('StartBuildingSection', () => {
     it('navigates to /applications when the button is clicked', () => {
       render(<StartBuildingSection />);
       fireEvent.click(screen.getByRole('button', {name: 'Create Applications'}));
-      expect(mockNavigate).toHaveBeenCalledWith('/applications');
+      expect(mockNavigate).toHaveBeenCalledWith('/applications/create');
     });
 
     it('does not render the create-only button when apps exist', () => {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request updates the navigation behavior in the `StartBuildingSection` component. Now, when the relevant button is clicked, users are directed to the application creation page instead of the general applications list.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Navigation update:

* Changed the navigation path in the button's `onClick` handler from `/applications` to `/applications/create` in `StartBuildingSection.tsx`, so users are taken directly to the application creation flow.

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/2155

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "view/create applications" button to navigate directly to application creation for users with existing applications, ensuring consistent behavior across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->