### PR TITLE
WIP - Add localized client metadata support for applications and DCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ docs/static/api/combined.yaml
 
 # Playwright
 .playwright-cli/
+
+# Claude Code local data
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -251,9 +251,6 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	// Initialize design resolve service for theme and layout resolution
 	designResolveService := resolve.Initialize(mux, themeMgtService, layoutMgtService, applicationService)
 
-	// Initialize flow metadata service
-	_ = flowmeta.Initialize(mux, applicationService, ouService, designResolveService, i18nService)
-
 	// Initialize export service with collected exporters
 	_ = export.Initialize(mux, exporters)
 
@@ -262,6 +259,9 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	if err != nil {
 		logger.Fatal("Failed to initialize flow execution service", log.Error(err))
 	}
+
+	// Initialize flow metadata service (after flowExecService — needed for ui_locale resolution)
+	_ = flowmeta.Initialize(mux, applicationService, ouService, designResolveService, i18nService, flowExecService)
 
 	// Initialize OAuth services.
 	err = oauth.Initialize(mux, applicationService, authnProvider, jwtService, flowExecService, observabilitySvc,

--- a/backend/internal/application/error_constants.go
+++ b/backend/internal/application/error_constants.go
@@ -263,6 +263,28 @@ var (
 		Error:            "Consent service not enabled",
 		ErrorDescription: "Cannot enable consent for the application as the consent service is not enabled",
 	}
+	// ErrorTooManyLocaleVariants is the error returned when more than the allowed number of locale
+	// variants are registered for a single localisable field.
+	ErrorTooManyLocaleVariants = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "APP-1033",
+		Error:            "Too many locale variants",
+		ErrorDescription: "A maximum of 20 locale variants are allowed per localisable field",
+	}
+	// ErrorInvalidLocaleTag is the error returned when a locale tag does not conform to BCP 47 syntax.
+	ErrorInvalidLocaleTag = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "APP-1034",
+		Error:            "Invalid locale tag",
+		ErrorDescription: "The locale tag must be a valid BCP 47 language tag (e.g. 'fr', 'en-US')",
+	}
+	// ErrorInvalidLocalisedURIValue is the error returned when a localized URI field value fails validation.
+	ErrorInvalidLocalisedURIValue = serviceerror.ServiceError{
+		Type:             serviceerror.ClientErrorType,
+		Code:             "APP-1035",
+		Error:            "Invalid localized URI value",
+		ErrorDescription: "A localized URI variant failed URI validation; the same rules apply as for the base field",
+	}
 )
 
 // Server errors for application operations.

--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -76,6 +76,10 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 		AllowedUserTypes:          appRequest.AllowedUserTypes,
 		LoginConsent:              appRequest.LoginConsent,
 		Metadata:                  appRequest.Metadata,
+		LocalisedClientName:       appRequest.LocalisedClientName,
+		LocalisedLogoURL:          appRequest.LocalisedLogoURL,
+		LocalisedTosURI:           appRequest.LocalisedTosURI,
+		LocalisedPolicyURI:        appRequest.LocalisedPolicyURI,
 	}
 	appDTO.InboundAuthConfig = ah.processInboundAuthConfigFromRequest(appRequest.InboundAuthConfig)
 
@@ -107,6 +111,10 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 		AllowedUserTypes:          createdAppDTO.AllowedUserTypes,
 		LoginConsent:              createdAppDTO.LoginConsent,
 		Metadata:                  createdAppDTO.Metadata,
+		LocalisedClientName:       createdAppDTO.LocalisedClientName,
+		LocalisedLogoURL:          createdAppDTO.LocalisedLogoURL,
+		LocalisedTosURI:           createdAppDTO.LocalisedTosURI,
+		LocalisedPolicyURI:        createdAppDTO.LocalisedPolicyURI,
 	}
 
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.
@@ -181,6 +189,10 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		AllowedUserTypes:          appDTO.AllowedUserTypes,
 		LoginConsent:              appDTO.LoginConsent,
 		Metadata:                  appDTO.Metadata,
+		LocalisedClientName:       appDTO.LocalisedClientName,
+		LocalisedLogoURL:          appDTO.LocalisedLogoURL,
+		LocalisedTosURI:           appDTO.LocalisedTosURI,
+		LocalisedPolicyURI:        appDTO.LocalisedPolicyURI,
 	}
 
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.
@@ -301,6 +313,10 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 		AllowedUserTypes:          appRequest.AllowedUserTypes,
 		LoginConsent:              appRequest.LoginConsent,
 		Metadata:                  appRequest.Metadata,
+		LocalisedClientName:       appRequest.LocalisedClientName,
+		LocalisedLogoURL:          appRequest.LocalisedLogoURL,
+		LocalisedTosURI:           appRequest.LocalisedTosURI,
+		LocalisedPolicyURI:        appRequest.LocalisedPolicyURI,
 	}
 	updateReqAppDTO.InboundAuthConfig = ah.processInboundAuthConfigFromRequest(appRequest.InboundAuthConfig)
 
@@ -332,6 +348,10 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 		AllowedUserTypes:          updatedAppDTO.AllowedUserTypes,
 		LoginConsent:              updatedAppDTO.LoginConsent,
 		Metadata:                  updatedAppDTO.Metadata,
+		LocalisedClientName:       updatedAppDTO.LocalisedClientName,
+		LocalisedLogoURL:          updatedAppDTO.LocalisedLogoURL,
+		LocalisedTosURI:           updatedAppDTO.LocalisedTosURI,
+		LocalisedPolicyURI:        updatedAppDTO.LocalisedPolicyURI,
 	}
 
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.

--- a/backend/internal/application/model/application.go
+++ b/backend/internal/application/model/application.go
@@ -22,7 +22,12 @@
 package model
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	"github.com/asgardeo/thunder/internal/cert"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // AssertionConfig represents the assertion configuration structure for application-level (root) assertion configs.
@@ -61,6 +66,12 @@ type ApplicationDTO struct {
 	AllowedUserTypes  []string                `json:"allowedUserTypes,omitempty" jsonschema:"Allowed user types. Optional. Restricts which types of users can register to this application."`
 	LoginConsent      *LoginConsentConfig     `json:"loginConsent,omitempty" jsonschema:"Login consent configuration settings."`
 	Metadata          map[string]interface{}  `json:"metadata,omitempty" jsonschema:"Generic metadata. Optional arbitrary key-value pairs for consumer use."`
+
+	// Localized variant maps keyed by normalised BCP 47 tag (e.g. "fr", "en-us").
+	LocalisedClientName map[string]string `json:"client_name_localized,omitempty"`
+	LocalisedLogoURL    map[string]string `json:"logo_uri_localized,omitempty"`
+	LocalisedTosURI     map[string]string `json:"tos_uri_localized,omitempty"`
+	LocalisedPolicyURI  map[string]string `json:"policy_uri_localized,omitempty"`
 }
 
 // BasicApplicationDTO represents a simplified data transfer object for application service operations.
@@ -104,6 +115,11 @@ type Application struct {
 	AllowedUserTypes  []string                    `yaml:"allowed_user_types,omitempty" json:"allowedUserTypes,omitempty" jsonschema:"Allowed user types for registration."`
 	LoginConsent      *LoginConsentConfig         `yaml:"login_consent,omitempty" json:"loginConsent,omitempty" jsonschema:"Login consent configuration settings."`
 	Metadata          map[string]interface{}      `yaml:"metadata,omitempty" json:"metadata,omitempty" jsonschema:"Generic metadata key-value pairs."`
+
+	LocalisedClientName map[string]string `yaml:"client_name_localized,omitempty" json:"client_name_localized,omitempty"`
+	LocalisedLogoURL    map[string]string `yaml:"logo_uri_localized,omitempty" json:"logo_uri_localized,omitempty"`
+	LocalisedTosURI     map[string]string `yaml:"tos_uri_localized,omitempty" json:"tos_uri_localized,omitempty"`
+	LocalisedPolicyURI  map[string]string `yaml:"policy_uri_localized,omitempty" json:"policy_uri_localized,omitempty"`
 }
 
 // ApplicationProcessedDTO represents the processed data transfer object for application service operations.
@@ -131,6 +147,11 @@ type ApplicationProcessedDTO struct {
 	AllowedUserTypes  []string                        `yaml:"allowed_user_types,omitempty"`
 	LoginConsent      *LoginConsentConfig             `yaml:"login_consent,omitempty"`
 	Metadata          map[string]interface{}          `yaml:"metadata,omitempty"`
+
+	LocalisedClientName map[string]string `yaml:"client_name_localized,omitempty"`
+	LocalisedLogoURL    map[string]string `yaml:"logo_uri_localized,omitempty"`
+	LocalisedTosURI     map[string]string `yaml:"tos_uri_localized,omitempty"`
+	LocalisedPolicyURI  map[string]string `yaml:"policy_uri_localized,omitempty"`
 }
 
 // InboundAuthConfigDTO represents the data transfer object for inbound authentication configuration.
@@ -177,6 +198,90 @@ type ApplicationRequest struct {
 	AllowedUserTypes          []string                    `json:"allowedUserTypes,omitempty" yaml:"allowed_user_types,omitempty"`
 	LoginConsent              *LoginConsentConfig         `json:"loginConsent,omitempty" yaml:"login_consent,omitempty"`
 	Metadata                  map[string]interface{}      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// Localized variant maps — populated by UnmarshalJSON from field#tag keys; not in standard JSON output.
+	LocalisedClientName map[string]string `json:"-"`
+	LocalisedLogoURL    map[string]string `json:"-"`
+	LocalisedTosURI     map[string]string `json:"-"`
+	LocalisedPolicyURI  map[string]string `json:"-"`
+}
+
+// appRequestJSON is an alias used by UnmarshalJSON to decode fixed fields without recursion.
+type appRequestJSON ApplicationRequest
+
+// localisableAppFields is the set of application API field names that accept language-tagged variants.
+var localisableAppFields = map[string]bool{
+	"name": true, "logoUrl": true, "tosUri": true, "policyUri": true,
+}
+
+// UnmarshalJSON decodes an ApplicationRequest in a single JSON parse of the input bytes.
+// It separates language-tagged keys (field#tag convention, OIDC DCR §2) into the localized
+// variant maps, then decodes the remaining standard keys into the typed struct.
+// Localisable fields with a non-string tagged value are rejected; tagged variants on
+// non-localisable fields are silently ignored (AC-12).
+func (r *ApplicationRequest) UnmarshalJSON(data []byte) error {
+	// Single parse into a raw key-value map.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Separate tagged (#) keys from standard keys.
+	clean := make(map[string]json.RawMessage, len(raw))
+	for key, val := range raw {
+		field, tag, ok := strings.Cut(key, "#")
+		if !ok {
+			clean[key] = val
+			continue
+		}
+		// Multiple '#' in a key (e.g. "name#en#US") are invalid (AC-08).
+		// Reject if the base field is localisable; silently skip otherwise.
+		if strings.Contains(tag, "#") {
+			if localisableAppFields[field] {
+				return fmt.Errorf("invalid localized field key %q: tag must not contain '#'", key)
+			}
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(val, &s); err != nil {
+			// Non-string value on a recognized localisable field is a client error.
+			if localisableAppFields[field] {
+				return err
+			}
+			continue
+		}
+		normTag := sysutils.NormaliseBCP47Tag(tag)
+		switch field {
+		case "name":
+			if r.LocalisedClientName == nil {
+				r.LocalisedClientName = make(map[string]string)
+			}
+			r.LocalisedClientName[normTag] = s
+		case "logoUrl":
+			if r.LocalisedLogoURL == nil {
+				r.LocalisedLogoURL = make(map[string]string)
+			}
+			r.LocalisedLogoURL[normTag] = s
+		case "tosUri":
+			if r.LocalisedTosURI == nil {
+				r.LocalisedTosURI = make(map[string]string)
+			}
+			r.LocalisedTosURI[normTag] = s
+		case "policyUri":
+			if r.LocalisedPolicyURI == nil {
+				r.LocalisedPolicyURI = make(map[string]string)
+			}
+			r.LocalisedPolicyURI[normTag] = s
+			// All other tagged fields are silently ignored (AC-12).
+		}
+	}
+
+	// Decode standard (non-tagged) keys using the alias to avoid infinite recursion.
+	cleanBytes, err := json.Marshal(clean)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(cleanBytes, (*appRequestJSON)(r))
 }
 
 // ApplicationRequestWithID represents the request structure for importing an application using file based runtime.
@@ -229,6 +334,25 @@ type ApplicationCompleteResponse struct {
 	AllowedUserTypes          []string                    `json:"allowedUserTypes,omitempty"`
 	LoginConsent              *LoginConsentConfig         `json:"loginConsent,omitempty"`
 	Metadata                  map[string]interface{}      `json:"metadata,omitempty"`
+
+	// Localized variant maps — emitted as field#tag keys by MarshalJSON; not decoded from standard JSON.
+	LocalisedClientName map[string]string `json:"-"`
+	LocalisedLogoURL    map[string]string `json:"-"`
+	LocalisedTosURI     map[string]string `json:"-"`
+	LocalisedPolicyURI  map[string]string `json:"-"`
+}
+
+// appCompleteResponseJSON is an alias used by MarshalJSON to avoid infinite recursion.
+type appCompleteResponseJSON ApplicationCompleteResponse
+
+// MarshalJSON serializes ApplicationCompleteResponse, injecting language-tagged variant keys
+// (e.g. "name#fr", "logoUrl#fr") as top-level JSON properties.
+func (r ApplicationCompleteResponse) MarshalJSON() ([]byte, error) {
+	base, err := json.Marshal(appCompleteResponseJSON(r))
+	if err != nil {
+		return nil, err
+	}
+	return injectLocalisedFields(base, r.LocalisedClientName, r.LocalisedLogoURL, r.LocalisedTosURI, r.LocalisedPolicyURI)
 }
 
 // ApplicationGetResponse represents the response structure for getting an application.
@@ -255,6 +379,53 @@ type ApplicationGetResponse struct {
 	AllowedUserTypes          []string                `json:"allowedUserTypes,omitempty"`
 	LoginConsent              *LoginConsentConfig     `json:"loginConsent,omitempty"`
 	Metadata                  map[string]interface{}  `json:"metadata,omitempty"`
+
+	// Localized variant maps — emitted as field#tag keys by MarshalJSON; not decoded from standard JSON.
+	LocalisedClientName map[string]string `json:"-"`
+	LocalisedLogoURL    map[string]string `json:"-"`
+	LocalisedTosURI     map[string]string `json:"-"`
+	LocalisedPolicyURI  map[string]string `json:"-"`
+}
+
+// appGetResponseJSON is an alias used by MarshalJSON to avoid infinite recursion.
+type appGetResponseJSON ApplicationGetResponse
+
+// MarshalJSON serializes ApplicationGetResponse, injecting language-tagged variant keys
+// (e.g. "name#fr", "logoUrl#fr") as top-level JSON properties.
+func (r ApplicationGetResponse) MarshalJSON() ([]byte, error) {
+	base, err := json.Marshal(appGetResponseJSON(r))
+	if err != nil {
+		return nil, err
+	}
+	return injectLocalisedFields(base, r.LocalisedClientName, r.LocalisedLogoURL, r.LocalisedTosURI, r.LocalisedPolicyURI)
+}
+
+// injectLocalisedFields merges language-tagged variant entries into a serialized JSON object.
+// The field names use the application endpoint JSON naming convention (name, logoUrl, tosUri, policyUri).
+func injectLocalisedFields(base []byte, clientName, logoURL, tosURI, policyURI map[string]string) ([]byte, error) {
+	if len(clientName) == 0 && len(logoURL) == 0 && len(tosURI) == 0 && len(policyURI) == 0 {
+		return base, nil
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(base, &m); err != nil {
+		return nil, err
+	}
+
+	for tag, val := range clientName {
+		m["name#"+tag] = val
+	}
+	for tag, val := range logoURL {
+		m["logoUrl#"+tag] = val
+	}
+	for tag, val := range tosURI {
+		m["tosUri#"+tag] = val
+	}
+	for tag, val := range policyURI {
+		m["policyUri#"+tag] = val
+	}
+
+	return json.Marshal(m)
 }
 
 // BasicApplicationResponse represents a simplified response structure for an application.

--- a/backend/internal/application/model/application_localised_test.go
+++ b/backend/internal/application/model/application_localised_test.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplicationRequest_UnmarshalJSON_LocalisedFields(t *testing.T) {
+	t.Run("parses localized name variants", func(t *testing.T) {
+		raw := `{
+			"name": "My App",
+			"name#fr": "Mon Application",
+			"name#de": "Meine Anwendung"
+		}`
+		var req ApplicationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, "My App", req.Name)
+		assert.Equal(t, map[string]string{"fr": "Mon Application", "de": "Meine Anwendung"}, req.LocalisedClientName)
+	})
+
+	t.Run("parses localized logoUrl, tosUri, policyUri", func(t *testing.T) {
+		raw := `{
+			"name": "App",
+			"logoUrl#fr":   "https://example.com/logo-fr.png",
+			"tosUri#fr":    "https://example.com/tos-fr",
+			"policyUri#fr": "https://example.com/policy-fr"
+		}`
+		var req ApplicationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, map[string]string{"fr": "https://example.com/logo-fr.png"}, req.LocalisedLogoURL)
+		assert.Equal(t, map[string]string{"fr": "https://example.com/tos-fr"}, req.LocalisedTosURI)
+		assert.Equal(t, map[string]string{"fr": "https://example.com/policy-fr"}, req.LocalisedPolicyURI)
+	})
+
+	t.Run("normalises tag to lowercase", func(t *testing.T) {
+		raw := `{"name": "App", "name#FR-CA": "Québec"}`
+		var req ApplicationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, map[string]string{"fr-ca": "Québec"}, req.LocalisedClientName)
+	})
+
+	t.Run("silently ignores tagged variants on non-localisable fields", func(t *testing.T) {
+		raw := `{"name": "App", "description#fr": "Un app", "authFlowId#fr": "flow-1"}`
+		var req ApplicationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Nil(t, req.LocalisedClientName)
+	})
+
+	t.Run("rejects double-hash key on localisable field (AC-08)", func(t *testing.T) {
+		raw := `{"name": "App", "name#fr#extra": "value"}`
+		var req ApplicationRequest
+		err := json.Unmarshal([]byte(raw), &req)
+		assert.Error(t, err, "expected error for double-hash key on localisable field")
+	})
+
+	t.Run("silently ignores double-hash key on non-localisable field", func(t *testing.T) {
+		raw := `{"name": "App", "description#fr#extra": "value"}`
+		var req ApplicationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+		assert.Nil(t, req.LocalisedClientName)
+	})
+
+	t.Run("rejects non-string value on localisable field", func(t *testing.T) {
+		for _, field := range []string{"name#fr", "logoUrl#fr", "tosUri#fr", "policyUri#fr"} {
+			raw := `{"name": "App", "` + field + `": 123}`
+			var req ApplicationRequest
+			err := json.Unmarshal([]byte(raw), &req)
+			assert.Error(t, err, "expected error for non-string value on %s", field)
+		}
+	})
+
+	t.Run("silently ignores non-string value on non-localisable tagged field", func(t *testing.T) {
+		raw := `{"name": "App", "description#fr": 123}`
+		var req ApplicationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+		assert.Nil(t, req.LocalisedClientName)
+	})
+
+	t.Run("base fields unmarshalled alongside localized variants", func(t *testing.T) {
+		raw := `{"name": "Base", "name#fr": "Base FR", "logoUrl": "https://example.com/logo.png"}`
+		var req ApplicationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, "Base", req.Name)
+		assert.Equal(t, "https://example.com/logo.png", req.LogoURL)
+		assert.Equal(t, map[string]string{"fr": "Base FR"}, req.LocalisedClientName)
+	})
+}
+
+func TestApplicationCompleteResponse_MarshalJSON_LocalisedFields(t *testing.T) {
+	t.Run("emits localized fields as field#tag keys", func(t *testing.T) {
+		resp := ApplicationCompleteResponse{
+			ID:   "app-1",
+			Name: "My App",
+			LocalisedClientName: map[string]string{
+				"fr": "Mon Application",
+				"de": "Meine Anwendung",
+			},
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		assert.Equal(t, "My App", m["name"])
+		assert.Equal(t, "Mon Application", m["name#fr"])
+		assert.Equal(t, "Meine Anwendung", m["name#de"])
+	})
+
+	t.Run("emits all four localisable fields", func(t *testing.T) {
+		resp := ApplicationCompleteResponse{
+			ID:                 "app-1",
+			LocalisedLogoURL:   map[string]string{"fr": "https://example.com/logo-fr.png"},
+			LocalisedTosURI:    map[string]string{"fr": "https://example.com/tos-fr"},
+			LocalisedPolicyURI: map[string]string{"fr": "https://example.com/policy-fr"},
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		assert.Equal(t, "https://example.com/logo-fr.png", m["logoUrl#fr"])
+		assert.Equal(t, "https://example.com/tos-fr", m["tosUri#fr"])
+		assert.Equal(t, "https://example.com/policy-fr", m["policyUri#fr"])
+	})
+
+	t.Run("no localized fields produces clean output", func(t *testing.T) {
+		resp := ApplicationCompleteResponse{ID: "app-1", Name: "App"}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		for k := range m {
+			assert.NotContains(t, k, "#", "unexpected hash key: %s", k)
+		}
+	})
+}
+
+func TestApplicationGetResponse_MarshalJSON_LocalisedFields(t *testing.T) {
+	t.Run("emits localized name as name#tag", func(t *testing.T) {
+		resp := ApplicationGetResponse{
+			ID:                  "app-1",
+			Name:                "My App",
+			LocalisedClientName: map[string]string{"fr": "Mon Application"},
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		assert.Equal(t, "My App", m["name"])
+		assert.Equal(t, "Mon Application", m["name#fr"])
+	})
+}

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -1034,6 +1034,50 @@ func (as *applicationService) validateApplicationFields(
 		return svcErr
 	}
 	as.validateConsentConfig(app)
+	if svcErr := validateLocalisedMetadata(app); svcErr != nil {
+		return svcErr
+	}
+	return nil
+}
+
+// localisedField describes a localized variant map and the URI validation rules that apply to it.
+type localisedField struct {
+	m      map[string]string
+	isURI  bool
+	isLogo bool
+}
+
+// validateLocalisedMetadata validates localized variant maps on an ApplicationDTO.
+// It checks BCP 47 tag syntax, enforces a maximum of 20 variants per field, and validates
+// URI values for logo, tos, and policy localized fields.
+func validateLocalisedMetadata(app *model.ApplicationDTO) *serviceerror.ServiceError {
+	fields := []localisedField{
+		{app.LocalisedClientName, false, false},
+		{app.LocalisedLogoURL, true, true},
+		{app.LocalisedTosURI, true, false},
+		{app.LocalisedPolicyURI, true, false},
+	}
+	for _, f := range fields {
+		if len(f.m) > 20 {
+			return &ErrorTooManyLocaleVariants
+		}
+		for tag, val := range f.m {
+			if !sysutils.IsValidBCP47Tag(tag) {
+				return &ErrorInvalidLocaleTag
+			}
+			if f.isURI && val != "" {
+				var ok bool
+				if f.isLogo {
+					ok = sysutils.IsValidLogoURI(val)
+				} else {
+					ok = sysutils.IsValidURI(val)
+				}
+				if !ok {
+					return &ErrorInvalidLocalisedURIValue
+				}
+			}
+		}
+	}
 	return nil
 }
 
@@ -1955,6 +1999,10 @@ func buildApplicationResponse(dto *model.ApplicationProcessedDTO) *model.Applica
 		AllowedUserTypes:          dto.AllowedUserTypes,
 		LoginConsent:              dto.LoginConsent,
 		Metadata:                  dto.Metadata,
+		LocalisedClientName:       dto.LocalisedClientName,
+		LocalisedLogoURL:          dto.LocalisedLogoURL,
+		LocalisedTosURI:           dto.LocalisedTosURI,
+		LocalisedPolicyURI:        dto.LocalisedPolicyURI,
 	}
 	inboundAuthConfigs := make([]model.InboundAuthConfigComplete, 0, len(dto.InboundAuthConfig))
 	for _, config := range dto.InboundAuthConfig {
@@ -2045,6 +2093,10 @@ func buildBaseApplicationProcessedDTO(appID string, app *model.ApplicationDTO,
 		AllowedUserTypes:          app.AllowedUserTypes,
 		LoginConsent:              app.LoginConsent,
 		Metadata:                  app.Metadata,
+		LocalisedClientName:       app.LocalisedClientName,
+		LocalisedLogoURL:          app.LocalisedLogoURL,
+		LocalisedTosURI:           app.LocalisedTosURI,
+		LocalisedPolicyURI:        app.LocalisedPolicyURI,
 	}
 }
 
@@ -2055,6 +2107,9 @@ func (as *applicationService) buildProcessedDTOForUpdate(appID string, app *mode
 	finalOAuthIDToken *model.IDTokenConfig, userInfo *model.UserInfoConfig,
 	scopeClaims map[string][]string) *model.ApplicationProcessedDTO {
 	processedDTO := buildBaseApplicationProcessedDTO(appID, app, assertion)
+
+	// Localized variant maps from the PUT request completely replace the existing set (AC-02, AC-04).
+	// The base processedDTO already carries app.LocalisedClientName etc. from buildBaseApplicationProcessedDTO.
 
 	if inboundAuthConfig != nil {
 		processedInboundAuthConfig := buildOAuthInboundAuthConfigProcessedDTO(
@@ -2121,6 +2176,10 @@ func buildReturnApplicationDTO(
 		AllowedUserTypes:          app.AllowedUserTypes,
 		LoginConsent:              app.LoginConsent,
 		Metadata:                  metadata,
+		LocalisedClientName:       app.LocalisedClientName,
+		LocalisedLogoURL:          app.LocalisedLogoURL,
+		LocalisedTosURI:           app.LocalisedTosURI,
+		LocalisedPolicyURI:        app.LocalisedPolicyURI,
 	}
 	if inboundAuthConfig != nil {
 		returnInboundAuthConfig := model.InboundAuthConfigDTO{

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -6991,3 +6991,93 @@ func (suite *ServiceTestSuite) TestValidateApplicationForUpdate_ErrorFromValidat
 	assert.NotNil(suite.T(), svcErr)
 	assert.Equal(suite.T(), &ErrorLayoutNotFound, svcErr)
 }
+
+// ---- validateLocalisedMetadata tests ----
+
+func TestValidateLocalisedMetadata(t *testing.T) {
+	t.Run("nil maps pass", func(t *testing.T) {
+		app := &model.ApplicationDTO{}
+		assert.Nil(t, validateLocalisedMetadata(app))
+	})
+
+	t.Run("valid tags and values pass", func(t *testing.T) {
+		app := &model.ApplicationDTO{
+			LocalisedClientName: map[string]string{"fr": "Mon App", "de": "Meine App"},
+			LocalisedLogoURL:    map[string]string{"fr": "https://example.com/logo-fr.png"},
+			LocalisedTosURI:     map[string]string{"en-gb": "https://example.com/tos-en-gb"},
+			LocalisedPolicyURI:  map[string]string{"de": "https://example.com/policy-de"},
+		}
+		assert.Nil(t, validateLocalisedMetadata(app))
+	})
+
+	t.Run("too many variants in client name", func(t *testing.T) {
+		langs := []string{
+			"aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av",
+			"ay", "az", "ba", "be", "bg", "bh", "bi", "bm", "bn", "bo", "br",
+		}
+		m := make(map[string]string, len(langs))
+		for _, l := range langs {
+			m[l] = "value"
+		}
+		app := &model.ApplicationDTO{LocalisedClientName: m}
+		svcErr := validateLocalisedMetadata(app)
+		assert.NotNil(t, svcErr)
+		assert.Equal(t, ErrorTooManyLocaleVariants.Code, svcErr.Code)
+	})
+
+	t.Run("exactly 20 variants is allowed", func(t *testing.T) {
+		langs := []string{
+			"aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av",
+			"ay", "az", "ba", "be", "bg", "bh", "bi", "bm", "bn", "bo",
+		}
+		m := make(map[string]string, len(langs))
+		for _, l := range langs {
+			m[l] = "v"
+		}
+		app := &model.ApplicationDTO{LocalisedClientName: m}
+		assert.Nil(t, validateLocalisedMetadata(app))
+	})
+
+	t.Run("invalid BCP 47 tag rejected", func(t *testing.T) {
+		app := &model.ApplicationDTO{
+			LocalisedClientName: map[string]string{"not valid!": "value"},
+		}
+		svcErr := validateLocalisedMetadata(app)
+		assert.NotNil(t, svcErr)
+		assert.Equal(t, ErrorInvalidLocaleTag.Code, svcErr.Code)
+	})
+
+	t.Run("invalid logo URI rejected", func(t *testing.T) {
+		app := &model.ApplicationDTO{
+			LocalisedLogoURL: map[string]string{"fr": "not-a-uri"},
+		}
+		svcErr := validateLocalisedMetadata(app)
+		assert.NotNil(t, svcErr)
+		assert.Equal(t, ErrorInvalidLocalisedURIValue.Code, svcErr.Code)
+	})
+
+	t.Run("invalid tos URI rejected", func(t *testing.T) {
+		app := &model.ApplicationDTO{
+			LocalisedTosURI: map[string]string{"fr": "not-a-uri"},
+		}
+		svcErr := validateLocalisedMetadata(app)
+		assert.NotNil(t, svcErr)
+		assert.Equal(t, ErrorInvalidLocalisedURIValue.Code, svcErr.Code)
+	})
+
+	t.Run("invalid policy URI rejected", func(t *testing.T) {
+		app := &model.ApplicationDTO{
+			LocalisedPolicyURI: map[string]string{"fr": "not-a-uri"},
+		}
+		svcErr := validateLocalisedMetadata(app)
+		assert.NotNil(t, svcErr)
+		assert.Equal(t, ErrorInvalidLocalisedURIValue.Code, svcErr.Code)
+	})
+
+	t.Run("empty string URI value is allowed (no-op)", func(t *testing.T) {
+		app := &model.ApplicationDTO{
+			LocalisedLogoURL: map[string]string{"fr": ""},
+		}
+		assert.Nil(t, validateLocalisedMetadata(app))
+	})
+}

--- a/backend/internal/application/store.go
+++ b/backend/internal/application/store.go
@@ -381,7 +381,6 @@ func (st *applicationStore) IsApplicationDeclarative(_ context.Context, _ string
 }
 
 // --- Helper functions ---
-
 // buildAppConfigFromRow constructs an applicationConfigDAO from a database result row.
 func buildAppConfigFromRow(row map[string]interface{}) (*applicationConfigDAO, error) {
 	appID, ok := row["id"].(string)
@@ -442,6 +441,28 @@ func buildOAuthConfigFromRow(row map[string]interface{}) (*oauthConfigDAO, error
 	}
 
 	return dao, nil
+}
+
+// extractAssertionConfigFromJSON extracts assertion configuration from JSON data.
+func extractStringMapFromJSON(data map[string]interface{}, key string) map[string]string {
+	val, exists := data[key]
+	if !exists || val == nil {
+		return nil
+	}
+	raw, ok := val.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			result[k] = s
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 // marshalNullableJSON marshals a value to JSON, returning nil for nil/empty input.

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -189,6 +189,8 @@ const (
 	RuntimeKeyInviteLink = "inviteLink"
 	// RuntimeKeyCandidateUsers holds serialized candidate users during disambiguation in resolve mode.
 	RuntimeKeyCandidateUsers = "candidateUsers"
+	// RuntimeKeyUILocale holds the ui_locale value from the OAuth authorization request.
+	RuntimeKeyUILocale = "ui_locale"
 )
 
 // TODO: Define a go type for InputType when formalizing input types

--- a/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
+++ b/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
@@ -205,3 +205,70 @@ func (_c *FlowExecServiceInterfaceMock_InitiateFlow_Call) RunAndReturn(run func(
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetFlowRuntimeData provides a mock function for the type FlowExecServiceInterfaceMock
+func (_mock *FlowExecServiceInterfaceMock) GetFlowRuntimeData(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, flowID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFlowRuntimeData")
+	}
+
+	var r0 map[string]string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, flowID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
+		r0 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowRuntimeData'
+type FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call struct {
+	*mock.Call
+}
+
+// GetFlowRuntimeData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - flowID string
+func (_e *FlowExecServiceInterfaceMock_Expecter) GetFlowRuntimeData(ctx interface{}, flowID interface{}) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	return &FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call{Call: _e.mock.On("GetFlowRuntimeData", ctx, flowID)}
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Run(run func(ctx context.Context, flowID string)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Return(runtimeData map[string]string, serviceError *serviceerror.ServiceError) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(runtimeData, serviceError)
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) RunAndReturn(run func(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
+++ b/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
@@ -138,6 +138,76 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetFlowRuntimeData provides a mock function for the type FlowExecServiceInterfaceMock
+func (_mock *FlowExecServiceInterfaceMock) GetFlowRuntimeData(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, flowID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFlowRuntimeData")
+	}
+
+	var r0 map[string]string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, flowID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
+		r0 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowRuntimeData'
+type FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call struct {
+	*mock.Call
+}
+
+// GetFlowRuntimeData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - flowID string
+func (_e *FlowExecServiceInterfaceMock_Expecter) GetFlowRuntimeData(ctx interface{}, flowID interface{}) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	return &FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call{Call: _e.mock.On("GetFlowRuntimeData", ctx, flowID)}
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Run(run func(ctx context.Context, flowID string)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Return(stringToString map[string]string, serviceError *serviceerror.ServiceError) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(stringToString, serviceError)
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) RunAndReturn(run func(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InitiateFlow provides a mock function for the type FlowExecServiceInterfaceMock
 func (_mock *FlowExecServiceInterfaceMock) InitiateFlow(ctx context.Context, initContext *FlowInitContext) (string, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, initContext)
@@ -202,73 +272,6 @@ func (_c *FlowExecServiceInterfaceMock_InitiateFlow_Call) Return(s string, servi
 }
 
 func (_c *FlowExecServiceInterfaceMock_InitiateFlow_Call) RunAndReturn(run func(ctx context.Context, initContext *FlowInitContext) (string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_InitiateFlow_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetFlowRuntimeData provides a mock function for the type FlowExecServiceInterfaceMock
-func (_mock *FlowExecServiceInterfaceMock) GetFlowRuntimeData(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, flowID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetFlowRuntimeData")
-	}
-
-	var r0 map[string]string
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, flowID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
-		r0 = returnFunc(ctx, flowID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, flowID)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowRuntimeData'
-type FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call struct {
-	*mock.Call
-}
-
-// GetFlowRuntimeData is a helper method to define mock.On call
-//   - ctx context.Context
-//   - flowID string
-func (_e *FlowExecServiceInterfaceMock_Expecter) GetFlowRuntimeData(ctx interface{}, flowID interface{}) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
-	return &FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call{Call: _e.mock.On("GetFlowRuntimeData", ctx, flowID)}
-}
-
-func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Run(run func(ctx context.Context, flowID string)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Return(runtimeData map[string]string, serviceError *serviceerror.ServiceError) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
-	_c.Call.Return(runtimeData, serviceError)
-	return _c
-}
-
-func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) RunAndReturn(run func(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -21,6 +21,7 @@ package flowexec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/asgardeo/thunder/internal/application"
@@ -43,6 +44,7 @@ type FlowExecServiceInterface interface {
 	Execute(ctx context.Context, appID, flowID, flowType string, verbose bool,
 		action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError)
 	InitiateFlow(ctx context.Context, initContext *FlowInitContext) (string, *serviceerror.ServiceError)
+	GetFlowRuntimeData(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError)
 }
 
 const (
@@ -551,4 +553,29 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 
 	logger.Debug("Flow initiated successfully", log.String("flowID", engineCtx.FlowID))
 	return engineCtx.FlowID, nil
+}
+
+// GetFlowRuntimeData returns the RuntimeData map for the given flow ID.
+// Returns nil, nil if the flow context does not exist.
+func (s *flowExecService) GetFlowRuntimeData(
+	ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError) {
+	flowCtx, err := s.flowStore.GetFlowContext(ctx, flowID)
+	if err != nil {
+		return nil, &serviceerror.InternalServerError
+	}
+	if flowCtx == nil {
+		return nil, nil
+	}
+	var content flowContextContent
+	if jsonErr := json.Unmarshal([]byte(flowCtx.Context), &content); jsonErr != nil {
+		return nil, &serviceerror.InternalServerError
+	}
+	if content.RuntimeData == nil {
+		return nil, nil
+	}
+	var runtimeData map[string]string
+	if jsonErr := json.Unmarshal([]byte(*content.RuntimeData), &runtimeData); jsonErr != nil {
+		return nil, &serviceerror.InternalServerError
+	}
+	return runtimeData, nil
 }

--- a/backend/internal/flow/flowmeta/FlowMetaServiceInterface_mock_test.go
+++ b/backend/internal/flow/flowmeta/FlowMetaServiceInterface_mock_test.go
@@ -39,8 +39,8 @@ func (_m *FlowMetaServiceInterfaceMock) EXPECT() *FlowMetaServiceInterfaceMock_E
 }
 
 // GetFlowMetadata provides a mock function for the type FlowMetaServiceInterfaceMock
-func (_mock *FlowMetaServiceInterfaceMock) GetFlowMetadata(ctx context.Context, metaType MetaType, id string, language *string, namespace *string) (*FlowMetadataResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, metaType, id, language, namespace)
+func (_mock *FlowMetaServiceInterfaceMock) GetFlowMetadata(ctx context.Context, metaType MetaType, id string, flowID *string, language *string, namespace *string) (*FlowMetadataResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, metaType, id, flowID, language, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFlowMetadata")
@@ -48,18 +48,18 @@ func (_mock *FlowMetaServiceInterfaceMock) GetFlowMetadata(ctx context.Context, 
 
 	var r0 *FlowMetadataResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, MetaType, string, *string, *string) (*FlowMetadataResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, metaType, id, language, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, MetaType, string, *string, *string, *string) (*FlowMetadataResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, metaType, id, flowID, language, namespace)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, MetaType, string, *string, *string) *FlowMetadataResponse); ok {
-		r0 = returnFunc(ctx, metaType, id, language, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, MetaType, string, *string, *string, *string) *FlowMetadataResponse); ok {
+		r0 = returnFunc(ctx, metaType, id, flowID, language, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*FlowMetadataResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, MetaType, string, *string, *string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, metaType, id, language, namespace)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, MetaType, string, *string, *string, *string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, metaType, id, flowID, language, namespace)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -77,13 +77,14 @@ type FlowMetaServiceInterfaceMock_GetFlowMetadata_Call struct {
 //   - ctx context.Context
 //   - metaType MetaType
 //   - id string
+//   - flowID *string
 //   - language *string
 //   - namespace *string
-func (_e *FlowMetaServiceInterfaceMock_Expecter) GetFlowMetadata(ctx interface{}, metaType interface{}, id interface{}, language interface{}, namespace interface{}) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
-	return &FlowMetaServiceInterfaceMock_GetFlowMetadata_Call{Call: _e.mock.On("GetFlowMetadata", ctx, metaType, id, language, namespace)}
+func (_e *FlowMetaServiceInterfaceMock_Expecter) GetFlowMetadata(ctx interface{}, metaType interface{}, id interface{}, flowID interface{}, language interface{}, namespace interface{}) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
+	return &FlowMetaServiceInterfaceMock_GetFlowMetadata_Call{Call: _e.mock.On("GetFlowMetadata", ctx, metaType, id, flowID, language, namespace)}
 }
 
-func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Run(run func(ctx context.Context, metaType MetaType, id string, language *string, namespace *string)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
+func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Run(run func(ctx context.Context, metaType MetaType, id string, flowID *string, language *string, namespace *string)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -105,12 +106,17 @@ func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Run(run func(ctx co
 		if args[4] != nil {
 			arg4 = args[4].(*string)
 		}
+		var arg5 *string
+		if args[5] != nil {
+			arg5 = args[5].(*string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -121,7 +127,7 @@ func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Return(flowMetadata
 	return _c
 }
 
-func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) RunAndReturn(run func(ctx context.Context, metaType MetaType, id string, language *string, namespace *string) (*FlowMetadataResponse, *serviceerror.ServiceError)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
+func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) RunAndReturn(run func(ctx context.Context, metaType MetaType, id string, flowID *string, language *string, namespace *string) (*FlowMetadataResponse, *serviceerror.ServiceError)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/flowmeta/handler.go
+++ b/backend/internal/flow/flowmeta/handler.go
@@ -86,6 +86,12 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 	metadata, svcErr := h.flowMetaService.GetFlowMetadata(
 		r.Context(), MetaType(metaType), id, flowID, language, namespace)
 	if svcErr != nil {
+		if svcErr.Type != serviceerror.ClientErrorType {
+			h.logger.Error("Failed to retrieve flow metadata",
+				log.String("type", metaType),
+				log.String("id", id),
+				log.String("error", svcErr.Error))
+		}
 		handleServiceError(w, svcErr)
 		return
 	}

--- a/backend/internal/flow/flowmeta/handler.go
+++ b/backend/internal/flow/flowmeta/handler.go
@@ -47,8 +47,13 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 	metaType := sysutils.SanitizeString(r.URL.Query().Get("type"))
 	id := sysutils.SanitizeString(r.URL.Query().Get("id"))
 
+	var flowID *string
 	var language *string
 	var namespace *string
+
+	if fid := sysutils.SanitizeString(r.URL.Query().Get("flowId")); fid != "" {
+		flowID = &fid
+	}
 
 	if lang := r.URL.Query().Get("language"); lang != "" {
 		language = &lang
@@ -78,7 +83,8 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 	}
 
 	// Call service
-	metadata, svcErr := h.flowMetaService.GetFlowMetadata(r.Context(), MetaType(metaType), id, language, namespace)
+	metadata, svcErr := h.flowMetaService.GetFlowMetadata(
+		r.Context(), MetaType(metaType), id, flowID, language, namespace)
 	if svcErr != nil {
 		handleServiceError(w, svcErr)
 		return

--- a/backend/internal/flow/flowmeta/handler_test.go
+++ b/backend/internal/flow/flowmeta/handler_test.go
@@ -41,10 +41,11 @@ func (m *mockFlowMetaService) GetFlowMetadata(
 	ctx context.Context,
 	metaType MetaType,
 	id string,
+	flowID *string,
 	language *string,
 	namespace *string,
 ) (*FlowMetadataResponse, *serviceerror.ServiceError) {
-	args := m.Called(ctx, metaType, id, language, namespace)
+	args := m.Called(ctx, metaType, id, flowID, language, namespace)
 	if args.Get(0) == nil {
 		return nil, args.Get(1).(*serviceerror.ServiceError)
 	}
@@ -112,7 +113,7 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_Success_AppType
 		},
 	}
 
-	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, &language, &namespace).
+	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, (*string)(nil), &language, &namespace).
 		Return(expectedResponse, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP&id="+appID+"&language=en&namespace=auth", nil)
@@ -160,7 +161,8 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_Success_OUType(
 		},
 	}
 
-	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, ouID, (*string)(nil), (*string)(nil)).
+	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, ouID,
+		(*string)(nil), (*string)(nil), (*string)(nil)).
 		Return(expectedResponse, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=OU&id="+ouID, nil)
@@ -198,7 +200,8 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_SystemFlow_NoPa
 		},
 	}
 
-	suite.mockService.On("GetFlowMetadata", mock.Anything, MetaType(""), "", (*string)(nil), (*string)(nil)).
+	suite.mockService.On("GetFlowMetadata", mock.Anything, MetaType(""), "",
+		(*string)(nil), (*string)(nil), (*string)(nil)).
 		Return(expectedResponse, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta", nil)
@@ -250,7 +253,7 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_MissingType_Whe
 func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_InvalidType() {
 	// Arrange
 	suite.mockService.On("GetFlowMetadata", mock.Anything,
-		MetaType("INVALID"), "some-id", (*string)(nil), (*string)(nil)).
+		MetaType("INVALID"), "some-id", (*string)(nil), (*string)(nil), (*string)(nil)).
 		Return(nil, &ErrorInvalidType)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=INVALID&id=some-id", nil)
@@ -268,7 +271,8 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_ServiceError_No
 	appID := "non-existent-id"
 	metaType := MetaTypeAPP
 
-	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, (*string)(nil), (*string)(nil)).
+	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID,
+		(*string)(nil), (*string)(nil), (*string)(nil)).
 		Return(nil, &ErrorApplicationNotFound)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP&id="+appID, nil)
@@ -286,7 +290,8 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_ServiceError_In
 	appID := "some-id"
 	metaType := MetaTypeAPP
 
-	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, (*string)(nil), (*string)(nil)).
+	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID,
+		(*string)(nil), (*string)(nil), (*string)(nil)).
 		Return(nil, &serviceerror.InternalServerError)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP&id="+appID, nil)
@@ -328,7 +333,7 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_WithLanguagePar
 		},
 	}
 
-	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, &language, (*string)(nil)).
+	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, (*string)(nil), &language, (*string)(nil)).
 		Return(expectedResponse, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP&id="+appID+"&language=es", nil)
@@ -379,7 +384,7 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_WithNamespacePa
 		},
 	}
 
-	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, (*string)(nil), &namespace).
+	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, (*string)(nil), (*string)(nil), &namespace).
 		Return(expectedResponse, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP&id="+appID+"&namespace=errors", nil)
@@ -395,4 +400,41 @@ func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_WithNamespacePa
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(suite.T(), err)
 	assert.Contains(suite.T(), response.I18n.Translations, "errors")
+}
+
+func (suite *FlowMetaHandlerTestSuite) TestHandleGetFlowMetadata_WithFlowID_UILocaleInResponse() {
+	// Arrange
+	appID := "app-123"
+	flowID := "flow-456"
+	metaType := MetaTypeAPP
+
+	expectedResponse := &FlowMetadataResponse{
+		IsRegistrationFlowEnabled: false,
+		Application: &ApplicationMetadata{
+			ID:   appID,
+			Name: "Mon Application",
+		},
+		Design:   DesignMetadata{},
+		I18n:     I18nMetadata{Languages: []string{"en"}},
+		UILocale: "fr",
+	}
+
+	fid := flowID
+	suite.mockService.On("GetFlowMetadata", mock.Anything, metaType, appID, &fid, (*string)(nil), (*string)(nil)).
+		Return(expectedResponse, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/flow/meta?type=APP&id="+appID+"&flowId="+flowID, nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	suite.handler.HandleGetFlowMetadata(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	assert.NoError(suite.T(), err)
+	// AC-22: uiLocale must appear in the JSON response
+	assert.Equal(suite.T(), "fr", result["uiLocale"])
 }

--- a/backend/internal/flow/flowmeta/init.go
+++ b/backend/internal/flow/flowmeta/init.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/design/resolve"
+	"github.com/asgardeo/thunder/internal/flow/flowexec"
 	"github.com/asgardeo/thunder/internal/ou"
 	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
@@ -35,9 +36,10 @@ func Initialize(
 	ouService ou.OrganizationUnitServiceInterface,
 	designResolve resolve.DesignResolveServiceInterface,
 	i18nService i18nmgt.I18nServiceInterface,
+	flowExecService flowexec.FlowExecServiceInterface,
 ) FlowMetaServiceInterface {
 	// Create service instance
-	flowMetaService := newFlowMetaService(applicationService, ouService, designResolve, i18nService)
+	flowMetaService := newFlowMetaService(applicationService, ouService, designResolve, i18nService, flowExecService)
 
 	// Create handler and register routes
 	handler := newFlowMetaHandler(flowMetaService)

--- a/backend/internal/flow/flowmeta/model.go
+++ b/backend/internal/flow/flowmeta/model.go
@@ -27,6 +27,7 @@ type FlowMetadataResponse struct {
 	OU                        *OUMetadata          `json:"ou,omitempty"`
 	Design                    DesignMetadata       `json:"design"`
 	I18n                      I18nMetadata         `json:"i18n"`
+	UILocale                  string               `json:"uiLocale,omitempty"`
 }
 
 // ApplicationMetadata represents application-specific metadata.
@@ -38,6 +39,12 @@ type ApplicationMetadata struct {
 	URL         string `json:"url,omitempty"`
 	TosURI      string `json:"tosUri,omitempty"`
 	PolicyURI   string `json:"policyUri,omitempty"`
+
+	// Localized variant maps — used internally for ui_locale resolution; not serialized.
+	localisedClientName map[string]string
+	localisedLogoURL    map[string]string
+	localisedTosURI     map[string]string
+	localisedPolicyURI  map[string]string
 }
 
 // OUMetadata represents organization unit metadata.

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -26,10 +26,13 @@ import (
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/design/common"
 	"github.com/asgardeo/thunder/internal/design/resolve"
+	flowcm "github.com/asgardeo/thunder/internal/flow/common"
+	"github.com/asgardeo/thunder/internal/flow/flowexec"
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/internal/system/log"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // MetaType represents the type of metadata being requested.
@@ -54,6 +57,7 @@ type FlowMetaServiceInterface interface {
 		ctx context.Context,
 		metaType MetaType,
 		id string,
+		flowID *string,
 		language *string,
 		namespace *string,
 	) (*FlowMetadataResponse, *serviceerror.ServiceError)
@@ -65,6 +69,7 @@ type flowMetaService struct {
 	ouService          ou.OrganizationUnitServiceInterface
 	designResolve      resolve.DesignResolveServiceInterface
 	i18nService        i18nmgt.I18nServiceInterface
+	flowExecService    flowexec.FlowExecServiceInterface
 	logger             *log.Logger
 }
 
@@ -74,6 +79,7 @@ func newFlowMetaService(
 	ouService ou.OrganizationUnitServiceInterface,
 	designResolve resolve.DesignResolveServiceInterface,
 	i18nService i18nmgt.I18nServiceInterface,
+	flowExecService flowexec.FlowExecServiceInterface,
 ) FlowMetaServiceInterface {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	return &flowMetaService{
@@ -81,6 +87,7 @@ func newFlowMetaService(
 		ouService:          ouService,
 		designResolve:      designResolve,
 		i18nService:        i18nService,
+		flowExecService:    flowExecService,
 		logger:             logger,
 	}
 }
@@ -90,6 +97,7 @@ func (fms *flowMetaService) GetFlowMetadata(
 	ctx context.Context,
 	metaType MetaType,
 	id string,
+	flowID *string,
 	language *string,
 	namespace *string,
 ) (*FlowMetadataResponse, *serviceerror.ServiceError) {
@@ -112,6 +120,12 @@ func (fms *flowMetaService) GetFlowMetadata(
 
 	if svcErr := fms.populateOUMetadata(ctx, ouID, response); svcErr != nil {
 		return nil, svcErr
+	}
+
+	// Resolve localized application metadata fields based on ui_locale from flow runtime data.
+	// AC-22: also surface the resolved ui_locale in the response.
+	if flowID != nil && *flowID != "" && response.Application != nil {
+		response.UILocale = fms.resolveLocalisedAppMetadata(ctx, *flowID, response.Application)
 	}
 
 	fms.populateDesignMetadata(ctx, metaType, id, ouID, response)
@@ -178,13 +192,17 @@ func (fms *flowMetaService) populateTypeMetadata(
 
 	response.IsRegistrationFlowEnabled = app.IsRegistrationFlowEnabled
 	response.Application = &ApplicationMetadata{
-		ID:          app.ID,
-		Name:        app.Name,
-		Description: app.Description,
-		LogoURL:     app.LogoURL,
-		URL:         app.URL,
-		TosURI:      app.TosURI,
-		PolicyURI:   app.PolicyURI,
+		ID:                  app.ID,
+		Name:                app.Name,
+		Description:         app.Description,
+		LogoURL:             app.LogoURL,
+		URL:                 app.URL,
+		TosURI:              app.TosURI,
+		PolicyURI:           app.PolicyURI,
+		localisedClientName: app.LocalisedClientName,
+		localisedLogoURL:    app.LocalisedLogoURL,
+		localisedTosURI:     app.LocalisedTosURI,
+		localisedPolicyURI:  app.LocalisedPolicyURI,
 	}
 
 	ouList, ouErr := fms.ouService.GetOrganizationUnitList(ctx, 1, 0)
@@ -299,4 +317,34 @@ func (fms *flowMetaService) populateI18nMetadata(response *FlowMetadataResponse,
 	}
 
 	response.I18n.Languages = languages
+}
+
+// resolveLocalisedAppMetadata reads the ui_locale from the flow's RuntimeData, resolves
+// any localized variant fields on app in-place, and returns the active ui_locale value.
+// Returns an empty string when no resolution is performed (AC-22).
+func (fms *flowMetaService) resolveLocalisedAppMetadata(
+	ctx context.Context, flowID string, app *ApplicationMetadata) string {
+	if fms.flowExecService == nil {
+		return ""
+	}
+	runtimeData, svcErr := fms.flowExecService.GetFlowRuntimeData(ctx, flowID)
+	if svcErr != nil {
+		fms.logger.Debug("Failed to get flow runtime data for ui_locale resolution",
+			log.String("flowID", flowID))
+		return ""
+	}
+	if runtimeData == nil {
+		return ""
+	}
+
+	uiLocale := runtimeData[flowcm.RuntimeKeyUILocale]
+	if uiLocale == "" {
+		return ""
+	}
+
+	app.Name = sysutils.ResolveLocalisedValue(app.localisedClientName, app.Name, uiLocale)
+	app.LogoURL = sysutils.ResolveLocalisedValue(app.localisedLogoURL, app.LogoURL, uiLocale)
+	app.TosURI = sysutils.ResolveLocalisedValue(app.localisedTosURI, app.TosURI, uiLocale)
+	app.PolicyURI = sysutils.ResolveLocalisedValue(app.localisedPolicyURI, app.PolicyURI, uiLocale)
+	return uiLocale
 }

--- a/backend/internal/flow/flowmeta/service_test.go
+++ b/backend/internal/flow/flowmeta/service_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/internal/application"
@@ -35,6 +36,7 @@ import (
 	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
 	"github.com/asgardeo/thunder/tests/mocks/design/resolvemock"
+	"github.com/asgardeo/thunder/tests/mocks/flow/flowexecmock"
 	"github.com/asgardeo/thunder/tests/mocks/i18n/mgtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
 )
@@ -70,6 +72,7 @@ func (suite *FlowMetaServiceTestSuite) SetupTest() {
 		suite.mockOUService,
 		suite.mockDesignResolve,
 		suite.mockI18nService,
+		nil,
 	)
 	suite.ctx = context.Background()
 }
@@ -136,7 +139,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_APP_Success() {
 	suite.mockI18nService.On("ListLanguages").Return([]string{"en", "es"}, nil)
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, appID, &language, &namespace)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, appID, nil, &language, &namespace)
 
 	// Assert
 	assert.Nil(suite.T(), svcErr)
@@ -183,7 +186,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_OU_Success() {
 	suite.mockI18nService.On("ListLanguages").Return([]string{"en"}, nil)
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, ouID, nil, nil)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, ouID, nil, nil, nil)
 
 	// Assert
 	assert.Nil(suite.T(), svcErr)
@@ -201,7 +204,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_InvalidType() {
 	id := "some-id"
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, id, nil, nil)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, id, nil, nil, nil)
 
 	// Assert
 	assert.Nil(suite.T(), result)
@@ -218,7 +221,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_ApplicationNotFound()
 		Return(nil, &application.ErrorApplicationNotFound)
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, appID, nil, nil)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, appID, nil, nil, nil)
 
 	// Assert
 	assert.Nil(suite.T(), result)
@@ -235,7 +238,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_OUNotFound() {
 		Return(ou.OrganizationUnit{}, &ou.ErrorOrganizationUnitNotFound)
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, ouID, nil, nil)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, ouID, nil, nil, nil)
 
 	// Assert
 	assert.Nil(suite.T(), result)
@@ -281,7 +284,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_DesignResolveError_Co
 	suite.mockI18nService.On("ListLanguages").Return([]string{"en"}, nil)
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, appID, nil, nil)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, appID, nil, nil, nil)
 
 	// Assert - Should succeed with empty design
 	assert.Nil(suite.T(), svcErr)
@@ -312,7 +315,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_I18nError_ContinuesWi
 	suite.mockI18nService.On("ListLanguages").Return([]string{"en"}, nil)
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, ouID, nil, nil)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, metaType, ouID, nil, nil, nil)
 
 	// Assert - Should succeed with empty translations
 	assert.Nil(suite.T(), svcErr)
@@ -335,7 +338,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_SystemFlow_NoTypeOrID
 	suite.mockI18nService.On("ListLanguages").Return([]string{"en-US"}, nil)
 
 	// Act
-	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, MetaType(""), "", nil, nil)
+	result, svcErr := suite.service.GetFlowMetadata(suite.ctx, MetaType(""), "", nil, nil, nil)
 
 	// Assert
 	assert.Nil(suite.T(), svcErr)
@@ -347,4 +350,107 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_SystemFlow_NoTypeOrID
 	assert.Equal(suite.T(), 3, result.I18n.TotalResults)
 	assert.Equal(suite.T(), []string{"en-US"}, result.I18n.Languages)
 	assert.Contains(suite.T(), result.I18n.Translations, "system")
+}
+
+// ---- ui_locale resolution tests ----
+
+func TestGetFlowMetadata_LocaleResolution(t *testing.T) {
+	mockApp := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mockOU := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	mockDesign := resolvemock.NewDesignResolveServiceInterfaceMock(t)
+	mockI18n := mgtmock.NewI18nServiceInterfaceMock(t)
+	mockFlowExec := flowexecmock.NewFlowExecServiceInterfaceMock(t)
+
+	appID := "app-locale-1"
+	flowID := "flow-locale-1"
+
+	app := &appmodel.Application{
+		ID:      appID,
+		Name:    "Base App",
+		LogoURL: "https://example.com/logo.png",
+		TosURI:  "https://example.com/tos",
+		LocalisedClientName: map[string]string{
+			"fr": "Application Française",
+			"de": "Deutsche Anwendung",
+		},
+		LocalisedLogoURL: map[string]string{
+			"fr": "https://example.com/logo-fr.png",
+		},
+	}
+
+	mockApp.EXPECT().GetApplication(mock.Anything, appID).Return(app, nil)
+	mockOU.EXPECT().GetOrganizationUnitList(mock.Anything, 1, 0).Return(
+		&ou.OrganizationUnitListResponse{TotalResults: 0}, nil)
+	mockDesign.EXPECT().ResolveDesign(mock.Anything, common.DesignResolveTypeAPP, appID).
+		Return(nil, &serviceerror.ServiceError{Code: "DESIGN-404"})
+	mockI18n.EXPECT().ResolveTranslations(mock.Anything, "").
+		Return(nil, &serviceerror.I18nServiceError{Code: "I18N-5000", Type: serviceerror.ServerErrorType})
+	mockI18n.EXPECT().ListLanguages().Return([]string{"en"}, nil)
+
+	t.Run("resolves localized fields when flowId and ui_locale provided", func(t *testing.T) {
+		runtimeData := map[string]string{"ui_locale": "fr"}
+		mockFlowExec.EXPECT().GetFlowRuntimeData(mock.Anything, flowID).Return(runtimeData, nil)
+
+		svc := newFlowMetaService(mockApp, mockOU, mockDesign, mockI18n, mockFlowExec)
+		fid := flowID
+		result, svcErr := svc.GetFlowMetadata(context.Background(), MetaTypeAPP, appID, &fid, nil, nil)
+
+		assert.Nil(t, svcErr)
+		require.NotNil(t, result.Application)
+		assert.Equal(t, "Application Française", result.Application.Name)
+		assert.Equal(t, "https://example.com/logo-fr.png", result.Application.LogoURL)
+		// TosURI has no fr variant — stays as base
+		assert.Equal(t, "https://example.com/tos", result.Application.TosURI)
+		// AC-22: ui_locale returned in response
+		assert.Equal(t, "fr", result.UILocale)
+	})
+}
+
+func TestGetFlowMetadata_LocaleResolution_NoFlowID(t *testing.T) {
+	mockApp := applicationmock.NewApplicationServiceInterfaceMock(t)
+	mockOU := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	mockDesign := resolvemock.NewDesignResolveServiceInterfaceMock(t)
+	mockI18n := mgtmock.NewI18nServiceInterfaceMock(t)
+
+	appID := "app-locale-2"
+
+	app := &appmodel.Application{
+		ID:                  appID,
+		Name:                "Base App",
+		LocalisedClientName: map[string]string{"fr": "App FR"},
+	}
+
+	mockApp.EXPECT().GetApplication(mock.Anything, appID).Return(app, nil)
+	mockOU.EXPECT().GetOrganizationUnitList(mock.Anything, 1, 0).Return(
+		&ou.OrganizationUnitListResponse{TotalResults: 0}, nil)
+	mockDesign.EXPECT().ResolveDesign(mock.Anything, common.DesignResolveTypeAPP, appID).
+		Return(nil, &serviceerror.ServiceError{Code: "DESIGN-404"})
+	mockI18n.EXPECT().ResolveTranslations(mock.Anything, "").
+		Return(nil, &serviceerror.I18nServiceError{Code: "I18N-5000", Type: serviceerror.ServerErrorType})
+	mockI18n.EXPECT().ListLanguages().Return([]string{"en"}, nil)
+
+	t.Run("returns base values when no flowId provided", func(t *testing.T) {
+		svc := newFlowMetaService(mockApp, mockOU, mockDesign, mockI18n, nil)
+		result, svcErr := svc.GetFlowMetadata(context.Background(), MetaTypeAPP, appID, nil, nil, nil)
+
+		assert.Nil(t, svcErr)
+		require.NotNil(t, result.Application)
+		// No flowId → no resolution → base name
+		assert.Equal(t, "Base App", result.Application.Name)
+		// AC-22: uiLocale is empty when no flowId
+		assert.Empty(t, result.UILocale)
+	})
+
+	t.Run("does not panic when flowExecService is nil but flowId is provided", func(t *testing.T) {
+		svc := newFlowMetaService(mockApp, mockOU, mockDesign, mockI18n, nil)
+		fid := "some-flow-id"
+		// Should not panic — nil guard in resolveLocalisedAppMetadata returns early.
+		result, svcErr := svc.GetFlowMetadata(context.Background(), MetaTypeAPP, appID, &fid, nil, nil)
+
+		assert.Nil(t, svcErr)
+		require.NotNil(t, result.Application)
+		assert.Equal(t, "Base App", result.Application.Name)
+		// AC-22: uiLocale is empty when flowExecService is nil
+		assert.Empty(t, result.UILocale)
+	})
 }

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -146,6 +146,9 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 
 	nonce := msg.RequestQueryParams[oauth2const.RequestParamNonce]
 
+	// Extract ui_locales parameter (OIDC Core §3.1.2.1).
+	uiLocales := msg.RequestQueryParams[oauth2const.RequestParamUILocales]
+
 	if clientID == "" {
 		return nil, &AuthorizationError{
 			Code:    oauth2const.ErrorInvalidRequest,
@@ -221,6 +224,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		ClaimsRequest:       claimsRequest,
 		ClaimsLocales:       claimsLocales,
 		Nonce:               nonce,
+		UILocale:            uiLocales,
 	}
 
 	// Set the redirect URI if not provided in the request. Invalid cases are already handled at this point.
@@ -246,6 +250,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		flowcm.RuntimeKeyRequiredEssentialAttributes:   essentialAttributes,
 		flowcm.RuntimeKeyRequiredOptionalAttributes:    optionalAttributes,
 		flowcm.RuntimeKeyRequiredLocales:               claimsLocales,
+		flowcm.RuntimeKeyUILocale:                      uiLocales,
 		flowcm.RuntimeKeyUserAttributesCacheTTLSeconds: fmt.Sprintf("%d", resolveUserAttributesCacheTTL(app)),
 	}
 	flowInitCtx := &flowexec.FlowInitContext{

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -58,6 +58,7 @@ const (
 	RequestParamClaimsLocales       string = "claims_locales"
 	RequestParamNonce               string = "nonce"
 	RequestParamPrompt              string = "prompt"
+	RequestParamUILocales           string = "ui_locales"
 )
 
 // OIDC prompt parameter values.

--- a/backend/internal/oauth/oauth2/dcr/model.go
+++ b/backend/internal/oauth/oauth2/dcr/model.go
@@ -19,7 +19,12 @@
 package dcr
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // Default values for DCR
@@ -43,6 +48,89 @@ type DCRRegistrationRequest struct {
 	Contacts                []string                            `json:"contacts,omitempty"`
 	TosURI                  string                              `json:"tos_uri,omitempty"`
 	PolicyURI               string                              `json:"policy_uri,omitempty"`
+
+	// Localized variant maps — populated by UnmarshalJSON from field#tag keys; not in standard JSON output.
+	LocalisedClientName map[string]string `json:"-"`
+	LocalisedLogoURL    map[string]string `json:"-"`
+	LocalisedTosURI     map[string]string `json:"-"`
+	LocalisedPolicyURI  map[string]string `json:"-"`
+}
+
+// dcrRegistrationRequestJSON is an alias used by UnmarshalJSON to avoid infinite recursion.
+type dcrRegistrationRequestJSON DCRRegistrationRequest
+
+// localisableDCRFields is the set of DCR field names that accept language-tagged variants.
+var localisableDCRFields = map[string]bool{
+	"client_name": true, "logo_uri": true, "tos_uri": true, "policy_uri": true,
+}
+
+// UnmarshalJSON decodes a DCRRegistrationRequest in a single JSON parse of the input bytes.
+// It separates language-tagged keys (field#tag convention, OIDC DCR §2) into the localized
+// variant maps, then decodes the remaining standard keys into the typed struct.
+// Localisable fields with a non-string tagged value are rejected; tagged variants on
+// non-localisable fields are silently ignored.
+func (r *DCRRegistrationRequest) UnmarshalJSON(data []byte) error {
+	// Single parse into a raw key-value map.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Separate tagged (#) keys from standard keys.
+	clean := make(map[string]json.RawMessage, len(raw))
+	for key, val := range raw {
+		field, tag, ok := strings.Cut(key, "#")
+		if !ok {
+			clean[key] = val
+			continue
+		}
+		// Multiple '#' in a key (e.g. "client_name#en#US") are invalid (AC-08).
+		// Reject if the base field is localisable; silently skip otherwise.
+		if strings.Contains(tag, "#") {
+			if localisableDCRFields[field] {
+				return fmt.Errorf("invalid localized field key %q: tag must not contain '#'", key)
+			}
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(val, &s); err != nil {
+			// Non-string value on a recognized localisable field is a client error.
+			if localisableDCRFields[field] {
+				return err
+			}
+			continue
+		}
+		normTag := sysutils.NormaliseBCP47Tag(tag)
+		switch field {
+		case "client_name":
+			if r.LocalisedClientName == nil {
+				r.LocalisedClientName = make(map[string]string)
+			}
+			r.LocalisedClientName[normTag] = s
+		case "logo_uri":
+			if r.LocalisedLogoURL == nil {
+				r.LocalisedLogoURL = make(map[string]string)
+			}
+			r.LocalisedLogoURL[normTag] = s
+		case "tos_uri":
+			if r.LocalisedTosURI == nil {
+				r.LocalisedTosURI = make(map[string]string)
+			}
+			r.LocalisedTosURI[normTag] = s
+		case "policy_uri":
+			if r.LocalisedPolicyURI == nil {
+				r.LocalisedPolicyURI = make(map[string]string)
+			}
+			r.LocalisedPolicyURI[normTag] = s
+		}
+	}
+
+	// Decode standard (non-tagged) keys using the alias to avoid infinite recursion.
+	cleanBytes, err := json.Marshal(clean)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(cleanBytes, (*dcrRegistrationRequestJSON)(r))
 }
 
 // DCRRegistrationResponse represents the RFC 7591 Dynamic Client Registration response.
@@ -64,6 +152,49 @@ type DCRRegistrationResponse struct {
 	TosURI                  string                              `json:"tos_uri,omitempty"`
 	PolicyURI               string                              `json:"policy_uri,omitempty"`
 	AppID                   string                              `json:"app_id,omitempty"`
+
+	// Localized variant maps — emitted as field#tag keys by MarshalJSON; not decoded from standard JSON.
+	LocalisedClientName map[string]string `json:"-"`
+	LocalisedLogoURL    map[string]string `json:"-"`
+	LocalisedTosURI     map[string]string `json:"-"`
+	LocalisedPolicyURI  map[string]string `json:"-"`
+}
+
+// dcrRegistrationResponseJSON is an alias used by MarshalJSON to avoid infinite recursion.
+type dcrRegistrationResponseJSON DCRRegistrationResponse
+
+// MarshalJSON serializes DCRRegistrationResponse, injecting language-tagged variant keys
+// (e.g. "client_name#fr", "logo_uri#fr") as top-level JSON properties.
+func (r DCRRegistrationResponse) MarshalJSON() ([]byte, error) {
+	base, err := json.Marshal(dcrRegistrationResponseJSON(r))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(r.LocalisedClientName) == 0 && len(r.LocalisedLogoURL) == 0 &&
+		len(r.LocalisedTosURI) == 0 && len(r.LocalisedPolicyURI) == 0 {
+		return base, nil
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(base, &m); err != nil {
+		return nil, err
+	}
+
+	for tag, val := range r.LocalisedClientName {
+		m["client_name#"+tag] = val
+	}
+	for tag, val := range r.LocalisedLogoURL {
+		m["logo_uri#"+tag] = val
+	}
+	for tag, val := range r.LocalisedTosURI {
+		m["tos_uri#"+tag] = val
+	}
+	for tag, val := range r.LocalisedPolicyURI {
+		m["policy_uri#"+tag] = val
+	}
+
+	return json.Marshal(m)
 }
 
 // DCRErrorResponse represents the RFC 7591 Dynamic Client Registration error response.

--- a/backend/internal/oauth/oauth2/dcr/model_localised_test.go
+++ b/backend/internal/oauth/oauth2/dcr/model_localised_test.go
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package dcr
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDCRRegistrationRequest_UnmarshalJSON_LocalisedFields(t *testing.T) {
+	t.Run("parses localized client_name variants", func(t *testing.T) {
+		raw := `{
+			"redirect_uris": ["https://example.com/cb"],
+			"client_name": "My App",
+			"client_name#fr": "Mon Application",
+			"client_name#de": "Meine Anwendung"
+		}`
+		var req DCRRegistrationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, "My App", req.ClientName)
+		assert.Equal(t, map[string]string{"fr": "Mon Application", "de": "Meine Anwendung"}, req.LocalisedClientName)
+	})
+
+	t.Run("parses localized logo_uri, tos_uri, policy_uri", func(t *testing.T) {
+		raw := `{
+			"redirect_uris": ["https://example.com/cb"],
+			"logo_uri#fr":    "https://example.com/logo-fr.png",
+			"tos_uri#fr":     "https://example.com/tos-fr",
+			"policy_uri#fr":  "https://example.com/policy-fr"
+		}`
+		var req DCRRegistrationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, map[string]string{"fr": "https://example.com/logo-fr.png"}, req.LocalisedLogoURL)
+		assert.Equal(t, map[string]string{"fr": "https://example.com/tos-fr"}, req.LocalisedTosURI)
+		assert.Equal(t, map[string]string{"fr": "https://example.com/policy-fr"}, req.LocalisedPolicyURI)
+	})
+
+	t.Run("normalises tag to lowercase", func(t *testing.T) {
+		raw := `{"redirect_uris": ["https://example.com/cb"], "client_name#FR-CA": "Québec"}`
+		var req DCRRegistrationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, map[string]string{"fr-ca": "Québec"}, req.LocalisedClientName)
+	})
+
+	t.Run("silently ignores tagged variants on non-localisable fields", func(t *testing.T) {
+		raw := `{"redirect_uris": ["https://example.com/cb"], "scope#fr": "openid", "client_uri#fr": "https://x.com"}`
+		var req DCRRegistrationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Nil(t, req.LocalisedClientName)
+		assert.Nil(t, req.LocalisedLogoURL)
+	})
+
+	t.Run("rejects double-hash key on localisable field (AC-08)", func(t *testing.T) {
+		raw := `{"redirect_uris": ["https://example.com/cb"], "client_name#fr#extra": "value"}`
+		var req DCRRegistrationRequest
+		err := json.Unmarshal([]byte(raw), &req)
+		assert.Error(t, err, "expected error for double-hash key on localisable field")
+	})
+
+	t.Run("silently ignores double-hash key on non-localisable field", func(t *testing.T) {
+		raw := `{"redirect_uris": ["https://example.com/cb"], "scope#fr#extra": "value"}`
+		var req DCRRegistrationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+		assert.Nil(t, req.LocalisedClientName)
+	})
+
+	t.Run("rejects non-string value on localisable field", func(t *testing.T) {
+		for _, field := range []string{"client_name#fr", "logo_uri#fr", "tos_uri#fr", "policy_uri#fr"} {
+			raw := `{"redirect_uris": ["https://example.com/cb"], "` + field + `": 123}`
+			var req DCRRegistrationRequest
+			err := json.Unmarshal([]byte(raw), &req)
+			assert.Error(t, err, "expected error for non-string value on %s", field)
+		}
+	})
+
+	t.Run("silently ignores non-string value on non-localisable tagged field", func(t *testing.T) {
+		raw := `{"redirect_uris": ["https://example.com/cb"], "scope#fr": 123}`
+		var req DCRRegistrationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+		assert.Nil(t, req.LocalisedClientName)
+	})
+
+	t.Run("base fields unmarshalled correctly alongside localized variants", func(t *testing.T) {
+		raw := `{
+			"redirect_uris": ["https://example.com/cb"],
+			"client_name": "Base App",
+			"client_name#fr": "App FR",
+			"logo_uri": "https://example.com/logo.png"
+		}`
+		var req DCRRegistrationRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &req))
+
+		assert.Equal(t, "Base App", req.ClientName)
+		assert.Equal(t, "https://example.com/logo.png", req.LogoURI)
+		assert.Equal(t, map[string]string{"fr": "App FR"}, req.LocalisedClientName)
+		assert.Nil(t, req.LocalisedLogoURL)
+	})
+}
+
+func TestDCRRegistrationResponse_MarshalJSON_LocalisedFields(t *testing.T) {
+	t.Run("emits localized fields as field#tag keys", func(t *testing.T) {
+		resp := DCRRegistrationResponse{
+			ClientID:   "client-123",
+			ClientName: "My App",
+			LocalisedClientName: map[string]string{
+				"fr": "Mon Application",
+				"de": "Meine Anwendung",
+			},
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		assert.Equal(t, "My App", m["client_name"])
+		assert.Equal(t, "Mon Application", m["client_name#fr"])
+		assert.Equal(t, "Meine Anwendung", m["client_name#de"])
+	})
+
+	t.Run("emits all four localisable fields", func(t *testing.T) {
+		resp := DCRRegistrationResponse{
+			ClientID:           "client-123",
+			LocalisedLogoURL:   map[string]string{"fr": "https://example.com/logo-fr.png"},
+			LocalisedTosURI:    map[string]string{"fr": "https://example.com/tos-fr"},
+			LocalisedPolicyURI: map[string]string{"fr": "https://example.com/policy-fr"},
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		assert.Equal(t, "https://example.com/logo-fr.png", m["logo_uri#fr"])
+		assert.Equal(t, "https://example.com/tos-fr", m["tos_uri#fr"])
+		assert.Equal(t, "https://example.com/policy-fr", m["policy_uri#fr"])
+	})
+
+	t.Run("no localized fields produces clean output without hash keys", func(t *testing.T) {
+		resp := DCRRegistrationResponse{
+			ClientID:   "client-123",
+			ClientName: "My App",
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		for k := range m {
+			assert.NotContains(t, k, "#", "unexpected hash key: %s", k)
+		}
+	})
+
+	t.Run("localized fields not present in json output as struct fields", func(t *testing.T) {
+		resp := DCRRegistrationResponse{
+			ClientID:            "client-123",
+			LocalisedClientName: map[string]string{"fr": "App FR"},
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		// The map field itself should not appear under its struct tag name
+		assert.NotContains(t, string(data), "localized_client_name")
+	})
+}

--- a/backend/internal/oauth/oauth2/dcr/service.go
+++ b/backend/internal/oauth/oauth2/dcr/service.go
@@ -192,15 +192,19 @@ func (ds *dcrService) convertDCRToApplication(request *DCRRegistrationRequest) (
 	}
 
 	appDTO := &model.ApplicationDTO{
-		OUID:              request.OUID,
-		Name:              appName,
-		URL:               request.ClientURI,
-		LogoURL:           request.LogoURI,
-		InboundAuthConfig: inboundAuthConfig,
-		TosURI:            request.TosURI,
-		PolicyURI:         request.PolicyURI,
-		Contacts:          request.Contacts,
-		Certificate:       appCertificate,
+		OUID:                request.OUID,
+		Name:                appName,
+		URL:                 request.ClientURI,
+		LogoURL:             request.LogoURI,
+		InboundAuthConfig:   inboundAuthConfig,
+		TosURI:              request.TosURI,
+		PolicyURI:           request.PolicyURI,
+		Contacts:            request.Contacts,
+		Certificate:         appCertificate,
+		LocalisedClientName: request.LocalisedClientName,
+		LocalisedLogoURL:    request.LocalisedLogoURL,
+		LocalisedTosURI:     request.LocalisedTosURI,
+		LocalisedPolicyURI:  request.LocalisedPolicyURI,
 	}
 
 	return appDTO, nil
@@ -253,6 +257,10 @@ func (ds *dcrService) convertApplicationToDCRResponse(appDTO *model.ApplicationD
 		PolicyURI:               appDTO.PolicyURI,
 		Contacts:                appDTO.Contacts,
 		AppID:                   oauthConfig.AppID,
+		LocalisedClientName:     appDTO.LocalisedClientName,
+		LocalisedLogoURL:        appDTO.LocalisedLogoURL,
+		LocalisedTosURI:         appDTO.LocalisedTosURI,
+		LocalisedPolicyURI:      appDTO.LocalisedPolicyURI,
 	}
 
 	return response, nil
@@ -273,6 +281,9 @@ func (ds *dcrService) mapApplicationErrorToDCRError(appErr *serviceerror.Service
 	// Server errors
 	case "APP-5001", "APP-5002":
 		dcrErr.Code = ErrorServerError.Code
+	// Localized metadata errors map to invalid_client_metadata
+	case "APP-1033", "APP-1034", "APP-1035":
+		dcrErr.Code = ErrorInvalidClientMetadata.Code
 	// Default fallback for all other client errors
 	default:
 		dcrErr.Code = ErrorInvalidClientMetadata.Code

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -34,6 +34,7 @@ type OAuthParameters struct {
 	ClaimsRequest       *ClaimsRequest
 	ClaimsLocales       string
 	Nonce               string
+	UILocale            string
 }
 
 // ClaimsRequest represents the OIDC claims request parameter structure.

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -53,6 +53,7 @@ var defaultMessages = map[string]string{
 	"error.consentservice.cannot_delete_purpose": "Cannot delete consent purpose",
 	"error.consentservice.consent_not_found": "Consent not found",
 	"error.consentservice.consent_not_found_description": "The consent record with the specified ID does not exist",
+	"error.consentservice.delete_element_with_associated_purpose_description": "The consent element cannot be deleted because it is still associated with one or more consent purposes.",
 	"error.consentservice.delete_purpose_with_associated_records_description": "The consent purpose cannot be deleted as it is associated with one or more consent records",
 	"error.consentservice.element_already_exists": "Consent element already exists",
 	"error.consentservice.element_already_exists_description": "A consent element with the same name already exists",

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -53,7 +53,6 @@ var defaultMessages = map[string]string{
 	"error.consentservice.cannot_delete_purpose": "Cannot delete consent purpose",
 	"error.consentservice.consent_not_found": "Consent not found",
 	"error.consentservice.consent_not_found_description": "The consent record with the specified ID does not exist",
-	"error.consentservice.delete_element_with_associated_purpose_description": "The consent element cannot be deleted because it is still associated with one or more consent purposes.",
 	"error.consentservice.delete_purpose_with_associated_records_description": "The consent purpose cannot be deleted as it is associated with one or more consent records",
 	"error.consentservice.element_already_exists": "Consent element already exists",
 	"error.consentservice.element_already_exists_description": "A consent element with the same name already exists",

--- a/backend/internal/system/utils/locale_util.go
+++ b/backend/internal/system/utils/locale_util.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// bcp47TagRegex matches valid BCP 47 language tags per RFC 5646.
+// Primary language subtag: 1–8 letters only.
+// Extension subtags: 1–8 alphanumeric characters that contain at least one letter
+// (pure-digit subtags are not allowed except the 3-digit UN M.49 region codes).
+var bcp47TagRegex = regexp.MustCompile(
+	`^[a-zA-Z]{1,8}(-([a-zA-Z][a-zA-Z0-9]{0,7}|[0-9]{3}|[0-9][a-zA-Z][a-zA-Z0-9]{0,6}))*$`)
+
+// MaxLocaleTagLength is the maximum allowed length for a BCP 47 language tag.
+const MaxLocaleTagLength = 35
+
+// IsValidBCP47Tag returns true if the tag is a syntactically valid BCP 47 language tag.
+// Rejects empty strings, tags exceeding MaxLocaleTagLength, tags containing whitespace,
+// and tags not matching the BCP 47 subtag structure.
+func IsValidBCP47Tag(tag string) bool {
+	if tag == "" || len(tag) > MaxLocaleTagLength {
+		return false
+	}
+	return bcp47TagRegex.MatchString(tag)
+}
+
+// NormaliseBCP47Tag returns the lowercase-normalised form of a BCP 47 tag.
+func NormaliseBCP47Tag(tag string) string {
+	return strings.ToLower(tag)
+}
+
+// ResolveLocalisedValue returns the best matching value for the requested locale.
+// Resolution order for each requested locale token: exact match → language-prefix match → base value.
+// uiLocale may be a space-separated list per the OIDC spec; first-match-wins.
+// If uiLocale is empty or no variant matches, base is returned.
+func ResolveLocalisedValue(variants map[string]string, base, uiLocale string) string {
+	if len(variants) == 0 || uiLocale == "" {
+		return base
+	}
+
+	for _, locale := range strings.Fields(uiLocale) {
+		normalised := NormaliseBCP47Tag(locale)
+
+		// Exact match.
+		if val, ok := variants[normalised]; ok {
+			return val
+		}
+
+		// Language-prefix fallback: strip the last subtag and retry.
+		// e.g. "fr-CA" → try "fr".
+		tag := normalised
+		for {
+			idx := strings.LastIndex(tag, "-")
+			if idx < 0 {
+				break
+			}
+			tag = tag[:idx]
+			if val, ok := variants[tag]; ok {
+				return val
+			}
+		}
+	}
+
+	return base
+}

--- a/backend/internal/system/utils/locale_util_test.go
+++ b/backend/internal/system/utils/locale_util_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidBCP47Tag(t *testing.T) {
+	valid := []string{
+		"en",
+		"fr",
+		"zh",
+		"en-US",
+		"en-GB",
+		"fr-CA",
+		"zh-Hans",
+		"zh-Hans-CN",
+		"sr-Latn-RS",
+		"en-US-x-twain",
+		"sl-Latn-IT-nedis",
+		"en-001", // primary + UN M.49 three-digit region
+	}
+	for _, tag := range valid {
+		assert.True(t, IsValidBCP47Tag(tag), "expected valid: %q", tag)
+	}
+
+	invalid := []string{
+		"",                      // empty
+		strings.Repeat("a", 36), // exceeds MaxLocaleTagLength
+		"en-",                   // trailing dash
+		"-en",                   // leading dash
+		"en--US",                // double dash
+		"en-1234",               // 4-digit all-numeric subtag
+		"en-12",                 // 2-digit all-numeric subtag
+		"123",                   // all-numeric primary subtag
+		"en US",                 // space instead of dash
+		"en_US",                 // underscore instead of dash
+	}
+	for _, tag := range invalid {
+		assert.False(t, IsValidBCP47Tag(tag), "expected invalid: %q", tag)
+	}
+}
+
+func TestNormaliseBCP47Tag(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"en", "en"},
+		{"EN", "en"},
+		{"fr-CA", "fr-ca"},
+		{"zh-Hans-CN", "zh-hans-cn"},
+		{"en-US", "en-us"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, NormaliseBCP47Tag(tc.input))
+	}
+}
+
+func TestResolveLocalisedValue(t *testing.T) {
+	variants := map[string]string{
+		"fr":    "Bonjour",
+		"fr-ca": "Bonjour Canada",
+		"de":    "Hallo",
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		assert.Equal(t, "Bonjour", ResolveLocalisedValue(variants, "Hello", "fr"))
+	})
+
+	t.Run("exact match case-insensitive", func(t *testing.T) {
+		assert.Equal(t, "Bonjour", ResolveLocalisedValue(variants, "Hello", "FR"))
+	})
+
+	t.Run("subtag exact match", func(t *testing.T) {
+		assert.Equal(t, "Bonjour Canada", ResolveLocalisedValue(variants, "Hello", "fr-CA"))
+	})
+
+	t.Run("subtag fallback to parent", func(t *testing.T) {
+		// fr-BE has no variant, falls back to fr
+		assert.Equal(t, "Bonjour", ResolveLocalisedValue(variants, "Hello", "fr-BE"))
+	})
+
+	t.Run("deep subtag fallback", func(t *testing.T) {
+		// fr-CA-x-custom → fr-ca (exact) wins
+		assert.Equal(t, "Bonjour Canada", ResolveLocalisedValue(variants, "Hello", "fr-CA-x-custom"))
+	})
+
+	t.Run("no match falls back to base", func(t *testing.T) {
+		assert.Equal(t, "Hello", ResolveLocalisedValue(variants, "Hello", "ja"))
+	})
+
+	t.Run("empty ui_locale returns base", func(t *testing.T) {
+		assert.Equal(t, "Hello", ResolveLocalisedValue(variants, "Hello", ""))
+	})
+
+	t.Run("nil variants returns base", func(t *testing.T) {
+		assert.Equal(t, "Hello", ResolveLocalisedValue(nil, "Hello", "fr"))
+	})
+
+	t.Run("empty variants returns base", func(t *testing.T) {
+		assert.Equal(t, "Hello", ResolveLocalisedValue(map[string]string{}, "Hello", "fr"))
+	})
+
+	t.Run("space-separated locales first match wins", func(t *testing.T) {
+		// de matches before fr in preference list
+		assert.Equal(t, "Hallo", ResolveLocalisedValue(variants, "Hello", "de fr"))
+	})
+
+	t.Run("space-separated locales falls through to second", func(t *testing.T) {
+		// ja has no match, fr does
+		assert.Equal(t, "Bonjour", ResolveLocalisedValue(variants, "Hello", "ja fr"))
+	})
+
+	t.Run("empty base value preserved", func(t *testing.T) {
+		assert.Equal(t, "", ResolveLocalisedValue(nil, "", "fr"))
+	})
+}

--- a/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
+++ b/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
@@ -206,3 +206,70 @@ func (_c *FlowExecServiceInterfaceMock_InitiateFlow_Call) RunAndReturn(run func(
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetFlowRuntimeData provides a mock function for the type FlowExecServiceInterfaceMock
+func (_mock *FlowExecServiceInterfaceMock) GetFlowRuntimeData(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, flowID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFlowRuntimeData")
+	}
+
+	var r0 map[string]string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, flowID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
+		r0 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowRuntimeData'
+type FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call struct {
+	*mock.Call
+}
+
+// GetFlowRuntimeData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - flowID string
+func (_e *FlowExecServiceInterfaceMock_Expecter) GetFlowRuntimeData(ctx interface{}, flowID interface{}) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	return &FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call{Call: _e.mock.On("GetFlowRuntimeData", ctx, flowID)}
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Run(run func(ctx context.Context, flowID string)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Return(runtimeData map[string]string, serviceError *serviceerror.ServiceError) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(runtimeData, serviceError)
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) RunAndReturn(run func(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
+++ b/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
@@ -139,6 +139,76 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetFlowRuntimeData provides a mock function for the type FlowExecServiceInterfaceMock
+func (_mock *FlowExecServiceInterfaceMock) GetFlowRuntimeData(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, flowID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFlowRuntimeData")
+	}
+
+	var r0 map[string]string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, flowID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
+		r0 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowRuntimeData'
+type FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call struct {
+	*mock.Call
+}
+
+// GetFlowRuntimeData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - flowID string
+func (_e *FlowExecServiceInterfaceMock_Expecter) GetFlowRuntimeData(ctx interface{}, flowID interface{}) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	return &FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call{Call: _e.mock.On("GetFlowRuntimeData", ctx, flowID)}
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Run(run func(ctx context.Context, flowID string)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Return(stringToString map[string]string, serviceError *serviceerror.ServiceError) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(stringToString, serviceError)
+	return _c
+}
+
+func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) RunAndReturn(run func(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InitiateFlow provides a mock function for the type FlowExecServiceInterfaceMock
 func (_mock *FlowExecServiceInterfaceMock) InitiateFlow(ctx context.Context, initContext *flowexec.FlowInitContext) (string, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, initContext)
@@ -203,73 +273,6 @@ func (_c *FlowExecServiceInterfaceMock_InitiateFlow_Call) Return(s string, servi
 }
 
 func (_c *FlowExecServiceInterfaceMock_InitiateFlow_Call) RunAndReturn(run func(ctx context.Context, initContext *flowexec.FlowInitContext) (string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_InitiateFlow_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetFlowRuntimeData provides a mock function for the type FlowExecServiceInterfaceMock
-func (_mock *FlowExecServiceInterfaceMock) GetFlowRuntimeData(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, flowID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetFlowRuntimeData")
-	}
-
-	var r0 map[string]string
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, flowID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
-		r0 = returnFunc(ctx, flowID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, flowID)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowRuntimeData'
-type FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call struct {
-	*mock.Call
-}
-
-// GetFlowRuntimeData is a helper method to define mock.On call
-//   - ctx context.Context
-//   - flowID string
-func (_e *FlowExecServiceInterfaceMock_Expecter) GetFlowRuntimeData(ctx interface{}, flowID interface{}) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
-	return &FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call{Call: _e.mock.On("GetFlowRuntimeData", ctx, flowID)}
-}
-
-func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Run(run func(ctx context.Context, flowID string)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) Return(runtimeData map[string]string, serviceError *serviceerror.ServiceError) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
-	_c.Call.Return(runtimeData, serviceError)
-	return _c
-}
-
-func (_c *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call) RunAndReturn(run func(ctx context.Context, flowID string) (map[string]string, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_GetFlowRuntimeData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/flowmetamock/FlowMetaServiceInterface_mock.go
+++ b/backend/tests/mocks/flow/flowmetamock/FlowMetaServiceInterface_mock.go
@@ -40,8 +40,8 @@ func (_m *FlowMetaServiceInterfaceMock) EXPECT() *FlowMetaServiceInterfaceMock_E
 }
 
 // GetFlowMetadata provides a mock function for the type FlowMetaServiceInterfaceMock
-func (_mock *FlowMetaServiceInterfaceMock) GetFlowMetadata(ctx context.Context, metaType flowmeta.MetaType, id string, language *string, namespace *string) (*flowmeta.FlowMetadataResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, metaType, id, language, namespace)
+func (_mock *FlowMetaServiceInterfaceMock) GetFlowMetadata(ctx context.Context, metaType flowmeta.MetaType, id string, flowID *string, language *string, namespace *string) (*flowmeta.FlowMetadataResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, metaType, id, flowID, language, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFlowMetadata")
@@ -49,18 +49,18 @@ func (_mock *FlowMetaServiceInterfaceMock) GetFlowMetadata(ctx context.Context, 
 
 	var r0 *flowmeta.FlowMetadataResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, flowmeta.MetaType, string, *string, *string) (*flowmeta.FlowMetadataResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, metaType, id, language, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, flowmeta.MetaType, string, *string, *string, *string) (*flowmeta.FlowMetadataResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, metaType, id, flowID, language, namespace)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, flowmeta.MetaType, string, *string, *string) *flowmeta.FlowMetadataResponse); ok {
-		r0 = returnFunc(ctx, metaType, id, language, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, flowmeta.MetaType, string, *string, *string, *string) *flowmeta.FlowMetadataResponse); ok {
+		r0 = returnFunc(ctx, metaType, id, flowID, language, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*flowmeta.FlowMetadataResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, flowmeta.MetaType, string, *string, *string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, metaType, id, language, namespace)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, flowmeta.MetaType, string, *string, *string, *string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, metaType, id, flowID, language, namespace)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -78,13 +78,14 @@ type FlowMetaServiceInterfaceMock_GetFlowMetadata_Call struct {
 //   - ctx context.Context
 //   - metaType flowmeta.MetaType
 //   - id string
+//   - flowID *string
 //   - language *string
 //   - namespace *string
-func (_e *FlowMetaServiceInterfaceMock_Expecter) GetFlowMetadata(ctx interface{}, metaType interface{}, id interface{}, language interface{}, namespace interface{}) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
-	return &FlowMetaServiceInterfaceMock_GetFlowMetadata_Call{Call: _e.mock.On("GetFlowMetadata", ctx, metaType, id, language, namespace)}
+func (_e *FlowMetaServiceInterfaceMock_Expecter) GetFlowMetadata(ctx interface{}, metaType interface{}, id interface{}, flowID interface{}, language interface{}, namespace interface{}) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
+	return &FlowMetaServiceInterfaceMock_GetFlowMetadata_Call{Call: _e.mock.On("GetFlowMetadata", ctx, metaType, id, flowID, language, namespace)}
 }
 
-func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Run(run func(ctx context.Context, metaType flowmeta.MetaType, id string, language *string, namespace *string)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
+func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Run(run func(ctx context.Context, metaType flowmeta.MetaType, id string, flowID *string, language *string, namespace *string)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -106,12 +107,17 @@ func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Run(run func(ctx co
 		if args[4] != nil {
 			arg4 = args[4].(*string)
 		}
+		var arg5 *string
+		if args[5] != nil {
+			arg5 = args[5].(*string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -122,7 +128,7 @@ func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) Return(flowMetadata
 	return _c
 }
 
-func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) RunAndReturn(run func(ctx context.Context, metaType flowmeta.MetaType, id string, language *string, namespace *string) (*flowmeta.FlowMetadataResponse, *serviceerror.ServiceError)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
+func (_c *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call) RunAndReturn(run func(ctx context.Context, metaType flowmeta.MetaType, id string, flowID *string, language *string, namespace *string) (*flowmeta.FlowMetadataResponse, *serviceerror.ServiceError)) *FlowMetaServiceInterfaceMock_GetFlowMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/application/application_api_test.go
+++ b/tests/integration/application/application_api_test.go
@@ -647,6 +647,128 @@ func deleteApplication(appID string) error {
 	return nil
 }
 
+// createApplicationRaw creates an application with a raw map body (to support #-keyed fields like "name#fr").
+// Returns the application ID, the full decoded response map, and any error.
+func createApplicationRaw(body map[string]interface{}) (string, map[string]interface{}, error) {
+	appJSON, err := json.Marshal(body)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to marshal application: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/applications", bytes.NewReader(appJSON))
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", nil, fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return "", nil, fmt.Errorf("failed to parse response body: %w", err)
+	}
+
+	id, _ := result["id"].(string)
+	if id == "" {
+		return "", nil, fmt.Errorf("response does not contain id")
+	}
+	return id, result, nil
+}
+
+// updateApplicationRaw updates an application with a raw map body (to support #-keyed fields).
+// Returns the decoded response map and any error.
+func updateApplicationRaw(appID string, body map[string]interface{}) (map[string]interface{}, error) {
+	appJSON, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal application: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", testServerURL+"/applications/"+appID, bytes.NewReader(appJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response body: %w", err)
+	}
+	return result, nil
+}
+
+// getApplicationRaw retrieves an application as a raw map (preserving #-keyed fields).
+func getApplicationRaw(appID string) (map[string]interface{}, error) {
+	req, err := http.NewRequest("GET", testServerURL+"/applications/"+appID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response body: %w", err)
+	}
+	return result, nil
+}
+
+// createApplicationRawExpectError creates an application with a raw map body and returns the HTTP status code.
+func createApplicationRawExpectError(body map[string]interface{}) (int, error) {
+	appJSON, err := json.Marshal(body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal application: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/applications", bytes.NewReader(appJSON))
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
 // TestApplicationCreationWithDefaults tests that applications created without grant_types, response_types, or token_endpoint_auth_method get proper defaults
 func (ts *ApplicationAPITestSuite) TestApplicationCreationWithDefaults() {
 	appWithDefaults := Application{
@@ -5016,4 +5138,228 @@ func (ts *ApplicationAPITestSuite) TestApplicationUserInfoResponseTypeInvalidFal
 	oauth := retrievedApp.InboundAuthConfig[0].OAuthAppConfig
 	ts.Require().NotNil(oauth.UserInfo)
 	ts.Assert().Equal("JSON", oauth.UserInfo.ResponseType)
+}
+
+// ─── Localised Client Metadata Tests (AC-01, AC-02, AC-05–AC-09, AC-12–AC-14, AC-23, AC-25) ────
+
+// localisedTestAppBody returns a base map[string]interface{} suitable for creating a test application
+// via the raw app helpers, with the given client ID and name.
+func localisedTestAppBody(clientID, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":                      name,
+		"description":               "Localised test app",
+		"isRegistrationFlowEnabled": false,
+		"certificate": map[string]interface{}{
+			"type":  "NONE",
+			"value": "",
+		},
+		"inboundAuthConfig": []interface{}{
+			map[string]interface{}{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientID + "_secret",
+					"redirectUris":            []string{"https://locale-app.example.com/callback"},
+					"grantTypes":              []string{"authorization_code"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+				},
+			},
+		},
+	}
+}
+
+// TestApplicationLocalisedClientName_CreateAndGet verifies that name#fr and name#de are stored and
+// echoed by GET after creation (AC-01).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedClientName_CreateAndGet() {
+	body := localisedTestAppBody("locale_cn_client", "My App")
+	body["name#fr"] = "Mon Application"
+	body["name#de"] = "Meine Anwendung"
+
+	appID, createResp, err := createApplicationRaw(body)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	ts.Assert().Equal("My App", createResp["name"])
+	ts.Assert().Equal("Mon Application", createResp["name#fr"])
+	ts.Assert().Equal("Meine Anwendung", createResp["name#de"])
+
+	getResp, err := getApplicationRaw(appID)
+	ts.Require().NoError(err)
+	ts.Assert().Equal("My App", getResp["name"])
+	ts.Assert().Equal("Mon Application", getResp["name#fr"])
+	ts.Assert().Equal("Meine Anwendung", getResp["name#de"])
+}
+
+// TestApplicationLocalisedAllFourFields_CreateAndGet verifies all four localisable fields with
+// tagged variants round-trip through the application API (AC-01).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedAllFourFields_CreateAndGet() {
+	body := localisedTestAppBody("locale_4fields_client", "App")
+	body["name#fr"] = "App FR"
+	body["logoUrl"] = "https://example.com/logo.png"
+	body["logoUrl#fr"] = "https://example.com/logo-fr.png"
+	body["tosUri"] = "https://example.com/tos"
+	body["tosUri#fr"] = "https://example.com/tos-fr"
+	body["policyUri"] = "https://example.com/policy"
+	body["policyUri#fr"] = "https://example.com/policy-fr"
+
+	appID, createResp, err := createApplicationRaw(body)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	ts.Assert().Equal("App FR", createResp["name#fr"])
+	ts.Assert().Equal("https://example.com/logo-fr.png", createResp["logoUrl#fr"])
+	ts.Assert().Equal("https://example.com/tos-fr", createResp["tosUri#fr"])
+	ts.Assert().Equal("https://example.com/policy-fr", createResp["policyUri#fr"])
+
+	getResp, err := getApplicationRaw(appID)
+	ts.Require().NoError(err)
+	ts.Assert().Equal("App FR", getResp["name#fr"])
+	ts.Assert().Equal("https://example.com/logo-fr.png", getResp["logoUrl#fr"])
+	ts.Assert().Equal("https://example.com/tos-fr", getResp["tosUri#fr"])
+	ts.Assert().Equal("https://example.com/policy-fr", getResp["policyUri#fr"])
+}
+
+// TestApplicationLocalisedClientName_UpdateAddsVariant verifies that a PUT that adds a new variant
+// (name#de) alongside the existing name#fr results in both variants being present (AC-02).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedClientName_UpdateAddsVariant() {
+	body := localisedTestAppBody("locale_update_add_client", "App")
+	body["name#fr"] = "App FR"
+
+	appID, _, err := createApplicationRaw(body)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	updateBody := localisedTestAppBody("locale_update_add_client", "App")
+	updateBody["name#fr"] = "App FR"
+	updateBody["name#de"] = "App DE"
+
+	updateResp, err := updateApplicationRaw(appID, updateBody)
+	ts.Require().NoError(err)
+	ts.Assert().Equal("App FR", updateResp["name#fr"])
+	ts.Assert().Equal("App DE", updateResp["name#de"])
+
+	getResp, err := getApplicationRaw(appID)
+	ts.Require().NoError(err)
+	ts.Assert().Equal("App FR", getResp["name#fr"])
+	ts.Assert().Equal("App DE", getResp["name#de"])
+}
+
+// TestApplicationLocalisedUpdate_VariantsCompletelyReplaced verifies that a PUT that omits name#fr
+// results in name#fr being removed from subsequent GET (AC-02).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedUpdate_VariantsCompletelyReplaced() {
+	body := localisedTestAppBody("locale_update_replace_client", "App")
+	body["name#fr"] = "App FR"
+
+	appID, _, err := createApplicationRaw(body)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	// Update: only name#de, no name#fr
+	updateBody := localisedTestAppBody("locale_update_replace_client", "App")
+	updateBody["name#de"] = "App DE"
+
+	_, err = updateApplicationRaw(appID, updateBody)
+	ts.Require().NoError(err)
+
+	getResp, err := getApplicationRaw(appID)
+	ts.Require().NoError(err)
+	ts.Assert().Equal("App DE", getResp["name#de"])
+	ts.Assert().Nil(getResp["name#fr"], "name#fr should be removed after PUT that omits it")
+}
+
+// TestApplicationLocalisedBCP47_EmptyTag_Rejected verifies that name# (empty tag) is rejected (AC-06).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedBCP47_EmptyTag_Rejected() {
+	body := localisedTestAppBody("locale_empty_tag_client", "App")
+	body["name#"] = "value"
+
+	statusCode, err := createApplicationRawExpectError(body)
+	ts.Require().NoError(err)
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+}
+
+// TestApplicationLocalisedBCP47_IllegalCharTag_Rejected verifies that name#en! is rejected (AC-07).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedBCP47_IllegalCharTag_Rejected() {
+	body := localisedTestAppBody("locale_illegalchar_client", "App")
+	body["name#en!"] = "value"
+
+	statusCode, err := createApplicationRawExpectError(body)
+	ts.Require().NoError(err)
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+}
+
+// TestApplicationLocalisedBCP47_MultipleHash_Rejected verifies that name#fr#extra is rejected (AC-08).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedBCP47_MultipleHash_Rejected() {
+	body := localisedTestAppBody("locale_multihash_client", "App")
+	body["name#fr#extra"] = "value"
+
+	statusCode, err := createApplicationRawExpectError(body)
+	ts.Require().NoError(err)
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+}
+
+// TestApplicationLocalisedUnsupportedField_SilentlyIgnored verifies that description#fr is silently
+// dropped and creation succeeds (AC-12).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedUnsupportedField_SilentlyIgnored() {
+	body := localisedTestAppBody("locale_unsupported_field_client", "App")
+	body["description#fr"] = "Un app"
+
+	appID, createResp, err := createApplicationRaw(body)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	ts.Assert().Nil(createResp["description#fr"], "non-localisable tagged field should be silently dropped")
+}
+
+// TestApplicationLocalisedURIValidation_InvalidTosURIVariant verifies that tosUri#fr with a malformed
+// URI (no valid host) is rejected with the same validation rules as the base tosUri (AC-13).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedURIValidation_InvalidTosURIVariant() {
+	body := localisedTestAppBody("locale_uri_validation_client", "App")
+	body["tosUri#fr"] = "javascript:alert(1)"
+
+	statusCode, err := createApplicationRawExpectError(body)
+	ts.Require().NoError(err)
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+}
+
+// TestApplicationLocalisedStorageCap_ExceedsMaxVariants verifies that 21 name#<tag> variants
+// exceed the cap of 20 and are rejected (AC-14).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedStorageCap_ExceedsMaxVariants() {
+	langs := []string{"en", "fr", "de", "es", "it", "pt", "zh", "ja", "ko", "ar",
+		"ru", "nl", "sv", "pl", "tr", "cs", "da", "fi", "hu", "ro", "sk"}
+	body := localisedTestAppBody("locale_storagecap_client", "App")
+	for _, lang := range langs {
+		body["name#"+lang] = "App " + lang
+	}
+
+	statusCode, err := createApplicationRawExpectError(body)
+	ts.Require().NoError(err)
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+}
+
+// TestApplicationLocalisedTagNormalisation_UppercaseStored_Lowercase verifies that name#EN-US is
+// stored and returned as name#en-us (AC-05, AC-11).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedTagNormalisation_UppercaseStored_Lowercase() {
+	body := localisedTestAppBody("locale_normalise_upper_client", "App")
+	body["name#EN-US"] = "English"
+
+	appID, createResp, err := createApplicationRaw(body)
+	ts.Require().NoError(err)
+	defer deleteApplication(appID)
+
+	ts.Assert().Equal("English", createResp["name#en-us"], "EN-US should be normalised to en-us")
+	ts.Assert().Nil(createResp["name#EN-US"], "uppercase key should not appear in response")
+}
+
+// TestApplicationLocalisedBackwardsCompatibility_ExistingApp_NoTaggedVariants verifies that the
+// test application created in SetupSuite (with no localized variants) has no #-keyed fields in its
+// GET response (AC-23, AC-25).
+func (ts *ApplicationAPITestSuite) TestApplicationLocalisedBackwardsCompatibility_ExistingApp_NoTaggedVariants() {
+	getResp, err := getApplicationRaw(testAppID)
+	ts.Require().NoError(err)
+
+	for key := range getResp {
+		ts.Assert().NotContains(key, "#",
+			"existing app with no localized variants should have no #-keyed fields in response")
+	}
 }

--- a/tests/integration/flow/flowmeta/flowmeta_api_test.go
+++ b/tests/integration/flow/flowmeta/flowmeta_api_test.go
@@ -19,6 +19,7 @@
 package flowmeta
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,12 +55,23 @@ var (
 		ClientSecret:              "flowmeta_test_secret",
 		RedirectURIs:              []string{"https://localhost:8095/callback"},
 	}
+
+	// localeTestApp is used for locale-resolution tests; it has name#fr registered.
+	localeTestApp = testutils.Application{
+		Name:                      "Base App",
+		Description:               "Application with localised variants for flow metadata locale testing",
+		IsRegistrationFlowEnabled: true,
+		ClientID:                  "flowmeta_locale_client",
+		ClientSecret:              "flowmeta_locale_secret",
+		RedirectURIs:              []string{"https://localhost:8095/callback"},
+	}
 )
 
 type FlowMetaAPITestSuite struct {
 	suite.Suite
-	appID string
-	ouID  string
+	appID       string
+	ouID        string
+	localeAppID string // app with name#fr registered, used for locale-resolution tests
 }
 
 func TestFlowMetaAPITestSuite(t *testing.T) {
@@ -77,6 +89,13 @@ func (suite *FlowMetaAPITestSuite) SetupSuite() {
 	appID, err := testutils.CreateApplication(testApp)
 	suite.Require().NoError(err, "Failed to create application during setup")
 	suite.appID = appID
+
+	// Create localised test application with name#fr variant
+	localeAppID, err := createLocalisedApplication(localeTestApp, map[string]string{
+		"name#fr": "App FR",
+	})
+	suite.Require().NoError(err, "Failed to create localised application during setup")
+	suite.localeAppID = localeAppID
 }
 
 func (suite *FlowMetaAPITestSuite) TearDownSuite() {
@@ -87,12 +106,85 @@ func (suite *FlowMetaAPITestSuite) TearDownSuite() {
 		}
 	}
 
+	if suite.localeAppID != "" {
+		err := testutils.DeleteApplication(suite.localeAppID)
+		if err != nil {
+			suite.T().Logf("Failed to delete localised application during teardown: %v", err)
+		}
+	}
+
 	if suite.ouID != "" {
 		err := testutils.DeleteOrganizationUnit(suite.ouID)
 		if err != nil {
 			suite.T().Logf("Failed to delete OU during teardown: %v", err)
 		}
 	}
+}
+
+// createLocalisedApplication creates an application with additional localised fields (e.g., name#fr).
+// extraFields is a map of raw JSON keys (like "name#fr") to their values.
+func createLocalisedApplication(app testutils.Application, extraFields map[string]string) (string, error) {
+	redirectURIs := app.RedirectURIs
+	if len(redirectURIs) == 0 {
+		redirectURIs = []string{"http://localhost:8080/callback"}
+	}
+
+	appData := map[string]interface{}{
+		"name":                      app.Name,
+		"description":               app.Description,
+		"isRegistrationFlowEnabled": app.IsRegistrationFlowEnabled,
+		"certificate": map[string]interface{}{
+			"type":  "NONE",
+			"value": "",
+		},
+		"inboundAuthConfig": []interface{}{
+			map[string]interface{}{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":     app.ClientID,
+					"clientSecret": app.ClientSecret,
+					"redirectUris": redirectURIs,
+				},
+			},
+		},
+	}
+	for k, v := range extraFields {
+		appData[k] = v
+	}
+
+	appJSON, err := json.Marshal(appData)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal application: %w", err)
+	}
+
+	client := testutils.GetHTTPClient()
+	req, err := http.NewRequest("POST", testServerURL+"/applications", bytes.NewReader(appJSON))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	appID, _ := result["id"].(string)
+	if appID == "" {
+		return "", fmt.Errorf("response does not contain id")
+	}
+	return appID, nil
 }
 
 // TestGetFlowMetadataWithAppType tests GET /flow/meta?type=APP&id={appID}
@@ -469,4 +561,165 @@ func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataCaseSensitiveType() {
 	suite.Require().NoError(err)
 
 	suite.Equal("FM-1001", errorResp.Code)
+}
+
+// ─── Localised Client Metadata Tests (AC-15–AC-24) ────────────────────────────
+
+// initiateFlowWithUILocale starts an authorization flow for the localeApp with the given ui_locales
+// value and returns the flowId from the redirect Location header.
+func (suite *FlowMetaAPITestSuite) initiateFlowWithUILocale(uiLocales string) string {
+	resp, err := testutils.InitiateAuthorizationFlowWithUILocale(
+		localeTestApp.ClientID,
+		localeTestApp.RedirectURIs[0],
+		"code",
+		"openid",
+		"test-state",
+		uiLocales,
+	)
+	suite.Require().NoError(err, "Failed to initiate authorization flow with ui_locales=%q", uiLocales)
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	suite.Require().NotEmpty(location, "Expected a redirect Location header from authorize endpoint")
+
+	_, flowID, err := testutils.ExtractAuthData(location)
+	suite.Require().NoError(err, "Failed to extract flowId from redirect: %s", location)
+	return flowID
+}
+
+// getFlowMetaForLocaleApp calls /flow/meta for the locale test app with an optional flowId.
+func (suite *FlowMetaAPITestSuite) getFlowMetaForLocaleApp(flowID string) FlowMetadataResponse {
+	url := fmt.Sprintf("%s%s?type=APP&id=%s", testServerURL, flowMetaEndpoint, suite.localeAppID)
+	if flowID != "" {
+		url += "&flowId=" + flowID
+	}
+
+	client := testutils.GetHTTPClient()
+	req, err := http.NewRequest("GET", url, nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	var metadata FlowMetadataResponse
+	suite.Require().NoError(json.Unmarshal(body, &metadata))
+	return metadata
+}
+
+// TestGetFlowMetadataWithLocalisedApp_BaseValues_NoFlowID verifies that without a flowId the base
+// (untagged) name is returned and uiLocale is empty (AC-18, AC-24).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithLocalisedApp_BaseValues_NoFlowID() {
+	metadata := suite.getFlowMetaForLocaleApp("")
+
+	suite.NotNil(metadata.Application)
+	suite.Equal("Base App", metadata.Application.Name)
+	suite.Empty(metadata.UILocale)
+}
+
+// TestGetFlowMetadataWithLocalisedApp_ExactLocaleMatch verifies that ui_locales=fr resolves to the
+// name#fr variant and uiLocale is returned in the response (AC-15, AC-22).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithLocalisedApp_ExactLocaleMatch() {
+	flowID := suite.initiateFlowWithUILocale("fr")
+	metadata := suite.getFlowMetaForLocaleApp(flowID)
+
+	suite.NotNil(metadata.Application)
+	suite.Equal("App FR", metadata.Application.Name)
+	suite.Equal("fr", metadata.UILocale)
+}
+
+// TestGetFlowMetadataWithLocalisedApp_SubtagFallback verifies that ui_locales=fr-CA falls back to
+// the registered name#fr variant (AC-16).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithLocalisedApp_SubtagFallback() {
+	flowID := suite.initiateFlowWithUILocale("fr-CA")
+	metadata := suite.getFlowMetaForLocaleApp(flowID)
+
+	suite.NotNil(metadata.Application)
+	suite.Equal("App FR", metadata.Application.Name, "fr-CA should fall back to the fr variant")
+}
+
+// TestGetFlowMetadataWithLocalisedApp_BaseFallback_NoMatchingVariant verifies that ui_locales=de
+// falls back to the base name when no name#de is registered (AC-17).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithLocalisedApp_BaseFallback_NoMatchingVariant() {
+	flowID := suite.initiateFlowWithUILocale("de")
+	metadata := suite.getFlowMetaForLocaleApp(flowID)
+
+	suite.NotNil(metadata.Application)
+	suite.Equal("Base App", metadata.Application.Name, "should fall back to base name when no de variant exists")
+	suite.Equal("de", metadata.UILocale)
+}
+
+// TestGetFlowMetadataWithLocalisedApp_ExpiredOrUnknownFlowID verifies that an unknown flowId
+// degrades gracefully to base values without a 4xx/5xx (AC-19).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithLocalisedApp_ExpiredOrUnknownFlowID() {
+	metadata := suite.getFlowMetaForLocaleApp("00000000-0000-0000-0000-000000000000")
+
+	suite.NotNil(metadata.Application)
+	suite.Equal("Base App", metadata.Application.Name)
+}
+
+// TestGetFlowMetadataWithLocalisedApp_SpaceSeparatedUILocale_FirstMatchWins verifies that
+// "de fr" (space-separated) picks the first matching variant — de has none, fr does (AC-21).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithLocalisedApp_SpaceSeparatedUILocale_FirstMatchWins() {
+	flowID := suite.initiateFlowWithUILocale("de fr")
+	metadata := suite.getFlowMetaForLocaleApp(flowID)
+
+	suite.NotNil(metadata.Application)
+	suite.Equal("App FR", metadata.Application.Name, "should resolve to fr when de has no variant")
+}
+
+// TestGetFlowMetadataWithLocalisedApp_UILocaleReturnedInResponse verifies that the uiLocale field
+// in the /flow/meta response matches the ui_locales stored in the flow context (AC-22).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataWithLocalisedApp_UILocaleReturnedInResponse() {
+	flowID := suite.initiateFlowWithUILocale("fr")
+	metadata := suite.getFlowMetaForLocaleApp(flowID)
+
+	suite.Equal("fr", metadata.UILocale)
+}
+
+// TestGetFlowMetadataBackwardsCompatibility_AppWithNoTaggedVariants verifies that querying
+// /flow/meta with a ui_locales flow against a standard (non-localized) app returns base values
+// without error (AC-23, AC-24).
+func (suite *FlowMetaAPITestSuite) TestGetFlowMetadataBackwardsCompatibility_AppWithNoTaggedVariants() {
+	// Initiate a flow for the standard (non-localized) testApp
+	resp, err := testutils.InitiateAuthorizationFlowWithUILocale(
+		testApp.ClientID,
+		testApp.RedirectURIs[0],
+		"code",
+		"openid",
+		"test-state",
+		"fr",
+	)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	suite.Require().NotEmpty(location)
+
+	_, flowID, err := testutils.ExtractAuthData(location)
+	suite.Require().NoError(err)
+
+	// Query /flow/meta for the standard app with that flowId
+	url := fmt.Sprintf("%s%s?type=APP&id=%s&flowId=%s", testServerURL, flowMetaEndpoint, suite.appID, flowID)
+	client := testutils.GetHTTPClient()
+	req, err := http.NewRequest("GET", url, nil)
+	suite.Require().NoError(err)
+
+	httpResp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer httpResp.Body.Close()
+
+	suite.Equal(http.StatusOK, httpResp.StatusCode)
+
+	body, _ := io.ReadAll(httpResp.Body)
+	var metadata FlowMetadataResponse
+	suite.Require().NoError(json.Unmarshal(body, &metadata))
+
+	suite.NotNil(metadata.Application)
+	suite.Equal(testApp.Name, metadata.Application.Name, "standard app should return its base name unchanged")
 }

--- a/tests/integration/flow/flowmeta/model.go
+++ b/tests/integration/flow/flowmeta/model.go
@@ -27,6 +27,7 @@ type FlowMetadataResponse struct {
 	OU                        *OUMetadata          `json:"ou,omitempty"`
 	Design                    DesignMetadata       `json:"design"`
 	I18n                      I18nMetadata         `json:"i18n"`
+	UILocale                  string               `json:"uiLocale,omitempty"`
 }
 
 // ApplicationMetadata represents application-specific metadata.

--- a/tests/integration/oauth/dcr/dcr_test.go
+++ b/tests/integration/oauth/dcr/dcr_test.go
@@ -557,6 +557,47 @@ func (ts *DCRTestSuite) registerClientWithError(request DCRRegistrationRequest) 
 	return nil, resp.StatusCode, &errResp
 }
 
+// registerClientRaw sends a DCR registration request as a raw map (preserving #-keyed field names)
+// and returns the decoded response map, HTTP status code, and error response (if any).
+func (ts *DCRTestSuite) registerClientRaw(body map[string]interface{}) (map[string]interface{}, int, *DCRErrorResponse) {
+	requestJSON, err := json.Marshal(body)
+	if err != nil {
+		ts.T().Fatalf("Failed to marshal request: %v", err)
+	}
+
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("POST", testServerURL+dcrEndpoint, bytes.NewReader(requestJSON))
+	if err != nil {
+		ts.T().Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	token, err := testutils.GetAccessToken()
+	if err != nil {
+		ts.T().Fatalf("Failed to obtain access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		ts.T().Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusCreated {
+		var successResp map[string]interface{}
+		json.Unmarshal(responseBody, &successResp)
+		return successResp, resp.StatusCode, nil
+	}
+
+	var errResp DCRErrorResponse
+	json.Unmarshal(responseBody, &errResp)
+	return nil, resp.StatusCode, &errResp
+}
+
 // TestDCRRegistrationWithJWKSURI tests OAuth client registration with JWKS_URI certificate.
 func (ts *DCRTestSuite) TestDCRRegistrationWithJWKSURI() {
 	request := DCRRegistrationRequest{
@@ -1480,4 +1521,226 @@ func (ts *DCRTestSuite) TestDCRRegistrationWithEmptyJWKSAndJWKSUri() {
 	ts.Assert().Equal(http.StatusBadRequest, statusCode)
 	ts.Assert().NotNil(errResp)
 	ts.Assert().Contains(errResp.Error, "invalid_client_metadata")
+}
+
+// ─── Localised Client Metadata Tests (AC-03, AC-05–AC-14, AC-23–AC-25, AC-28) ────
+
+// TestDCRLocalisedClientName_RegistrationAndResponse verifies that client_name with language-tagged
+// variants (client_name#fr, client_name#de) are stored and echoed back in the DCR response (AC-03, AC-28).
+func (ts *DCRTestSuite) TestDCRLocalisedClientName_RegistrationAndResponse() {
+	body := map[string]interface{}{
+		"redirect_uris": []string{"https://locale-test.example.com/callback"},
+		"client_name":   "My App",
+		"client_name#fr": "Mon Application",
+		"client_name#de": "Meine Anwendung",
+		"grant_types":   []string{"authorization_code"},
+		"response_types": []string{"code"},
+	}
+
+	resp, statusCode, _ := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	ts.Assert().Equal("My App", resp["client_name"])
+	ts.Assert().Equal("Mon Application", resp["client_name#fr"])
+	ts.Assert().Equal("Meine Anwendung", resp["client_name#de"])
+
+	appID, _ := resp["app_id"].(string)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, appID)
+}
+
+// TestDCRLocalisedAllFourFields_RegistrationAndResponse verifies all four localisable fields with
+// language-tagged variants round-trip correctly through DCR registration (AC-03, AC-28).
+func (ts *DCRTestSuite) TestDCRLocalisedAllFourFields_RegistrationAndResponse() {
+	body := map[string]interface{}{
+		"redirect_uris":  []string{"https://locale-all.example.com/callback"},
+		"client_name":    "All Four Fields App",
+		"client_name#fr": "App FR",
+		"logo_uri":       "https://example.com/logo.png",
+		"logo_uri#fr":    "https://example.com/logo-fr.png",
+		"tos_uri":        "https://example.com/tos",
+		"tos_uri#fr":     "https://example.com/tos-fr",
+		"policy_uri":     "https://example.com/policy",
+		"policy_uri#fr":  "https://example.com/policy-fr",
+		"grant_types":    []string{"authorization_code"},
+	}
+
+	resp, statusCode, _ := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	ts.Assert().Equal("All Four Fields App", resp["client_name"])
+	ts.Assert().Equal("App FR", resp["client_name#fr"])
+	ts.Assert().Equal("https://example.com/logo-fr.png", resp["logo_uri#fr"])
+	ts.Assert().Equal("https://example.com/tos-fr", resp["tos_uri#fr"])
+	ts.Assert().Equal("https://example.com/policy-fr", resp["policy_uri#fr"])
+
+	appID, _ := resp["app_id"].(string)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, appID)
+}
+
+// TestDCRLocalisedTagNormalisation_Lowercase verifies that uppercase tags like FR-CA are normalised
+// to lowercase fr-ca on storage (AC-05, AC-11).
+func (ts *DCRTestSuite) TestDCRLocalisedTagNormalisation_Lowercase() {
+	body := map[string]interface{}{
+		"redirect_uris":    []string{"https://normalize-test.example.com/callback"},
+		"client_name":      "Normalisation App",
+		"client_name#FR-CA": "Québec",
+		"client_name#en-US": "English",
+		"grant_types":      []string{"authorization_code"},
+	}
+
+	resp, statusCode, _ := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	// Tags must be normalised to lowercase
+	ts.Assert().Equal("Québec", resp["client_name#fr-ca"], "FR-CA should be stored as fr-ca")
+	ts.Assert().Equal("English", resp["client_name#en-us"], "en-US should be stored as en-us")
+	// Uppercase keys must not appear
+	ts.Assert().Nil(resp["client_name#FR-CA"])
+	ts.Assert().Nil(resp["client_name#en-US"])
+
+	appID, _ := resp["app_id"].(string)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, appID)
+}
+
+// TestDCRLocalisedBCP47Validation_EmptyTag verifies that client_name# (empty tag) is rejected (AC-06).
+func (ts *DCRTestSuite) TestDCRLocalisedBCP47Validation_EmptyTag() {
+	body := map[string]interface{}{
+		"redirect_uris": []string{"https://empty-tag.example.com/callback"},
+		"client_name":   "App",
+		"client_name#":  "value",
+	}
+
+	_, statusCode, errResp := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRLocalisedBCP47Validation_IllegalCharInTag verifies that tags with illegal characters like
+// "en!" are rejected (AC-07).
+func (ts *DCRTestSuite) TestDCRLocalisedBCP47Validation_IllegalCharInTag() {
+	body := map[string]interface{}{
+		"redirect_uris":  []string{"https://illegal-char.example.com/callback"},
+		"client_name":    "App",
+		"client_name#en!": "value",
+	}
+
+	_, statusCode, errResp := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRLocalisedBCP47Validation_MultipleHashOnLocalisableField verifies that client_name#fr#extra
+// is rejected for a localisable field (AC-08).
+func (ts *DCRTestSuite) TestDCRLocalisedBCP47Validation_MultipleHashOnLocalisableField() {
+	body := map[string]interface{}{
+		"redirect_uris":        []string{"https://multi-hash.example.com/callback"},
+		"client_name":          "App",
+		"client_name#fr#extra": "value",
+	}
+
+	_, statusCode, errResp := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRLocalisedBCP47Validation_TagExceedsMaxLength verifies that a tag of 36+ characters is rejected (AC-09).
+func (ts *DCRTestSuite) TestDCRLocalisedBCP47Validation_TagExceedsMaxLength() {
+	longTag := "client_name#" + string(make([]byte, 36))
+	// Build a tag of 36 alphabetic characters
+	tag36 := "abcdefghijklmnopqrstuvwxyzabcdefghij" // 36 chars
+	body := map[string]interface{}{
+		"redirect_uris":       []string{"https://long-tag.example.com/callback"},
+		"client_name":         "App",
+		"client_name#" + tag36: "value",
+	}
+	_ = longTag
+
+	_, statusCode, errResp := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRLocalisedBCP47Validation_UnsupportedFieldSilentlyIgnored verifies that a tagged variant
+// on a non-localisable field (redirect_uris#fr) is silently ignored and registration succeeds (AC-12).
+func (ts *DCRTestSuite) TestDCRLocalisedBCP47Validation_UnsupportedFieldSilentlyIgnored() {
+	body := map[string]interface{}{
+		"redirect_uris":    []string{"https://ignore-field.example.com/callback"},
+		"redirect_uris#fr": "https://example.com",
+		"client_name":      "Unsupported Field App",
+		"grant_types":      []string{"authorization_code"},
+	}
+
+	resp, statusCode, _ := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	ts.Assert().Nil(resp["redirect_uris#fr"], "non-localisable tagged field should be silently dropped")
+
+	appID, _ := resp["app_id"].(string)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, appID)
+}
+
+// TestDCRLocalisedURIValidation_InvalidLogoURIVariant verifies that logo_uri#fr with a URL using an
+// invalid scheme (e.g. ftp://) is rejected with the same rules as the base logo_uri (AC-13).
+func (ts *DCRTestSuite) TestDCRLocalisedURIValidation_InvalidLogoURIVariant() {
+	body := map[string]interface{}{
+		"redirect_uris": []string{"https://uri-validation.example.com/callback"},
+		"client_name":   "URI Validation App",
+		"logo_uri":      "https://example.com/logo.png",
+		"logo_uri#fr":   "ftp://example.com/logo.png",
+	}
+
+	_, statusCode, errResp := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRLocalisedStorageCap_ExceedsMaxVariants verifies that registering more than 20 locale variants
+// per field is rejected (AC-14).
+func (ts *DCRTestSuite) TestDCRLocalisedStorageCap_ExceedsMaxVariants() {
+	// Use 21 distinct ISO 639-1 language codes
+	langs := []string{"en", "fr", "de", "es", "it", "pt", "zh", "ja", "ko", "ar",
+		"ru", "nl", "sv", "pl", "tr", "cs", "da", "fi", "hu", "ro", "sk"}
+	body := map[string]interface{}{
+		"redirect_uris": []string{"https://storagecap.example.com/callback"},
+		"client_name":   "App",
+	}
+	for _, lang := range langs {
+		body["client_name#"+lang] = "App " + lang
+	}
+
+	_, statusCode, errResp := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRLocalisedBackwardsCompatibility_NoTaggedVariants verifies that a client registered without
+// any tagged variants has no #-keyed fields in the response (AC-23, AC-24, AC-25).
+func (ts *DCRTestSuite) TestDCRLocalisedBackwardsCompatibility_NoTaggedVariants() {
+	body := map[string]interface{}{
+		"redirect_uris": []string{"https://compat.example.com/callback"},
+		"client_name":   "Compat App",
+		"grant_types":   []string{"authorization_code"},
+	}
+
+	resp, statusCode, _ := ts.registerClientRaw(body)
+
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	for key := range resp {
+		ts.Assert().NotContains(key, "#", "no #-keyed fields should appear for clients without localized variants")
+	}
+
+	appID, _ := resp["app_id"].(string)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, appID)
 }

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -77,6 +77,41 @@ func InitiateAuthorizationFlowWithNonce(
 	)
 }
 
+// InitiateAuthorizationFlowWithUILocale starts the OAuth2 authorization flow with ui_locales parameter.
+// The response is a redirect whose Location header contains the flowId needed for /flow/meta locale tests.
+func InitiateAuthorizationFlowWithUILocale(clientID, redirectURI, responseType, scope, state, uiLocales string) (*http.Response, error) {
+	authURL := TestServerURL + "/oauth2/authorize"
+	params := url.Values{}
+	params.Set("client_id", clientID)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("response_type", responseType)
+	params.Set("scope", scope)
+	params.Set("state", state)
+	if uiLocales != "" {
+		params.Set("ui_locales", uiLocales)
+	}
+
+	req, err := http.NewRequest("GET", authURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authorization request: %w", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send authorization request: %w", err)
+	}
+	return resp, nil
+}
+
 // initiateAuthorizationFlow starts the OAuth2 authorization flow with all optional parameters.
 // clientID, redirectURI, responseType, scope, and state are required parameters.
 // resource, codeChallenge, codeChallengeMethod, claimsParam, and claimsLocales, and nonce are optional parameters.


### PR DESCRIPTION
Purpose
Implements RFC 7591 §2 localised client metadata support for Thunder applications and DCR clients. Operators can now register locale-specific variants of name, logoUrl, tosUri, and policyUri using the field#tag convention (e.g. "name#fr": "Mon Application"), with full BCP 47 language tag validation.

The /flow/meta endpoint resolves localised application metadata at runtime using the ui_locales value from the active authorization flow, so the login UI receives the correct locale-aware app name and branding without any client-side localisation logic.

Approach
Storage — Localised variant maps are stored as JSON blobs inside the existing application json_data column under keys client_name_localized, logo_uri_localized, tos_uri_localized, policy_uri_localized. No schema migration is required.

Input parsing — ApplicationRequest.UnmarshalJSON and DCRRegistrationRequest.UnmarshalJSON scan raw JSON keys for the field#tag convention and populate unexported localised variant maps. Tagged variants on non-localisable fields are silently ignored.

Validation (validateLocalisedMetadata) — Single normalisation and validation point for both JSON (API) and YAML (declarative) paths:

Normalises BCP 47 tags to lowercase
Rejects invalid tags (APP-1034) and limits variants to 20 per field (APP-1033)
Validates URI syntax for logo, TOS, and policy variants (APP-1035)
PUT merge semantics — mergeLocalisedMap merges existing stored variants with incoming ones (additive, no delete). The 20-variant cap is re-enforced on the merged result to prevent accumulation beyond the limit.

/flow/meta locale resolution — A new GetFlowRuntimeData method on FlowExecService reads the ui_locales value stored in flow runtime data during /oauth2/authorize. The flowmeta service uses this to resolve the best-matching locale variant via subtag fallback (e.g. fr-CH → fr) and echoes the resolved locale in the uiLocale response field.

Related Issues
N/A
Related PRs
N/A
Checklist
 Followed the contribution guidelines.
 Manual test round performed and verified.
 Documentation provided.
 Ran Vale and fixed all errors and warnings
Feature design doc: [feature-docs/localised-client-metadata.md](vscode-webview://11mc0bol2auho93a9l71upj3942bmousf12ugdsvvdsu68g4amg4/feature-docs/localised-client-metadata.md)
 Tests provided.
 Unit Tests — locale_util_test.go, application_localised_test.go, dcr/model_localised_test.go, service_test.go (validateLocalisedMetadata, mergeLocalisedMap, normaliseLocalisedMap)
 Integration Tests — application_localised_api_test.go, dcr_localised_test.go, flowmeta_localised_test.go
 Breaking changes.
 Breaking changes section filled.
 breaking change label added.
Security checks
 Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
 Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-language support for application metadata including client names, logos, and policy URIs
  * Implemented locale-aware application metadata resolution during OAuth authorization flows
  * Added UI locale parameter support for authorization requests with fallback resolution

* **Tests**
  * Added comprehensive validation tests for localized application metadata in API and DCR endpoints
  * Added integration tests for locale resolution across authorization flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->