### PR TITLE
Improve Redis Cache key prefix for Deployment Isolation

### DIFF
--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -206,6 +206,20 @@ func (cm *CacheManager) reset() {
 	cm.enabled = false
 }
 
+// buildRedisKeyPrefix composes the Redis key prefix with deployment ID for per-deployment isolation.
+func buildRedisKeyPrefix(basePrefix string) string {
+	deploymentID := config.GetThunderRuntime().Config.Server.Identifier
+	if deploymentID == "" {
+		return basePrefix
+	}
+
+	if basePrefix == "" {
+		return deploymentID
+	}
+
+	return basePrefix + ":" + deploymentID
+}
+
 // newCache creates a new cache instance.
 func newCache[T any](cacheName string) CacheInterface[T] {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"),
@@ -253,7 +267,7 @@ func newCache[T any](cacheName string) CacheInterface[T] {
 				cacheImpl: nil,
 			}
 		} else {
-			keyPrefix := cacheConfig.Redis.KeyPrefix
+			keyPrefix := buildRedisKeyPrefix(cacheConfig.Redis.KeyPrefix)
 			internalCache = newRedisCache[T](
 				cacheName,
 				!cacheProperty.Disabled,

--- a/backend/internal/system/cache/manager_test.go
+++ b/backend/internal/system/cache/manager_test.go
@@ -415,6 +415,62 @@ func (suite *CacheManagerTestSuite) TestGetCleanupInterval() {
 	interval := getCleanupInterval(config)
 	assert.Equal(t, time.Duration(120)*time.Second, interval, "Should use configured cleanup interval")
 }
+func (suite *CacheManagerTestSuite) TestBuildRedisKeyPrefix() {
+	t := suite.T()
+
+	// Preserve runtime config because this test mutates the global runtime singleton.
+	originalConfig := config.GetThunderRuntime().Config
+	defer func() {
+		config.ResetThunderRuntime()
+		err := config.InitializeThunderRuntime("/test/thunder/home", &originalConfig)
+		assert.NoError(t, err)
+	}()
+
+	testCases := []struct {
+		name         string
+		basePrefix   string
+		deploymentID string
+		expected     string
+	}{
+		{
+			name:         "both basePrefix and deploymentID",
+			basePrefix:   "thunder",
+			deploymentID: "deployment-1",
+			expected:     "thunder:deployment-1",
+		},
+		{
+			name:         "only deploymentID",
+			basePrefix:   "",
+			deploymentID: "deployment-1",
+			expected:     "deployment-1",
+		},
+		{
+			name:         "only basePrefix",
+			basePrefix:   "thunder",
+			deploymentID: "",
+			expected:     "thunder",
+		},
+		{
+			name:         "both empty",
+			basePrefix:   "",
+			deploymentID: "",
+			expected:     "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := originalConfig
+			cfg.Server.Identifier = tc.deploymentID
+			config.ResetThunderRuntime()
+			err := config.InitializeThunderRuntime("/test/thunder/home", &cfg)
+			assert.NoError(t, err)
+
+			result := buildRedisKeyPrefix(tc.basePrefix)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
 
 func (suite *CacheManagerTestSuite) TestStartCleanupRoutine() {
 	t := suite.T()


### PR DESCRIPTION
### Purpose
This pull request enhances the cache key management for Redis by introducing deployment-specific key prefixes, ensuring better isolation between deployments. It also adds comprehensive unit tests to verify the new key prefix logic.

**Redis key prefix isolation:**
* Added the `buildRedisKeyPrefix` function in `manager.go` to compose Redis key prefixes with the deployment ID, enabling per-deployment cache isolation.
* Updated the cache initialization logic in `newCache` to use the new `buildRedisKeyPrefix` function when setting the Redis key prefix.

**Testing improvements:**
* Added `TestBuildRedisKeyPrefix` unit test in `manager_test.go` to verify the behavior of the new key prefix logic under different scenarios, ensuring correct key composition based on base prefix and deployment ID.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2162

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redis cache keys are now scoped to individual deployments for improved isolation and cache separation.

* **Tests**
  * Added comprehensive test coverage for deployment-scoped Redis key prefix generation across various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->