### PR TITLE
Add display names to bootstrap schema properties

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -116,53 +116,65 @@ $userSchemaData = ([ordered]@{
     schema = [ordered]@{
         username = @{
             type = "string"
+            displayName = "Username"
             required = $true
             unique = $true
         }
         email = @{
             type = "string"
+            displayName = "Email"
             required = $true
             unique = $true
             regex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         }
         email_verified = @{
             type = "boolean"
+            displayName = "Email Verified"
             required = $false
         }
         given_name = @{
             type = "string"
+            displayName = "First Name"
             required = $false
         }
         family_name = @{
             type = "string"
+            displayName = "Last Name"
             required = $false
         }
         mobileNumber = @{
             type = "string"
+            displayName = "Mobile Number"
             required = $false
         }
         phone_number = @{
             type = "string"
+            displayName = "Phone Number"
             required = $false
         }
         phone_number_verified = @{
             type = "boolean"
+            displayName = "Phone Number Verified"
             required = $false
         }
         sub = @{
             type = "string"
+            displayName = "Subject"
             required = $false
         }
         name = @{
             type = "string"
+            displayName = "Full Name"
             required = $false
         }
         picture = @{
             type = "string"
+            displayName = "Picture"
             required = $false
         }
         password = @{
             type = "string"
+            displayName = "Password"
             required = $true
             credential = $true
         }

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -107,53 +107,65 @@ RESPONSE=$(thunder_api_call POST "/user-schemas" '{
   "schema": {
     "username": {
       "type": "string",
+      "displayName": "Username",
       "required": true,
       "unique": true
     },
     "email": {
       "type": "string",
+      "displayName": "Email",
       "required": true,
       "unique": true,
       "regex": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
     },
     "email_verified": {
       "type": "boolean",
+      "displayName": "Email Verified",
       "required": false
     },
     "given_name": {
       "type": "string",
+      "displayName": "First Name",
       "required": false
     },
     "family_name": {
       "type": "string",
+      "displayName": "Last Name",
       "required": false
     },
     "mobileNumber": {
       "type": "string",
+      "displayName": "Mobile Number",
       "required": false
     },
     "phone_number": {
       "type": "string",
+      "displayName": "Phone Number",
       "required": false
     },
     "phone_number_verified": {
       "type": "boolean",
+      "displayName": "Phone Number Verified",
       "required": false
     },
     "sub": {
       "type": "string",
+      "displayName": "Subject",
       "required": false
     },
     "name": {
       "type": "string",
+      "displayName": "Full Name",
       "required": false
     },
     "picture": {
       "type": "string",
+      "displayName": "Picture",
       "required": false
     },
     "password": {
       "type": "string",
+      "displayName": "Password",
       "required": true,
       "credential": true
     }

--- a/backend/cmd/server/bootstrap/02-sample-resources.ps1
+++ b/backend/cmd/server/bootstrap/02-sample-resources.ps1
@@ -108,30 +108,36 @@ $customerUserTypeData = ([ordered]@{
     schema = [ordered]@{
         username = @{
             type = "string"
+            displayName = "Username"
             required = $true
             unique = $true
         }
         password = @{
             type = "string"
+            displayName = "Password"
             required = $true
             credential = $true
         }
         email = @{
             type = "string"
+            displayName = "Email"
             required = $true
             unique = $true
             regex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         }
         given_name = @{
             type = "string"
+            displayName = "First Name"
             required = $false
         }
         family_name = @{
             type = "string"
+            displayName = "Last Name"
             required = $false
         }
         mobileNumber = @{
             type = "string"
+            displayName = "Mobile Number"
             required = $false
         }
     }

--- a/backend/cmd/server/bootstrap/02-sample-resources.sh
+++ b/backend/cmd/server/bootstrap/02-sample-resources.sh
@@ -96,30 +96,36 @@ read -r -d '' CUSTOMER_USER_TYPE_PAYLOAD <<JSON || true
   "schema": {
     "username": {
       "type": "string",
+      "displayName": "Username",
       "required": true,
       "unique": true
     },
     "password": {
       "type": "string",
+      "displayName": "Password",
       "required": true,
       "credential": true
     },
     "email": {
       "type": "string",
+      "displayName": "Email",
       "required": true,
       "unique": true,
       "regex": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$"
     },
     "given_name": {
       "type": "string",
+      "displayName": "First Name",
       "required": false
     },
     "family_name": {
       "type": "string",
+      "displayName": "Last Name",
       "required": false
     },
     "mobileNumber": {
       "type": "string",
+      "displayName": "Mobile Number",
       "required": false
     }
   },


### PR DESCRIPTION
### Purpose

The Person and Customer user type schemas created by the bootstrap scripts were missing `displayName` values for their properties. This caused the console UI to show empty display name fields for all schema properties.

This adds human-readable display names (e.g., `given_name` → "First Name", `family_name` → "Last Name") to all properties in both the bash and PowerShell bootstrap scripts.

### Approach

Added `displayName` field to each schema property definition in all four bootstrap scripts:
- `01-default-resources.sh` / `.ps1` (Person user type)
- `02-sample-resources.sh` / `.ps1` (Customer user type)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced user profile schema with `displayName` field support across key attributes including username, email, name components, and contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->