### PR TITLE
Remove registration flow info box and role edit handle field

### DIFF
--- a/frontend/apps/thunder-console/src/features/applications/components/edit-application/flows-settings/RegistrationFlowSection.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/edit-application/flows-settings/RegistrationFlowSection.tsx
@@ -16,9 +16,8 @@
  * under the License.
  */
 
-import {Box, Typography, TextField, Autocomplete, CircularProgress, Alert} from '@wso2/oxygen-ui';
-import {useTranslation, Trans} from 'react-i18next';
-import {Link} from 'react-router';
+import {Box, Typography, TextField, Autocomplete, CircularProgress} from '@wso2/oxygen-ui';
+import {useTranslation} from 'react-i18next';
 import SettingsCard from '../../../../../components/SettingsCard';
 import useGetFlows from '../../../../flows/api/useGetFlows';
 import {FlowType} from '../../../../flows/models/flows';
@@ -70,25 +69,6 @@ export default function RegistrationFlowSection({application, editedApp, onField
       enabled={editedApp.isRegistrationFlowEnabled ?? application.isRegistrationFlowEnabled ?? false}
       onToggle={(enabled) => onFieldChange('isRegistrationFlowEnabled', enabled)}
     >
-      {(editedApp.registrationFlowId ?? application.registrationFlowId) && (
-        <Alert severity="info" sx={{mb: 2}}>
-          <Trans
-            i18nKey="applications:edit.flows.registrationFlow.alert"
-            components={[
-              <Link
-                key="edit"
-                to={`/flows/signup/${editedApp.registrationFlowId ?? application.registrationFlowId}`}
-                style={{color: 'inherit', fontWeight: 'bold', textDecoration: 'underline'}}
-              />,
-              <Link
-                key="create"
-                to="/flows"
-                style={{color: 'inherit', fontWeight: 'bold', textDecoration: 'underline'}}
-              />,
-            ]}
-          />
-        </Alert>
-      )}
       <Autocomplete
         fullWidth
         options={regFlowOptions}

--- a/frontend/apps/thunder-console/src/features/applications/components/edit-application/flows-settings/__tests__/RegistrationFlowSection.test.tsx
+++ b/frontend/apps/thunder-console/src/features/applications/components/edit-application/flows-settings/__tests__/RegistrationFlowSection.test.tsx
@@ -127,59 +127,6 @@ describe('RegistrationFlowSection', () => {
 
       expect(screen.getByTestId('toggle-button')).toBeInTheDocument();
     });
-
-    it('should display alert when registration flow is selected', () => {
-      vi.mocked(useGetFlows).mockReturnValue({
-        data: {flows: mockRegFlows},
-        isLoading: false,
-      } as MockedUseGetFlows);
-
-      render(
-        <MemoryRouter>
-          <RegistrationFlowSection application={mockApplication} editedApp={{}} onFieldChange={mockOnFieldChange} />
-        </MemoryRouter>,
-      );
-
-      expect(screen.getByRole('alert')).toBeInTheDocument();
-    });
-
-    it('should not display alert when no registration flow is selected', () => {
-      vi.mocked(useGetFlows).mockReturnValue({
-        data: {flows: mockRegFlows},
-        isLoading: false,
-      } as MockedUseGetFlows);
-
-      const appWithoutFlow = {...mockApplication, registrationFlowId: undefined};
-
-      render(
-        <MemoryRouter>
-          <RegistrationFlowSection application={appWithoutFlow} editedApp={{}} onFieldChange={mockOnFieldChange} />
-        </MemoryRouter>,
-      );
-
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    });
-
-    it('should display alert when registration flow is in editedApp', () => {
-      vi.mocked(useGetFlows).mockReturnValue({
-        data: {flows: mockRegFlows},
-        isLoading: false,
-      } as MockedUseGetFlows);
-
-      const appWithoutFlow = {...mockApplication, registrationFlowId: undefined};
-
-      render(
-        <MemoryRouter>
-          <RegistrationFlowSection
-            application={appWithoutFlow}
-            editedApp={{registrationFlowId: 'reg-flow-2'}}
-            onFieldChange={mockOnFieldChange}
-          />
-        </MemoryRouter>,
-      );
-
-      expect(screen.getByRole('alert')).toBeInTheDocument();
-    });
   });
 
   describe('Loading State', () => {
@@ -443,63 +390,6 @@ describe('RegistrationFlowSection', () => {
       );
 
       expect(screen.getByPlaceholderText('Select a registration flow')).toBeInTheDocument();
-    });
-  });
-
-  describe('Alert Links', () => {
-    it('should display edit link with correct flow ID from application', () => {
-      vi.mocked(useGetFlows).mockReturnValue({
-        data: {flows: mockRegFlows},
-        isLoading: false,
-      } as MockedUseGetFlows);
-
-      const {container} = render(
-        <MemoryRouter>
-          <RegistrationFlowSection application={mockApplication} editedApp={{}} onFieldChange={mockOnFieldChange} />
-        </MemoryRouter>,
-      );
-
-      const links = container.querySelectorAll('a');
-      const editLink = Array.from(links).find((link) => link.getAttribute('href')?.includes('/flows/signup/'));
-      expect(editLink).toHaveAttribute('href', '/flows/signup/reg-flow-1');
-    });
-
-    it('should display edit link with correct flow ID from editedApp', () => {
-      vi.mocked(useGetFlows).mockReturnValue({
-        data: {flows: mockRegFlows},
-        isLoading: false,
-      } as MockedUseGetFlows);
-
-      const {container} = render(
-        <MemoryRouter>
-          <RegistrationFlowSection
-            application={mockApplication}
-            editedApp={{registrationFlowId: 'reg-flow-2'}}
-            onFieldChange={mockOnFieldChange}
-          />
-        </MemoryRouter>,
-      );
-
-      const links = container.querySelectorAll('a');
-      const editLink = Array.from(links).find((link) => link.getAttribute('href')?.includes('/flows/signup/'));
-      expect(editLink).toHaveAttribute('href', '/flows/signup/reg-flow-2');
-    });
-
-    it('should display create link', () => {
-      vi.mocked(useGetFlows).mockReturnValue({
-        data: {flows: mockRegFlows},
-        isLoading: false,
-      } as MockedUseGetFlows);
-
-      const {container} = render(
-        <MemoryRouter>
-          <RegistrationFlowSection application={mockApplication} editedApp={{}} onFieldChange={mockOnFieldChange} />
-        </MemoryRouter>,
-      );
-
-      const links = container.querySelectorAll('a');
-      const createLink = Array.from(links).find((link) => link.getAttribute('href') === '/flows');
-      expect(createLink).toHaveAttribute('href', '/flows');
     });
   });
 });

--- a/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/thunder-console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
@@ -60,47 +60,6 @@ export default function EditGeneralSettings({role, onDeleteClick}: EditGeneralSe
       >
         <Stack spacing={2}>
           <TextField
-            label={t('roles:edit.general.sections.organizationUnit.handleLabel', 'Handle')}
-            value={role.ouHandle ?? '-'}
-            fullWidth
-            size="small"
-            slotProps={{
-              input: {
-                readOnly: true,
-                endAdornment: role.ouHandle ? (
-                  <InputAdornment position="end">
-                    <Tooltip
-                      title={
-                        copiedField === 'ouHandle'
-                          ? t('common:actions.copied')
-                          : t(
-                              'roles:edit.general.sections.organizationUnit.copyHandle',
-                              'Copy Organization Unit Handle',
-                            )
-                      }
-                    >
-                      <IconButton
-                        aria-label={t(
-                          'roles:edit.general.sections.organizationUnit.copyHandle',
-                          'Copy Organization Unit Handle',
-                        )}
-                        onClick={() => {
-                          handleCopyToClipboard(role.ouHandle!, 'ouHandle').catch(() => {
-                            /* noop */
-                          });
-                        }}
-                        edge="end"
-                      >
-                        {copiedField === 'ouHandle' ? <Check size={16} /> : <Copy size={16} />}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ) : undefined,
-              },
-            }}
-            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
-          />
-          <TextField
             label={t('roles:edit.general.sections.organizationUnit.idLabel', 'ID')}
             value={role.ouId}
             fullWidth


### PR DESCRIPTION
## Summary
- Remove the info alert box from the registration flow section in the application edit page
- Remove the OU handle text field from the role edit general settings since the backend does not return the handle yet

## Test plan
- [ ] Verify the registration flow section in application edit no longer shows the info box
- [ ] Verify the role edit general settings only shows the OU ID field
- [ ] Run existing tests to ensure no regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the informational alert and its registration-flow edit/create links from the registration flow settings.
  * Removed the Organization Unit "Handle" display and its copy-to-clipboard control from role general settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->