### PR TITLE
Update default flows to show signup link on sign in page

### DIFF
--- a/backend/cmd/server/bootstrap/flows/apps/console/auth_flow_console.json
+++ b/backend/cmd/server/bootstrap/flows/apps/console/auth_flow_console.json
@@ -45,6 +45,13 @@
                                 "label": "{{ t(signin:forms.credentials.actions.submit.label) }}",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
+                            },
+                            {
+                                "category": "DISPLAY",
+                                "id": "rich_text_signup",
+                                "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.sign_up_url)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
+                                "resourceType": "ELEMENT",
+                                "type": "RICH_TEXT"
                             }
                         ]
                     }

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_basic.json
@@ -56,6 +56,13 @@
                                 "label": "{{ t(signin:forms.credentials.actions.submit.label) }}",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
+                            },
+                            {
+                                "category": "DISPLAY",
+                                "id": "rich_text_signup",
+                                "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.sign_up_url)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
+                                "resourceType": "ELEMENT",
+                                "type": "RICH_TEXT"
                             }
                         ]
                     }

--- a/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
+++ b/backend/cmd/server/bootstrap/flows/authentication/auth_flow_passkey.json
@@ -46,6 +46,13 @@
                                 "label": "{{ t(signin:forms.passkey.actions.submit.label) }}",
                                 "variant": "PRIMARY",
                                 "eventType": "SUBMIT"
+                            },
+                            {
+                                "category": "DISPLAY",
+                                "id": "rich_text_signup",
+                                "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.sign_up_url)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>",
+                                "resourceType": "ELEMENT",
+                                "type": "RICH_TEXT"
                             }
                         ]
                     }


### PR DESCRIPTION
### Purpose
Update default flows to show signup link on sign in page

Console flow (Not shown as Self registration is disabled)

<img width="1728" height="1117" alt="Screenshot 2026-04-03 at 19 20 41" src="https://github.com/user-attachments/assets/b020a05e-755f-41cf-9cd4-d63a742b37a8" />

Default Basic Flow
<img width="1728" height="1117" alt="Screenshot 2026-04-03 at 19 20 56" src="https://github.com/user-attachments/assets/31741373-a33d-4b0f-b1a5-10e3eca384ca" />


Passkey flow
<img width="1728" height="1117" alt="Screenshot 2026-04-03 at 19 21 06" src="https://github.com/user-attachments/assets/4d5b05e6-9d10-462b-a145-436244619284" />


### Approach
This pull request updates multiple authentication flow JSON files to add a rich text "Sign up" link for users who do not have an account. This link appears on the sign-in forms and directs users to the application's sign-up page in a new tab.

**Enhancements to authentication flows:**

* Added a rich text element with a "Don't have an account? Sign up" link to the credentials-based sign-in form in `auth_flow_basic.json` and the passkey-based sign-in form in `auth_flow_passkey.json`. This improves user navigation by providing a clear path to account creation. [[1]](diffhunk://#diff-43c8ee0d5797fe4d22d607650ad3e34f5363403177a7350aea72169c38fca369R59-R65) [[2]](diffhunk://#diff-2b27d3e248553c2765d96fb6a0781827f27ade3929017cf4538361836af309eeR49-R55)
* Added the same rich text sign-up link to the console authentication flow in `auth_flow_console.json`, ensuring consistency across all authentication UIs.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication screens with sign-up prompts that guide users without accounts to the registration page with a direct link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->