### PR TITLE
Revert "Enhance release workflow with version bump"

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -11,15 +11,10 @@ on:
     - cron: '30 6 * * 5'
   workflow_dispatch:
     inputs:
-      bump_type:
-        description: 'Version bump type to apply to version.txt (major, minor, or patch)'
+      version:
+        description: 'Release version (e.g., X for v0.X.0, X.Y for v0.X.Y, or X.Y.Z for v0.Y.Z). Leave empty to use version.txt'
         required: false
-        type: choice
-        options:
-          - minor
-          - patch
-          - major
-        default: minor
+        type: string
       prerelease:
         description: 'Set as a pre-release'
         required: false
@@ -35,10 +30,10 @@ on:
 permissions:
   contents: write
   packages: write
-  issues: write
 
 env:
   GOFLAGS: "-mod=readonly"
+  RELEASE_MAJOR_VERSION: 0
 
 jobs:
   dependency-guard:
@@ -61,60 +56,56 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
 
       - name: 📝 Determine Release Version
         id: get_version
         run: |
-          # Read current version from version.txt
-          if [ ! -f version.txt ] || [ -z "$(cat version.txt | tr -d '[:space:]')" ]; then
-            echo "❌ Error: version.txt not found or empty"
-            exit 1
-          fi
-          CURRENT_VERSION=$(tr -d '[:space:]' < version.txt)
-          # Strip leading 'v' for semver parsing
-          SEMVER="${CURRENT_VERSION#v}"
-
-          if [[ $SEMVER =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            CUR_MAJOR="${BASH_REMATCH[1]}"
-            CUR_MINOR="${BASH_REMATCH[2]}"
-            CUR_PATCH="${BASH_REMATCH[3]}"
-          else
-            echo "❌ Error: Could not parse version '$CURRENT_VERSION' from version.txt"
-            exit 1
-          fi
-
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            # Manual trigger - always use input values for flags
             PRERELEASE="${{ github.event.inputs.prerelease }}"
             RUN_PERF_TEST="${{ github.event.inputs.run_performance_test }}"
-            BUMP_TYPE="${{ github.event.inputs.bump_type }}"
+            INPUT_VERSION="${{ github.event.inputs.version }}"
+            MAJOR="${{ env.RELEASE_MAJOR_VERSION }}"
+
+            if [ -n "$INPUT_VERSION" ]; then
+              # Handle manually provided version
+              if [[ $INPUT_VERSION =~ ^v?[0-9]+\.([0-9]+)\.([0-9]+) ]]; then
+                # Full format (vX.Y.Z) -> Parse and use MAJOR
+                MINOR="${BASH_REMATCH[1]}"
+                PATCH="${BASH_REMATCH[2]}"
+                VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+              elif [[ $INPUT_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+                # minor.patch format (X.Y) -> v0.X.Y
+                VERSION="v${MAJOR}.${INPUT_VERSION}"
+              elif [[ $INPUT_VERSION =~ ^[0-9]+$ ]]; then
+                # minor format (X) -> v0.X.0
+                VERSION="v${MAJOR}.${INPUT_VERSION}.0"
+              else
+                echo "❌ Error: Invalid version format '$INPUT_VERSION'. Use 'X', 'X.Y', or 'vX.Y.Z'"
+                exit 1
+              fi
+            else
+              # Manual run without version - read from version.txt
+              if [ ! -f version.txt ] || [ -z "$(cat version.txt | tr -d '[:space:]')" ]; then
+                echo "❌ Error: version.txt not found or empty"
+                exit 1
+              fi
+              VERSION=$(tr -d '[:space:]' < version.txt)
+            fi
           else
-            # Scheduled run — default to minor bump
-            PRERELEASE="false"
-            RUN_PERF_TEST="true"
-            BUMP_TYPE="minor"
-          fi
-
-          case "$BUMP_TYPE" in
-            major)
-              VERSION="v$((CUR_MAJOR + 1)).0.0"
-              ;;
-            minor)
-              VERSION="v${CUR_MAJOR}.$((CUR_MINOR + 1)).0"
-              ;;
-            patch)
-              VERSION="v${CUR_MAJOR}.${CUR_MINOR}.$((CUR_PATCH + 1))"
-              ;;
-            *)
-              echo "❌ Error: Invalid bump_type '$BUMP_TYPE'. Must be major, minor, or patch."
+            # Scheduled run or manual run without version - read from version.txt
+            if [ ! -f version.txt ] || [ -z "$(cat version.txt | tr -d '[:space:]')" ]; then
+              echo "❌ Error: version.txt not found or empty"
               exit 1
-              ;;
-          esac
-
-          echo "✅ Bumping $CURRENT_VERSION → $VERSION (bump: $BUMP_TYPE, Prerelease: $PRERELEASE, Perf Test: $RUN_PERF_TEST)"
+            fi
+            VERSION=$(tr -d '[:space:]' < version.txt)
+            PRERELEASE="true"
+            RUN_PERF_TEST="true"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
           echo "run_performance_test=$RUN_PERF_TEST" >> $GITHUB_OUTPUT
+          echo "✅ Using version: $VERSION (Prerelease: $PRERELEASE, Perf Test: $RUN_PERF_TEST)"
 
       - name: ✅ Validate Release Version
         run: |
@@ -139,37 +130,7 @@ jobs:
       - name: 🏷️ Update Product Version
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
-          echo "$VERSION" > version.txt
-          echo "✅ Updated version.txt to $VERSION"
-
-      - name: 📝 Update README Version References
-        run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
-
-          echo "📝 Updating README.md docker-compose curl URL to $VERSION"
-
-          # Update the docker-compose.yml curl URL in README.md
-          sed -i -E "s|(https://raw\.githubusercontent\.com/asgardeo/thunder/)v[0-9]+\.[0-9]+\.[0-9]+(/.+docker-compose\.yml)|\1${VERSION}\2|g" README.md
-
-          echo "✅ Updated README.md curl URL to $VERSION"
-          grep 'docker-compose.yml' README.md
-
-      - name: 📤 Commit and Push Version Bump
-        run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
-
-          git config --local user.name "thunder-automation-bot"
-          git config --local user.email "thunder-bot@wso2.com"
-
-          git add version.txt README.md
-
-          if git diff --cached --quiet; then
-            echo "✅ No changes to commit (files already at $VERSION)"
-          else
-            git commit -m "[Release] Bump version to ${VERSION}"
-            git push origin HEAD:main
-            echo "✅ Pushed version bump commit to main"
-          fi
+          echo "$VERSION" > version.txt  
 
       - name: ⚙️ Set up Go Environment  
         uses: ./.github/actions/setup-go  
@@ -483,12 +444,10 @@ jobs:
           # Parse version components (handle both X.Y and X.Y.Z formats)
           if [[ $RELEASE_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             # X.Y.Z format
-            MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="${BASH_REMATCH[3]}"
           elif [[ $RELEASE_VERSION =~ ^([0-9]+)\.([0-9]+) ]]; then
             # X.Y format
-            MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="0"
           else
@@ -496,7 +455,10 @@ jobs:
             exit 1
           fi
           
-          # Bump minor version for next development cycle
+          # Use fixed major version
+          MAJOR="${{ env.RELEASE_MAJOR_VERSION }}"
+          
+          # Bump minor version
           NEXT_MINOR=$((MINOR + 1))
           NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.0"
           
@@ -549,6 +511,23 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           echo "✅ Updated sample apps version to $NEXT_VERSION"
 
+      # - name: 📈 Commit and Push Version Update
+      #   run: |
+      #     git config --local user.email "action@github.com"
+      #     git config --local user.name "GitHub Action"
+          
+      #     NEXT_VERSION="${{ steps.next_version.outputs.next_version }}"
+          
+      #     # Add and commit the version changes
+      #     git add version.txt samples/apps/react-vanilla-sample/package.json samples/apps/react-vanilla-sample/server/package.json
+
+      #     if ! git diff --cached --quiet; then
+      #         git commit -m "[Release] Update version to ${NEXT_VERSION} for the next development iteration"
+      #         git push origin HEAD:main
+      #         echo "✅ Pushed version update to main branch"
+      #     else
+      #       echo "✅ No changes to commit"
+      #     fi
 
   package-samples-linux:
     name: 📦 Package Linux & Windows Samples


### PR DESCRIPTION
Reverts asgardeo/thunder#2143

As the release builder is failed due to the following error

```
remote: Permission to asgardeo/thunder.git denied to thunder-automation-bot.
fatal: unable to access 'https://github.com/asgardeo/thunder/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

https://github.com/asgardeo/thunder/actions/runs/23950306424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to accept specific version strings (e.g., `1.0.0`, `2.1`) instead of bump type selections for manual releases.
  * Modified release automation to streamline version management and adjust release workflow control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->