### PR TITLE
Remove dependency guard from the release builder

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -41,16 +41,8 @@ env:
   GOFLAGS: "-mod=readonly"
 
 jobs:
-  dependency-guard:
-    name: 🛡️ Dependency Guard
-    uses: ./.github/workflows/dependency-guard.yml
-    with:
-      detection-mode: commit
-
   build-thunder:
     name: ⚡ Build Thunder
-    needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
### Purpose
Remove dependency guard from the release builder

### Approach
This pull request simplifies the workflow configuration in `.github/workflows/release-builder.yml` by removing the `dependency-guard` job and related dependencies.

Workflow simplification:

* Removed the `dependency-guard` job, which previously checked dependencies before building. (`.github/workflows/release-builder.yml`)
* Updated the `build-thunder` job to no longer depend on the `dependency-guard` job, removing conditional logic and simplifying the workflow. (`.github/workflows/release-builder.yml`)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Optimized build workflow for improved efficiency.

---

**Note:** This release contains internal process improvements with no user-facing feature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->