### PR TITLE
Update default issuer helm value

### DIFF
--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -268,6 +268,7 @@ configuration:
 
   # Token Configuration
   jwt:
+    issuer: ""  # Optional. Derived from server's URL if not set.
     validityPeriod: 3600
     audience: "application"
     # This must match the key ID defined in the crypto.keys section


### PR DESCRIPTION
This pull request introduces a configuration option for the JWT issuer in the Helm chart values file. This allows users to optionally specify a custom issuer for JWT tokens, otherwise it will be derived from the server's URL.

Configuration improvements:

* Added an optional `issuer` field under the `jwt` section in `install/helm/values.yaml` to allow explicit configuration of the JWT issuer. If not set, it defaults to being derived from the server's URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional JWT issuer configuration setting during deployment. Users can now specify a custom JWT issuer value, which defaults to empty when unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->