### PR TITLE
ACR values support

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -158,6 +158,7 @@ paths:
                     scopeClaims:
                       profile: ["name", "family_name", "given_name", "picture"]
                       employee: ["emp_id", "department"]
+                    acrValues: ["urn:thunder:silver", "urn:thunder:gold"]
       responses:
         "201":
           description: Application created
@@ -227,6 +228,7 @@ paths:
                       scopeClaims:
                         profile: ["name", "family_name", "given_name", "picture"]
                         employee: ["emp_id", "department"]
+                      acrValues: ["urn:thunder:silver", "urn:thunder:gold"]
         "400":
           description: Bad request
           content:
@@ -362,6 +364,7 @@ paths:
                       scopeClaims:
                         profile: ["name", "family_name", "given_name", "picture"]
                         employee: ["emp_id", "department"]
+                      acrValues: ["urn:thunder:silver", "urn:thunder:gold"]
         "400":
           description: Bad request
           content:
@@ -485,6 +488,7 @@ paths:
                     scopeClaims:
                       profile: ["name", "family_name", "given_name", "picture"]
                       employee: ["emp_id", "department"]
+                    acrValues: ["urn:thunder:silver", "urn:thunder:gold"]
       responses:
         "200":
           description: Application updated
@@ -556,6 +560,7 @@ paths:
                       scopeClaims:
                         profile: ["name", "family_name", "given_name", "picture"]
                         employee: ["emp_id", "department"]
+                      acrValues: ["urn:thunder:silver", "urn:thunder:gold"]
         "400":
           description: Bad request
           content:
@@ -1278,6 +1283,18 @@ components:
           example:
             profile: ["name", "family_name", "given_name", "picture"]
             employee: ["emp_id", "department"]
+        acrValues:
+          type: array
+          items:
+            type: string
+          description: |
+            ACR (Authentication Context Class Reference) values for the application.
+            Defines the allowed set of ACR values for authorization requests. When acr_values is
+            provided in an authorization request, only values present in this list are accepted;
+            unrecognised values are silently ignored. If filtering removes all requested ACRs,
+            the full list is used as a fallback. When acr_values is omitted from the request,
+            this configured list is used as the effective ACR set.
+          example: ["urn:thunder:silver", "urn:thunder:gold"]
 
     OAuthAppConfigComplete:
       type: object
@@ -1356,6 +1373,18 @@ components:
           example:
             profile: ["name", "family_name", "given_name", "picture"]
             employee: ["emp_id", "department"]
+        acrValues:
+          type: array
+          items:
+            type: string
+          description: |
+            ACR (Authentication Context Class Reference) values for the application.
+            Defines the allowed set of ACR values for authorization requests. When acr_values is
+            provided in an authorization request, only values present in this list are accepted;
+            unrecognised values are silently ignored. If filtering removes all requested ACRs,
+            the full list is used as a fallback. When acr_values is omitted from the request,
+            this configured list is used as the effective ACR set.
+          example: ["urn:thunder:silver", "urn:thunder:gold"]
 
     Error:
       type: object

--- a/backend/internal/application/error_constants.go
+++ b/backend/internal/application/error_constants.go
@@ -448,4 +448,17 @@ var (
 			DefaultValue: "Cannot enable consent for the application as the consent service is not enabled",
 		},
 	}
+	// ErrorInvalidAcrValues is the error returned when an unrecognized ACR value is provided in acrValues.
+	ErrorInvalidAcrValues = serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "APP-1033",
+		Error: core.I18nMessage{
+			Key:          "error.applicationservice.invalid_acr_values",
+			DefaultValue: "Invalid ACR value",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "error.applicationservice.invalid_acr_values_description",
+			DefaultValue: "One or more ACR values in acr_values are not recognized by the system",
+		},
+	}
 )

--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -241,6 +241,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 				UserInfo:                           config.OAuthAppConfig.UserInfo,
 				ScopeClaims:                        config.OAuthAppConfig.ScopeClaims,
 				Certificate:                        config.OAuthAppConfig.Certificate,
+				AcrValues:                          config.OAuthAppConfig.AcrValues,
 			}
 			returnInboundAuthConfigs = append(returnInboundAuthConfigs, model.InboundAuthConfig{
 				Type:           config.Type,
@@ -423,6 +424,7 @@ func (ah *applicationHandler) processInboundAuthConfig(logger *log.Logger, appDT
 				UserInfo:                           config.OAuthAppConfig.UserInfo,
 				ScopeClaims:                        config.OAuthAppConfig.ScopeClaims,
 				Certificate:                        config.OAuthAppConfig.Certificate,
+				AcrValues:                          config.OAuthAppConfig.AcrValues,
 			}
 			returnInboundAuthConfigs = append(returnInboundAuthConfigs, model.InboundAuthConfigComplete{
 				Type:           config.Type,
@@ -498,6 +500,7 @@ func (ah *applicationHandler) processInboundAuthConfigFromRequest(
 				UserInfo:                           config.OAuthAppConfig.UserInfo,
 				ScopeClaims:                        config.OAuthAppConfig.ScopeClaims,
 				Certificate:                        config.OAuthAppConfig.Certificate,
+				AcrValues:                          config.OAuthAppConfig.AcrValues,
 			},
 		}
 		inboundAuthConfigDTOs = append(inboundAuthConfigDTOs, inboundAuthConfigDTO)

--- a/backend/internal/application/model/oauth_app.go
+++ b/backend/internal/application/model/oauth_app.go
@@ -41,6 +41,7 @@ type OAuthAppConfig struct {
 	UserInfo                           *inboundmodel.UserInfoConfig        `json:"userInfo,omitempty"`
 	ScopeClaims                        map[string][]string                 `json:"scopeClaims,omitempty"`
 	Certificate                        *inboundmodel.Certificate           `json:"certificate,omitempty"`
+	AcrValues                          []string                            `json:"acrValues,omitempty"`
 }
 
 // OAuthAppConfigComplete represents the complete structure for OAuth application configuration.
@@ -59,6 +60,7 @@ type OAuthAppConfigComplete struct {
 	UserInfo                           *inboundmodel.UserInfoConfig        `json:"userInfo,omitempty" yaml:"user_info,omitempty"`
 	ScopeClaims                        map[string][]string                 `json:"scopeClaims,omitempty" yaml:"scope_claims,omitempty"`
 	Certificate                        *inboundmodel.Certificate           `json:"certificate,omitempty" jsonschema:"Application certificate. Optional. For certificate-based authentication or JWT validation."`
+	AcrValues                          []string                            `json:"acrValues,omitempty" yaml:"acr_values,omitempty"`
 }
 
 // OAuthAppConfigDTO represents the data transfer object for OAuth application configuration.
@@ -78,6 +80,7 @@ type OAuthAppConfigDTO struct {
 	UserInfo                           *inboundmodel.UserInfoConfig        `json:"userInfo,omitempty" jsonschema:"UserInfo endpoint configuration. Configure user attributes returned from the OIDC userinfo endpoint."`
 	ScopeClaims                        map[string][]string                 `json:"scopeClaims,omitempty" jsonschema:"Scope-to-claims mapping. Maps OAuth scopes to user claims for both ID token and userinfo."`
 	Certificate                        *inboundmodel.Certificate           `json:"certificate,omitempty" jsonschema:"Application certificate. Optional. For certificate-based authentication or JWT validation."`
+	AcrValues                          []string                            `json:"acrValues,omitempty" jsonschema:"ACR values. Optional. Defines the allowed set of ACR values for authorization requests. Requested ACRs not in this list are silently ignored; if none match or acr_values is omitted, all configured ACR values are used."`
 }
 
 // IsAllowedGrantType reports whether the input DTO allows the given grant type.

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -34,6 +34,7 @@ import (
 	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	oauthutils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
 	oupkg "github.com/asgardeo/thunder/internal/ou"
+	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
 	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
@@ -709,6 +710,7 @@ func buildOAuthConfigData(inboundAuth model.InboundAuthConfigProcessedDTO) *inbo
 		Token:                              oa.Token,
 		UserInfo:                           oa.UserInfo,
 		Certificate:                        oa.Certificate,
+		AcrValues:                          oa.AcrValues,
 	}
 }
 
@@ -899,7 +901,31 @@ func validateOAuthParamsForCreateAndUpdate(app *model.ApplicationDTO) (*model.In
 		oauthAppConfig.TokenEndpointAuthMethod = oauth2const.TokenEndpointAuthMethodClientSecretBasic
 	}
 
+	if err := validateAcrValues(oauthAppConfig.AcrValues); err != nil {
+		return nil, err
+	}
+
 	return inboundAuthConfig, nil
+}
+
+// isValidACR reports whether acr is present in the deployment config ACR-AMR mapping.
+func isValidACR(acr string) bool {
+	mapping := config.GetServerRuntime().Config.OAuth.AuthClass
+	_, ok := mapping.AcrAMR[acr]
+	return ok
+}
+
+// validateAcrValues rejects acr values not registered in the ACR-AMR mapping.
+func validateAcrValues(acrValues []string) *serviceerror.ServiceError {
+	for _, acr := range acrValues {
+		if !isValidACR(acr) {
+			return serviceerror.CustomServiceError(ErrorInvalidAcrValues, core.I18nMessage{
+				Key:          "error.applicationservice.invalid_acr_values_unrecognized",
+				DefaultValue: fmt.Sprintf("ACR value %q is not recognized by the system", acr),
+			})
+		}
+	}
+	return nil
 }
 
 func translateOAuthValidationError(err error) *serviceerror.ServiceError {
@@ -1340,6 +1366,7 @@ func buildApplicationResponse(dto *model.ApplicationProcessedDTO) *model.Applica
 					Scopes:                             oauthAppConfig.Scopes,
 					UserInfo:                           oauthAppConfig.UserInfo,
 					ScopeClaims:                        oauthAppConfig.ScopeClaims,
+					AcrValues:                          oauthAppConfig.AcrValues,
 				},
 			})
 		}
@@ -1457,6 +1484,7 @@ func buildOAuthInboundAuthConfigProcessedDTO(
 			UserInfo:                           userInfo,
 			ScopeClaims:                        scopeClaims,
 			Certificate:                        certificate,
+			AcrValues:                          inboundAuthConfig.OAuthAppConfig.AcrValues,
 		},
 	}
 }
@@ -1512,6 +1540,7 @@ func buildReturnApplicationDTO(
 				UserInfo:                           userInfo,
 				ScopeClaims:                        scopeClaims,
 				Certificate:                        oauthCert,
+				AcrValues:                          inboundAuthConfig.OAuthAppConfig.AcrValues,
 			},
 		}
 		returnApp.InboundAuthConfig = []model.InboundAuthConfigDTO{returnInboundAuthConfig}

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -2647,5 +2647,114 @@ func (suite *ServiceTestSuite) TestValidateApplication_ErrorFromProcessInboundAu
 	assert.Equal(suite.T(), &ErrorInvalidInboundAuthConfig, svcErr)
 }
 
-// TestValidateApplication_ErrorFromValidateAuthFlowID tests error from validateAuthFlowID
-// when an invalid auth flow ID is provided.
+var validAcrMapping = config.AuthClassConfig{
+	Amrs: []string{"PWD", "OTP"},
+	AcrAMR: map[string][]string{
+		"urn:thunder:acr:password":       {"PWD"},
+		"urn:thunder:acr:generated-code": {"OTP"},
+	},
+}
+
+type AcrValidationTestSuite struct {
+	suite.Suite
+}
+
+func TestAcrValidationTestSuite(t *testing.T) {
+	suite.Run(t, new(AcrValidationTestSuite))
+}
+
+func (s *AcrValidationTestSuite) initRegistry(mapping config.AuthClassConfig) {
+	config.ResetServerRuntime()
+	s.Require().NoError(config.InitializeServerRuntime("", &config.Config{
+		OAuth: config.OAuthConfig{
+			AuthClass: mapping,
+		},
+	}))
+	s.T().Cleanup(config.ResetServerRuntime)
+}
+
+func (s *AcrValidationTestSuite) TestValidateAcrValues_EmptyList() {
+	err := validateAcrValues(nil)
+	s.Nil(err)
+
+	err = validateAcrValues([]string{})
+	s.Nil(err)
+}
+
+func (s *AcrValidationTestSuite) TestValidateAcrValues_AllValid() {
+	s.initRegistry(validAcrMapping)
+
+	err := validateAcrValues([]string{
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:generated-code",
+	})
+
+	s.Nil(err)
+}
+
+func (s *AcrValidationTestSuite) TestValidateAcrValues_SingleValid() {
+	s.initRegistry(validAcrMapping)
+
+	err := validateAcrValues([]string{"urn:thunder:acr:password"})
+
+	s.Nil(err)
+}
+
+func (s *AcrValidationTestSuite) TestValidateAcrValues_UnknownACR() {
+	s.initRegistry(validAcrMapping)
+
+	svcErr := validateAcrValues([]string{
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:unknown-method",
+	})
+
+	s.NotNil(svcErr)
+	s.Equal("APP-1033", svcErr.Code)
+	s.Contains(svcErr.ErrorDescription.DefaultValue, "urn:thunder:acr:unknown-method")
+}
+
+func (s *AcrValidationTestSuite) TestValidateAcrValues_FirstEntryInvalid() {
+	s.initRegistry(validAcrMapping)
+
+	svcErr := validateAcrValues([]string{"totally-invalid-acr"})
+
+	s.NotNil(svcErr)
+	s.Equal("APP-1033", svcErr.Code)
+	s.Contains(svcErr.ErrorDescription.DefaultValue, "totally-invalid-acr")
+}
+
+func (s *AcrValidationTestSuite) TestIsValidACR_KnownACR() {
+	s.initRegistry(validAcrMapping)
+
+	s.True(isValidACR("urn:thunder:acr:password"))
+}
+
+func (s *AcrValidationTestSuite) TestIsValidACR_UnknownACR() {
+	s.initRegistry(validAcrMapping)
+
+	s.False(isValidACR("urn:thunder:acr:unknown"))
+}
+
+func (s *AcrValidationTestSuite) TestIsValidACR_EmptyString() {
+	s.initRegistry(validAcrMapping)
+
+	s.False(isValidACR(""))
+}
+
+func (s *AcrValidationTestSuite) TestIsValidACR_AllMappedACRs() {
+	s.initRegistry(validAcrMapping)
+
+	knownACRs := []string{
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:generated-code",
+	}
+	for _, acr := range knownACRs {
+		s.True(isValidACR(acr), "expected ACR %q to be valid", acr)
+	}
+}
+
+func (s *AcrValidationTestSuite) TestIsValidACR_EmptyMapping() {
+	s.initRegistry(config.AuthClassConfig{})
+
+	s.False(isValidACR("urn:thunder:acr:password"))
+}

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -146,6 +146,14 @@ const (
 // DefaultHTTPTimeout defines the default timeout duration for HTTP requests.
 const DefaultHTTPTimeout = 5 * time.Second
 
+// NodeVariant identifies a PROMPT node sub-type that activates a variant-specific code path.
+type NodeVariant string
+
+const (
+	// NodeVariantLoginOptions identifies a PROMPT node that presents login method choices to the user.
+	NodeVariantLoginOptions NodeVariant = "LOGIN_OPTIONS"
+)
+
 const (
 	// NodePropertyAllowAuthenticationWithoutLocalUser indicates whether authentication is allowed without a local user
 	NodePropertyAllowAuthenticationWithoutLocalUser = "allowAuthenticationWithoutLocalUser"
@@ -160,6 +168,8 @@ const (
 	NodePropertyOUResolveFrom = "resolveFrom"
 	// NodePropertyRecipientAttribute specifies the destination parameter to use for verification (e.g., email, phone).
 	NodePropertyRecipientAttribute = "destinationAttribute"
+	// NodePropertyAuthMethodMapping maps authentication classes to action refs on login_options PROMPT nodes.
+	NodePropertyAuthMethodMapping = "authMethodMapping"
 )
 
 const (
@@ -223,6 +233,12 @@ const (
 	InvalidMagicLinkToken = "Invalid magic link token"
 	// RuntimeKeyOAuthState holds the generated OAuth state parameter for CSRF validation.
 	RuntimeKeyOAuthState = "oauthState"
+	// RuntimeKeyRequestedAuthClasses holds the space-separated ACR values from acr_values.
+	RuntimeKeyRequestedAuthClasses = "requested_auth_classes"
+	// RuntimeKeySelectedAuthClass holds the ACR value of the chosen authentication method.
+	RuntimeKeySelectedAuthClass = "selected_auth_class"
+	// RuntimeKeyAllowedLoginOptions holds the space-separated action refs allowed on a LOGIN_OPTIONS node.
+	RuntimeKeyAllowedLoginOptions = "allowed_login_options"
 )
 
 // TODO: Define a go type for InputType when formalizing input types

--- a/backend/internal/flow/core/PromptNodeInterface_mock_test.go
+++ b/backend/internal/flow/core/PromptNodeInterface_mock_test.go
@@ -679,6 +679,50 @@ func (_c *PromptNodeInterfaceMock_GetType_Call) RunAndReturn(run func() common.N
 	return _c
 }
 
+// GetVariant provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) GetVariant() common.NodeVariant {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetVariant")
+	}
+
+	var r0 common.NodeVariant
+	if returnFunc, ok := ret.Get(0).(func() common.NodeVariant); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(common.NodeVariant)
+	}
+	return r0
+}
+
+// PromptNodeInterfaceMock_GetVariant_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVariant'
+type PromptNodeInterfaceMock_GetVariant_Call struct {
+	*mock.Call
+}
+
+// GetVariant is a helper method to define mock.On call
+func (_e *PromptNodeInterfaceMock_Expecter) GetVariant() *PromptNodeInterfaceMock_GetVariant_Call {
+	return &PromptNodeInterfaceMock_GetVariant_Call{Call: _e.mock.On("GetVariant")}
+}
+
+func (_c *PromptNodeInterfaceMock_GetVariant_Call) Run(run func()) *PromptNodeInterfaceMock_GetVariant_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetVariant_Call) Return(nodeVariant common.NodeVariant) *PromptNodeInterfaceMock_GetVariant_Call {
+	_c.Call.Return(nodeVariant)
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetVariant_Call) RunAndReturn(run func() common.NodeVariant) *PromptNodeInterfaceMock_GetVariant_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsDisplayOnly provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) IsDisplayOnly() bool {
 	ret := _mock.Called()
@@ -1233,6 +1277,46 @@ func (_c *PromptNodeInterfaceMock_SetPrompts_Call) Return() *PromptNodeInterface
 }
 
 func (_c *PromptNodeInterfaceMock_SetPrompts_Call) RunAndReturn(run func(prompts []common.Prompt)) *PromptNodeInterfaceMock_SetPrompts_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetVariant provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) SetVariant(variant common.NodeVariant) {
+	_mock.Called(variant)
+	return
+}
+
+// PromptNodeInterfaceMock_SetVariant_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetVariant'
+type PromptNodeInterfaceMock_SetVariant_Call struct {
+	*mock.Call
+}
+
+// SetVariant is a helper method to define mock.On call
+//   - variant common.NodeVariant
+func (_e *PromptNodeInterfaceMock_Expecter) SetVariant(variant interface{}) *PromptNodeInterfaceMock_SetVariant_Call {
+	return &PromptNodeInterfaceMock_SetVariant_Call{Call: _e.mock.On("SetVariant", variant)}
+}
+
+func (_c *PromptNodeInterfaceMock_SetVariant_Call) Run(run func(variant common.NodeVariant)) *PromptNodeInterfaceMock_SetVariant_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 common.NodeVariant
+		if args[0] != nil {
+			arg0 = args[0].(common.NodeVariant)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetVariant_Call) Return() *PromptNodeInterfaceMock_SetVariant_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetVariant_Call) RunAndReturn(run func(variant common.NodeVariant)) *PromptNodeInterfaceMock_SetVariant_Call {
 	_c.Run(run)
 	return _c
 }

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -19,10 +19,15 @@
 package core
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
+
+const failureReasonInvalidAction = "Invalid action selected"
 
 // PromptNodeInterface extends NodeInterface for nodes that require user interaction.
 type PromptNodeInterface interface {
@@ -36,6 +41,8 @@ type PromptNodeInterface interface {
 	GetMessage() string
 	SetMessage(message string)
 	IsDisplayOnly() bool
+	GetVariant() common.NodeVariant
+	SetVariant(variant common.NodeVariant)
 }
 
 // promptNode represents a node that prompts for user input/ action in the flow execution.
@@ -45,6 +52,7 @@ type promptNode struct {
 	meta     interface{}
 	nextNode string
 	message  string
+	variant  common.NodeVariant
 	logger   *log.Logger
 }
 
@@ -113,16 +121,20 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 		return nodeResp, nil
 	}
 
+	if n.variant == common.NodeVariantLoginOptions {
+		return n.executeLoginOptions(ctx, nodeResp)
+	}
+
 	if n.resolvePromptInputs(ctx, nodeResp) {
 		logger.Debug("All required inputs and action are available, returning complete status")
 
 		if ctx.CurrentAction != "" {
-			if nextNode := n.getNextNodeForActionRef(ctx.CurrentAction, logger); nextNode != "" {
+			if nextNode := n.getNextNodeForActionRef(ctx.CurrentAction); nextNode != "" {
 				nodeResp.NextNodeID = nextNode
 			} else {
-				logger.Debug("Invalid action selected", log.String("actionRef", ctx.CurrentAction))
+				logger.Debug(failureReasonInvalidAction, log.String("actionRef", ctx.CurrentAction))
 				nodeResp.Status = common.NodeStatusFailure
-				nodeResp.FailureReason = "Invalid action selected"
+				nodeResp.FailureReason = failureReasonInvalidAction
 				return nodeResp, nil
 			}
 		}
@@ -146,13 +158,113 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 
 	// Include meta in the response if verbose mode is enabled
 	if ctx.Verbose && n.GetMeta() != nil {
-		trimmed := n.trimMetaToRequestedInputs(nodeResp.Inputs, nodeResp.Actions)
+		trimmed := n.trimMetaToRequestedInputs(n.meta, nodeResp.Inputs, nodeResp.Actions)
 		nodeResp.Meta = n.appendSyntheticMetaComponents(trimmed, nodeResp.Inputs)
 	}
 
 	nodeResp.Status = common.NodeStatusIncomplete
 	nodeResp.Type = common.NodeResponseTypeView
 	return nodeResp, nil
+}
+
+// executeLoginOptions handles the LOGIN_OPTIONS variant.
+func (n *promptNode) executeLoginOptions(ctx *NodeContext,
+	nodeResp *common.NodeResponse) (*common.NodeResponse, *serviceerror.ServiceError) {
+	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+	authClassToAction := n.authClassToActionMapping()
+
+	if ctx.CurrentAction != "" {
+		if allowedRaw := ctx.RuntimeData[common.RuntimeKeyAllowedLoginOptions]; allowedRaw != "" {
+			if !slices.Contains(strings.Fields(allowedRaw), ctx.CurrentAction) {
+				logger.Debug("Selected action is not in allowed login options",
+					log.String("actionRef", ctx.CurrentAction))
+				nodeResp.Status = common.NodeStatusFailure
+				nodeResp.FailureReason = failureReasonInvalidAction
+				return nodeResp, nil
+			}
+		}
+		if n.resolvePromptInputs(ctx, nodeResp) {
+			return n.finalizeLoginOptionsAction(ctx, nodeResp, authClassToAction)
+		}
+		n.applyMetaForLoginOptions(ctx, nodeResp, nil)
+		nodeResp.Status = common.NodeStatusIncomplete
+		nodeResp.Type = common.NodeResponseTypeView
+		return nodeResp, nil
+	}
+
+	requestedAuthClasses := parseAuthClasses(ctx.RuntimeData[common.RuntimeKeyRequestedAuthClasses])
+	effectivePrompts := n.filterAndOrderPrompts(requestedAuthClasses, authClassToAction)
+	actions := make([]common.Action, 0)
+	for _, p := range effectivePrompts {
+		if p.Action != nil {
+			actions = append(actions, *p.Action)
+		}
+	}
+
+	// Auto-select the sole remaining option so the user skips a single-choice chooser.
+	if len(actions) == 1 && len(requestedAuthClasses) > 0 {
+		ctx.CurrentAction = actions[0].Ref
+		logger.Debug("Auto-selected single login option", log.String("actionRef", ctx.CurrentAction))
+		if n.resolvePromptInputs(ctx, nodeResp) {
+			return n.finalizeLoginOptionsAction(ctx, nodeResp, authClassToAction)
+		}
+		nodeResp.RuntimeData[common.RuntimeKeyAllowedLoginOptions] = ctx.CurrentAction
+		n.applyMetaForLoginOptions(ctx, nodeResp, nil)
+		nodeResp.Status = common.NodeStatusIncomplete
+		nodeResp.Type = common.NodeResponseTypeView
+		return nodeResp, nil
+	}
+
+	nodeResp.Actions = append(nodeResp.Actions, actions...)
+	nodeResp.RuntimeData[common.RuntimeKeyAllowedLoginOptions] = joinActionRefs(effectivePrompts)
+	n.applyMetaForLoginOptions(ctx, nodeResp, effectivePrompts)
+	nodeResp.Status = common.NodeStatusIncomplete
+	nodeResp.Type = common.NodeResponseTypeView
+	return nodeResp, nil
+}
+
+// finalizeLoginOptionsAction completes the chooser once an action is selected and inputs are satisfied.
+func (n *promptNode) finalizeLoginOptionsAction(ctx *NodeContext, nodeResp *common.NodeResponse,
+	authClassToAction map[string]string) (*common.NodeResponse, *serviceerror.ServiceError) {
+	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+	nextNode := n.getNextNodeForActionRef(ctx.CurrentAction)
+	if nextNode == "" {
+		logger.Debug(failureReasonInvalidAction, log.String("actionRef", ctx.CurrentAction))
+		nodeResp.Status = common.NodeStatusFailure
+		nodeResp.FailureReason = failureReasonInvalidAction
+		return nodeResp, nil
+	}
+	nodeResp.NextNodeID = nextNode
+	for authClass, ref := range authClassToAction {
+		if ref == ctx.CurrentAction {
+			nodeResp.RuntimeData[common.RuntimeKeySelectedAuthClass] = authClass
+			break
+		}
+	}
+	if actionType := n.getActionTypeForRef(ctx.CurrentAction); actionType != "" {
+		if nodeResp.ForwardedData == nil {
+			nodeResp.ForwardedData = make(map[string]interface{})
+		}
+		nodeResp.ForwardedData[common.ForwardedDataKeyActionType] = actionType
+	}
+	nodeResp.Status = common.NodeStatusComplete
+	nodeResp.Type = ""
+	return nodeResp, nil
+}
+
+// applyMetaForLoginOptions sets verbose-mode meta on the response, reordering it to match
+// effectivePrompts when provided.
+func (n *promptNode) applyMetaForLoginOptions(ctx *NodeContext, nodeResp *common.NodeResponse,
+	effectivePrompts []common.Prompt) {
+	if !ctx.Verbose || n.GetMeta() == nil {
+		return
+	}
+	meta := n.meta
+	if effectivePrompts != nil {
+		meta = n.filteredMeta(effectivePrompts)
+	}
+	trimmed := n.trimMetaToRequestedInputs(meta, nodeResp.Inputs, nodeResp.Actions)
+	nodeResp.Meta = n.appendSyntheticMetaComponents(trimmed, nodeResp.Inputs)
 }
 
 // GetPrompts returns the prompts for the prompt node
@@ -199,6 +311,16 @@ func (n *promptNode) SetMessage(message string) {
 // A prompt node is considered display-only if it has a next node, but no prompts (inputs or actions).
 func (n *promptNode) IsDisplayOnly() bool {
 	return n.nextNode != "" && len(n.prompts) == 0
+}
+
+// GetVariant returns the variant of the prompt node
+func (n *promptNode) GetVariant() common.NodeVariant {
+	return n.variant
+}
+
+// SetVariant sets the variant of the prompt node
+func (n *promptNode) SetVariant(variant common.NodeVariant) {
+	n.variant = variant
 }
 
 // resolvePromptInputs resolves the inputs and actions for the prompt node.
@@ -425,11 +547,11 @@ func (n *promptNode) getAllActions() []common.Action {
 }
 
 // getNextNodeForActionRef finds the next node for the given action reference.
-func (n *promptNode) getNextNodeForActionRef(actionRef string, logger *log.Logger) string {
+func (n *promptNode) getNextNodeForActionRef(actionRef string) string {
 	actions := n.getAllActions()
 	for i := range actions {
 		if actions[i].Ref == actionRef {
-			logger.Debug("Action selected successfully", log.String("actionRef", actions[i].Ref),
+			n.logger.Debug("Action selected successfully", log.String("actionRef", actions[i].Ref),
 				log.String("nextNode", actions[i].NextNode))
 			return actions[i].NextNode
 		}
@@ -447,13 +569,14 @@ func (n *promptNode) getActionTypeForRef(actionRef string) string {
 	return ""
 }
 
-// trimMetaToRequestedInputs returns a copy of n.meta with the "components" list trimmed to only
+// trimMetaToRequestedInputs returns a copy of meta with the "components" list trimmed to only
 // include components matching the given inputs and actions (plus structural components like TEXT
 // and BLOCK containers that are not themselves inputs or actions).
-func (n *promptNode) trimMetaToRequestedInputs(inputs []common.Input, actions []common.Action) interface{} {
-	metaMap, ok := n.meta.(map[string]interface{})
+func (n *promptNode) trimMetaToRequestedInputs(meta interface{}, inputs []common.Input,
+	actions []common.Action) interface{} {
+	metaMap, ok := meta.(map[string]interface{})
 	if !ok {
-		return n.meta
+		return meta
 	}
 
 	allowedRefs := make(map[string]struct{})
@@ -705,4 +828,148 @@ func collectMetaComponentMap(comps interface{}, compMap map[string]map[string]in
 		}
 		collectMetaComponentMap(cm["components"], compMap)
 	}
+}
+
+// filterAndOrderPrompts returns prompts whose action matches a requested auth class (in
+// preference order), followed by non-gated prompts. Falls back to all prompts if nothing matches.
+func (n *promptNode) filterAndOrderPrompts(requestedAuthClasses []string,
+	authClassToAction map[string]string) []common.Prompt {
+	if len(requestedAuthClasses) == 0 {
+		return n.prompts
+	}
+
+	actionToPrompt := make(map[string]common.Prompt)
+	gatedActions := make(map[string]struct{})
+	for _, p := range n.prompts {
+		if p.Action != nil && p.Action.Ref != "" {
+			actionToPrompt[p.Action.Ref] = p
+		}
+	}
+	for _, ref := range authClassToAction {
+		gatedActions[ref] = struct{}{}
+	}
+
+	result := make([]common.Prompt, 0)
+	for _, authClass := range requestedAuthClasses {
+		ref, ok := authClassToAction[authClass]
+		if !ok {
+			continue
+		}
+		if p, ok := actionToPrompt[ref]; ok {
+			result = append(result, p)
+		}
+	}
+
+	for _, p := range n.prompts {
+		if p.Action == nil || p.Action.Ref == "" {
+			result = append(result, p)
+			continue
+		}
+		if _, gated := gatedActions[p.Action.Ref]; !gated {
+			result = append(result, p)
+		}
+	}
+
+	if len(result) == 0 {
+		return n.prompts
+	}
+	return result
+}
+
+// authClassToActionMapping returns the authMethodMapping property as an auth class → action ref map.
+func (n *promptNode) authClassToActionMapping() map[string]string {
+	result := make(map[string]string)
+	props := n.GetProperties()
+	if props == nil {
+		return result
+	}
+	raw, ok := props[common.NodePropertyAuthMethodMapping]
+	if !ok {
+		return result
+	}
+	mapping, ok := raw.(map[string]interface{})
+	if !ok {
+		return result
+	}
+	for authClass, refVal := range mapping {
+		if ref, ok := refVal.(string); ok {
+			result[authClass] = ref
+		}
+	}
+	return result
+}
+
+// joinActionRefs returns a space-separated list of action refs from the given prompts.
+func joinActionRefs(prompts []common.Prompt) string {
+	refs := make([]string, 0, len(prompts))
+	for _, p := range prompts {
+		if p.Action != nil && p.Action.Ref != "" {
+			refs = append(refs, p.Action.Ref)
+		}
+	}
+	return strings.Join(refs, " ")
+}
+
+// filteredMeta returns a copy of n.meta with ACTION components reordered to match prompts.
+// Non-ACTION components keep their original positions; filtered-out actions are dropped.
+func (n *promptNode) filteredMeta(prompts []common.Prompt) interface{} {
+	metaMap, ok := n.meta.(map[string]interface{})
+	if !ok {
+		return n.meta
+	}
+	components, ok := metaMap["components"].([]interface{})
+	if !ok {
+		return n.meta
+	}
+
+	actionCompMap := make(map[string]interface{}, len(prompts))
+	for _, comp := range components {
+		compMap, ok := comp.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if compMap["type"] == "ACTION" {
+			if id, ok := compMap["id"].(string); ok {
+				actionCompMap[id] = comp
+			}
+		}
+	}
+
+	orderedActions := make([]interface{}, 0, len(prompts))
+	for _, p := range prompts {
+		if p.Action != nil && p.Action.Ref != "" {
+			if comp, ok := actionCompMap[p.Action.Ref]; ok {
+				orderedActions = append(orderedActions, comp)
+			}
+		}
+	}
+
+	actionIdx := 0
+	result := make([]interface{}, 0, len(components))
+	for _, comp := range components {
+		compMap, ok := comp.(map[string]interface{})
+		if !ok || compMap["type"] != "ACTION" {
+			result = append(result, comp)
+			continue
+		}
+		if actionIdx < len(orderedActions) {
+			result = append(result, orderedActions[actionIdx])
+			actionIdx++
+		}
+	}
+
+	resultMap := make(map[string]interface{}, len(metaMap))
+	for k, v := range metaMap {
+		resultMap[k] = v
+	}
+	resultMap["components"] = result
+	return resultMap
+}
+
+// parseAuthClasses splits the space-separated auth class values string from RuntimeData into an ordered slice.
+func parseAuthClasses(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	return strings.Fields(raw)
 }

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -901,13 +901,13 @@ func (s *PromptOnlyNodeTestSuite) TestGetNextNodeForActionRef() {
 	})
 
 	// Test finding existing actions
-	nextNode := promptNode.getNextNodeForActionRef("login", promptNode.logger)
+	nextNode := promptNode.getNextNodeForActionRef("login")
 	s.Equal("auth_node", nextNode)
 
-	nextNode = promptNode.getNextNodeForActionRef("signup", promptNode.logger)
+	nextNode = promptNode.getNextNodeForActionRef("signup")
 	s.Equal("register_node", nextNode)
 
-	nextNode = promptNode.getNextNodeForActionRef("cancel", promptNode.logger)
+	nextNode = promptNode.getNextNodeForActionRef("cancel")
 	s.Equal("exit_node", nextNode)
 }
 
@@ -926,7 +926,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetNextNodeForActionRefNotFound() {
 	})
 
 	// Test finding non-existent action
-	nextNode := promptNode.getNextNodeForActionRef("nonexistent", promptNode.logger)
+	nextNode := promptNode.getNextNodeForActionRef("nonexistent")
 	s.Equal("", nextNode, "Should return empty string when action not found")
 }
 
@@ -942,7 +942,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetNextNodeForActionRefEmptyRef() {
 	})
 
 	// Test with empty action ref
-	nextNode := promptNode.getNextNodeForActionRef("", promptNode.logger)
+	nextNode := promptNode.getNextNodeForActionRef("")
 	s.Equal("", nextNode, "Should return empty string for empty action ref")
 }
 
@@ -2763,4 +2763,412 @@ func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_EmptyInputType_FallsBackToTe
 		}
 	}
 	s.Fail("synthetic component for schemaField not found in meta")
+}
+
+func loginOptionsProps() map[string]interface{} {
+	return map[string]interface{}{
+		common.NodePropertyAuthMethodMapping: map[string]interface{}{
+			"urn:thunder:acr:password":       "pwd",
+			"urn:thunder:acr:generated-code": "otp",
+			"urn:thunder:acr:linked-wallet":  "wallet",
+		},
+	}
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_GetSetVariant() {
+	node := newPromptNode("login-chooser", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+
+	s.Equal(common.NodeVariant(""), pn.GetVariant())
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	s.Equal(common.NodeVariantLoginOptions, pn.GetVariant())
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_NoACRFilter_AllActionsReturned() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+
+	// No requested_acr_values in RuntimeData → all actions returned
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Len(resp.Actions, 2)
+	refs := []string{resp.Actions[0].Ref, resp.Actions[1].Ref}
+	s.ElementsMatch([]string{"pwd", "otp"}, refs)
+	// On the prompt-out leg, allowed_login_options should record the action refs.
+	s.NotEmpty(resp.RuntimeData[common.RuntimeKeyAllowedLoginOptions],
+		"allowed_login_options must be set on the prompt-out leg")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_SingleACRFilter() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+		{Action: &common.Action{Ref: "wallet", NextNode: "wallet-node"}},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusComplete, resp.Status,
+		"login_options node must auto-select when only one ACR option remains after filtering")
+	s.Equal("otp-node", resp.NextNodeID, "must forward to the next node for the auto-selected action")
+	s.Empty(resp.Actions, "chooser actions must not be returned after auto-selection")
+	s.Equal("otp", ctx.CurrentAction, "context must have the auto-selected action")
+	s.Equal("urn:thunder:acr:generated-code", resp.RuntimeData[common.RuntimeKeySelectedAuthClass],
+		"selected_auth_class must be recorded for the auto-selected ACR")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_PreferenceOrder() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	// Graph order: password first, then OTP
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+
+	// Preference order: OTP first, then password
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code urn:thunder:acr:password",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Require().Len(resp.Actions, 2)
+	s.Equal("otp", resp.Actions[0].Ref, "OTP should be first per preference order")
+	s.Equal("pwd", resp.Actions[1].Ref, "password should be second per preference order")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_UntaggedPromptsAlwaysIncluded() {
+	// authMethodMapping covers only "pwd"; "other" is not gated by ACR and should always appear.
+	node := newPromptNode("login-chooser", map[string]interface{}{
+		common.NodePropertyAuthMethodMapping: map[string]interface{}{
+			"urn:thunder:acr:password": "pwd",
+		},
+	}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		// Action ref not in authMethodMapping — non-ACR-gated, should always be included
+		{Action: &common.Action{Ref: "other", NextNode: "other-node"}},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{
+			// Only password requested; non-gated prompt should still appear
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:password",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Require().Len(resp.Actions, 2)
+	refs := []string{resp.Actions[0].Ref, resp.Actions[1].Ref}
+	s.Contains(refs, "pwd")
+	s.Contains(refs, "other")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_GracefulFallback_NoMatchingACR() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+
+	// Requested ACR not present in any prompt → graceful fallback returns all
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:biometrics",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Require().Len(resp.Actions, 2, "all prompts should be returned as fallback")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_CompletedACRWritten() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		UserInputs:    map[string]string{},
+		CurrentAction: "pwd",
+		RuntimeData:   map[string]string{},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusComplete, resp.Status)
+	s.Equal("pwd-node", resp.NextNodeID)
+	s.Equal("urn:thunder:acr:password", resp.RuntimeData[common.RuntimeKeySelectedAuthClass])
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_CompletedACRWritten_WithACRFilter() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+
+	// Only OTP requested; user picks otp
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		UserInputs:    map[string]string{},
+		CurrentAction: "otp",
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code",
+			common.RuntimeKeyAllowedLoginOptions:  "otp",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusComplete, resp.Status)
+	s.Equal("otp-node", resp.NextNodeID)
+	s.Equal("urn:thunder:acr:generated-code", resp.RuntimeData[common.RuntimeKeySelectedAuthClass])
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_DisallowedActionRejected() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+
+	// Allowed list (from a prior prompt-out leg) restricts to "otp" only.
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		UserInputs:    map[string]string{},
+		CurrentAction: "pwd",
+		RuntimeData: map[string]string{
+			common.RuntimeKeyAllowedLoginOptions: "otp",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusFailure, resp.Status,
+		"selecting an action outside allowed_login_options must fail")
+	s.Equal("Invalid action selected", resp.FailureReason)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestLoginOptionsVariant_AllowedLoginOptionsCaptured() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+		{Action: &common.Action{Ref: "wallet", NextNode: "wallet-node"}},
+	})
+
+	// Two requested ACRs ⇒ two allowed options on the prompt-out leg.
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code urn:thunder:acr:password",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Equal("otp pwd", resp.RuntimeData[common.RuntimeKeyAllowedLoginOptions],
+		"allowed_login_options must list refs in ACR-preference order")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestNonLoginOptionsVariant_UnaffectedByACRValues() {
+	node := newPromptNode("standard-prompt", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	// No variant set
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	// Both actions must be returned — no filtering for non-login_options nodes
+	s.Nil(err)
+	s.Require().Len(resp.Actions, 2)
+	s.Empty(resp.RuntimeData[common.RuntimeKeyAllowedLoginOptions],
+		"allowed_login_options must not be set for non-login_options nodes")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestFilteredMeta_ActionComponentsReorderedByACR() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(*promptNode)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	// Graph order: password, otp, wallet
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+		{Action: &common.Action{Ref: "wallet", NextNode: "wallet-node"}},
+	})
+	pn.SetMeta(map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"type": "ACTION", "id": "pwd"},
+			map[string]interface{}{"type": "ACTION", "id": "otp"},
+			map[string]interface{}{"type": "ACTION", "id": "wallet"},
+		},
+	})
+
+	// ACR preference: otp first, then wallet, then password
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code " +
+				"urn:thunder:acr:linked-wallet " + "urn:thunder:acr:password",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Require().NotNil(resp.Meta)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	components, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+	s.Require().Len(components, 3)
+
+	ids := make([]string, 3)
+	for i, c := range components {
+		ids[i], _ = c.(map[string]interface{})["id"].(string)
+	}
+	s.Equal([]string{"otp", "wallet", "pwd"}, ids, "ACTION components should follow ACR preference order")
+}
+
+func (s *PromptOnlyNodeTestSuite) TestFilteredMeta_NonActionComponentsRetainPosition() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(*promptNode)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+	})
+	pn.SetMeta(map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"type": "TEXT", "id": "heading"},
+			map[string]interface{}{"type": "ACTION", "id": "pwd"},
+			map[string]interface{}{"type": "DIVIDER", "id": "div1"},
+			map[string]interface{}{"type": "ACTION", "id": "otp"},
+			map[string]interface{}{"type": "TEXT", "id": "footer"},
+		},
+	})
+
+	// Preference: otp first, then password
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code urn:thunder:acr:password",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Require().NotNil(resp.Meta)
+
+	metaMap := resp.Meta.(map[string]interface{})
+	components := metaMap["components"].([]interface{})
+	s.Require().Len(components, 5)
+
+	ids := make([]string, 5)
+	for i, c := range components {
+		ids[i], _ = c.(map[string]interface{})["id"].(string)
+	}
+	// Non-ACTION components stay; ACTION slots are filled in ACR preference order
+	s.Equal([]string{"heading", "otp", "div1", "pwd", "footer"}, ids)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestFilteredMeta_FilteredOutActionsDropped() {
+	node := newPromptNode("login-chooser", loginOptionsProps(), false, false)
+	pn := node.(*promptNode)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"}},
+		{Action: &common.Action{Ref: "otp", NextNode: "otp-node"}},
+		{Action: &common.Action{Ref: "wallet", NextNode: "wallet-node"}},
+	})
+	pn.SetMeta(map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"type": "ACTION", "id": "pwd"},
+			map[string]interface{}{"type": "ACTION", "id": "otp"},
+			map[string]interface{}{"type": "ACTION", "id": "wallet"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
+		RuntimeData: map[string]string{
+			common.RuntimeKeyRequestedAuthClasses: "urn:thunder:acr:generated-code",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.Equal(common.NodeStatusComplete, resp.Status,
+		"single ACR filter must trigger auto-selection and complete the node")
+	s.Equal("otp-node", resp.NextNodeID)
+	s.Nil(resp.Meta, "meta is not returned for a completed (auto-selected) chooser node")
 }

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -168,6 +168,10 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 		jwtClaims["authorized_permissions"] = permissions
 	}
 
+	if completedACR, exists := ctx.RuntimeData[common.RuntimeKeySelectedAuthClass]; exists && completedACR != "" {
+		jwtClaims[oauth2const.ClaimCompletedAuthClass] = completedACR
+	}
+
 	requiredAttributes := a.getRequiredUserAttributes(ctx)
 
 	resolvedAttributes, attrErr := a.resolveUserAttributes(ctx, requiredAttributes)

--- a/backend/internal/flow/mgt/graph_builder.go
+++ b/backend/internal/flow/mgt/graph_builder.go
@@ -158,6 +158,7 @@ func (b *graphBuilder) processNode(nodeDef *NodeDefinition, allNodes []NodeDefin
 
 	b.configureNodeInputs(nodeDef, node)
 	b.configureNodeMeta(nodeDef, node)
+	b.configureNodeVariant(nodeDef, node)
 	b.configureNodeCondition(nodeDef, node)
 
 	if err := b.configureNodePrompts(nodeDef, node, edges); err != nil {
@@ -282,6 +283,16 @@ func (b *graphBuilder) configureNodeInputs(nodeDef *NodeDefinition, node core.No
 		}
 	}
 	executorNode.SetInputs(inputs)
+}
+
+// configureNodeVariant sets the prompt node's variant from the node definition.
+func (b *graphBuilder) configureNodeVariant(nodeDef *NodeDefinition, node core.NodeInterface) {
+	if nodeDef.Variant == "" {
+		return
+	}
+	if promptNode, ok := node.(core.PromptNodeInterface); ok {
+		promptNode.SetVariant(nodeDef.Variant)
+	}
 }
 
 // configureNodeMeta configures the meta object for a prompt node.

--- a/backend/internal/flow/mgt/graph_builder_test.go
+++ b/backend/internal/flow/mgt/graph_builder_test.go
@@ -671,6 +671,52 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithMeta() {
 	s.Nil(err)
 }
 
+func (s *GraphBuilderTestSuite) TestBuildGraph_VariantExplicitlySet() {
+	flow := &CompleteFlowDefinition{
+		ID:       "flow-1",
+		Handle:   "test-handle",
+		Name:     "Test Flow",
+		FlowType: common.FlowTypeAuthentication,
+		Nodes: []NodeDefinition{
+			{ID: "start", Type: "START", OnSuccess: "chooser"},
+			{
+				ID:      "chooser",
+				Type:    "PROMPT",
+				Variant: common.NodeVariantLoginOptions,
+			},
+		},
+	}
+
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockStartNode := coremock.NewRepresentationNodeInterfaceMock(s.T())
+	mockPromptNode := coremock.NewPromptNodeInterfaceMock(s.T())
+
+	s.mockFlowFactory.EXPECT().CreateGraph(
+		"flow-1", common.FlowTypeAuthentication).Return(mockGraph)
+	s.mockFlowFactory.EXPECT().CreateNode(
+		"start", "START", map[string]interface{}(nil), false, false).Return(mockStartNode, nil)
+	s.mockFlowFactory.EXPECT().CreateNode(
+		"chooser", "PROMPT", map[string]interface{}(nil), false, true).Return(mockPromptNode, nil)
+
+	mockStartNode.EXPECT().SetOnSuccess("chooser")
+	mockPromptNode.EXPECT().SetVariant(common.NodeVariantLoginOptions)
+
+	mockGraph.EXPECT().AddNode(mockStartNode).Return(nil)
+	mockGraph.EXPECT().AddNode(mockPromptNode).Return(nil)
+	mockGraph.EXPECT().AddEdge("start", "chooser").Return(nil)
+	mockGraph.EXPECT().GetNodes().Return(
+		map[string]core.NodeInterface{"start": mockStartNode, "chooser": mockPromptNode})
+	mockStartNode.EXPECT().GetType().Return(common.NodeTypeStart)
+	mockPromptNode.EXPECT().GetType().Return(common.NodeTypePrompt).Maybe()
+	mockStartNode.EXPECT().GetID().Return("start")
+	mockGraph.EXPECT().SetStartNode("start").Return(nil)
+
+	graph, err := s.builder.buildGraph(flow)
+
+	s.NotNil(graph)
+	s.Nil(err)
+}
+
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithCondition() {
 	flow := &CompleteFlowDefinition{
 		ID:       "flow-1",

--- a/backend/internal/flow/mgt/model.go
+++ b/backend/internal/flow/mgt/model.go
@@ -143,6 +143,7 @@ type NodeDefinition struct {
 	Layout       *NodeLayout            `json:"layout,omitempty" yaml:"layout,omitempty" jsonschema:"Optional UI layout information for flow composer (position and size on canvas)"`
 	Meta         interface{}            `json:"meta,omitempty" yaml:"meta,omitempty" jsonschema:"Optional metadata. For PROMPT nodes, must include 'components' array for UI rendering. See existing flows for examples."`
 	Prompts      []PromptDefinition     `json:"prompts,omitempty" yaml:"prompts,omitempty" jsonschema:"For PROMPT nodes: defines user inputs and actions. Each prompt has inputs (form fields) and an action (what happens on submit)."`
+	Variant      common.NodeVariant     `json:"variant,omitempty" yaml:"variant,omitempty" jsonschema:"Optional PROMPT node variant. Use 'LOGIN_OPTIONS' to enable login option filtering on this node."`
 	Next         string                 `json:"next,omitempty" yaml:"next,omitempty" jsonschema:"For display-only PROMPT nodes: ID of the next node. Mutually exclusive with 'prompts'."`
 	Message      string                 `json:"message,omitempty" yaml:"message,omitempty" jsonschema:"For display-only PROMPT nodes: textual message for non-verbose mode."`
 	Properties   map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty" jsonschema:"Optional node-specific properties for configuration"`

--- a/backend/internal/inboundclient/model/oauth.go
+++ b/backend/internal/inboundclient/model/oauth.go
@@ -55,6 +55,7 @@ type OAuthProfileData struct {
 	UserInfo                           *UserInfoConfig     `json:"userInfo,omitempty"`
 	ScopeClaims                        map[string][]string `json:"scopeClaims,omitempty"`
 	Certificate                        *Certificate        `json:"certificate,omitempty"`
+	AcrValues                          []string            `json:"acrValues,omitempty"`
 }
 
 // OAuthTokenConfig wraps access and ID token configs.
@@ -131,6 +132,7 @@ type OAuthClient struct {
 	UserInfo                           *UserInfoConfig                     `yaml:"user_info,omitempty"`
 	ScopeClaims                        map[string][]string                 `yaml:"scope_claims,omitempty"`
 	Certificate                        *Certificate                        `yaml:"certificate,omitempty"`
+	AcrValues                          []string                            `yaml:"acr_values,omitempty"`
 }
 
 // IsAllowedGrantType reports whether the OAuth client allows the given grant type.

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -420,6 +420,7 @@ func BuildOAuthClient(entityID, clientID, ouID string, oauthDAO *inboundmodel.OA
 		Token:                              p.Token,
 		UserInfo:                           p.UserInfo,
 		Certificate:                        p.Certificate,
+		AcrValues:                          p.AcrValues,
 	}
 	for _, gt := range p.GrantTypes {
 		client.GrantTypes = append(client.GrantTypes, oauth2const.GrantType(gt))

--- a/backend/internal/inboundclient/store_test.go
+++ b/backend/internal/inboundclient/store_test.go
@@ -233,6 +233,147 @@ func (suite *InboundClientStoreTestSuite) TestBuildOAuthProfileFromRow_Malformed
 	suite.Contains(err.Error(), "failed to unmarshal OAuth profile JSON")
 }
 
+func (suite *InboundClientStoreTestSuite) TestMarshalOAuthProfileData_WithAcrValues() {
+	profile := &inboundmodel.OAuthProfileData{
+		RedirectURIs: []string{"https://example.com/callback"},
+		GrantTypes:   []string{"authorization_code"},
+		AcrValues:    []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"},
+	}
+
+	data, err := marshalOAuthProfileData(profile)
+
+	suite.NoError(err)
+	suite.NotNil(data)
+
+	var result map[string]interface{}
+	suite.NoError(json.Unmarshal(data, &result))
+
+	acrRaw, ok := result["acrValues"].([]interface{})
+	suite.True(ok, "acrValues should be present in JSON")
+	suite.Len(acrRaw, 2)
+	suite.Equal("urn:thunder:acr:password", acrRaw[0])
+	suite.Equal("urn:thunder:acr:generated-code", acrRaw[1])
+}
+
+func (suite *InboundClientStoreTestSuite) TestMarshalOAuthProfileData_WithEmptyAcrValues() {
+	profile := &inboundmodel.OAuthProfileData{
+		RedirectURIs: []string{"https://example.com/callback"},
+		GrantTypes:   []string{"authorization_code"},
+		AcrValues:    []string{},
+	}
+
+	data, err := marshalOAuthProfileData(profile)
+
+	suite.NoError(err)
+	var result map[string]interface{}
+	suite.NoError(json.Unmarshal(data, &result))
+
+	suite.Nil(result["acrValues"])
+}
+
+func (suite *InboundClientStoreTestSuite) TestMarshalOAuthProfileData_WithNilAcrValues() {
+	profile := &inboundmodel.OAuthProfileData{
+		RedirectURIs: []string{"https://example.com/callback"},
+		AcrValues:    nil,
+	}
+
+	data, err := marshalOAuthProfileData(profile)
+
+	suite.NoError(err)
+	var result map[string]interface{}
+	suite.NoError(json.Unmarshal(data, &result))
+
+	suite.Nil(result["acrValues"])
+}
+
+func (suite *InboundClientStoreTestSuite) TestBuildOAuthProfileFromRow_WithAcrValues() {
+	cfg := inboundmodel.OAuthProfileData{
+		RedirectURIs:            []string{"https://example.com/callback"},
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+		AcrValues:               []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"},
+	}
+	cfgBytes, _ := json.Marshal(cfg)
+
+	row := map[string]interface{}{
+		"entity_id":    testEntityID,
+		"oauth_config": string(cfgBytes),
+	}
+
+	result, err := buildOAuthProfileFromRow(row)
+
+	suite.NoError(err)
+	suite.Require().NotNil(result.OAuthProfile)
+	suite.Equal(
+		[]string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"},
+		result.OAuthProfile.AcrValues,
+	)
+}
+
+func (suite *InboundClientStoreTestSuite) TestBuildOAuthProfileFromRow_WithSingleAcrValue() {
+	cfg := inboundmodel.OAuthProfileData{
+		RedirectURIs: []string{"https://example.com/callback"},
+		GrantTypes:   []string{"authorization_code"},
+		AcrValues:    []string{"urn:thunder:acr:password"},
+	}
+	cfgBytes, _ := json.Marshal(cfg)
+
+	row := map[string]interface{}{
+		"entity_id":    testEntityID,
+		"oauth_config": string(cfgBytes),
+	}
+
+	result, err := buildOAuthProfileFromRow(row)
+
+	suite.NoError(err)
+	suite.Require().NotNil(result.OAuthProfile)
+	suite.Equal([]string{"urn:thunder:acr:password"}, result.OAuthProfile.AcrValues)
+}
+
+func (suite *InboundClientStoreTestSuite) TestBuildOAuthProfileFromRow_WithoutAcrValues() {
+	cfg := inboundmodel.OAuthProfileData{
+		RedirectURIs: []string{"https://example.com/callback"},
+		GrantTypes:   []string{"authorization_code"},
+	}
+	cfgBytes, _ := json.Marshal(cfg)
+
+	row := map[string]interface{}{
+		"entity_id":    testEntityID,
+		"oauth_config": string(cfgBytes),
+	}
+
+	result, err := buildOAuthProfileFromRow(row)
+
+	suite.NoError(err)
+	suite.Require().NotNil(result.OAuthProfile)
+	suite.Nil(result.OAuthProfile.AcrValues)
+}
+
+func (suite *InboundClientStoreTestSuite) TestAcrValues_RoundTrip() {
+	acrs := []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}
+
+	profile := &inboundmodel.OAuthProfileData{
+		RedirectURIs:            []string{"https://example.com/callback"},
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+		AcrValues:               acrs,
+	}
+
+	data, err := marshalOAuthProfileData(profile)
+	suite.NoError(err)
+
+	row := map[string]interface{}{
+		"entity_id":    testEntityID,
+		"oauth_config": string(data),
+	}
+
+	result, err := buildOAuthProfileFromRow(row)
+	suite.NoError(err)
+	suite.Equal(acrs, result.OAuthProfile.AcrValues)
+}
+
 // --- Helper tests ---
 
 func (suite *InboundClientStoreTestSuite) TestParseBoolFromCount() {

--- a/backend/internal/oauth/oauth2/authz/auth_code_store.go
+++ b/backend/internal/oauth/oauth2/authz/auth_code_store.go
@@ -48,6 +48,7 @@ const (
 	jsonDataKeyClaimsRequest       = "claims_request"
 	jsonDataKeyClaimsLocales       = "claims_locales"
 	jsonDataKeyNonce               = "nonce"
+	jsonDataKeyCompletedACR        = "completed_acr"
 )
 
 // AuthorizationCodeStoreInterface defines the interface for managing authorization codes.
@@ -143,6 +144,7 @@ func (acs *authorizationCodeStore) getJSONDataBytes(authzCode AuthorizationCode)
 		jsonDataKeyResource:            authzCode.Resources,
 		jsonDataKeyClaimsLocales:       authzCode.ClaimsLocales,
 		jsonDataKeyNonce:               authzCode.Nonce,
+		jsonDataKeyCompletedACR:        authzCode.CompletedACR,
 	}
 
 	// Include user attributes if present
@@ -268,6 +270,9 @@ func appendAuthzDataJSON(row map[string]interface{}, authzCode *AuthorizationCod
 	}
 	if attributeCacheID, ok := authzData[jsonDataKeyAttributeCacheID].(string); ok {
 		authzCode.AttributeCacheID = attributeCacheID
+	}
+	if completedACR, ok := authzData[jsonDataKeyCompletedACR].(string); ok {
+		authzCode.CompletedACR = completedACR
 	}
 
 	if claimsData, ok := authzData[jsonDataKeyClaimsRequest]; ok && claimsData != nil {

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -818,6 +818,29 @@ func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_NonStr
 	assert.Contains(suite.T(), err.Error(), "JWT 'aci' claim is not a string")
 }
 
+func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_WithCompletedAuthClass() {
+	// JWT payload: {"sub":"test-user","completed_auth_class":"urn:thunder:acr:password"}
+	jwtToken := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJjb21wbGV0ZWRfYXV0aF9jbGFzcyI6InVybjp0aHVuZGVyOmFjcjpwYXNzd29yZCJ9."
+
+	clms, _, err := decodeAttributesFromAssertion(jwtToken)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "test-user", clms.userID)
+	assert.Equal(suite.T(), "urn:thunder:acr:password", clms.completedACR)
+}
+
+func (suite *AuthorizeHandlerTestSuite) TestDecodeAttributesFromAssertion_NonStringCompletedAuthClass() {
+	// JWT payload: {"sub":"test-user","completed_auth_class":12345}
+	jwtToken := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJjb21wbGV0ZWRfYXV0aF9jbGFzcyI6MTIzNDV9."
+
+	_, _, err := decodeAttributesFromAssertion(jwtToken)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "JWT 'completed_auth_class' claim is not a string")
+}
+
 func (suite *AuthorizeHandlerTestSuite) TestValidateSubClaimConstraint() {
 	tests := []struct {
 		name          string

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -51,6 +51,7 @@ type AuthorizationCode struct {
 	ClaimsRequest       *oauth2model.ClaimsRequest
 	ClaimsLocales       string
 	Nonce               string
+	CompletedACR        string
 }
 
 // AuthZPostRequest represents the request body for the authorization POST request.
@@ -83,4 +84,5 @@ type assertionClaims struct {
 	userID                string
 	authorizedPermissions string
 	attributeCacheID      string
+	completedACR          string
 }

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
@@ -133,3 +133,33 @@ func ValidatePromptParameter(prompt string) (string, string) {
 
 	return "", ""
 }
+
+// ResolveACRValues returns the effective acr_values: requested ACRs filtered against the
+// app's list, falling back to the app's full list when nothing matches or none were requested.
+func ResolveACRValues(requestedAcrValues string, appAcrValues []string) string {
+	requested := parseACRValues(requestedAcrValues)
+	filtered := make([]string, 0, len(requested))
+	for _, acr := range requested {
+		if slices.Contains(appAcrValues, acr) {
+			filtered = append(filtered, acr)
+		}
+	}
+	if len(filtered) == 0 {
+		return strings.Join(appAcrValues, " ")
+	}
+	return strings.Join(filtered, " ")
+}
+
+// parseACRValues splits acr_values into a deduplicated, order-preserving slice.
+func parseACRValues(acrValues string) []string {
+	parts := strings.Fields(acrValues)
+	seen := make(map[string]bool, len(parts))
+	result := make([]string, 0, len(parts))
+	for _, acr := range parts {
+		if !seen[acr] {
+			seen[acr] = true
+			result = append(result, acr)
+		}
+	}
+	return result
+}

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
@@ -290,3 +290,97 @@ func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_LoginConsent(
 	errCode, _ := ValidatePromptParameter("login consent")
 	assert.Equal(suite.T(), constants.ErrorConsentRequired, errCode)
 }
+
+type ACRValuesTestSuite struct {
+	suite.Suite
+}
+
+func TestACRValuesTestSuite(t *testing.T) {
+	suite.Run(t, new(ACRValuesTestSuite))
+}
+
+func (suite *ACRValuesTestSuite) TestParseACRValues_SingleACR() {
+	result := parseACRValues("urn:thunder:acr:password")
+	assert.Equal(suite.T(), []string{"urn:thunder:acr:password"}, result)
+}
+
+func (suite *ACRValuesTestSuite) TestParseACRValues_MultipleACRs() {
+	result := parseACRValues("urn:thunder:acr:password urn:thunder:acr:generated-code")
+	assert.Equal(suite.T(),
+		[]string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}, result)
+}
+
+func (suite *ACRValuesTestSuite) TestParseACRValues_DeduplicatesPreservingFirstOccurrence() {
+	result := parseACRValues("urn:thunder:acr:generated-code urn:thunder:acr:generated-code urn:thunder:acr:password")
+	assert.Equal(suite.T(),
+		[]string{"urn:thunder:acr:generated-code", "urn:thunder:acr:password"}, result)
+}
+
+func (suite *ACRValuesTestSuite) TestParseACRValues_EmptyString() {
+	result := parseACRValues("")
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *ACRValuesTestSuite) TestParseACRValues_OnlyWhitespace() {
+	result := parseACRValues("   ")
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *ACRValuesTestSuite) TestParseACRValues_ExtraSpacesBetweenACRs() {
+	result := parseACRValues("urn:thunder:acr:password   urn:thunder:acr:generated-code")
+	assert.Equal(suite.T(),
+		[]string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}, result)
+}
+
+func (suite *ACRValuesTestSuite) TestParseACRValues_PreservesOrder() {
+	result := parseACRValues("urn:thunder:acr:biometrics urn:thunder:acr:password urn:thunder:acr:generated-code")
+	assert.Equal(suite.T(), []string{
+		"urn:thunder:acr:biometrics",
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:generated-code",
+	}, result)
+}
+
+func (suite *ACRValuesTestSuite) TestResolveACRValues_NoRequest_NoDefaults() {
+	assert.Equal(suite.T(), "", ResolveACRValues("", nil))
+}
+
+func (suite *ACRValuesTestSuite) TestResolveACRValues_NoRequest_FallsBackToDefaults() {
+	defaults := []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}
+	result := ResolveACRValues("", defaults)
+	assert.ElementsMatch(suite.T(), defaults, strings.Fields(result))
+}
+
+func (suite *ACRValuesTestSuite) TestResolveACRValues_AllRequestedInDefaults_PreservesRequestedOrder() {
+	defaults := []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}
+	result := ResolveACRValues("urn:thunder:acr:generated-code urn:thunder:acr:password", defaults)
+	assert.Equal(suite.T(),
+		[]string{"urn:thunder:acr:generated-code", "urn:thunder:acr:password"},
+		strings.Fields(result))
+}
+
+func (suite *ACRValuesTestSuite) TestResolveACRValues_SomeNotInDefaults_FiltersOutUnknown() {
+	defaults := []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}
+	result := ResolveACRValues("urn:thunder:acr:password urn:thunder:acr:biometrics", defaults)
+	assert.Equal(suite.T(), []string{"urn:thunder:acr:password"}, strings.Fields(result))
+}
+
+func (suite *ACRValuesTestSuite) TestResolveACRValues_NoneInDefaults_FallsBackToDefaults() {
+	defaults := []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}
+	result := ResolveACRValues("urn:thunder:acr:biometrics urn:thunder:acr:linked-wallet", defaults)
+	assert.ElementsMatch(suite.T(), defaults, strings.Fields(result))
+}
+
+func (suite *ACRValuesTestSuite) TestResolveACRValues_DuplicatesDeduped() {
+	defaults := []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}
+	result := ResolveACRValues(
+		"urn:thunder:acr:password urn:thunder:acr:password urn:thunder:acr:generated-code", defaults)
+	assert.Equal(suite.T(),
+		[]string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"},
+		strings.Fields(result))
+}
+
+func (suite *ACRValuesTestSuite) TestResolveACRValues_RequestPresent_NoDefaults_ReturnsEmpty() {
+	result := ResolveACRValues("urn:thunder:acr:password urn:thunder:acr:generated-code", nil)
+	assert.Equal(suite.T(), "", result)
+}

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/flowexec"
 	"github.com/asgardeo/thunder/internal/inboundclient"
 	inboundmodel "github.com/asgardeo/thunder/internal/inboundclient/model"
+	"github.com/asgardeo/thunder/internal/oauth/oauth2/authz/requestvalidator"
 	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	oauth2model "github.com/asgardeo/thunder/internal/oauth/oauth2/model"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/par"
@@ -219,6 +220,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 	claimsLocales := msg.RequestQueryParams[oauth2const.RequestParamClaimsLocales]
 
 	nonce := msg.RequestQueryParams[oauth2const.RequestParamNonce]
+	acrValues := msg.RequestQueryParams[oauth2const.RequestParamAcrValues]
 
 	// Parse the claims parameter if present.
 	var claimsRequest *oauth2model.ClaimsRequest
@@ -280,6 +282,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 		ClaimsRequest:       claimsRequest,
 		ClaimsLocales:       claimsLocales,
 		Nonce:               nonce,
+		AcrValues:           acrValues,
 	}
 
 	// Set the redirect URI if not provided in the request. Invalid cases are already handled at this point.
@@ -304,6 +307,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 func (as *authorizeService) initiateFlowAndStoreRequest(
 	ctx context.Context, oauthParams *oauth2model.OAuthParameters, app *inboundmodel.OAuthClient,
 ) (*AuthorizationInitResult, *AuthorizationError) {
+	effectiveAcrValues := requestvalidator.ResolveACRValues(oauthParams.AcrValues, app.AcrValues)
 	essentialAttributes, optionalAttributes := getRequiredAttributes(
 		oauthParams.StandardScopes, oauthParams.ClaimsRequest, oauthParams.ResponseType, app)
 
@@ -315,6 +319,9 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 		flowcm.RuntimeKeyRequiredOptionalAttributes:    optionalAttributes,
 		flowcm.RuntimeKeyRequiredLocales:               oauthParams.ClaimsLocales,
 		flowcm.RuntimeKeyUserAttributesCacheTTLSeconds: fmt.Sprintf("%d", resolveUserAttributesCacheTTL(app)),
+	}
+	if effectiveAcrValues != "" {
+		runtimeData[flowcm.RuntimeKeyRequestedAuthClasses] = effectiveAcrValues
 	}
 	flowInitCtx := &flowexec.FlowInitContext{
 		ApplicationID: app.AppID,
@@ -625,6 +632,15 @@ func decodeAttributesFromAssertion(assertion string) (assertionClaims, time.Time
 			claims.attributeCacheID = strValue
 			continue
 		}
+
+		if key == oauth2const.ClaimCompletedAuthClass {
+			strValue, ok := value.(string)
+			if !ok {
+				return claims, time.Time{}, errors.New("JWT 'completed_auth_class' claim is not a string")
+			}
+			claims.completedACR = strValue
+			continue
+		}
 	}
 
 	return claims, authTime, nil
@@ -689,6 +705,7 @@ func createAuthorizationCode(
 		ClaimsRequest:       authRequestCtx.OAuthParameters.ClaimsRequest,
 		ClaimsLocales:       authRequestCtx.OAuthParameters.ClaimsLocales,
 		Nonce:               authRequestCtx.OAuthParameters.Nonce,
+		CompletedACR:        claims.completedACR,
 	}, nil
 }
 

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -1710,3 +1710,195 @@ func determineClaimsForTokens(oidcScopes []string, claimsRequest *oauth2model.Cl
 
 	return accessTokenClaims, idTokenClaims, userInfoClaims
 }
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_NoAcrValues_NoDefaults() {
+	app := suite.testApp()
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything,
+		mock.AnythingOfType("*flowexec.FlowInitContext")).
+		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
+			assert.NotContains(suite.T(), initContext.RuntimeData, flowcm.RuntimeKeyRequestedAuthClasses)
+		}).
+		Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), suite.testMsg())
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_AcrValues_NoDefaults() {
+	app := suite.testApp()
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything,
+		mock.AnythingOfType("*flowexec.FlowInitContext")).
+		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
+			assert.NotContains(suite.T(), initContext.RuntimeData, flowcm.RuntimeKeyRequestedAuthClasses)
+		}).
+		Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
+		"urn:thunder:acr:password urn:thunder:acr:generated-code"
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_AcrValues_AllInDefaults() {
+	app := suite.testApp()
+	app.AcrValues = []string{
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:generated-code",
+		"urn:thunder:acr:biometrics",
+	}
+
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything,
+		mock.AnythingOfType("*flowexec.FlowInitContext")).
+		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
+			assert.Equal(suite.T(),
+				[]string{"urn:thunder:acr:generated-code", "urn:thunder:acr:password"},
+				strings.Fields(initContext.RuntimeData[flowcm.RuntimeKeyRequestedAuthClasses]))
+		}).
+		Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
+		"urn:thunder:acr:generated-code urn:thunder:acr:password"
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_AcrValues_SomeNotInDefaults() {
+	app := suite.testApp()
+	app.AcrValues = []string{
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:generated-code",
+	}
+
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything,
+		mock.AnythingOfType("*flowexec.FlowInitContext")).
+		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
+			effective := initContext.RuntimeData[flowcm.RuntimeKeyRequestedAuthClasses]
+			assert.Equal(suite.T(), []string{"urn:thunder:acr:password"}, strings.Fields(effective))
+			assert.NotContains(suite.T(), effective, "urn:thunder:acr:biometrics")
+		}).
+		Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] = "urn:thunder:acr:password urn:thunder:acr:biometrics"
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_AcrValues_NoneInDefaults() {
+	defaults := []string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"}
+	app := suite.testApp()
+	app.AcrValues = defaults
+
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything,
+		mock.AnythingOfType("*flowexec.FlowInitContext")).
+		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
+			assert.ElementsMatch(suite.T(), defaults,
+				strings.Fields(initContext.RuntimeData[flowcm.RuntimeKeyRequestedAuthClasses]))
+		}).
+		Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
+		"urn:thunder:acr:biometrics urn:thunder:acr:linked-wallet"
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_AcrValues_DuplicatesDeduped() {
+	app := suite.testApp()
+	app.AcrValues = []string{
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:generated-code",
+	}
+
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything,
+		mock.AnythingOfType("*flowexec.FlowInitContext")).
+		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
+			assert.Equal(suite.T(),
+				[]string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"},
+				strings.Fields(initContext.RuntimeData[flowcm.RuntimeKeyRequestedAuthClasses]))
+		}).
+		Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
+		"urn:thunder:acr:password urn:thunder:acr:password urn:thunder:acr:generated-code"
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_AcrValues_SingleDefault() {
+	app := suite.testApp()
+	app.AcrValues = []string{"urn:thunder:acr:password"}
+
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything,
+		mock.AnythingOfType("*flowexec.FlowInitContext")).
+		Run(func(_ context.Context, initContext *flowexec.FlowInitContext) {
+			assert.Equal(suite.T(),
+				"urn:thunder:acr:password",
+				initContext.RuntimeData[flowcm.RuntimeKeyRequestedAuthClasses])
+		}).
+		Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] = "urn:thunder:acr:password"
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+}

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -60,6 +60,7 @@ const (
 	RequestParamNonce               string = "nonce"
 	RequestParamPrompt              string = "prompt"
 	RequestParamRequestURI          string = "request_uri"
+	RequestParamAcrValues           string = "acr_values"
 )
 
 // OIDC prompt parameter values.
@@ -311,12 +312,13 @@ const (
 
 // Custom JWT claim names.
 const (
-	ClaimUserType      string = "userType"
-	ClaimOUID          string = "ouId"
-	ClaimOUName        string = "ouName"
-	ClaimOUHandle      string = "ouHandle"
-	ClaimClaimsRequest string = "claims_req"
-	ClaimClaimsLocales string = "claims_locales"
+	ClaimUserType           string = "userType"
+	ClaimOUID               string = "ouId"
+	ClaimOUName             string = "ouName"
+	ClaimOUHandle           string = "ouHandle"
+	ClaimClaimsRequest      string = "claims_req"
+	ClaimClaimsLocales      string = "claims_locales"
+	ClaimCompletedAuthClass string = "completed_auth_class"
 )
 
 // OIDC subject types.

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -81,6 +81,15 @@ func (suite *DiscoveryTestSuite) SetupTest() {
 			Issuer:         "https://auth.example.com",
 			ValidityPeriod: 3600,
 		},
+		OAuth: config.OAuthConfig{
+			AuthClass: config.AuthClassConfig{
+				Amrs: []string{"PWD", "OTP"},
+				AcrAMR: map[string][]string{
+					"urn:thunder:acr:password":       {"PWD"},
+					"urn:thunder:acr:generated-code": {"OTP"},
+				},
+			},
+		},
 	}
 	_ = config.InitializeServerRuntime("test", testConfig)
 
@@ -161,6 +170,8 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery() {
 
 	// Verify RFC 9207 advertisement (inherited from embedded OAuth2AuthorizationServerMetadata)
 	assert.True(suite.T(), metadata.AuthorizationResponseIssParameterSupported)
+	assert.Contains(suite.T(), metadata.AcrValuesSupported, "urn:thunder:acr:password")
+	assert.Contains(suite.T(), metadata.AcrValuesSupported, "urn:thunder:acr:generated-code")
 }
 
 // TestGrantTypeIsValid tests the GrantType.IsValid() method

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -49,4 +49,5 @@ type OIDCProviderMetadata struct {
 	ClaimsSupported                      []string `json:"claims_supported"`
 	ClaimsParameterSupported             bool     `json:"claims_parameter_supported"`
 	EndSessionEndpoint                   string   `json:"end_session_endpoint,omitempty"`
+	AcrValuesSupported                   []string `json:"acr_values_supported,omitempty"`
 }

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -20,6 +20,7 @@ package discovery
 
 import (
 	"context"
+	"sort"
 
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/pkce"
@@ -91,6 +92,7 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) *OIDCProviderMe
 		UserInfoEncryptionEncValuesSupported: supportedUserInfoEncryptionEncs,
 		ClaimsSupported:                      ds.getSupportedClaims(),
 		ClaimsParameterSupported:             true,
+		AcrValuesSupported:                   ds.getSupportedAcrValues(),
 	}
 }
 
@@ -156,6 +158,17 @@ func (ds *discoveryService) isGlobalPARRequired() bool {
 
 func (ds *discoveryService) getSupportedSubjectTypes() []string {
 	return constants.GetSupportedSubjectTypes()
+}
+
+// getSupportedAcrValues returns the sorted ACR values from the auth_class.acr_amr mapping.
+func (ds *discoveryService) getSupportedAcrValues() []string {
+	acrAMR := config.GetServerRuntime().Config.OAuth.AuthClass.AcrAMR
+	acrs := make([]string, 0, len(acrAMR))
+	for acr := range acrAMR {
+		acrs = append(acrs, acr)
+	}
+	sort.Strings(acrs)
+	return acrs
 }
 
 func (ds *discoveryService) getSupportedClaims() []string {

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -225,6 +225,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			OAuthApp:       oauthApp,
 			ClaimsRequest:  authCode.ClaimsRequest,
 			Nonce:          authCode.Nonce,
+			CompletedACR:   authCode.CompletedACR,
 		})
 		if err != nil {
 			logger.Error("Failed to generate ID token", log.Error(err))

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -34,6 +34,7 @@ type OAuthParameters struct {
 	ClaimsRequest       *ClaimsRequest
 	ClaimsLocales       string
 	Nonce               string
+	AcrValues           string
 }
 
 // ClaimsRequest represents the OIDC claims request parameter structure.

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -134,6 +134,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 		ClaimsRequest:       claimsRequest,
 		ClaimsLocales:       params[oauth2const.RequestParamClaimsLocales],
 		Nonce:               params[oauth2const.RequestParamNonce],
+		AcrValues:           params[oauth2const.RequestParamAcrValues],
 	}
 
 	parRequest := pushedAuthorizationRequest{

--- a/backend/internal/oauth/oauth2/par/service_test.go
+++ b/backend/internal/oauth/oauth2/par/service_test.go
@@ -355,6 +355,28 @@ func (s *ServiceTestSuite) TestHandlePAR_ScopesDownscopedAgainstResourceServers(
 	assert.Equal(s.T(), []string{"read"}, captured.OAuthParameters.PermissionScopes)
 }
 
+func (s *ServiceTestSuite) TestHandlePAR_AcrValuesPropagated() {
+	store := newParStoreInterfaceMock(s.T())
+	var captured pushedAuthorizationRequest
+	store.EXPECT().Store(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req pushedAuthorizationRequest, _ int64) {
+			captured = req
+		}).Return("test-uri", nil)
+
+	svc := newPARService(store, s.newPermissiveResourceMock())
+	app := s.newTestApp()
+	params := s.newValidParams()
+	params[oauth2const.RequestParamAcrValues] = "urn:thunder:acr:password urn:thunder:acr:generated-code"
+
+	resp, errCode, _ := svc.HandlePushedAuthorizationRequest(s.ctx, params, nil, app)
+
+	assert.Empty(s.T(), errCode)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(),
+		"urn:thunder:acr:password urn:thunder:acr:generated-code",
+		captured.OAuthParameters.AcrValues)
+}
+
 func (s *ServiceTestSuite) TestHandlePAR_NonceTooLong() {
 	store := newParStoreInterfaceMock(s.T())
 	svc := newPARService(store, s.newPermissiveResourceMock())

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -351,6 +351,10 @@ func (tb *tokenBuilder) buildIDTokenClaims(ctx *IDTokenBuildContext) map[string]
 		claims[constants.RequestParamNonce] = ctx.Nonce
 	}
 
+	if ctx.CompletedACR != "" {
+		claims["acr"] = ctx.CompletedACR
+	}
+
 	userAttributes := ctx.UserAttributes
 	if userAttributes == nil {
 		userAttributes = make(map[string]interface{})

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -88,6 +88,7 @@ type IDTokenBuildContext struct {
 	OAuthApp       *inboundmodel.OAuthClient
 	ClaimsRequest  *oauth2model.ClaimsRequest
 	Nonce          string
+	CompletedACR   string
 }
 
 // RefreshTokenClaims represents the validated claims from a refresh token.

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -218,6 +218,7 @@ type OAuthConfig struct {
 	AuthorizationCode AuthorizationCodeConfig `yaml:"authorization_code" json:"authorization_code"`
 	DCR               DCRConfig               `yaml:"dcr" json:"dcr"`
 	PAR               PARConfig               `yaml:"par" json:"par"`
+	AuthClass         AuthClassConfig         `yaml:"auth_class" json:"auth_class"`
 	// AllowWildcardRedirectURI enables wildcard pattern matching for redirect URIs.
 	// When false (default), only exact redirect URI matching is performed.
 	AllowWildcardRedirectURI bool `yaml:"allow_wildcard_redirect_uri" json:"allow_wildcard_redirect_uri"`
@@ -576,6 +577,46 @@ func (c *TrustedIssuerConfig) Validate() error {
 	}
 }
 
+// AuthClassConfig holds the ACR-AMR mapping configuration.
+type AuthClassConfig struct {
+	Amrs   []string            `yaml:"amrs" json:"amrs"`
+	AcrAMR map[string][]string `yaml:"acr_amr" json:"acr_amr"`
+}
+
+// Validate checks the ACR-AMR mapping for configuration errors.
+func (c *AuthClassConfig) Validate() error {
+	amrSet := make(map[string]struct{}, len(c.Amrs))
+	for _, amr := range c.Amrs {
+		if strings.TrimSpace(amr) == "" {
+			return fmt.Errorf("auth_class: AMR entry must not be empty")
+		}
+		amrSet[amr] = struct{}{}
+	}
+
+	if len(c.AcrAMR) == 0 {
+		return nil
+	}
+
+	for acr, amrKeys := range c.AcrAMR {
+		if strings.TrimSpace(acr) == "" {
+			return fmt.Errorf("auth_class: ACR value must not be empty")
+		}
+		if len(amrKeys) == 0 {
+			return fmt.Errorf("auth_class: ACR %q has an empty AMR list", acr)
+		}
+		for _, amrKey := range amrKeys {
+			if strings.TrimSpace(amrKey) == "" {
+				return fmt.Errorf("auth_class: ACR %q references an empty AMR key", acr)
+			}
+			if _, ok := amrSet[amrKey]; !ok {
+				return fmt.Errorf("auth_class: ACR %q references unknown AMR key %q", acr, amrKey)
+			}
+		}
+	}
+
+	return nil
+}
+
 // Config holds the complete configuration details of the server.
 type Config struct {
 	Server               ServerConfig           `yaml:"server" json:"server"`
@@ -653,6 +694,11 @@ func LoadConfig(configPath string, defaultPath string, serverHome string) (*Conf
 		return nil, err
 	}
 	if err := cfg.CORS.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Validate ACR-AMR mapping.
+	if err := cfg.OAuth.AuthClass.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/system/config/config_test.go
+++ b/backend/internal/system/config/config_test.go
@@ -993,3 +993,99 @@ func (suite *ConfigTestSuite) createTempFile(dir, pattern, content string) strin
 
 	return tempFile.Name()
 }
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_EmptyConfig() {
+	cfg := AuthClassConfig{}
+	assert.NoError(suite.T(), cfg.Validate())
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_ValidMapping() {
+	cfg := AuthClassConfig{
+		Amrs: []string{"PWD", "OTP"},
+		AcrAMR: map[string][]string{
+			"urn:thunder:acr:password":       {"PWD"},
+			"urn:thunder:acr:generated-code": {"OTP"},
+			"urn:thunder:acr:multi":          {"PWD", "OTP"},
+		},
+	}
+	assert.NoError(suite.T(), cfg.Validate())
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_EmptyAMRList() {
+	cfg := AuthClassConfig{
+		Amrs: []string{"PWD"},
+		AcrAMR: map[string][]string{
+			"urn:thunder:acr:password": {"PWD"},
+			"urn:thunder:acr:empty":    {},
+		},
+	}
+	err := cfg.Validate()
+	suite.Require().Error(err)
+	assert.Contains(suite.T(), err.Error(), "urn:thunder:acr:empty")
+	assert.Contains(suite.T(), err.Error(), "empty AMR list")
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_UnknownAMRKey() {
+	cfg := AuthClassConfig{
+		Amrs: []string{"PWD"},
+		AcrAMR: map[string][]string{
+			"urn:thunder:acr:password": {"PWD"},
+			"urn:thunder:acr:otp":      {"NonExistentAMR"},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "NonExistentAMR")
+	assert.Contains(suite.T(), err.Error(), "unknown AMR key")
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_NoAMRSection() {
+	cfg := AuthClassConfig{
+		AcrAMR: map[string][]string{
+			"urn:thunder:acr:password": {"PWD"},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "unknown AMR key")
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_AcrAMREmptyButAMRPresent() {
+	cfg := AuthClassConfig{
+		Amrs: []string{"PWD"},
+	}
+	assert.NoError(suite.T(), cfg.Validate())
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_EmptyACRKey() {
+	cfg := AuthClassConfig{
+		Amrs: []string{"PWD"},
+		AcrAMR: map[string][]string{
+			"": {"PWD"},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "ACR value must not be empty")
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_EmptyAMREntry() {
+	cfg := AuthClassConfig{
+		Amrs: []string{"PWD", ""},
+	}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "AMR entry must not be empty")
+}
+
+func (suite *ConfigTestSuite) TestAuthClassValidate_EmptyAMRReference() {
+	cfg := AuthClassConfig{
+		Amrs: []string{"PWD"},
+		AcrAMR: map[string][]string{
+			"urn:thunder:acr:password": {"PWD", ""},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "references an empty AMR key")
+}

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -122,6 +122,8 @@ var defaultMessages = map[string]string{
 	"error.applicationservice.consent_synchronization_failed_description": "Failed to synchronize consent configurations for the application",
 	"error.applicationservice.error_retrieving_flow_definition": "Error retrieving flow definition",
 	"error.applicationservice.error_retrieving_flow_definition_description": "An error occurred while retrieving the flow definition",
+	"error.applicationservice.invalid_acr_values": "Invalid ACR value",
+	"error.applicationservice.invalid_acr_values_description": "One or more ACR values in acr_values are not recognized by the system",
 	"error.applicationservice.invalid_application_id": "Invalid application ID",
 	"error.applicationservice.invalid_application_id_description": "The provided application ID is invalid or empty",
 	"error.applicationservice.invalid_application_name": "Invalid application name",

--- a/backend/tests/mocks/flow/coremock/PromptNodeInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/PromptNodeInterface_mock.go
@@ -680,6 +680,50 @@ func (_c *PromptNodeInterfaceMock_GetType_Call) RunAndReturn(run func() common.N
 	return _c
 }
 
+// GetVariant provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) GetVariant() common.NodeVariant {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetVariant")
+	}
+
+	var r0 common.NodeVariant
+	if returnFunc, ok := ret.Get(0).(func() common.NodeVariant); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(common.NodeVariant)
+	}
+	return r0
+}
+
+// PromptNodeInterfaceMock_GetVariant_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVariant'
+type PromptNodeInterfaceMock_GetVariant_Call struct {
+	*mock.Call
+}
+
+// GetVariant is a helper method to define mock.On call
+func (_e *PromptNodeInterfaceMock_Expecter) GetVariant() *PromptNodeInterfaceMock_GetVariant_Call {
+	return &PromptNodeInterfaceMock_GetVariant_Call{Call: _e.mock.On("GetVariant")}
+}
+
+func (_c *PromptNodeInterfaceMock_GetVariant_Call) Run(run func()) *PromptNodeInterfaceMock_GetVariant_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetVariant_Call) Return(nodeVariant common.NodeVariant) *PromptNodeInterfaceMock_GetVariant_Call {
+	_c.Call.Return(nodeVariant)
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_GetVariant_Call) RunAndReturn(run func() common.NodeVariant) *PromptNodeInterfaceMock_GetVariant_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsDisplayOnly provides a mock function for the type PromptNodeInterfaceMock
 func (_mock *PromptNodeInterfaceMock) IsDisplayOnly() bool {
 	ret := _mock.Called()
@@ -1234,6 +1278,46 @@ func (_c *PromptNodeInterfaceMock_SetPrompts_Call) Return() *PromptNodeInterface
 }
 
 func (_c *PromptNodeInterfaceMock_SetPrompts_Call) RunAndReturn(run func(prompts []common.Prompt)) *PromptNodeInterfaceMock_SetPrompts_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetVariant provides a mock function for the type PromptNodeInterfaceMock
+func (_mock *PromptNodeInterfaceMock) SetVariant(variant common.NodeVariant) {
+	_mock.Called(variant)
+	return
+}
+
+// PromptNodeInterfaceMock_SetVariant_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetVariant'
+type PromptNodeInterfaceMock_SetVariant_Call struct {
+	*mock.Call
+}
+
+// SetVariant is a helper method to define mock.On call
+//   - variant common.NodeVariant
+func (_e *PromptNodeInterfaceMock_Expecter) SetVariant(variant interface{}) *PromptNodeInterfaceMock_SetVariant_Call {
+	return &PromptNodeInterfaceMock_SetVariant_Call{Call: _e.mock.On("SetVariant", variant)}
+}
+
+func (_c *PromptNodeInterfaceMock_SetVariant_Call) Run(run func(variant common.NodeVariant)) *PromptNodeInterfaceMock_SetVariant_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 common.NodeVariant
+		if args[0] != nil {
+			arg0 = args[0].(common.NodeVariant)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetVariant_Call) Return() *PromptNodeInterfaceMock_SetVariant_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *PromptNodeInterfaceMock_SetVariant_Call) RunAndReturn(run func(variant common.NodeVariant)) *PromptNodeInterfaceMock_SetVariant_Call {
 	_c.Run(run)
 	return _c
 }

--- a/tests/integration/application/acr_values_test.go
+++ b/tests/integration/application/acr_values_test.go
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package application
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+var acrValuesTestOU = testutils.OrganizationUnit{
+	Handle:      "test-acr-values-ou",
+	Name:        "Test Organization Unit for ACR Values",
+	Description: "Organization unit for ACR values application testing",
+	Parent:      nil,
+}
+
+var acrValuesTestOUID string
+
+type AcrValuesAPITestSuite struct {
+	suite.Suite
+}
+
+func TestAcrValuesAPITestSuite(t *testing.T) {
+	suite.Run(t, new(AcrValuesAPITestSuite))
+}
+
+func (ts *AcrValuesAPITestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(acrValuesTestOU)
+	ts.Require().NoError(err, "failed to create test organization unit")
+	acrValuesTestOUID = ouID
+
+	if defaultAuthFlowID == "" {
+		defaultAuthFlowID, err = testutils.GetFlowIDByHandle("default-basic-flow", "AUTHENTICATION")
+		ts.Require().NoError(err, "failed to get default auth flow ID")
+	}
+}
+
+func (ts *AcrValuesAPITestSuite) TearDownSuite() {
+	if acrValuesTestOUID != "" {
+		if err := testutils.DeleteOrganizationUnit(acrValuesTestOUID); err != nil {
+			ts.T().Logf("failed to delete test organization unit: %v", err)
+		}
+	}
+}
+
+func (ts *AcrValuesAPITestSuite) TestCreateApplicationWithValidAcrValues() {
+	app := Application{
+		Name:                      "ACR Values Test App",
+		Description:               "Application for testing acr_values",
+		IsRegistrationFlowEnabled: false,
+		OUID:                      acrValuesTestOUID,
+		AuthFlowID:                defaultAuthFlowID,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                "acr_values_test_client",
+					ClientSecret:            "acr_values_test_secret",
+					RedirectURIs:            []string{"http://localhost/acr_values_test/callback"},
+					GrantTypes:              []string{"authorization_code"},
+					ResponseTypes:           []string{"code"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					AcrValues: []string{
+						"urn:thunder:acr:password",
+						"urn:thunder:acr:generated-code",
+					},
+				},
+			},
+		},
+	}
+
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "failed to create application with acr_values")
+	defer func() {
+		if err := deleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application: %v", err)
+		}
+	}()
+
+	retrieved, err := getApplicationByID(appID)
+	ts.Require().NoError(err, "failed to retrieve application")
+	ts.Require().NotNil(retrieved.InboundAuthConfig)
+	ts.Require().Len(retrieved.InboundAuthConfig, 1)
+	ts.Require().NotNil(retrieved.InboundAuthConfig[0].OAuthAppConfig)
+
+	ts.Assert().ElementsMatch(
+		[]string{"urn:thunder:acr:password", "urn:thunder:acr:generated-code"},
+		retrieved.InboundAuthConfig[0].OAuthAppConfig.AcrValues,
+		"acr_values should be persisted and returned",
+	)
+}
+
+func (ts *AcrValuesAPITestSuite) TestCreateApplicationWithInvalidAcrValues() {
+	app := Application{
+		Name:                      "Invalid ACR App",
+		Description:               "Application with invalid acr_values",
+		IsRegistrationFlowEnabled: false,
+		OUID:                      acrValuesTestOUID,
+		AuthFlowID:                defaultAuthFlowID,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                "invalid_acr_client",
+					ClientSecret:            "invalid_acr_secret",
+					RedirectURIs:            []string{"http://localhost/invalid_acr/callback"},
+					GrantTypes:              []string{"authorization_code"},
+					ResponseTypes:           []string{"code"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					AcrValues:        []string{"urn:unknown:acr:value"},
+				},
+			},
+		},
+	}
+
+	appJSON, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	client := testutils.GetHTTPClient()
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/applications", bytes.NewReader(appJSON))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusBadRequest, resp.StatusCode,
+		"unrecognised ACR value should cause 400 Bad Request")
+}
+
+func (ts *AcrValuesAPITestSuite) TestUpdateApplicationAcrValues() {
+	app := Application{
+		Name:                      "ACR Update Test App",
+		Description:               "Application for testing acr_values update",
+		IsRegistrationFlowEnabled: false,
+		OUID:                      acrValuesTestOUID,
+		AuthFlowID:                defaultAuthFlowID,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                "acr_update_test_client",
+					ClientSecret:            "acr_update_test_secret",
+					RedirectURIs:            []string{"http://localhost/acr_update/callback"},
+					GrantTypes:              []string{"authorization_code"},
+					ResponseTypes:           []string{"code"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+				},
+			},
+		},
+	}
+
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "failed to create test application")
+	defer func() {
+		if err := deleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application: %v", err)
+		}
+	}()
+
+	updated := app
+	updated.InboundAuthConfig = []InboundAuthConfig{
+		{
+			Type: "oauth2",
+			OAuthAppConfig: &OAuthAppConfig{
+				ClientID:                "acr_update_test_client",
+				RedirectURIs:            []string{"http://localhost/acr_update/callback"},
+				GrantTypes:              []string{"authorization_code"},
+				ResponseTypes:           []string{"code"},
+				TokenEndpointAuthMethod: "client_secret_basic",
+				AcrValues:        []string{"urn:thunder:acr:biometrics"},
+			},
+		},
+	}
+
+	err = updateApplication(appID, updated)
+	ts.Require().NoError(err, "failed to update application")
+
+	retrieved, err := getApplicationByID(appID)
+	ts.Require().NoError(err, "failed to retrieve updated application")
+	ts.Require().NotNil(retrieved.InboundAuthConfig[0].OAuthAppConfig)
+
+	ts.Assert().Equal(
+		[]string{"urn:thunder:acr:biometrics"},
+		retrieved.InboundAuthConfig[0].OAuthAppConfig.AcrValues,
+		"acr_values should reflect the updated value",
+	)
+}
+
+func (ts *AcrValuesAPITestSuite) TestClearApplicationAcrValues() {
+	app := Application{
+		Name:                      "ACR Clear Test App",
+		Description:               "Application for testing clearing of acr_values",
+		IsRegistrationFlowEnabled: false,
+		OUID:                      acrValuesTestOUID,
+		AuthFlowID:                defaultAuthFlowID,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                "acr_clear_test_client",
+					ClientSecret:            "acr_clear_test_secret",
+					RedirectURIs:            []string{"http://localhost/acr_clear/callback"},
+					GrantTypes:              []string{"authorization_code"},
+					ResponseTypes:           []string{"code"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					AcrValues:        []string{"urn:thunder:acr:password"},
+				},
+			},
+		},
+	}
+
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "failed to create test application")
+	defer func() {
+		if err := deleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application: %v", err)
+		}
+	}()
+
+	cleared := app
+	cleared.InboundAuthConfig = []InboundAuthConfig{
+		{
+			Type: "oauth2",
+			OAuthAppConfig: &OAuthAppConfig{
+				ClientID:                "acr_clear_test_client",
+				RedirectURIs:            []string{"http://localhost/acr_clear/callback"},
+				GrantTypes:              []string{"authorization_code"},
+				ResponseTypes:           []string{"code"},
+				TokenEndpointAuthMethod: "client_secret_basic",
+			},
+		},
+	}
+
+	err = updateApplication(appID, cleared)
+	ts.Require().NoError(err, "failed to update application to clear acr_values")
+
+	retrieved, err := getApplicationByID(appID)
+	ts.Require().NoError(err, "failed to retrieve application after clearing")
+	ts.Require().NotNil(retrieved.InboundAuthConfig[0].OAuthAppConfig)
+
+	ts.Assert().Empty(retrieved.InboundAuthConfig[0].OAuthAppConfig.AcrValues,
+		"acr_values should be empty after clearing")
+}

--- a/tests/integration/application/model.go
+++ b/tests/integration/application/model.go
@@ -71,6 +71,7 @@ type OAuthAppConfig struct {
 	ScopeClaims             map[string][]string `json:"scopeClaims,omitempty"`
 	UserInfo                *UserInfoConfig     `json:"userInfo,omitempty"`
 	Certificate             *ApplicationCert    `json:"certificate,omitempty"`
+	AcrValues               []string            `json:"acrValues,omitempty"`
 }
 
 // OAuthTokenConfig represents the OAuth token configuration.
@@ -270,6 +271,10 @@ func (app *Application) equals(expectedApp Application) bool {
 				}
 
 				if oauth.PublicClient != expectedOAuth.PublicClient {
+					return false
+				}
+
+				if !compareStringSlices(oauth.AcrValues, expectedOAuth.AcrValues) {
 					return false
 				}
 

--- a/tests/integration/flow/authentication/acr_options_flow_test.go
+++ b/tests/integration/flow/authentication/acr_options_flow_test.go
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authentication
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/flow/common"
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+// acrOptionsFlow is a flow that contains a login_options PROMPT node followed by two
+// separate password-based authentication paths, each tagged to a distinct ACR value.
+//
+// Flow graph:
+//
+//	START → acr_chooser (login_options)
+//	  ├─ "pwd_action"  (acr: urn:thunder:acr:password)       → prompt_pwd  → basic_auth_pwd  → auth_assert → END
+//	  └─ "code_action" (acr: urn:thunder:acr:generated-code)  → prompt_code → basic_auth_code → auth_assert → END
+var acrOptionsFlow = testutils.Flow{
+	Name:     "ACR Options Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_acr_options_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "acr_chooser",
+		},
+		// login_options prompt node — the ACR chooser
+		{
+			"id":      "acr_chooser",
+			"type":    "PROMPT",
+			"variant": "LOGIN_OPTIONS",
+			"properties": map[string]interface{}{
+				"authMethodMapping": map[string]interface{}{
+					"urn:thunder:acr:password":       "pwd_action",
+					"urn:thunder:acr:generated-code": "code_action",
+					"urn:thunder:acr:biometrics":     "bio_action",
+				},
+			},
+			"prompts": []map[string]interface{}{
+				{
+					"action": map[string]interface{}{
+						"ref":      "pwd_action",
+						"nextNode": "prompt_pwd",
+					},
+				},
+				{
+					"action": map[string]interface{}{
+						"ref":      "code_action",
+						"nextNode": "prompt_code",
+					},
+				},
+				{
+					"action": map[string]interface{}{
+						"ref":      "bio_action",
+						"nextNode": "prompt_bio",
+					},
+				},
+			},
+		},
+		// Credentials prompt for the password ACR path
+		{
+			"id":   "prompt_pwd",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_u1",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_p1",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "submit_pwd",
+						"nextNode": "basic_auth_pwd",
+					},
+				},
+			},
+		},
+		// Credentials prompt for the generated-code (OTP-style password) ACR path.
+		// For simplicity in tests both paths use the BasicAuthExecutor.
+		{
+			"id":   "prompt_code",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_u2",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_p2",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "submit_code",
+						"nextNode": "basic_auth_code",
+					},
+				},
+			},
+		},
+		// Credentials prompt for the biometrics ACR path.
+		// For simplicity in tests this path also uses the BasicAuthExecutor.
+		{
+			"id":   "prompt_bio",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_u3",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_p3",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "submit_bio",
+						"nextNode": "basic_auth_bio",
+					},
+				},
+			},
+		},
+		{
+			"id":   "basic_auth_pwd",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "BasicAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_u1", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_p1", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess":    "auth_assert",
+			"onIncomplete": "prompt_pwd",
+		},
+		{
+			"id":   "basic_auth_code",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "BasicAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_u2", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_p2", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess":    "auth_assert",
+			"onIncomplete": "prompt_code",
+		},
+		{
+			"id":   "basic_auth_bio",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "BasicAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_u3", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_p3", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess":    "auth_assert",
+			"onIncomplete": "prompt_bio",
+		},
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	},
+}
+
+// acrOptionsTestApp is a minimal OAuth2 application used across ACR options tests.
+var acrOptionsTestApp = testutils.Application{
+	Name:                      "ACR Options Flow Test Application",
+	Description:               "Application for testing login_options flow behaviour",
+	IsRegistrationFlowEnabled: false,
+	ClientID:                  "acr_options_flow_test_client",
+	ClientSecret:              "acr_options_flow_test_secret",
+	RedirectURIs:              []string{"https://localhost:3000/acr-options-callback"},
+	AllowedUserTypes:          []string{"acr_options_test_person"},
+	InboundAuthConfig: []map[string]interface{}{
+		{
+			"type": "oauth2",
+			"config": map[string]interface{}{
+				"clientId":                "acr_options_flow_test_client",
+				"clientSecret":            "acr_options_flow_test_secret",
+				"redirectUris":            []string{"https://localhost:3000/acr-options-callback"},
+				"grantTypes":              []string{"authorization_code"},
+				"responseTypes":           []string{"code"},
+				"tokenEndpointAuthMethod": "client_secret_basic",
+				"acrValues": []string{
+					"urn:thunder:acr:password",
+					"urn:thunder:acr:generated-code",
+					"urn:thunder:acr:biometrics",
+				},
+			},
+		},
+	},
+}
+
+var acrOptionsTestOU = testutils.OrganizationUnit{
+	Handle:      "acr-options-flow-test-ou",
+	Name:        "ACR Options Flow Test Organization Unit",
+	Description: "Organization unit for ACR options flow testing",
+	Parent:      nil,
+}
+
+var acrOptionsUserType = testutils.UserType{
+	Name: "acr_options_test_person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{"type": "string"},
+		"password": map[string]interface{}{"type": "string", "credential": true},
+		"email":    map[string]interface{}{"type": "string"},
+	},
+}
+
+var acrOptionsTestUser = testutils.User{
+	Type: acrOptionsUserType.Name,
+	Attributes: json.RawMessage(`{
+		"username": "acroptionsuser",
+		"password": "testpassword",
+		"email": "acroptionsuser@example.com"
+	}`),
+}
+
+var (
+	acrOptionsTestAppID  string
+	acrOptionsTestOUID   string
+	acrOptionsFlowID     string
+	acrOptionsUserTypeID string
+)
+
+// AcrOptionsFlowTestSuite tests the login_options PROMPT node filtering, ordering,
+// auto-selection, AMR validation, and the ACR claim in the auth assertion JWT.
+type AcrOptionsFlowTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+}
+
+func TestAcrOptionsFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(AcrOptionsFlowTestSuite))
+}
+
+func (ts *AcrOptionsFlowTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(acrOptionsTestOU)
+	ts.Require().NoError(err, "failed to create OU for ACR options tests")
+	acrOptionsTestOUID = ouID
+
+	acrOptionsUserType.OUID = acrOptionsTestOUID
+	schemaID, err := testutils.CreateUserType(acrOptionsUserType)
+	ts.Require().NoError(err, "failed to create user schema for ACR options tests")
+	acrOptionsUserTypeID = schemaID
+
+	user := acrOptionsTestUser
+	user.OUID = acrOptionsTestOUID
+	userIDs, err := testutils.CreateMultipleUsers(user)
+	ts.Require().NoError(err, "failed to create test user for ACR options tests")
+	ts.config.CreatedUserIDs = userIDs
+
+	flowID, err := testutils.CreateFlow(acrOptionsFlow)
+	ts.Require().NoError(err, "failed to create ACR options flow")
+	acrOptionsFlowID = flowID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	acrOptionsTestApp.AuthFlowID = flowID
+	acrOptionsTestApp.OUID = acrOptionsTestOUID
+	appID, err := testutils.CreateApplication(acrOptionsTestApp)
+	ts.Require().NoError(err, "failed to create ACR options test application")
+	acrOptionsTestAppID = appID
+}
+
+func (ts *AcrOptionsFlowTestSuite) TearDownSuite() {
+	if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+		ts.T().Logf("failed to cleanup users: %v", err)
+	}
+	if acrOptionsTestAppID != "" {
+		if err := testutils.DeleteApplication(acrOptionsTestAppID); err != nil {
+			ts.T().Logf("failed to delete test application: %v", err)
+		}
+	}
+	for _, id := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(id); err != nil {
+			ts.T().Logf("failed to delete flow %s: %v", id, err)
+		}
+	}
+	if acrOptionsUserTypeID != "" {
+		if err := testutils.DeleteUserType(acrOptionsUserTypeID); err != nil {
+			ts.T().Logf("failed to delete user schema: %v", err)
+		}
+	}
+	if acrOptionsTestOUID != "" {
+		if err := testutils.DeleteOrganizationUnit(acrOptionsTestOUID); err != nil {
+			ts.T().Logf("failed to delete OU: %v", err)
+		}
+	}
+}
+
+func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_NodeValidInFlowGraph() {
+	flowStep, err := common.InitiateAuthenticationFlow(acrOptionsTestAppID, false, nil, "")
+	ts.Require().NoError(err, "flow initiation should succeed")
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().Equal("VIEW", flowStep.Type)
+	ts.Require().NotEmpty(flowStep.ExecutionID)
+
+	ts.Require().NotEmpty(flowStep.Data.Actions, "login_options node should return actions")
+	ts.Require().True(
+		common.HasAction(flowStep.Data.Actions, "pwd_action"),
+		"pwd_action should be present")
+	ts.Require().True(
+		common.HasAction(flowStep.Data.Actions, "code_action"),
+		"code_action should be present")
+}
+
+func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_FilteredToRequestedACR() {
+	authID, flowID, err := ts.initiateAuthorizeAndExtract("urn:thunder:acr:password urn:thunder:acr:biometrics")
+	ts.Require().NoError(err, "authorization initiation should succeed")
+	ts.Require().NotEmpty(authID)
+	ts.Require().NotEmpty(flowID)
+
+	flowStep, err := common.ResumeFlow(flowID)
+	ts.Require().NoError(err, "flow resumption should succeed")
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	actionRefs := ts.actionRefs(flowStep.Data.Actions)
+	ts.Require().Contains(actionRefs, "pwd_action", "pwd_action should be present")
+	ts.Require().Contains(actionRefs, "bio_action", "bio_action should be present")
+	ts.Require().NotContains(actionRefs, "code_action", "code_action should be filtered out")
+}
+
+func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_OrderedByPreference() {
+	authID, flowID, err := ts.initiateAuthorizeAndExtract("urn:thunder:acr:generated-code urn:thunder:acr:password")
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(authID)
+	ts.Require().NotEmpty(flowID)
+
+	flowStep, err := common.ResumeFlow(flowID)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().Len(flowStep.Data.Actions, 2, "both ACR actions should be present")
+
+	ts.Require().Equal("code_action", flowStep.Data.Actions[0].Ref,
+		"generated-code action should be first")
+	ts.Require().Equal("pwd_action", flowStep.Data.Actions[1].Ref,
+		"password action should be second")
+}
+
+func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_AutoSelectsWhenSingleACR() {
+	authID, flowID, err := ts.initiateAuthorizeAndExtract("urn:thunder:acr:password")
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(authID)
+	ts.Require().NotEmpty(flowID)
+
+	flowStep, err := common.ResumeFlow(flowID)
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	ts.Require().NotEmpty(flowStep.Data.Inputs, "credential inputs should be returned after auto-selection")
+	ts.Require().True(
+		common.HasInput(flowStep.Data.Inputs, "username"),
+		"username input should be returned for the password path")
+	ts.Require().True(
+		common.HasInput(flowStep.Data.Inputs, "password"),
+		"password input should be returned for the password path")
+	ts.Require().False(
+		common.HasAction(flowStep.Data.Actions, "pwd_action"),
+		"chooser action must not be present after auto-selection")
+	ts.Require().False(
+		common.HasAction(flowStep.Data.Actions, "code_action"),
+		"chooser action must not be present after auto-selection")
+	ts.Require().False(
+		common.HasAction(flowStep.Data.Actions, "bio_action"),
+		"chooser action must not be present after auto-selection")
+}
+
+func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_AcrInAuthAssertionJWT() {
+	// Step 1: Start the flow without acr filtering so the chooser is shown.
+	flowStep, err := common.InitiateAuthenticationFlow(acrOptionsTestAppID, false, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Data.Actions)
+
+	// Step 2: Select the password ACR action.
+	credStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "pwd_action", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", credStep.FlowStatus)
+	ts.Require().NotEmpty(credStep.Data.Inputs, "credential inputs should be requested")
+
+	// Step 3: Submit valid credentials.
+	var userAttrs map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(acrOptionsTestUser.Attributes, &userAttrs))
+	inputs := map[string]string{
+		"username": userAttrs["username"].(string),
+		"password": userAttrs["password"].(string),
+	}
+	completeStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "submit_pwd", credStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("COMPLETE", completeStep.FlowStatus, "flow should complete successfully")
+	ts.Require().NotEmpty(completeStep.Assertion, "auth assertion JWT must be present")
+
+	// Decode the assertion and verify the completed_auth_class claim is set.
+	jwtClaims, err := testutils.DecodeJWT(completeStep.Assertion)
+	ts.Require().NoError(err, "assertion JWT must be decodable")
+	ts.Require().NotNil(jwtClaims)
+
+	acrClaim, ok := jwtClaims.Additional["completed_auth_class"]
+	ts.Require().True(ok, "completed_auth_class claim must be present in the auth assertion JWT")
+	ts.Require().Equal("urn:thunder:acr:password", acrClaim,
+		"completed_auth_class claim must reflect the selected authentication class")
+}
+
+func (ts *AcrOptionsFlowTestSuite) actionRefs(actions []common.Action) []string {
+	refs := make([]string, len(actions))
+	for i, a := range actions {
+		refs[i] = a.Ref
+	}
+	return refs
+}
+
+// initiateAuthorizeAndExtract sends GET /oauth2/authorize with the given acr_values and
+// returns the authID and flowID extracted from the redirect location.
+func (ts *AcrOptionsFlowTestSuite) initiateAuthorizeAndExtract(acrValues string) (string, string, error) {
+	params := url.Values{}
+	params.Set("client_id", "acr_options_flow_test_client")
+	params.Set("redirect_uri", "https://localhost:3000/acr-options-callback")
+	params.Set("response_type", "code")
+	params.Set("scope", "openid")
+	params.Set("state", "acr_state")
+	if acrValues != "" {
+		params.Set("acr_values", acrValues)
+	}
+
+	resp, err := testutils.GetNoRedirectHTTPClient().Get(testutils.TestServerURL + "/oauth2/authorize?" + params.Encode())
+	if err != nil {
+		return "", "", fmt.Errorf("authorize request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", "", fmt.Errorf("no Location header in authorize response (status %d)", resp.StatusCode)
+	}
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to extract auth data from location %q: %w", location, err)
+	}
+	return authID, flowID, nil
+}

--- a/tests/integration/flow/common/utils.go
+++ b/tests/integration/flow/common/utils.go
@@ -139,6 +139,11 @@ func InitiateAuthFlowWithError(appID string, inputs map[string]string) (*ErrorRe
 	return &errorResponse, nil
 }
 
+// ResumeFlow resumes a flow without new inputs or an action selection.
+func ResumeFlow(flowID string) (*FlowStep, error) {
+	return CompleteFlow(flowID, map[string]string{}, "", "")
+}
+
 // CompleteFlow completes the flow with given inputs, action and challenge token
 func CompleteFlow(executionId string, inputs map[string]string, action string, challengeToken string) (
 	*FlowStep, error) {

--- a/tests/integration/oauth/authz/acr_id_token_test.go
+++ b/tests/integration/oauth/authz/acr_id_token_test.go
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authz
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	acrE2EClientID     = "acr_e2e_test_client"
+	acrE2EClientSecret = "acr_e2e_test_secret"
+	acrE2ERedirectURI  = "https://localhost:3000/acr-e2e-callback"
+)
+
+var acrE2EFlow = testutils.Flow{
+	Name:     "ACR E2E ID Token Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_acr_e2e_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "acr_chooser",
+		},
+		{
+			"id":      "acr_chooser",
+			"type":    "PROMPT",
+			"variant": "LOGIN_OPTIONS",
+			"properties": map[string]interface{}{
+				"authMethodMapping": map[string]interface{}{
+					"urn:thunder:acr:password":       "pwd_action",
+					"urn:thunder:acr:generated-code": "code_action",
+				},
+			},
+			"prompts": []map[string]interface{}{
+				{
+					"action": map[string]interface{}{
+						"ref":      "pwd_action",
+						"nextNode": "prompt_pwd",
+					},
+				},
+				{
+					"action": map[string]interface{}{
+						"ref":      "code_action",
+						"nextNode": "prompt_code",
+					},
+				},
+			},
+		},
+		{
+			"id":   "prompt_pwd",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_u1", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_p1", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{
+						"ref":      "submit_pwd",
+						"nextNode": "basic_auth_pwd",
+					},
+				},
+			},
+		},
+		{
+			"id":   "prompt_code",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_u2", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_p2", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{
+						"ref":      "submit_code",
+						"nextNode": "basic_auth_code",
+					},
+				},
+			},
+		},
+		{
+			"id":   "basic_auth_pwd",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "BasicAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_u1", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_p1", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess":    "auth_assert",
+			"onIncomplete": "prompt_pwd",
+		},
+		{
+			"id":   "basic_auth_code",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "BasicAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_u2", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_p2", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess":    "auth_assert",
+			"onIncomplete": "prompt_code",
+		},
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	},
+}
+
+var acrE2ETestOU = testutils.OrganizationUnit{
+	Handle:      "acr-e2e-test-ou",
+	Name:        "ACR E2E Test Organization Unit",
+	Description: "Organization unit for ACR E2E ID token testing",
+	Parent:      nil,
+}
+
+var acrE2EUserSchema = testutils.UserType{
+	Name: "acr_e2e_test_person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{"type": "string"},
+		"password": map[string]interface{}{"type": "string", "credential": true},
+		"email":    map[string]interface{}{"type": "string"},
+	},
+}
+
+var acrE2ETestUser = testutils.User{
+	Type: acrE2EUserSchema.Name,
+	Attributes: json.RawMessage(`{
+		"username": "acre2euser",
+		"password": "testpassword",
+		"email": "acre2euser@example.com"
+	}`),
+}
+
+type AcrIDTokenTestSuite struct {
+	suite.Suite
+	client        *http.Client
+	applicationID string
+	authFlowID    string
+	ouID          string
+	userSchemaID  string
+	userIDs       []string
+}
+
+func TestAcrIDTokenTestSuite(t *testing.T) {
+	suite.Run(t, new(AcrIDTokenTestSuite))
+}
+
+func (ts *AcrIDTokenTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(acrE2ETestOU)
+	ts.Require().NoError(err, "failed to create OU")
+	ts.ouID = ouID
+
+	schema := acrE2EUserSchema
+	schema.OUID = ts.ouID
+	schemaID, err := testutils.CreateUserType(schema)
+	ts.Require().NoError(err, "failed to create user schema")
+	ts.userSchemaID = schemaID
+
+	user := acrE2ETestUser
+	user.OUID = ts.ouID
+	userIDs, err := testutils.CreateMultipleUsers(user)
+	ts.Require().NoError(err, "failed to create test user")
+	ts.userIDs = userIDs
+
+	flowID, err := testutils.CreateFlow(acrE2EFlow)
+	ts.Require().NoError(err, "failed to create ACR E2E flow")
+	ts.authFlowID = flowID
+
+	app := testutils.Application{
+		Name:                      "ACR E2E ID Token Test App",
+		Description:               "Application for ACR E2E ID token tests",
+		IsRegistrationFlowEnabled: false,
+		OUID:                      ts.ouID,
+		AuthFlowID:                ts.authFlowID,
+		ClientID:                  acrE2EClientID,
+		ClientSecret:              acrE2EClientSecret,
+		RedirectURIs:              []string{acrE2ERedirectURI},
+		AllowedUserTypes:          []string{acrE2EUserSchema.Name},
+		InboundAuthConfig: []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                acrE2EClientID,
+					"clientSecret":            acrE2EClientSecret,
+					"redirectUris":            []string{acrE2ERedirectURI},
+					"grantTypes":              []string{"authorization_code"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"acrValues": []string{
+						"urn:thunder:acr:password",
+						"urn:thunder:acr:generated-code",
+					},
+				},
+			},
+		},
+	}
+
+	appID, err := testutils.CreateApplication(app)
+	ts.Require().NoError(err, "failed to create ACR E2E test application")
+	ts.applicationID = appID
+}
+
+func (ts *AcrIDTokenTestSuite) TearDownSuite() {
+	if err := testutils.CleanupUsers(ts.userIDs); err != nil {
+		ts.T().Logf("failed to cleanup users: %v", err)
+	}
+	if ts.applicationID != "" {
+		if err := testutils.DeleteApplication(ts.applicationID); err != nil {
+			ts.T().Logf("failed to delete application: %v", err)
+		}
+	}
+	if ts.authFlowID != "" {
+		if err := testutils.DeleteFlow(ts.authFlowID); err != nil {
+			ts.T().Logf("failed to delete flow: %v", err)
+		}
+	}
+	if ts.userSchemaID != "" {
+		if err := testutils.DeleteUserType(ts.userSchemaID); err != nil {
+			ts.T().Logf("failed to delete user schema: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("failed to delete OU: %v", err)
+		}
+	}
+}
+
+// TestAcrClaimInIDToken runs the full authorization_code flow and asserts the acr claim.
+func (ts *AcrIDTokenTestSuite) TestAcrClaimInIDToken() {
+	resp, err := ts.initiateAuthorize("urn:thunder:acr:password")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(authID)
+	ts.Require().NotEmpty(flowID)
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	flowStep, err = testutils.ExecuteAuthenticationFlow(flowID, map[string]string{
+		"username": "acre2euser",
+		"password": "testpassword",
+	}, "submit_pwd", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "flow should complete after valid credentials")
+	ts.Require().NotEmpty(flowStep.Assertion, "assertion must be present")
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(authzResp.RedirectURI)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err, "authorization code must be in the redirect")
+	ts.Require().NotEmpty(code)
+
+	tokenResult, err := testutils.RequestToken(
+		acrE2EClientID, acrE2EClientSecret, code, acrE2ERedirectURI, "authorization_code")
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, "token exchange should succeed")
+	ts.Require().NotNil(tokenResult.Token)
+	ts.Require().NotEmpty(tokenResult.Token.IDToken, "ID token must be present in token response")
+
+	idTokenClaims, err := testutils.DecodeJWT(tokenResult.Token.IDToken)
+	ts.Require().NoError(err, "ID token must be decodable")
+	ts.Require().NotNil(idTokenClaims)
+
+	acrClaim, ok := idTokenClaims.Additional["acr"]
+	ts.Require().True(ok, "acr claim must be present in the ID token")
+	ts.Require().Equal("urn:thunder:acr:password", acrClaim,
+		"acr claim in ID token must reflect the ACR the user satisfied")
+}
+
+// TestAcrClaimInIDToken_WithManualSelection runs the flow with user-selected ACR.
+func (ts *AcrIDTokenTestSuite) TestAcrClaimInIDToken_WithManualSelection() {
+	resp, err := ts.initiateAuthorize("urn:thunder:acr:generated-code urn:thunder:acr:password")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err)
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	flowStep, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "pwd_action", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	flowStep, err = testutils.ExecuteAuthenticationFlow(flowID, map[string]string{
+		"username": "acre2euser",
+		"password": "testpassword",
+	}, "submit_pwd", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Assertion)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+
+	tokenResult, err := testutils.RequestToken(
+		acrE2EClientID, acrE2EClientSecret, code, acrE2ERedirectURI, "authorization_code")
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode)
+	ts.Require().NotNil(tokenResult.Token)
+	ts.Require().NotEmpty(tokenResult.Token.IDToken)
+
+	idTokenClaims, err := testutils.DecodeJWT(tokenResult.Token.IDToken)
+	ts.Require().NoError(err)
+
+	acrClaim, ok := idTokenClaims.Additional["acr"]
+	ts.Require().True(ok, "acr claim must be present in the ID token")
+	ts.Require().Equal("urn:thunder:acr:password", acrClaim,
+		"acr claim must reflect the manually selected authentication class")
+}
+
+// TestAcrClaimPresentWithAcrValues verifies the fallback to app-configured acrValues
+// when the request omits acr_values.
+func (ts *AcrIDTokenTestSuite) TestAcrClaimPresentWithAcrValues() {
+	resp, err := ts.initiateAuthorize("")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err)
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+
+	flowStep, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "pwd_action", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	flowStep, err = testutils.ExecuteAuthenticationFlow(flowID, map[string]string{
+		"username": "acre2euser",
+		"password": "testpassword",
+	}, "submit_pwd", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Assertion)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+
+	tokenResult, err := testutils.RequestToken(
+		acrE2EClientID, acrE2EClientSecret, code, acrE2ERedirectURI, "authorization_code")
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode)
+	ts.Require().NotNil(tokenResult.Token)
+	ts.Require().NotEmpty(tokenResult.Token.IDToken)
+
+	idTokenClaims, err := testutils.DecodeJWT(tokenResult.Token.IDToken)
+	ts.Require().NoError(err)
+
+	acrClaim, ok := idTokenClaims.Additional["acr"]
+	ts.Require().True(ok, "acr claim must be present when acrValues are configured")
+	ts.Require().Equal("urn:thunder:acr:password", acrClaim,
+		"acr claim should reflect the selected authentication class")
+}
+
+// initiateAuthorize sends GET /oauth2/authorize with the given acr_values parameter.
+func (ts *AcrIDTokenTestSuite) initiateAuthorize(acrValues string) (*http.Response, error) {
+	params := url.Values{}
+	params.Set("client_id", acrE2EClientID)
+	params.Set("redirect_uri", acrE2ERedirectURI)
+	params.Set("response_type", "code")
+	params.Set("scope", "openid")
+	params.Set("state", "acr_e2e_state")
+	if acrValues != "" {
+		params.Set("acr_values", acrValues)
+	}
+
+	req, err := http.NewRequest(http.MethodGet,
+		testutils.TestServerURL+"/oauth2/authorize?"+params.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return testutils.GetNoRedirectHTTPClient().Do(req)
+}

--- a/tests/integration/oauth/authz/acr_values_test.go
+++ b/tests/integration/oauth/authz/acr_values_test.go
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authz
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/asgardeo/thunder/tests/integration/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	acrClientID     = "acr_authz_test_client"
+	acrClientSecret = "acr_authz_test_secret"
+	acrAppName      = "ACRAuthzTestApp"
+	acrRedirectURI  = "https://localhost:3000/acr-callback"
+)
+
+var acrValuesAuthzTestOU = testutils.OrganizationUnit{
+	Handle:      "acr-values-authz-test-ou",
+	Name:        "ACR Values Authorization Test Organization Unit",
+	Description: "Organization unit for ACR values authorization testing",
+	Parent:      nil,
+}
+
+var acrValuesAuthzFlow = testutils.Flow{
+	Name:     "ACR Values Authorization Test Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_acr_values_authz_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "basic_auth"},
+				},
+			},
+		},
+		{
+			"id":   "basic_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "BasicAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	},
+}
+
+// AcrValuesAuthzTestSuite tests acr_values behaviour in the authorization endpoint.
+type AcrValuesAuthzTestSuite struct {
+	suite.Suite
+	client        *http.Client
+	applicationID string
+	authFlowID    string
+	ouID          string
+}
+
+func TestAcrValuesAuthzTestSuite(t *testing.T) {
+	suite.Run(t, new(AcrValuesAuthzTestSuite))
+}
+
+func (ts *AcrValuesAuthzTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(acrValuesAuthzTestOU)
+	ts.Require().NoError(err, "failed to create test organization unit")
+	ts.ouID = ouID
+
+	flowID, err := testutils.CreateFlow(acrValuesAuthzFlow)
+	ts.Require().NoError(err, "failed to create auth flow for ACR values test")
+	ts.authFlowID = flowID
+
+	app := map[string]interface{}{
+		"name":                      acrAppName,
+		"description":               "Application for acr_values authorization integration tests",
+		"ouId":                      ts.ouID,
+		"authFlowId":                ts.authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":     acrClientID,
+					"clientSecret": acrClientSecret,
+					"redirectUris": []string{acrRedirectURI},
+					"grantTypes":   []string{"authorization_code"},
+					"responseTypes": []string{
+						"code",
+					},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"acrValues": []string{
+						"urn:thunder:acr:password",
+						"urn:thunder:acr:generated-code",
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		ts.T().Fatalf("failed to create ACR test application: status=%d body=%s", resp.StatusCode, body)
+	}
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&respData))
+	ts.applicationID = respData["id"].(string)
+}
+
+func (ts *AcrValuesAuthzTestSuite) TearDownSuite() {
+	if ts.applicationID != "" {
+		req, err := http.NewRequest(http.MethodDelete,
+			fmt.Sprintf("%s/applications/%s", testutils.TestServerURL, ts.applicationID), nil)
+		if err != nil {
+			ts.T().Logf("failed to build delete request: %v", err)
+			return
+		}
+		resp, err := ts.client.Do(req)
+		if err != nil {
+			ts.T().Logf("failed to delete ACR test application: %v", err)
+			return
+		}
+		resp.Body.Close()
+	}
+
+	if ts.authFlowID != "" {
+		if err := testutils.DeleteFlow(ts.authFlowID); err != nil {
+			ts.T().Logf("failed to delete ACR test auth flow: %v", err)
+		}
+	}
+
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("failed to delete test organization unit: %v", err)
+		}
+	}
+}
+
+// initiateAuthorizeWithAcrValues sends a GET /oauth2/authorize request with acr_values.
+func (ts *AcrValuesAuthzTestSuite) initiateAuthorizeWithAcrValues(acrValues string) *http.Response {
+	params := url.Values{}
+	params.Set("client_id", acrClientID)
+	params.Set("redirect_uri", acrRedirectURI)
+	params.Set("response_type", "code")
+	params.Set("scope", "openid")
+	params.Set("state", "acr_test_state")
+	if acrValues != "" {
+		params.Set("acr_values", acrValues)
+	}
+
+	req, err := http.NewRequest(http.MethodGet,
+		testutils.TestServerURL+"/oauth2/authorize?"+params.Encode(), nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetNoRedirectHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	return resp
+}
+
+// TestAcrValues_WithMatchingValues verifies that an acr_values param whose values are all
+// present in the app's acr_values list results in a valid authorization redirect.
+func (ts *AcrValuesAuthzTestSuite) TestAcrValues_WithMatchingValues() {
+	resp := ts.initiateAuthorizeWithAcrValues("urn:thunder:acr:password")
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	ts.Assert().NotEmpty(location, "expected redirect to login page")
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	ts.Assert().NoError(err, "expected valid flow redirect for matching acr_values")
+	ts.Assert().NotEmpty(authID)
+	ts.Assert().NotEmpty(flowID)
+}
+
+// TestAcrValues_WithNoDefaults_PassThrough verifies that when no acr_values are requested
+// the authorization request succeeds for an app with acr_values configured.
+func (ts *AcrValuesAuthzTestSuite) TestAcrValues_WithNoDefaults_PassThrough() {
+	resp := ts.initiateAuthorizeWithAcrValues("")
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	ts.Assert().NotEmpty(location)
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	ts.Assert().NoError(err, "expected valid flow redirect")
+	ts.Assert().NotEmpty(authID)
+	ts.Assert().NotEmpty(flowID)
+}
+
+// TestAcrValues_WithNoneInDefaults_FallsBackToDefaults verifies that when none of the
+// requested acr_values match the app's acr_values list, the authorization
+// request still succeeds (falls back to all defaults).
+func (ts *AcrValuesAuthzTestSuite) TestAcrValues_WithNoneInDefaults_FallsBackToDefaults() {
+	// "urn:thunder:acr:biometrics" is not in the app's acr_values list.
+	resp := ts.initiateAuthorizeWithAcrValues("urn:thunder:acr:biometrics")
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	ts.Assert().NotEmpty(location)
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	ts.Assert().NoError(err, "expected valid flow redirect even when requested ACR not in defaults")
+	ts.Assert().NotEmpty(authID)
+	ts.Assert().NotEmpty(flowID)
+}
+
+// TestAcrValues_PartialMatchWithDefaults verifies that when only some of the requested
+// acr_values are in the app's acr_values list, the authorization succeeds.
+func (ts *AcrValuesAuthzTestSuite) TestAcrValues_PartialMatchWithDefaults() {
+	// "urn:thunder:acr:password" is in the list; "urn:thunder:acr:biometrics" is not.
+	resp := ts.initiateAuthorizeWithAcrValues("urn:thunder:acr:password urn:thunder:acr:biometrics")
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	ts.Assert().NotEmpty(location)
+
+	authID, flowID, err := testutils.ExtractAuthData(location)
+	ts.Assert().NoError(err, "expected valid flow redirect for partial ACR match")
+	ts.Assert().NotEmpty(authID)
+	ts.Assert().NotEmpty(flowID)
+}

--- a/tests/integration/oauth/discovery/discovery_test.go
+++ b/tests/integration/oauth/discovery/discovery_test.go
@@ -58,6 +58,7 @@ type OIDCProviderMetadata struct {
 	SubjectTypesSupported            []string `json:"subject_types_supported"`
 	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 	ClaimsSupported                  []string `json:"claims_supported"`
+	AcrValuesSupported               []string `json:"acr_values_supported,omitempty"`
 	EndSessionEndpoint               string   `json:"end_session_endpoint,omitempty"`
 }
 
@@ -206,6 +207,29 @@ func (ts *DiscoveryTestSuite) TestOIDCDiscovery_GET_Success() {
 	// Verify RFC 9207 issuer identification support
 	ts.True(metadata.AuthorizationResponseIssParameterSupported,
 		"authorization_response_iss_parameter_supported must be true (RFC 9207)")
+}
+
+func (ts *DiscoveryTestSuite) TestOIDCDiscovery_AcrValuesSupported() {
+	req, err := http.NewRequest("GET", testServerURL+oidcDiscoveryEndpoint, nil)
+	ts.Require().NoError(err)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode)
+
+	var metadata OIDCProviderMetadata
+	err = json.NewDecoder(resp.Body).Decode(&metadata)
+	ts.Require().NoError(err)
+
+	expectedACRs := []string{
+		"urn:thunder:acr:password",
+		"urn:thunder:acr:generated-code",
+		"urn:thunder:acr:biometrics",
+	}
+	ts.ElementsMatch(expectedACRs, metadata.AcrValuesSupported,
+		"acr_values_supported must contain exactly the ACR values from the ACR-AMR config")
 }
 
 // TestOIDCDiscovery_OPTIONS_Success tests OPTIONS request for CORS

--- a/tests/integration/resources/deployment.yaml
+++ b/tests/integration/resources/deployment.yaml
@@ -36,3 +36,15 @@ consent:
 
 oauth:
   allow_wildcard_redirect_uri: true
+  auth_class:
+    amrs:
+      - PWD
+      - OTP
+      - BIO
+    acr_amr:
+      "urn:thunder:acr:password":
+        - PWD
+      "urn:thunder:acr:generated-code":
+        - OTP
+      "urn:thunder:acr:biometrics":
+        - BIO

--- a/tests/integration/resources/scripts/setup-test-config.ps1
+++ b/tests/integration/resources/scripts/setup-test-config.ps1
@@ -120,6 +120,21 @@ $footer = @"
 
 flow:
   max_version_history: 3
+
+oauth:
+  allow_wildcard_redirect_uri: true
+  auth_class:
+    amrs:
+      - PWD
+      - OTP
+      - BIO
+    acr_amr:
+      "urn:thunder:acr:password":
+        - PWD
+      "urn:thunder:acr:generated-code":
+        - OTP
+      "urn:thunder:acr:biometrics":
+        - BIO
 "@
 
 $content = $header + "`n" + $dbConfig + $footer

--- a/tests/integration/resources/scripts/setup-test-config.sh
+++ b/tests/integration/resources/scripts/setup-test-config.sh
@@ -98,4 +98,16 @@ flow:
 
 oauth:
   allow_wildcard_redirect_uri: true
+  auth_class:
+    amrs:
+      - PWD
+      - OTP
+      - BIO
+    acr_amr:
+      "urn:thunder:acr:password":
+        - PWD
+      "urn:thunder:acr:generated-code":
+        - OTP
+      "urn:thunder:acr:biometrics":
+        - BIO
 EOF

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 const (
@@ -35,6 +36,19 @@ const (
 // GetHTTPClient returns a configured HTTP client for test requests with automatic auth injection
 func GetHTTPClient() *http.Client {
 	return NewHTTPClientWithTokenProvider(GetAccessToken)
+}
+
+// GetNoRedirectHTTPClient returns an HTTP client that does not follow redirects.
+func GetNoRedirectHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: 30 * time.Second,
+	}
 }
 
 // CreateUserType creates a user type via API and returns the schema ID
@@ -276,15 +290,9 @@ func CreateApplication(app Application) (string, error) {
 		redirectURIs = []string{"http://localhost:8080/callback"}
 	}
 
-	// Convert Application to the format expected by the application API
-	appData := map[string]interface{}{
-		"name":                      app.Name,
-		"description":               app.Description,
-		"ouId":                      app.OUID,
-		"isRegistrationFlowEnabled": app.IsRegistrationFlowEnabled,
-		"authFlowId":                app.AuthFlowID,
-		"registrationFlowId":        app.RegistrationFlowID,
-		"inboundAuthConfig": []map[string]interface{}{
+	inboundAuthConfig := app.InboundAuthConfig
+	if len(inboundAuthConfig) == 0 {
+		inboundAuthConfig = []map[string]interface{}{
 			{
 				"type": "oauth2",
 				"config": map[string]interface{}{
@@ -293,7 +301,17 @@ func CreateApplication(app Application) (string, error) {
 					"redirectUris": redirectURIs,
 				},
 			},
-		},
+		}
+	}
+
+	appData := map[string]interface{}{
+		"name":                      app.Name,
+		"description":               app.Description,
+		"ouId":                      app.OUID,
+		"isRegistrationFlowEnabled": app.IsRegistrationFlowEnabled,
+		"authFlowId":                app.AuthFlowID,
+		"registrationFlowId":        app.RegistrationFlowID,
+		"inboundAuthConfig":         inboundAuthConfig,
 	}
 
 	// Add allowed_user_types if provided

--- a/tests/integration/testutils/test_utils.go
+++ b/tests/integration/testutils/test_utils.go
@@ -878,6 +878,25 @@ func PatchDeploymentConfig(patch map[string]interface{}) error {
 	return nil
 }
 
+// ReadDeploymentConfigKey returns a top-level key from the deployment.yaml, or nil if missing.
+func ReadDeploymentConfigKey(key string) (interface{}, error) {
+	ensureInitialized()
+
+	configPath := filepath.Join(extractedProductHome, "repository", "conf", "deployment.yaml")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read deployment.yaml: %w", err)
+	}
+
+	var cfg map[string]interface{}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse deployment.yaml: %w", err)
+	}
+
+	return cfg[key], nil
+}
+
 // RunSetupScript runs the setup script from the extracted product directory.
 // This script starts the server without security, runs bootstrap scripts, and stops the server.
 func RunSetupScript() error {


### PR DESCRIPTION
### Purpose
ACR values support for Thunder.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Thunder currently ignores the acr_values OIDC parameter entirely. This feature adds full support for it, letting relying parties specify required authentication assurance levels (e.g., OTP-only vs. password-only).
The work covers eight areas: ACR-AMR mapping in server config, per-application ACR allowlists at registration, parsing and validating acr_values on the authorize endpoint, a new acr_options flow node variant for declarative ACR selection, filtering/reordering/auto-skipping that node at execution time, AMR validation in the auth executor to prevent method substitution attacks, including the acr claim in issued ID tokens, and publishing acr_values_supported in the OIDC discovery document.

### Related Issues
- [ISSUE 2102](https://github.com/asgardeo/thunder/issues/2102)

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Authentication Class Reference (ACR) values support for OAuth2 applications.
  * Introduced login options prompt allowing users to select authentication methods during authorization.
  * ACR claim now included in OpenID Connect ID tokens.
  * OIDC discovery endpoint now exposes supported ACR values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->