### PR TITLE
Skip integration and E2E tests for docs-only PRs

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -467,10 +467,28 @@ jobs:
           name: sample-app-react-sdk
           path: target/dist/sample-app-react-sdk-*.zip
 
+  detect-docs-changes:
+    name: 🔍 Detect Docs-Only Changes
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: filter
+        with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
+          filters: |
+            docs:
+              - 'docs/**'
+              - '*.md'
+
   test-integration:
     name: 🧪 Integration Tests (${{ matrix.database }})
-    needs: build
-    if: ${{ always() && needs.build.result == 'success' }}
+    needs: [build, detect-docs-changes]
+    if: ${{ always() && needs.build.result == 'success' && !(contains(github.event.pull_request.labels.*.name, 'Type/Docs') && needs.detect-docs-changes.outputs.docs-only == 'true') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -559,8 +577,8 @@ jobs:
 
   test-e2e:
     name: 🎭 Playwright E2E Tests
-    needs: [build, build_samples]
-    if: ${{ always() && needs.build.result == 'success' && needs.build_samples.result == 'success' }}
+    needs: [build, build_samples, detect-docs-changes]
+    if: ${{ always() && needs.build.result == 'success' && needs.build_samples.result == 'success' && !(contains(github.event.pull_request.labels.*.name, 'Type/Docs') && needs.detect-docs-changes.outputs.docs-only == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -28,6 +28,7 @@ jobs:
                 'Type/Improvement',
                 'Type/Bug',
                 'Type/Task',
+                'Type/Docs',
                 'skip-changelog'
             ];
 


### PR DESCRIPTION
## Purpose
PRs labelled `Type/Docs` currently trigger the full integration and E2E test suites despite touching only documentation. This change skips those expensive jobs for docs-only PRs to save CI resources.

## Related Issue
Fixes #2205 and https://github.com/asgardeo/thunder/issues/1256

## Implementation
- Added `!contains(github.event.pull_request.labels.*.name, 'Type/Docs')` to the `if` conditions of the `test-integration` and `test-e2e` jobs in `.github/workflows/pr-builder.yml`.
- Added `Type/Docs` to the list of recognised labels in `.github/workflows/pr-label-check.yml` so the label check passes when that label is applied to a PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to skip integration and end-to-end tests for documentation-only pull requests by adding a docs-change detection job and gating test jobs accordingly.
  * Pull request label checks expanded to recognize the "Type/Docs" label as satisfying required-label rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->