### PR TITLE
Rename flowID in flow execution to executionId

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -54,3 +54,4 @@ VSCode
 PascalCase
 Rolldown
 [Rr]edirect-?[Uu][Rr][Ii]s
+[Ee]xecution[Ii][Dd]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,11 +50,11 @@ Authentication/registration are JSON node graphs (`START → PROMPT → TASK →
 ### (Mode 1)
 
 ```text
-Client → GET /oauth2/authorize → 302 /gate?flowId=…
+Client → GET /oauth2/authorize → 302 /gate?executionId=…
 Gate SPA → POST /flow/execute (loop) → 302 redirect_uri?code=…
 Client → POST /oauth2/token → { access_token, id_token }
 ```
 
 ### Mode 2
 
-Client posts directly to `POST /flow/execute` with `applicationId` (first call) then `flowId` until `status: COMPLETE`.
+Client posts directly to `POST /flow/execute` with `applicationId` (first call) then `executionId` until `status: COMPLETE`.

--- a/README.md
+++ b/README.md
@@ -231,20 +231,20 @@ To access the system APIs of Thunder, you need a token with system permissions. 
 curl -k -X POST 'https://localhost:8090/flow/execute' \
   -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}'
 ```
-2. Extract the `flowId` value from the response.
+2. Extract the `executionId` value from the response.
 ```json
-{"flowId":"<flow_id>","flowStatus":"INCOMPLETE", ...}
+{"executionId":"<execution_id>","flowStatus":"INCOMPLETE", ...}
 ```
 
-3. Run the following command, replacing `<flow_id>` with the `flowId` value you extracted above.
+3. Run the following command, replacing `<execution_id>` with the `executionId` value you extracted above.
 ```bash
 curl -k -X POST 'https://localhost:8090/flow/execute' \
-  -d '{"flowId":"<flow_id>", "inputs":{"username":"admin","password":"admin", "requested_permissions":"system"},"action": "action_001"}'
+  -d '{"executionId":"<execution_id>", "inputs":{"username":"admin","password":"admin", "requested_permissions":"system"},"action": "action_001"}'
 ```
 
 4. Obtain the system API token by extracting the `assertion` value from the response.
 ```json
-{"flowId":"<flow_id>","flowStatus":"COMPLETE","data":{},"assertion":"<assertion>"}
+{"executionId":"<execution_id>","flowStatus":"COMPLETE","data":{},"assertion":"<assertion>"}
 ```
 
 #### Try Out Client Credentials Flow

--- a/api/flow-execution.yaml
+++ b/api/flow-execution.yaml
@@ -40,7 +40,7 @@ paths:
               subSequentRequestExample:
                 summary: Subsequent request
                 value:
-                  flowId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+                  executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
                   actionId: "basic_auth"
                   inputs: {
                     "username": "thor",
@@ -60,7 +60,7 @@ paths:
                 incompleteFlow:
                   summary: Incomplete flow (prompt for user input)
                   value:
-                    flowId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+                    executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
                     flowStatus: "PROMPT_ONLY"
                     stepId: "3071b6c6-0119-465c-b00b-3a0e6f88a730"
                     type: "VIEW"
@@ -88,7 +88,7 @@ paths:
                 displayOnlyFlow:
                   summary: Incomplete flow (display-only prompt)
                   value:
-                    flowId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+                    executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
                     flowStatus: "INCOMPLETE"
                     stepId: "3071b6c6-0119-465c-b00b-3a0e6f88a730"
                     type: "VIEW"
@@ -109,13 +109,13 @@ paths:
                 completeFlow:
                   summary: Complete flow
                   value:
-                    flowId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+                    executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
                     flowStatus: "COMPLETE"
                     assertion: "<jwt_token>"
                 errorFlow:
                   summary: Erroneous flow
                   value:
-                    flowId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+                    executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
                     flowStatus: "ERROR"
                     failureReason: "Invalid credentials"
         
@@ -155,9 +155,9 @@ components:
     SubSequentFlowRequest:
       type: object
       required:
-        - flowId
+        - executionId
       properties:
-        flowId:
+        executionId:
           type: string
           description: Identifier of an existing flow execution
           example: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
@@ -176,12 +176,12 @@ components:
     IncompleteFlowResponse:
       type: object
       required:
-        - flowId
+        - executionId
         - flowStatus
         - stepId
         - type
       properties:
-        flowId:
+        executionId:
           type: string
           description: Unique identifier of the flow execution
           example: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
@@ -205,11 +205,11 @@ components:
     CompleteFlowResponse:
       type: object
       required:
-        - flowId
+        - executionId
         - flowStatus
         - assertion
       properties:
-        flowId:
+        executionId:
           type: string
           description: Unique identifier of the flow execution
           example: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
@@ -225,11 +225,11 @@ components:
     ErrorFlowResponse:
       type: object
       required:
-        - flowId
+        - executionId
         - flowStatus
         - failureReason
       properties:
-        flowId:
+        executionId:
           type: string
           description: Unique identifier of the flow execution
           example: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -93,7 +93,7 @@ func (e *executor) GetPrerequisites() []common.Input {
 func (e *executor) HasRequiredInputs(ctx *NodeContext, execResp *common.ExecutorResponse) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "Executor"),
 		log.String(log.LoggerKeyExecutorName, e.GetName()),
-		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+		log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Checking inputs for the executor")
 
 	requiredData := e.GetRequiredInputs(ctx)
@@ -114,7 +114,7 @@ func (e *executor) HasRequiredInputs(ctx *NodeContext, execResp *common.Executor
 func (e *executor) ValidatePrerequisites(ctx *NodeContext, execResp *common.ExecutorResponse) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "Executor"),
 		log.String(log.LoggerKeyExecutorName, e.GetName()),
-		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+		log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	prerequisites := e.GetPrerequisites()
 	if len(prerequisites) == 0 {
@@ -185,7 +185,7 @@ func (e *executor) appendMissingInputs(ctx *NodeContext, execResp *common.Execut
 	requiredInputs []common.Input) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "Executor"),
 		log.String(log.LoggerKeyExecutorName, e.GetName()),
-		log.String(log.LoggerKeyFlowID, ctx.FlowID))
+		log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	requireData := false
 	for _, input := range requiredInputs {

--- a/backend/internal/flow/core/executor_test.go
+++ b/backend/internal/flow/core/executor_test.go
@@ -66,7 +66,7 @@ func (s *ExecutorTestSuite) TestGetType() {
 
 func (s *ExecutorTestSuite) TestExecute() {
 	exec := newExecutor(testExecutorName, common.ExecutorTypeAuthentication, nil, nil)
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 
 	resp, err := exec.Execute(ctx)
 
@@ -188,7 +188,7 @@ func (s *ExecutorTestSuite) TestHasRequiredInputs() {
 		s.Run(tt.name, func() {
 			exec := newExecutor(testExecutorName, common.ExecutorTypeAuthentication, tt.defaultInputs, nil)
 			ctx := &NodeContext{
-				FlowID:      "test-flow",
+				ExecutionID: "test-flow",
 				UserInputs:  tt.userInputs,
 				RuntimeData: tt.runtimeData,
 			}
@@ -327,7 +327,7 @@ func (s *ExecutorTestSuite) TestValidatePrerequisites() {
 		s.Run(tt.name, func() {
 			exec := newExecutor(testExecutorName, common.ExecutorTypeAuthentication, nil, tt.prerequisites)
 			ctx := &NodeContext{
-				FlowID:            "test-flow",
+				ExecutionID:       "test-flow",
 				AuthenticatedUser: tt.authenticatedUser,
 				UserInputs:        tt.userInputs,
 				RuntimeData:       tt.runtimeData,
@@ -450,7 +450,7 @@ func (s *ExecutorTestSuite) TestGetRequiredInputs() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			exec := newExecutor(testExecutorName, common.ExecutorTypeAuthentication, tt.defaultInputs, nil)
-			ctx := &NodeContext{FlowID: "test-flow", NodeInputs: tt.nodeInputs}
+			ctx := &NodeContext{ExecutionID: "test-flow", NodeInputs: tt.nodeInputs}
 
 			result := exec.GetRequiredInputs(ctx)
 

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -30,7 +30,7 @@ import (
 type NodeContext struct {
 	Context context.Context
 
-	FlowID        string
+	ExecutionID   string
 	FlowType      common.FlowType
 	AppID         string
 	Verbose       bool

--- a/backend/internal/flow/core/node_test.go
+++ b/backend/internal/flow/core/node_test.go
@@ -37,7 +37,7 @@ func TestNodeTestSuite(t *testing.T) {
 func (s *NodeTestSuite) TestExecuteBaseNodeReturnsError() {
 	node := newTaskExecutionNode("node-1", nil, false, false)
 
-	resp, err := node.Execute(&NodeContext{FlowID: "f1"})
+	resp, err := node.Execute(&NodeContext{ExecutionID: "f1"})
 
 	s.NotNil(err)
 	s.Nil(resp)

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -69,7 +69,7 @@ func newPromptNode(id string, properties map[string]interface{},
 
 // Execute executes the prompt node logic based on the current context.
 func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
-	logger := n.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing prompt node")
 
 	nodeResp := &common.NodeResponse{
@@ -227,7 +227,7 @@ func (n *promptNode) resolvePromptInputs(ctx *NodeContext, nodeResp *common.Node
 // hasRequiredInputs checks if all required inputs are available in the context. Adds missing
 // inputs to the node response. Returns true if all required inputs are available, otherwise false.
 func (n *promptNode) hasRequiredInputs(ctx *NodeContext, nodeResp *common.NodeResponse) bool {
-	logger := n.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if nodeResp.Inputs == nil {
 		nodeResp.Inputs = make([]common.Input, 0)
@@ -255,7 +255,7 @@ func (n *promptNode) hasRequiredInputs(ctx *NodeContext, nodeResp *common.NodeRe
 // Returns true if any required data is found missing, otherwise false.
 func (n *promptNode) appendMissingInputs(ctx *NodeContext, nodeResp *common.NodeResponse,
 	requiredInputs []common.Input) bool {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := log.GetLogger().With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	requireInputs := false
 	for _, input := range requiredInputs {
@@ -349,7 +349,7 @@ func (n *promptNode) tryAutoSelectSingleAction(ctx *NodeContext) bool {
 	// Skip auto-select for confirmation prompts (no inputs) - they should wait for explicit action
 	if len(actions) == 1 && ctx.CurrentAction == "" && len(allInputs) > 0 {
 		ctx.CurrentAction = actions[0].Ref
-		n.logger.Debug("Auto-selected single action", log.String(log.LoggerKeyFlowID, ctx.FlowID),
+		n.logger.Debug("Auto-selected single action", log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
 			log.String("actionRef", actions[0].Ref))
 		return true
 	}

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -46,7 +46,7 @@ func (s *PromptOnlyNodeTestSuite) TestNewPromptOnlyNode() {
 
 func (s *PromptOnlyNodeTestSuite) TestExecuteNoInputs() {
 	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
-	ctx := &NodeContext{FlowID: "test-flow", UserInputs: map[string]string{}}
+	ctx := &NodeContext{ExecutionID: "test-flow", UserInputs: map[string]string{}}
 
 	resp, err := node.Execute(ctx)
 
@@ -87,7 +87,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithRequiredData() {
 				},
 			})
 
-			ctx := &NodeContext{FlowID: "test-flow", CurrentAction: "submit", UserInputs: tt.userInputs}
+			ctx := &NodeContext{ExecutionID: "test-flow", CurrentAction: "submit", UserInputs: tt.userInputs}
 			resp, err := node.Execute(ctx)
 
 			s.Nil(err)
@@ -119,7 +119,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithOptionalData() {
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "submit",
 		UserInputs:    map[string]string{"username": "testuser"},
 	}
@@ -145,7 +145,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteMissingRequiredOnly() {
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "submit",
 		UserInputs:    map[string]string{"nickname": "testnick"},
 	}
@@ -191,9 +191,9 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithVerboseModeEnabled() {
 
 	// Test with verbose mode enabled
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
-		Verbose:    true,
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
 	}
 	resp, err := node.Execute(ctx)
 
@@ -230,9 +230,9 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithVerboseModeDisabled() {
 
 	// Test with verbose mode disabled (default)
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
-		Verbose:    false,
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     false,
 	}
 	resp, err := node.Execute(ctx)
 
@@ -257,9 +257,9 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteVerboseModeNoMeta() {
 
 	// Test with verbose mode enabled but no meta defined
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
-		Verbose:    true,
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
 	}
 	resp, err := node.Execute(ctx)
 
@@ -289,7 +289,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithSets_ActionWithInputs() {
 
 	// Select action_001 but don't provide inputs
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "action_001",
 		UserInputs:    map[string]string{},
 	}
@@ -320,7 +320,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithSets_ActionWithoutInputs() {
 
 	// Select action_002 which has no inputs
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "action_002",
 		UserInputs:    map[string]string{},
 	}
@@ -348,7 +348,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithSets_ActionWithInputsProvided()
 
 	// Select action_001 with all inputs provided
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "action_001",
 		UserInputs: map[string]string{
 			"username": "testuser",
@@ -378,7 +378,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithSets_NoActionSelected() {
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "",
 		UserInputs:    map[string]string{},
 	}
@@ -407,7 +407,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithInvalidAction() {
 
 	// Select an action that doesn't exist
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "unknown_action",
 		UserInputs:    map[string]string{},
 	}
@@ -435,7 +435,7 @@ func (s *PromptOnlyNodeTestSuite) TestAutoSelectSingleAction_NoInputs() {
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "", // No action selected
 		UserInputs:    map[string]string{},
 	}
@@ -465,7 +465,7 @@ func (s *PromptOnlyNodeTestSuite) TestAutoSelectSingleAction_WithInputsProvided(
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "", // No action selected
 		UserInputs: map[string]string{
 			"username": "testuser",
@@ -498,7 +498,7 @@ func (s *PromptOnlyNodeTestSuite) TestAutoSelectSingleAction_WithMissingInputs()
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "",                  // No action selected
 		UserInputs:    map[string]string{}, // No inputs
 	}
@@ -529,7 +529,7 @@ func (s *PromptOnlyNodeTestSuite) TestAutoSelectSingleAction_MultipleActionsNoAu
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "", // No action selected
 		UserInputs:    map[string]string{},
 	}
@@ -556,8 +556,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithFailureReason() {
 
 	// Context with failure reason in runtime data
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			"failureReason": "Authentication failed",
 		},
@@ -586,7 +586,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithFailureReason_ClearsUserInputs(
 
 	// User submitted inputs, but downstream task failed - routed back with failureReason
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"username": "takenuser",
 			"password": "secret",
@@ -618,7 +618,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithFailureReason_ClearsCurrentActi
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "submit",
 		UserInputs: map[string]string{
 			"email": "existing@example.com",
@@ -650,8 +650,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithEmptyFailureReason() {
 
 	// Context with empty failure reason
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			"failureReason": "",
 		},
@@ -679,7 +679,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithNilRuntimeData() {
 
 	// Context with nil runtime data
 	ctx := &NodeContext{
-		FlowID:      "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs:  map[string]string{},
 		RuntimeData: nil,
 	}
@@ -709,7 +709,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteInvalidActionReturnsFailure() {
 	// Provide all required inputs but with an action that matches but has no nextNode
 	// This simulates when getNextNodeForActionRef returns empty string
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "valid_action",
 		UserInputs: map[string]string{
 			"username": "testuser",
@@ -959,7 +959,7 @@ func (s *PromptOnlyNodeTestSuite) TestAutoSelectClearsActionsFromResponse() {
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "", // No action selected
 		UserInputs: map[string]string{
 			"username": "testuser",
@@ -989,8 +989,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithFailureAndRecovery() {
 
 	// First execution with failure
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			"failureReason": "Invalid credentials",
 			"otherData":     "should remain",
@@ -1040,8 +1040,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataOptions() {
 
 	// Execute with ForwardedData containing inputs with options
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		ForwardedData: map[string]interface{}{
 			common.ForwardedDataKeyInputs: []common.Input{
 				{
@@ -1083,8 +1083,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataNoMatch() {
 
 	// ForwardedData has inputs but different Identifier
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		ForwardedData: map[string]interface{}{
 			common.ForwardedDataKeyInputs: []common.Input{
 				{
@@ -1120,8 +1120,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithNoForwardedData() {
 
 	// No ForwardedData
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 	}
 	resp, err := node.Execute(ctx)
 
@@ -1151,8 +1151,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataMultipleInputs() {
 
 	// ForwardedData has options for only userType
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		ForwardedData: map[string]interface{}{
 			common.ForwardedDataKeyInputs: []common.Input{
 				{
@@ -1205,8 +1205,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataNonInputType() {
 
 	// ForwardedData has wrong type (string instead of []common.Input)
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		ForwardedData: map[string]interface{}{
 			common.ForwardedDataKeyInputs: "not-an-input-slice",
 		},
@@ -1242,8 +1242,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataPreservesPromptFie
 
 	// ForwardedData has different Ref and Type (should NOT overwrite)
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		ForwardedData: map[string]interface{}{
 			common.ForwardedDataKeyInputs: []common.Input{
 				{
@@ -1285,8 +1285,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithForwardedDataEmptyOptions() {
 
 	// ForwardedData has matching input but with empty options
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 		ForwardedData: map[string]interface{}{
 			common.ForwardedDataKeyInputs: []common.Input{
 				{
@@ -1390,9 +1390,9 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteDisplayOnlyPrompt_WithMessage() {
 
 	// Execute with verbose mode to get meta
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
-		Verbose:    true,
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     true,
 	}
 	resp, err := node.Execute(ctx)
 
@@ -1413,8 +1413,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteDisplayOnlyPrompt_WithoutMessage() 
 	promptNode.SetPrompts([]common.Prompt{})
 
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
 	}
 	resp, err := node.Execute(ctx)
 
@@ -1438,8 +1438,8 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteDisplayOnlyPrompt_IgnoresUserInputs
 
 	// Even though user inputs are provided, display-only prompt should ignore them
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{"username": "user123"},
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{"username": "user123"},
 	}
 	resp, err := node.Execute(ctx)
 
@@ -1467,9 +1467,9 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteDisplayOnlyPrompt_WithVerboseModeDi
 
 	// Execute with verbose mode disabled
 	ctx := &NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: map[string]string{},
-		Verbose:    false,
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		Verbose:     false,
 	}
 	resp, err := node.Execute(ctx)
 
@@ -1510,7 +1510,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteActionTypeForwarding() {
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "login_action",
 		UserInputs:    map[string]string{"username": "testuser"},
 	}
@@ -1539,7 +1539,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteActionTypeForwarding_MultipleAction
 
 	// Test with google action
 	ctx1 := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "google",
 		UserInputs:    map[string]string{},
 	}
@@ -1552,7 +1552,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteActionTypeForwarding_MultipleAction
 
 	// Test with github action
 	ctx2 := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "github",
 		UserInputs:    map[string]string{},
 	}
@@ -1579,7 +1579,7 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteActionTypeForwarding_NoTypeField() 
 	})
 
 	ctx := &NodeContext{
-		FlowID:        "test-flow",
+		ExecutionID:   "test-flow",
 		CurrentAction: "submit",
 		UserInputs:    map[string]string{"username": "testuser"},
 	}

--- a/backend/internal/flow/core/representation_node_test.go
+++ b/backend/internal/flow/core/representation_node_test.go
@@ -67,7 +67,7 @@ func (s *RepresentationNodeTestSuite) TestExecuteWithOnSuccess() {
 	repNode.SetOnSuccess("next_node")
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 	}
 
 	resp, err := node.Execute(ctx)
@@ -84,7 +84,7 @@ func (s *RepresentationNodeTestSuite) TestExecuteWithoutOnSuccess() {
 	node := newRepresentationNode("end", common.NodeTypeEnd, nil, false, true)
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 	}
 
 	resp, err := node.Execute(ctx)
@@ -122,7 +122,7 @@ func (s *RepresentationNodeTestSuite) TestShouldExecuteWithoutCondition() {
 	node := newRepresentationNode("test", common.NodeTypeStart, nil, true, false)
 
 	ctx := &NodeContext{
-		FlowID:      "test-flow",
+		ExecutionID: "test-flow",
 		RuntimeData: map[string]string{},
 	}
 
@@ -138,7 +138,7 @@ func (s *RepresentationNodeTestSuite) TestShouldExecuteWithConditionMet() {
 	})
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		RuntimeData: map[string]string{
 			"key1": "value1",
 		},
@@ -156,7 +156,7 @@ func (s *RepresentationNodeTestSuite) TestShouldExecuteWithConditionNotMet() {
 	})
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		RuntimeData: map[string]string{
 			"key1": "different_value",
 		},

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -83,7 +83,7 @@ func newTaskExecutionNode(id string, properties map[string]interface{}, isStartN
 
 // Execute executes the node's executor.
 func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := log.GetLogger().With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing task execution node")
 
 	if n.executor == nil {

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -71,7 +71,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecutorMethods() {
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteNoExecutor() {
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 
 	resp, err := node.Execute(ctx)
 
@@ -154,7 +154,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteSuccess() {
 			tt.setupMock(mockExec)
 			execNode.SetExecutor(mockExec)
 
-			ctx := &NodeContext{FlowID: "test-flow"}
+			ctx := &NodeContext{ExecutionID: "test-flow"}
 			resp, err := node.Execute(ctx)
 
 			s.Nil(err)
@@ -176,7 +176,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailure() {
 	execNode, _ := node.(ExecutorBackedNodeInterface)
 	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -197,7 +197,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureHandler() {
 	execNode.SetOnFailure("error-prompt")
 	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -217,7 +217,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteExecutorError() {
 	execNode, _ := node.(ExecutorBackedNodeInterface)
 	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.NotNil(err)
@@ -232,7 +232,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteNilExecutorResponse() {
 	s.mockExecutor.On("Execute", mock.Anything).Return(nil, nil).Once()
 	execNode.SetExecutor(s.mockExecutor)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.NotNil(err)
@@ -253,7 +253,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecutePopulatedNodeProperties() {
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -330,7 +330,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteWithMode() {
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -359,7 +359,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteEnrichesRuntimeData() {
 	execNode.SetExecutor(mockExec)
 
 	ctx := &NodeContext{
-		FlowID:      "test-flow",
+		ExecutionID: "test-flow",
 		AppID:       "app-789",
 		RuntimeData: map[string]string{"existing": "value"},
 	}
@@ -424,7 +424,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteWithOnSuccess() {
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -448,7 +448,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteWithEmptyNodeProperties() {
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -471,7 +471,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithoutOnFailureHandler()
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -493,7 +493,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteCompleteWithoutOnSuccess() {
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -576,7 +576,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureStoresFailur
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -607,7 +607,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureInitializesR
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -637,7 +637,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithEmptyFailureReasonAnd
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -671,7 +671,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureClearsNodeIn
 	execNode.SetExecutor(mockExec)
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"email": "existing@example.com",
 		},
@@ -706,7 +706,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureNoNodeInputs
 	execNode.SetExecutor(mockExec)
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
@@ -755,7 +755,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteHandle
 
 	execNode.SetExecutor(mockExec)
 
-	ctx := &NodeContext{FlowID: "test-flow"}
+	ctx := &NodeContext{ExecutionID: "test-flow"}
 	resp, err := node.Execute(ctx)
 
 	s.Nil(err)
@@ -791,7 +791,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteAndFai
 	execNode.SetExecutor(mockExec)
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"username": "testuser",
 			"password": "wrongpassword",
@@ -839,7 +839,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteAndFai
 	execNode.SetExecutor(mockExec)
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"username": "nonexistent",
 		},
@@ -878,7 +878,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteNoFail
 	execNode.SetExecutor(mockExec)
 
 	ctx := &NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"username": "testuser",
 		},

--- a/backend/internal/flow/executor/attribute_collector.go
+++ b/backend/internal/flow/executor/attribute_collector.go
@@ -72,7 +72,7 @@ func newAttributeCollector(
 
 // Execute executes the attribute collection logic.
 func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing attribute collect executor")
 
 	execResp := &common.ExecutorResponse{
@@ -122,7 +122,7 @@ func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 // missing inputs to the executor response. Returns true if required inputs are found, otherwise false.
 func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Checking inputs for the attribute collector")
 
 	if a.ExecutorInterface.HasRequiredInputs(ctx, execResp) {
@@ -225,7 +225,7 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 
 // getUserAttributes retrieves the user attributes from the user profile.
 func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[string]interface{}, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Retrieving user attributes from the user profile")
 
 	user, err := a.getUserFromStore(ctx)
@@ -252,7 +252,7 @@ func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[strin
 
 // updateUserInStore updates the user profile with the collected attributes.
 func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Updating user attributes")
 
 	user, err := a.getUserFromStore(ctx)
@@ -302,7 +302,7 @@ func (a *attributeCollector) getUserFromStore(ctx *core.NodeContext) (*userprovi
 // getUpdatedUserObject creates a new user object with the updated attributes.
 func (a *attributeCollector) getUpdatedUserObject(ctx *core.NodeContext,
 	userData *userprovider.User) (bool, *userprovider.User, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	updatedUser := &userprovider.User{
 		UserID:   userData.UserID,

--- a/backend/internal/flow/executor/attribute_collector_test.go
+++ b/backend/internal/flow/executor/attribute_collector_test.go
@@ -104,8 +104,8 @@ func (suite *AttributeCollectorTestSuite) TestNewAttributeCollector() {
 
 func (suite *AttributeCollectorTestSuite) TestExecute_RegistrationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -117,7 +117,7 @@ func (suite *AttributeCollectorTestSuite) TestExecute_RegistrationFlow() {
 
 func (suite *AttributeCollectorTestSuite) TestExecute_UserNotAuthenticated() {
 	ctx := &core.NodeContext{
-		FlowID:            "flow-123",
+		ExecutionID:       "flow-123",
 		FlowType:          common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: false},
 	}
@@ -132,7 +132,7 @@ func (suite *AttributeCollectorTestSuite) TestExecute_UserNotAuthenticated() {
 
 func (suite *AttributeCollectorTestSuite) TestExecute_PrerequisitesNotMet() {
 	ctx := &core.NodeContext{
-		FlowID:            "flow-123",
+		ExecutionID:       "flow-123",
 		FlowType:          common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: true},
 		RuntimeData:       map[string]string{},
@@ -157,7 +157,7 @@ func (suite *AttributeCollectorTestSuite) TestExecute_UserInputRequired() {
 	suite.mockUserProvider.On("GetUser", testUserID).Return(existingUser, nil)
 
 	ctx := &core.NodeContext{
-		FlowID:            "flow-123",
+		ExecutionID:       "flow-123",
 		FlowType:          common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: true},
 		RuntimeData:       map[string]string{userAttributeUserID: testUserID},
@@ -176,7 +176,7 @@ func (suite *AttributeCollectorTestSuite) TestExecute_UserInputRequired() {
 
 func (suite *AttributeCollectorTestSuite) TestExecute_Success() {
 	ctx := &core.NodeContext{
-		FlowID:            "flow-123",
+		ExecutionID:       "flow-123",
 		FlowType:          common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: true},
 		RuntimeData:       map[string]string{userAttributeUserID: testUserID},
@@ -215,7 +215,7 @@ func (suite *AttributeCollectorTestSuite) TestExecute_Success() {
 
 func (suite *AttributeCollectorTestSuite) TestExecute_UpdateUserFails() {
 	ctx := &core.NodeContext{
-		FlowID:            "flow-123",
+		ExecutionID:       "flow-123",
 		FlowType:          common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: true},
 		RuntimeData:       map[string]string{userAttributeUserID: testUserID},
@@ -245,8 +245,8 @@ func (suite *AttributeCollectorTestSuite) TestExecute_UpdateUserFails() {
 
 func (suite *AttributeCollectorTestSuite) TestHasRequiredInputs_AttributesInAuthenticatedUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			Attributes:      map[string]interface{}{"email": "test@example.com"},
@@ -272,7 +272,7 @@ func (suite *AttributeCollectorTestSuite) TestHasRequiredInputs_AttributesInUser
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:            "flow-123",
+		ExecutionID:       "flow-123",
 		FlowType:          common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: true},
 		RuntimeData:       map[string]string{userAttributeUserID: testUserID},

--- a/backend/internal/flow/executor/attribute_uniqueness_validator.go
+++ b/backend/internal/flow/executor/attribute_uniqueness_validator.go
@@ -69,7 +69,7 @@ func newAttributeUniquenessValidator(
 // Returns ExecUserInputRequired (triggering onIncomplete routing) with the specific attribute
 // named in FailureReason when a conflict is detected, or ExecComplete when all values are free.
 func (e *attributeUniquenessValidator) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing uniqueness checker executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/attribute_uniqueness_validator_test.go
+++ b/backend/internal/flow/executor/attribute_uniqueness_validator_test.go
@@ -77,7 +77,7 @@ func (suite *AttributeUniquenessValidatorTestSuite) SetupTest() {
 
 func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_NoUserType_SkipsCheck() {
 	ctx := &core.NodeContext{
-		FlowID:      "flow-1",
+		ExecutionID: "flow-1",
 		UserInputs:  map[string]string{"email": "test@example.com"},
 		RuntimeData: map[string]string{},
 	}
@@ -91,8 +91,8 @@ func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_NoUserType_Skips
 
 func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_NoConflict_ReturnsComplete() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-1",
-		UserInputs: map[string]string{"email": "free@example.com", "username": "newuser"},
+		ExecutionID: "flow-1",
+		UserInputs:  map[string]string{"email": "free@example.com", "username": "newuser"},
 		RuntimeData: map[string]string{
 			userTypeKey: testUniquenessUserType,
 		},
@@ -127,8 +127,8 @@ func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_AttributeConflic
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
 			ctx := &core.NodeContext{
-				FlowID:     "flow-1",
-				UserInputs: map[string]string{tt.attribute: tt.value},
+				ExecutionID: "flow-1",
+				UserInputs:  map[string]string{tt.attribute: tt.value},
 				RuntimeData: map[string]string{
 					userTypeKey: testUniquenessUserType,
 				},
@@ -155,8 +155,8 @@ func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_AttributeConflic
 func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_UniqueAttrNotInInputs_Skipped() {
 	// Schema says "email" is unique, but the user hasn't provided it yet — skip the check.
 	ctx := &core.NodeContext{
-		FlowID:     "flow-1",
-		UserInputs: map[string]string{"username": "newuser"},
+		ExecutionID: "flow-1",
+		UserInputs:  map[string]string{"username": "newuser"},
 		RuntimeData: map[string]string{
 			userTypeKey: testUniquenessUserType,
 		},
@@ -180,8 +180,8 @@ func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_UniqueAttrNotInI
 
 func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_SchemaServiceError_ReturnsFailure() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-1",
-		UserInputs: map[string]string{"email": "test@example.com"},
+		ExecutionID: "flow-1",
+		UserInputs:  map[string]string{"email": "test@example.com"},
 		RuntimeData: map[string]string{
 			userTypeKey: testUniquenessUserType,
 		},
@@ -199,8 +199,8 @@ func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_SchemaServiceErr
 
 func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_IdentifyUserSystemError_ReturnsFailure() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-1",
-		UserInputs: map[string]string{"email": "test@example.com"},
+		ExecutionID: "flow-1",
+		UserInputs:  map[string]string{"email": "test@example.com"},
 		RuntimeData: map[string]string{
 			userTypeKey: testUniquenessUserType,
 		},
@@ -221,8 +221,8 @@ func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_IdentifyUserSyst
 
 func (suite *AttributeUniquenessValidatorTestSuite) TestExecute_NoUniqueAttributesInSchema_ReturnsComplete() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-1",
-		UserInputs: map[string]string{"given_name": "John"},
+		ExecutionID: "flow-1",
+		UserInputs:  map[string]string{"given_name": "John"},
 		RuntimeData: map[string]string{
 			userTypeKey: testUniquenessUserType,
 		},

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -95,7 +95,7 @@ func newAuthAssertExecutor(
 
 // Execute executes the authentication assertion logic.
 func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing authentication assertion executor")
 
 	execResp := &common.ExecutorResponse{
@@ -263,7 +263,7 @@ func (a *authAssertExecutor) extractAuthenticatorReferences(
 // getRequiredUserAttributes determines the list of user attribute keys that should be included in the
 // assertion based on runtime and application configuration.
 func (a *authAssertExecutor) getRequiredUserAttributes(ctx *core.NodeContext) (userAttributes []string) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// Check if consent was recorded in this flow. If recorded, we should only include consented attributes
 	// We check RuntimeKeyConsentID to determine if the consent executor ran and recorded a consent.

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -125,9 +125,9 @@ func (suite *AuthAssertExecutorTestSuite) TestNewAuthAssertExecutor() {
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -174,8 +174,8 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserAuthenticated_Success(
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_UserNotAuthenticated() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: false,
 		},
@@ -191,9 +191,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_UserNotAuthenticated() {
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAuthorizedPermissions() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -225,9 +225,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserAttributes() {
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -263,9 +263,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserAttributes() {
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_JWTGenerationFails() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -291,9 +291,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_JWTGenerationFails() {
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_AssertionGenerationFails_ServerError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -516,9 +516,9 @@ func (suite *AuthAssertExecutorTestSuite) TestGetUserAttributesFromAuthnProvider
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -552,9 +552,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithUserTypeAndOU() {
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithCustomTokenConfig() {
 	// App-level assertion config (validity period only — issuer always comes from Thunder config)
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -580,9 +580,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithCustomTokenConfig() {
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithOUNameAndHandle() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -624,9 +624,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -688,9 +688,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendUserDetailsToClaimsF
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendOUDetailsToClaimsFails() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -719,9 +719,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_AppendOUDetailsToClaimsFai
 
 func (suite *AuthAssertExecutorTestSuite) TestAppendUserDetailsToClaims_GetUserAttributesFails() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -750,9 +750,9 @@ func (suite *AuthAssertExecutorTestSuite) TestAppendUserDetailsToClaims_GetUserA
 
 func (suite *AuthAssertExecutorTestSuite) TestAppendOUDetailsToClaims_GetOrganizationUnitFails() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -785,9 +785,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConfiguredUserAttribut
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -827,9 +827,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConfiguredUserAttribut
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -871,9 +871,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups() {
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_EmptyGroups() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -906,9 +906,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_EmptyGroups() {
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithGroups_GetUserGroupsFails() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1107,7 +1107,7 @@ func (suite *AuthAssertExecutorTestSuite) TestBuildGetAttributesMetadata_WithEmp
 
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_ConsentRecordedWithoutConsentedKey() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		RuntimeData: map[string]string{
 			common.RuntimeKeyConsentID: "consent-123",
 		},
@@ -1120,7 +1120,7 @@ func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_ConsentR
 
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_ConsentRecordedWithConsentedKey() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		RuntimeData: map[string]string{
 			common.RuntimeKeyConsentID:           "consent-123",
 			common.RuntimeKeyConsentedAttributes: "email name",
@@ -1134,7 +1134,7 @@ func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_ConsentR
 
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_RuntimeEssentialOnly() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		RuntimeData: map[string]string{
 			common.RuntimeKeyRequiredEssentialAttributes: "email name",
 		},
@@ -1147,7 +1147,7 @@ func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_RuntimeE
 
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_RuntimeOptionalOnly() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		RuntimeData: map[string]string{
 			common.RuntimeKeyRequiredOptionalAttributes: "email phone",
 		},
@@ -1160,7 +1160,7 @@ func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_RuntimeO
 
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_RuntimeEssentialAndOptional() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		RuntimeData: map[string]string{
 			common.RuntimeKeyRequiredEssentialAttributes: "email",
 			common.RuntimeKeyRequiredOptionalAttributes:  "phone name",
@@ -1174,7 +1174,7 @@ func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_RuntimeE
 
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_FallbackToAssertion() {
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		RuntimeData: map[string]string{},
 		Application: appmodel.Application{
 			Assertion: &appmodel.AssertionConfig{UserAttributes: []string{"email", "phone"}},
@@ -1188,7 +1188,7 @@ func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_Fallback
 
 func (suite *AuthAssertExecutorTestSuite) TestGetRequiredUserAttributes_NoRuntimeOrAssertion() {
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		RuntimeData: map[string]string{},
 		Application: appmodel.Application{},
 	}
@@ -1205,9 +1205,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConsentedAttributes_Fi
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1250,9 +1250,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithConsentedAttributes_Fi
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithEmptyConsentedAttributes() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1277,9 +1277,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithEmptyConsentedAttribut
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithoutConsentedAttributes() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1306,9 +1306,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_AttrsSt
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		AppID:   "app-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1361,9 +1361,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilUser
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		AppID:   "app-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1410,9 +1410,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OnlyRes
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		AppID:   "app-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1464,9 +1464,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilAsse
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		AppID:   "app-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1508,8 +1508,8 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_NilAsse
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "user-123",
 		},
@@ -1536,8 +1536,8 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups()
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups_FetchError() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "user-123",
 		},
@@ -1557,8 +1557,8 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups_F
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups_EmptyUserID_GroupsSkipped() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "",
 		},
@@ -1576,8 +1576,8 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithGroups_E
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithUserType() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID:   "user-123",
 			UserType: "INTERNAL",
@@ -1594,8 +1594,8 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithUserType
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithEmptyUserType_NotAdded() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID:   "user-123",
 			UserType: "",
@@ -1612,8 +1612,8 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithEmptyUse
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetails() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "user-123",
 			OUID:   testAuthOUID,
@@ -1637,8 +1637,8 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetail
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetails_FetchError() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "user-123",
 			OUID:   "ou-invalid",
@@ -1662,8 +1662,8 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetail
 
 func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetails_EmptyOUID_OUDetailsSkipped() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			UserID: "user-123",
 			OUID:   "",
@@ -1683,9 +1683,9 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetail
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_GroupsIncludedInCache() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		AppID:   "app-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1731,9 +1731,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_GroupsI
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_UserTypeIncludedInCache() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		AppID:   "app-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1771,9 +1771,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_UserTyp
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_OUDetailsIncludedInCache() {
 	ctx := &core.NodeContext{
-		FlowID:  "flow-123",
-		AppID:   "app-123",
-		Context: context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		Context:     context.Background(),
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -1818,9 +1818,9 @@ func (suite *AuthAssertExecutorTestSuite) TestExecute_WithRuntimeRequiredEssenti
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		AppID:    "app-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",

--- a/backend/internal/flow/executor/authz_executor.go
+++ b/backend/internal/flow/executor/authz_executor.go
@@ -70,7 +70,7 @@ func newAuthorizationExecutor(
 // Execute executes the authorization logic by determining required permissions based on context,
 // calling the authorization service, and storing authorized permissions in runtime data.
 func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing authorization executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/authz_executor_test.go
+++ b/backend/internal/flow/executor/authz_executor_test.go
@@ -78,8 +78,8 @@ func TestAuthorizationExecutor_Execute_Success(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
@@ -127,8 +127,8 @@ func TestAuthorizationExecutor_Execute_PartialPermissions(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
@@ -165,8 +165,8 @@ func TestAuthorizationExecutor_Execute_NoPermissions(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
@@ -202,8 +202,8 @@ func TestAuthorizationExecutor_Execute_NotAuthenticated(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: false,
 		},
@@ -229,8 +229,8 @@ func TestAuthorizationExecutor_Execute_ServiceError(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
@@ -263,8 +263,8 @@ func TestAuthorizationExecutor_Execute_GroupExtractionError(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
@@ -301,8 +301,8 @@ func TestAuthorizationExecutor_Execute_NoRequestedPermissions(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
@@ -489,8 +489,8 @@ func TestAuthorizationExecutor_Execute_WithMultipleGroups(t *testing.T) {
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user123",
@@ -568,8 +568,8 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_UnauthenticatedWithoutPe
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-registration-flow",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "test-registration-flow",
+		FlowType:    common.FlowTypeRegistration,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: false,
 		},
@@ -595,8 +595,8 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_UnauthenticatedWithPermi
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-registration-flow",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "test-registration-flow",
+		FlowType:    common.FlowTypeRegistration,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: false,
 			UserID:          "", // No user ID yet in registration
@@ -624,8 +624,8 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_AuthenticatedWithPermiss
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockUserProvider)
 
 	ctx := &core.NodeContext{
-		FlowID:   "test-registration-flow",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "test-registration-flow",
+		FlowType:    common.FlowTypeRegistration,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "existing-user-123",
@@ -684,8 +684,8 @@ func TestAuthorizationExecutor_Execute_NonRegistrationFlow_UnauthenticatedShould
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &core.NodeContext{
-				FlowID:   "test-flow",
-				FlowType: tc.flowType,
+				ExecutionID: "test-flow",
+				FlowType:    tc.flowType,
 				AuthenticatedUser: authncm.AuthenticatedUser{
 					IsAuthenticated: false,
 				},

--- a/backend/internal/flow/executor/basic_auth_executor.go
+++ b/backend/internal/flow/executor/basic_auth_executor.go
@@ -84,7 +84,7 @@ func newBasicAuthExecutor(
 
 // Execute executes the basic authentication logic.
 func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := b.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := b.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing basic authentication executor")
 
 	execResp := &common.ExecutorResponse{
@@ -168,7 +168,7 @@ func (b *basicAuthExecutor) getCredentialInputs(ctx *core.NodeContext) []common.
 // credential attributes and returns the authenticated user details.
 func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*authncm.AuthenticatedUser, error) {
-	logger := b.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := b.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	userIdentifiers := map[string]interface{}{}
 	userCredentials := map[string]interface{}{}

--- a/backend/internal/flow/executor/basic_auth_executor_test.go
+++ b/backend/internal/flow/executor/basic_auth_executor_test.go
@@ -145,8 +145,8 @@ func (suite *BasicAuthExecutorTestSuite) TestNewBasicAuthExecutor() {
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_AuthenticationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "password123",
@@ -187,8 +187,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_AuthenticationFlow(
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_WithEmailAttribute() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"email":    "test@example.com",
 			"password": "password123",
@@ -237,8 +237,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_WithEmailAttribute(
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_RegistrationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			userAttributeUsername: "newuser",
 			userAttributePassword: "password123",
@@ -262,8 +262,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_RegistrationFlow() 
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_WithMultipleAttributes() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"email":    "test@example.com",
 			"phone":    "+1234567890",
@@ -316,7 +316,7 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_Success_WithMultipleAttribu
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_UserInputRequired() {
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeAuthentication,
 		UserInputs:  map[string]string{},
 		RuntimeData: make(map[string]string),
@@ -332,8 +332,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_UserInputRequired() {
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_AuthenticationFailed() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "wrongpassword",
@@ -362,8 +362,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_AuthenticationFailed() {
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_UserNotFound_AuthenticationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "nonexistent",
 			userAttributePassword: "password123",
@@ -394,8 +394,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_UserNotFound_Authentication
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_UserAlreadyExists_RegistrationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			userAttributeUsername: "existinguser",
 			userAttributePassword: "password123",
@@ -419,8 +419,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_UserAlreadyExists_Registrat
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_ServiceError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "password123",
@@ -448,8 +448,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_ServiceError() {
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_AuthenticationServiceError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "password123",
@@ -474,8 +474,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_AuthenticationServiceError(
 
 func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_SuccessfulAuthentication() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "password123",
@@ -523,8 +523,8 @@ func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_SuccessfulAuth
 
 func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_Success_WithFetchedAttributes() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "password123",
@@ -579,8 +579,8 @@ func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_Success_WithFe
 
 func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_AuthenticationFlow_NoRedundantIdentifyUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "password123",
@@ -626,8 +626,8 @@ func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_Authentication
 
 func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_RegistrationFlow_CallsIdentifyUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			userAttributeUsername: "newuser",
 			userAttributePassword: "password123",
@@ -686,8 +686,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_RetryableAuthenticationErro
 		suite.T().Run(tt.name, func(t *testing.T) {
 			suite.mockCredsService.ExpectedCalls = nil
 			ctx := &core.NodeContext{
-				FlowID:   "flow-123",
-				FlowType: common.FlowTypeAuthentication,
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeAuthentication,
 				UserInputs: map[string]string{
 					userAttributeUsername: tt.username,
 					userAttributePassword: tt.password,
@@ -719,8 +719,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_RetryableAuthenticationErro
 
 func (suite *BasicAuthExecutorTestSuite) TestGetAuthenticatedUser_ClientError_ReturnsInputsForRetry() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributeUsername: "testuser",
 			userAttributePassword: "password123",
@@ -926,9 +926,9 @@ func (suite *BasicAuthExecutorTestSuite) TestBuildAuthnMetadata_WithMixedInbound
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_PreResolvedUser_RequestsPassword() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeAuthentication,
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			userAttributeUserID: "pre-resolved-user-123",
 		},
@@ -945,8 +945,8 @@ func (suite *BasicAuthExecutorTestSuite) TestExecute_PreResolvedUser_RequestsPas
 
 func (suite *BasicAuthExecutorTestSuite) TestExecute_PreResolvedUser_WithPassword() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			userAttributePassword: "password123",
 		},

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -89,7 +89,7 @@ func newConsentExecutor(
 
 // Execute runs the consent enforcement logic.
 func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing consent executor")
 
 	execResp := &common.ExecutorResponse{
@@ -122,7 +122,7 @@ func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespon
 // checkConsent resolves whether consent is needed and either completes or forwards to a prompt.
 func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	ouID, appID, userID string) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Checking if user consent is required")
 
 	essentialAttributes, optionalAttributes := e.getRequiredAttributes(ctx)
@@ -185,7 +185,7 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 // handleConsentDecisions processes the user's consent decisions.
 func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	ouID, appID, userID string) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Processing consent decisions from user")
 
 	decisionsJSON, ok := ctx.UserInputs[userInputConsentDecisions]

--- a/backend/internal/flow/executor/consent_executor_test.go
+++ b/backend/internal/flow/executor/consent_executor_test.go
@@ -87,9 +87,9 @@ func createMockExecutorWithInputs(t *testing.T) *coremock.ExecutorInterfaceMock 
 
 func buildConsentNodeContext() *core.NodeContext {
 	return &core.NodeContext{
-		Context: context.Background(),
-		FlowID:  "flow-123",
-		AppID:   "app-123",
+		Context:     context.Background(),
+		ExecutionID: "flow-123",
+		AppID:       "app-123",
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          testUserID,

--- a/backend/internal/flow/executor/credential_setter.go
+++ b/backend/internal/flow/executor/credential_setter.go
@@ -67,7 +67,7 @@ func newCredentialSetter(
 
 // Execute sets the password for the user identified by userID in RuntimeData.
 func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing credential set")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/credential_setter_test.go
+++ b/backend/internal/flow/executor/credential_setter_test.go
@@ -64,7 +64,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_Success() {
 	userID := testUserID
 	password := "securePass123!"
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			userAttributePassword: password,
 		},
@@ -95,8 +95,8 @@ func (suite *CredentialSetterTestSuite) TestExecute_Success() {
 
 func (suite *CredentialSetterTestSuite) TestExecute_MissingInput() {
 	ctx := &core.NodeContext{
-		FlowID:     "test-flow",
-		UserInputs: make(map[string]string),
+		ExecutionID: "test-flow",
+		UserInputs:  make(map[string]string),
 	}
 
 	suite.mockBaseExecutor.On("HasRequiredInputs", ctx, mock.Anything).Return(false)
@@ -109,7 +109,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_MissingInput() {
 
 func (suite *CredentialSetterTestSuite) TestExecute_MissingUserID() {
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			userAttributePassword: "password",
 		},
@@ -129,7 +129,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_MissingUserID() {
 func (suite *CredentialSetterTestSuite) TestExecute_EmptyPassword() {
 	userID := testUserID
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			userAttributePassword: "",
 		},
@@ -157,7 +157,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_ServiceError() {
 	userID := testUserID
 	password := "password"
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			userAttributePassword: password,
 		},
@@ -190,7 +190,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_CustomAttribute() {
 	pinValue := "1234"
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			customAttr: pinValue,
 		},
@@ -226,7 +226,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_CustomAttribute() {
 func (suite *CredentialSetterTestSuite) TestExecute_NoRequiredInputs() {
 	userID := testUserID
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			userAttributePassword: "password",
 		},
@@ -250,7 +250,7 @@ func (suite *CredentialSetterTestSuite) TestExecute_NoRequiredInputs() {
 func (suite *CredentialSetterTestSuite) TestExecute_EmptyInputIdentifier() {
 	userID := testUserID
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			userAttributePassword: "password",
 		},

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -72,7 +72,7 @@ func (e *emailExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 // executeSend resolves the email template, constructs the email, and sends it.
 // If the email client is not configured, it completes without sending (no-op).
 func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing email executor in send mode")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/email_executor_test.go
+++ b/backend/internal/flow/executor/email_executor_test.go
@@ -62,14 +62,14 @@ func (suite *EmailExecutorTestSuite) SetupTest() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Success() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -81,7 +81,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Suc
 		template.ScenarioUserInvite,
 		template.TemplateTypeEmail,
 		template.TemplateData{
-			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"inviteLink": "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
@@ -108,14 +108,14 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Suc
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_InviteLinkNotExposed() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		FlowType:     common.FlowTypeRegistration,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "SELF_REGISTRATION",
@@ -127,7 +127,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Invit
 		template.ScenarioSelfRegistration,
 		template.TemplateTypeEmail,
 		template.TemplateData{
-			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"inviteLink": "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
@@ -149,14 +149,14 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Invit
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRuntimeRecipient() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
 			"email":                     "runtime@example.com",
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -168,7 +168,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRunti
 		template.ScenarioUserInvite,
 		template.TemplateTypeEmail,
 		template.TemplateData{
-			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"inviteLink": "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
@@ -191,12 +191,12 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRunti
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
 			"email":                     "runtime@example.com",
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -208,7 +208,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData()
 		template.ScenarioUserInvite,
 		template.TemplateTypeEmail,
 		template.TemplateData{
-			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"inviteLink": "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
@@ -231,11 +231,11 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData()
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingRecipient() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -252,7 +252,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingRecipient() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingInviteLink() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -273,7 +273,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingInviteLink() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_MissingInviteLink() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		FlowType:     common.FlowTypeRegistration,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
@@ -295,13 +295,13 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Missi
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplateProperty_DefaultsToUserInvite() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{},
 	}
@@ -312,7 +312,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplatePropert
 		template.ScenarioUserInvite,
 		template.TemplateTypeEmail,
 		template.TemplateData{
-			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"inviteLink": "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
@@ -335,13 +335,13 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplatePropert
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmptyTemplateString_DefaultsToUserInvite() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "",
@@ -353,7 +353,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmptyTemplateString_De
 		template.ScenarioUserInvite,
 		template.TemplateTypeEmail,
 		template.TemplateData{
-			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			"inviteLink": "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 			"appName":    "",
 		},
 	).Return(&template.RenderedTemplate{
@@ -376,13 +376,13 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmptyTemplateString_De
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_InvalidTemplateType_ReturnsError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": 123,
@@ -398,13 +398,13 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_InvalidTemplateType_Re
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_TemplateRenderError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -441,13 +441,13 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilTemplateService() {
 	noServiceExecutor := newEmailExecutor(mockFactory, suite.mockEmailClient, nil)
 
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -463,13 +463,13 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilTemplateService() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ClientError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -498,13 +498,13 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ClientError() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ServerError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -546,14 +546,14 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_NoOp() 
 	noEmailExecutor := newEmailExecutor(mockFactory, nil, suite.mockTemplateService)
 
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "USER_INVITE",
@@ -571,14 +571,14 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_SelfReg
 	noEmailExecutor := newEmailExecutor(suite.mockFlowFactory, nil, suite.mockTemplateService)
 
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		FlowType:     common.FlowTypeRegistration,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
+			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
 		},
 		NodeProperties: map[string]interface{}{
 			"emailTemplate": "SELF_REGISTRATION",
@@ -595,7 +595,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_SelfReg
 
 func (suite *EmailExecutorTestSuite) TestExecute_InvalidMode() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: "invalid",
 		UserInputs:   make(map[string]string),
 		RuntimeData:  make(map[string]string),

--- a/backend/internal/flow/executor/federated_auth_resolver_executor.go
+++ b/backend/internal/flow/executor/federated_auth_resolver_executor.go
@@ -69,7 +69,7 @@ func newFederatedAuthResolverExecutor(
 // It filters candidates generically against all user inputs (e.g., ouHandle, userType, or any
 // attribute), matching the same pattern used by the IdentifyingExecutor's filterUsersByAttributes.
 func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := f.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := f.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing federated auth resolver")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/federated_auth_resolver_executor_test.go
+++ b/backend/internal/flow/executor/federated_auth_resolver_executor_test.go
@@ -66,8 +66,8 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_SingleCandidateMatch() 
 	candidatesJSON, _ := json.Marshal(candidates)
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{"ouHandle": "org-alpha"},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"ouHandle": "org-alpha"},
 		RuntimeData: map[string]string{
 			common.RuntimeKeyCandidateUsers: string(candidatesJSON),
 			"sub":                           "sub-123",
@@ -92,7 +92,7 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_SingleCandidateMatch() 
 
 func (suite *FederatedAuthResolverTestSuite) TestExecute_NoCandidatesInRuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		UserInputs:  map[string]string{"ouHandle": "org-alpha"},
 		RuntimeData: map[string]string{},
 	}
@@ -111,8 +111,8 @@ func (suite *FederatedAuthResolverTestSuite) executeWithCandidatesAndInput(
 	candidatesJSON, _ := json.Marshal(candidates)
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: inputs,
+		ExecutionID: "flow-123",
+		UserInputs:  inputs,
 		RuntimeData: map[string]string{
 			common.RuntimeKeyCandidateUsers: string(candidatesJSON),
 		},
@@ -169,7 +169,7 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_IndistinguishableCandid
 
 func (suite *FederatedAuthResolverTestSuite) TestExecute_RequiredInputsMissing() {
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
 	}
@@ -185,8 +185,8 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_RequiredInputsMissing()
 
 func (suite *FederatedAuthResolverTestSuite) TestExecute_InvalidCandidatesJSON() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{"ouHandle": "org-alpha"},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"ouHandle": "org-alpha"},
 		RuntimeData: map[string]string{
 			common.RuntimeKeyCandidateUsers: "invalid-json",
 		},
@@ -208,8 +208,8 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_PreservesSubInRuntimeDa
 	candidatesJSON, _ := json.Marshal(candidates)
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{"ouHandle": "org-alpha"},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"ouHandle": "org-alpha"},
 		RuntimeData: map[string]string{
 			common.RuntimeKeyCandidateUsers: string(candidatesJSON),
 			"sub":                           "federated-sub-123",
@@ -236,8 +236,8 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_FailsWithoutFederatedSu
 	candidatesJSON, _ := json.Marshal(candidates)
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{"ouHandle": "org-alpha"},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"ouHandle": "org-alpha"},
 		RuntimeData: map[string]string{
 			common.RuntimeKeyCandidateUsers: string(candidatesJSON),
 		},
@@ -265,7 +265,7 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_IgnoresUnexpectedInputK
 
 	// Malicious client sends userID as an extra input
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		UserInputs: map[string]string{
 			"ouHandle": "org-alpha",
 			"userID":   "user-2", // should be ignored

--- a/backend/internal/flow/executor/http_request_executor.go
+++ b/backend/internal/flow/executor/http_request_executor.go
@@ -98,7 +98,7 @@ func newHTTPRequestExecutor(
 
 // Execute executes the HTTP request logic.
 func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := h.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing HTTP request executor")
 
 	execResp := &common.ExecutorResponse{
@@ -316,7 +316,7 @@ func (h *httpRequestExecutor) resolveMapPlaceholders(ctx *core.NodeContext, data
 // executeRequestWithRetry executes the HTTP request with retry logic.
 func (h *httpRequestExecutor) executeRequestWithRetry(ctx *core.NodeContext,
 	config *httpRequestConfig) (*http.Response, error) {
-	logger := h.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	retryCount := 0
 	retryDelay := 0
@@ -351,7 +351,7 @@ func (h *httpRequestExecutor) executeRequestWithRetry(ctx *core.NodeContext,
 // executeRequest executes a single HTTP request.
 func (h *httpRequestExecutor) executeRequest(ctx *core.NodeContext, config *httpRequestConfig,
 	httpClient httpservice.HTTPClientInterface) (*http.Response, error) {
-	logger := h.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// Prepare request body
 	var bodyReader io.Reader
@@ -393,7 +393,7 @@ func (h *httpRequestExecutor) executeRequest(ctx *core.NodeContext, config *http
 // processResponse processes the HTTP response and extracts data based on response mapping.
 func (h *httpRequestExecutor) processResponse(ctx *core.NodeContext, config *httpRequestConfig,
 	response *http.Response, execResp *common.ExecutorResponse) error {
-	logger := h.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	defer func() {
 		if err := response.Body.Close(); err != nil {
 			logger.Error("Failed to close response body", log.Error(err))

--- a/backend/internal/flow/executor/http_request_executor_test.go
+++ b/backend/internal/flow/executor/http_request_executor_test.go
@@ -70,7 +70,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholdersInConfig() {
 	}))
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"username": "testuser",
 			"email":    "test@example.com",
@@ -123,7 +123,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderUserIDSpecialHa
 	}))
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"userId": "input-user-id", // This should NOT be used for userId
 		},
@@ -162,7 +162,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderRuntimeDataPrec
 	}))
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"key": "user-input-value",
 		},
@@ -200,7 +200,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderNonExistentKey(
 	}))
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
 		NodeProperties: map[string]interface{}{
@@ -223,7 +223,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestResolvePlaceholderNonExistentKey(
 
 func (suite *HTTPRequestExecutorTestSuite) TestResolveMapPlaceholders() {
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		UserInputs: map[string]string{
 			"username": "testuser",
 			"email":    "test@example.com",
@@ -292,7 +292,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_SuccessfulGETRequest() {
 	responseMappingJSON := `{"id": "response.data.id", "name": "response.data.name"}`
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url":             suite.mockServer.URL + "/api/users/123",
 			"method":          "GET",
@@ -335,7 +335,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_SuccessfulPOSTRequest() {
 	responseMappingJSON := `{"status": "response.data.status", "userId": "response.data.userId"}`
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url":             suite.mockServer.URL + "/api/users",
 			"method":          "POST",
@@ -387,7 +387,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_ResponseMapping() {
 	"profileUrl": "response.data.data.profileUrl", "timestamp": "response.data.metadata.timestamp"}`
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url":             suite.mockServer.URL + "/api/data",
 			"responseMapping": responseMappingJSON,
@@ -414,7 +414,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_DefaultMethod() {
 	}))
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url": suite.mockServer.URL + "/api/test",
 			// method not specified, should default to GET
@@ -437,7 +437,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_ErrorHandling_FailOnError
 	}))
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url": suite.mockServer.URL + "/api/error",
 		},
@@ -462,7 +462,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_ErrorHandling_FailOnError
 	errorHandlingJSON := `{"failOnError": true}`
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url":           suite.mockServer.URL + "/api/error",
 			"errorHandling": errorHandlingJSON,
@@ -480,7 +480,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_ErrorHandling_FailOnError
 
 func (suite *HTTPRequestExecutorTestSuite) TestExecute_MissingURL() {
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			// URL is missing
 			"method": "GET",
@@ -499,7 +499,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_MissingURL() {
 
 func (suite *HTTPRequestExecutorTestSuite) TestExecute_InvalidHTTPMethod() {
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url":    "https://example.com/api/test",
 			"method": "INVALID",
@@ -563,7 +563,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_AllHTTPMethods() {
 			defer suite.mockServer.Close()
 
 			ctx := &core.NodeContext{
-				FlowID: "test-flow",
+				ExecutionID: "test-flow",
 				NodeProperties: map[string]interface{}{
 					"url":    suite.mockServer.URL + "/api/test",
 					"method": method,
@@ -643,7 +643,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_NonJSONResponse() {
 	responseMappingJSON := `{"raw": "response.data.raw"}`
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url":             suite.mockServer.URL + "/api/text",
 			"responseMapping": responseMappingJSON,
@@ -673,7 +673,7 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_ResponseStatusExtraction(
 	responseMappingJSON := `{"resourceId": "response.data.id", "statusCode": "response.status"}`
 
 	ctx := &core.NodeContext{
-		FlowID: "test-flow",
+		ExecutionID: "test-flow",
 		NodeProperties: map[string]interface{}{
 			"url":             suite.mockServer.URL + "/api/resource",
 			"method":          "POST",

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -118,7 +118,7 @@ func (i *identifyingExecutor) IdentifyUser(filters map[string]interface{},
 
 // Execute executes the identifying executor logic.
 func (i *identifyingExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := i.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := i.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing identifying executor")
 
 	execResp := &common.ExecutorResponse{
@@ -146,7 +146,7 @@ func (i *identifyingExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 // executeIdentify handles the default identify mode which expects exactly one user match.
 func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := i.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := i.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	userSearchAttributes := i.buildSearchAttributes(ctx)
 
@@ -182,7 +182,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 // executeResolve handles the resolve mode for user disambiguation.
 func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := i.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := i.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing identifying executor in resolve mode")
 
 	userSearchAttributes := i.buildSearchAttributes(ctx)

--- a/backend/internal/flow/executor/identifying_executor_test.go
+++ b/backend/internal/flow/executor/identifying_executor_test.go
@@ -205,8 +205,8 @@ func (suite *IdentifyingExecutorTestSuite) TestIdentifyUser_WithMobileNumber() {
 
 func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_UserInputs() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{"username": "testuser"},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"username": "testuser"},
 	}
 	// Use package-level testUserID constant
 	// Configure mock base executor
@@ -233,7 +233,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_UserInputs() {
 
 func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_RuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		UserInputs:  make(map[string]string),
 		RuntimeData: map[string]string{"username": "testuser"},
 	}
@@ -261,8 +261,8 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_RuntimeData() {
 
 func (suite *IdentifyingExecutorTestSuite) TestExecute_UserInputRequired() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
 	}
 
 	mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
@@ -277,8 +277,8 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_UserInputRequired() {
 
 func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_IdentifyUserError() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{"username": "testuser"},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"username": "testuser"},
 	}
 
 	mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
@@ -304,8 +304,8 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_IdentifyUserError
 
 func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_UserNotFound() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{"username": "nonexistent"},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"username": "nonexistent"},
 	}
 
 	mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
@@ -343,8 +343,8 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_WithVariousAttrib
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 			ctx := &core.NodeContext{
-				FlowID:     "flow-123",
-				UserInputs: map[string]string{tc.attribute: tc.value},
+				ExecutionID: "flow-123",
+				UserInputs:  map[string]string{tc.attribute: tc.value},
 			}
 
 			mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
@@ -370,7 +370,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_WithVariousAttrib
 
 func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_WithMultipleAttributes() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		UserInputs: map[string]string{
 			"username": "testuser",
 			"email":    "test@example.com",
@@ -414,8 +414,8 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_UserNotFoundByAtt
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 			ctx := &core.NodeContext{
-				FlowID:     "flow-123",
-				UserInputs: map[string]string{tc.attribute: tc.value},
+				ExecutionID: "flow-123",
+				UserInputs:  map[string]string{tc.attribute: tc.value},
 			}
 
 			mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
@@ -455,7 +455,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Success_FromRuntimeData()
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 			ctx := &core.NodeContext{
-				FlowID:      "flow-123",
+				ExecutionID: "flow-123",
 				UserInputs:  make(map[string]string),
 				RuntimeData: map[string]string{tc.attribute: tc.value},
 			}
@@ -495,8 +495,8 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_EmptyInput() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 			ctx := &core.NodeContext{
-				FlowID:     "flow-123",
-				UserInputs: map[string]string{tc.attribute: ""},
+				ExecutionID: "flow-123",
+				UserInputs:  map[string]string{tc.attribute: ""},
 			}
 
 			mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
@@ -540,7 +540,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_UserInputsPriorityOverRun
 			// Both UserInputs and RuntimeData have the same key
 			// UserInputs should take priority
 			ctx := &core.NodeContext{
-				FlowID:      "flow-123",
+				ExecutionID: "flow-123",
 				UserInputs:  map[string]string{tc.attribute: tc.userInputValue},
 				RuntimeData: map[string]string{tc.attribute: tc.runtimeValue},
 			}
@@ -580,7 +580,7 @@ var (
 
 func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_UniqueUser() {
 	ctx := &core.NodeContext{
-		FlowID:       "flow-123",
+		ExecutionID:  "flow-123",
 		ExecutorMode: ExecutorModeResolve,
 		UserInputs:   map[string]string{"given_name": "Alex"},
 		RuntimeData:  make(map[string]string),
@@ -607,7 +607,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_UniqueUser() {
 
 func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_AmbiguousUser() {
 	ctx := &core.NodeContext{
-		FlowID:       "flow-123",
+		ExecutionID:  "flow-123",
 		ExecutorMode: ExecutorModeResolve,
 		UserInputs:   map[string]string{"given_name": "Alex"},
 		RuntimeData:  make(map[string]string),
@@ -642,7 +642,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_FilteredToOne() {
 	candidatesJSON, _ := json.Marshal(candidates)
 
 	ctx := &core.NodeContext{
-		FlowID:       "flow-123",
+		ExecutionID:  "flow-123",
 		ExecutorMode: ExecutorModeResolve,
 		UserInputs:   map[string]string{"given_name": "Alex", "family_name": "Smith"},
 		RuntimeData: map[string]string{
@@ -672,7 +672,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_StillAmbiguous() {
 	candidatesJSON, _ := json.Marshal(candidates)
 
 	ctx := &core.NodeContext{
-		FlowID:       "flow-123",
+		ExecutionID:  "flow-123",
 		ExecutorMode: ExecutorModeResolve,
 		UserInputs:   map[string]string{"given_name": "Alex", "family_name": "Smith"},
 		RuntimeData: map[string]string{
@@ -701,7 +701,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_FilteredToNone() {
 	candidatesJSON, _ := json.Marshal(candidates)
 
 	ctx := &core.NodeContext{
-		FlowID:       "flow-123",
+		ExecutionID:  "flow-123",
 		ExecutorMode: ExecutorModeResolve,
 		UserInputs:   map[string]string{"given_name": "Alex", "family_name": "Williams"},
 		RuntimeData: map[string]string{
@@ -725,7 +725,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_FilteredToNone() {
 
 func (suite *IdentifyingExecutorTestSuite) TestExecute_IdentifyMode_AmbiguousUser() {
 	ctx := &core.NodeContext{
-		FlowID:       "flow-123",
+		ExecutionID:  "flow-123",
 		ExecutorMode: ExecutorModeIdentify,
 		UserInputs:   map[string]string{"given_name": "Alex"},
 		RuntimeData:  make(map[string]string),

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -72,7 +72,7 @@ func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespons
 
 // executeGenerate generates the invite token and link.
 func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing invite executor in generate mode")
 
 	execResp := &common.ExecutorResponse{
@@ -102,7 +102,7 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 
 // executeVerify validates the user-provided invite token against the stored token.
 func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing invite executor in verify mode")
 
 	execResp := &common.ExecutorResponse{
@@ -128,7 +128,7 @@ func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorR
 	}
 
 	if inviteTokenInput != storedToken {
-		logger.Debug("Invite token mismatch", log.String("flowId", ctx.FlowID))
+		logger.Debug("Invite token mismatch", log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 		execResp.Status = common.ExecFailure
 		execResp.FailureReason = "Invalid invite token"
 		return execResp, nil
@@ -157,7 +157,7 @@ func (e *inviteExecutor) generateInviteLink(ctx *core.NodeContext, inviteToken s
 		gateConfig.Port,
 		gateConfig.Path)
 	queryParams := url.Values{
-		"flowId":      []string{ctx.FlowID},
+		"executionId": []string{ctx.ExecutionID},
 		"inviteToken": []string{inviteToken},
 	}
 

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -74,7 +74,7 @@ func (suite *InviteExecutorTestSuite) TearDownTest() {
 
 func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		AppID:        "test-app-id",
 		ExecutorMode: ExecutorModeGenerate,
 		UserInputs:   make(map[string]string),
@@ -88,14 +88,14 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode() {
 	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyStoredInviteToken])
 	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink])
 	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "inviteToken=")
-	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "flowId=test-flow-id")
+	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "executionId=test-flow-id")
 	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "applicationId=test-app-id")
 	assert.Empty(suite.T(), resp.AdditionalData[common.DataInviteLink])
 }
 
 func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_UserOnboarding_ExposesInviteLink() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		AppID:        "test-app-id",
 		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeGenerate,
@@ -114,7 +114,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_UserOnboarding_Ex
 func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_Idempotency() {
 	existingToken := "existing-token-123"
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeGenerate,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
@@ -133,7 +133,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_Idempotency() {
 
 func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_NoTokenProvided() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeVerify,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
@@ -153,7 +153,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_NoTokenProvided() {
 func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationSuccess() {
 	token := "valid-token"
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeVerify,
 		UserInputs: map[string]string{
 			userInputInviteToken: token,
@@ -174,7 +174,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationSuccess()
 
 func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationFailure_Mismatch() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeVerify,
 		UserInputs: map[string]string{
 			userInputInviteToken: "wrong-token",
@@ -196,7 +196,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationFailure_M
 
 func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationFailure_NoStoredToken() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeVerify,
 		UserInputs: map[string]string{
 			userInputInviteToken: "some-token",
@@ -216,7 +216,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_VerifyMode_ValidationFailure_N
 
 func (suite *InviteExecutorTestSuite) TestExecute_InvalidMode() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: "invalid",
 		UserInputs:   make(map[string]string),
 		RuntimeData:  make(map[string]string),

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -119,7 +119,7 @@ func newOAuthExecutor(
 
 // Execute executes the OAuth authentication flow.
 func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing OAuth authentication executor")
 
 	execResp := &common.ExecutorResponse{
@@ -155,7 +155,7 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 
 // BuildAuthorizeFlow constructs the redirection to the external OAuth provider for user authentication.
 func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *common.ExecutorResponse) error {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Initiating OAuth authentication flow")
 
 	idpID, err := o.GetIdpID(ctx)
@@ -195,7 +195,7 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 // ProcessAuthFlowResponse processes the response from the OAuth authentication flow and authenticates the user.
 func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Processing OAuth authentication response")
 
 	code, ok := ctx.UserInputs[userInputCode]
@@ -278,7 +278,7 @@ func (o *oAuthExecutor) HasRequiredInputs(ctx *core.NodeContext, execResp *commo
 // ExchangeCodeForToken exchanges the authorization code for an access token.
 func (o *oAuthExecutor) ExchangeCodeForToken(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	code string) (*OAuthTokenResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Exchanging authorization code for a token")
 
 	idpID, err := o.GetIdpID(ctx)
@@ -312,7 +312,7 @@ func (o *oAuthExecutor) ExchangeCodeForToken(ctx *core.NodeContext, execResp *co
 // GetUserInfo fetches user information from the OAuth provider using the access token.
 func (o *oAuthExecutor) GetUserInfo(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	accessToken string) (map[string]string, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Fetching user info from OAuth provider")
 
 	idpID, err := o.GetIdpID(ctx)
@@ -419,7 +419,7 @@ func (o *oAuthExecutor) ResolveContextUser(ctx *core.NodeContext,
 func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse, sub string, internalUser *userprovider.User) (
 	*authncm.AuthenticatedUser, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// If no local user is found, check if authentication without local user is allowed
 	if internalUser == nil {
@@ -496,7 +496,7 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse, sub string, internalUser *userprovider.User) (
 	*authncm.AuthenticatedUser, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// If no local user is found, proceed with registration
 	if internalUser == nil {
@@ -564,7 +564,7 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 // resolveUserTypeForAutoProvisioning resolves the user type for auto provisioning in authentication flows.
 func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Resolving user type for automatic provisioning")
 
 	if len(ctx.Application.AllowedUserTypes) == 0 {

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -74,10 +74,10 @@ func (suite *OAuthExecutorTestSuite) TestNewOAuthExecutor() {
 
 func (suite *OAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorizeURL() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeAuthentication,
-		UserInputs: map[string]string{},
-		NodeInputs: []common.Input{{Identifier: "code", Type: "string", Required: true}},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
+		NodeInputs:  []common.Input{{Identifier: "code", Type: "string", Required: true}},
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -102,8 +102,8 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorize
 
 func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -152,8 +152,8 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeProvided_AuthenticatesUser(
 
 func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_Success() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -181,7 +181,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_Success() {
 
 func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_IDPNotConfigured() {
 	ctx := &core.NodeContext{
-		FlowID:         "flow-123",
+		ExecutionID:    "flow-123",
 		FlowType:       common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{},
 	}
@@ -199,8 +199,8 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_IDPNotConfigured() {
 
 func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLClientError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -227,8 +227,8 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLClientError(
 
 func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLServerError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -255,8 +255,8 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLServerError(
 
 func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_Success() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -292,8 +292,8 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_Success() {
 
 func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ClientError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -321,8 +321,8 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ClientError() {
 
 func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ServerError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -350,8 +350,8 @@ func (suite *OAuthExecutorTestSuite) TestExchangeCodeForToken_ServerError() {
 
 func (suite *OAuthExecutorTestSuite) TestGetUserInfo_Success() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -383,8 +383,8 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_Success() {
 
 func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ClientError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -412,8 +412,8 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ClientError() {
 
 func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ServerError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -441,8 +441,8 @@ func (suite *OAuthExecutorTestSuite) TestGetUserInfo_ServerError() {
 
 func (suite *OAuthExecutorTestSuite) TestGetIdpID_Success() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -456,7 +456,7 @@ func (suite *OAuthExecutorTestSuite) TestGetIdpID_Success() {
 
 func (suite *OAuthExecutorTestSuite) TestGetIdpID_NotConfigured() {
 	ctx := &core.NodeContext{
-		FlowID:         "flow-123",
+		ExecutionID:    "flow-123",
 		FlowType:       common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{},
 	}
@@ -470,8 +470,8 @@ func (suite *OAuthExecutorTestSuite) TestGetIdpID_NotConfigured() {
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlow_UserNotFound() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -520,8 +520,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlo
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -567,8 +567,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNo
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExists_RegistrationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -616,9 +616,9 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExis
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvided() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeAuthentication,
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -637,8 +637,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvided(
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyScope() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -672,8 +672,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyScope() {
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -714,8 +714,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
 
 func (suite *OAuthExecutorTestSuite) TestHasRequiredInputs_CodeProvided() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -732,10 +732,10 @@ func (suite *OAuthExecutorTestSuite) TestHasRequiredInputs_CodeProvided() {
 
 func (suite *OAuthExecutorTestSuite) TestHasRequiredInputs_CodeNotProvided() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeAuthentication,
-		UserInputs: map[string]string{},
-		NodeInputs: []common.Input{{Identifier: "code", Type: "string", Required: true}},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
+		NodeInputs:  []common.Input{{Identifier: "code", Type: "string", Required: true}},
 	}
 
 	execResp := &common.ExecutorResponse{
@@ -832,8 +832,8 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserAttributes_FilterSkipAttr
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlow_WithEmail() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -903,8 +903,8 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserAttributes_WithEmail_NilR
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithoutLocalUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -965,8 +965,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithou
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthWithoutLocalUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1013,8 +1013,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthWith
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrationWithExistingUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1067,8 +1067,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrati
 
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistrationWithExistingUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1118,8 +1118,8 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistra
 
 func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"INTERNAL"},
 		},
@@ -1196,8 +1196,8 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
 			ctx := &core.NodeContext{
-				FlowID:   "flow-123",
-				FlowType: common.FlowTypeAuthentication,
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeAuthentication,
 				Application: appmodel.Application{
 					AllowedUserTypes: tt.allowedUserTypes,
 				},
@@ -1222,8 +1222,8 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 
 func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_GetUserSchemaError() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"INTERNAL"},
 		},
@@ -1347,8 +1347,8 @@ func (suite *OAuthExecutorTestSuite) TestGetInternalUser_Success() {
 
 func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_WithExistingUser_SkipProvisioningFlag() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		RuntimeData: map[string]string{
 			common.RuntimeKeySkipProvisioning: dataValueTrue,
 		},
@@ -1432,7 +1432,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 			suite.mockUserSchemaService.ExpectedCalls = nil
 
 			ctx := &core.NodeContext{
-				FlowID: "flow-123",
+				ExecutionID: "flow-123",
 				Application: appmodel.Application{
 					AllowedUserTypes: tt.allowedUserTypes,
 				},
@@ -1464,7 +1464,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 
 func (suite *OAuthExecutorTestSuite) TestGetContextUserForAuthentication_WithoutLocalUser_NotAllowed() {
 	ctx := &core.NodeContext{
-		FlowID:         "flow-123",
+		ExecutionID:    "flow-123",
 		FlowType:       common.FlowTypeAuthentication,
 		NodeProperties: map[string]interface{}{
 			// allowAuthenticationWithoutLocalUser not set or false
@@ -1487,8 +1487,8 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForAuthentication_Without
 
 func (suite *OAuthExecutorTestSuite) TestExecute_InvalidFlowType() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: "InvalidFlowType",
+		ExecutionID: "flow-123",
+		FlowType:    "InvalidFlowType",
 	}
 
 	resp, err := suite.executor.Execute(ctx)

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -88,7 +88,7 @@ func newOIDCAuthExecutor(
 
 // Execute executes the OIDC authentication logic.
 func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing OIDC authentication executor")
 
 	execResp := &common.ExecutorResponse{
@@ -119,7 +119,7 @@ func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 // ProcessAuthFlowResponse processes the response from the OIDC authentication flow and authenticates the user.
 func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Processing OIDC authentication response")
 
 	code, ok := ctx.UserInputs[userInputCode]
@@ -229,7 +229,7 @@ func (o *oidcAuthExecutor) GetIDTokenClaims(execResp *common.ExecutorResponse,
 // TODO: Need to convert attributes as per the IDP to local attribute mapping when the support is implemented.
 func (o *oidcAuthExecutor) getContextUserAttributes(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	idTokenClaims map[string]interface{}, accessToken string) (map[string]interface{}, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	userClaims := make(map[string]interface{})
 
 	// Resolve and add ID token claims

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -74,10 +74,10 @@ func (suite *OIDCAuthExecutorTestSuite) TestNewOIDCAuthExecutor() {
 
 func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorizeURL() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeAuthentication,
-		UserInputs: map[string]string{},
-		NodeInputs: []common.Input{{Identifier: "code", Type: "string", Required: true}},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
+		NodeInputs:  []common.Input{{Identifier: "code", Type: "string", Required: true}},
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -102,8 +102,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthor
 
 func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_AuthenticatesUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -163,8 +163,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_Au
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidIDToken_Success() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -222,8 +222,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidIDToken
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code":  "auth_code_123",
 			"nonce": "expected_nonce_123",
@@ -266,8 +266,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -309,8 +309,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoSubClaim()
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlow_UserNotFound() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -365,8 +365,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNotFound() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -412,8 +412,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_Use
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExists_RegistrationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -547,8 +547,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestGetIDTokenClaims_Errors() {
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_WithAdditionalScopes_FetchesUserInfo() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -614,9 +614,9 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_WithAddition
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvided() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeAuthentication,
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -635,8 +635,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoCodeProvid
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUserClaimsFromIDToken() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -707,8 +707,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUs
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDToken() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -768,8 +768,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoEmailInIDToken() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -829,8 +829,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoEmailInIDT
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyEmailInIDToken() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -890,8 +890,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmptyEmailIn
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_RegistrationFlow_WithEmail() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -950,8 +950,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_Registration
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailFromUserInfo() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1019,8 +1019,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailFromUse
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDToken_NilRuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1081,8 +1081,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailInIDTok
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWithoutLocalUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1154,8 +1154,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowAuthWit
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthWithoutLocalUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1206,8 +1206,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventAuthW
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistrationWithExistingUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1271,8 +1271,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_AllowRegistr
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_PreventRegistrationWithExistingUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},
@@ -1372,7 +1372,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OAuthClient
 			suite.mockOIDCService.ExpectedCalls = nil
 
 			ctx := &core.NodeContext{
-				FlowID: "flow-123",
+				ExecutionID: "flow-123",
 				NodeProperties: map[string]interface{}{
 					"idpId": "idp-123",
 				},
@@ -1406,7 +1406,7 @@ func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OAuthClient
 
 func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OnlyOpenIDScope_NoUserInfoCall() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
 		},
@@ -1459,8 +1459,8 @@ func (suite *OIDCAuthExecutorTestSuite) TestGetContextUserAttributes_OnlyOpenIDS
 
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NonStringSubClaim() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
 		},

--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -74,7 +74,7 @@ func newOUExecutor(
 
 // Execute executes the ou creation logic.
 func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing OU creation executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/ou_executor_test.go
+++ b/backend/internal/flow/executor/ou_executor_test.go
@@ -210,7 +210,7 @@ func (suite *OUExecutorTestSuite) TestExecute_Success() {
 			suite.SetupTest()
 
 			ctx := &core.NodeContext{
-				FlowID:      "flow-123",
+				ExecutionID: "flow-123",
 				FlowType:    common.FlowTypeRegistration,
 				UserInputs:  tc.userInputs,
 				RuntimeData: map[string]string{},
@@ -248,8 +248,8 @@ func (suite *OUExecutorTestSuite) TestExecute_NonRegistrationFlow() {
 			suite.SetupTest()
 
 			ctx := &core.NodeContext{
-				FlowID:   "flow-123",
-				FlowType: tc.flowType,
+				ExecutionID: "flow-123",
+				FlowType:    tc.flowType,
 			}
 
 			result, err := suite.executor.Execute(ctx)
@@ -318,7 +318,7 @@ func (suite *OUExecutorTestSuite) TestExecute_PrerequisitesFailure() {
 		{
 			name: "Missing prerequisite field",
 			ctx: &core.NodeContext{
-				FlowID:      "flow-123",
+				ExecutionID: "flow-123",
 				FlowType:    common.FlowTypeRegistration,
 				UserInputs:  map[string]string{},
 				RuntimeData: map[string]string{},
@@ -370,9 +370,9 @@ func (suite *OUExecutorTestSuite) TestExecute_UserInputRequired() {
 			suite.SetupTest()
 
 			ctx := &core.NodeContext{
-				FlowID:     "flow-123",
-				FlowType:   common.FlowTypeRegistration,
-				UserInputs: tc.userInputs,
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeRegistration,
+				UserInputs:  tc.userInputs,
 			}
 
 			result, err := suite.executor.Execute(ctx)
@@ -468,7 +468,7 @@ func (suite *OUExecutorTestSuite) TestExecute_ErrorScenarios() {
 			suite.SetupTest()
 
 			ctx := &core.NodeContext{
-				FlowID:      "flow-123",
+				ExecutionID: "flow-123",
 				FlowType:    common.FlowTypeRegistration,
 				UserInputs:  tc.userInputs,
 				RuntimeData: map[string]string{},
@@ -503,8 +503,8 @@ func (suite *OUExecutorTestSuite) TestExecute_EmptyOUID() {
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			userInputOuName:   "Engineering",
 			userInputOuHandle: "engineering",

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -82,7 +82,7 @@ func newOUResolverExecutor(
 //   - "prompt": checks for child OUs and prompts the user to select one if applicable.
 //   - "promptAll": shows the full OU tree from root, independent of UserTypeResolver.
 func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	execResp := &common.ExecutorResponse{
 		Status:      common.ExecComplete,

--- a/backend/internal/flow/executor/ou_resolver_executor_test.go
+++ b/backend/internal/flow/executor/ou_resolver_executor_test.go
@@ -80,8 +80,8 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_ResolveFromCaller_Success(
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromCaller,
 		},
@@ -107,8 +107,8 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_ResolveFromCaller_CallerOU
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromCaller,
 		},
@@ -130,7 +130,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_ResolveFromNotConfigured()
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:         "test-flow",
+		ExecutionID:    "test-flow",
 		Context:        httpCtx,
 		NodeProperties: map[string]interface{}{},
 		RuntimeData: map[string]string{
@@ -149,8 +149,8 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_UnsupportedResolveFrom() {
 	httpCtx := context.Background()
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: "unsupported",
 		},
@@ -167,7 +167,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PropertyMissing() {
 	httpCtx := context.Background()
 
 	ctx := &core.NodeContext{
-		FlowID:         "test-flow",
+		ExecutionID:    "test-flow",
 		Context:        httpCtx,
 		NodeProperties: map[string]interface{}{},
 		RuntimeData: map[string]string{
@@ -186,7 +186,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_NilNodeProperties() {
 	httpCtx := context.Background()
 
 	ctx := &core.NodeContext{
-		FlowID:         "test-flow",
+		ExecutionID:    "test-flow",
 		Context:        httpCtx,
 		NodeProperties: nil,
 		RuntimeData: map[string]string{
@@ -210,8 +210,8 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PropertyWrongType() {
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: 123, // Not a string.
 		},
@@ -226,8 +226,8 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PropertyWrongType() {
 
 func (suite *OUResolverExecutorTestSuite) TestExecute_NilContext() {
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: nil,
+		ExecutionID: "test-flow",
+		Context:     nil,
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromCaller,
 		},
@@ -244,7 +244,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_NilContext() {
 
 func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_NoDefaultOUID_ReturnsError() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -267,7 +267,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_Vali
 	selectedOUID := testChildOUID
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -295,7 +295,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_NotI
 	selectedOUID := "unrelated-ou-789"
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -323,7 +323,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_Serv
 	selectedOUID := testChildOUID
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -356,7 +356,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_Clie
 	selectedOUID := testChildOUID
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -388,7 +388,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_NoChildOUs_Skips() 
 	parentOUID := testParentOUID
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -412,7 +412,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_HasChildOUs_Request
 	parentOUID := testParentOUID
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -440,7 +440,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_GetChildrenError_Re
 	parentOUID := testParentOUID
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
 		},
@@ -470,7 +470,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_GetChildrenError_Re
 
 func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_FirstInvocation_RequestsInput() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
 		},
@@ -494,7 +494,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_ValidOUSelection
 	selectedOUID := "valid-ou-123"
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
 		},
@@ -519,7 +519,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_NonExistentOU() 
 	selectedOUID := "nonexistent-ou-999"
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
 		},
@@ -544,7 +544,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_ServiceError() {
 	selectedOUID := "some-ou-123"
 
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
 		},
@@ -572,7 +572,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_ServiceError() {
 
 func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_EmptyOUInput_RequestsInput() {
 	ctx := &core.NodeContext{
-		FlowID: "flow-123",
+		ExecutionID: "flow-123",
 		NodeProperties: map[string]interface{}{
 			common.NodePropertyOUResolveFrom: ouResolveFromPromptAll,
 		},

--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -139,7 +139,7 @@ func newPasskeyAuthExecutor(
 
 // Execute executes the passkey authentication logic.
 func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing passkey authentication executor")
 
 	execResp := &common.ExecutorResponse{
@@ -170,7 +170,7 @@ func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 // executeChallenge generates and returns a passkey authentication challenge.
 func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// Get userID from context (may be empty for usernameless flow)
 	userID := p.GetUserIDFromContext(ctx)
@@ -232,7 +232,7 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 // executeVerify verifies the passkey authentication response.
 func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Verifying passkey authentication response")
 
 	// Check for required inputs
@@ -364,7 +364,7 @@ func (p *passkeyAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 // executeRegisterStart initiates passkey credential registration.
 func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Starting passkey registration")
 
 	userID := p.GetUserIDFromContext(ctx)
@@ -431,7 +431,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 // executeRegisterFinish completes passkey credential registration.
 func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Finishing passkey registration")
 
 	// Check for required inputs

--- a/backend/internal/flow/executor/passkey_executor_test.go
+++ b/backend/internal/flow/executor/passkey_executor_test.go
@@ -131,7 +131,7 @@ func createMockPasskeyAuthExecutor(t *testing.T) core.ExecutorInterface {
 // Helper to create a node context with common properties
 func createPasskeyNodeContext(mode string, flowType common.FlowType) *core.NodeContext {
 	return &core.NodeContext{
-		FlowID:       testPasskeyFlowID,
+		ExecutionID:  testPasskeyFlowID,
 		FlowType:     flowType,
 		ExecutorMode: mode,
 		UserInputs:   make(map[string]string),

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -55,7 +55,7 @@ func newPermissionValidator(flowFactory core.FlowFactoryInterface) *permissionVa
 
 // Execute validates that the request has the required permission/scope to access the next node.
 func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),

--- a/backend/internal/flow/executor/permission_validator_test.go
+++ b/backend/internal/flow/executor/permission_validator_test.go
@@ -59,8 +59,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_DefaultScopeCheck_Success
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -78,8 +78,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_DefaultScopeCheck_Failure
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -164,7 +164,7 @@ func (suite *PermissionValidatorTestSuite) TestExecute_CustomScopeCheck_Success(
 			httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 			ctx := &core.NodeContext{
-				FlowID:         "test-flow",
+				ExecutionID:    "test-flow",
 				Context:        httpCtx,
 				NodeProperties: tc.nodeProps,
 			}
@@ -186,8 +186,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_MultipleRequiredScopes_OR
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 		NodeProperties: map[string]interface{}{
 			propertyKeyRequiredScopes: []interface{}{"scopeA", "scopeB"},
 		},
@@ -208,8 +208,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_AuthorizedPermissionsChec
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 		NodeProperties: map[string]interface{}{
 			propertyKeyRequiredScopes: []interface{}{"admin"},
 		},
@@ -223,8 +223,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_AuthorizedPermissionsChec
 
 func (suite *PermissionValidatorTestSuite) TestExecute_NoHTTPContext() {
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: nil,
+		ExecutionID: "test-flow",
+		Context:     nil,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -243,8 +243,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_EmptyScopes() {
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -263,8 +263,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_NoScopesInContext() {
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -283,8 +283,8 @@ func (suite *PermissionValidatorTestSuite) TestExecute_ScopesWithUnexpectedType(
 	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
 
 	ctx := &core.NodeContext{
-		FlowID:  "test-flow",
-		Context: httpCtx,
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
 	}
 
 	resp, err := suite.executor.Execute(ctx)

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -75,7 +75,7 @@ func newProvisioningExecutor(
 
 // Execute executes the user provisioning logic based on the inputs provided.
 func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing user provisioning executor")
 
 	execResp := &common.ExecutorResponse{
@@ -232,7 +232,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 // missing inputs to the executor response. Returns true if required inputs are found, otherwise false.
 func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Checking inputs for the provisioning executor")
 
 	if p.ExecutorInterface.HasRequiredInputs(ctx, execResp) {
@@ -337,7 +337,7 @@ func (p *provisioningExecutor) appendNonIdentifyingAttributes(ctx *core.NodeCont
 // createUserInStore creates a new user in the user store with the provided attributes.
 func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 	userAttributes map[string]interface{}) (*userprovider.User, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, nodeCtx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, nodeCtx.ExecutionID))
 	logger.Debug("Creating the user account")
 
 	ouID := p.getOUID(nodeCtx)
@@ -403,7 +403,7 @@ func (p *provisioningExecutor) assignGroupsAndRoles(
 	ctx *core.NodeContext,
 	userID string,
 ) error {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// Get configured group and role from properties
 	groupID := p.getGroupToAssign(ctx)

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -112,8 +112,8 @@ func (suite *ProvisioningExecutorTestSuite) createMockProvisioningExecutor() cor
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_NonRegistrationFlow() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -128,8 +128,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 			"email":    "new@example.com",
@@ -194,8 +194,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success() {
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAlreadyExists() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "existinguser",
 		},
@@ -218,10 +218,10 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAlreadyExists() {
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_NoUserAttributes() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeRegistration,
-		UserInputs: map[string]string{},
-		NodeInputs: []common.Input{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{},
+		NodeInputs:  []common.Input{},
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -234,8 +234,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_NoUserAttributes() {
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 		},
@@ -262,8 +262,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AttributesFromAuthUser() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			Attributes: map[string]interface{}{"email": "test@example.com"},
 		},
@@ -461,8 +461,8 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Fil
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_UserAlreadyExists() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "existinguser",
 		},
@@ -494,8 +494,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_UserAlr
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_ProceedsNormally() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 			"email":    "new@example.com",
@@ -552,8 +552,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_Proceed
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_UserEligibleForProvisioning() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"username": "provisioneduser",
 			"email":    "provisioned@example.com",
@@ -604,8 +604,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAutoProvisionedFlag_
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"username": "newuser",
 			"email":    "new@example.com",
@@ -708,8 +708,8 @@ func (suite *ProvisioningExecutorTestSuite) TestAppendNonIdentifyingAttributes()
 func (suite *ProvisioningExecutorTestSuite) TestExecute_RegistrationFlow_SkipProvisioningWithExistingUser() {
 	userID := "existing-user-id"
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "existinguser",
 		},
@@ -759,8 +759,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_MissingInputs() {
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
 			ctx := &core.NodeContext{
-				FlowID:   "flow-123",
-				FlowType: common.FlowTypeRegistration,
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeRegistration,
 				UserInputs: map[string]string{
 					"username": "newuser",
 				},
@@ -827,8 +827,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFailures() {
 			suite.mockUserProvider.ExpectedCalls = nil
 
 			ctx := &core.NodeContext{
-				FlowID:   "flow-123",
-				FlowType: common.FlowTypeRegistration,
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeRegistration,
 				UserInputs: map[string]string{
 					"username": "newuser",
 				},
@@ -941,8 +941,8 @@ func (suite *ProvisioningExecutorTestSuite) TestGetUserType() {
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AllAttributesInRuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			"email":    "user@example.com",
 			"username": "testuser",
@@ -973,8 +973,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_GroupAssignmentF
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 		},
@@ -1028,8 +1028,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_BothGroupAndRole
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 		},
@@ -1084,8 +1084,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Failure_RoleAssignmentFa
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 		},
@@ -1141,8 +1141,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_GroupWithExistingMembers
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 		},
@@ -1194,8 +1194,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_AuthFlow_AutoProvisionin
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"username": "provisioneduser",
 		},
@@ -1247,8 +1247,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_Success_WithGroupAndRole
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"username": "newuser",
 			"email":    "new@example.com",
@@ -1332,8 +1332,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_Success() {
 	}
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"sub": "user-sub-123",
 		},
@@ -1366,8 +1366,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NotEnabled_Fails
 	existingUserID := testExistingUserID
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"sub": "user-sub-123",
 		},
@@ -1397,8 +1397,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_SameOU_Fails() {
 	}
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"sub": "user-sub-123",
 		},
@@ -1427,8 +1427,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NoTargetOU_Fails
 	existingUserID := testExistingUserID
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"sub": "user-sub-123",
 		},
@@ -1456,8 +1456,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_GetUserError() {
 	existingUserID := testExistingUserID
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			"sub": "user-sub-123",
 		},

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -88,7 +88,7 @@ func newSMSOTPAuthExecutor(
 
 // Execute executes the SMS OTP authentication logic.
 func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing SMS OTP authentication executor")
 
 	execResp := &common.ExecutorResponse{
@@ -114,7 +114,7 @@ func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 // executeSend executes the OTP sending step.
 func (s *smsOTPAuthExecutor) executeSend(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	err := s.InitiateOTP(ctx, execResp)
 	if err != nil {
@@ -129,7 +129,7 @@ func (s *smsOTPAuthExecutor) executeSend(ctx *core.NodeContext,
 // executeVerify executes the OTP verification step.
 func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if !s.HasRequiredInputs(ctx, execResp) {
 		logger.Debug("Required inputs for SMS OTP verification are not provided")
@@ -152,7 +152,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 // InitiateOTP initiates the OTP sending process to the user's mobile number.
 func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Sending SMS OTP to user")
 
 	phoneAttr := s.resolvePhoneInput(ctx, mobileNumberInput).Identifier
@@ -225,7 +225,7 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 // ProcessAuthFlowResponse processes the authentication flow response for SMS OTP.
 func (s *smsOTPAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Processing authentication flow response for SMS OTP")
 
 	err := s.validateOTP(ctx, execResp, logger)
@@ -256,7 +256,7 @@ func (s *smsOTPAuthExecutor) ValidatePrerequisites(ctx *core.NodeContext,
 		return true
 	}
 
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if ctx.FlowType == common.FlowTypeRegistration {
 		logger.Debug("Prerequisites not met for registration flow, prompting for mobile number")
@@ -328,7 +328,7 @@ func (s *smsOTPAuthExecutor) getUserMobileFromContext(ctx *core.NodeContext, pho
 // satisfyPrerequisites tries to satisfy the prerequisites for the SMSOTPAuthExecutor.
 func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	execResp.Status = ""
 	execResp.FailureReason = ""
@@ -376,7 +376,7 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 // resolveUserID resolves the user ID from the context based on various attributes.
 // TODO: Move to a separate resolver when the support is added.
 func (s *smsOTPAuthExecutor) resolveUserID(ctx *core.NodeContext) (bool, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// First, check if the user ID is already available in the context.
 	userID := s.GetUserIDFromContext(ctx)
@@ -455,7 +455,8 @@ func (s *smsOTPAuthExecutor) resolveUserIDFromAttribute(ctx *core.NodeContext,
 // getUserMobileNumber retrieves the mobile number for the given user ID.
 func (s *smsOTPAuthExecutor) getUserMobileNumber(userID string, ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (string, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String("userID", userID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
+		log.String("userID", userID))
 	logger.Debug("Retrieving user mobile number")
 
 	// Try to get mobile number from context
@@ -627,7 +628,7 @@ func (s *smsOTPAuthExecutor) validateOTP(ctx *core.NodeContext, execResp *common
 // getAuthenticatedUser returns the authenticated user details for the given user ID.
 func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*authncm.AuthenticatedUser, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	phoneAttr := ctx.RuntimeData[runtimeKeySMSOTPPhoneAttr]
 	if phoneAttr == "" {

--- a/backend/internal/flow/executor/sms_auth_executor_test.go
+++ b/backend/internal/flow/executor/sms_auth_executor_test.go
@@ -95,7 +95,7 @@ func (suite *SMSAuthExecutorTestSuite) SetupTest() {
 
 func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlow_PromptsMobileNumber() {
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow-123",
+		ExecutionID: "test-flow-123",
 		FlowType:    common.FlowTypeRegistration,
 		UserInputs:  make(map[string]string),
 		RuntimeData: make(map[string]string),
@@ -123,8 +123,8 @@ func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlo
 
 func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlow_CustomPhoneAttr() {
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "test-flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		NodeInputs: []common.Input{
 			{Ref: "phone_input", Identifier: "phoneNumber", Type: common.InputTypePhone, Required: true},
 		},
@@ -148,8 +148,8 @@ func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlo
 
 func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlow_PrerequisitesMet() {
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "test-flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+1234567890",
 		},
@@ -176,7 +176,7 @@ func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_AuthenticationF
 	suite.executor.ExecutorInterface = mockExec
 
 	ctx := &core.NodeContext{
-		FlowID:      "test-flow-123",
+		ExecutionID: "test-flow-123",
 		FlowType:    common.FlowTypeAuthentication, // Authentication flow, NOT registration
 		UserInputs:  make(map[string]string),
 		RuntimeData: make(map[string]string),
@@ -196,8 +196,8 @@ func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_AuthenticationF
 // TestGetAuthenticatedUser_MFA_AddsMobileNumberToAttributes verifies that when user is already authenticated
 func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_MFA_AddsMobileNumberToAttributes() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		RuntimeData: map[string]string{
 			runtimeKeySMSOTPMobileNumber: "+1234567890",
 		},
@@ -238,8 +238,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_FetchFromStore_A
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		RuntimeData: map[string]string{
 			userAttributeUserID:          "user-123",
 			runtimeKeySMSOTPMobileNumber: "+1234567890", // Mobile from RuntimeData
@@ -284,8 +284,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_FetchFromStore_P
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		RuntimeData: map[string]string{
 			userAttributeUserID:          "user-123",
 			runtimeKeySMSOTPMobileNumber: "+1234567890", // Different mobile in RuntimeData
@@ -329,8 +329,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetUserMobileNumber_NotFoundInAttribu
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		// No mobile number in UserInputs or RuntimeData
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -362,8 +362,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetUserMobileNumber_NotFoundInAttribu
 // phone value in UserInputs is not treated as a met prerequisite.
 func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlow_EmptyPhoneInUserInputs() {
 	ctx := &core.NodeContext{
-		FlowID:   "test-flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "test-flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "",
 		},
@@ -384,9 +384,9 @@ func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlo
 // phone value in RuntimeData is not treated as a met prerequisite.
 func (suite *SMSAuthExecutorTestSuite) TestValidatePrerequisites_RegistrationFlow_EmptyPhoneInRuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:     "test-flow-123",
-		FlowType:   common.FlowTypeRegistration,
-		UserInputs: make(map[string]string),
+		ExecutionID: "test-flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  make(map[string]string),
 		RuntimeData: map[string]string{
 			common.AttributeMobileNumber: "",
 		},
@@ -411,7 +411,7 @@ func (suite *SMSAuthExecutorTestSuite) TestGetUserMobileNumber_NonStringAttribut
 	attrsJSON, _ := json.Marshal(attrs)
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeAuthentication,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -442,8 +442,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetUserMobileNumber_NonStringAttribut
 // has nil Attributes map, it is initialized before adding mobile number.
 func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_MFA_NilAttributes() {
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		RuntimeData: map[string]string{
 			runtimeKeySMSOTPMobileNumber: "+1234567890",
 		},
@@ -476,8 +476,8 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_FetchFromStore_N
 	attrsJSON := []byte("null")
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		RuntimeData: map[string]string{
 			userAttributeUserID:          "user-123",
 			runtimeKeySMSOTPMobileNumber: "+1234567890",

--- a/backend/internal/flow/executor/sms_executor.go
+++ b/backend/internal/flow/executor/sms_executor.go
@@ -68,7 +68,7 @@ func newSMSExecutor(flowFactory core.FlowFactoryInterface,
 // Execute resolves the recipient from user inputs or runtime data and the sender ID from node properties,
 // then renders the SMS body from a template and sends it.
 func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing SMS executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/sms_executor_test.go
+++ b/backend/internal/flow/executor/sms_executor_test.go
@@ -65,7 +65,7 @@ func (suite *SMSExecutorTestSuite) SetupTest() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_Success() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -97,7 +97,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_Success() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_RecipientFromRuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
@@ -129,7 +129,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_RecipientFromRuntimeData
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_UserInputOverridesRuntimeData() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -163,7 +163,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_UserInputOverridesRuntim
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_CustomPhoneAttribute() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"phoneNumber": "+94714627887",
@@ -198,7 +198,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_CustomPhoneAttribute() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_PrerequisiteNotMet_ReturnsFailure() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs:   make(map[string]string),
 		RuntimeData:  make(map[string]string),
@@ -219,7 +219,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_PrerequisiteNotMet_ReturnsFailure
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_MissingRecipient() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs:   make(map[string]string),
 		RuntimeData:  make(map[string]string),
@@ -243,7 +243,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_MissingRecipient() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_MissingSenderID() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -267,7 +267,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_MissingSenderID() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_InvalidSenderIDType() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -291,7 +291,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_InvalidSenderIDType() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_InvalidPhoneNumber() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "not-a-phone",
@@ -330,7 +330,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_NilSMSSenderService_Retu
 	noServiceExecutor := newSMSExecutor(mockFactory, nil, suite.mockTemplateService)
 
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -350,7 +350,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_NilSMSSenderService_Retu
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_ClientError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -386,7 +386,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_ClientError() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_ServerError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -421,7 +421,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_ServerError() {
 
 func (suite *SMSExecutorTestSuite) TestExecute_NoSMSTemplateProperty_ReturnsFlowError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -448,7 +448,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_NoSMSTemplateProperty_ReturnsFlow
 
 func (suite *SMSExecutorTestSuite) TestExecute_EmptySMSTemplateProperty_ReturnsFlowError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -476,7 +476,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_EmptySMSTemplateProperty_ReturnsF
 
 func (suite *SMSExecutorTestSuite) TestExecute_SMSTemplatePropertySet_UsesCustomScenario() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",
@@ -509,7 +509,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SMSTemplatePropertySet_UsesCustom
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_TemplateRenderFailure_ReturnsError() {
 	ctx := &core.NodeContext{
-		FlowID:       "test-flow-id",
+		ExecutionID:  "test-flow-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			common.AttributeMobileNumber: "+94714627887",

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -82,7 +82,7 @@ func newUserTypeResolver(
 
 // Execute resolves the user type from inputs or prompts the user to select one.
 func (u *userTypeResolver) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := u.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing user type resolver")
 
 	execResp := &common.ExecutorResponse{
@@ -109,7 +109,7 @@ func (u *userTypeResolver) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 // handleAuthenticationFlows handles user type resolution for authentication flows.
 func (u *userTypeResolver) handleAuthenticationFlows(ctx *core.NodeContext, execResp *common.ExecutorResponse) (
 	*common.ExecutorResponse, error) {
-	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := u.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// Validate that allowed user types are defined
 	if len(ctx.Application.AllowedUserTypes) == 0 {
@@ -127,7 +127,7 @@ func (u *userTypeResolver) handleAuthenticationFlows(ctx *core.NodeContext, exec
 func (u *userTypeResolver) handleRegistrationFlows(ctx *core.NodeContext, execResp *common.ExecutorResponse) (
 	*common.ExecutorResponse, error) {
 	reqCtx := ctx.Context
-	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := u.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	allowed := ctx.Application.AllowedUserTypes
 
 	// Check for allowed user types to decide next steps
@@ -184,7 +184,7 @@ func (u *userTypeResolver) handleRegistrationFlows(ctx *core.NodeContext, execRe
 // handleUserOnboardingFlows handles user type resolution for user onboarding flows.
 func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := u.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	// Read optional allowedUserTypes from node properties
 	allowedUserTypes := u.getAllowedUserTypesFromProperties(ctx)

--- a/backend/internal/flow/executor/user_type_resolver_test.go
+++ b/backend/internal/flow/executor/user_type_resolver_test.go
@@ -126,8 +126,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_AuthenticationFlow_WithAllow
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer"},
 		},
@@ -147,8 +147,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_AuthenticationFlow_NoAllowed
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{},
 		},
@@ -184,8 +184,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UnsupportedFlowType() {
 			suite.SetupTest()
 
 			ctx := &core.NodeContext{
-				FlowID:   "flow-123",
-				FlowType: tc.flowType,
+				ExecutionID: "flow-123",
+				FlowType:    tc.flowType,
 				Application: appmodel.Application{
 					AllowedUserTypes: []string{"employee"},
 				},
@@ -223,8 +223,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_Succ
 			suite.SetupTest()
 
 			ctx := &core.NodeContext{
-				FlowID:   "flow-123",
-				FlowType: common.FlowTypeRegistration,
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeRegistration,
 				Application: appmodel.Application{
 					AllowedUserTypes: tc.allowedUserTypes,
 				},
@@ -260,8 +260,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_NoOU
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer"},
 		},
@@ -292,8 +292,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_NotA
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer"},
 		},
@@ -316,8 +316,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_OURe
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee"},
 		},
@@ -348,8 +348,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_NoAllowedUserTypes() {
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{},
 		},
@@ -370,8 +370,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_Succes
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee"},
 		},
@@ -403,8 +403,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_NoOU()
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee"},
 		},
@@ -433,8 +433,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_OUReso
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee"},
 		},
@@ -463,8 +463,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_Pro
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer", "partner"},
 		},
@@ -506,8 +506,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_EmptyUserTypeInput() {
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer"},
 		},
@@ -548,8 +548,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserTypeProvidedInInput_Self
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee"},
 		},
@@ -581,8 +581,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_SingleAllowedUserType_SelfRe
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee"},
 		},
@@ -612,8 +612,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_Onl
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer", "partner"},
 		},
@@ -662,8 +662,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_NoS
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer"},
 		},
@@ -703,8 +703,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_MultipleAllowedUserTypes_Sch
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer"},
 		},
@@ -743,8 +743,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowed
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer", "partner"},
 		},
@@ -774,8 +774,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowed
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer", "partner"},
 		},
@@ -802,8 +802,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowed
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer"},
 		},
@@ -826,8 +826,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_RegistrationFlow_NodeAllowed
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeRegistration,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
 		Application: appmodel.Application{
 			AllowedUserTypes: []string{"employee", "customer", "partner"},
 		},
@@ -915,8 +915,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_UserTypeP
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeUserOnboarding, // User Onboarding Flow
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding, // User Onboarding Flow
 		UserInputs: map[string]string{
 			userTypeKey: "employee",
 		},
@@ -946,8 +946,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_UserTypeP
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeUserOnboarding,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs: map[string]string{
 			userTypeKey: "invalid_user",
 		},
@@ -978,7 +978,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -1003,7 +1003,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -1028,7 +1028,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -1056,7 +1056,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_NoUserTyp
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -1089,7 +1089,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -1122,7 +1122,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -1157,7 +1157,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{},
@@ -1188,7 +1188,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{userTypeKey: "partner"},
 		RuntimeData: map[string]string{},
@@ -1209,7 +1209,7 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboardingFlow_AllowedUs
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:      "flow-123",
+		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs:  map[string]string{userTypeKey: "employee"},
 		RuntimeData: map[string]string{},
@@ -1313,8 +1313,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_UserT
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeUserOnboarding,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs: map[string]string{
 			userTypeKey: "employee",
 		},
@@ -1347,8 +1347,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_UserT
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeUserOnboarding,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs: map[string]string{
 			userTypeKey: "employee",
 		},
@@ -1380,8 +1380,8 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_IsPar
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:   "flow-123",
-		FlowType: common.FlowTypeUserOnboarding,
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
 		UserInputs: map[string]string{
 			userTypeKey: "employee",
 		},
@@ -1416,9 +1416,9 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_Filte
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeUserOnboarding,
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			ouIDKey: "child-ou-456",
 		},
@@ -1456,9 +1456,9 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_Filte
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeUserOnboarding,
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			ouIDKey: "child-ou-456",
 		},
@@ -1492,9 +1492,9 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_AllSc
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeUserOnboarding,
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			ouIDKey: "unrelated-ou-999",
 		},
@@ -1527,9 +1527,9 @@ func (suite *UserTypeResolverTestSuite) TestExecute_UserOnboarding_OUFirst_IsPar
 	suite.SetupTest()
 
 	ctx := &core.NodeContext{
-		FlowID:     "flow-123",
-		FlowType:   common.FlowTypeUserOnboarding,
-		UserInputs: map[string]string{},
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeUserOnboarding,
+		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
 			ouIDKey: "child-ou-456",
 		},

--- a/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
+++ b/backend/internal/flow/flowexec/FlowExecServiceInterface_mock_test.go
@@ -39,8 +39,8 @@ func (_m *FlowExecServiceInterfaceMock) EXPECT() *FlowExecServiceInterfaceMock_E
 }
 
 // Execute provides a mock function for the type FlowExecServiceInterfaceMock
-func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, flowID string, flowType string, verbose bool, action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, appID, flowID, flowType, verbose, action, inputs)
+func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, appID, executionID, flowType, verbose, action, inputs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
@@ -49,17 +49,17 @@ func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID st
 	var r0 *FlowStep
 	var r1 *serviceerror.ServiceError
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) (*FlowStep, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, appID, flowID, flowType, verbose, action, inputs)
+		return returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) *FlowStep); ok {
-		r0 = returnFunc(ctx, appID, flowID, flowType, verbose, action, inputs)
+		r0 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*FlowStep)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, bool, string, map[string]string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, appID, flowID, flowType, verbose, action, inputs)
+		r1 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -76,16 +76,16 @@ type FlowExecServiceInterfaceMock_Execute_Call struct {
 // Execute is a helper method to define mock.On call
 //   - ctx context.Context
 //   - appID string
-//   - flowID string
+//   - executionID string
 //   - flowType string
 //   - verbose bool
 //   - action string
 //   - inputs map[string]string
-func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, flowID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
-	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, flowID, flowType, verbose, action, inputs)}
+func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, executionID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
+	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, executionID, flowType, verbose, action, inputs)}
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, flowID string, flowType string, verbose bool, action string, inputs map[string]string)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -133,7 +133,7 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Return(flowStep *FlowStep, 
 	return _c
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, flowID string, flowType string, verbose bool, action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -61,7 +61,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine"))
 
 	flowStep := FlowStep{
-		FlowID: ctx.FlowID,
+		ExecutionID: ctx.ExecutionID,
 	}
 
 	// Track flow execution start time
@@ -86,7 +86,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 
 		nodeCtx := &core.NodeContext{
 			Context:           ctx.Context,
-			FlowID:            ctx.FlowID,
+			ExecutionID:       ctx.ExecutionID,
 			FlowType:          ctx.FlowType,
 			AppID:             ctx.AppID,
 			CurrentAction:     ctx.CurrentAction,
@@ -820,12 +820,12 @@ func publishNodeExecutionStartedEvent(
 	}
 
 	evt := event.NewEvent(
-		ctx.FlowID, // Use FlowID as TraceID
+		ctx.ExecutionID, // Use ExecutionID as TraceID
 		string(event.EventTypeFlowNodeExecutionStarted),
 		event.ComponentFlowEngine,
 	).
 		WithStatus(event.StatusInProgress).
-		WithData(event.DataKey.FlowID, ctx.FlowID).
+		WithData(event.DataKey.ExecutionID, ctx.ExecutionID).
 		WithData(event.DataKey.FlowType, string(ctx.FlowType)).
 		WithData(event.DataKey.NodeID, node.GetID()).
 		WithData(event.DataKey.NodeType, string(node.GetType())).
@@ -891,12 +891,12 @@ func publishNodeExecutionCompletedEvent(ctx *EngineContext, node core.NodeInterf
 	durationMs := executionEndTime - executionStartTime
 
 	evt := event.NewEvent(
-		ctx.FlowID, // Use FlowID as TraceID
+		ctx.ExecutionID, // Use ExecutionID as TraceID
 		string(eventType),
 		event.ComponentFlowEngine,
 	).
 		WithStatus(status).
-		WithData(event.DataKey.FlowID, ctx.FlowID).
+		WithData(event.DataKey.ExecutionID, ctx.ExecutionID).
 		WithData(event.DataKey.FlowType, string(ctx.FlowType)).
 		WithData(event.DataKey.NodeID, node.GetID()).
 		WithData(event.DataKey.NodeType, string(node.GetType())).
@@ -938,7 +938,7 @@ func publishFlowStartedEvent(ctx *EngineContext, obsSvc observability.Observabil
 		event.ComponentFlowEngine,
 	).
 		WithStatus(event.StatusInProgress).
-		WithData(event.DataKey.FlowID, ctx.FlowID).
+		WithData(event.DataKey.ExecutionID, ctx.ExecutionID).
 		WithData(event.DataKey.FlowType, string(ctx.FlowType)).
 		WithData(event.DataKey.AppID, ctx.AppID)
 
@@ -965,12 +965,12 @@ func publishFlowCompletedEvent(
 	durationMs := flowEndTime - flowStartTime
 
 	evt := event.NewEvent(
-		ctx.FlowID, // Use FlowID as TraceID
+		ctx.ExecutionID, // Use ExecutionID as TraceID
 		string(event.EventTypeFlowCompleted),
 		event.ComponentFlowEngine,
 	).
 		WithStatus(event.StatusSuccess).
-		WithData(event.DataKey.FlowID, ctx.FlowID).
+		WithData(event.DataKey.ExecutionID, ctx.ExecutionID).
 		WithData(event.DataKey.FlowType, string(ctx.FlowType)).
 		WithData(event.DataKey.AppID, ctx.AppID).
 		WithData(event.DataKey.DurationMs, fmt.Sprintf("%d", durationMs))
@@ -999,7 +999,7 @@ func publishFlowFailedEvent(ctx *EngineContext, svcErr *serviceerror.ServiceErro
 		event.ComponentFlowEngine,
 	).
 		WithStatus(event.StatusFailure).
-		WithData(event.DataKey.FlowID, ctx.FlowID).
+		WithData(event.DataKey.ExecutionID, ctx.ExecutionID).
 		WithData(event.DataKey.FlowType, string(ctx.FlowType)).
 		WithData(event.DataKey.AppID, ctx.AppID).
 		WithData(event.DataKey.DurationMs, fmt.Sprintf("%d", durationMs))

--- a/backend/internal/flow/flowexec/engine_event_enabled_test.go
+++ b/backend/internal/flow/flowexec/engine_event_enabled_test.go
@@ -73,9 +73,9 @@ func TestPublishFlowStartedEvent(t *testing.T) {
 
 	t.Run("with_authenticated_user", func(t *testing.T) {
 		ctx := &EngineContext{
-			FlowID:   "flow-001",
-			FlowType: common.FlowTypeAuthentication,
-			AppID:    "app-001",
+			ExecutionID: "flow-001",
+			FlowType:    common.FlowTypeAuthentication,
+			AppID:       "app-001",
 			AuthenticatedUser: authncm.AuthenticatedUser{
 				IsAuthenticated: true,
 				UserID:          "user-123",
@@ -93,7 +93,7 @@ func TestPublishFlowStartedEvent(t *testing.T) {
 
 	t.Run("without_authenticated_user", func(t *testing.T) {
 		ctx := &EngineContext{
-			FlowID:           "flow-002",
+			ExecutionID:      "flow-002",
 			FlowType:         common.FlowTypeRegistration,
 			AppID:            "app-002",
 			ExecutionHistory: make(map[string]*common.NodeExecutionRecord),
@@ -115,9 +115,9 @@ func TestPublishFlowCompletedEvent(t *testing.T) {
 	defer config.ResetThunderRuntime()
 
 	ctx := &EngineContext{
-		FlowID:   "flow-003",
-		FlowType: common.FlowTypeAuthentication,
-		AppID:    "app-003",
+		ExecutionID: "flow-003",
+		FlowType:    common.FlowTypeAuthentication,
+		AppID:       "app-003",
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-456",
@@ -144,7 +144,7 @@ func TestPublishFlowFailedEvent(t *testing.T) {
 
 	t.Run("with_error_description", func(t *testing.T) {
 		ctx := &EngineContext{
-			FlowID:           "flow-004",
+			ExecutionID:      "flow-004",
 			FlowType:         common.FlowTypeAuthentication,
 			AppID:            "app-004",
 			ExecutionHistory: make(map[string]*common.NodeExecutionRecord),
@@ -169,7 +169,7 @@ func TestPublishFlowFailedEvent(t *testing.T) {
 
 	t.Run("without_error_description", func(t *testing.T) {
 		ctx := &EngineContext{
-			FlowID:           "flow-005",
+			ExecutionID:      "flow-005",
 			FlowType:         common.FlowTypeAuthentication,
 			AppID:            "app-005",
 			ExecutionHistory: make(map[string]*common.NodeExecutionRecord),
@@ -204,7 +204,7 @@ func TestPublishNodeExecutionStartedEvent(t *testing.T) {
 		node.On("GetType").Return(common.NodeTypePrompt)
 
 		ctx := &EngineContext{
-			FlowID:           "flow-006",
+			ExecutionID:      "flow-006",
 			FlowType:         common.FlowTypeAuthentication,
 			AppID:            "app-006",
 			ExecutionHistory: make(map[string]*common.NodeExecutionRecord),
@@ -224,7 +224,7 @@ func TestPublishNodeExecutionStartedEvent(t *testing.T) {
 		node.On("GetType").Return(common.NodeTypeTaskExecution)
 
 		ctx := &EngineContext{
-			FlowID:           "flow-007",
+			ExecutionID:      "flow-007",
 			FlowType:         common.FlowTypeAuthentication,
 			AppID:            "app-007",
 			ExecutionHistory: make(map[string]*common.NodeExecutionRecord),
@@ -261,9 +261,9 @@ func TestPublishNodeExecutionCompletedEvent(t *testing.T) {
 		node.On("GetType").Return(common.NodeTypePrompt)
 
 		ctx := &EngineContext{
-			FlowID:   "flow-008",
-			FlowType: common.FlowTypeAuthentication,
-			AppID:    "app-008",
+			ExecutionID: "flow-008",
+			FlowType:    common.FlowTypeAuthentication,
+			AppID:       "app-008",
 			AuthenticatedUser: authncm.AuthenticatedUser{
 				IsAuthenticated: true,
 				UserID:          "user-789",
@@ -298,7 +298,7 @@ func TestPublishNodeExecutionCompletedEvent(t *testing.T) {
 		node.On("GetType").Return(common.NodeTypeTaskExecution)
 
 		ctx := &EngineContext{
-			FlowID:           "flow-009",
+			ExecutionID:      "flow-009",
 			FlowType:         common.FlowTypeAuthentication,
 			AppID:            "app-009",
 			ExecutionHistory: make(map[string]*common.NodeExecutionRecord),
@@ -336,7 +336,7 @@ func TestPublishNodeExecutionCompletedEvent(t *testing.T) {
 		node.On("GetType").Return(common.NodeTypePrompt)
 
 		ctx := &EngineContext{
-			FlowID:           "flow-010",
+			ExecutionID:      "flow-010",
 			FlowType:         common.FlowTypeAuthentication,
 			AppID:            "app-010",
 			ExecutionHistory: make(map[string]*common.NodeExecutionRecord),
@@ -386,7 +386,7 @@ func TestObservabilityDisabled(t *testing.T) {
 
 	// Try to publish an event
 	ctx := &EngineContext{
-		FlowID:           "test-flow",
+		ExecutionID:      "test-flow",
 		FlowType:         common.FlowTypeAuthentication,
 		AppID:            "test-app",
 		ExecutionHistory: make(map[string]*common.NodeExecutionRecord),

--- a/backend/internal/flow/flowexec/error_constants.go
+++ b/backend/internal/flow/flowexec/error_constants.go
@@ -48,12 +48,12 @@ var ErrorInvalidAppID = serviceerror.ServiceError{
 	ErrorDescription: "Invalid app ID provided in the request",
 }
 
-// ErrorInvalidFlowID defines the error response for invalid flow ID errors.
-var ErrorInvalidFlowID = serviceerror.ServiceError{
+// ErrorInvalidExecutionID defines the error response for invalid execution ID errors.
+var ErrorInvalidExecutionID = serviceerror.ServiceError{
 	Code:             "FES-1004",
 	Type:             serviceerror.ClientErrorType,
 	Error:            "Invalid request",
-	ErrorDescription: "Invalid flow ID provided in the request",
+	ErrorDescription: "Invalid flow execution ID provided in the request",
 }
 
 // ErrorInvalidFlowType defines the error response for invalid flow type errors.

--- a/backend/internal/flow/flowexec/flowStoreInterface_mock_test.go
+++ b/backend/internal/flow/flowexec/flowStoreInterface_mock_test.go
@@ -38,8 +38,8 @@ func (_m *flowStoreInterfaceMock) EXPECT() *flowStoreInterfaceMock_Expecter {
 }
 
 // DeleteFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) DeleteFlowContext(ctx context.Context, flowID string) error {
-	ret := _mock.Called(ctx, flowID)
+func (_mock *flowStoreInterfaceMock) DeleteFlowContext(ctx context.Context, executionID string) error {
+	ret := _mock.Called(ctx, executionID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteFlowContext")
@@ -47,7 +47,7 @@ func (_mock *flowStoreInterfaceMock) DeleteFlowContext(ctx context.Context, flow
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, flowID)
+		r0 = returnFunc(ctx, executionID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -61,12 +61,12 @@ type flowStoreInterfaceMock_DeleteFlowContext_Call struct {
 
 // DeleteFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - flowID string
-func (_e *flowStoreInterfaceMock_Expecter) DeleteFlowContext(ctx interface{}, flowID interface{}) *flowStoreInterfaceMock_DeleteFlowContext_Call {
-	return &flowStoreInterfaceMock_DeleteFlowContext_Call{Call: _e.mock.On("DeleteFlowContext", ctx, flowID)}
+//   - executionID string
+func (_e *flowStoreInterfaceMock_Expecter) DeleteFlowContext(ctx interface{}, executionID interface{}) *flowStoreInterfaceMock_DeleteFlowContext_Call {
+	return &flowStoreInterfaceMock_DeleteFlowContext_Call{Call: _e.mock.On("DeleteFlowContext", ctx, executionID)}
 }
 
-func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) Run(run func(ctx context.Context, flowID string)) *flowStoreInterfaceMock_DeleteFlowContext_Call {
+func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) Run(run func(ctx context.Context, executionID string)) *flowStoreInterfaceMock_DeleteFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -89,14 +89,14 @@ func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) Return(err error) *flow
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) RunAndReturn(run func(ctx context.Context, flowID string) error) *flowStoreInterfaceMock_DeleteFlowContext_Call {
+func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) RunAndReturn(run func(ctx context.Context, executionID string) error) *flowStoreInterfaceMock_DeleteFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) GetFlowContext(ctx context.Context, flowID string) (*FlowContextDB, error) {
-	ret := _mock.Called(ctx, flowID)
+func (_mock *flowStoreInterfaceMock) GetFlowContext(ctx context.Context, executionID string) (*FlowContextDB, error) {
+	ret := _mock.Called(ctx, executionID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFlowContext")
@@ -105,17 +105,17 @@ func (_mock *flowStoreInterfaceMock) GetFlowContext(ctx context.Context, flowID 
 	var r0 *FlowContextDB
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*FlowContextDB, error)); ok {
-		return returnFunc(ctx, flowID)
+		return returnFunc(ctx, executionID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *FlowContextDB); ok {
-		r0 = returnFunc(ctx, flowID)
+		r0 = returnFunc(ctx, executionID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*FlowContextDB)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, flowID)
+		r1 = returnFunc(ctx, executionID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -129,12 +129,12 @@ type flowStoreInterfaceMock_GetFlowContext_Call struct {
 
 // GetFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - flowID string
-func (_e *flowStoreInterfaceMock_Expecter) GetFlowContext(ctx interface{}, flowID interface{}) *flowStoreInterfaceMock_GetFlowContext_Call {
-	return &flowStoreInterfaceMock_GetFlowContext_Call{Call: _e.mock.On("GetFlowContext", ctx, flowID)}
+//   - executionID string
+func (_e *flowStoreInterfaceMock_Expecter) GetFlowContext(ctx interface{}, executionID interface{}) *flowStoreInterfaceMock_GetFlowContext_Call {
+	return &flowStoreInterfaceMock_GetFlowContext_Call{Call: _e.mock.On("GetFlowContext", ctx, executionID)}
 }
 
-func (_c *flowStoreInterfaceMock_GetFlowContext_Call) Run(run func(ctx context.Context, flowID string)) *flowStoreInterfaceMock_GetFlowContext_Call {
+func (_c *flowStoreInterfaceMock_GetFlowContext_Call) Run(run func(ctx context.Context, executionID string)) *flowStoreInterfaceMock_GetFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -157,7 +157,7 @@ func (_c *flowStoreInterfaceMock_GetFlowContext_Call) Return(flowContextDB *Flow
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_GetFlowContext_Call) RunAndReturn(run func(ctx context.Context, flowID string) (*FlowContextDB, error)) *flowStoreInterfaceMock_GetFlowContext_Call {
+func (_c *flowStoreInterfaceMock_GetFlowContext_Call) RunAndReturn(run func(ctx context.Context, executionID string) (*FlowContextDB, error)) *flowStoreInterfaceMock_GetFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -50,14 +50,14 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 
 	// Sanitize the input to prevent injection attacks
 	appID := sysutils.SanitizeString(flowR.ApplicationID)
-	flowID := sysutils.SanitizeString(flowR.FlowID)
+	executionID := sysutils.SanitizeString(flowR.ExecutionID)
 	flowTypeStr := sysutils.SanitizeString(flowR.FlowType)
 	verbose := flowR.Verbose
 	action := sysutils.SanitizeString(flowR.Action)
 	inputs := sysutils.SanitizeStringMap(flowR.Inputs)
 
 	flowStep, flowErr := h.flowExecService.Execute(
-		r.Context(), appID, flowID, flowTypeStr, verbose, action, inputs)
+		r.Context(), appID, executionID, flowTypeStr, verbose, action, inputs)
 
 	if flowErr != nil {
 		handleFlowError(w, flowErr)
@@ -65,7 +65,7 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 	}
 
 	flowResp := FlowResponse{
-		FlowID:        flowStep.FlowID,
+		ExecutionID:   flowStep.ExecutionID,
 		StepID:        flowStep.StepID,
 		FlowStatus:    string(flowStep.Status),
 		Type:          string(flowStep.Type),
@@ -76,7 +76,8 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, flowResp)
 
-	logger.Debug("Flow execution request handled successfully", log.String("flowID", flowResp.FlowID))
+	logger.Debug("Flow execution request handled successfully",
+		log.String(log.LoggerKeyExecutionID, flowResp.ExecutionID))
 }
 
 // handleFlowError handles errors that occur during flow execution as an API error response.

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -37,7 +37,7 @@ import (
 type EngineContext struct {
 	Context context.Context
 
-	FlowID         string
+	ExecutionID    string
 	FlowType       common.FlowType
 	AppID          string
 	Verbose        bool
@@ -61,7 +61,7 @@ type EngineContext struct {
 
 // FlowStep represents the outcome of a individual flow step
 type FlowStep struct {
-	FlowID        string
+	ExecutionID   string
 	StepID        string
 	Type          common.FlowStepType
 	Status        common.FlowStatus
@@ -81,7 +81,7 @@ type FlowData struct {
 
 // FlowResponse represents the flow execution API response body
 type FlowResponse struct {
-	FlowID        string   `json:"flowId"`
+	ExecutionID   string   `json:"executionId"`
 	StepID        string   `json:"stepId,omitempty"`
 	FlowStatus    string   `json:"flowStatus"`
 	Type          string   `json:"type,omitempty"`
@@ -95,7 +95,7 @@ type FlowRequest struct {
 	ApplicationID string            `json:"applicationId"`
 	FlowType      string            `json:"flowType"`
 	Verbose       bool              `json:"verbose,omitempty"`
-	FlowID        string            `json:"flowId"`
+	ExecutionID   string            `json:"executionId"`
 	Action        string            `json:"action"`
 	Inputs        map[string]string `json:"inputs"`
 }
@@ -109,11 +109,11 @@ type FlowInitContext struct {
 
 // FlowContextDB represents the database row for a flow context.
 type FlowContextDB struct {
-	FlowID     string
-	Context    string
-	ExpiryTime time.Time
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	ExecutionID string
+	Context     string
+	ExpiryTime  time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // flowContextContent holds all flow state serialized into the CONTEXT JSON column.
@@ -244,7 +244,7 @@ func (f *FlowContextDB) ToEngineContext(graph core.GraphInterface) (EngineContex
 	}
 
 	return EngineContext{
-		FlowID:            f.FlowID,
+		ExecutionID:       f.ExecutionID,
 		TraceID:           "", // TraceID is transient and set from request context
 		FlowType:          graph.GetType(),
 		AppID:             content.AppID,
@@ -372,7 +372,7 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 	}
 
 	return &FlowContextDB{
-		FlowID:  ctx.FlowID,
-		Context: string(contextJSON),
+		ExecutionID: ctx.ExecutionID,
+		Context:     string(contextJSON),
 	}, nil
 }

--- a/backend/internal/flow/flowexec/model_test.go
+++ b/backend/internal/flow/flowexec/model_test.go
@@ -71,10 +71,10 @@ func (s *ModelTestSuite) TestFromEngineContext_WithToken() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		Verbose:  true,
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		Verbose:     true,
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"username": "testuser",
 		},
@@ -99,7 +99,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithToken() {
 	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
-	s.Equal("test-flow-id", dbModel.FlowID)
+	s.Equal("test-flow-id", dbModel.ExecutionID)
 
 	content := s.getContextContent(dbModel)
 	s.Equal("test-app-id", content.AppID)
@@ -122,10 +122,10 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutToken() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		Verbose:  false,
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		Verbose:     false,
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"username": "testuser",
 		},
@@ -146,7 +146,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutToken() {
 	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
-	s.Equal("test-flow-id", dbModel.FlowID)
+	s.Equal("test-flow-id", dbModel.ExecutionID)
 
 	content := s.getContextContent(dbModel)
 	s.True(content.IsAuthenticated)
@@ -161,7 +161,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithEmptyAuthenticatedUser() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
-		FlowID:            "test-flow-id",
+		ExecutionID:       "test-flow-id",
 		AppID:             "test-app-id",
 		Verbose:           false,
 		FlowType:          common.FlowTypeAuthentication,
@@ -194,9 +194,9 @@ func (s *ModelTestSuite) TestToEngineContext_WithToken() {
 
 	// Create the context and convert to DB model to get encrypted token
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-456",
@@ -221,7 +221,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithToken() {
 
 	// Verify
 	s.NoError(err)
-	s.Equal("test-flow-id", resultCtx.FlowID)
+	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.Equal("test-app-id", resultCtx.AppID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal("user-456", resultCtx.AuthenticatedUser.UserID)
@@ -255,8 +255,8 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutToken() {
 	}
 	contextJSON, _ := json.Marshal(content)
 	dbModel := &FlowContextDB{
-		FlowID:  "test-flow-id",
-		Context: string(contextJSON),
+		ExecutionID: "test-flow-id",
+		Context:     string(contextJSON),
 	}
 
 	// Execute
@@ -264,7 +264,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutToken() {
 
 	// Verify
 	s.NoError(err)
-	s.Equal("test-flow-id", resultCtx.FlowID)
+	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal(testUserID789, resultCtx.AuthenticatedUser.UserID)
 
@@ -289,9 +289,9 @@ func (s *ModelTestSuite) TestTokenEncryptionDecryptionRoundTrip() {
 		s.Run("Token: "+testToken[:min(20, len(testToken))], func() {
 			// Create context with token
 			ctx := EngineContext{
-				FlowID:   "test-flow-id",
-				AppID:    "test-app-id",
-				FlowType: common.FlowTypeAuthentication,
+				ExecutionID: "test-flow-id",
+				AppID:       "test-app-id",
+				FlowType:    common.FlowTypeAuthentication,
 				AuthenticatedUser: authncm.AuthenticatedUser{
 					IsAuthenticated: true,
 					UserID:          "user-123",
@@ -345,8 +345,8 @@ func (s *ModelTestSuite) TestToEngineContext_WithInvalidEncryptedToken() {
 	}
 	contextJSON, _ := json.Marshal(content)
 	dbModel := &FlowContextDB{
-		FlowID:  "test-flow-id",
-		Context: string(contextJSON),
+		ExecutionID: "test-flow-id",
+		Context:     string(contextJSON),
 	}
 
 	// Execute
@@ -364,7 +364,7 @@ func (s *ModelTestSuite) TestFromEngineContext_PreservesOtherFields() {
 
 	currentAction := "test-action"
 	ctx := EngineContext{
-		FlowID:        "flow-123",
+		ExecutionID:   "flow-123",
 		AppID:         "app-123",
 		Verbose:       true,
 		FlowType:      common.FlowTypeAuthentication,
@@ -397,7 +397,7 @@ func (s *ModelTestSuite) TestFromEngineContext_PreservesOtherFields() {
 
 	// Verify all fields are preserved
 	s.NoError(err)
-	s.Equal("flow-123", dbModel.FlowID)
+	s.Equal("flow-123", dbModel.ExecutionID)
 
 	content := s.getContextContent(dbModel)
 	s.Equal("app-123", content.AppID)
@@ -440,10 +440,10 @@ func (s *ModelTestSuite) TestFromEngineContext_WithAvailableAttributes() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		Verbose:  true,
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		Verbose:     true,
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"username": "testuser",
 		},
@@ -468,7 +468,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithAvailableAttributes() {
 	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
-	s.Equal("test-flow-id", dbModel.FlowID)
+	s.Equal("test-flow-id", dbModel.ExecutionID)
 
 	content := s.getContextContent(dbModel)
 	s.Equal("test-app-id", content.AppID)
@@ -492,10 +492,10 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutAvailableAttributes() {
 	mockGraph.On("GetID").Return("test-graph-id")
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		Verbose:  false,
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		Verbose:     false,
+		FlowType:    common.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"username": "testuser",
 		},
@@ -516,7 +516,7 @@ func (s *ModelTestSuite) TestFromEngineContext_WithoutAvailableAttributes() {
 	// Verify
 	s.NoError(err)
 	s.NotNil(dbModel)
-	s.Equal("test-flow-id", dbModel.FlowID)
+	s.Equal("test-flow-id", dbModel.ExecutionID)
 
 	content := s.getContextContent(dbModel)
 	s.True(content.IsAuthenticated)
@@ -548,9 +548,9 @@ func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
 
 	// Create the context and convert to DB model to get serialized available attributes
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     true,
 			UserID:              "user-456",
@@ -575,7 +575,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithAvailableAttributes() {
 
 	// Verify
 	s.NoError(err)
-	s.Equal("test-flow-id", resultCtx.FlowID)
+	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.Equal("test-app-id", resultCtx.AppID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal("user-456", resultCtx.AuthenticatedUser.UserID)
@@ -614,8 +614,8 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutAvailableAttributes() {
 	}
 	contextJSON, _ := json.Marshal(content)
 	dbModel := &FlowContextDB{
-		FlowID:  "test-flow-id",
-		Context: string(contextJSON),
+		ExecutionID: "test-flow-id",
+		Context:     string(contextJSON),
 	}
 
 	// Execute
@@ -623,7 +623,7 @@ func (s *ModelTestSuite) TestToEngineContext_WithoutAvailableAttributes() {
 
 	// Verify
 	s.NoError(err)
-	s.Equal("test-flow-id", resultCtx.FlowID)
+	s.Equal("test-flow-id", resultCtx.ExecutionID)
 	s.True(resultCtx.AuthenticatedUser.IsAuthenticated)
 	s.Equal("user-987", resultCtx.AuthenticatedUser.UserID)
 
@@ -701,9 +701,9 @@ func (s *ModelTestSuite) TestAvailableAttributesSerializationRoundTrip() {
 		s.Run(tc.name, func() {
 			// Create context with available attributes
 			ctx := EngineContext{
-				FlowID:   "test-flow-id",
-				AppID:    "test-app-id",
-				FlowType: common.FlowTypeAuthentication,
+				ExecutionID: "test-flow-id",
+				AppID:       "test-app-id",
+				FlowType:    common.FlowTypeAuthentication,
 				AuthenticatedUser: authncm.AuthenticatedUser{
 					IsAuthenticated:     true,
 					UserID:              "user-123",

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -40,7 +40,7 @@ import (
 // FlowExecServiceInterface defines the interface for flow orchestration and acts as the
 // entry point for flow execution
 type FlowExecServiceInterface interface {
-	Execute(ctx context.Context, appID, flowID, flowType string, verbose bool,
+	Execute(ctx context.Context, appID, executionID, flowType string, verbose bool,
 		action string, inputs map[string]string) (*FlowStep, *serviceerror.ServiceError)
 	InitiateFlow(ctx context.Context, initContext *FlowInitContext) (string, *serviceerror.ServiceError)
 }
@@ -78,7 +78,7 @@ func newFlowExecService(flowMgtService flowmgt.FlowMgtServiceInterface,
 
 // Execute executes a flow with the given data
 func (s *flowExecService) Execute(ctx context.Context,
-	appID, flowID, flowType string, verbose bool, action string, inputs map[string]string) (
+	appID, executionID, flowType string, verbose bool, action string, inputs map[string]string) (
 	*FlowStep, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowExecService"))
 
@@ -88,7 +88,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	var context *EngineContext
 	var loadErr *serviceerror.ServiceError
 
-	if isNewFlow(flowID) {
+	if isNewFlow(executionID) {
 		context, loadErr = s.loadNewContext(ctx, appID, flowType, verbose, action, inputs, logger)
 		if loadErr != nil {
 			logger.Error("Failed to load new flow context",
@@ -117,10 +117,10 @@ func (s *flowExecService) Execute(ctx context.Context,
 			return nil, loadErr
 		}
 	} else {
-		context, loadErr = s.loadPrevContext(ctx, flowID, action, inputs, logger)
+		context, loadErr = s.loadPrevContext(ctx, executionID, action, inputs, logger)
 		if loadErr != nil {
 			logger.Error("Failed to load previous flow context",
-				log.String("flowID", flowID),
+				log.String(log.LoggerKeyExecutionID, executionID),
 				log.String("error", loadErr.Error))
 			return nil, loadErr
 		}
@@ -132,10 +132,10 @@ func (s *flowExecService) Execute(ctx context.Context,
 	flowStep, flowErr := s.flowEngine.Execute(context)
 
 	if flowErr != nil {
-		if !isNewFlow(flowID) {
-			if removeErr := s.removeContext(ctx, context.FlowID, logger); removeErr != nil {
+		if !isNewFlow(executionID) {
+			if removeErr := s.removeContext(ctx, context.ExecutionID, logger); removeErr != nil {
 				logger.Error("Failed to remove flow context after engine failure",
-					log.String("flowID", context.FlowID), log.Error(removeErr))
+					log.String(log.LoggerKeyExecutionID, context.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		}
@@ -143,23 +143,23 @@ func (s *flowExecService) Execute(ctx context.Context,
 	}
 
 	if isComplete(flowStep) {
-		if !isNewFlow(flowID) {
-			if removeErr := s.removeContext(ctx, context.FlowID, logger); removeErr != nil {
+		if !isNewFlow(executionID) {
+			if removeErr := s.removeContext(ctx, context.ExecutionID, logger); removeErr != nil {
 				logger.Error("Failed to remove flow context after completion",
-					log.String("flowID", context.FlowID), log.Error(removeErr))
+					log.String(log.LoggerKeyExecutionID, context.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		}
 	} else {
-		if isNewFlow(flowID) {
+		if isNewFlow(executionID) {
 			if storeErr := s.storeContext(ctx, context, logger); storeErr != nil {
 				logger.Error("Failed to store initial flow context",
-					log.String("flowID", context.FlowID), log.Error(storeErr))
+					log.String(log.LoggerKeyExecutionID, context.ExecutionID), log.Error(storeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		} else {
 			if updateErr := s.updateContext(ctx, context, &flowStep, logger); updateErr != nil {
-				logger.Error("Failed to update flow context", log.String("flowID", context.FlowID),
+				logger.Error("Failed to update flow context", log.String(log.LoggerKeyExecutionID, context.ExecutionID),
 					log.Error(updateErr))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -196,12 +196,12 @@ func (s *flowExecService) initContext(ctx context.Context, appID string, flowTyp
 	}
 
 	engineCtx := EngineContext{}
-	flowID, err := sysutils.GenerateUUIDv7()
+	executionID, err := sysutils.GenerateUUIDv7()
 	if err != nil {
 		logger.Error("Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
-	engineCtx.FlowID = flowID
+	engineCtx.ExecutionID = executionID
 
 	graph, svcErr := s.flowMgtService.GetGraph(ctx, graphID)
 	if svcErr != nil {
@@ -240,9 +240,9 @@ func (s *flowExecService) getFlowExpirySeconds(flowType common.FlowType) int64 {
 }
 
 // loadPrevContext retrieves the flow context from the store based on the given details.
-func (s *flowExecService) loadPrevContext(ctx context.Context, flowID, action string,
+func (s *flowExecService) loadPrevContext(ctx context.Context, executionID, action string,
 	inputs map[string]string, logger *log.Logger) (*EngineContext, *serviceerror.ServiceError) {
-	engineCtx, err := s.loadContextFromStore(ctx, flowID, logger)
+	engineCtx, err := s.loadContextFromStore(ctx, executionID, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -252,27 +252,28 @@ func (s *flowExecService) loadPrevContext(ctx context.Context, flowID, action st
 }
 
 // loadContextFromStore retrieves the flow context from the store based on the given details.
-func (s *flowExecService) loadContextFromStore(ctx context.Context, flowID string, logger *log.Logger) (
+func (s *flowExecService) loadContextFromStore(ctx context.Context, executionID string, logger *log.Logger) (
 	*EngineContext, *serviceerror.ServiceError) {
-	if flowID == "" {
-		return nil, &ErrorInvalidFlowID
+	if executionID == "" {
+		return nil, &ErrorInvalidExecutionID
 	}
 
-	dbModel, err := s.flowStore.GetFlowContext(ctx, flowID)
+	dbModel, err := s.flowStore.GetFlowContext(ctx, executionID)
 	if err != nil {
-		logger.Error("Error retrieving flow context from store", log.String("flowID", flowID),
+		logger.Error("Error retrieving flow context from store",
+			log.String(log.LoggerKeyExecutionID, executionID),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	if dbModel == nil {
-		return nil, &ErrorInvalidFlowID
+		return nil, &ErrorInvalidExecutionID
 	}
 
 	graphID, err := dbModel.GetGraphID()
 	if err != nil {
 		logger.Error("Failed to extract graph ID from flow context",
-			log.String("flowID", flowID), log.Error(err))
+			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -286,7 +287,7 @@ func (s *flowExecService) loadContextFromStore(ctx context.Context, flowID strin
 	engineContext, err := dbModel.ToEngineContext(graph)
 	if err != nil {
 		logger.Error("Failed to convert flow context from database format",
-			log.String("flowID", flowID), log.Error(err))
+			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -334,19 +335,20 @@ func (s *flowExecService) setApplicationToContext(engineCtx *EngineContext,
 }
 
 // removeContext removes the flow context from the store.
-func (s *flowExecService) removeContext(ctx context.Context, flowID string, logger *log.Logger) error {
-	if flowID == "" {
+func (s *flowExecService) removeContext(ctx context.Context, executionID string, logger *log.Logger) error {
+	if executionID == "" {
 		return fmt.Errorf("flow ID cannot be empty")
 	}
 
 	txErr := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		return s.flowStore.DeleteFlowContext(txCtx, flowID)
+		return s.flowStore.DeleteFlowContext(txCtx, executionID)
 	})
 	if txErr != nil {
 		return fmt.Errorf("failed to remove flow context from database: %w", txErr)
 	}
 
-	logger.Debug("Flow context removed successfully from database", log.String("flowID", flowID))
+	logger.Debug("Flow context removed successfully from database",
+		log.String(log.LoggerKeyExecutionID, executionID))
 	return nil
 }
 
@@ -354,12 +356,12 @@ func (s *flowExecService) removeContext(ctx context.Context, flowID string, logg
 func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineContext,
 	flowStep *FlowStep, logger *log.Logger) error {
 	if flowStep.Status == common.FlowStatusComplete {
-		return s.removeContext(ctx, engineCtx.FlowID, logger)
+		return s.removeContext(ctx, engineCtx.ExecutionID, logger)
 	} else {
 		logger.Debug("Flow execution is incomplete, updating the flow context",
-			log.String("flowID", engineCtx.FlowID))
+			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 
-		if engineCtx.FlowID == "" {
+		if engineCtx.ExecutionID == "" {
 			return fmt.Errorf("flow ID cannot be empty")
 		}
 
@@ -371,7 +373,7 @@ func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineCo
 		}
 
 		logger.Debug("Flow context updated successfully in database",
-			log.String("flowID", engineCtx.FlowID))
+			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 		return nil
 	}
 }
@@ -379,7 +381,7 @@ func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineCo
 // storeContext stores the flow context in the store.
 func (s *flowExecService) storeContext(ctx context.Context, engineCtx *EngineContext,
 	logger *log.Logger) error {
-	if engineCtx.FlowID == "" {
+	if engineCtx.ExecutionID == "" {
 		return fmt.Errorf("flow ID cannot be empty")
 	}
 
@@ -392,7 +394,8 @@ func (s *flowExecService) storeContext(ctx context.Context, engineCtx *EngineCon
 		return fmt.Errorf("failed to store flow context in database: %w", txErr)
 	}
 
-	logger.Debug("Flow context stored successfully in database", log.String("flowID", engineCtx.FlowID))
+	logger.Debug("Flow context stored successfully in database",
+		log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	return nil
 }
 
@@ -457,8 +460,8 @@ func validateFlowType(flowTypeStr string) (common.FlowType, *serviceerror.Servic
 }
 
 // isNewFlow checks if the flow is a new flow based on the provided input.
-func isNewFlow(flowID string) bool {
-	return flowID == ""
+func isNewFlow(executionID string) bool {
+	return executionID == ""
 }
 
 // getSystemFlowGraph retrieves the flow graph for system flows by handle.
@@ -544,11 +547,11 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 	// Store the context without executing the flow
 	if storeErr := s.storeContext(ctx, engineCtx, logger); storeErr != nil {
 		logger.Error("Failed to store initial flow context",
-			log.String("flowID", engineCtx.FlowID),
+			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID),
 			log.Error(storeErr))
 		return "", &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Flow initiated successfully", log.String("flowID", engineCtx.FlowID))
-	return engineCtx.FlowID, nil
+	logger.Debug("Flow initiated successfully", log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
+	return engineCtx.ExecutionID, nil
 }

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -50,11 +50,11 @@ func TestInitiateFlowNilContext(t *testing.T) {
 	service := &flowExecService{}
 
 	// Execute
-	flowID, err := service.InitiateFlow(context.Background(), nil)
+	executionID, err := service.InitiateFlow(context.Background(), nil)
 
 	// Assert
 	assert.NotNil(t, err)
-	assert.Empty(t, flowID)
+	assert.Empty(t, executionID)
 	assert.Equal(t, "FES-1008", err.Code)
 }
 
@@ -69,11 +69,11 @@ func TestInitiateFlowEmptyApplicationID(t *testing.T) {
 	}
 
 	// Execute
-	flowID, err := service.InitiateFlow(context.Background(), initContext)
+	executionID, err := service.InitiateFlow(context.Background(), initContext)
 
 	// Assert
 	assert.NotNil(t, err)
-	assert.Empty(t, flowID)
+	assert.Empty(t, executionID)
 	assert.Equal(t, "FES-1008", err.Code)
 }
 
@@ -88,11 +88,11 @@ func TestInitiateFlowEmptyFlowType(t *testing.T) {
 	}
 
 	// Execute
-	flowID, err := service.InitiateFlow(context.Background(), initContext)
+	executionID, err := service.InitiateFlow(context.Background(), initContext)
 
 	// Assert
 	assert.NotNil(t, err)
-	assert.Empty(t, flowID)
+	assert.Empty(t, executionID)
 	assert.Equal(t, "FES-1008", err.Code)
 }
 
@@ -107,11 +107,11 @@ func TestInitiateFlowInvalidFlowType(t *testing.T) {
 	}
 
 	// Execute
-	flowID, err := service.InitiateFlow(context.Background(), initContext)
+	executionID, err := service.InitiateFlow(context.Background(), initContext)
 
 	// Assert
 	assert.NotNil(t, err)
-	assert.Empty(t, flowID)
+	assert.Empty(t, executionID)
 	assert.Equal(t, "FES-1005", err.Code) // ErrorInvalidFlowType
 }
 
@@ -235,8 +235,8 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 				mockStore.EXPECT().StoreFlowContext(mock.MatchedBy(func(ctx context.Context) bool {
 					return ctx.Value(txMarkerKey{}) == "tx"
 				}), mock.MatchedBy(func(ctx EngineContext) bool {
-					// Verify flowID is generated
-					if ctx.FlowID == "" {
+					// Verify executionID is generated
+					if ctx.ExecutionID == "" {
 						return false
 					}
 					// Verify runtime data according to test case expectation
@@ -258,8 +258,8 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 				mockStore.EXPECT().StoreFlowContext(mock.MatchedBy(func(ctx context.Context) bool {
 					return ctx.Value(txMarkerKey{}) == "tx"
 				}), mock.MatchedBy(func(ctx EngineContext) bool {
-					// Verify flowID is generated
-					if ctx.FlowID == "" {
+					// Verify executionID is generated
+					if ctx.ExecutionID == "" {
 						return false
 					}
 					// Verify runtime data according to test case expectation
@@ -278,10 +278,10 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 			}
 
 			// Execute
-			flowID, svcErr := service.InitiateFlow(context.Background(), initContext)
+			executionID, svcErr := service.InitiateFlow(context.Background(), initContext)
 
 			// Assert
-			assert.NotEmpty(t, flowID)
+			assert.NotEmpty(t, executionID)
 			assert.Nil(t, svcErr)
 
 			// All mocks automatically verified by mockery
@@ -418,10 +418,10 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 			tt.setupMocks(mockStore, mockAppService, mockFlowMgtSvc)
 
 			// Execute
-			flowID, svcErr := service.InitiateFlow(context.Background(), initContext)
+			executionID, svcErr := service.InitiateFlow(context.Background(), initContext)
 
 			// Assert
-			assert.Empty(t, flowID)
+			assert.Empty(t, executionID)
 			assert.NotNil(t, svcErr)
 			assert.Equal(t, tt.expectedErrorCode, svcErr.Code)
 

--- a/backend/internal/flow/flowexec/store.go
+++ b/backend/internal/flow/flowexec/store.go
@@ -32,9 +32,9 @@ import (
 // flowStoreInterface defines the methods for flow context storage operations.
 type flowStoreInterface interface {
 	StoreFlowContext(ctx context.Context, engineCtx EngineContext, expirySeconds int64) error
-	GetFlowContext(ctx context.Context, flowID string) (*FlowContextDB, error)
+	GetFlowContext(ctx context.Context, executionID string) (*FlowContextDB, error)
 	UpdateFlowContext(ctx context.Context, engineCtx EngineContext) error
-	DeleteFlowContext(ctx context.Context, flowID string) error
+	DeleteFlowContext(ctx context.Context, executionID string) error
 }
 
 // flowStore implements the FlowStoreInterface for managing flow contexts.
@@ -62,18 +62,18 @@ func (s *flowStore) StoreFlowContext(ctx context.Context, engineCtx EngineContex
 
 	return withRuntimeDBClientContext(ctx, s.dbProvider, func(dbClient provider.DBClientInterface) error {
 		_, err := dbClient.ExecuteContext(ctx, QueryCreateFlowContext,
-			dbModel.FlowID, s.deploymentID, dbModel.Context, expiryTime)
+			dbModel.ExecutionID, s.deploymentID, dbModel.Context, expiryTime)
 		return err
 	})
 }
 
 // GetFlowContext retrieves the flow context from the database.
-func (s *flowStore) GetFlowContext(ctx context.Context, flowID string) (*FlowContextDB, error) {
+func (s *flowStore) GetFlowContext(ctx context.Context, executionID string) (*FlowContextDB, error) {
 	var result *FlowContextDB
 
 	err := withRuntimeDBClientContext(ctx, s.dbProvider, func(dbClient provider.DBClientInterface) error {
 		results, err := dbClient.QueryContext(ctx, QueryGetFlowContext,
-			flowID, s.deploymentID, time.Now().UTC())
+			executionID, s.deploymentID, time.Now().UTC())
 		if err != nil {
 			return fmt.Errorf("failed to execute query: %w", err)
 		}
@@ -107,15 +107,15 @@ func (s *flowStore) UpdateFlowContext(ctx context.Context, engineCtx EngineConte
 
 	return withRuntimeDBClientContext(ctx, s.dbProvider, func(dbClient provider.DBClientInterface) error {
 		_, err := dbClient.ExecuteContext(ctx, QueryUpdateFlowContext,
-			dbModel.FlowID, dbModel.Context, s.deploymentID)
+			dbModel.ExecutionID, dbModel.Context, s.deploymentID)
 		return err
 	})
 }
 
 // DeleteFlowContext removes the flow context from the database.
-func (s *flowStore) DeleteFlowContext(ctx context.Context, flowID string) error {
+func (s *flowStore) DeleteFlowContext(ctx context.Context, executionID string) error {
 	return withRuntimeDBClientContext(ctx, s.dbProvider, func(dbClient provider.DBClientInterface) error {
-		_, err := dbClient.ExecuteContext(ctx, QueryDeleteFlowContext, flowID, s.deploymentID)
+		_, err := dbClient.ExecuteContext(ctx, QueryDeleteFlowContext, executionID, s.deploymentID)
 		return err
 	})
 }
@@ -148,9 +148,9 @@ func (s *flowStore) buildFlowContextFromResultRow(row map[string]interface{}) (*
 	}
 
 	return &FlowContextDB{
-		FlowID:     id,
-		Context:    *contextStr,
-		ExpiryTime: expiryTime,
+		ExecutionID: id,
+		Context:     *contextStr,
+		ExpiryTime:  expiryTime,
 	}, nil
 }
 

--- a/backend/internal/flow/flowexec/store_test.go
+++ b/backend/internal/flow/flowexec/store_test.go
@@ -91,10 +91,10 @@ func (s *StoreTestSuite) TestStoreFlowContext_WithToken() {
 
 	expirySeconds := int64(1800) // 30 minutes
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		Verbose:  false,
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		Verbose:     false,
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-123",
@@ -137,10 +137,10 @@ func (s *StoreTestSuite) TestStoreFlowContext_WithoutToken() {
 	}
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		Verbose:  false,
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		Verbose:     false,
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: false,
 			Token:           "", // No token
@@ -181,9 +181,9 @@ func (s *StoreTestSuite) TestUpdateFlowContext_WithToken() {
 	}
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-456",
@@ -216,9 +216,9 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 
 	// Create encrypted token
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "user-789",
@@ -264,7 +264,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	// Verify
 	s.NoError(err)
 	s.NotNil(result)
-	s.Equal("test-flow-id", result.FlowID)
+	s.Equal("test-flow-id", result.ExecutionID)
 
 	content = s.getContextContent(result)
 	s.True(content.IsAuthenticated)
@@ -318,7 +318,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithoutToken() {
 	// Verify
 	s.NoError(err)
 	s.NotNil(result)
-	s.Equal("test-flow-id", result.FlowID)
+	s.Equal("test-flow-id", result.ExecutionID)
 
 	content := s.getContextContent(result)
 	s.False(content.IsAuthenticated)
@@ -339,10 +339,10 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_TokenRoundTrip() {
 	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
 
 	originalCtx := EngineContext{
-		FlowID:   "integration-flow-id",
-		AppID:    "integration-app-id",
-		Verbose:  true,
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "integration-flow-id",
+		AppID:       "integration-app-id",
+		Verbose:     true,
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
 			UserID:          "integration-user-123",
@@ -385,7 +385,7 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_TokenRoundTrip() {
 	s.NoError(err)
 
 	// Step 4: Verify all data is preserved correctly
-	s.Equal(originalCtx.FlowID, retrievedCtx.FlowID)
+	s.Equal(originalCtx.ExecutionID, retrievedCtx.ExecutionID)
 	s.Equal(originalCtx.AppID, retrievedCtx.AppID)
 	s.Equal(originalCtx.Verbose, retrievedCtx.Verbose)
 	s.Equal(originalCtx.AuthenticatedUser.IsAuthenticated, retrievedCtx.AuthenticatedUser.IsAuthenticated)
@@ -411,9 +411,9 @@ func (s *StoreTestSuite) TestBuildFlowContextFromResultRow_WithToken() {
 	expiryTime := time.Now().Add(30 * time.Minute)
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			Token:      testToken,
 			Attributes: map[string]interface{}{},
@@ -456,9 +456,9 @@ func (s *StoreTestSuite) TestBuildFlowContextFromResultRow_WithByteToken() {
 	expiryTime := time.Now().Add(30 * time.Minute)
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			Token:      testToken,
 			Attributes: map[string]interface{}{},
@@ -525,7 +525,7 @@ func (s *StoreTestSuite) TestStoreFlowContext_WithAvailableAttributes() {
 
 	expirySeconds := int64(1800) // 30 minutes
 	ctx := EngineContext{
-		FlowID:      "test-flow-id",
+		ExecutionID: "test-flow-id",
 		AppID:       "test-app-id",
 		Verbose:     false,
 		FlowType:    common.FlowTypeAuthentication,
@@ -582,9 +582,9 @@ func (s *StoreTestSuite) TestUpdateFlowContext_WithAvailableAttributes() {
 	}
 
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     true,
 			UserID:              "user-456",
@@ -631,9 +631,9 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 
 	// Create serialized available attributes
 	ctx := EngineContext{
-		FlowID:   "test-flow-id",
-		AppID:    "test-app-id",
-		FlowType: common.FlowTypeAuthentication,
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated:     true,
 			UserID:              "user-789",
@@ -679,7 +679,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	// Verify
 	s.NoError(err)
 	s.NotNil(result)
-	s.Equal("test-flow-id", result.FlowID)
+	s.Equal("test-flow-id", result.ExecutionID)
 
 	content = s.getContextContent(result)
 	s.True(content.IsAuthenticated)

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -197,9 +197,9 @@ func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessage_NilResponseWriter() 
 func (suite *AuthorizeHandlerTestSuite) TestHandleAuthorizeGetRequest_Success() {
 	result := &AuthorizationInitResult{
 		QueryParams: map[string]string{
-			oauth2const.AuthID: testAuthID,
-			oauth2const.AppID:  "test-app-id",
-			oauth2const.FlowID: "test-flow-id",
+			oauth2const.AuthID:      testAuthID,
+			oauth2const.AppID:       "test-app-id",
+			oauth2const.ExecutionID: "test-flow-id",
 		},
 	}
 	suite.mockAuthzService.EXPECT().HandleInitialAuthorizationRequest(mock.Anything, mock.Anything).Return(result, nil)

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -254,7 +254,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		RuntimeData:   runtimeData,
 	}
 
-	flowID, flowErr := as.flowExecService.InitiateFlow(ctx, flowInitCtx)
+	executionID, flowErr := as.flowExecService.InitiateFlow(ctx, flowInitCtx)
 	if flowErr != nil {
 		as.logger.Error("Failed to initiate authentication flow",
 			log.String("error_code", flowErr.Code))
@@ -288,7 +288,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	queryParams := make(map[string]string)
 	queryParams[oauth2const.AuthID] = identifier
 	queryParams[oauth2const.AppID] = app.AppID
-	queryParams[oauth2const.FlowID] = flowID
+	queryParams[oauth2const.ExecutionID] = executionID
 
 	// Add insecure warning if the redirect URI is not using TLS.
 	// TODO: May require another redirection to a warn consent page when it directly goes to a federated IDP.

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -273,7 +273,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Su
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), testAuthID, result.QueryParams[oauth2const.AuthID])
 	assert.Equal(suite.T(), "test-app-id", result.QueryParams[oauth2const.AppID])
-	assert.Equal(suite.T(), "test-flow-id", result.QueryParams[oauth2const.FlowID])
+	assert.Equal(suite.T(), "test-flow-id", result.QueryParams[oauth2const.ExecutionID])
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_InsecureRedirectURI() {
@@ -401,7 +401,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Se
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), "test-flow-id", result.QueryParams[oauth2const.FlowID])
+	assert.Equal(suite.T(), "test-flow-id", result.QueryParams[oauth2const.ExecutionID])
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidAuthID() {

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -86,7 +86,7 @@ const (
 	SessionDataKeyConsent string = "sessionDataKeyConsent"
 	ShowInsecureWarning   string = "showInsecureWarning"
 	AppID                 string = "applicationId"
-	FlowID                string = "flowId"
+	ExecutionID           string = "executionId"
 	Assertion             string = "assertion"
 )
 

--- a/backend/internal/system/log/constants.go
+++ b/backend/internal/system/log/constants.go
@@ -23,8 +23,8 @@ const (
 	LoggerKeyComponentName = "component"
 	// LoggerKeyExecutorName is the key used to identify the executor ID in the logger.
 	LoggerKeyExecutorName = "executorName"
-	// LoggerKeyFlowID is the key used to identify the flow ID in the logger.
-	LoggerKeyFlowID = "flowId"
+	// LoggerKeyExecutionID is the key used to identify the flow execution ID in the logger.
+	LoggerKeyExecutionID = "executionID"
 	// LoggerKeyNodeID is the key used to identify the node ID in the logger.
 	LoggerKeyNodeID = "nodeId"
 	// LoggerKeyTraceID is the key used to identify the trace ID (correlation ID) in the logger.

--- a/backend/internal/system/observability/event/datakeys.go
+++ b/backend/internal/system/observability/event/datakeys.go
@@ -33,7 +33,7 @@ var DataKey = struct {
 	AppID    string
 
 	// Flow Execution Keys
-	FlowID        string
+	ExecutionID   string
 	FlowType      string
 	NodeID        string
 	NodeType      string
@@ -71,7 +71,7 @@ var DataKey = struct {
 	AppID:    "app_id",
 
 	// Flow Execution Keys
-	FlowID:        "flow_id",
+	ExecutionID:   "execution_id",
 	FlowType:      "flow_type",
 	NodeID:        "node_id",
 	NodeType:      "node_type",

--- a/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
+++ b/backend/tests/mocks/flow/flowexecmock/FlowExecServiceInterface_mock.go
@@ -40,8 +40,8 @@ func (_m *FlowExecServiceInterfaceMock) EXPECT() *FlowExecServiceInterfaceMock_E
 }
 
 // Execute provides a mock function for the type FlowExecServiceInterfaceMock
-func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, flowID string, flowType string, verbose bool, action string, inputs map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, appID, flowID, flowType, verbose, action, inputs)
+func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, appID, executionID, flowType, verbose, action, inputs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
@@ -50,17 +50,17 @@ func (_mock *FlowExecServiceInterfaceMock) Execute(ctx context.Context, appID st
 	var r0 *flowexec.FlowStep
 	var r1 *serviceerror.ServiceError
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, appID, flowID, flowType, verbose, action, inputs)
+		return returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, bool, string, map[string]string) *flowexec.FlowStep); ok {
-		r0 = returnFunc(ctx, appID, flowID, flowType, verbose, action, inputs)
+		r0 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*flowexec.FlowStep)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, bool, string, map[string]string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, appID, flowID, flowType, verbose, action, inputs)
+		r1 = returnFunc(ctx, appID, executionID, flowType, verbose, action, inputs)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -77,16 +77,16 @@ type FlowExecServiceInterfaceMock_Execute_Call struct {
 // Execute is a helper method to define mock.On call
 //   - ctx context.Context
 //   - appID string
-//   - flowID string
+//   - executionID string
 //   - flowType string
 //   - verbose bool
 //   - action string
 //   - inputs map[string]string
-func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, flowID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
-	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, flowID, flowType, verbose, action, inputs)}
+func (_e *FlowExecServiceInterfaceMock_Expecter) Execute(ctx interface{}, appID interface{}, executionID interface{}, flowType interface{}, verbose interface{}, action interface{}, inputs interface{}) *FlowExecServiceInterfaceMock_Execute_Call {
+	return &FlowExecServiceInterfaceMock_Execute_Call{Call: _e.mock.On("Execute", ctx, appID, executionID, flowType, verbose, action, inputs)}
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, flowID string, flowType string, verbose bool, action string, inputs map[string]string)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) Run(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -134,7 +134,7 @@ func (_c *FlowExecServiceInterfaceMock_Execute_Call) Return(flowStep *flowexec.F
 	return _c
 }
 
-func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, flowID string, flowType string, verbose bool, action string, inputs map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
+func (_c *FlowExecServiceInterfaceMock_Execute_Call) RunAndReturn(run func(ctx context.Context, appID string, executionID string, flowType string, verbose bool, action string, inputs map[string]string) (*flowexec.FlowStep, *serviceerror.ServiceError)) *FlowExecServiceInterfaceMock_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/flowexecmock/flowStoreInterface_mock.go
+++ b/backend/tests/mocks/flow/flowexecmock/flowStoreInterface_mock.go
@@ -39,8 +39,8 @@ func (_m *flowStoreInterfaceMock) EXPECT() *flowStoreInterfaceMock_Expecter {
 }
 
 // DeleteFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) DeleteFlowContext(ctx context.Context, flowID string) error {
-	ret := _mock.Called(ctx, flowID)
+func (_mock *flowStoreInterfaceMock) DeleteFlowContext(ctx context.Context, executionID string) error {
+	ret := _mock.Called(ctx, executionID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteFlowContext")
@@ -48,7 +48,7 @@ func (_mock *flowStoreInterfaceMock) DeleteFlowContext(ctx context.Context, flow
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, flowID)
+		r0 = returnFunc(ctx, executionID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -62,12 +62,12 @@ type flowStoreInterfaceMock_DeleteFlowContext_Call struct {
 
 // DeleteFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - flowID string
-func (_e *flowStoreInterfaceMock_Expecter) DeleteFlowContext(ctx interface{}, flowID interface{}) *flowStoreInterfaceMock_DeleteFlowContext_Call {
-	return &flowStoreInterfaceMock_DeleteFlowContext_Call{Call: _e.mock.On("DeleteFlowContext", ctx, flowID)}
+//   - executionID string
+func (_e *flowStoreInterfaceMock_Expecter) DeleteFlowContext(ctx interface{}, executionID interface{}) *flowStoreInterfaceMock_DeleteFlowContext_Call {
+	return &flowStoreInterfaceMock_DeleteFlowContext_Call{Call: _e.mock.On("DeleteFlowContext", ctx, executionID)}
 }
 
-func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) Run(run func(ctx context.Context, flowID string)) *flowStoreInterfaceMock_DeleteFlowContext_Call {
+func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) Run(run func(ctx context.Context, executionID string)) *flowStoreInterfaceMock_DeleteFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -90,14 +90,14 @@ func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) Return(err error) *flow
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) RunAndReturn(run func(ctx context.Context, flowID string) error) *flowStoreInterfaceMock_DeleteFlowContext_Call {
+func (_c *flowStoreInterfaceMock_DeleteFlowContext_Call) RunAndReturn(run func(ctx context.Context, executionID string) error) *flowStoreInterfaceMock_DeleteFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetFlowContext provides a mock function for the type flowStoreInterfaceMock
-func (_mock *flowStoreInterfaceMock) GetFlowContext(ctx context.Context, flowID string) (*flowexec.FlowContextDB, error) {
-	ret := _mock.Called(ctx, flowID)
+func (_mock *flowStoreInterfaceMock) GetFlowContext(ctx context.Context, executionID string) (*flowexec.FlowContextDB, error) {
+	ret := _mock.Called(ctx, executionID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFlowContext")
@@ -106,17 +106,17 @@ func (_mock *flowStoreInterfaceMock) GetFlowContext(ctx context.Context, flowID 
 	var r0 *flowexec.FlowContextDB
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*flowexec.FlowContextDB, error)); ok {
-		return returnFunc(ctx, flowID)
+		return returnFunc(ctx, executionID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *flowexec.FlowContextDB); ok {
-		r0 = returnFunc(ctx, flowID)
+		r0 = returnFunc(ctx, executionID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*flowexec.FlowContextDB)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, flowID)
+		r1 = returnFunc(ctx, executionID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -130,12 +130,12 @@ type flowStoreInterfaceMock_GetFlowContext_Call struct {
 
 // GetFlowContext is a helper method to define mock.On call
 //   - ctx context.Context
-//   - flowID string
-func (_e *flowStoreInterfaceMock_Expecter) GetFlowContext(ctx interface{}, flowID interface{}) *flowStoreInterfaceMock_GetFlowContext_Call {
-	return &flowStoreInterfaceMock_GetFlowContext_Call{Call: _e.mock.On("GetFlowContext", ctx, flowID)}
+//   - executionID string
+func (_e *flowStoreInterfaceMock_Expecter) GetFlowContext(ctx interface{}, executionID interface{}) *flowStoreInterfaceMock_GetFlowContext_Call {
+	return &flowStoreInterfaceMock_GetFlowContext_Call{Call: _e.mock.On("GetFlowContext", ctx, executionID)}
 }
 
-func (_c *flowStoreInterfaceMock_GetFlowContext_Call) Run(run func(ctx context.Context, flowID string)) *flowStoreInterfaceMock_GetFlowContext_Call {
+func (_c *flowStoreInterfaceMock_GetFlowContext_Call) Run(run func(ctx context.Context, executionID string)) *flowStoreInterfaceMock_GetFlowContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -158,7 +158,7 @@ func (_c *flowStoreInterfaceMock_GetFlowContext_Call) Return(flowContextDB *flow
 	return _c
 }
 
-func (_c *flowStoreInterfaceMock_GetFlowContext_Call) RunAndReturn(run func(ctx context.Context, flowID string) (*flowexec.FlowContextDB, error)) *flowStoreInterfaceMock_GetFlowContext_Call {
+func (_c *flowStoreInterfaceMock_GetFlowContext_Call) RunAndReturn(run func(ctx context.Context, executionID string) (*flowexec.FlowContextDB, error)) *flowStoreInterfaceMock_GetFlowContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/__backup__/README.md
+++ b/docs/__backup__/README.md
@@ -19,19 +19,19 @@ System APIs of Thunder are secured by default. You need to obtain an access toke
      -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}'
    ```
 
-2. **Extract the flowId from the response:**
+2. **Extract the executionId from the response:**
 
    ```json
-   {"flowId":"<flow_id>","flowStatus":"INCOMPLETE", ...}
+   {"executionId":"<execution_id>","flowStatus":"INCOMPLETE", ...}
    ```
 
 3. **Submit credentials:**
 
-   Run the following command, replacing `<flow_id>` with the `flowId` value you extracted above.
+   Run the following command, replacing `<execution_id>` with the `executionId` value you extracted above.
 
    ```bash
    curl -k -X POST 'https://localhost:8090/flow/execute' \
-     -d '{"flowId":"<flow_id>", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}'
+     -d '{"executionId":"<execution_id>", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}'
    ```
 
 4. **Extract the assertion from the response:**
@@ -39,7 +39,7 @@ System APIs of Thunder are secured by default. You need to obtain an access toke
    Obtain the system API token by extracting the `assertion` value from the response.
 
    ```json
-   {"flowId":"<flow_id>","flowStatus":"COMPLETE","data":{},"assertion":"<assertion>"}
+   {"executionId":"<execution_id>","flowStatus":"COMPLETE","data":{},"assertion":"<assertion>"}
    ```
 
 3. **Use the assertion as a Bearer token:**

--- a/docs/__backup__/authentication/server-orchestrated-flow/authentication.md
+++ b/docs/__backup__/authentication/server-orchestrated-flow/authentication.md
@@ -87,7 +87,7 @@ Follow the steps below to configure and execute a login flow using username and 
 
     ```json
     {
-        "flowId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
+        "executionId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
         "flowStatus": "PROMPT_ONLY",
         "type": "VIEW",
         "data": {
@@ -117,12 +117,12 @@ Follow the steps below to configure and execute a login flow using username and 
 
 5. **Complete the Login Flow**
 
-    Make the second cURL request to complete the login flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response. Also, replace the `username` and `password` with the credentials of the user you created in the first step.
+    Make the second cURL request to complete the login flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response. Also, replace the `username` and `password` with the credentials of the user you created in the first step.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "username": "thor",
@@ -243,7 +243,7 @@ Follow the steps below to configure and execute a login flow using username and 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "mobileNumber": "+1234567890"
@@ -260,7 +260,7 @@ Follow the steps below to configure and execute a login flow using username and 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "otp": "696546"
@@ -354,7 +354,7 @@ Follow the steps below to configure and execute a login flow using Google OAuth 
 
     ```json
     {
-        "flowId": "80d57e64-8082-4096-bb0e-22b2187f8265",
+        "executionId": "80d57e64-8082-4096-bb0e-22b2187f8265",
         "flowStatus": "INCOMPLETE",
         "type": "REDIRECTION",
         "data": {
@@ -390,12 +390,12 @@ Follow the steps below to configure and execute a login flow using Google OAuth 
 
 7. **Complete the Login Flow**
 
-    Copy the authorization code and make the second cURL request to complete the login flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response.
+    Copy the authorization code and make the second cURL request to complete the login flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "inputs": {
             "code": "<code>"
         }
@@ -487,7 +487,7 @@ Follow the steps below to configure and execute a login flow using GitHub OAuth 
 
     ```json
     {
-        "flowId": "80d57e64-8082-4096-bb0e-22b2187f8265",
+        "executionId": "80d57e64-8082-4096-bb0e-22b2187f8265",
         "flowStatus": "INCOMPLETE",
         "type": "REDIRECTION",
         "data": {
@@ -518,12 +518,12 @@ Follow the steps below to configure and execute a login flow using GitHub OAuth 
 
 7. **Complete the Login Flow**
 
-    Copy the authorization code and make the second cURL request to complete the login flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response.
+    Copy the authorization code and make the second cURL request to complete the login flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "inputs": {
             "code": "<code>"
         }

--- a/docs/__backup__/authorization/flow-based-authorization.md
+++ b/docs/__backup__/authorization/flow-based-authorization.md
@@ -196,7 +196,7 @@ curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute
 
 ```json
 {
-    "flowId": "flow-123",
+    "executionId": "flow-123",
     "flowStatus": "INCOMPLETE",
     "type": "VIEW",
     "data": {
@@ -216,7 +216,7 @@ curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute
 }
 ```
 
-Note the `flowId` from the response.
+Note the `executionId` from the response.
 
 ### Step 8: Complete Authentication
 
@@ -225,7 +225,7 @@ Complete the authentication by providing credentials:
 ```bash
 curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
 -d '{
-    "flowId": "<flow-id>",
+    "executionId": "<execution_id>",
     "inputs": {
         "username": "alice",
         "password": "<password>"
@@ -237,7 +237,7 @@ curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute
 
 ```json
 {
-    "flowId": "flow-123",
+    "executionId": "flow-123",
     "flowStatus": "COMPLETE",
     "assertion": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
 }

--- a/docs/__backup__/flows/flow-execution.md
+++ b/docs/__backup__/flows/flow-execution.md
@@ -38,7 +38,7 @@ Continue the flow by providing the flow ID, selected action, and user inputs:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `flowId` | Yes | Flow session ID from previous response |
+| `executionId` | Yes | Flow session ID from previous response |
 | `action` | No | Reference to the selected action |
 | `inputs` | No | User-provided input values |
 
@@ -48,7 +48,7 @@ Continue the flow by providing the flow ID, selected action, and user inputs:
 curl -X POST https://localhost:8090/flow/execute \
   -H 'Content-Type: application/json' \
   -d '{
-    "flowId": "<flow-uuid>",
+    "executionId": "<flow-uuid>",
     "action": "action_001",
     "inputs": {
       "username": "user@example.com",
@@ -82,7 +82,7 @@ curl -X POST https://localhost:8090/flow/execute \
 
 ```json
 {
-  "flowId": "abc-123",
+  "executionId": "abc-123",
   "flowStatus": "PROMPT_ONLY",
   "stepId": "node_001",
   "type": "VIEW",
@@ -113,7 +113,7 @@ curl -X POST https://localhost:8090/flow/execute \
 
 ```json
 {
-  "flowId": "abc-123",
+  "executionId": "abc-123",
   "flowStatus": "PROMPT_ONLY",
   "stepId": "node_001",
   "type": "VIEW",
@@ -138,7 +138,7 @@ curl -X POST https://localhost:8090/flow/execute \
 
 | Field | Description |
 |-------|-------------|
-| `flowId` | Session identifier to use in subsequent requests |
+| `executionId` | Session identifier to use in following requests |
 | `flowStatus` | Current flow state (see Flow Status below) |
 | `stepId` | Current node/step identifier |
 | `type` | Response type (VIEW or REDIRECTION) |
@@ -175,7 +175,7 @@ On successful completion, the response includes a JWT assertion:
 
 ```json
 {
-  "flowId": "abc-123",
+  "executionId": "abc-123",
   "flowStatus": "COMPLETE",
   "assertion": "<jwt-token>"
 }

--- a/docs/__backup__/observability/events.md
+++ b/docs/__backup__/observability/events.md
@@ -139,7 +139,7 @@ Common data keys used across events (defined in `event.DataKey`).
 |-----|------------|-------------|
 | `UserID` | `user_id` | Unique identifier for the user. |
 | `ClientID` | `client_id` | Unique identifier for the OAuth client/app. |
-| `FlowID` | `flow_id` | Correlation ID for a specific flow execution session. |
+| `executionId` | `execution_id` | Correlation ID for a specific flow execution session. |
 | `TraceParent` | `trace_parent` | Used for linking spans in distributed tracing. |
 | `Error` | `error` | Technical error description or stack trace. |
 | `FailureReason` | `failure_reason` | Functional reason for a failure. |

--- a/docs/__backup__/registration/server-orchestrated-flow/registration.md
+++ b/docs/__backup__/registration/server-orchestrated-flow/registration.md
@@ -51,7 +51,7 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
     ```json
     {
-        "flowId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
+        "executionId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
         "flowStatus": "PROMPT_ONLY",
         "type": "VIEW",
         "data": {
@@ -81,12 +81,12 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
 4. **Continue the Registration Flow**
 
-    Make the second cURL request to continue the registration flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response. Also, replace the `username` and `password` with the desired credentials for the new user.
+    Make the second cURL request to continue the registration flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response. Also, replace the `username` and `password` with the desired credentials for the new user.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "username": "thor",
@@ -99,7 +99,7 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
     ```json
     {
-        "flowId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
+        "executionId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
         "flowStatus": "PROMPT_ONLY",
         "type": "VIEW",
         "data": {
@@ -126,12 +126,12 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
 5. **Complete the Registration Flow**
 
-    Make the third cURL request to complete the registration flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response.
+    Make the third cURL request to complete the registration flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "email": "thor@thunder.sky",
@@ -216,7 +216,7 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
     ```json
     {
-        "flowId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
+        "executionId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
         "flowStatus": "PROMPT_ONLY",
         "type": "VIEW",
         "data": {
@@ -233,12 +233,12 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
 6. **Continue the Registration Flow**
 
-    Make the second cURL request to continue the registration flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response. Also, replace the `mobileNumber` with the desired mobile number for the new user.
+    Make the second cURL request to continue the registration flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response. Also, replace the `mobileNumber` with the desired mobile number for the new user.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "mobileNumber": "+94xxxxxxxxx"
@@ -255,7 +255,7 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "otp": "696546"
@@ -267,7 +267,7 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
     ```json
     {
-        "flowId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
+        "executionId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
         "flowStatus": "PROMPT_ONLY",
         "type": "VIEW",
         "data": {
@@ -294,12 +294,12 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
 8. **Complete the Registration Flow**
 
-    Make the third cURL request to complete the registration flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response.
+    Make the third cURL request to complete the registration flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "action": "<action_ref>",
         "inputs": {
             "email": "thor@thunder.sky",
@@ -393,7 +393,7 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
     ```json
     {
-        "flowId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
+        "executionId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
         "flowStatus": "PROMPT_ONLY",
         "type": "REDIRECTION",
         "data": {
@@ -429,12 +429,12 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
 7. **Complete the Registration Flow**
 
-    Copy the authorization code and make the second cURL request to complete the registration flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response.
+    Copy the authorization code and make the second cURL request to complete the registration flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "inputs": {
             "code": "<code>"
         }
@@ -527,7 +527,7 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
     ```json
     {
-        "flowId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
+        "executionId": "db93a19e-c23f-4cfc-a45f-0e0bc157f6d5",
         "flowStatus": "PROMPT_ONLY",
         "type": "REDIRECTION",
         "data": {
@@ -558,12 +558,12 @@ To enable self-registration, set the `is_registration_flow_enabled` property to 
 
 7. **Complete the Registration Flow**
 
-    Copy the authorization code and make the second cURL request to complete the registration flow. Make sure to replace `<flow_id>` with the `flowId` received in the previous response.
+    Copy the authorization code and make the second cURL request to complete the registration flow. Make sure to replace `<execution_id>` with the `executionId` received in the previous response.
 
     ```bash
     curl -kL -H 'Content-Type: application/json' https://localhost:8090/flow/execute \
     -d '{
-        "flowId": "<flow_id>",
+        "executionId": "<execution_id>",
         "inputs": {
             "code": "<code>"
         }

--- a/docs/__backup__/standards-based/oauth2-oidc/features/public-clients.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/features/public-clients.md
@@ -27,16 +27,16 @@ Run the following command, replacing `<application_id>` with your sample app ID 
 FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
   -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
 
-FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+EXECUTION_ID=$(echo $FLOW_RESPONSE | jq -r '.executionId')
 ```
 
 #### 1.2: Submit Admin Credentials
 
-Run the following command with the extracted `flowId`.
+Run the following command with the extracted `executionId`.
 
 ```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -d '{"flowId":"'$FLOW_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
+  -d '{"executionId":"'$EXECUTION_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```

--- a/docs/__backup__/standards-based/oauth2-oidc/grant-types/authorization-code.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/grant-types/authorization-code.md
@@ -38,16 +38,16 @@ Run the following command, replacing `<application_id>` with your sample app ID 
 FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
   -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
 
-FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+EXECUTION_ID=$(echo $FLOW_RESPONSE | jq -r '.executionId')
 ```
 
 #### 1.2: Submit Admin Credentials
 
-Run the following command with the extracted `flowId`.
+Run the following command with the extracted `executionId`.
 
 ```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -d '{"flowId":"'$FLOW_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
+  -d '{"executionId":"'$EXECUTION_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```
@@ -56,7 +56,7 @@ ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 
 ```json
 {
-  "flowId": "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc",
+  "executionId": "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc",
   "flowStatus": "COMPLETE",
   "data": {},
   "assertion": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."

--- a/docs/__backup__/standards-based/oauth2-oidc/grant-types/client-credentials.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/grant-types/client-credentials.md
@@ -37,16 +37,16 @@ Run the following command, replacing `<application_id>` with your sample app ID 
 FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
   -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
 
-FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+EXECUTION_ID=$(echo $FLOW_RESPONSE | jq -r '.executionId')
 ```
 
 #### 1.2: Submit Admin Credentials
 
-Run the following command with the extracted `flowId`.
+Run the following command with the extracted `executionId`.
 
 ```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -d '{"flowId":"'$FLOW_ID'", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action": "action_001"}')
+  -d '{"executionId":"'$EXECUTION_ID'", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action": "action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```

--- a/docs/__backup__/standards-based/oauth2-oidc/grant-types/token-exchange.md
+++ b/docs/__backup__/standards-based/oauth2-oidc/grant-types/token-exchange.md
@@ -34,16 +34,16 @@ Run the following command, replacing `<application_id>` with your sample app ID 
 FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
   -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
 
-FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+EXECUTION_ID=$(echo $FLOW_RESPONSE | jq -r '.executionId')
 ```
 
 #### 1.2: Submit Admin Credentials
 
-Run the following command with the extracted `flowId`.
+Run the following command with the extracted `executionId`.
 
 ```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -d '{"flowId":"'$FLOW_ID'", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action": "action_001"}')
+  -d '{"executionId":"'$EXECUTION_ID'", "inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action": "action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```

--- a/docs/content/community/contributing/contributing-code/backend-development/observability.md
+++ b/docs/content/community/contributing/contributing-code/backend-development/observability.md
@@ -81,7 +81,7 @@ Always use predefined keys from `event.DataKey` for consistency:
 |-----|-------|
 | `UserID` | Authenticated user identifier |
 | `ClientID` | OAuth client identifier |
-| `FlowID` | Flow execution identifier |
+| `ExecutionID` | Flow execution identifier |
 | `Message` | Human-readable message |
 | `Error` | Error message for failures |
 | `LatencyUs` | Operation latency in microseconds |

--- a/docs/content/guides/key-concepts/authentication/passwordless/passkeys.mdx
+++ b/docs/content/guides/key-concepts/authentication/passwordless/passkeys.mdx
@@ -184,7 +184,7 @@ curl -k -X POST https://localhost:8090/flow/execute \
   }'
 ```
 
-- The response includes a `flowId` and a step `action` for passkeys. `data.additionalData.passkeyChallenge` contains the WebAuthn request options. The passkey session token is stored server-side in the flow context runtime data and is managed by the server; the client does not need to read or send it.
+- The response includes an `executionId` and a step `action` for passkeys. `data.additionalData.passkeyChallenge` contains the WebAuthn request options. The passkey session token is stored server-side in the flow context runtime data and is managed by the server; the client does not need to read or send it.
 
 2) **Run WebAuthn in the browser** – call `navigator.credentials.get()` with the decoded `passkeyChallenge`.
 
@@ -194,7 +194,7 @@ curl -k -X POST https://localhost:8090/flow/execute \
 curl -k -X POST https://localhost:8090/flow/execute \
   -H "Content-Type: application/json" \
   -d '{
-    "flowId": "<flow-id-from-step>",
+    "executionId": "<execution-id-from-step>",
     "action": "<action-ref-from-step>",
     "inputs": {
       "credentialId": "<credential-id>",
@@ -225,7 +225,7 @@ curl -k -X POST https://localhost:8090/flow/execute \
 
 > Reminder: Calling `/flow/execute` with a flow that only runs the passkey registration executor is impractical; the flow must first provision or resolve the user so registration has a valid subject.
 
-- The response includes a `flowId`, a registration step `action`, and `data.additionalData.passkeyCreationOptions` with the WebAuthn creation options. The passkey session state is maintained server-side and associated with the flow, so clients only need to carry `flowId` (and the step `action`) between calls. Ensure the flow has already collected the user identifier before this step because registration requires a user ID.
+- The response includes an `executionId`, a registration step `action`, and `data.additionalData.passkeyCreationOptions` with the WebAuthn creation options. The passkey session state is maintained server-side and associated with the flow, so clients only need to carry `executionId` (and the step `action`) between calls. Ensure the flow has already collected the user identifier before this step because registration requires a user ID.
 
 2) **Run WebAuthn in the browser** – call `navigator.credentials.create()` with the decoded `passkeyCreationOptions`.
 
@@ -235,7 +235,7 @@ curl -k -X POST https://localhost:8090/flow/execute \
 curl -k -X POST https://localhost:8090/flow/execute \
   -H "Content-Type: application/json" \
   -d '{
-    "flowId": "<flow-id-from-step>",
+    "executionId": "<execution-id-from-step>",
     "action": "<action-ref-from-step>",
     "inputs": {
       "credentialId": "<credential-id>",

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -1793,7 +1793,7 @@ paths:
               subSequentRequestExample:
                 summary: Subsequent request
                 value:
-                  flowId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
+                  executionId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
                   actionId: basic_auth
                   inputs:
                     username: thor
@@ -1812,7 +1812,7 @@ paths:
                 incompleteFlow:
                   summary: Incomplete flow (prompt for user input)
                   value:
-                    flowId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
+                    executionId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
                     flowStatus: PROMPT_ONLY
                     stepId: 3071b6c6-0119-465c-b00b-3a0e6f88a730
                     type: VIEW
@@ -1832,7 +1832,7 @@ paths:
                 displayOnlyFlow:
                   summary: Incomplete flow (display-only prompt)
                   value:
-                    flowId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
+                    executionId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
                     flowStatus: INCOMPLETE
                     stepId: 3071b6c6-0119-465c-b00b-3a0e6f88a730
                     type: VIEW
@@ -1853,13 +1853,13 @@ paths:
                 completeFlow:
                   summary: Complete flow
                   value:
-                    flowId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
+                    executionId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
                     flowStatus: COMPLETE
                     assertion: <jwt_token>
                 errorFlow:
                   summary: Erroneous flow
                   value:
-                    flowId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
+                    executionId: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
                     flowStatus: ERROR
                     failureReason: Invalid credentials
         "400":
@@ -10201,9 +10201,9 @@ components:
     SubSequentFlowRequest:
       type: object
       required:
-        - flowId
+        - executionId
       properties:
-        flowId:
+        executionId:
           type: string
           description: Identifier of an existing flow execution
           example: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
@@ -10220,12 +10220,12 @@ components:
     IncompleteFlowResponse:
       type: object
       required:
-        - flowId
+        - executionId
         - flowStatus
         - stepId
         - type
       properties:
-        flowId:
+        executionId:
           type: string
           description: Unique identifier of the flow execution
           example: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
@@ -10248,11 +10248,11 @@ components:
     CompleteFlowResponse:
       type: object
       required:
-        - flowId
+        - executionId
         - flowStatus
         - assertion
       properties:
-        flowId:
+        executionId:
           type: string
           description: Unique identifier of the flow execution
           example: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc
@@ -10267,11 +10267,11 @@ components:
     ErrorFlowResponse:
       type: object
       required:
-        - flowId
+        - executionId
         - flowStatus
         - failureReason
       properties:
-        flowId:
+        executionId:
           type: string
           description: Unique identifier of the flow execution
           example: 2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc

--- a/frontend/apps/thunder-gate/src/pages/AcceptInvitePage.tsx
+++ b/frontend/apps/thunder-gate/src/pages/AcceptInvitePage.tsx
@@ -23,8 +23,8 @@ import AcceptInviteBox from '../components/AcceptInvite/AcceptInviteBox';
 /**
  * AcceptInvitePage - Page for end users to accept an invite and set their password.
  *
- * This page is accessed via an invite link containing flowId and inviteToken query parameters.
- * Example: /invite?flowId=xxx&inviteToken=yyy
+ * This page is accessed via an invite link containing executionId and inviteToken query parameters.
+ * Example: /invite?executionId=xxx&inviteToken=yyy
  */
 export default function AcceptInvitePage(): JSX.Element {
   return (

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@asgardeo/react':
-      specifier: 0.21.3
-      version: 0.21.3
+      specifier: 0.22.0
+      version: 0.22.0
     '@asgardeo/react-router':
       specifier: 2.0.0
       version: 2.0.0
@@ -254,10 +254,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.21.3(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.0(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.21.3(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.22.0(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/abstract':
         specifier: 0.1.21
         version: 0.1.21
@@ -477,10 +477,10 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.21.3(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.0(@types/react@19.2.7)(react@19.2.3)
       '@asgardeo/react-router':
         specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.21.3(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(@asgardeo/react@0.22.0(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -699,7 +699,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.21.3(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.0(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -939,7 +939,7 @@ importers:
     dependencies:
       '@asgardeo/react':
         specifier: 'catalog:'
-        version: 0.21.3(@types/react@19.2.7)(react@19.2.3)
+        version: 0.22.0(@types/react@19.2.7)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1319,14 +1319,14 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@asgardeo/browser@0.6.3':
-    resolution: {integrity: sha512-H8e9wWSJdQVhRcBsxOKO5Z3hcARARt/ADSPwFZG+RczwUUmo43DxewvV7OuMaoJ+YtTfSxDl6t8pZwhS5P3KBg==}
+  '@asgardeo/browser@0.6.5':
+    resolution: {integrity: sha512-eEymRn13jIloLgduxgrQCqtRAbvcIINwMnuAyXeMDMUx+9TDh2NjDhyIpcd3O7mwXdze2RtVIqgAv/mlWoQj1A==}
 
   '@asgardeo/i18n@0.4.5':
     resolution: {integrity: sha512-p1DVVI7lNu7KeDqhRNgAuSrHvVgCbbVXc04koyiiwjDx+sJaXychuC9pwVJ2PDUnIyEp3Xgdb3KqMq+Sx4e7xA==}
 
-  '@asgardeo/javascript@0.16.1':
-    resolution: {integrity: sha512-0lqYQZqsgIXWXTk1Tre0BPEspHodIbSbK8BdXBuu+nzYYnWaDMt5ecMPzpFs2bHQ5K/guk6YUJk9ZvKdoEey2w==}
+  '@asgardeo/javascript@0.17.0':
+    resolution: {integrity: sha512-5Cz6M7ULqCGa3FqmnrK+unwuxl3F2imBVfmOakIjT9WiTBUiqz6CHwfWX+xIxgm/nkloTVwQzGv9gRVfkSXYLQ==}
 
   '@asgardeo/react-router@2.0.0':
     resolution: {integrity: sha512-RvHol3VgjV466y7RhpmPosER89Yz1prREvjWjhu95X9e4l761+3n8bRSQR5lpP1tasAVKtVH6RzWvWoPST7+Zg==}
@@ -1335,8 +1335,8 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@asgardeo/react@0.21.3':
-    resolution: {integrity: sha512-zOID43dHpwJ08/3VpHbyriytzzcjg0t6fV/E2kluIwhBMsYcKd3EkAriOb0vh6LcURT5SpdxVJol6qc2igv23g==}
+  '@asgardeo/react@0.22.0':
+    resolution: {integrity: sha512-6VNJkOBndQtAXHZaNlT8DzxrSYplG/oPl0E5QaCJYttfxJxGCWjnBiq7QuNr4Buy+9aBXJD3rIYu2CLikJX4aw==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -11461,9 +11461,9 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@asgardeo/browser@0.6.3':
+  '@asgardeo/browser@0.6.5':
     dependencies:
-      '@asgardeo/javascript': 0.16.1
+      '@asgardeo/javascript': 0.17.0
       base64url: 3.0.1
       buffer: 6.0.3
       core-js: 3.42.0
@@ -11479,22 +11479,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@asgardeo/javascript@0.16.1':
+  '@asgardeo/javascript@0.17.0':
     dependencies:
       '@asgardeo/i18n': 0.4.5
       jose: 5.10.0
       tslib: 2.8.1
 
-  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.21.3(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.22.0(@types/react@19.2.7)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@asgardeo/react': 0.21.3(@types/react@19.2.7)(react@19.2.3)
+      '@asgardeo/react': 0.22.0(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@asgardeo/react@0.21.3(@types/react@19.2.7)(react@19.2.3)':
+  '@asgardeo/react@0.22.0(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
-      '@asgardeo/browser': 0.6.3
+      '@asgardeo/browser': 0.6.5
       '@asgardeo/i18n': 0.4.5
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.4(react@19.2.3))(react@19.2.3)

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - ../docs
 
 catalog:
-  '@asgardeo/react': 0.21.3
+  '@asgardeo/react': 0.22.0
   '@asgardeo/react-router': 2.0.0
   '@hookform/resolvers': 5.2.2
   '@tanstack/react-query': 5.90.5

--- a/samples/api/postman/authentication/README.md
+++ b/samples/api/postman/authentication/README.md
@@ -195,7 +195,7 @@ These variables are used to manage tokens and authentication state. These will b
 | `codeVerifier` | PKCE code verifier |
 | `codeChallenge` | PKCE code challenge |
 | `authId` | Authentication session ID |
-| `flowId` | Flow execution ID |
+| `executionId` | Flow execution ID |
 | `assertion` | Authentication assertion |
 | `authCode` | Authorization code |
 

--- a/samples/api/postman/authentication/authentication_demo.json
+++ b/samples/api/postman/authentication/authentication_demo.json
@@ -55,13 +55,13 @@
                   "if (location) {",
                   "    const url = new URL(location);",
                   "    const authId = url.searchParams.get(\"authId\");",
-                  "    const flowId = url.searchParams.get(\"flowId\");",
+                  "    const executionId = url.searchParams.get(\"executionId\");",
                   "    ",
                   "    pm.environment.set(\"authId\", authId);",
-                  "    pm.environment.set(\"flowId\", flowId);",
+                  "    pm.environment.set(\"executionId\", executionId);",
                   "    ",
                   "    console.log(\"AuthId:\", authId);",
-                  "    console.log(\"FlowId:\", flowId);",
+                  "    console.log(\"ExecutionId:\", executionId);",
                   "}",
                   ""
                 ],
@@ -149,7 +149,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"flowId\": \"{{flowId}}\"\n}",
+              "raw": "{\n    \"executionId\": \"{{executionId}}\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -216,7 +216,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"flowId\": \"{{flowId}}\",\n    \"inputs\": {\n        \"username\": \"{{ADMIN_USERNAME}}\",\n        \"password\": \"{{ADMIN_PASSWORD}}\"\n    },\n    \"action\": \"action_001\"\n}",
+              "raw": "{\n    \"executionId\": \"{{executionId}}\",\n    \"inputs\": {\n        \"username\": \"{{ADMIN_USERNAME}}\",\n        \"password\": \"{{ADMIN_PASSWORD}}\"\n    },\n    \"action\": \"action_001\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1981,11 +1981,11 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the flowId from the response",
-                      "const flowId = jsonResponse.flowId;",
+                      "// Extract the executionId from the response",
+                      "const executionId = jsonResponse.executionId;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2057,7 +2057,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2156,11 +2156,11 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the flowId from the response",
-                      "const flowId = jsonResponse.flowId;",
+                      "// Extract the executionId from the response",
+                      "const executionId = jsonResponse.executionId;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2232,7 +2232,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2331,11 +2331,11 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the flowId from the response",
-                      "const flowId = jsonResponse.flowId;",
+                      "// Extract the executionId from the response",
+                      "const executionId = jsonResponse.executionId;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2407,7 +2407,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2456,7 +2456,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"443375\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"443375\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2555,11 +2555,11 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the flowId from the response",
-                      "const flowId = jsonResponse.flowId;",
+                      "// Extract the executionId from the response",
+                      "const executionId = jsonResponse.executionId;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2631,7 +2631,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2680,7 +2680,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"921262\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"otp\": \"921262\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2779,11 +2779,11 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the flowId from the response",
-                      "const flowId = jsonResponse.flowId;",
+                      "// Extract the executionId from the response",
+                      "const executionId = jsonResponse.executionId;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2855,7 +2855,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n        // \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n        // \"mobileNumber\": \"{{demoLoginUser1Mobile}}\"\n\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2885,11 +2885,11 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the flowId from the response",
-                      "const flowId = jsonResponse.flowId;",
+                      "// Extract the executionId from the response",
+                      "const executionId = jsonResponse.executionId;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -2961,7 +2961,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"action\": \"action_002\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"action\": \"action_002\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3010,7 +3010,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"code\": \"<GOOGLE_AUTHORIZATION_CODE>\"\n    }\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"code\": \"<GOOGLE_AUTHORIZATION_CODE>\"\n    }\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3141,11 +3141,11 @@
                       "// Parse the JSON response",
                       "const jsonResponse = pm.response.json();",
                       "",
-                      "// Extract the flowId from the response",
-                      "const flowId = jsonResponse.flowId;",
+                      "// Extract the executionId from the response",
+                      "const executionId = jsonResponse.executionId;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"exec_flow_id\", flowId);",
+                      "pm.collectionVariables.set(\"exec_flow_id\", executionId);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -3217,7 +3217,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"kurt\",\n        \"password\": \"kurt@123\"\n    },\n    \"action\": \"action_001\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"kurt\",\n        \"password\": \"kurt@123\"\n    },\n    \"action\": \"action_001\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3266,7 +3266,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"flowId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"given_name\": \"Kurt\",\n        \"family_name\": \"Weller\",\n        \"email\": \"kurt@fbi.com\",\n        \"mobileNumber\": \"+94712345688\"\n    },\n    \"action\": \"action_002\"\n}\n",
+                  "raw": "{\n    \"executionId\": \"{{exec_flow_id}}\",\n    \"inputs\": {\n        \"given_name\": \"Kurt\",\n        \"family_name\": \"Weller\",\n        \"email\": \"kurt@fbi.com\",\n        \"mobileNumber\": \"+94712345688\"\n    },\n    \"action\": \"action_002\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3398,13 +3398,13 @@
                   "if (location) {",
                   "    const url = new URL(location);",
                   "    const authId = url.searchParams.get(\"authId\");",
-                  "    const flowId = url.searchParams.get(\"flowId\");",
+                  "    const executionId = url.searchParams.get(\"executionId\");",
                   "    ",
                   "    pm.collectionVariables.set(\"auth_std_auth_id\", authId);",
-                  "    pm.collectionVariables.set(\"auth_std_flow_id\", flowId);",
+                  "    pm.collectionVariables.set(\"auth_std_flow_id\", executionId);",
                   "    ",
                   "    console.log(\"AuthId:\", authId);",
-                  "    console.log(\"FlowId:\", flowId);",
+                  "    console.log(\"ExecutionId:\", executionId);",
                   "}",
                   ""
                 ],
@@ -3489,7 +3489,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"flowId\": \"{{auth_std_flow_id}}\"\n}\n",
+              "raw": "{\n    \"executionId\": \"{{auth_std_flow_id}}\"\n}\n",
               "options": {
                 "raw": {
                   "language": "json"
@@ -3556,7 +3556,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"flowId\": \"{{auth_std_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}",
+              "raw": "{\n    \"executionId\": \"{{auth_std_flow_id}}\",\n    \"inputs\": {\n        \"username\": \"{{demoLoginUser1Username}}\",\n        \"password\": \"{{demoLoginUser1Password}}\"\n    },\n    \"action\": \"action_001\"\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/samples/api/postman/authentication/environment.json
+++ b/samples/api/postman/authentication/environment.json
@@ -63,7 +63,7 @@
 			"enabled": true
 		},
 		{
-			"key": "flowId",
+			"key": "executionId",
 			"value": "",
 			"type": "default",
 			"enabled": true

--- a/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
@@ -85,7 +85,7 @@ interface AuthResponse {
             passkeyChallenge?: string;
         };
     };
-    flowId?: string;
+    executionId?: string;
 }
 
 // Define the interface for the submission error
@@ -101,7 +101,7 @@ interface SubmissionError {
 const LoginPage = () => {
 
     const START_INIT_KEY = 'startInit';
-    const FLOW_ID_KEY = 'flowId';
+    const EXECUTION_ID_KEY = 'executionId';
 
     const isComponentReMount = useRef(false);
     const { setToken, clearToken } = useAuth();
@@ -114,7 +114,7 @@ const LoginPage = () => {
 
     const [loading, setLoading] = useState<boolean>(true);
     const [retryCount, setRetryCount] = useState<number>(0);
-    const [flowId, setFlowId] = useState<string>(sessionStorage.getItem(FLOW_ID_KEY) || '');
+    const [executionId, setExecutionId] = useState<string>(sessionStorage.getItem(EXECUTION_ID_KEY) || '');
     const [startInit] = useState<boolean>(JSON.parse(sessionStorage.getItem(START_INIT_KEY) || 'true'));
 
     // Unified form data state
@@ -253,17 +253,17 @@ const LoginPage = () => {
 
     const handleSocialLoginClick = useCallback((redirectURL: string) => {
         setLoading(true);
-        sessionStorage.setItem(FLOW_ID_KEY, flowId);
+        sessionStorage.setItem(EXECUTION_ID_KEY, executionId);
         sessionStorage.setItem(START_INIT_KEY, "false");
         window.location.href = redirectURL;
-    }, [flowId]);
+    }, [executionId]);
 
     // Process authentication response
     const processAuthResponse = useCallback((data: AuthResponse, selectedAction?: string) => {
         const isCameFromDecision = needsDecision;
         const isMobileLogin = selectedAction && selectedAction.includes('mobile');
 
-        setFlowId(data.flowId || '');
+        setExecutionId(data.executionId || '');
         if (data.flowStatus && data.flowStatus == 'ERROR') {
             if (isMobileLogin && data?.failureReason && data.failureReason.includes("User not found")) {
                 console.log("User not found, prompting registration");
@@ -343,7 +343,7 @@ const LoginPage = () => {
                 // This handles intermediate steps like "send_sms" that don't need user input
                 const singleAction = data.data.actions[0];
                 setLoading(true);
-                submitAuthDecision(flowId, singleAction.ref)
+                submitAuthDecision(executionId, singleAction.ref)
                     .then((result) => {
                         processAuthResponse(result.data, singleAction.ref);
                     })
@@ -381,7 +381,7 @@ const LoginPage = () => {
         setLoading(true);
         setSelectedAction(actionId);
         
-        submitAuthDecision(flowId, actionId)
+        submitAuthDecision(executionId, actionId)
             .then((result) => {
                 processAuthResponse(result.data);
             })
@@ -450,7 +450,7 @@ const LoginPage = () => {
                     } else if (data.data?.actions && data.data.actions.length === 1) {
                         // Single action without inputs - auto-execute it
                         const singleAction = data.data.actions[0];
-                        submitAuthDecision(data.flowId, singleAction.ref)
+                        submitAuthDecision(data.executionId, singleAction.ref)
                             .then((result) => {
                                 processAuthResponse(result.data, singleAction.ref);
                             })
@@ -474,7 +474,7 @@ const LoginPage = () => {
                     }
                 }
 
-                setFlowId(data.flowId);
+                setExecutionId(data.executionId);
                 setLoading(false);
             }).catch((error) => {
                 const errorType = isSignupMode ? "registration" : "auth";
@@ -546,7 +546,7 @@ const LoginPage = () => {
                     } else if (data.data?.actions && data.data.actions.length === 1) {
                         // Single action without inputs - auto-execute it
                         const singleAction = data.data.actions[0];
-                        submitAuthDecision(data.flowId, singleAction.ref)
+                        submitAuthDecision(data.executionId, singleAction.ref)
                             .then((result) => {
                                 processAuthResponse(result.data, singleAction.ref);
                             })
@@ -570,7 +570,7 @@ const LoginPage = () => {
                     }
                 }
 
-                setFlowId(data.flowId);
+                setExecutionId(data.executionId);
                 setLoading(false);
             }).catch((error) => {
                 console.error(`Error during user registration:`, error);
@@ -600,7 +600,7 @@ const LoginPage = () => {
             const formAction = event.currentTarget.getAttribute('data-action-id');
             if (formAction) {
                 setSelectedAction(formAction);
-                submitAuthDecision(flowId, formAction, completeFormData)
+                submitAuthDecision(executionId, formAction, completeFormData)
                     .then((result) => {
                         processAuthResponse(result.data, formAction);
                     })
@@ -612,7 +612,7 @@ const LoginPage = () => {
         } else {
             // This is a direct input submission - include action if available
             const actionRef = availableActions.length > 0 ? availableActions[0].ref : undefined;
-            submitNativeAuth(flowId, completeFormData, actionRef)
+            submitNativeAuth(executionId, completeFormData, actionRef)
                 .then((result) => {
                     if (isMobileInput) {
                         processAuthResponse(result.data, "mobile");
@@ -651,7 +651,7 @@ const LoginPage = () => {
         };
 
         const actionRef = availableActions.length > 0 ? availableActions[0].ref : undefined;
-        submitNativeAuth(flowId, passkeyInputs, actionRef)
+        submitNativeAuth(executionId, passkeyInputs, actionRef)
             .then((result) => {
                 processAuthResponse(result.data);
             })
@@ -687,7 +687,7 @@ const LoginPage = () => {
 
         // Include action ref if available (consistent with other direct submissions)
         const actionRef = availableActions.length > 0 ? availableActions[0].ref : undefined;
-        submitNativeAuth(flowId, passkeyInputs, actionRef)
+        submitNativeAuth(executionId, passkeyInputs, actionRef)
             .then((result) => {
                 processAuthResponse(result.data);
             })
@@ -757,7 +757,7 @@ const LoginPage = () => {
                 // Clear query parameters to avoid re-submission
                 window.history.replaceState({}, document.title, window.location.pathname);
 
-                submitNativeAuth(flowId, { type: NativeAuthSubmitType.SOCIAL, code: code })
+                submitNativeAuth(executionId, { type: NativeAuthSubmitType.SOCIAL, code: code })
                     .then((result) => {
                         processAuthResponse(result.data);
                     }).catch((error) => {
@@ -771,7 +771,7 @@ const LoginPage = () => {
 
             sessionStorage.setItem(START_INIT_KEY, "true");
         }
-    },[startInit, init, flowId, setToken, processAuthResponse]);
+    },[startInit, init, executionId, setToken, processAuthResponse]);
 
     // Render input fields based on the current inputs array
     const renderInputFields = () => {

--- a/samples/apps/react-vanilla-sample/src/services/authService.ts
+++ b/samples/apps/react-vanilla-sample/src/services/authService.ts
@@ -367,18 +367,18 @@ export const initiateNativeAuthFlowWithData = async (flowType: 'LOGIN' | 'REGIST
 /**
  * Submits the user's selected authentication option when multiple options are available.
  * 
- * @param {string} flowId - The flow ID received from the initiateNativeAuth response.
+ * @param {string} executionId - The flow ID received from the initiateNativeAuth response.
  * @param {string} actionId - The ID of the selected authentication action.
  * @param {object} inputs - Optional input data to submit with the decision.
  * @returns {Promise<object>} - A promise that resolves to the response data from the server.
  */
-export const submitAuthDecision = async (flowId: string, actionId: string, inputs?: Record<string, unknown>) => {
+export const submitAuthDecision = async (executionId: string, actionId: string, inputs?: Record<string, unknown>) => {
     const headers = {
         'Content-Type': 'application/json'
     };
 
     const data: Record<string, unknown> = {
-        flowId: flowId,
+        executionId: executionId,
         action: actionId
     };
 
@@ -407,13 +407,13 @@ export const submitAuthDecision = async (flowId: string, actionId: string, input
 /**
  * Submits the native authentication form data to the server.
  * 
- * @param {string} flowId - The flow ID received from the initiateNativeAuth response.
+ * @param {string} executionId - The flow ID received from the initiateNativeAuth response.
  * @param {object} payload - The payload containing the form data or other required information.
  * @param {string} action - Optional action ref to include in the request.
  * @returns {Promise<object>} - A promise that resolves to the response data from the server.
  */
 export const submitNativeAuth = async (
-    flowId: string,
+    executionId: string,
     payload: Record<string, unknown> | NativeAuthSubmitPayload,
     action?: string
 ) => {
@@ -422,7 +422,7 @@ export const submitNativeAuth = async (
     };
 
     const data: Record<string, unknown> = {
-        flowId: flowId
+        executionId: executionId
     };
 
     // Include action if provided

--- a/tests/e2e/tests/sample-app-authentication/README-MFA.md
+++ b/tests/e2e/tests/sample-app-authentication/README-MFA.md
@@ -121,14 +121,14 @@ Run the following command, replacing `<application_id>` with your sample app ID 
 FLOW_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
   -d '{"applicationId":"<application_id>","flowType":"AUTHENTICATION"}')
 
-FLOW_ID=$(echo $FLOW_RESPONSE | jq -r '.flowId')
+EXECUTION_ID=$(echo $FLOW_RESPONSE | jq -r '.executionId')
 ```
 
-Run the following command with the extracted `flowId`.
+Run the following command with the extracted `executionId`.
 
 ```bash
 ADMIN_TOKEN_RESPONSE=$(curl -k -s -X POST 'https://localhost:8090/flow/execute' \
-  -d '{"flowId":"'$FLOW_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
+  -d '{"executionId":"'$EXECUTION_ID'","inputs":{"username":"admin","password":"admin","requested_permissions":"system"},"action":"action_001"}')
 
 ADMIN_TOKEN=$(echo $ADMIN_TOKEN_RESPONSE | jq -r '.assertion')
 ```

--- a/tests/e2e/utils/thunder-setup/mfa-setup.ts
+++ b/tests/e2e/utils/thunder-setup/mfa-setup.ts
@@ -193,12 +193,12 @@ export class ThunderMFASetup {
     }
 
     const flowData = await flowResponse.json();
-    const flowId = flowData.flowId;
+    const executionId = flowData.executionId;
 
     // Step 2: Submit credentials
     const authResponse = await this.request.post(`${this.config.thunderUrl}/flow/execute`, {
       data: {
-        flowId,
+        executionId: executionId,
         inputs: {
           username: this.config.adminUsername,
           password: this.config.adminPassword,

--- a/tests/integration/flow/authentication/assurance_test.go
+++ b/tests/integration/flow/authentication/assurance_test.go
@@ -501,7 +501,7 @@ func (ts *AssuranceTestSuite) TestAssurance_SMSOTPOnly() {
 		"mobileNumber": userAttrs["mobileNumber"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	ts.Require().NoError(err)
 	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus)
 
@@ -515,7 +515,7 @@ func (ts *AssuranceTestSuite) TestAssurance_SMSOTPOnly() {
 
 	// Step 3: Submit OTP
 	otpInputs := map[string]string{"otp": lastMessage.OTP}
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
 	ts.Require().NoError(err)
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
 	ts.Require().NotEmpty(completeFlowStep.Assertion)
@@ -555,7 +555,7 @@ func (ts *AssuranceTestSuite) TestAssurance_CredentialsPlusSMSOTP() {
 		"password": userAttrs["password"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, credInputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, credInputs, "action_001")
 	ts.Require().NoError(err)
 	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus)
 
@@ -569,7 +569,7 @@ func (ts *AssuranceTestSuite) TestAssurance_CredentialsPlusSMSOTP() {
 
 	// Step 3: Submit OTP
 	otpInputs := map[string]string{"otp": lastMessage.OTP}
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
 	ts.Require().NoError(err)
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
 	ts.Require().NotEmpty(completeFlowStep.Assertion)
@@ -606,7 +606,7 @@ func (ts *AssuranceTestSuite) TestAssurance_BasicAuthOnly() {
 		"password": userAttrs["password"].(string),
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, credInputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, credInputs, "action_001")
 	ts.Require().NoError(err)
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus)
 	ts.Require().NotEmpty(completeFlowStep.Assertion)

--- a/tests/integration/flow/authentication/attribute_collect_test.go
+++ b/tests/integration/flow/authentication/attribute_collect_test.go
@@ -352,7 +352,7 @@ func (ts *AttributeCollectFlowTestSuite) TestAttributeCollectionFlow() {
 				ts.validateRequiredInputs(flowStep.Data.Inputs, []string{"username", "password"})
 
 				// Step 2: Provide credentials - should authenticate and proceed to attribute collection
-				credentialStep, err := common.CompleteFlow(flowStep.FlowID, testCase.credentials, "")
+				credentialStep, err := common.CompleteFlow(flowStep.ExecutionID, testCase.credentials, "")
 				ts.Require().NoError(err, "Failed to complete basic authentication")
 
 				if len(testCase.expectedMissingAttrs) == 0 {
@@ -371,7 +371,7 @@ func (ts *AttributeCollectFlowTestSuite) TestAttributeCollectionFlow() {
 
 					// Step 3: Provide missing attributes
 					if len(testCase.providedAttrs) > 0 {
-						finalStep, err := common.CompleteFlow(credentialStep.FlowID, testCase.providedAttrs, "")
+						finalStep, err := common.CompleteFlow(credentialStep.ExecutionID, testCase.providedAttrs, "")
 						ts.Require().NoError(err, "Failed to complete attribute collection")
 						ts.Require().Equal("COMPLETE", finalStep.FlowStatus, "Expected flow status to be COMPLETE")
 						ts.Require().NotEmpty(finalStep.Assertion, "Expected assertion after attribute collection")
@@ -389,7 +389,7 @@ func (ts *AttributeCollectFlowTestSuite) TestAttributeCollectionFlow() {
 					ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
 
 					// Provide credentials
-					credentialStep, err := common.CompleteFlow(flowStep.FlowID, testCase.credentials, "")
+					credentialStep, err := common.CompleteFlow(flowStep.ExecutionID, testCase.credentials, "")
 					ts.Require().NoError(err, "Failed to complete second authentication")
 					ts.Require().Equal("COMPLETE", credentialStep.FlowStatus,
 						"Expected flow to complete on second login")
@@ -416,7 +416,7 @@ func (ts *AttributeCollectFlowTestSuite) TestSingleRequestLogin_WithAllInputs() 
 		"email":        "john.doe2@example.com",
 		"mobileNumber": "+1987654345",
 	}
-	finalStep, err := common.CompleteFlow(flowStep.FlowID, allInputs, "")
+	finalStep, err := common.CompleteFlow(flowStep.ExecutionID, allInputs, "")
 	ts.Require().NoError(err, "Failed to complete authentication with all inputs")
 	ts.Require().Equal("COMPLETE", finalStep.FlowStatus, "Expected flow status to be COMPLETE")
 	ts.Require().NotEmpty(finalStep.Assertion, "Expected assertion after completing flow with all inputs")
@@ -431,7 +431,7 @@ func (ts *AttributeCollectFlowTestSuite) TestInvalidCredentials() {
 	flowStep, err := common.InitiateAuthenticationFlow(attrCollectTestAppID, false, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
 
-	errorResp, err := common.CompleteFlow(flowStep.FlowID, invalidCredentials, "")
+	errorResp, err := common.CompleteFlow(flowStep.ExecutionID, invalidCredentials, "")
 	ts.Require().NoError(err, "Expected error response for invalid credentials")
 	ts.Require().NotEmpty(errorResp.FailureReason, "Expected failure reason for invalid credentials")
 	ts.Require().Contains(errorResp.FailureReason, "User not found",

--- a/tests/integration/flow/authentication/authz_test.go
+++ b/tests/integration/flow/authentication/authz_test.go
@@ -352,7 +352,7 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithDirectRoleAssignment
 	flowStep, err := common.InitiateAuthenticationFlow(authzTestAppID, false, inputs, "")
 	ts.Require().NoError(err, "Failed to initiate flow")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Execute basic auth step with authorized user credentials
 	authInputs := map[string]string{
@@ -360,7 +360,7 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithDirectRoleAssignment
 		"password": "SecurePass123!",
 	}
 
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, authInputs, "action_001")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001")
 	ts.Require().NoError(err, "Failed to complete authentication")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")
@@ -396,7 +396,7 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithNoRole() {
 	flowStep, err := common.InitiateAuthenticationFlow(authzTestAppID, false, inputs, "")
 	ts.Require().NoError(err, "Failed to initiate flow")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Execute basic auth step with unauthorized user credentials
 	authInputs := map[string]string{
@@ -404,7 +404,7 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithNoRole() {
 		"password": "SecurePass123!",
 	}
 
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, authInputs, "action_001")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001")
 	ts.Require().NoError(err, "Failed to complete authentication")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")
@@ -432,7 +432,7 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithPartialPermissions()
 	flowStep, err := common.InitiateAuthenticationFlow(authzTestAppID, false, inputs, "")
 	ts.Require().NoError(err, "Failed to initiate flow")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Execute basic auth step with authorized user credentials
 	authInputs := map[string]string{
@@ -440,7 +440,7 @@ func (ts *FlowAuthzTestSuite) TestAuthorizationFlow_UserWithPartialPermissions()
 		"password": "SecurePass123!",
 	}
 
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, authInputs, "action_001")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, authInputs, "action_001")
 	ts.Require().NoError(err, "Failed to complete authentication")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should be complete")

--- a/tests/integration/flow/authentication/basic_auth_test.go
+++ b/tests/integration/flow/authentication/basic_auth_test.go
@@ -312,7 +312,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccess() {
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate that the required inputs are returned
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -334,7 +334,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowSuccess() {
 		"password": userAttrs["password"].(string),
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow: %v", err)
 	}
@@ -409,7 +409,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
 		ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 	}
 
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	var userAttrs map[string]interface{}
 	err = json.Unmarshal(testUser.Attributes, &userAttrs)
@@ -420,14 +420,14 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
 		"username": userAttrs["username"].(string),
 	}
 
-	intermediateFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	intermediateFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with missing credentials: %v", err)
 	}
 
 	ts.Require().Equal("INCOMPLETE", intermediateFlowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", intermediateFlowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(intermediateFlowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(intermediateFlowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate that the required inputs are returned
 	ts.Require().NotEmpty(intermediateFlowStep.Data, "Flow data should not be empty")
@@ -441,7 +441,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowWithTwoStepInput() {
 		"password": userAttrs["password"].(string),
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow: %v", err)
 	}
@@ -476,7 +476,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowInvalidCredentials() {
 		ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 	}
 
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Step 2: Continue with invalid credentials
 	inputs := map[string]string{
@@ -484,7 +484,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowInvalidCredentials() {
 		"password": "wrong_password",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with invalid credentials: %v", err)
 	}
@@ -513,7 +513,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowRetryAfterInvalidCredentials(
 	if err != nil {
 		ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 	}
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Step 2: Submit invalid credentials
 	invalidInputs := map[string]string{
@@ -521,7 +521,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowRetryAfterInvalidCredentials(
 		"password": "wrong_password",
 	}
 
-	retryFlowStep, err := common.CompleteFlow(flowStep.FlowID, invalidInputs, "action_001")
+	retryFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, invalidInputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with invalid credentials: %v", err)
 	}
@@ -536,7 +536,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowRetryAfterInvalidCredentials(
 		"password": "testpassword",
 	}
 
-	successFlowStep, err := common.CompleteFlow(flowStep.FlowID, validInputs, "action_001")
+	successFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, validInputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow after retry: %v", err)
 	}
@@ -571,7 +571,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowInvalidFlowID() {
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
 	ts.Require().NotEmpty(flowStep.Data.Inputs, "Flow should require inputs")
 
@@ -589,7 +589,7 @@ func (ts *BasicAuthFlowTestSuite) TestBasicAuthFlowInvalidFlowID() {
 	// Verify the error response
 	ts.Require().Equal("FES-1004", errorResp.Code, "Expected error code for invalid flow ID")
 	ts.Require().Equal("Invalid request", errorResp.Message, "Expected error message for invalid request")
-	ts.Require().Equal("Invalid flow ID provided in the request", errorResp.Description,
+	ts.Require().Equal("Invalid flow execution ID provided in the request", errorResp.Description,
 		"Expected error description for invalid flow ID")
 }
 

--- a/tests/integration/flow/authentication/conditional_exec_auth_test.go
+++ b/tests/integration/flow/authentication/conditional_exec_auth_test.go
@@ -380,7 +380,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestSkipConditionalNodes() {
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECTION")
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 	redirectURLStr := flowStep.Data.RedirectURL
 
 	// Step 2: Simulate user authorization at Google
@@ -391,7 +391,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestSkipConditionalNodes() {
 	inputs := map[string]string{
 		"code": authCode,
 	}
-	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Failed to complete authentication flow")
 
 	// For existing user, flow should complete directly
@@ -425,7 +425,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestExecuteConditionalNodes() {
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECTION")
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 	redirectURLStr := flowStep.Data.RedirectURL
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
@@ -438,7 +438,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestExecuteConditionalNodes() {
 	inputs := map[string]string{
 		"code": authCode,
 	}
-	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Failed to complete authentication flow")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
@@ -449,7 +449,7 @@ func (ts *ConditionalExecAuthFlowTestSuite) TestExecuteConditionalNodes() {
 		"ouHandle":      conditionalExecNewOUHandle,
 		"ouDescription": "Organization Unit created during conditional exec auth flow test",
 	}
-	flowStep, err = common.CompleteFlow(flowID, ouInputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, ouInputs, "")
 	ts.Require().NoError(err, "Failed to complete authentication flow after OU details")
 	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Expected flow status to be COMPLETE")
 	ts.Require().NotEmpty(flowStep.Assertion, "Assertion token should be present")

--- a/tests/integration/flow/authentication/github_auth_test.go
+++ b/tests/integration/flow/authentication/github_auth_test.go
@@ -320,7 +320,7 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowInitiation() {
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate redirect information
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -368,9 +368,9 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteSuccess() {
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 	redirectURLStr := flowStep.Data.RedirectURL
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
@@ -386,7 +386,7 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteSuccess() {
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete GitHub authentication flow: %v", err)
 	}
@@ -415,14 +415,14 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteWithInvalidCode() {
 		ts.T().Fatalf("Failed to initiate GitHub authentication flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 
 	// Step 2: Try to complete with invalid authorization code
 	inputs := map[string]string{
 		"code": "invalid-auth-code-12345",
 	}
 
-	_, err = common.CompleteFlow(flowID, inputs, "")
+	_, err = common.CompleteFlow(ExecutionID, inputs, "")
 	ts.Require().Error(err, "Should fail with invalid authorization code")
 }
 
@@ -433,14 +433,14 @@ func (ts *GithubAuthFlowTestSuite) TestGithubAuthFlowCompleteWithMissingCode() {
 		ts.T().Fatalf("Failed to initiate GitHub authentication flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 
 	// Step 2: Try to complete without providing authorization code
 	inputs := map[string]string{}
 
 	// When required inputs are missing, the flow returns INCOMPLETE status (not an error)
 	// and asks for the missing inputs again
-	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Should not return error when inputs are missing")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
 		"Flow should remain INCOMPLETE when required inputs are missing")

--- a/tests/integration/flow/authentication/google_auth_test.go
+++ b/tests/integration/flow/authentication/google_auth_test.go
@@ -332,7 +332,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowInitiation() {
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate redirect information
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -383,9 +383,9 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteSuccess() {
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 	redirectURLStr := flowStep.Data.RedirectURL
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
@@ -401,7 +401,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteSuccess() {
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete Google authentication flow: %v", err)
 	}
@@ -430,14 +430,14 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteWithInvalidCode() {
 		ts.T().Fatalf("Failed to initiate Google authentication flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 
 	// Step 2: Try to complete with invalid authorization code
 	inputs := map[string]string{
 		"code": "invalid-auth-code-12345",
 	}
 
-	_, err = common.CompleteFlow(flowID, inputs, "")
+	_, err = common.CompleteFlow(ExecutionID, inputs, "")
 	ts.Require().Error(err, "Should fail with invalid authorization code")
 }
 
@@ -448,14 +448,14 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowCompleteWithMissingCode() {
 		ts.T().Fatalf("Failed to initiate Google authentication flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 
 	// Step 2: Try to complete without providing authorization code
 	inputs := map[string]string{}
 
 	// When required inputs are missing, the flow returns INCOMPLETE status (not an error)
 	// and asks for the missing inputs again
-	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Should not return error when inputs are missing")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
 		"Flow should remain INCOMPLETE when required inputs are missing")
@@ -483,7 +483,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowMultipleUsersSuccess() {
 		ts.T().Fatalf("Failed to initiate Google authentication flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 	redirectURLStr := flowStep.Data.RedirectURL
 
 	// Step 2: Simulate user authorization at Google
@@ -497,7 +497,7 @@ func (ts *GoogleAuthFlowTestSuite) TestGoogleAuthFlowMultipleUsersSuccess() {
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(ExecutionID, inputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete Google authentication flow: %v", err)
 	}

--- a/tests/integration/flow/authentication/multi_action_input_binding_test.go
+++ b/tests/integration/flow/authentication/multi_action_input_binding_test.go
@@ -347,10 +347,10 @@ func (ts *MultiActionInputBindingTestSuite) TestInitiateFlow_ShowsAllActions() {
 func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithoutInputs_ShouldRedirectToGoogle() {
 	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
-	ts.Require().NotEmpty(flowStep.FlowID)
+	ts.Require().NotEmpty(flowStep.ExecutionID)
 
 	// Select action_google which has no inputs - should redirect to Google
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, nil, "action_google")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_google")
 	ts.Require().NoError(err, "Failed to complete flow with action_google")
 
 	// Should redirect to Google OAuth
@@ -362,10 +362,10 @@ func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithoutInputs_Should
 func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputs_ShouldPromptForInputs() {
 	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
-	ts.Require().NotEmpty(flowStep.FlowID)
+	ts.Require().NotEmpty(flowStep.ExecutionID)
 
 	// Select action_basic which requires username and password
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, nil, "action_basic")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_basic")
 	ts.Require().NoError(err, "Failed to complete flow with action_basic")
 
 	ts.Equal("INCOMPLETE", flowStep.FlowStatus)
@@ -383,10 +383,10 @@ func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputs_ShouldPro
 func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputsProvided_ShouldComplete() {
 	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
-	ts.Require().NotEmpty(flowStep.FlowID)
+	ts.Require().NotEmpty(flowStep.ExecutionID)
 
 	// Select action_basic
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, nil, "action_basic")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, nil, "action_basic")
 	ts.Require().NoError(err, "Failed to select action_basic")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -395,7 +395,7 @@ func (ts *MultiActionInputBindingTestSuite) TestSelectActionWithInputsProvided_S
 		"username": "multiactionuser",
 		"password": "testpassword",
 	}
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Failed to complete flow with inputs")
 
 	ts.Equal("COMPLETE", flowStep.FlowStatus, "Flow should complete after providing required inputs")
@@ -406,10 +406,10 @@ func (ts *MultiActionInputBindingTestSuite) TestGoogleAuthFlowComplete() {
 	flowStep, err := common.InitiateAuthenticationFlow(multiActionInputBindingTestAppID, false, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
 
-	flowID := flowStep.FlowID
+	ExecutionID := flowStep.ExecutionID
 
 	// Select action_google
-	flowStep, err = common.CompleteFlow(flowID, nil, "action_google")
+	flowStep, err = common.CompleteFlow(ExecutionID, nil, "action_google")
 	ts.Require().NoError(err, "Failed to select action_google")
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 	ts.Require().Equal("REDIRECTION", flowStep.Type)
@@ -424,7 +424,7 @@ func (ts *MultiActionInputBindingTestSuite) TestGoogleAuthFlowComplete() {
 
 	// Complete flow with authorization code
 	inputs := map[string]string{"code": authCode}
-	flowStep, err = common.CompleteFlow(flowID, inputs, "")
+	flowStep, err = common.CompleteFlow(ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Failed to complete flow with auth code")
 
 	ts.Equal("COMPLETE", flowStep.FlowStatus)

--- a/tests/integration/flow/authentication/prompt_actions_test.go
+++ b/tests/integration/flow/authentication/prompt_actions_test.go
@@ -413,7 +413,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() 
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate that decision input is required
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -425,7 +425,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() 
 		"Expected actions basic_auth and prompt_mobile should be present")
 
 	// Step 2: Choose basic auth
-	basicAuthStep, err := common.CompleteFlow(flowStep.FlowID, map[string]string{}, "basic_auth")
+	basicAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 	}
@@ -451,7 +451,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() 
 	// Clear any previous messages before SMS flow
 	ts.mockServer.ClearMessages()
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, basicInputs, "")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with credentials: %v", err)
 	}
@@ -482,7 +482,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithMobileUserSMSOTP() 
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -528,7 +528,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 		}
 
 		// Step 2: Choose basic auth
-		_, err = common.CompleteFlow(flowStep.FlowID, map[string]string{}, "basic_auth")
+		_, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth")
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 		}
@@ -543,7 +543,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"password": userAttrs["password"].(string),
 		}
 
-		mobilePromptStep, err := common.CompleteFlow(flowStep.FlowID, basicInputs, "")
+		mobilePromptStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "")
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with credentials: %v", err)
 		}
@@ -569,7 +569,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"mobileNumber": "+1987654321",
 		}
 
-		otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, mobileInputs, "")
+		otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, mobileInputs, "")
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 		}
@@ -600,7 +600,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"otp": lastMessage.OTP,
 		}
 
-		completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_otp")
+		completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 		}
@@ -645,7 +645,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 		}
 
 		// Step 2: Choose basic auth
-		basicAuthStep, err := common.CompleteFlow(flowStep.FlowID, map[string]string{}, "basic_auth")
+		basicAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "basic_auth")
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 		}
@@ -676,7 +676,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"password": userAttrs["password"].(string),
 		}
 
-		otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, basicInputs, "")
+		otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, basicInputs, "")
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 		}
@@ -707,7 +707,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestBasicAuthWithoutMobileUserSMSOTP
 			"otp": lastMessage.OTP,
 		}
 
-		completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_otp")
+		completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
 		if err != nil {
 			ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 		}
@@ -752,7 +752,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 	}
 
 	// Step 2: Choose sms OTP auth
-	smsAuthStep, err := common.CompleteFlow(flowStep.FlowID, map[string]string{}, "prompt_mobile")
+	smsAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "prompt_mobile")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 	}
@@ -782,7 +782,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 		"mobileNumber": userAttrs["mobileNumber"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, mobileInputs, "action_mobile")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, mobileInputs, "action_mobile")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 	}
@@ -813,7 +813,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithValidMobile() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -858,7 +858,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithInvalidMobile() {
 	}
 
 	// Step 2: Choose sms OTP auth
-	smsAuthStep, err := common.CompleteFlow(flowStep.FlowID, map[string]string{}, "prompt_mobile")
+	smsAuthStep, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "prompt_mobile")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with decision: %v", err)
 	}
@@ -872,7 +872,7 @@ func (ts *PromptActionsAndMFAFlowTestSuite) TestSMSOTPAuthWithInvalidMobile() {
 	}
 
 	// This should result in failure or error
-	errorResp, err := common.CompleteAuthFlowWithError(flowStep.FlowID, mobileInputs)
+	errorResp, err := common.CompleteAuthFlowWithError(flowStep.ExecutionID, mobileInputs)
 	if err != nil {
 		// If the API returned an error response, that's expected
 		ts.T().Logf("Expected error occurred: %v", err)

--- a/tests/integration/flow/authentication/sensitive_input_cleanup_test.go
+++ b/tests/integration/flow/authentication/sensitive_input_cleanup_test.go
@@ -252,7 +252,7 @@ func (ts *SensitiveInputCleanupTestSuite) TestPasswordClearedAfterAuthExecution(
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Verify both username and password are requested
 	ts.Require().True(common.HasInput(flowStep.Data.Inputs, "username"),
@@ -273,7 +273,7 @@ func (ts *SensitiveInputCleanupTestSuite) TestPasswordClearedAfterAuthExecution(
 	// After basic_auth completes, password should be cleared from context.
 	// The second prompt node (prompt_password_again) should detect the missing password
 	// and return INCOMPLETE, asking for it again.
-	step2, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	step2, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	ts.Require().NoError(err, "Failed to complete flow step 2")
 
 	ts.Require().Equal("INCOMPLETE", step2.FlowStatus,
@@ -292,7 +292,7 @@ func (ts *SensitiveInputCleanupTestSuite) TestPasswordClearedAfterAuthExecution(
 		"password": userAttrs["password"].(string),
 	}
 
-	step3, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_002")
+	step3, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002")
 	ts.Require().NoError(err, "Failed to complete flow step 3")
 
 	ts.Require().Equal("COMPLETE", step3.FlowStatus, "Expected flow to complete after re-submitting password")

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -446,7 +446,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate that mobile number input is required
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -466,7 +466,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 		"mobileNumber": userAttrs["mobileNumber"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 	}
@@ -493,7 +493,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -536,7 +536,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate that username input is required
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -562,7 +562,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
 		"username": userAttrs["username"].(string),
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with username: %v", err)
 	}
@@ -594,7 +594,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithUsername() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_002")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}
@@ -637,7 +637,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
 	ts.mockServer.ClearMessages()
 
 	// Continue flow to trigger OTP sending
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
 	}
@@ -652,7 +652,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
 		"otp": "000000", // Invalid OTP
 	}
 
-	completeFlowStep, err := common.CompleteFlow(otpFlowStep.FlowID, invalidOTPInputs, "action_002")
+	completeFlowStep, err := common.CompleteFlow(otpFlowStep.ExecutionID, invalidOTPInputs, "action_002")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with invalid OTP: %v", err)
 	}
@@ -700,7 +700,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete authentication flow with OTP: %v", err)
 	}

--- a/tests/integration/flow/authentication/verbose_meta_test.go
+++ b/tests/integration/flow/authentication/verbose_meta_test.go
@@ -333,7 +333,7 @@ func (ts *VerboseMetaTestSuite) TestVerboseModeEnabled() {
 		"password": "testpassword123",
 	}
 	action := "action_001"
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, action)
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action)
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 
@@ -365,7 +365,7 @@ func (ts *VerboseMetaTestSuite) TestVerboseModeDisabled() {
 		"password": "testpassword123",
 	}
 	action := "action_001"
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, action)
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action)
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 
@@ -413,7 +413,7 @@ func (ts *VerboseMetaTestSuite) TestVerboseModeWithGraphWithoutMeta() {
 		"username": "verboseuser",
 		"password": "testpassword123",
 	}
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "")
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 
@@ -438,7 +438,7 @@ func (ts *VerboseMetaTestSuite) TestVerbosePersistsAcrossRequests() {
 	action := "action_001"
 
 	// Note: We're not sending verbose flag here, it should be retrieved from stored context
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, action)
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, action)
 	ts.Require().NoError(err, "Failed to continue auth flow")
 	ts.Require().NotNil(flowStep, "Flow step should not be nil")
 

--- a/tests/integration/flow/common/model.go
+++ b/tests/integration/flow/common/model.go
@@ -31,7 +31,7 @@ type TestSuiteConfig struct {
 }
 
 type FlowStep struct {
-	FlowID        string   `json:"flowId"`
+	ExecutionID   string   `json:"executionId"`
 	FlowStatus    string   `json:"flowStatus"`
 	Type          string   `json:"type,omitempty"`
 	Data          FlowData `json:"data,omitempty"`

--- a/tests/integration/flow/common/utils.go
+++ b/tests/integration/flow/common/utils.go
@@ -140,10 +140,10 @@ func InitiateAuthFlowWithError(appID string, inputs map[string]string) (*ErrorRe
 }
 
 // CompleteFlow completes the flow with given inputs and action
-func CompleteFlow(flowID string, inputs map[string]string, action string) (
+func CompleteFlow(executionId string, inputs map[string]string, action string) (
 	*FlowStep, error) {
 	flowReqBody := map[string]interface{}{
-		"flowId": flowID,
+		"executionId": executionId,
 	}
 	if len(inputs) > 0 {
 		flowReqBody["inputs"] = inputs
@@ -188,10 +188,10 @@ func CompleteFlow(flowID string, inputs map[string]string, action string) (
 }
 
 // CompleteAuthFlowWithError completes the authentication flow and expects an error response
-func CompleteAuthFlowWithError(flowID string, inputs map[string]string) (*ErrorResponse, error) {
+func CompleteAuthFlowWithError(executionId string, inputs map[string]string) (*ErrorResponse, error) {
 	flowReqBody := map[string]interface{}{
-		"flowId": flowID,
-		"inputs": inputs,
+		"executionId": executionId,
+		"inputs":      inputs,
 	}
 
 	reqBody, err := json.Marshal(flowReqBody)

--- a/tests/integration/flow/registration/basic_registration_test.go
+++ b/tests/integration/flow/registration/basic_registration_test.go
@@ -158,7 +158,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSuccess() {
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
 	ts.Require().NotEmpty(flowStep.Data.Inputs, "Flow should require inputs")
 
@@ -174,7 +174,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSuccess() {
 		"password": "testpassword123",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow: %v", err)
 	}
@@ -193,7 +193,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowSuccess() {
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.FlowID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with additional attributes: %v", err)
 	}
@@ -260,7 +260,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowDuplicateUser
 		"password": "newpassword123",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow: %v", err)
 	}
@@ -285,7 +285,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 	inputs := map[string]string{
 		"username": username,
 	}
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow: %v", err)
 	}
@@ -301,7 +301,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 	inputs = map[string]string{
 		"password": "testpassword123",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.FlowID, inputs, "action_credentials")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_credentials")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with username input: %v", err)
 	}
@@ -320,7 +320,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlowInitialInvali
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.FlowID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with additional attributes: %v", err)
 	}
@@ -438,7 +438,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithoutToken
 		"username": username,
 		"password": "testpassword123",
 	}
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
 	ts.Require().NoError(err, "Failed to complete registration flow")
 
 	inputs = map[string]string{
@@ -446,7 +446,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithoutToken
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.FlowID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
 	ts.Require().NoError(err, "Failed to complete registration flow with additional attributes")
 
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be COMPLETE")
@@ -505,7 +505,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithEmptyUse
 		"username": username,
 		"password": "testpassword123",
 	}
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_credentials")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_credentials")
 	ts.Require().NoError(err, "Failed to complete registration flow")
 
 	inputs = map[string]string{
@@ -513,7 +513,7 @@ func (ts *BasicRegistrationFlowTestSuite) TestBasicRegistrationFlow_WithEmptyUse
 		"given_name":  "Test",
 		"family_name": "User",
 	}
-	completeFlowStep, err = common.CompleteFlow(completeFlowStep.FlowID, inputs, "action_user_info")
+	completeFlowStep, err = common.CompleteFlow(completeFlowStep.ExecutionID, inputs, "action_user_info")
 	ts.Require().NoError(err, "Failed to complete registration flow with additional attributes")
 
 	ts.Require().Equal("COMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be COMPLETE")

--- a/tests/integration/flow/registration/github_registration_test.go
+++ b/tests/integration/flow/registration/github_registration_test.go
@@ -479,7 +479,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowInitiation(
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate redirect information
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -515,9 +515,9 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteSuc
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
-	flowID := flowStep.FlowID
+	flowID := flowStep.ExecutionID
 	redirectURLStr := flowStep.Data.RedirectURL
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
@@ -582,7 +582,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteWit
 		ts.T().Fatalf("Failed to initiate GitHub registration flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	flowID := flowStep.ExecutionID
 
 	// Step 2: Try to complete with invalid authorization code
 	inputs := map[string]string{
@@ -600,7 +600,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowCompleteWit
 		ts.T().Fatalf("Failed to initiate GitHub registration flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	flowID := flowStep.ExecutionID
 
 	// Step 2: Try to complete without providing authorization code
 	inputs := map[string]string{}
@@ -642,7 +642,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowDuplicateUs
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete first GitHub registration flow: %v", err)
 	}
@@ -671,7 +671,7 @@ func (ts *GithubRegistrationFlowTestSuite) TestGithubRegistrationFlowDuplicateUs
 		"code": authCode2,
 	}
 
-	completeFlowStep2, err := common.CompleteFlow(flowStep2.FlowID, inputs2, "")
+	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete second GitHub registration flow: %v", err)
 	}

--- a/tests/integration/flow/registration/google_registration_test.go
+++ b/tests/integration/flow/registration/google_registration_test.go
@@ -462,7 +462,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowInitiation(
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate redirect information
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -501,9 +501,9 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteSuc
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
-	flowID := flowStep.FlowID
+	flowID := flowStep.ExecutionID
 	redirectURLStr := flowStep.Data.RedirectURL
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
 
@@ -568,7 +568,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteWit
 		ts.T().Fatalf("Failed to initiate Google registration flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	flowID := flowStep.ExecutionID
 
 	// Step 2: Try to complete with invalid authorization code
 	inputs := map[string]string{
@@ -586,7 +586,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowCompleteWit
 		ts.T().Fatalf("Failed to initiate Google registration flow: %v", err)
 	}
 
-	flowID := flowStep.FlowID
+	flowID := flowStep.ExecutionID
 
 	// Step 2: Try to complete without providing authorization code
 	inputs := map[string]string{}
@@ -628,7 +628,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowDuplicateUs
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete first Google registration flow: %v", err)
 	}
@@ -657,7 +657,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowDuplicateUs
 		"code": authCode2,
 	}
 
-	completeFlowStep2, err := common.CompleteFlow(flowStep2.FlowID, inputs2, "")
+	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete second Google registration flow: %v", err)
 	}
@@ -685,7 +685,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowWithExistin
 		"code": authCode,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete first Google registration flow: %v", err)
 	}
@@ -726,7 +726,7 @@ func (ts *GoogleRegistrationFlowTestSuite) TestGoogleRegistrationFlowWithExistin
 		"code": authCode2,
 	}
 
-	completeFlowStep2, err := common.CompleteFlow(flowStep2.FlowID, inputs2, "")
+	completeFlowStep2, err := common.CompleteFlow(flowStep2.ExecutionID, inputs2, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete second Google registration flow: %v", err)
 	}

--- a/tests/integration/flow/registration/google_registration_with_role_group_test.go
+++ b/tests/integration/flow/registration/google_registration_with_role_group_test.go
@@ -437,7 +437,7 @@ func (ts *GoogleRegistrationGroupRoleTestSuite) TestGoogleRegistrationWithGroupA
 	// Verify flow status and type
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("REDIRECTION", flowStep.Type, "Expected flow type to be REDIRECT")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	redirectURLStr := flowStep.Data.RedirectURL
 	ts.Require().NotEmpty(redirectURLStr, "Redirect URL should not be empty")
@@ -449,7 +449,7 @@ func (ts *GoogleRegistrationGroupRoleTestSuite) TestGoogleRegistrationWithGroupA
 
 	// Step 3: Complete the flow
 	inputs := map[string]string{"code": authCode}
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 	ts.Require().NoError(err, "Failed to complete flow")
 
 	// Verify flow completion

--- a/tests/integration/flow/registration/http_request_executor_runtime_data_test.go
+++ b/tests/integration/flow/registration/http_request_executor_runtime_data_test.go
@@ -526,7 +526,7 @@ func (ts *HTTPRequestRuntimeDataRegistrationFlowTestSuite) TestHTTPRequestRuntim
 	ts.Require().NoError(err, "Failed to simulate Google authorization for runtime data flow")
 	ts.Require().NotEmpty(authCode, "Authorization code should not be empty")
 
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, map[string]string{
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
 		"code": authCode,
 	}, "")
 	ts.Require().NoError(err, "Failed to complete runtime data flow with authorization code")
@@ -534,7 +534,7 @@ func (ts *HTTPRequestRuntimeDataRegistrationFlowTestSuite) TestHTTPRequestRuntim
 	ts.Require().Equal("VIEW", flowStep.Type)
 	ts.Require().True(common.HasInput(flowStep.Data.Inputs, "mobileNumber"))
 
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, map[string]string{
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
 		"mobileNumber": mobileNumber,
 	}, "action_mobile")
 	ts.Require().NoError(err, "Failed to continue runtime data flow with mobile number")
@@ -547,7 +547,7 @@ func (ts *HTTPRequestRuntimeDataRegistrationFlowTestSuite) TestHTTPRequestRuntim
 	ts.Require().NotNil(otpMessage, "OTP message should be captured by mock notification server")
 	ts.Require().NotEmpty(otpMessage.OTP, "OTP should be available for verification")
 
-	flowStep, err = common.CompleteFlow(flowStep.FlowID, map[string]string{
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
 		"otp": otpMessage.OTP,
 	}, "action_otp")
 	ts.Require().NoError(err, "Failed to complete runtime data flow with OTP")

--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -749,7 +749,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"mobileNumber": mobileNumber,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -765,7 +765,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"otp": lastMessage.OTP,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "action_002")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002")
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -776,7 +776,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"ouDescription": tc.ouDescription,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -788,7 +788,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 				"email":        mobileNumber + "@example.com",
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 			ts.Require().NoError(err)
 			ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
 			ts.Require().NotEmpty(flowStep.Assertion)
@@ -879,7 +879,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 			// Wait for OTP to be sent
 			time.Sleep(1 * time.Second)
 
-			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -891,7 +891,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 				"otp": lastMessage.OTP,
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "action_002")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_002")
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
@@ -907,7 +907,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 				"ouDescription": "Should fail due to duplicate",
 			}
 
-			flowStep, err = common.CompleteFlow(flowStep.FlowID, inputs, "")
+			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "")
 			ts.Require().NoError(err)
 			ts.Require().Equal("ERROR", flowStep.FlowStatus)
 			ts.Require().Empty(flowStep.Assertion)

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -415,7 +415,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", flowStep.Type, "Expected flow type to be VIEW")
-	ts.Require().NotEmpty(flowStep.FlowID, "Flow ID should not be empty")
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
 
 	// Validate that mobile number input is required
 	ts.Require().NotEmpty(flowStep.Data, "Flow data should not be empty")
@@ -431,7 +431,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 		"mobileNumber": mobileNumber,
 	}
 
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with mobile number: %v", err)
 	}
@@ -456,7 +456,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 		"otp": lastMessage.OTP,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, otpInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, otpInputs, "action_otp")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with OTP: %v", err)
 	}
@@ -484,7 +484,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 	}
 	fillInputs = append(fillInputs, completeFlowStep.Data.Inputs...)
 	attrInputs := fillRequiredRegistrationAttributes(fillInputs, mobileNumber)
-	completeFlowStep, err = common.CompleteFlow(flowStep.FlowID, attrInputs, "")
+	completeFlowStep, err = common.CompleteFlow(flowStep.ExecutionID, attrInputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with attributes: %v", err)
 	}
@@ -547,7 +547,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 	ts.mockServer.ClearMessages()
 
 	// Continue flow to trigger OTP sending
-	otpFlowStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with mobile number: %v", err)
 	}
@@ -562,7 +562,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 		"otp": "000000",
 	}
 
-	completeFlowStep, err := common.CompleteFlow(flowStep.FlowID, invalidOTPInputs, "action_otp")
+	completeFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, invalidOTPInputs, "action_otp")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with invalid OTP: %v", err)
 	}
@@ -603,7 +603,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"mobileNumber": mobileNumber,
 	}
 
-	otpStep, err := common.CompleteFlow(flowStep.FlowID, inputs, "action_001")
+	otpStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001")
 	if err != nil {
 		ts.T().Fatalf("Failed to provide mobile number: %v", err)
 	}
@@ -625,7 +625,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"otp": lastMessage.OTP,
 	}
 
-	provisionStep, err := common.CompleteFlow(otpStep.FlowID, otpInputs, "action_otp")
+	provisionStep, err := common.CompleteFlow(otpStep.ExecutionID, otpInputs, "action_otp")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration flow with OTP: %v", err)
 	}
@@ -641,7 +641,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"mobileNumber": mobileNumber,
 	}
 
-	completeFlowStep, err := common.CompleteFlow(provisionStep.FlowID, userInputs, "")
+	completeFlowStep, err := common.CompleteFlow(provisionStep.ExecutionID, userInputs, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to complete registration with user attributes: %v", err)
 	}

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -397,10 +397,10 @@ func (ts *AuthzTestSuite) TestBasicAuthorizationRequest() {
 					err := testutils.ValidateOAuth2ErrorRedirect(location, tc.ExpectedError, "")
 					ts.NoError(err, "OAuth2 error redirect validation failed")
 				} else {
-					authId, flowId, err := testutils.ExtractAuthData(location)
+					authId, executionId, err := testutils.ExtractAuthData(location)
 					ts.NoError(err, "Failed to extract auth ID")
 					ts.NotEmpty(authId, "authId should be present")
-					ts.NotEmpty(flowId, "flowId should be present")
+					ts.NotEmpty(executionId, "executionId should be present")
 				}
 			} else {
 				bodyBytes, _ := io.ReadAll(resp.Body)
@@ -626,15 +626,15 @@ func initiateAuthorizeFlowAndRetrieveAuthzCode(ts *AuthzTestSuite, username stri
 
 	ts.Equal(http.StatusFound, resp.StatusCode, "Expected redirect status")
 	location := resp.Header.Get("Location")
-	authId, flowId, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	ts.NoError(err, "Failed to extract auth ID")
 
 	// Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowId, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err, "Failed to initiate authentication flow")
 
 	// Execute authentication flow
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowId, map[string]string{
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": username,
 		"password": password,
 	}, "action_001")
@@ -748,10 +748,10 @@ func (ts *AuthzTestSuite) TestRedirectURIValidation() {
 					ts.NoError(err, "OAuth2 error redirect validation failed")
 
 				} else {
-					authId, flowId, err := testutils.ExtractAuthData(location)
+					authId, executionId, err := testutils.ExtractAuthData(location)
 					ts.NoError(err, "Failed to extract auth ID")
 					ts.NotEmpty(authId, "authId should be present")
-					ts.NotEmpty(flowId, "flowId should be present")
+					ts.NotEmpty(executionId, "executionId should be present")
 				}
 			}
 		})
@@ -811,8 +811,8 @@ func (ts *AuthzTestSuite) TestCompleteAuthorizationCodeFlow() {
 			location := resp.Header.Get("Location")
 			ts.NotEmpty(location, "Expected redirect location header")
 
-			// Extract auth ID and flow ID
-			authId, flowId, err := testutils.ExtractAuthData(location)
+			// Extract auth ID and execution ID
+			authId, executionId, err := testutils.ExtractAuthData(location)
 			if err != nil {
 				ts.T().Fatalf("Failed to extract auth ID: %v", err)
 			}
@@ -821,13 +821,13 @@ func (ts *AuthzTestSuite) TestCompleteAuthorizationCodeFlow() {
 			}
 
 			// Initiate authentication flow
-			_, err = testutils.ExecuteAuthenticationFlow(flowId, nil, "")
+			_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 			if err != nil {
 				ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 			}
 
 			// Execute authentication flow
-			flowStep, err := testutils.ExecuteAuthenticationFlow(flowId, map[string]string{
+			flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 				"username": tc.Username,
 				"password": tc.Password,
 			}, "action_001")
@@ -838,8 +838,8 @@ func (ts *AuthzTestSuite) TestCompleteAuthorizationCodeFlow() {
 				ts.T().Fatalf("Expected flow step, got nil")
 			}
 
-			if flowStep.FlowID == "" {
-				ts.T().Fatalf("Expected flow ID, got empty string")
+			if flowStep.ExecutionID == "" {
+				ts.T().Fatalf("Expected execution ID, got empty string")
 			}
 			if flowStep.FlowStatus != "COMPLETE" {
 				ts.T().Fatalf("Expected flow status COMPLETE, got %s", flowStep.FlowStatus)
@@ -934,17 +934,17 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeErrorScenarios() {
 			location := resp.Header.Get("Location")
 			ts.NotEmpty(location, "Expected redirect location header")
 
-			authId, flowId, err := testutils.ExtractAuthData(location)
+			authId, executionId, err := testutils.ExtractAuthData(location)
 			ts.NoError(err, "Failed to extract auth ID")
 
 			// Initiate authentication flow
-			_, err = testutils.ExecuteAuthenticationFlow(flowId, nil, "")
+			_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 			if err != nil {
 				ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 			}
 
 			// Execute authentication flow
-			flowStep, err := testutils.ExecuteAuthenticationFlow(flowId, map[string]string{
+			flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 				"username": tc.Username,
 				"password": tc.Password,
 			}, "action_001")
@@ -1025,15 +1025,15 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithResourceParameter() {
 	location := resp.Header.Get("Location")
 	ts.NotEmpty(location, "Expected redirect location header")
 
-	authId, flowId, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	ts.NoError(err, "Failed to extract auth ID")
 
 	// Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowId, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err, "Failed to initiate authentication flow")
 
 	// Execute authentication flow
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowId, map[string]string{
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "resourcetest",
 		"password": "testpass123",
 	}, "action_001")
@@ -1133,15 +1133,15 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithClaimsLocales() {
 	location := resp.Header.Get("Location")
 	ts.NotEmpty(location, "Expected redirect location header")
 
-	authId, flowId, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	ts.NoError(err, "Failed to extract auth ID")
 
 	// Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowId, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err, "Failed to initiate authentication flow")
 
 	// Execute authentication flow
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowId, map[string]string{
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "localestest",
 		"password": "testpass123",
 	}, "action_001")
@@ -1225,15 +1225,15 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlowWithNonce() {
 	ts.Equal(http.StatusFound, resp.StatusCode)
 
 	location := resp.Header.Get("Location")
-	authId, flowId, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	ts.NoError(err)
 
 	// Initiate auth flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowId, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err)
 
 	// Execute credentials
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowId, map[string]string{
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "noncetest",
 		"password": "testpass123",
 	}, "action_001")
@@ -1316,14 +1316,14 @@ func (ts *AuthzTestSuite) TestNonceIgnoredWithoutOpenIDScope() {
 	ts.Equal(http.StatusFound, resp.StatusCode)
 
 	location := resp.Header.Get("Location")
-	authId, flowId, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	ts.NoError(err)
 
 	// Execute authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowId, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.NoError(err)
 
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowId, map[string]string{
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": "nonopeniduser",
 		"password": "testpass123",
 	}, "action_001")

--- a/tests/integration/oauth/token/refresh_token_test.go
+++ b/tests/integration/oauth/token/refresh_token_test.go
@@ -304,14 +304,14 @@ func (ts *RefreshTokenTestSuite) obtainTokensViaAuthCodeFlow(
 	location := resp.Header.Get("Location")
 	ts.Require().NotEmpty(location, "Expected Location header")
 
-	authID, flowID, err := testutils.ExtractAuthData(location)
+	authID, executionId, err := testutils.ExtractAuthData(location)
 	ts.Require().NoError(err, "Failed to extract auth data")
 
 	// Step 2: Execute authentication flow.
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	ts.Require().NoError(err, "Failed to initiate authentication flow")
 
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID,
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId,
 		map[string]string{
 			"username": refreshTokenTestUsername,
 			"password": refreshTokenTestPassword,

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -377,13 +377,13 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeToken(scope string) (string, er
 	}
 
 	// Step 2: Extract auth ID and flow ID
-	authId, flowID, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract auth ID: %w", err)
 	}
 
 	// Step 3: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to initiate authentication flow: %w", err)
 	}
@@ -393,7 +393,7 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeToken(scope string) (string, er
 		"username": "userinfo_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute authentication flow: %w", err)
 	}
@@ -447,13 +447,13 @@ func (ts *UserInfoTestSuite) getRefreshToken(scope string) (string, error) {
 	}
 
 	// Step 2: Extract auth ID and flow ID
-	authId, flowID, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract auth ID: %w", err)
 	}
 
 	// Step 3: Initiate authentication flow
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, map[string]string{}, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, map[string]string{}, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to initiate authentication flow: %w", err)
 	}
@@ -463,7 +463,7 @@ func (ts *UserInfoTestSuite) getRefreshToken(scope string) (string, error) {
 		"username": "userinfo_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute authentication flow: %w", err)
 	}
@@ -951,13 +951,13 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeTokenWithClient(scope, cID, cSe
 	location := authzResp.Header.Get("Location")
 
 	// 2. Extract
-	authId, flowID, err := testutils.ExtractAuthData(location)
+	authId, executionId, err := testutils.ExtractAuthData(location)
 	if err != nil {
 		return "", err
 	}
 
 	// 3. Initiate Auth
-	_, err = testutils.ExecuteAuthenticationFlow(flowID, nil, "")
+	_, err = testutils.ExecuteAuthenticationFlow(executionId, nil, "")
 	if err != nil {
 		return "", err
 	}
@@ -967,7 +967,7 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeTokenWithClient(scope, cID, cSe
 		"username": "userinfo_test_user",
 		"password": "SecurePass123!",
 	}
-	flowStep, err := testutils.ExecuteAuthenticationFlow(flowID, authInputs, "action_001")
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionId, authInputs, "action_001")
 	if err != nil {
 		return "", err
 	}

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -206,7 +206,7 @@ type ResourcePermissions struct {
 
 // FlowResponse represents the response from flow execution
 type FlowResponse struct {
-	FlowID        string    `json:"flowId"`
+	ExecutionID   string    `json:"executionId"`
 	FlowStatus    string    `json:"flowStatus"`
 	Type          string    `json:"type"`
 	Data          *FlowData `json:"data,omitempty"`
@@ -239,7 +239,7 @@ type FlowAction struct {
 
 // FlowStep represents a single step in a flow execution
 type FlowStep struct {
-	FlowID        string    `json:"flowId"`
+	ExecutionID   string    `json:"executionId"`
 	FlowStatus    string    `json:"flowStatus"`
 	Type          string    `json:"type"`
 	Data          *FlowData `json:"data,omitempty"`

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -129,9 +129,9 @@ func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state
 }
 
 // ExecuteAuthenticationFlow executes an authentication flow and returns the flow step
-func ExecuteAuthenticationFlow(flowID string, inputs map[string]string, action string) (*FlowStep, error) {
+func ExecuteAuthenticationFlow(executionId string, inputs map[string]string, action string) (*FlowStep, error) {
 	flowData := map[string]interface{}{
-		"flowId": flowID,
+		"executionId": executionId,
 	}
 
 	if len(inputs) > 0 {
@@ -333,12 +333,12 @@ func ExtractAuthData(location string) (string, string, error) {
 		return "", "", fmt.Errorf("authId not found in redirect")
 	}
 
-	flowId := redirectURL.Query().Get("flowId")
-	if flowId == "" {
-		return "", "", fmt.Errorf("flowId not found in redirect")
+	executionId := redirectURL.Query().Get("executionId")
+	if executionId == "" {
+		return "", "", fmt.Errorf("executionId not found in redirect")
 	}
 
-	return authID, flowId, nil
+	return authID, executionId, nil
 }
 
 // ValidateOAuth2ErrorRedirect validates OAuth2 error redirect responses
@@ -437,19 +437,19 @@ func ObtainAccessTokenWithPassword(clientID, redirectURI, scope, username, passw
 
 	log.Printf("Authorization redirect location: %s", location)
 	// Step 2: Extract auth ID and flow ID
-	authID, flowID, err := ExtractAuthData(location)
+	authID, executionId, err := ExtractAuthData(location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract auth ID: %w", err)
 	}
 
 	// Step 3: Execute initial authentication flow step (to get to the login prompt)
-	_, err = ExecuteAuthenticationFlow(flowID, nil, "")
+	_, err = ExecuteAuthenticationFlow(executionId, nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute initial authentication flow: %w", err)
 	}
 
 	// Step 4: Execute authentication flow with credentials
-	flowStep, err := ExecuteAuthenticationFlow(flowID, map[string]string{
+	flowStep, err := ExecuteAuthenticationFlow(executionId, map[string]string{
 		"username": username,
 		"password": password,
 	}, "action_001")


### PR DESCRIPTION
### Purpose
The flow execution response structure is confusing due to the use of two different flow IDs: one for the flow definition and one for the runtime flow execution instance.

This improvement rename `flowId` to `executionId` in flow execution context.

### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes

The` flowId` in the flow execution context has been renamed to `executionId`. This change is consistently applied across API request and response parameters in `flow/execute` endpoint, replacing all occurrences of `flowId` with `executionId`. To maintain alignment, the method parameters in both `FlowExecServiceInterface` and `flowStoreInterface` have also been updated accordingly.

The following models are impacted by this change:
- `NodeContext`
- `EngineContext`
- `FlowContextDB`

#### 💥 Impact
Any call/process goes through `flow/execute` endpoint or flow execution engine or executors expect the new value `executionId` to be present. 

#### 🔄 Migration Guide
N/A

### Approach
N/A

### Related Issues
- https://github.com/asgardeo/thunder/issues/2062

### Related PRs
- https://github.com/asgardeo/javascript/pull/443

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings : Vale warning for  recognizing `executionId` as misspelled is ignored.
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [x] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The flow identifier is now named executionId (replaces flowId) in API payloads and client/UI flows.

* **Bug Fixes**
  * Error messages updated to reference "flow execution ID" for clearer diagnostics.

* **Documentation**
  * Docs, examples, samples, and guides updated to use executionId throughout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->