### PR TITLE
Add SMS template support for OTP and flow-based SMS sending

### DIFF
--- a/backend/cmd/server/repository/resources/templates/sms_otp.yaml
+++ b/backend/cmd/server/repository/resources/templates/sms_otp.yaml
@@ -1,0 +1,6 @@
+id: "sms-otp"
+displayName: "SMS OTP Verification"
+scenario: "OTP"
+type: "sms"
+contentType: "text/plain"
+body: "Your verification code is: {{ctx(otp)}}. This code will expire in {{ctx(expiryMinutes)}} minutes."

--- a/backend/cmd/server/repository/resources/templates/sms_self_registration.yaml
+++ b/backend/cmd/server/repository/resources/templates/sms_self_registration.yaml
@@ -1,0 +1,6 @@
+id: "self-registration-invite-sms"
+displayName: "Self Registration Invite SMS"
+scenario: "SELF_REGISTRATION"
+type: "sms"
+contentType: "text/plain"
+body: "{{ctx(appName)}}: Finish your registration by clicking here: {{ctx(inviteLink)}}"

--- a/backend/cmd/server/repository/resources/templates/sms_user_invite.yaml
+++ b/backend/cmd/server/repository/resources/templates/sms_user_invite.yaml
@@ -1,0 +1,6 @@
+id: "user-invite-sms"
+displayName: "User Invitation SMS"
+scenario: "USER_INVITE"
+type: "sms"
+contentType: "text/plain"
+body: "You've been invited to register. Complete your account setup here: {{ctx(inviteLink)}}"

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -165,7 +165,13 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	}
 	exporters = append(exporters, idpExporter)
 
-	_, otpService, notifSenderSvc, notificationExporter, err := notification.Initialize(mux, jwtService)
+	templateService, err := template.Initialize()
+	if err != nil {
+		logger.Fatal("Failed to initialize template service", log.Error(err))
+	}
+
+	_, otpService, notifSenderSvc, notificationExporter, err := notification.Initialize(
+		mux, jwtService, templateService)
 	if err != nil {
 		logger.Fatal("Failed to initialize NotificationService", log.Error(err))
 	}
@@ -196,10 +202,6 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 		logger.Debug("Email client not configured. "+
 			"EmailExecutor will be registered but will not send emails.", log.Error(err))
 		emailClient = nil
-	}
-	templateService, err := template.Initialize()
-	if err != nil {
-		logger.Fatal("Failed to initialize template service", log.Error(err))
 	}
 	execRegistry := executor.Initialize(flowFactory, ouService,
 		idpService, otpService, notifSenderSvc, jwtService, authSvcRegistry, authZService, userSchemaService,

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -88,13 +88,10 @@ const (
 	propertyKeyAssignRole           = "assignRole"
 	propertyKeyRequiredScopes       = "requiredScopes"
 	propertyKeyEmailTemplate        = "emailTemplate"
+	propertyKeySMSTemplate          = "smsTemplate"
 	propertyKeyAllowedUserTypes     = "allowedUserTypes"
 	propertyKeyNotificationSenderID = "senderId"
 )
-
-// smsDefaultMessage is a temporary hardcoded SMS body used until template-based message support is implemented.
-// TODO: Replace with a proper message template engine in a future PR.
-const smsDefaultMessage = "You have a pending notification from the system."
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.
 var nonSearchableInputs = []string{"password", "code", "nonce", "otp"}

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -127,7 +127,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		"appName":    ctx.Application.Name,
 	}
 
-	rendered, svcErr := e.templateService.Render(ctx.Context, scenario, templateData)
+	rendered, svcErr := e.templateService.Render(ctx.Context, scenario, template.TemplateTypeEmail, templateData)
 	if svcErr != nil {
 		return nil, fmt.Errorf("failed to render email template: %s", svcErr.Code)
 	}

--- a/backend/internal/flow/executor/email_executor_test.go
+++ b/backend/internal/flow/executor/email_executor_test.go
@@ -79,6 +79,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Suc
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
 			"appName":    "",
@@ -124,6 +125,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Invit
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioSelfRegistration,
+		template.TemplateTypeEmail,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
 			"appName":    "",
@@ -164,6 +166,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRunti
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
 			"appName":    "",
@@ -203,6 +206,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData()
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
 			"appName":    "",
@@ -306,6 +310,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplatePropert
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
 			"appName":    "",
@@ -346,6 +351,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmptyTemplateString_De
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		template.TemplateData{
 			"inviteLink": "https://localhost:5190/gate/invite?flowId=test&inviteToken=abc",
 			"appName":    "",
@@ -408,6 +414,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_TemplateRenderError() 
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		mock.Anything,
 	).Return(nil, &serviceerror.I18nServiceError{Code: "TMP-5000"})
 
@@ -472,6 +479,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ClientError() {
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		mock.Anything,
 	).Return(&template.RenderedTemplate{
 		Subject: "You're Invited to Register",
@@ -506,6 +514,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ServerError() {
 	suite.mockTemplateService.On("Render",
 		mock.Anything,
 		template.ScenarioUserInvite,
+		template.TemplateTypeEmail,
 		mock.Anything,
 	).Return(&template.RenderedTemplate{
 		Subject: "You're Invited to Register",

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -98,7 +98,7 @@ func Initialize(
 	reg.RegisterExecutor(ExecutorNameOUResolver, newOUResolverExecutor(flowFactory, ouService))
 	reg.RegisterExecutor(ExecutorNameAttributeUniquenessValidator, newAttributeUniquenessValidator(
 		flowFactory, userSchemaService, userProvider))
-	reg.RegisterExecutor(ExecutorNameSMSExecutor, newSMSExecutor(flowFactory, notifSenderSvc))
+	reg.RegisterExecutor(ExecutorNameSMSExecutor, newSMSExecutor(flowFactory, notifSenderSvc, templateService))
 
 	return reg
 }

--- a/backend/internal/flow/executor/sms_executor.go
+++ b/backend/internal/flow/executor/sms_executor.go
@@ -29,22 +29,25 @@ import (
 	notifcm "github.com/asgardeo/thunder/internal/notification/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/template"
 )
 
 // phoneNumberRegex matches phone numbers in various formats including optional +, digits, spaces, dashes,
 // dots, and parentheses with a total length of 7 to 20 characters.
 var phoneNumberRegex = regexp.MustCompile(`^\+?[0-9\s\-().]{7,20}$`)
 
-// smsExecutor sends an SMS message using the configured sender from node properties and a default message body.
+// smsExecutor sends an SMS message using the configured sender from node properties and a template-based body.
 type smsExecutor struct {
 	core.ExecutorInterface
-	logger         *log.Logger
-	notifSenderSvc notification.NotificationSenderServiceInterface
+	logger          *log.Logger
+	notifSenderSvc  notification.NotificationSenderServiceInterface
+	templateService template.TemplateServiceInterface
 }
 
 // newSMSExecutor creates a new instance of smsExecutor.
 func newSMSExecutor(flowFactory core.FlowFactoryInterface,
-	notifSenderSvc notification.NotificationSenderServiceInterface) *smsExecutor {
+	notifSenderSvc notification.NotificationSenderServiceInterface,
+	templateService template.TemplateServiceInterface) *smsExecutor {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "SMSExecutor"))
 	base := flowFactory.CreateExecutor(
 		ExecutorNameSMSExecutor,
@@ -58,11 +61,12 @@ func newSMSExecutor(flowFactory core.FlowFactoryInterface,
 		ExecutorInterface: base,
 		logger:            logger,
 		notifSenderSvc:    notifSenderSvc,
+		templateService:   templateService,
 	}
 }
 
 // Execute resolves the recipient from user inputs or runtime data and the sender ID from node properties,
-// then sends the SMS with a default message body.
+// then renders the SMS body from a template and sends it.
 func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
 	logger.Debug("Executing SMS executor")
@@ -104,16 +108,43 @@ func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, 
 		return nil, fmt.Errorf("senderId is not configured in node properties: %w", err)
 	}
 
-	// TODO: Replace smsDefaultMessage with a proper template-based message body in a future PR.
-	svcErr := e.notifSenderSvc.Send(ctx.Context, notifcm.ChannelTypeSMS, senderID,
-		notifcm.NotificationData{Recipient: recipient, Body: smsDefaultMessage})
+	tmplProp, ok := ctx.NodeProperties[propertyKeySMSTemplate]
+	if !ok {
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "SMS template is required"
+		return execResp, nil
+	}
+	tmplStr, ok := tmplProp.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid type for %s: expected string, got %T with value %v",
+			propertyKeySMSTemplate, tmplProp, tmplProp)
+	}
+	if tmplStr == "" {
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "SMS template is required"
+		return execResp, nil
+	}
+	scenario := template.ScenarioType(tmplStr)
+
+	templateData := template.TemplateData{
+		"appName":    ctx.Application.Name,
+		"inviteLink": ctx.RuntimeData[common.RuntimeKeyInviteLink],
+	}
+
+	rendered, svcErr := e.templateService.Render(ctx.Context, scenario, template.TemplateTypeSMS, templateData)
 	if svcErr != nil {
-		if svcErr.Type == serviceerror.ClientErrorType {
+		return nil, fmt.Errorf("failed to render SMS template: %s", svcErr.Code)
+	}
+
+	notifSvcErr := e.notifSenderSvc.Send(ctx.Context, notifcm.ChannelTypeSMS, senderID,
+		notifcm.NotificationData{Recipient: recipient, Body: rendered.Body})
+	if notifSvcErr != nil {
+		if notifSvcErr.Type == serviceerror.ClientErrorType {
 			execResp.Status = common.ExecFailure
-			execResp.FailureReason = svcErr.ErrorDescription
+			execResp.FailureReason = notifSvcErr.ErrorDescription
 			return execResp, nil
 		}
-		return nil, fmt.Errorf("SMS send failed: %s", svcErr.ErrorDescription)
+		return nil, fmt.Errorf("SMS send failed: %s", notifSvcErr.ErrorDescription)
 	}
 
 	logger.Debug("SMS sent successfully", log.String("recipient", log.MaskString(recipient)))

--- a/backend/internal/flow/executor/sms_executor_test.go
+++ b/backend/internal/flow/executor/sms_executor_test.go
@@ -28,22 +28,28 @@ import (
 	"github.com/asgardeo/thunder/internal/flow/core"
 	notifcm "github.com/asgardeo/thunder/internal/notification/common"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/template"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 	"github.com/asgardeo/thunder/tests/mocks/notification/notificationmock"
+	"github.com/asgardeo/thunder/tests/mocks/templatemock"
 )
+
+const testRenderedSMSBody = "Your notification from the system."
 
 type SMSExecutorTestSuite struct {
 	suite.Suite
-	mockFlowFactory  *coremock.FlowFactoryInterfaceMock
-	mockBaseExecutor *coremock.ExecutorInterfaceMock
-	mockSMSSenderSvc *notificationmock.NotificationSenderServiceInterfaceMock
-	executor         *smsExecutor
+	mockFlowFactory     *coremock.FlowFactoryInterfaceMock
+	mockBaseExecutor    *coremock.ExecutorInterfaceMock
+	mockSMSSenderSvc    *notificationmock.NotificationSenderServiceInterfaceMock
+	mockTemplateService *templatemock.TemplateServiceInterfaceMock
+	executor            *smsExecutor
 }
 
 func (suite *SMSExecutorTestSuite) SetupTest() {
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
 	suite.mockBaseExecutor = coremock.NewExecutorInterfaceMock(suite.T())
 	suite.mockSMSSenderSvc = notificationmock.NewNotificationSenderServiceInterfaceMock(suite.T())
+	suite.mockTemplateService = templatemock.NewTemplateServiceInterfaceMock(suite.T())
 
 	suite.mockFlowFactory.On("CreateExecutor",
 		ExecutorNameSMSExecutor,
@@ -54,7 +60,7 @@ func (suite *SMSExecutorTestSuite) SetupTest() {
 		[]common.Input{},
 	).Return(suite.mockBaseExecutor)
 
-	suite.executor = newSMSExecutor(suite.mockFlowFactory, suite.mockSMSSenderSvc)
+	suite.executor = newSMSExecutor(suite.mockFlowFactory, suite.mockSMSSenderSvc, suite.mockTemplateService)
 }
 
 func (suite *SMSExecutorTestSuite) TestExecute_SendMode_Success() {
@@ -67,15 +73,19 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_Success() {
 		RuntimeData: make(map[string]string),
 		NodeProperties: map[string]interface{}{
 			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
 		},
 	}
 
 	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
 		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
 	})
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
 	suite.mockSMSSenderSvc.On("Send",
 		mock.Anything, mock.Anything, "sender-uuid-001",
-		notifcm.NotificationData{Recipient: "+94714627887", Body: smsDefaultMessage},
+		notifcm.NotificationData{Recipient: "+94714627887", Body: testRenderedSMSBody},
 	).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -95,15 +105,19 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_RecipientFromRuntimeData
 		},
 		NodeProperties: map[string]interface{}{
 			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
 		},
 	}
 
 	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
 		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
 	})
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
 	suite.mockSMSSenderSvc.On("Send",
 		mock.Anything, mock.Anything, "sender-uuid-001",
-		notifcm.NotificationData{Recipient: "+94714627887", Body: smsDefaultMessage},
+		notifcm.NotificationData{Recipient: "+94714627887", Body: testRenderedSMSBody},
 	).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -125,15 +139,19 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_UserInputOverridesRuntim
 		},
 		NodeProperties: map[string]interface{}{
 			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
 		},
 	}
 
 	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
 		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
 	})
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
 	suite.mockSMSSenderSvc.On("Send",
 		mock.Anything, mock.Anything, "sender-uuid-001",
-		notifcm.NotificationData{Recipient: "+94714627887", Body: smsDefaultMessage},
+		notifcm.NotificationData{Recipient: "+94714627887", Body: testRenderedSMSBody},
 	).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -156,15 +174,19 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_CustomPhoneAttribute() {
 		},
 		NodeProperties: map[string]interface{}{
 			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
 		},
 	}
 
 	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
 		{Identifier: "phoneNumber", Type: common.InputTypePhone, Required: true},
 	})
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
 	suite.mockSMSSenderSvc.On("Send",
 		mock.Anything, mock.Anything, "sender-uuid-001",
-		notifcm.NotificationData{Recipient: "+94714627887", Body: smsDefaultMessage},
+		notifcm.NotificationData{Recipient: "+94714627887", Body: testRenderedSMSBody},
 	).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -284,7 +306,7 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_NilSMSSenderService_Retu
 		[]common.Input{},
 	).Return(mockBaseExecutor)
 
-	noServiceExecutor := newSMSExecutor(mockFactory, nil)
+	noServiceExecutor := newSMSExecutor(mockFactory, nil, suite.mockTemplateService)
 
 	ctx := &core.NodeContext{
 		FlowID:       "test-flow-id",
@@ -315,12 +337,16 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_ClientError() {
 		RuntimeData: make(map[string]string),
 		NodeProperties: map[string]interface{}{
 			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
 		},
 	}
 
 	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
 		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
 	})
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
 	clientErr := &serviceerror.ServiceError{
 		Type:             serviceerror.ClientErrorType,
 		Code:             "MNS-1001",
@@ -347,12 +373,16 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_ServerError() {
 		RuntimeData: make(map[string]string),
 		NodeProperties: map[string]interface{}{
 			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
 		},
 	}
 
 	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
 		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
 	})
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
 	serverErr := &serviceerror.ServiceError{
 		Type:             serviceerror.ServerErrorType,
 		Code:             "MNS-5000",
@@ -366,6 +396,125 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_ServerError() {
 	suite.Error(err)
 	suite.Nil(resp)
 	suite.Contains(err.Error(), "SMS send failed")
+}
+
+func (suite *SMSExecutorTestSuite) TestExecute_NoSMSTemplateProperty_ReturnsFlowError() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeSend,
+		UserInputs: map[string]string{
+			userAttributeMobileNumber: "+94714627887",
+		},
+		RuntimeData: make(map[string]string),
+		NodeProperties: map[string]interface{}{
+			propertyKeyNotificationSenderID: "sender-uuid-001",
+		},
+	}
+
+	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
+	})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	suite.NoError(err)
+	suite.Equal(common.ExecFailure, resp.Status)
+	suite.Equal("SMS template is required", resp.FailureReason)
+	suite.mockTemplateService.AssertNotCalled(suite.T(), "Render", mock.Anything, mock.Anything, mock.Anything)
+	suite.mockSMSSenderSvc.AssertNotCalled(suite.T(), "Send",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *SMSExecutorTestSuite) TestExecute_EmptySMSTemplateProperty_ReturnsFlowError() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeSend,
+		UserInputs: map[string]string{
+			userAttributeMobileNumber: "+94714627887",
+		},
+		RuntimeData: make(map[string]string),
+		NodeProperties: map[string]interface{}{
+			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          "",
+		},
+	}
+
+	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
+	})
+
+	resp, err := suite.executor.Execute(ctx)
+
+	suite.NoError(err)
+	suite.Equal(common.ExecFailure, resp.Status)
+	suite.Equal("SMS template is required", resp.FailureReason)
+	suite.mockTemplateService.AssertNotCalled(suite.T(), "Render", mock.Anything, mock.Anything, mock.Anything)
+	suite.mockSMSSenderSvc.AssertNotCalled(suite.T(), "Send",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *SMSExecutorTestSuite) TestExecute_SMSTemplatePropertySet_UsesCustomScenario() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeSend,
+		UserInputs: map[string]string{
+			userAttributeMobileNumber: "+94714627887",
+		},
+		RuntimeData: make(map[string]string),
+		NodeProperties: map[string]interface{}{
+			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
+		},
+	}
+
+	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
+	})
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
+	suite.mockSMSSenderSvc.On("Send",
+		mock.Anything, mock.Anything, "sender-uuid-001",
+		notifcm.NotificationData{Recipient: "+94714627887", Body: testRenderedSMSBody},
+	).Return(nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	suite.NoError(err)
+	suite.Equal(common.ExecComplete, resp.Status)
+	suite.mockTemplateService.AssertCalled(suite.T(), "Render",
+		mock.Anything, template.ScenarioSelfRegistration, template.TemplateTypeSMS, mock.Anything)
+}
+
+func (suite *SMSExecutorTestSuite) TestExecute_SendMode_TemplateRenderFailure_ReturnsError() {
+	ctx := &core.NodeContext{
+		FlowID:       "test-flow-id",
+		ExecutorMode: ExecutorModeSend,
+		UserInputs: map[string]string{
+			userAttributeMobileNumber: "+94714627887",
+		},
+		RuntimeData: make(map[string]string),
+		NodeProperties: map[string]interface{}{
+			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioSelfRegistration),
+		},
+	}
+
+	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{Identifier: userAttributeMobileNumber, Type: common.InputTypePhone, Required: true},
+	})
+	renderErr := &serviceerror.I18nServiceError{Code: "TPL-5000"}
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioSelfRegistration,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(nil, renderErr)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	suite.Error(err)
+	suite.Nil(resp)
+	suite.Contains(err.Error(), "failed to render SMS template")
+	suite.mockSMSSenderSvc.AssertNotCalled(suite.T(), "Send",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestSMSExecutorSuite(t *testing.T) {

--- a/backend/internal/notification/init.go
+++ b/backend/internal/notification/init.go
@@ -26,11 +26,13 @@ import (
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/middleware"
+	"github.com/asgardeo/thunder/internal/system/template"
 	"github.com/asgardeo/thunder/internal/system/transaction"
 )
 
 // Initialize creates and configures the notification service components.
-func Initialize(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) (
+func Initialize(mux *http.ServeMux, jwtService jwt.JWTServiceInterface,
+	templateService template.TemplateServiceInterface) (
 	NotificationSenderMgtSvcInterface, OTPServiceInterface, NotificationSenderServiceInterface,
 	declarativeresource.ResourceExporter, error) {
 	var notificationStore notificationStoreInterface
@@ -55,7 +57,7 @@ func Initialize(mux *http.ServeMux, jwtService jwt.JWTServiceInterface) (
 		}
 	}
 
-	otpService := newOTPService(mgtService, jwtService)
+	otpService := newOTPService(mgtService, jwtService, templateService)
 	notificationSenderService := newNotificationSenderService(mgtService)
 	handler := newMessageNotificationSenderHandler(mgtService, otpService)
 	registerRoutes(mux, handler)

--- a/backend/internal/notification/init_test.go
+++ b/backend/internal/notification/init_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/config"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
+	"github.com/asgardeo/thunder/tests/mocks/templatemock"
 )
 
 const (
@@ -38,8 +39,9 @@ const (
 
 type InitTestSuite struct {
 	suite.Suite
-	mockJWTService *jwtmock.JWTServiceInterfaceMock
-	mux            *http.ServeMux
+	mockJWTService      *jwtmock.JWTServiceInterfaceMock
+	mockTemplateService *templatemock.TemplateServiceInterfaceMock
+	mux                 *http.ServeMux
 }
 
 func TestInitTestSuite(t *testing.T) {
@@ -73,6 +75,7 @@ func (suite *InitTestSuite) SetupSuite() {
 
 func (suite *InitTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
+	suite.mockTemplateService = templatemock.NewTemplateServiceInterfaceMock(suite.T())
 	suite.mux = http.NewServeMux()
 }
 
@@ -81,7 +84,7 @@ func (suite *InitTestSuite) TearDownSuite() {
 }
 
 func (suite *InitTestSuite) TestInitialize() {
-	mgtService, otpService, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	mgtService, otpService, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	suite.NotNil(mgtService)
@@ -215,7 +218,7 @@ properties:
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_ListEndpoint() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	req := httptest.NewRequest(http.MethodGet, "/notification-senders/message", nil)
@@ -227,7 +230,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_ListEndpoint() {
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_CreateEndpoint() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	req := httptest.NewRequest(http.MethodPost, "/notification-senders/message", nil)
@@ -239,7 +242,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CreateEndpoint() {
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_GetByIDEndpoint() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	req := httptest.NewRequest(http.MethodGet, "/notification-senders/message/test-id", nil)
@@ -251,7 +254,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_GetByIDEndpoint() {
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_UpdateEndpoint() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	req := httptest.NewRequest(http.MethodPut, "/notification-senders/message/test-id", nil)
@@ -263,7 +266,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_UpdateEndpoint() {
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_DeleteEndpoint() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/notification-senders/message/test-id", nil)
@@ -275,7 +278,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_DeleteEndpoint() {
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_SendOTPEndpoint() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	req := httptest.NewRequest(http.MethodPost, "/notification-senders/otp/send", nil)
@@ -287,7 +290,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_SendOTPEndpoint() {
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_VerifyOTPEndpoint() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	req := httptest.NewRequest(http.MethodPost, "/notification-senders/otp/verify", nil)
@@ -299,7 +302,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_VerifyOTPEndpoint() {
 }
 
 func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflight() {
-	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService)
+	_, _, _, _, err := Initialize(suite.mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.NoError(err)
 
 	paths := []string{
@@ -512,7 +515,7 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesEnabled_Inval
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to invalid YAML
-	_, _, _, _, err = Initialize(mux, suite.mockJWTService)
+	_, _, _, _, err = Initialize(mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to load notification sender resources")
 
@@ -590,7 +593,7 @@ properties:
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to validation failure
-	_, _, _, _, err = Initialize(mux, suite.mockJWTService)
+	_, _, _, _, err = Initialize(mux, suite.mockJWTService, suite.mockTemplateService)
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to load notification sender resources")
 

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strconv"
 	"time"
 
 	"github.com/asgardeo/thunder/internal/notification/common"
@@ -32,6 +33,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/template"
 )
 
 // otpUseOnlyNumericChars indicates whether to use only numeric characters for OTP generation.
@@ -48,15 +50,17 @@ type otpService struct {
 	jwtService       jwt.JWTServiceInterface
 	senderMgtService NotificationSenderMgtSvcInterface
 	clientProvider   notificationClientProviderInterface
+	templateService  template.TemplateServiceInterface
 }
 
 // newOTPService returns a new instance of OTPServiceInterface.
 func newOTPService(notifSenderSvc NotificationSenderMgtSvcInterface,
-	jwtSvc jwt.JWTServiceInterface) OTPServiceInterface {
+	jwtSvc jwt.JWTServiceInterface, templateSvc template.TemplateServiceInterface) OTPServiceInterface {
 	return &otpService{
 		jwtService:       jwtSvc,
 		senderMgtService: notifSenderSvc,
 		clientProvider:   newNotificationClientProvider(),
+		templateService:  templateSvc,
 	}
 }
 
@@ -94,7 +98,7 @@ func (s *otpService) SendOTP(
 	// Send OTP based on channel
 	switch common.ChannelType(otpDTO.Channel) {
 	case common.ChannelTypeSMS:
-		if svcErr := s.sendSMSOTP(otpDTO.Recipient, otp.Value, *sender, logger); svcErr != nil {
+		if svcErr := s.sendSMSOTP(ctx, otpDTO.Recipient, otp.Value, *sender, logger); svcErr != nil {
 			return nil, svcErr
 		}
 	default:
@@ -248,21 +252,26 @@ func (s *otpService) getOTPValidityPeriodInMillis() int64 {
 }
 
 // sendSMSOTP sends an SMS OTP to the recipient.
-func (s *otpService) sendSMSOTP(recipient, otp string, sender common.NotificationSenderDTO,
-	logger *log.Logger) *serviceerror.ServiceError {
-	// TODO: This needs to be configured as a property
-	body := fmt.Sprintf("Your verification code is: %s. This code will expire in 2 minutes.", otp)
-
-	_client, svcErr := s.clientProvider.GetClient(sender)
+func (s *otpService) sendSMSOTP(ctx context.Context, recipient, otp string,
+	sender common.NotificationSenderDTO, logger *log.Logger) *serviceerror.ServiceError {
+	expiryMinutes := strconv.FormatInt(s.getOTPValidityPeriodInMillis()/60000, 10)
+	templateData := template.TemplateData{"otp": otp, "expiryMinutes": expiryMinutes}
+	rendered, svcErr := s.templateService.Render(ctx, template.ScenarioOTP, template.TemplateTypeSMS, templateData)
 	if svcErr != nil {
-		return svcErr
+		logger.Error("Failed to render SMS OTP template", log.String("error", svcErr.Code))
+		return &ErrorInternalServerError
+	}
+
+	_client, clientSvcErr := s.clientProvider.GetClient(sender)
+	if clientSvcErr != nil {
+		return clientSvcErr
 	}
 
 	if !_client.IsChannelSupported(common.ChannelTypeSMS) {
 		return &ErrorUnsupportedChannel
 	}
 
-	notifData := common.NotificationData{Recipient: recipient, Body: body}
+	notifData := common.NotificationData{Recipient: recipient, Body: rendered.Body}
 	if err := _client.Send(common.ChannelTypeSMS, notifData); err != nil {
 		logger.Error("Failed to send SMS OTP", log.Error(err))
 		return &ErrorInternalServerError

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -35,16 +35,20 @@ import (
 	"github.com/asgardeo/thunder/internal/system/cmodels"
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/crypto/hash"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/log"
+	"github.com/asgardeo/thunder/internal/system/template"
 	"github.com/asgardeo/thunder/tests/mocks/jose/jwtmock"
 	"github.com/asgardeo/thunder/tests/mocks/notification/messagemock"
+	"github.com/asgardeo/thunder/tests/mocks/templatemock"
 )
 
 type OTPServiceTestSuite struct {
 	suite.Suite
-	mockJWTService    *jwtmock.JWTServiceInterfaceMock
-	mockSenderService *NotificationSenderMgtSvcInterfaceMock
-	service           *otpService
+	mockJWTService      *jwtmock.JWTServiceInterfaceMock
+	mockSenderService   *NotificationSenderMgtSvcInterfaceMock
+	mockTemplateService *templatemock.TemplateServiceInterfaceMock
+	service             *otpService
 }
 
 func TestOTPServiceTestSuite(t *testing.T) {
@@ -72,10 +76,12 @@ func (suite *OTPServiceTestSuite) SetupSuite() {
 func (suite *OTPServiceTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockSenderService = NewNotificationSenderMgtSvcInterfaceMock(suite.T())
+	suite.mockTemplateService = templatemock.NewTemplateServiceInterfaceMock(suite.T())
 	suite.service = &otpService{
 		jwtService:       suite.mockJWTService,
 		senderMgtService: suite.mockSenderService,
 		clientProvider:   newNotificationClientProvider(),
+		templateService:  suite.mockTemplateService,
 	}
 }
 
@@ -313,6 +319,10 @@ func (suite *OTPServiceTestSuite) TestSendOTP_Success() {
 	sender := suite.getValidSender()
 	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioOTP,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: "Your code is: 123456. Expires in 2 minutes."}, nil).Once()
+
 	mm := messagemock.NewNotificationClientInterfaceMock(suite.T())
 	mm.EXPECT().IsChannelSupported(common.ChannelTypeSMS).Return(true).Once()
 	mm.EXPECT().Send(common.ChannelTypeSMS, mock.Anything).Return(nil).Once()
@@ -338,6 +348,10 @@ func (suite *OTPServiceTestSuite) TestSendOTP_SendSMSError() {
 	sender := suite.getValidSender()
 	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioOTP,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: "Your code is: 123456. Expires in 2 minutes."}, nil).Once()
+
 	mm := messagemock.NewNotificationClientInterfaceMock(suite.T())
 	mm.EXPECT().IsChannelSupported(common.ChannelTypeSMS).Return(true).Once()
 	mm.EXPECT().Send(common.ChannelTypeSMS, mock.Anything).Return(errors.New("send failed")).Once()
@@ -359,6 +373,10 @@ func (suite *OTPServiceTestSuite) TestSendOTP_GenerateJWTError() {
 	}
 	sender := suite.getValidSender()
 	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
+
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioOTP,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: "Your code is: 123456. Expires in 2 minutes."}, nil).Once()
 
 	mm := messagemock.NewNotificationClientInterfaceMock(suite.T())
 	mm.EXPECT().IsChannelSupported(common.ChannelTypeSMS).Return(true).Once()
@@ -449,6 +467,10 @@ func (suite *OTPServiceTestSuite) TestSendOTP_ClientProviderError() {
 	sender := suite.getValidSender()
 	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
 
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioOTP,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: "Your code is: 123456. Expires in 2 minutes."}, nil).Once()
+
 	// client provider returns a service error
 	cp := newNotificationClientProviderInterfaceMock(suite.T())
 	cp.EXPECT().GetClient(mock.Anything).Return(nil, &ErrorInternalServerError).Once()
@@ -469,6 +491,10 @@ func (suite *OTPServiceTestSuite) TestSendOTP_ClientChannelNotSupported() {
 
 	sender := suite.getValidSender()
 	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
+
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioOTP,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: "Your code is: 123456. Expires in 2 minutes."}, nil).Once()
 
 	mm := messagemock.NewNotificationClientInterfaceMock(suite.T())
 	mm.EXPECT().IsChannelSupported(common.ChannelTypeSMS).Return(false).Once()
@@ -589,8 +615,60 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_UnmarshalError() {
 }
 
 func (suite *OTPServiceTestSuite) TestNewOTPService_Constructors() {
-	svc := newOTPService(suite.mockSenderService, suite.mockJWTService)
+	svc := newOTPService(suite.mockSenderService, suite.mockJWTService, suite.mockTemplateService)
 	suite.NotNil(svc)
+}
+
+func (suite *OTPServiceTestSuite) TestSendOTP_TemplateRenderSuccess_UsesRenderedBody() {
+	req := common.SendOTPDTO{
+		Recipient: "+15559876543",
+		SenderID:  "sender-123",
+		Channel:   "sms",
+	}
+
+	sender := suite.getValidSender()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
+
+	renderedBody := "Your verification code is: 654321. This code will expire in 2 minutes."
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioOTP,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(&template.RenderedTemplate{Body: renderedBody}, nil).Once()
+
+	mm := messagemock.NewNotificationClientInterfaceMock(suite.T())
+	mm.EXPECT().IsChannelSupported(common.ChannelTypeSMS).Return(true).Once()
+	mm.EXPECT().Send(common.ChannelTypeSMS, common.NotificationData{Recipient: "+15559876543", Body: renderedBody}).
+		Return(nil).Once()
+	cp := newNotificationClientProviderInterfaceMock(suite.T())
+	cp.EXPECT().GetClient(mock.Anything).Return(mm, nil).Once()
+	suite.service.clientProvider = cp
+
+	suite.mockJWTService.EXPECT().GenerateJWT(mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return("token", int64(0), nil).Once()
+
+	res, err := suite.service.SendOTP(context.Background(), req)
+	suite.Nil(err)
+	suite.NotNil(res)
+}
+
+func (suite *OTPServiceTestSuite) TestSendOTP_TemplateRenderFailure_ReturnsInternalError() {
+	req := common.SendOTPDTO{
+		Recipient: "+15559876543",
+		SenderID:  "sender-123",
+		Channel:   "sms",
+	}
+
+	sender := suite.getValidSender()
+	suite.mockSenderService.On("GetSender", mock.Anything, "sender-123").Return(sender, nil).Once()
+
+	renderErr := &serviceerror.I18nServiceError{Code: "TPL-5000"}
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioOTP,
+		template.TemplateTypeSMS, mock.Anything).
+		Return(nil, renderErr).Once()
+
+	res, err := suite.service.SendOTP(context.Background(), req)
+	suite.Nil(res)
+	suite.NotNil(err)
+	suite.Equal(ErrorInternalServerError.Code, err.Code)
 }
 
 func (suite *OTPServiceTestSuite) TestVerifyAndDecode_Success() {

--- a/backend/internal/system/template/TemplateServiceInterface_mock_test.go
+++ b/backend/internal/system/template/TemplateServiceInterface_mock_test.go
@@ -39,8 +39,8 @@ func (_m *TemplateServiceInterfaceMock) EXPECT() *TemplateServiceInterfaceMock_E
 }
 
 // GetTemplateByScenario provides a mock function for the type TemplateServiceInterfaceMock
-func (_mock *TemplateServiceInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario ScenarioType) (*TemplateDTO, *serviceerror.I18nServiceError) {
-	ret := _mock.Called(ctx, scenario)
+func (_mock *TemplateServiceInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario ScenarioType, tmplType TemplateType) (*TemplateDTO, *serviceerror.I18nServiceError) {
+	ret := _mock.Called(ctx, scenario, tmplType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTemplateByScenario")
@@ -48,18 +48,18 @@ func (_mock *TemplateServiceInterfaceMock) GetTemplateByScenario(ctx context.Con
 
 	var r0 *TemplateDTO
 	var r1 *serviceerror.I18nServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType) (*TemplateDTO, *serviceerror.I18nServiceError)); ok {
-		return returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateType) (*TemplateDTO, *serviceerror.I18nServiceError)); ok {
+		return returnFunc(ctx, scenario, tmplType)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType) *TemplateDTO); ok {
-		r0 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateType) *TemplateDTO); ok {
+		r0 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*TemplateDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ScenarioType) *serviceerror.I18nServiceError); ok {
-		r1 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ScenarioType, TemplateType) *serviceerror.I18nServiceError); ok {
+		r1 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.I18nServiceError)
@@ -76,11 +76,12 @@ type TemplateServiceInterfaceMock_GetTemplateByScenario_Call struct {
 // GetTemplateByScenario is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scenario ScenarioType
-func (_e *TemplateServiceInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
-	return &TemplateServiceInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario)}
+//   - tmplType TemplateType
+func (_e *TemplateServiceInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}, tmplType interface{}) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
+	return &TemplateServiceInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario, tmplType)}
 }
 
-func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario ScenarioType)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
+func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario ScenarioType, tmplType TemplateType)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -90,9 +91,14 @@ func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Run(run func(
 		if args[1] != nil {
 			arg1 = args[1].(ScenarioType)
 		}
+		var arg2 TemplateType
+		if args[2] != nil {
+			arg2 = args[2].(TemplateType)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -103,14 +109,14 @@ func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Return(templa
 	return _c
 }
 
-func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario ScenarioType) (*TemplateDTO, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
+func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario ScenarioType, tmplType TemplateType) (*TemplateDTO, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Render provides a mock function for the type TemplateServiceInterfaceMock
-func (_mock *TemplateServiceInterfaceMock) Render(ctx context.Context, scenario ScenarioType, data TemplateData) (*RenderedTemplate, *serviceerror.I18nServiceError) {
-	ret := _mock.Called(ctx, scenario, data)
+func (_mock *TemplateServiceInterfaceMock) Render(ctx context.Context, scenario ScenarioType, tmplType TemplateType, data TemplateData) (*RenderedTemplate, *serviceerror.I18nServiceError) {
+	ret := _mock.Called(ctx, scenario, tmplType, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Render")
@@ -118,18 +124,18 @@ func (_mock *TemplateServiceInterfaceMock) Render(ctx context.Context, scenario 
 
 	var r0 *RenderedTemplate
 	var r1 *serviceerror.I18nServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateData) (*RenderedTemplate, *serviceerror.I18nServiceError)); ok {
-		return returnFunc(ctx, scenario, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateType, TemplateData) (*RenderedTemplate, *serviceerror.I18nServiceError)); ok {
+		return returnFunc(ctx, scenario, tmplType, data)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateData) *RenderedTemplate); ok {
-		r0 = returnFunc(ctx, scenario, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateType, TemplateData) *RenderedTemplate); ok {
+		r0 = returnFunc(ctx, scenario, tmplType, data)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*RenderedTemplate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ScenarioType, TemplateData) *serviceerror.I18nServiceError); ok {
-		r1 = returnFunc(ctx, scenario, data)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ScenarioType, TemplateType, TemplateData) *serviceerror.I18nServiceError); ok {
+		r1 = returnFunc(ctx, scenario, tmplType, data)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.I18nServiceError)
@@ -146,12 +152,13 @@ type TemplateServiceInterfaceMock_Render_Call struct {
 // Render is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scenario ScenarioType
+//   - tmplType TemplateType
 //   - data TemplateData
-func (_e *TemplateServiceInterfaceMock_Expecter) Render(ctx interface{}, scenario interface{}, data interface{}) *TemplateServiceInterfaceMock_Render_Call {
-	return &TemplateServiceInterfaceMock_Render_Call{Call: _e.mock.On("Render", ctx, scenario, data)}
+func (_e *TemplateServiceInterfaceMock_Expecter) Render(ctx interface{}, scenario interface{}, tmplType interface{}, data interface{}) *TemplateServiceInterfaceMock_Render_Call {
+	return &TemplateServiceInterfaceMock_Render_Call{Call: _e.mock.On("Render", ctx, scenario, tmplType, data)}
 }
 
-func (_c *TemplateServiceInterfaceMock_Render_Call) Run(run func(ctx context.Context, scenario ScenarioType, data TemplateData)) *TemplateServiceInterfaceMock_Render_Call {
+func (_c *TemplateServiceInterfaceMock_Render_Call) Run(run func(ctx context.Context, scenario ScenarioType, tmplType TemplateType, data TemplateData)) *TemplateServiceInterfaceMock_Render_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -161,14 +168,19 @@ func (_c *TemplateServiceInterfaceMock_Render_Call) Run(run func(ctx context.Con
 		if args[1] != nil {
 			arg1 = args[1].(ScenarioType)
 		}
-		var arg2 TemplateData
+		var arg2 TemplateType
 		if args[2] != nil {
-			arg2 = args[2].(TemplateData)
+			arg2 = args[2].(TemplateType)
+		}
+		var arg3 TemplateData
+		if args[3] != nil {
+			arg3 = args[3].(TemplateData)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -179,7 +191,7 @@ func (_c *TemplateServiceInterfaceMock_Render_Call) Return(renderedTemplate *Ren
 	return _c
 }
 
-func (_c *TemplateServiceInterfaceMock_Render_Call) RunAndReturn(run func(ctx context.Context, scenario ScenarioType, data TemplateData) (*RenderedTemplate, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_Render_Call {
+func (_c *TemplateServiceInterfaceMock_Render_Call) RunAndReturn(run func(ctx context.Context, scenario ScenarioType, tmplType TemplateType, data TemplateData) (*RenderedTemplate, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_Render_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/system/template/declarative_resource.go
+++ b/backend/internal/system/template/declarative_resource.go
@@ -71,7 +71,7 @@ func validateTemplateDTO(dto interface{}) error {
 	if !IsValidScenario(tmpl.Scenario) {
 		return fmt.Errorf("unsupported template scenario: %s", tmpl.Scenario)
 	}
-	if tmpl.Subject == "" {
+	if tmpl.Type != TemplateTypeSMS && tmpl.Subject == "" {
 		return fmt.Errorf("template subject is required")
 	}
 	if tmpl.Body == "" {

--- a/backend/internal/system/template/declarative_resource_test.go
+++ b/backend/internal/system/template/declarative_resource_test.go
@@ -124,6 +124,54 @@ func (suite *TemplateDeclarativeResourceTestSuite) TestValidateTemplateDTO_Missi
 	}
 }
 
+func (suite *TemplateDeclarativeResourceTestSuite) TestValidateTemplateDTO_SMSWithoutSubject_Valid() {
+	dto := &TemplateDTO{
+		ID:       "sms-otp",
+		Scenario: ScenarioOTP,
+		Type:     TemplateTypeSMS,
+		Body:     "Your code is: {{ctx(otp)}}.",
+	}
+	err := validateTemplateDTO(dto)
+	suite.NoError(err)
+}
+
+func (suite *TemplateDeclarativeResourceTestSuite) TestLoadDeclarativeResources_WithSMSTemplateFile() {
+	tempDir := suite.T().TempDir()
+	testConfig := &config.Config{}
+	config.ResetThunderRuntime()
+	err := config.InitializeThunderRuntime(tempDir, testConfig)
+	suite.NoError(err)
+
+	runtime := config.GetThunderRuntime()
+	resourceDir := filepath.Join(runtime.ThunderHome, "repository", "resources", "templates")
+	err = os.MkdirAll(resourceDir, 0o750)
+	suite.NoError(err)
+
+	yamlData := []byte(`id: sms-otp
+displayName: SMS OTP Verification
+scenario: OTP
+type: sms
+contentType: text/plain
+body: "Your verification code is: {{ctx(otp)}}. This code will expire in {{ctx(expiryMinutes)}} minutes."
+`)
+	err = os.WriteFile(filepath.Join(resourceDir, "sms-otp.yaml"), yamlData, 0o600)
+	suite.NoError(err)
+
+	genericStore := declarativeresource.NewGenericFileBasedStoreForTest(entity.KeyTypeTemplate)
+	store := &templateFileBasedStore{
+		GenericFileBasedStore: genericStore,
+	}
+	err = loadDeclarativeResources(store)
+	suite.NoError(err)
+
+	tmpl, err := store.GetTemplateByScenario(context.Background(), ScenarioOTP, TemplateTypeSMS)
+	suite.NoError(err)
+	suite.Equal("sms-otp", tmpl.ID)
+	suite.Equal(ScenarioOTP, tmpl.Scenario)
+	suite.Equal(TemplateTypeSMS, tmpl.Type)
+	suite.Empty(tmpl.Subject)
+}
+
 func (suite *TemplateDeclarativeResourceTestSuite) TestValidateTemplateDTO_InvalidType() {
 	err := validateTemplateDTO("invalid type")
 	if suite.Error(err) {

--- a/backend/internal/system/template/file_based_store.go
+++ b/backend/internal/system/template/file_based_store.go
@@ -55,13 +55,14 @@ func (f *templateFileBasedStore) GetTemplate(_ context.Context, id string) (*Tem
 	return tmpl, nil
 }
 
-// GetTemplateByScenario retrieves a template by its scenario type.
+// GetTemplateByScenario retrieves a template by its scenario type and template type.
 func (f *templateFileBasedStore) GetTemplateByScenario(
-	_ context.Context, scenario ScenarioType,
+	_ context.Context, scenario ScenarioType, tmplType TemplateType,
 ) (*TemplateDTO, error) {
-	data, err := f.GenericFileBasedStore.GetByField(string(scenario), func(d interface{}) string {
+	compositeKey := string(scenario) + ":" + string(tmplType)
+	data, err := f.GenericFileBasedStore.GetByField(compositeKey, func(d interface{}) string {
 		if tmpl, ok := d.(*TemplateDTO); ok {
-			return string(tmpl.Scenario)
+			return string(tmpl.Scenario) + ":" + string(tmpl.Type)
 		}
 		return ""
 	})
@@ -70,7 +71,7 @@ func (f *templateFileBasedStore) GetTemplateByScenario(
 	}
 	tmpl, ok := data.(*TemplateDTO)
 	if !ok {
-		declarativeresource.LogTypeAssertionError("template", "scenario:"+string(scenario))
+		declarativeresource.LogTypeAssertionError("template", "scenario:"+string(scenario)+":"+string(tmplType))
 		return nil, errors.New("template data corrupted")
 	}
 	return tmpl, nil

--- a/backend/internal/system/template/file_based_store_test.go
+++ b/backend/internal/system/template/file_based_store_test.go
@@ -53,6 +53,7 @@ func (suite *FileBasedStoreTestSuite) TestFileBasedStore() {
 	dto := &TemplateDTO{
 		ID:       "t1",
 		Scenario: ScenarioUserInvite,
+		Type:     TemplateTypeEmail,
 	}
 	err := suite.store.Create("t1", dto)
 	suite.NoError(err)
@@ -62,7 +63,7 @@ func (suite *FileBasedStoreTestSuite) TestFileBasedStore() {
 	suite.NotNil(res)
 	suite.Equal("t1", res.ID)
 
-	resScen, err := suite.store.GetTemplateByScenario(context.Background(), ScenarioUserInvite)
+	resScen, err := suite.store.GetTemplateByScenario(context.Background(), ScenarioUserInvite, TemplateTypeEmail)
 	suite.NoError(err)
 	suite.NotNil(resScen)
 	suite.Equal("t1", resScen.ID)
@@ -77,7 +78,8 @@ func (suite *FileBasedStoreTestSuite) TestFileBasedStore() {
 	suite.ErrorIs(err, errTemplateNotFound)
 	suite.Nil(resNotFound)
 
-	resScenNotFound, err := suite.store.GetTemplateByScenario(context.Background(), ScenarioType("UNKNOWN"))
+	resScenNotFound, err := suite.store.GetTemplateByScenario(
+		context.Background(), ScenarioType("UNKNOWN"), TemplateTypeEmail)
 	suite.Error(err)
 	suite.ErrorIs(err, errTemplateNotFound)
 	suite.Nil(resScenNotFound)
@@ -107,6 +109,7 @@ func (suite *FileBasedStoreTestSuite) TestFileBasedStore_GetTemplateByScenario_C
 	dto := &TemplateDTO{
 		ID:       "t1",
 		Scenario: ScenarioUserInvite,
+		Type:     TemplateTypeEmail,
 	}
 	err := suite.store.Create("t1", dto)
 	suite.NoError(err)
@@ -120,6 +123,33 @@ func (suite *FileBasedStoreTestSuite) TestFileBasedStore_GetTemplateByScenario_C
 	suite.Error(err)
 	suite.Contains(err.Error(), "template data corrupted")
 	suite.Nil(res)
+}
+
+func (suite *FileBasedStoreTestSuite) TestFileBasedStore_SameScenarioDifferentType() {
+	emailDTO := &TemplateDTO{
+		ID:       "otp-email",
+		Scenario: ScenarioOTP,
+		Type:     TemplateTypeEmail,
+	}
+	smsDTO := &TemplateDTO{
+		ID:       "otp-sms",
+		Scenario: ScenarioOTP,
+		Type:     TemplateTypeSMS,
+	}
+	suite.NoError(suite.store.Create("otp-email", emailDTO))
+	suite.NoError(suite.store.Create("otp-sms", smsDTO))
+
+	resEmail, err := suite.store.GetTemplateByScenario(context.Background(), ScenarioOTP, TemplateTypeEmail)
+	suite.NoError(err)
+	suite.NotNil(resEmail)
+	suite.Equal("otp-email", resEmail.ID)
+	suite.Equal(TemplateTypeEmail, resEmail.Type)
+
+	resSMS, err := suite.store.GetTemplateByScenario(context.Background(), ScenarioOTP, TemplateTypeSMS)
+	suite.NoError(err)
+	suite.NotNil(resSMS)
+	suite.Equal("otp-sms", resSMS.ID)
+	suite.Equal(TemplateTypeSMS, resSMS.Type)
 }
 
 func (suite *FileBasedStoreTestSuite) TestFileBasedStore_ListTemplates_WithCorruptedData() {

--- a/backend/internal/system/template/interface.go
+++ b/backend/internal/system/template/interface.go
@@ -27,13 +27,18 @@ import (
 
 // TemplateServiceInterface defines the interface for template operations.
 type TemplateServiceInterface interface {
-	// GetTemplateByScenario retrieves a template by its scenario type.
-	GetTemplateByScenario(ctx context.Context, scenario ScenarioType) (*TemplateDTO, *serviceerror.I18nServiceError)
+	// GetTemplateByScenario retrieves a template by its scenario and template type.
+	GetTemplateByScenario(
+		ctx context.Context,
+		scenario ScenarioType,
+		tmplType TemplateType,
+	) (*TemplateDTO, *serviceerror.I18nServiceError)
 
 	// Render renders a template with the provided data.
 	Render(
 		ctx context.Context,
 		scenario ScenarioType,
+		tmplType TemplateType,
 		data TemplateData,
 	) (*RenderedTemplate, *serviceerror.I18nServiceError)
 }

--- a/backend/internal/system/template/model.go
+++ b/backend/internal/system/template/model.go
@@ -18,8 +18,15 @@
 
 package template
 
-// TemplateType represents the type of template (e.g., email).
+// TemplateType represents the type of template (e.g., email, sms).
 type TemplateType string
+
+const (
+	// TemplateTypeEmail represents an email template.
+	TemplateTypeEmail TemplateType = "email"
+	// TemplateTypeSMS represents an SMS template.
+	TemplateTypeSMS TemplateType = "sms"
+)
 
 // ScenarioType represents the scenario for which a template is used.
 type ScenarioType string
@@ -29,12 +36,15 @@ const (
 	ScenarioUserInvite ScenarioType = "USER_INVITE"
 	// ScenarioSelfRegistration represents the self-registration via invite link scenario.
 	ScenarioSelfRegistration ScenarioType = "SELF_REGISTRATION"
+	// ScenarioOTP represents the OTP verification scenario.
+	ScenarioOTP ScenarioType = "OTP"
 )
 
 // supportedScenarios contains all valid scenario types.
 var supportedScenarios = map[ScenarioType]bool{
 	ScenarioUserInvite:       true,
 	ScenarioSelfRegistration: true,
+	ScenarioOTP:              true,
 }
 
 // IsValidScenario checks if the given scenario type is supported.

--- a/backend/internal/system/template/service.go
+++ b/backend/internal/system/template/service.go
@@ -43,11 +43,16 @@ func newTemplateService(store templateStoreInterface) TemplateServiceInterface {
 	}
 }
 
-// GetTemplateByScenario retrieves a template for the specified scenario.
+// GetTemplateByScenario retrieves a template for the specified scenario and template type.
 func (s *templateService) GetTemplateByScenario(
-	ctx context.Context, scenario ScenarioType) (*TemplateDTO, *serviceerror.I18nServiceError) {
-	s.logger.Debug("Retrieving template by scenario", log.String("scenario", string(scenario)))
-	tmpl, err := s.store.GetTemplateByScenario(ctx, scenario)
+	ctx context.Context,
+	scenario ScenarioType,
+	tmplType TemplateType,
+) (*TemplateDTO, *serviceerror.I18nServiceError) {
+	s.logger.Debug("Retrieving template by scenario and type",
+		log.String("scenario", string(scenario)),
+		log.String("type", string(tmplType)))
+	tmpl, err := s.store.GetTemplateByScenario(ctx, scenario, tmplType)
 	if err != nil {
 		if errors.Is(err, errTemplateNotFound) {
 			return nil, &ErrorTemplateNotFound
@@ -61,11 +66,15 @@ func (s *templateService) GetTemplateByScenario(
 	return tmpl, nil
 }
 
-// Render renders a template for the specified scenario using the provided data.
+// Render renders a template for the specified scenario and template type using the provided data.
 func (s *templateService) Render(
-	ctx context.Context, scenario ScenarioType, data TemplateData) (*RenderedTemplate, *serviceerror.I18nServiceError) {
+	ctx context.Context,
+	scenario ScenarioType,
+	tmplType TemplateType,
+	data TemplateData,
+) (*RenderedTemplate, *serviceerror.I18nServiceError) {
 	s.logger.Debug("Rendering template", log.String("scenario", string(scenario)))
-	tmpl, svcErr := s.GetTemplateByScenario(ctx, scenario)
+	tmpl, svcErr := s.GetTemplateByScenario(ctx, scenario, tmplType)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -85,13 +94,20 @@ func (s *templateService) Render(
 		})
 	}
 
+	rendered := &RenderedTemplate{
+		Subject: replacePlaceholders(tmpl.Subject),
+		Body:    replacePlaceholders(tmpl.Body),
+		IsHTML:  tmpl.ContentType == "text/html",
+	}
+
 	s.logger.Debug("Template rendered successfully",
 		log.String("scenario", string(scenario)),
 		log.String("templateID", tmpl.ID))
 
-	return &RenderedTemplate{
-		Subject: replacePlaceholders(tmpl.Subject),
-		Body:    replacePlaceholders(tmpl.Body),
-		IsHTML:  tmpl.ContentType == "text/html",
-	}, nil
+	if tmpl.Type == TemplateTypeSMS && len(rendered.Body) > 160 {
+		s.logger.Warn("Rendered SMS body exceeds 160 characters; message may be split into multiple segments",
+			log.Int("length", len(rendered.Body)))
+	}
+
+	return rendered, nil
 }

--- a/backend/internal/system/template/service_test.go
+++ b/backend/internal/system/template/service_test.go
@@ -46,9 +46,9 @@ func (suite *TemplateServiceTestSuite) SetupTest() {
 
 func (suite *TemplateServiceTestSuite) TestGetTemplateByScenario() {
 	dto := &TemplateDTO{ID: "test-1", Scenario: ScenarioUserInvite}
-	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite).Return(dto, nil)
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite, TemplateTypeEmail).Return(dto, nil)
 
-	res, err := suite.service.GetTemplateByScenario(context.Background(), ScenarioUserInvite)
+	res, err := suite.service.GetTemplateByScenario(context.Background(), ScenarioUserInvite, TemplateTypeEmail)
 	suite.Nil(err)
 	suite.Equal("test-1", res.ID)
 }
@@ -61,9 +61,9 @@ func (suite *TemplateServiceTestSuite) TestRender() {
 		ContentType: "text/html",
 		Body:        "Link: {{ctx(inviteLink)}}",
 	}
-	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite).Return(dto, nil)
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite, TemplateTypeEmail).Return(dto, nil)
 
-	res, err := suite.service.Render(context.Background(), ScenarioUserInvite,
+	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateTypeEmail,
 		TemplateData{"inviteLink": "http://example.com"})
 	suite.Nil(err)
 	suite.Equal("Test Invite", res.Subject)
@@ -72,9 +72,10 @@ func (suite *TemplateServiceTestSuite) TestRender() {
 }
 
 func (suite *TemplateServiceTestSuite) TestRender_NotFound() {
-	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite).Return(nil, errTemplateNotFound)
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite, TemplateTypeEmail).
+		Return(nil, errTemplateNotFound)
 
-	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateData{})
+	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateTypeEmail, TemplateData{})
 	suite.NotNil(err)
 	suite.Equal(&ErrorTemplateNotFound, err)
 	suite.Nil(res)
@@ -82,9 +83,10 @@ func (suite *TemplateServiceTestSuite) TestRender_NotFound() {
 
 func (suite *TemplateServiceTestSuite) TestRender_StoreError() {
 	storeErr := errors.New("store error")
-	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite).Return(nil, storeErr)
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite, TemplateTypeEmail).
+		Return(nil, storeErr)
 
-	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateData{})
+	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateTypeEmail, TemplateData{})
 	suite.NotNil(err)
 	suite.Equal(&serviceerror.InternalServerErrorWithI18n, err)
 	suite.Nil(res)
@@ -98,9 +100,9 @@ func (suite *TemplateServiceTestSuite) TestRender_UnknownPlaceholder() {
 		ContentType: "text/html",
 		Body:        "Unknown: {{ctx(unknownKey)}}",
 	}
-	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite).Return(dto, nil)
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite, TemplateTypeEmail).Return(dto, nil)
 
-	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateData{})
+	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateTypeEmail, TemplateData{})
 	suite.Nil(err)
 	suite.Equal("Unknown: {{ctx(unknownKey)}}", res.Body)
 }
@@ -113,13 +115,47 @@ func (suite *TemplateServiceTestSuite) TestRender_SubjectPlaceholderReplaced() {
 		ContentType: "text/html",
 		Body:        "Click here: {{ctx(inviteLink)}}",
 	}
-	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioSelfRegistration).Return(dto, nil)
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioSelfRegistration, TemplateTypeEmail).
+		Return(dto, nil)
 
-	res, err := suite.service.Render(context.Background(), ScenarioSelfRegistration,
+	res, err := suite.service.Render(context.Background(), ScenarioSelfRegistration, TemplateTypeEmail,
 		TemplateData{"appName": "My App", "inviteLink": "https://example.com/invite"})
 	suite.Nil(err)
 	suite.Equal("Complete your registration for My App", res.Subject)
 	suite.Equal("Click here: https://example.com/invite", res.Body)
+}
+
+func (suite *TemplateServiceTestSuite) TestRender_SMSBodyOver160Chars_SucceedsAndReturnsRendered() {
+	longBody := "This is an intentionally long SMS body exceeding 160 characters to verify that rendering " +
+		"succeeds and returns the rendered result without failing or truncating the content."
+	dto := &TemplateDTO{
+		ID:          "sms-1",
+		Scenario:    ScenarioOTP,
+		Type:        TemplateTypeSMS,
+		ContentType: "text/plain",
+		Body:        longBody,
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioOTP, TemplateTypeSMS).Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioOTP, TemplateTypeSMS, TemplateData{})
+	suite.Nil(err)
+	suite.Equal(longBody, res.Body)
+}
+
+func (suite *TemplateServiceTestSuite) TestRender_EmailBodyOver160Chars_RendersSuccessfully() {
+	longBody := "This is an intentionally long email body exceeding 160 characters to verify that no SMS " +
+		"segment warning is triggered for non-SMS template types during rendering of the content."
+	dto := &TemplateDTO{
+		ID:          "email-1",
+		Scenario:    ScenarioUserInvite,
+		ContentType: "text/html",
+		Body:        longBody,
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioUserInvite, TemplateTypeEmail).Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioUserInvite, TemplateTypeEmail, TemplateData{})
+	suite.Nil(err)
+	suite.Equal(longBody, res.Body)
 }
 
 func (suite *TemplateServiceTestSuite) TestRender_SelfRegistrationScenario() {
@@ -130,9 +166,10 @@ func (suite *TemplateServiceTestSuite) TestRender_SelfRegistrationScenario() {
 		ContentType: "text/plain",
 		Body:        "Register at {{ctx(inviteLink)}}",
 	}
-	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioSelfRegistration).Return(dto, nil)
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioSelfRegistration, TemplateTypeEmail).
+		Return(dto, nil)
 
-	res, err := suite.service.Render(context.Background(), ScenarioSelfRegistration,
+	res, err := suite.service.Render(context.Background(), ScenarioSelfRegistration, TemplateTypeEmail,
 		TemplateData{"inviteLink": "https://example.com/invite"})
 	suite.Nil(err)
 	suite.Equal("You're invited", res.Subject)

--- a/backend/internal/system/template/store.go
+++ b/backend/internal/system/template/store.go
@@ -24,7 +24,7 @@ import "context"
 type templateStoreInterface interface {
 	GetTemplate(ctx context.Context, id string) (*TemplateDTO, error)
 
-	GetTemplateByScenario(ctx context.Context, scenario ScenarioType) (*TemplateDTO, error)
+	GetTemplateByScenario(ctx context.Context, scenario ScenarioType, tmplType TemplateType) (*TemplateDTO, error)
 
 	ListTemplates(ctx context.Context) ([]*TemplateDTO, error)
 }

--- a/backend/internal/system/template/templateStoreInterface_mock_test.go
+++ b/backend/internal/system/template/templateStoreInterface_mock_test.go
@@ -106,8 +106,8 @@ func (_c *templateStoreInterfaceMock_GetTemplate_Call) RunAndReturn(run func(ctx
 }
 
 // GetTemplateByScenario provides a mock function for the type templateStoreInterfaceMock
-func (_mock *templateStoreInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario ScenarioType) (*TemplateDTO, error) {
-	ret := _mock.Called(ctx, scenario)
+func (_mock *templateStoreInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario ScenarioType, tmplType TemplateType) (*TemplateDTO, error) {
+	ret := _mock.Called(ctx, scenario, tmplType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTemplateByScenario")
@@ -115,18 +115,18 @@ func (_mock *templateStoreInterfaceMock) GetTemplateByScenario(ctx context.Conte
 
 	var r0 *TemplateDTO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType) (*TemplateDTO, error)); ok {
-		return returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateType) (*TemplateDTO, error)); ok {
+		return returnFunc(ctx, scenario, tmplType)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType) *TemplateDTO); ok {
-		r0 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ScenarioType, TemplateType) *TemplateDTO); ok {
+		r0 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*TemplateDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ScenarioType) error); ok {
-		r1 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ScenarioType, TemplateType) error); ok {
+		r1 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -141,11 +141,12 @@ type templateStoreInterfaceMock_GetTemplateByScenario_Call struct {
 // GetTemplateByScenario is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scenario ScenarioType
-func (_e *templateStoreInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
-	return &templateStoreInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario)}
+//   - tmplType TemplateType
+func (_e *templateStoreInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}, tmplType interface{}) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
+	return &templateStoreInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario, tmplType)}
 }
 
-func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario ScenarioType)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
+func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario ScenarioType, tmplType TemplateType)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -155,9 +156,14 @@ func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Run(run func(ct
 		if args[1] != nil {
 			arg1 = args[1].(ScenarioType)
 		}
+		var arg2 TemplateType
+		if args[2] != nil {
+			arg2 = args[2].(TemplateType)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -168,7 +174,7 @@ func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Return(template
 	return _c
 }
 
-func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario ScenarioType) (*TemplateDTO, error)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
+func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario ScenarioType, tmplType TemplateType) (*TemplateDTO, error)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/templatemock/TemplateServiceInterface_mock.go
+++ b/backend/tests/mocks/templatemock/TemplateServiceInterface_mock.go
@@ -40,8 +40,8 @@ func (_m *TemplateServiceInterfaceMock) EXPECT() *TemplateServiceInterfaceMock_E
 }
 
 // GetTemplateByScenario provides a mock function for the type TemplateServiceInterfaceMock
-func (_mock *TemplateServiceInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario template.ScenarioType) (*template.TemplateDTO, *serviceerror.I18nServiceError) {
-	ret := _mock.Called(ctx, scenario)
+func (_mock *TemplateServiceInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType) (*template.TemplateDTO, *serviceerror.I18nServiceError) {
+	ret := _mock.Called(ctx, scenario, tmplType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTemplateByScenario")
@@ -49,18 +49,18 @@ func (_mock *TemplateServiceInterfaceMock) GetTemplateByScenario(ctx context.Con
 
 	var r0 *template.TemplateDTO
 	var r1 *serviceerror.I18nServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType) (*template.TemplateDTO, *serviceerror.I18nServiceError)); ok {
-		return returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateType) (*template.TemplateDTO, *serviceerror.I18nServiceError)); ok {
+		return returnFunc(ctx, scenario, tmplType)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType) *template.TemplateDTO); ok {
-		r0 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateType) *template.TemplateDTO); ok {
+		r0 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*template.TemplateDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, template.ScenarioType) *serviceerror.I18nServiceError); ok {
-		r1 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, template.ScenarioType, template.TemplateType) *serviceerror.I18nServiceError); ok {
+		r1 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.I18nServiceError)
@@ -77,11 +77,12 @@ type TemplateServiceInterfaceMock_GetTemplateByScenario_Call struct {
 // GetTemplateByScenario is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scenario template.ScenarioType
-func (_e *TemplateServiceInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
-	return &TemplateServiceInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario)}
+//   - tmplType template.TemplateType
+func (_e *TemplateServiceInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}, tmplType interface{}) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
+	return &TemplateServiceInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario, tmplType)}
 }
 
-func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario template.ScenarioType)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
+func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -91,9 +92,14 @@ func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Run(run func(
 		if args[1] != nil {
 			arg1 = args[1].(template.ScenarioType)
 		}
+		var arg2 template.TemplateType
+		if args[2] != nil {
+			arg2 = args[2].(template.TemplateType)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -104,14 +110,14 @@ func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) Return(templa
 	return _c
 }
 
-func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario template.ScenarioType) (*template.TemplateDTO, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
+func (_c *TemplateServiceInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType) (*template.TemplateDTO, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Render provides a mock function for the type TemplateServiceInterfaceMock
-func (_mock *TemplateServiceInterfaceMock) Render(ctx context.Context, scenario template.ScenarioType, data template.TemplateData) (*template.RenderedTemplate, *serviceerror.I18nServiceError) {
-	ret := _mock.Called(ctx, scenario, data)
+func (_mock *TemplateServiceInterfaceMock) Render(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType, data template.TemplateData) (*template.RenderedTemplate, *serviceerror.I18nServiceError) {
+	ret := _mock.Called(ctx, scenario, tmplType, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Render")
@@ -119,18 +125,18 @@ func (_mock *TemplateServiceInterfaceMock) Render(ctx context.Context, scenario 
 
 	var r0 *template.RenderedTemplate
 	var r1 *serviceerror.I18nServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateData) (*template.RenderedTemplate, *serviceerror.I18nServiceError)); ok {
-		return returnFunc(ctx, scenario, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateType, template.TemplateData) (*template.RenderedTemplate, *serviceerror.I18nServiceError)); ok {
+		return returnFunc(ctx, scenario, tmplType, data)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateData) *template.RenderedTemplate); ok {
-		r0 = returnFunc(ctx, scenario, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateType, template.TemplateData) *template.RenderedTemplate); ok {
+		r0 = returnFunc(ctx, scenario, tmplType, data)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*template.RenderedTemplate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, template.ScenarioType, template.TemplateData) *serviceerror.I18nServiceError); ok {
-		r1 = returnFunc(ctx, scenario, data)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, template.ScenarioType, template.TemplateType, template.TemplateData) *serviceerror.I18nServiceError); ok {
+		r1 = returnFunc(ctx, scenario, tmplType, data)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.I18nServiceError)
@@ -147,12 +153,13 @@ type TemplateServiceInterfaceMock_Render_Call struct {
 // Render is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scenario template.ScenarioType
+//   - tmplType template.TemplateType
 //   - data template.TemplateData
-func (_e *TemplateServiceInterfaceMock_Expecter) Render(ctx interface{}, scenario interface{}, data interface{}) *TemplateServiceInterfaceMock_Render_Call {
-	return &TemplateServiceInterfaceMock_Render_Call{Call: _e.mock.On("Render", ctx, scenario, data)}
+func (_e *TemplateServiceInterfaceMock_Expecter) Render(ctx interface{}, scenario interface{}, tmplType interface{}, data interface{}) *TemplateServiceInterfaceMock_Render_Call {
+	return &TemplateServiceInterfaceMock_Render_Call{Call: _e.mock.On("Render", ctx, scenario, tmplType, data)}
 }
 
-func (_c *TemplateServiceInterfaceMock_Render_Call) Run(run func(ctx context.Context, scenario template.ScenarioType, data template.TemplateData)) *TemplateServiceInterfaceMock_Render_Call {
+func (_c *TemplateServiceInterfaceMock_Render_Call) Run(run func(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType, data template.TemplateData)) *TemplateServiceInterfaceMock_Render_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -162,14 +169,19 @@ func (_c *TemplateServiceInterfaceMock_Render_Call) Run(run func(ctx context.Con
 		if args[1] != nil {
 			arg1 = args[1].(template.ScenarioType)
 		}
-		var arg2 template.TemplateData
+		var arg2 template.TemplateType
 		if args[2] != nil {
-			arg2 = args[2].(template.TemplateData)
+			arg2 = args[2].(template.TemplateType)
+		}
+		var arg3 template.TemplateData
+		if args[3] != nil {
+			arg3 = args[3].(template.TemplateData)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -180,7 +192,7 @@ func (_c *TemplateServiceInterfaceMock_Render_Call) Return(renderedTemplate *tem
 	return _c
 }
 
-func (_c *TemplateServiceInterfaceMock_Render_Call) RunAndReturn(run func(ctx context.Context, scenario template.ScenarioType, data template.TemplateData) (*template.RenderedTemplate, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_Render_Call {
+func (_c *TemplateServiceInterfaceMock_Render_Call) RunAndReturn(run func(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType, data template.TemplateData) (*template.RenderedTemplate, *serviceerror.I18nServiceError)) *TemplateServiceInterfaceMock_Render_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/templatemock/templateStoreInterface_mock.go
+++ b/backend/tests/mocks/templatemock/templateStoreInterface_mock.go
@@ -107,8 +107,8 @@ func (_c *templateStoreInterfaceMock_GetTemplate_Call) RunAndReturn(run func(ctx
 }
 
 // GetTemplateByScenario provides a mock function for the type templateStoreInterfaceMock
-func (_mock *templateStoreInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario template.ScenarioType) (*template.TemplateDTO, error) {
-	ret := _mock.Called(ctx, scenario)
+func (_mock *templateStoreInterfaceMock) GetTemplateByScenario(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType) (*template.TemplateDTO, error) {
+	ret := _mock.Called(ctx, scenario, tmplType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTemplateByScenario")
@@ -116,18 +116,18 @@ func (_mock *templateStoreInterfaceMock) GetTemplateByScenario(ctx context.Conte
 
 	var r0 *template.TemplateDTO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType) (*template.TemplateDTO, error)); ok {
-		return returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateType) (*template.TemplateDTO, error)); ok {
+		return returnFunc(ctx, scenario, tmplType)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType) *template.TemplateDTO); ok {
-		r0 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, template.ScenarioType, template.TemplateType) *template.TemplateDTO); ok {
+		r0 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*template.TemplateDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, template.ScenarioType) error); ok {
-		r1 = returnFunc(ctx, scenario)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, template.ScenarioType, template.TemplateType) error); ok {
+		r1 = returnFunc(ctx, scenario, tmplType)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -142,11 +142,12 @@ type templateStoreInterfaceMock_GetTemplateByScenario_Call struct {
 // GetTemplateByScenario is a helper method to define mock.On call
 //   - ctx context.Context
 //   - scenario template.ScenarioType
-func (_e *templateStoreInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
-	return &templateStoreInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario)}
+//   - tmplType template.TemplateType
+func (_e *templateStoreInterfaceMock_Expecter) GetTemplateByScenario(ctx interface{}, scenario interface{}, tmplType interface{}) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
+	return &templateStoreInterfaceMock_GetTemplateByScenario_Call{Call: _e.mock.On("GetTemplateByScenario", ctx, scenario, tmplType)}
 }
 
-func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario template.ScenarioType)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
+func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Run(run func(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -156,9 +157,14 @@ func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Run(run func(ct
 		if args[1] != nil {
 			arg1 = args[1].(template.ScenarioType)
 		}
+		var arg2 template.TemplateType
+		if args[2] != nil {
+			arg2 = args[2].(template.TemplateType)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -169,7 +175,7 @@ func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) Return(template
 	return _c
 }
 
-func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario template.ScenarioType) (*template.TemplateDTO, error)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
+func (_c *templateStoreInterfaceMock_GetTemplateByScenario_Call) RunAndReturn(run func(ctx context.Context, scenario template.ScenarioType, tmplType template.TemplateType) (*template.TemplateDTO, error)) *templateStoreInterfaceMock_GetTemplateByScenario_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

SMS message content was hardcoded in two places — smsExecutor used a static constant and otpService.sendSMSOTP used an inline fmt.Sprintf. This made the message content impossible to customize without a code change and inconsistent with how email already works (full template system).

This PR wires SMS sending into the existing template service, replacing both hardcoded bodies with rendered templates. Three SMS scenarios are introduced — OTP verification, self-registration invite, and user invitation — each backed by a YAML template file following the same declarative resource pattern as email templates.

### Approach

Two rendering sites, different reasons:

otpService.sendSMSOTP renders at the service level because the OTP value is generated and owned by otpService. The executor above it never sees the OTP, so rendering must happen where the value is in scope.
smsExecutor renders at the executor level, matching the emailExecutor pattern — the executor reads the scenario from node properties, builds TemplateData, and calls templateService.Render() before passing the body to the sender.
Template model changes:

Added TemplateTypeSMS constant to model.go — used by the validator to exempt SMS templates from the subject required check (SMS is text-only, no subject concept).
Added three new ScenarioType constants (SMS_OTP, SELF_REGISTRATION_SMS, USER_INVITE_SMS). Separate scenario keys from their email counterparts avoid key collision in the store's lookup map.
Initialization ordering fix:

template.Initialize() was called after notification.Initialize() in servicemanager.go, making it impossible to pass templateService into otpService. No circular dependency exists — this was a pure ordering issue. Fixed by moving template.Initialize() earlier and threading templateService into notification.Initialize() → newOTPService().

160-character warning:

A warning log is emitted (not an error) when a rendered body exceeds 160 characters, since longer messages incur multi-segment SMS billing. The flow continues normally.



### Related Issues
- https://github.com/asgardeo/thunder/issues/1928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMS template support for OTP verification, user invites, and self-registration.
  * Templates now support SMS type alongside email and can be authored without a subject for SMS.
  * SMS notifications are rendered from templates with context-specific data (OTP, expiry, app name, invite link) instead of fixed default text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->