### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ For code contributions, refer to the [Contributing Code](https://asgardeo.github
 
 ## Documentation
 
-Please refer to the [Documentation](https://asgardeo.github.io/thunder/docs/guides/introduction) for additional guidance on getting started with Thunder and exploring its features, concepts, and usage.
+Please refer to the [Documentation](https://asgardeo.github.io/thunder/docs/next/guides/getting-started/what-is-thunder) for additional guidance on getting started with Thunder and exploring its features, concepts, and usage.
 
 <details>
 <summary><h2>Advanced Setup & Configuration</h2></summary>


### PR DESCRIPTION
This pull request updates the documentation link in the `README.md` file to point to the latest "Getting Started" guide for Thunder. This ensures that users are directed to the most up-to-date onboarding material.

Documentation update:

* Updated the documentation link in `README.md` to reference the "What is Thunder" guide under the `/next/guides/getting-started/` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation link to point to the new getting-started guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->