### PR TITLE
Add a UI suspense state until `meta` is resolved in Thunder Gate

### DIFF
--- a/frontend/apps/thunder-console/src/main.tsx
+++ b/frontend/apps/thunder-console/src/main.tsx
@@ -18,8 +18,8 @@
 
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
-import {LoggerProvider, LogLevel} from '@thunder/logger/react';
 import {ConfigProvider} from '@thunder/contexts';
+import {LoggerProvider, LogLevel} from '@thunder/logger/react';
 import {StrictMode} from 'react';
 import * as ReactDOM from 'react-dom/client';
 import AppWithDecorators from './AppWithDecorators';

--- a/frontend/apps/thunder-gate/src/components/SignIn/SignIn.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/SignIn.tsx
@@ -22,12 +22,12 @@ import SignInBox from './SignInBox';
 import SignInSlogan from './SignInSlogan';
 
 export default function SignIn(): JSX.Element {
-  const {isDesignEnabled} = useDesign();
+  const {isDesignEnabled, isLoading} = useDesign();
 
   const showSlogan = !isDesignEnabled;
 
   return (
-    <AuthPageLayout variant="SignIn">
+    <AuthPageLayout variant="SignIn" isLoading={isLoading}>
       {showSlogan && <SignInSlogan />}
       <SignInBox />
     </AuthPageLayout>

--- a/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignIn.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignIn/__tests__/SignIn.test.tsx
@@ -45,6 +45,7 @@ describe('SignIn', () => {
     vi.clearAllMocks();
     mockUseDesign.mockReturnValue({
       isDesignEnabled: false,
+      isLoading: false,
     });
   });
 
@@ -61,6 +62,7 @@ describe('SignIn', () => {
   it('shows SignInSlogan when design is not enabled', () => {
     mockUseDesign.mockReturnValue({
       isDesignEnabled: false,
+      isLoading: false,
     });
     render(<SignIn />);
     expect(screen.getByTestId('signin-slogan')).toBeInTheDocument();
@@ -69,8 +71,19 @@ describe('SignIn', () => {
   it('hides SignInSlogan when design is enabled', () => {
     mockUseDesign.mockReturnValue({
       isDesignEnabled: true,
+      isLoading: false,
     });
     render(<SignIn />);
+    expect(screen.queryByTestId('signin-slogan')).not.toBeInTheDocument();
+  });
+
+  it('shows a spinner and hides content when isLoading is true', () => {
+    mockUseDesign.mockReturnValue({
+      isDesignEnabled: false,
+      isLoading: true,
+    });
+    render(<SignIn />);
+    expect(screen.queryByTestId('signin-box')).not.toBeInTheDocument();
     expect(screen.queryByTestId('signin-slogan')).not.toBeInTheDocument();
   });
 });

--- a/frontend/apps/thunder-gate/src/components/SignUp/SignUp.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/SignUp.tsx
@@ -16,13 +16,15 @@
  * under the License.
  */
 
-import {AuthPageLayout} from '@thunder/design';
+import {AuthPageLayout, useDesign} from '@thunder/design';
 import type {JSX} from 'react';
 import SignUpBox from './SignUpBox';
 
 export default function SignUp(): JSX.Element {
+  const {isLoading} = useDesign();
+
   return (
-    <AuthPageLayout variant="SignUp">
+    <AuthPageLayout variant="SignUp" isLoading={isLoading}>
       <SignUpBox />
     </AuthPageLayout>
   );

--- a/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUp.test.tsx
+++ b/frontend/apps/thunder-gate/src/components/SignUp/__tests__/SignUp.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import {render, screen} from '@thunder/test-utils';
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import SignUp from '../SignUp';
 
 // Mock child component
@@ -25,7 +25,25 @@ vi.mock('../SignUpBox', () => ({
   default: () => <div data-testid="signup-box">SignUpBox</div>,
 }));
 
+// Mock useDesign hook
+const mockUseDesign = vi.fn();
+vi.mock('@thunder/design', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunder/design')>();
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    useDesign: () => mockUseDesign(),
+  };
+});
+
 describe('SignUp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDesign.mockReturnValue({
+      isLoading: false,
+    });
+  });
+
   it('renders without crashing', () => {
     const {container} = render(<SignUp />);
     expect(container).toBeInTheDocument();
@@ -40,5 +58,13 @@ describe('SignUp', () => {
     render(<SignUp />);
     const main = screen.getByRole('main');
     expect(main).toBeInTheDocument();
+  });
+
+  it('shows a spinner and hides content when isLoading is true', () => {
+    mockUseDesign.mockReturnValue({
+      isLoading: true,
+    });
+    render(<SignUp />);
+    expect(screen.queryByTestId('signup-box')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/thunder-design/src/components/flow/AuthPageLayout.tsx
+++ b/frontend/packages/thunder-design/src/components/flow/AuthPageLayout.tsx
@@ -17,15 +17,16 @@
  */
 
 import {cn} from '@thunder/utils';
-import {Stack} from '@wso2/oxygen-ui';
-import type {JSX, ReactNode} from 'react';
+import {CircularProgress, Stack} from '@wso2/oxygen-ui';
+import type {JSX, PropsWithChildren} from 'react';
 
-export interface AuthPageLayoutProps {
+export interface AuthPageLayoutProps extends PropsWithChildren {
   /** Class name prefix for Thunder CSS (e.g. 'SignIn' → 'ThunderSignIn--root'). */
   variant?: string;
   /** Optional background CSS value (color, gradient, image). Falls back to the theme's background.default. */
   background?: string;
-  children: ReactNode;
+  /** Indicates whether the design is still loading. When true, the layout will show a spinner. */
+  isLoading?: boolean;
 }
 
 /**
@@ -38,6 +39,7 @@ export default function AuthPageLayout({
   variant = undefined,
   background = undefined,
   children,
+  isLoading = false,
 }: AuthPageLayoutProps): JSX.Element {
   return (
     <Stack
@@ -71,7 +73,7 @@ export default function AuthPageLayout({
             m: 'auto',
           }}
         >
-          {children}
+          {isLoading ? <CircularProgress /> : children}
         </Stack>
       </Stack>
     </Stack>

--- a/frontend/packages/thunder-design/src/components/flow/__tests__/AuthPageLayout.test.tsx
+++ b/frontend/packages/thunder-design/src/components/flow/__tests__/AuthPageLayout.test.tsx
@@ -96,6 +96,38 @@ describe('AuthPageLayout', () => {
     });
   });
 
+  describe('isLoading prop', () => {
+    it('shows a spinner instead of children when isLoading is true', () => {
+      renderWithProviders(
+        <AuthPageLayout isLoading={true}>
+          <span>Page content</span>
+        </AuthPageLayout>,
+      );
+      expect(screen.queryByText('Page content')).toBeNull();
+      expect(screen.getByRole('progressbar')).toBeTruthy();
+    });
+
+    it('shows children when isLoading is false (default)', () => {
+      renderWithProviders(
+        <AuthPageLayout>
+          <span>Page content</span>
+        </AuthPageLayout>,
+      );
+      expect(screen.getByText('Page content')).toBeTruthy();
+      expect(screen.queryByRole('progressbar')).toBeNull();
+    });
+
+    it('shows children when isLoading is explicitly false', () => {
+      renderWithProviders(
+        <AuthPageLayout isLoading={false}>
+          <span>Page content</span>
+        </AuthPageLayout>,
+      );
+      expect(screen.getByText('Page content')).toBeTruthy();
+      expect(screen.queryByRole('progressbar')).toBeNull();
+    });
+  });
+
   describe('combined props', () => {
     it('renders with both variant and background', () => {
       renderWithProviders(

--- a/frontend/packages/thunder-design/src/contexts/Design/DesignProvider.tsx
+++ b/frontend/packages/thunder-design/src/contexts/Design/DesignProvider.tsx
@@ -91,12 +91,12 @@ export default function DesignProvider({
     () => ({
       design,
       isDesignEnabled: Boolean(design) && (!isEmpty(design?.theme) || !isEmpty(design?.layout)),
-      isLoading: externalDesign ? false : isLoading,
+      isLoading: externalDesign ? false : shouldResolveDesignInternally ? isLoading : true,
       error: externalDesign ? null : error,
       theme: undefined,
       layout: isEmpty(design?.layout) ? undefined : design?.layout,
     }),
-    [design, externalDesign, isLoading, error],
+    [design, externalDesign, shouldResolveDesignInternally, isLoading, error],
   );
 
   return <DesignContext.Provider value={contextValue}>{children}</DesignContext.Provider>;

--- a/frontend/packages/thunder-design/src/contexts/Design/__tests__/DesignProvider.test.tsx
+++ b/frontend/packages/thunder-design/src/contexts/Design/__tests__/DesignProvider.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, cleanup} from '@testing-library/react';
+import {useContext} from 'react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import type {DesignResolveResponse} from '../../../models/responses';
+import DesignContext from '../DesignContext';
+import DesignProvider from '../DesignProvider';
+
+// Mock @thunder/contexts
+const mockGetClientUuid = vi.fn();
+vi.mock('@thunder/contexts', () => ({
+  useConfig: () => ({
+    getClientUuid: mockGetClientUuid,
+  }),
+}));
+
+// Mock useGetDesignResolve
+const mockUseGetDesignResolve = vi.fn();
+vi.mock('../../../api/useGetDesignResolve', () => ({
+  default: (...args: unknown[]) => mockUseGetDesignResolve(...args),
+}));
+
+function ContextConsumer() {
+  const ctx = useContext(DesignContext);
+  if (!ctx) return <div data-testid="no-context" />;
+  return (
+    <div
+      data-testid="context-values"
+      data-is-design-enabled={String(ctx.isDesignEnabled)}
+      data-is-loading={String(ctx.isLoading)}
+      data-has-error={String(Boolean(ctx.error))}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DesignProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetClientUuid.mockReturnValue('test-client-uuid');
+    mockUseGetDesignResolve.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('renders children', () => {
+    render(
+      <DesignProvider>
+        <span>child content</span>
+      </DesignProvider>,
+    );
+    expect(screen.getByText('child content')).toBeTruthy();
+  });
+
+  it('provides design context to children', () => {
+    render(
+      <DesignProvider>
+        <ContextConsumer />
+      </DesignProvider>,
+    );
+    expect(screen.getByTestId('context-values')).toBeTruthy();
+  });
+
+  describe('isLoading', () => {
+    it('reflects the hook loading state when resolving internally', () => {
+      mockUseGetDesignResolve.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      });
+      render(
+        <DesignProvider>
+          <ContextConsumer />
+        </DesignProvider>,
+      );
+      expect(screen.getByTestId('context-values').getAttribute('data-is-loading')).toBe('true');
+    });
+
+    it('is false when externalDesign is provided', () => {
+      const externalDesign: DesignResolveResponse = {
+        theme: {colorSchemes: {light: {}}} as DesignResolveResponse['theme'],
+        layout: {} as DesignResolveResponse['layout'],
+      };
+      render(
+        <DesignProvider design={externalDesign}>
+          <ContextConsumer />
+        </DesignProvider>,
+      );
+      expect(screen.getByTestId('context-values').getAttribute('data-is-loading')).toBe('false');
+    });
+
+    it('is true when shouldResolveDesignInternally is false and no external design is provided', () => {
+      render(
+        <DesignProvider shouldResolveDesignInternally={false}>
+          <ContextConsumer />
+        </DesignProvider>,
+      );
+      expect(screen.getByTestId('context-values').getAttribute('data-is-loading')).toBe('true');
+    });
+  });
+
+  describe('isDesignEnabled', () => {
+    it('is false when no design is resolved', () => {
+      render(
+        <DesignProvider>
+          <ContextConsumer />
+        </DesignProvider>,
+      );
+      expect(screen.getByTestId('context-values').getAttribute('data-is-design-enabled')).toBe('false');
+    });
+
+    it('is true when external design has a non-empty theme', () => {
+      const externalDesign: DesignResolveResponse = {
+        theme: {colorSchemes: {light: {}}} as DesignResolveResponse['theme'],
+        layout: {} as DesignResolveResponse['layout'],
+      };
+      render(
+        <DesignProvider design={externalDesign}>
+          <ContextConsumer />
+        </DesignProvider>,
+      );
+      expect(screen.getByTestId('context-values').getAttribute('data-is-design-enabled')).toBe('true');
+    });
+
+    it('is true when resolved design has a non-empty theme', () => {
+      mockUseGetDesignResolve.mockReturnValue({
+        data: {
+          theme: {colorSchemes: {light: {}}} as DesignResolveResponse['theme'],
+          layout: {} as DesignResolveResponse['layout'],
+        },
+        isLoading: false,
+        error: null,
+      });
+      render(
+        <DesignProvider>
+          <ContextConsumer />
+        </DesignProvider>,
+      );
+      expect(screen.getByTestId('context-values').getAttribute('data-is-design-enabled')).toBe('true');
+    });
+  });
+
+  describe('API call behavior', () => {
+    it('enables the resolve query when clientUuid is available and shouldResolveDesignInternally is true', () => {
+      mockGetClientUuid.mockReturnValue('valid-uuid');
+      render(
+        <DesignProvider>
+          <span />
+        </DesignProvider>,
+      );
+      expect(mockUseGetDesignResolve).toHaveBeenCalledWith(
+        expect.objectContaining({id: 'valid-uuid'}),
+        expect.objectContaining({enabled: true}),
+      );
+    });
+
+    it('disables the resolve query when clientUuid is empty', () => {
+      mockGetClientUuid.mockReturnValue('');
+      render(
+        <DesignProvider>
+          <span />
+        </DesignProvider>,
+      );
+      expect(mockUseGetDesignResolve).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({enabled: false}),
+      );
+    });
+
+    it('disables the resolve query when externalDesign is provided', () => {
+      const externalDesign: DesignResolveResponse = {
+        theme: {} as DesignResolveResponse['theme'],
+        layout: {} as DesignResolveResponse['layout'],
+      };
+      render(
+        <DesignProvider design={externalDesign}>
+          <span />
+        </DesignProvider>,
+      );
+      expect(mockUseGetDesignResolve).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({enabled: false}),
+      );
+    });
+
+    it('disables the resolve query when shouldResolveDesignInternally is false', () => {
+      render(
+        <DesignProvider shouldResolveDesignInternally={false}>
+          <span />
+        </DesignProvider>,
+      );
+      expect(mockUseGetDesignResolve).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({enabled: false}),
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request introduces a loading state to the authentication page layouts and improves the handling and testing of the design context's loading and enabled states. The main changes are the addition of an `isLoading` prop to `AuthPageLayout`, updates to both the SignIn and SignUp pages to use this prop, and enhanced logic and tests for the design context provider.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

**Authentication Page Loading State**

* `AuthPageLayout` now accepts an `isLoading` prop, displaying a spinner instead of children when loading. Tests were added to verify this behavior. [[1]](diffhunk://#diff-64ea166eb2f42e67213e8124daccc87e203f9438f633c706e807697080ade5f4L20-R29) [[2]](diffhunk://#diff-64ea166eb2f42e67213e8124daccc87e203f9438f633c706e807697080ade5f4L74-R76) [[3]](diffhunk://#diff-dc22d4aefd7750ad0a8ca318f6e3532d541a217105322901019c12a41cf823ecR99-R130)
* Both `SignIn` and `SignUp` components now consume the `isLoading` value from `useDesign` and pass it to `AuthPageLayout`, ensuring the spinner is shown during design resolution. [[1]](diffhunk://#diff-74f927e732a24ae6bf60e4325ca6c164e6bd3cf7660acebdfb122d2c267197d0L25-R30) [[2]](diffhunk://#diff-f8fbc371d7f01ebb62d85c0d0d83adb9a67fd3889dec7eda07f9ab7c4c643f2cL19-R27)

**Design Context Logic and Testing**

* The `DesignProvider` logic for the `isLoading` value has been improved to better handle cases with external design data and internal resolution.
* Comprehensive tests for `DesignProvider` were added to verify context values, loading state, and query behavior under various scenarios.

**SignIn and SignUp Page Tests**

* Tests for `SignIn` and `SignUp` were updated and extended to check for correct behavior when loading (spinner shown, content hidden) and to mock the `useDesign` hook appropriately. [[1]](diffhunk://#diff-b0d1636e915c621d281322918348ca1b052807a46d76c1655317d6e2facd6a36R48) [[2]](diffhunk://#diff-b0d1636e915c621d281322918348ca1b052807a46d76c1655317d6e2facd6a36R65) [[3]](diffhunk://#diff-b0d1636e915c621d281322918348ca1b052807a46d76c1655317d6e2facd6a36R74-R88) [[4]](diffhunk://#diff-ef50cad8c77b31d9f09bbdc8aac182aeaac39036f58dbba7a82d302790530c7cL20-R46) [[5]](diffhunk://#diff-ef50cad8c77b31d9f09bbdc8aac182aeaac39036f58dbba7a82d302790530c7cR62-R69)

**Other**

* Minor import reordering for clarity in `main.tsx`.

### Related Issues
- Fixes https://github.com/asgardeo/thunder/issues/2264

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators to Sign In and Sign Up pages that display during authentication initialization, replacing content with a loading spinner.

* **Tests**
  * Expanded test coverage for loading state behavior across authentication components and page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->