### PR TITLE
Refactor error handling for user provisioning in OAuthExecutor

### DIFF
--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -39,6 +39,7 @@ import (
 const (
 	oAuthLoggerComponentName            = "OAuthExecutor"
 	errCannotProvisionUserAutomatically = "user not found and cannot provision automatically"
+	errSelfRegistrationDisabled         = "self registration is disabled for the user type"
 )
 
 // OAuthTokenResponse represents the response from a OAuth token endpoint.
@@ -597,7 +598,7 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 	if len(selfRegEnabledSchemas) == 0 {
 		logger.Debug("No user types with self-registration enabled, cannot provision automatically")
 		execResp.Status = common.ExecFailure
-		execResp.FailureReason = errCannotProvisionUserAutomatically
+		execResp.FailureReason = errSelfRegistrationDisabled
 		return nil
 	}
 

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -1148,14 +1148,16 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning() {
 
 func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Failures() {
 	tests := []struct {
-		name             string
-		allowedUserTypes []string
-		mockSetup        func()
+		name                  string
+		allowedUserTypes      []string
+		mockSetup             func()
+		expectedFailureReason string
 	}{
 		{
-			name:             "NoAllowedUserTypes",
-			allowedUserTypes: []string{},
-			mockSetup:        func() {},
+			name:                  "NoAllowedUserTypes",
+			allowedUserTypes:      []string{},
+			mockSetup:             func() {},
+			expectedFailureReason: errCannotProvisionUserAutomatically,
 		},
 		{
 			name:             "NoSelfRegistrationEnabled",
@@ -1168,6 +1170,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 						OUID:                  "ou-123",
 					}, nil).Once()
 			},
+			expectedFailureReason: errSelfRegistrationDisabled,
 		},
 		{
 			name:             "MultipleSelfRegistrationEnabled",
@@ -1186,6 +1189,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 						OUID:                  "ou-456",
 					}, nil).Once()
 			},
+			expectedFailureReason: errCannotProvisionUserAutomatically,
 		},
 	}
 
@@ -1210,7 +1214,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 
 			assert.NoError(suite.T(), err)
 			assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-			assert.Equal(suite.T(), errCannotProvisionUserAutomatically, execResp.FailureReason)
+			assert.Equal(suite.T(), tt.expectedFailureReason, execResp.FailureReason)
 			suite.mockUserSchemaService.AssertExpectations(suite.T())
 		})
 	}
@@ -1377,14 +1381,16 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_WithExist
 
 func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_FailureScenarios() {
 	tests := []struct {
-		name             string
-		allowedUserTypes []string
-		userSchemas      map[string]*userschema.UserSchema
+		name                  string
+		allowedUserTypes      []string
+		userSchemas           map[string]*userschema.UserSchema
+		expectedFailureReason string
 	}{
 		{
-			name:             "NoAllowedUserTypes",
-			allowedUserTypes: []string{},
-			userSchemas:      nil,
+			name:                  "NoAllowedUserTypes",
+			allowedUserTypes:      []string{},
+			userSchemas:           nil,
+			expectedFailureReason: errCannotProvisionUserAutomatically,
 		},
 		{
 			name:             "NoSelfRegistrationEnabled",
@@ -1399,6 +1405,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 					AllowSelfRegistration: false,
 				},
 			},
+			expectedFailureReason: errSelfRegistrationDisabled,
 		},
 		{
 			name:             "MultipleEligibleTypes",
@@ -1415,6 +1422,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 					OUID:                  "ou-2",
 				},
 			},
+			expectedFailureReason: errCannotProvisionUserAutomatically,
 		},
 	}
 
@@ -1445,7 +1453,7 @@ func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_Fail
 
 			assert.NoError(suite.T(), err)
 			assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-			assert.Equal(suite.T(), errCannotProvisionUserAutomatically, execResp.FailureReason)
+			assert.Equal(suite.T(), tt.expectedFailureReason, execResp.FailureReason)
 
 			if tt.userSchemas != nil {
 				suite.mockUserSchemaService.AssertExpectations(suite.T())


### PR DESCRIPTION
### Purpose
This pull request improves the error handling and test coverage for user auto-provisioning failures in the OAuth executor. The main focus is on distinguishing between cases where no user types are allowed and where self-registration is disabled, and ensuring the correct failure reasons are used and tested.

**Error handling improvements:**

* Added a new error constant `errSelfRegistrationDisabled` to clarify when self-registration is disabled for the user type (`backend/internal/flow/executor/oauth_executor.go`).
* Updated the logic in `resolveUserTypeForAutoProvisioning` to set `execResp.FailureReason` to `errSelfRegistrationDisabled` when no user types with self-registration enabled are found (`backend/internal/flow/executor/oauth_executor.go`).

**Test coverage enhancements:**

* Updated test cases to expect the correct failure reason (`errCannotProvisionUserAutomatically` or `errSelfRegistrationDisabled`) based on the scenario in `TestResolveUserTypeForAutoProvisioning_Fail` (`backend/internal/flow/executor/oauth_executor_test.go`). [[1]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R1154-R1160) [[2]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R1173) [[3]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R1192) [[4]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R1387-R1393) [[5]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R1408) [[6]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14R1425)
* Changed assertions in the test to compare against the scenario-specific expected failure reason rather than always using `errCannotProvisionUserAutomatically` (`backend/internal/flow/executor/oauth_executor_test.go`). [[1]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14L1213-R1217) [[2]](diffhunk://#diff-6d45b668d3da3199e4959dca41c37c7f28c37649694de407af627f0e619bef14L1448-R1456)

### Related Issues
- https://github.com/asgardeo/thunder/issues/1889

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for OAuth auto-provisioning failures. Users now receive a more specific error message when self-registration is disabled for a user type, instead of a generic provisioning error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->