### PR TITLE
Add localized client metadata support for applications and DCR

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -63,3 +63,5 @@ ACLs
 [Uu]psert
 [Ii]dempotency
 [Ss]andboxed
+DCR
+BCP

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -282,7 +282,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 
 	// TODO: Remove entityService dependency after finalizing declarative resource loading pattern
 	applicationService, applicationExporter, err := application.Initialize(
-		mux, mcpServer, entityProvider, entityService, inboundClientService, ouService)
+		mux, mcpServer, entityProvider, entityService, inboundClientService, ouService, i18nService)
 	if err != nil {
 		logger.Fatal("Failed to initialize ApplicationService", log.Error(err))
 	}
@@ -326,7 +326,7 @@ func registerServices(mux *http.ServeMux) jwt.JWTServiceInterface {
 	// Initialize OAuth services.
 	err = oauth.Initialize(mux, applicationService, inboundClientService, authnProvider, jwtService, jweService,
 		flowExecService, observabilitySvc, pkiService, ouService, attributeCacheService, authZService, entityProvider,
-		resourceService)
+		resourceService, i18nService)
 	if err != nil {
 		logger.Fatal("Failed to initialize OAuth services", log.Error(err))
 	}

--- a/backend/internal/application/init.go
+++ b/backend/internal/application/init.go
@@ -31,6 +31,7 @@ import (
 	oupkg "github.com/asgardeo/thunder/internal/ou"
 	serverconst "github.com/asgardeo/thunder/internal/system/constants"
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
+	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
 
@@ -42,9 +43,10 @@ func Initialize(
 	entityService entity.EntityServiceInterface,
 	inboundClient inboundclient.InboundClientServiceInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
+	i18nService i18nmgt.I18nServiceInterface,
 ) (ApplicationServiceInterface, declarativeresource.ResourceExporter, error) {
 	appService := newApplicationService(
-		inboundClient, entityProvider, ouService,
+		inboundClient, entityProvider, ouService, i18nService,
 	)
 
 	if err := entityService.LoadIndexedAttributes(getAppIndexedAttributes()); err != nil {

--- a/backend/internal/application/init_test.go
+++ b/backend/internal/application/init_test.go
@@ -158,6 +158,7 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesDisabled() {
 		mockEntityService,
 		inboundclientmock.NewInboundClientServiceInterfaceMock(suite.T()),
 		nil, // ouService - not needed for this test
+		nil, // i18nService - not needed for this test
 	)
 
 	// Assert
@@ -199,6 +200,7 @@ func (suite *InitTestSuite) TestInitialize_WithMCPServer() {
 		mockEntityService,
 		inboundclientmock.NewInboundClientServiceInterfaceMock(suite.T()),
 		nil, // ouService - not needed for this test
+		nil, // i18nService - not needed for this test
 	)
 
 	// Assert
@@ -594,6 +596,7 @@ func TestInitialize_Standalone(t *testing.T) {
 		mockEntityService,
 		inboundclientmock.NewInboundClientServiceInterfaceMock(t),
 		nil, // ouService - not needed for this test
+		nil, // i18nService - not needed for this test
 	)
 
 	// Assert
@@ -643,6 +646,7 @@ func TestInitialize_WithDeclarativeResources_Standalone(t *testing.T) {
 		mockEntityService,
 		mockInboundClient,
 		nil, // ouService - not needed for this test
+		nil, // i18nService - not needed for this test
 	)
 
 	// Assert

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -36,6 +36,7 @@ import (
 	oupkg "github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
+	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/internal/system/log"
 	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
@@ -62,6 +63,7 @@ type applicationService struct {
 	inboundClientService inboundclient.InboundClientServiceInterface
 	entityProvider       entityprovider.EntityProviderInterface
 	ouService            oupkg.OrganizationUnitServiceInterface
+	i18nService          i18nmgt.I18nServiceInterface
 }
 
 // newApplicationService creates a new instance of ApplicationService.
@@ -69,12 +71,14 @@ func newApplicationService(
 	inboundClient inboundclient.InboundClientServiceInterface,
 	entityProvider entityprovider.EntityProviderInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
+	i18nService i18nmgt.I18nServiceInterface,
 ) ApplicationServiceInterface {
 	return &applicationService{
 		logger:               log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationService")),
 		inboundClientService: inboundClient,
 		entityProvider:       entityProvider,
 		ouService:            ouService,
+		i18nService:          i18nService,
 	}
 }
 
@@ -325,7 +329,7 @@ func (as *applicationService) UpdateApplication(ctx context.Context, appID strin
 	if as.inboundClientService.IsDeclarative(ctx, appID) {
 		return nil, &ErrorCannotModifyDeclarativeResource
 	}
-	_, inboundAuthConfig, svcErr := as.validateApplicationForUpdate(ctx, appID, app)
+	existingApp, inboundAuthConfig, svcErr := as.validateApplicationForUpdate(ctx, appID, app)
 
 	if svcErr != nil {
 		return nil, svcErr
@@ -359,6 +363,10 @@ func (as *applicationService) UpdateApplication(ctx context.Context, appID strin
 	}
 
 	if svcErr := as.updateEntityDataForApplicationUpdate(appID, app, inboundAuthConfig); svcErr != nil {
+		return nil, svcErr
+	}
+
+	if svcErr := as.cleanupStaleI18nKeys(ctx, appID, existingApp, app); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -463,7 +471,7 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 		return &serviceerror.InternalServerError
 	}
 
-	return nil
+	return as.deleteLocalizedVariants(ctx, appID)
 }
 
 // isIdentifierTaken checks if an entity with the given identifier already exists.
@@ -1518,4 +1526,62 @@ func (as *applicationService) mapStoreError(err error) *serviceerror.ServiceErro
 	}
 	as.logger.Error("Failed to retrieve application", log.Error(err))
 	return &serviceerror.InternalServerError
+}
+
+// deleteLocalizedVariants removes all i18n translations for an application's fields.
+// All fields are attempted; returns an internal server error if any deletion fails.
+func (as *applicationService) deleteLocalizedVariants(ctx context.Context, appID string) *serviceerror.ServiceError {
+	if as.i18nService == nil {
+		return nil
+	}
+	var hasErr bool
+	for _, field := range []string{"name", "logo_uri", "tos_uri", "policy_uri"} {
+		if svcErr := as.i18nService.DeleteTranslationsByKey(
+			ctx, AppI18nNamespace(), AppI18nKey(appID, field)); svcErr != nil {
+			as.logger.Error("Failed to delete localized variant on app deletion",
+				log.String("appID", appID),
+				log.String("field", field),
+				log.String("namespace", AppI18nNamespace()))
+			hasErr = true
+		}
+	}
+	if hasErr {
+		return &serviceerror.InternalServerError
+	}
+	return nil
+}
+
+// cleanupStaleI18nKeys removes i18n keys for fields that changed from an i18n ref back to plain text.
+// Returns an internal server error if any deletion fails.
+func (as *applicationService) cleanupStaleI18nKeys(
+	ctx context.Context, appID string,
+	existing *model.ApplicationProcessedDTO, updated *model.ApplicationDTO,
+) *serviceerror.ServiceError {
+	if as.i18nService == nil {
+		return nil
+	}
+	type pair struct{ old, updated, field string }
+	fields := []pair{
+		{existing.Name, updated.Name, "name"},
+		{existing.LogoURL, updated.LogoURL, "logo_uri"},
+		{existing.TosURI, updated.TosURI, "tos_uri"},
+		{existing.PolicyURI, updated.PolicyURI, "policy_uri"},
+	}
+	var hasErr bool
+	for _, f := range fields {
+		if isI18nRef(f.old) && !isI18nRef(f.updated) {
+			if svcErr := as.i18nService.DeleteTranslationsByKey(
+				ctx, AppI18nNamespace(), AppI18nKey(appID, f.field)); svcErr != nil {
+				as.logger.Error("Failed to delete stale i18n key",
+					log.String("appID", appID),
+					log.String("field", f.field),
+					log.String("namespace", AppI18nNamespace()))
+				hasErr = true
+			}
+		}
+	}
+	if hasErr {
+		return &serviceerror.InternalServerError
+	}
+	return nil
 }

--- a/backend/internal/application/utils.go
+++ b/backend/internal/application/utils.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package application
+
+import "strings"
+
+// AppI18nNamespace returns the i18n namespace for application localized metadata.
+func AppI18nNamespace() string {
+	return "custom"
+}
+
+// AppI18nKey returns the i18n key for an application field.
+func AppI18nKey(appID, field string) string {
+	return "app." + appID + "." + field
+}
+
+// AppI18nRef returns the i18n template reference string for an application field.
+// The returned value is stored as the application's display field so the UI can
+// resolve it to the correct locale at render time.
+func AppI18nRef(appID, field string) string {
+	return "{{t(" + AppI18nNamespace() + ":" + AppI18nKey(appID, field) + ")}}"
+}
+
+// isI18nRef reports whether s is an i18n template reference (e.g. "{{t(custom:app.123.name)}}").
+func isI18nRef(s string) bool {
+	return strings.HasPrefix(s, "{{t(") && strings.HasSuffix(s, ")}}")
+}

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -44,6 +44,7 @@ import (
 	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/database/provider"
 	syshttp "github.com/asgardeo/thunder/internal/system/http"
+	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/internal/system/jose/jwe"
 	"github.com/asgardeo/thunder/internal/system/jose/jwt"
 	"github.com/asgardeo/thunder/internal/system/observability"
@@ -65,6 +66,7 @@ func Initialize(
 	authzService authz.AuthorizationServiceInterface,
 	entityProvider entityprovider.EntityProviderInterface,
 	resourceService resource.ResourceServiceInterface,
+	i18nService i18nmgt.I18nServiceInterface,
 ) error {
 	// Fetch runtime transactioner for OAuth services.
 	transactioner, err := provider.GetDBProvider().GetRuntimeDBTransactioner()
@@ -92,6 +94,6 @@ func Initialize(
 			return syshttp.IsSSRFSafeURL(req.URL.String())
 		}),
 		tokenValidator, inboundClient, ouService, attributeCacheSvc, transactioner)
-	dcr.Initialize(mux, applicationService, ouService, transactioner)
+	dcr.Initialize(mux, applicationService, ouService, i18nService, transactioner)
 	return nil
 }

--- a/backend/internal/oauth/oauth2/dcr/error_constants.go
+++ b/backend/internal/oauth/oauth2/dcr/error_constants.go
@@ -19,9 +19,28 @@
 package dcr
 
 import (
+	"strconv"
+
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/core"
 )
+
+// errInvalidBCP47Tag is returned when a language tag in a DCR request field is not valid BCP 47.
+type errInvalidBCP47Tag struct{ key string }
+
+// Error implements the error interface.
+func (e *errInvalidBCP47Tag) Error() string {
+	return "invalid BCP 47 language tag in field \"" + e.key + "\""
+}
+
+// errTooManyLocalizedVariants is returned when a localizable field exceeds maxLocalizedVariantsPerField.
+type errTooManyLocalizedVariants struct{ field string }
+
+// Error implements the error interface.
+func (e *errTooManyLocalizedVariants) Error() string {
+	return "field \"" + e.field + "\" exceeds the maximum of " +
+		strconv.Itoa(maxLocalizedVariantsPerField) + " localized variants"
+}
 
 // DCR standard service error constants
 var (

--- a/backend/internal/oauth/oauth2/dcr/init.go
+++ b/backend/internal/oauth/oauth2/dcr/init.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/ou"
+	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 	"github.com/asgardeo/thunder/internal/system/transaction"
 )
@@ -33,9 +34,10 @@ func Initialize(
 	mux *http.ServeMux,
 	appService application.ApplicationServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
+	i18nService i18nmgt.I18nServiceInterface,
 	transactioner transaction.Transactioner,
 ) DCRServiceInterface {
-	dcrService := newDCRService(appService, ouService, transactioner)
+	dcrService := newDCRService(appService, ouService, i18nService, transactioner)
 	dcrHandler := newDCRHandler(dcrService)
 	registerRoutes(mux, dcrHandler)
 	return dcrService
@@ -49,7 +51,6 @@ func registerRoutes(mux *http.ServeMux, dcrHandler *dcrHandler) {
 		AllowCredentials: true,
 		MaxAge:           600,
 	}
-
 	mux.HandleFunc(middleware.WithCORS("POST /oauth2/dcr/register",
 		dcrHandler.HandleDCRRegistration, opts))
 	mux.HandleFunc(middleware.WithCORS("OPTIONS /oauth2/dcr/register",

--- a/backend/internal/oauth/oauth2/dcr/init_test.go
+++ b/backend/internal/oauth/oauth2/dcr/init_test.go
@@ -62,7 +62,7 @@ func (suite *InitTestSuite) TearDownTest() {
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
 
-	service := Initialize(mux, suite.mockAppService, suite.mockOUService, &MockTransactioner{})
+	service := Initialize(mux, suite.mockAppService, suite.mockOUService, nil, &MockTransactioner{})
 
 	assert.NotNil(suite.T(), service)
 	assert.Implements(suite.T(), (*DCRServiceInterface)(nil), service)
@@ -71,7 +71,7 @@ func (suite *InitTestSuite) TestInitialize() {
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
 
-	Initialize(mux, suite.mockAppService, suite.mockOUService, &MockTransactioner{})
+	Initialize(mux, suite.mockAppService, suite.mockOUService, nil, &MockTransactioner{})
 
 	// Verify that the routes are registered by attempting to get a handler for them.
 	// The pattern includes the method because of CORS middleware wrapping.

--- a/backend/internal/oauth/oauth2/dcr/model.go
+++ b/backend/internal/oauth/oauth2/dcr/model.go
@@ -19,12 +19,17 @@
 package dcr
 
 import (
+	"encoding/json"
+	"strings"
+
 	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
+	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 )
 
 // Default values for DCR
 const (
-	ClientSecretExpiresAtNever = 0 // Never expires
+	ClientSecretExpiresAtNever   = 0 // Never expires
+	maxLocalizedVariantsPerField = 20
 )
 
 // DCRRegistrationRequest represents the RFC 7591 Dynamic Client Registration request.
@@ -44,11 +49,78 @@ type DCRRegistrationRequest struct {
 	TosURI                  string                              `json:"tos_uri,omitempty"`
 	PolicyURI               string                              `json:"policy_uri,omitempty"`
 
-	RequirePushedAuthorizationRequests bool `json:"require_pushed_authorization_requests,omitempty"`
+	RequirePushedAuthorizationRequests bool   `json:"require_pushed_authorization_requests,omitempty"`
+	UserInfoSignedResponseAlg          string `json:"userinfo_signed_response_alg,omitempty"`
+	UserInfoEncryptedResponseAlg       string `json:"userinfo_encrypted_response_alg,omitempty"`
+	UserInfoEncryptedResponseEnc       string `json:"userinfo_encrypted_response_enc,omitempty"`
+	// Localized variant maps — populated from #-keyed JSON fields (e.g. "client_name#fr").
+	LocalizedClientName map[string]string `json:"-"`
+	LocalizedLogoURI    map[string]string `json:"-"`
+	LocalizedTosURI     map[string]string `json:"-"`
+	LocalizedPolicyURI  map[string]string `json:"-"`
+}
 
-	UserInfoSignedResponseAlg    string `json:"userinfo_signed_response_alg,omitempty"`
-	UserInfoEncryptedResponseAlg string `json:"userinfo_encrypted_response_alg,omitempty"`
-	UserInfoEncryptedResponseEnc string `json:"userinfo_encrypted_response_enc,omitempty"`
+// UnmarshalJSON decodes DCRRegistrationRequest from JSON, extracting OIDC language-tagged fields
+// (e.g. "client_name#fr") into the localized variant maps.
+func (r *DCRRegistrationRequest) UnmarshalJSON(data []byte) error {
+	type Alias DCRRegistrationRequest
+	if err := json.Unmarshal(data, (*Alias)(r)); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	return parseLocalizedFields(raw, r)
+}
+
+// parseLocalizedFields extracts language-tagged fields (e.g. "client_name#fr") from a raw JSON map
+// and populates the localized variant maps on r.
+func parseLocalizedFields(raw map[string]json.RawMessage, r *DCRRegistrationRequest) error {
+	for key, val := range raw {
+		field, tag, ok := strings.Cut(key, "#")
+		if !ok {
+			continue
+		}
+		canonical, valid := i18nmgt.NormaliseBCP47Tag(tag)
+		if !valid {
+			return &errInvalidBCP47Tag{key: key}
+		}
+		var s string
+		if err := json.Unmarshal(val, &s); err != nil {
+			continue
+		}
+		var target *map[string]string
+		switch field {
+		case "client_name":
+			target = &r.LocalizedClientName
+		case "logo_uri":
+			target = &r.LocalizedLogoURI
+		case "tos_uri":
+			target = &r.LocalizedTosURI
+		case "policy_uri":
+			target = &r.LocalizedPolicyURI
+		}
+		if target == nil {
+			continue
+		}
+		if err := setLocalizedVariant(target, field, canonical, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setLocalizedVariant initializes the map if needed, stores the value, and enforces the variant limit.
+func setLocalizedVariant(m *map[string]string, field, tag, val string) error {
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+	(*m)[tag] = val
+	if len(*m) > maxLocalizedVariantsPerField {
+		return &errTooManyLocalizedVariants{field: field}
+	}
+	return nil
 }
 
 // DCRRegistrationResponse represents the RFC 7591 Dynamic Client Registration response.
@@ -71,11 +143,47 @@ type DCRRegistrationResponse struct {
 	PolicyURI               string                              `json:"policy_uri,omitempty"`
 	AppID                   string                              `json:"app_id,omitempty"`
 
-	RequirePushedAuthorizationRequests bool `json:"require_pushed_authorization_requests,omitempty"`
+	RequirePushedAuthorizationRequests bool   `json:"require_pushed_authorization_requests,omitempty"`
+	UserInfoSignedResponseAlg          string `json:"userinfo_signed_response_alg,omitempty"`
+	UserInfoEncryptedResponseAlg       string `json:"userinfo_encrypted_response_alg,omitempty"`
+	UserInfoEncryptedResponseEnc       string `json:"userinfo_encrypted_response_enc,omitempty"`
+	// Localized variant maps — injected as #-keyed top-level fields during serialization.
+	LocalizedClientName map[string]string `json:"-"`
+	LocalizedLogoURI    map[string]string `json:"-"`
+	LocalizedTosURI     map[string]string `json:"-"`
+	LocalizedPolicyURI  map[string]string `json:"-"`
+}
 
-	UserInfoSignedResponseAlg    string `json:"userinfo_signed_response_alg,omitempty"`
-	UserInfoEncryptedResponseAlg string `json:"userinfo_encrypted_response_alg,omitempty"`
-	UserInfoEncryptedResponseEnc string `json:"userinfo_encrypted_response_enc,omitempty"`
+// MarshalJSON serializes DCRRegistrationResponse to JSON, injecting OIDC language-tagged
+// fields (e.g. "client_name#fr") as top-level keys.
+func (r DCRRegistrationResponse) MarshalJSON() ([]byte, error) {
+	type Alias DCRRegistrationResponse
+	base, err := json.Marshal(Alias(r))
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(base, &m); err != nil {
+		return nil, err
+	}
+	appendLocalizedFields(m, r)
+	return json.Marshal(m)
+}
+
+// appendLocalizedFields injects localized variant maps from r into m as #-keyed top-level entries.
+func appendLocalizedFields(m map[string]interface{}, r DCRRegistrationResponse) {
+	for tag, val := range r.LocalizedClientName {
+		m["client_name#"+tag] = val
+	}
+	for tag, val := range r.LocalizedLogoURI {
+		m["logo_uri#"+tag] = val
+	}
+	for tag, val := range r.LocalizedTosURI {
+		m["tos_uri#"+tag] = val
+	}
+	for tag, val := range r.LocalizedPolicyURI {
+		m["policy_uri#"+tag] = val
+	}
 }
 
 // DCRErrorResponse represents the RFC 7591 Dynamic Client Registration error response.

--- a/backend/internal/oauth/oauth2/dcr/model_test.go
+++ b/backend/internal/oauth/oauth2/dcr/model_test.go
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package dcr
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// DCRModelTestSuite is the test suite for DCR model marshaling/unmarshaling.
+type DCRModelTestSuite struct {
+	suite.Suite
+}
+
+func TestDCRModelTestSuite(t *testing.T) {
+	suite.Run(t, new(DCRModelTestSuite))
+}
+
+func (s *DCRModelTestSuite) TestUnmarshalJSON_BasicFields() {
+	input := `{
+		"client_name": "My App",
+		"redirect_uris": ["https://example.com/cb"],
+		"scope": "openid profile"
+	}`
+	var req DCRRegistrationRequest
+	s.Require().NoError(json.Unmarshal([]byte(input), &req))
+
+	s.Equal("My App", req.ClientName)
+	s.Equal([]string{"https://example.com/cb"}, req.RedirectURIs)
+	s.Equal("openid profile", req.Scope)
+	s.Nil(req.LocalizedClientName)
+}
+
+func (s *DCRModelTestSuite) TestUnmarshalJSON_LocalizedFields() {
+	input := `{
+		"client_name": "My App",
+		"client_name#fr": "Mon Application",
+		"client_name#de": "Meine Anwendung",
+		"logo_uri": "https://example.com/logo.png",
+		"logo_uri#fr": "https://example.com/fr/logo.png",
+		"tos_uri#fr": "https://example.com/fr/tos",
+		"policy_uri#fr": "https://example.com/fr/policy"
+	}`
+	var req DCRRegistrationRequest
+	s.Require().NoError(json.Unmarshal([]byte(input), &req))
+
+	s.Equal("My App", req.ClientName)
+	s.Equal("Mon Application", req.LocalizedClientName["fr"])
+	s.Equal("Meine Anwendung", req.LocalizedClientName["de"])
+	s.Equal("https://example.com/fr/logo.png", req.LocalizedLogoURI["fr"])
+	s.Equal("https://example.com/fr/tos", req.LocalizedTosURI["fr"])
+	s.Equal("https://example.com/fr/policy", req.LocalizedPolicyURI["fr"])
+}
+
+func (s *DCRModelTestSuite) TestUnmarshalJSON_InvalidBCP47Tag() {
+	input := `{"client_name#not!!valid": "Bad"}`
+	var req DCRRegistrationRequest
+	err := json.Unmarshal([]byte(input), &req)
+
+	s.Error(err)
+	s.Contains(err.Error(), "invalid BCP 47 language tag")
+}
+
+func (s *DCRModelTestSuite) TestUnmarshalJSON_InvalidJSON() {
+	input := `{"client_name": invalid json}`
+	var req DCRRegistrationRequest
+	s.Error(json.Unmarshal([]byte(input), &req))
+}
+
+func (s *DCRModelTestSuite) TestUnmarshalJSON_NonStringLocalizedValue() {
+	input := `{"client_name#fr": 42}`
+	var req DCRRegistrationRequest
+	s.Require().NoError(json.Unmarshal([]byte(input), &req))
+	s.Nil(req.LocalizedClientName)
+}
+
+func (s *DCRModelTestSuite) TestMarshalJSON_NoLocalizedFields() {
+	resp := DCRRegistrationResponse{
+		ClientID:   "client-123",
+		ClientName: "My App",
+	}
+	data, err := json.Marshal(resp)
+	s.Require().NoError(err)
+
+	var m map[string]interface{}
+	s.Require().NoError(json.Unmarshal(data, &m))
+	s.Equal("client-123", m["client_id"])
+	s.Equal("My App", m["client_name"])
+
+	for key := range m {
+		s.NotContains(key, "#")
+	}
+}
+
+func (s *DCRModelTestSuite) TestMarshalJSON_WithLocalizedFields() {
+	resp := DCRRegistrationResponse{
+		ClientID:   "client-123",
+		ClientName: "My App",
+		LocalizedClientName: map[string]string{
+			"fr": "Mon Application",
+			"de": "Meine Anwendung",
+		},
+		LocalizedLogoURI: map[string]string{
+			"fr": "https://example.com/fr/logo.png",
+		},
+		LocalizedTosURI: map[string]string{
+			"fr": "https://example.com/fr/tos",
+		},
+		LocalizedPolicyURI: map[string]string{
+			"fr": "https://example.com/fr/policy",
+		},
+	}
+	data, err := json.Marshal(resp)
+	s.Require().NoError(err)
+
+	var m map[string]interface{}
+	s.Require().NoError(json.Unmarshal(data, &m))
+	s.Equal("Mon Application", m["client_name#fr"])
+	s.Equal("Meine Anwendung", m["client_name#de"])
+	s.Equal("https://example.com/fr/logo.png", m["logo_uri#fr"])
+	s.Equal("https://example.com/fr/tos", m["tos_uri#fr"])
+	s.Equal("https://example.com/fr/policy", m["policy_uri#fr"])
+	s.Equal("My App", m["client_name"])
+}
+
+func (s *DCRModelTestSuite) TestErrInvalidBCP47Tag_Error() {
+	err := &errInvalidBCP47Tag{key: "client_name#not!!valid"}
+	s.Equal(`invalid BCP 47 language tag in field "client_name#not!!valid"`, err.Error())
+}
+
+func (s *DCRModelTestSuite) TestUnmarshalJSON_DuplicateTagsNormalized() {
+	input := `{
+		"client_name#FR": "Première valeur",
+		"client_name#fr": "Deuxième valeur"
+	}`
+	var req DCRRegistrationRequest
+	s.Require().NoError(json.Unmarshal([]byte(input), &req))
+
+	s.Require().NotNil(req.LocalizedClientName)
+	s.Len(req.LocalizedClientName, 1, "duplicate normalised tags must collapse to a single entry")
+	s.Contains(req.LocalizedClientName, "fr")
+}
+
+func (s *DCRModelTestSuite) TestUnmarshalJSON_MaxLocalizedVariants() {
+	langs := []string{
+		"aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av",
+		"ay", "az", "ba", "be", "bg", "bh", "bi", "bm", "bn", "bo", "br",
+	}
+	s.Require().Greater(len(langs), maxLocalizedVariantsPerField, "test data must exceed the limit")
+
+	input := `{"client_name": "Base"`
+	for _, lang := range langs {
+		input += `, "client_name#` + lang + `": "Value ` + lang + `"`
+	}
+	input += `}`
+
+	var req DCRRegistrationRequest
+	err := json.Unmarshal([]byte(input), &req)
+
+	s.Error(err)
+	s.Contains(err.Error(), "exceeds the maximum")
+}

--- a/backend/internal/oauth/oauth2/dcr/service.go
+++ b/backend/internal/oauth/oauth2/dcr/service.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/application/model"
@@ -32,8 +33,10 @@ import (
 	oauthutils "github.com/asgardeo/thunder/internal/oauth/oauth2/utils"
 	"github.com/asgardeo/thunder/internal/ou"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/internal/system/log"
 	"github.com/asgardeo/thunder/internal/system/transaction"
+	sysutils "github.com/asgardeo/thunder/internal/system/utils"
 )
 
 // DCRServiceInterface defines the interface for the DCR service.
@@ -47,6 +50,7 @@ type DCRServiceInterface interface {
 type dcrService struct {
 	appService    application.ApplicationServiceInterface
 	ouService     ou.OrganizationUnitServiceInterface
+	i18nService   i18nmgt.I18nServiceInterface
 	transactioner transaction.Transactioner
 }
 
@@ -54,11 +58,13 @@ type dcrService struct {
 func newDCRService(
 	appService application.ApplicationServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
+	i18nService i18nmgt.I18nServiceInterface,
 	transactioner transaction.Transactioner,
 ) DCRServiceInterface {
 	return &dcrService{
 		appService:    appService,
 		ouService:     ouService,
+		i18nService:   i18nService,
 		transactioner: transactioner,
 	}
 }
@@ -99,9 +105,10 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 
 	var response *DCRRegistrationResponse
 	var capturedErr *serviceerror.ServiceError
+	var createdAppID string
 
-	err := ds.transactioner.Transact(ctx, func(ctx context.Context) error {
-		createdApp, svcErr := ds.appService.CreateApplication(ctx, appDTO)
+	err := ds.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		createdApp, svcErr := ds.appService.CreateApplication(txCtx, appDTO)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ServerErrorType {
 				logger.Error("Failed to create application via Application service",
@@ -114,6 +121,8 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 			capturedErr = ds.mapApplicationErrorToDCRError(svcErr)
 			return errors.New("failed to create application")
 		}
+
+		createdAppID = createdApp.ID
 
 		var convErr *serviceerror.ServiceError
 		response, convErr = ds.convertApplicationToDCRResponse(createdApp, request.ClientName)
@@ -133,6 +142,38 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 		}
 		return nil, &ErrorServerError
 	}
+
+	// Write localized variants outside the transaction above because the i18n service
+	// uses a separate configDB connection and cannot join the same transaction.
+	// If writing fails, clean up any partial i18n rows and compensate by deleting the created app.
+	// Note: writeLocalizedVariants only returns an error when i18nService is non-nil,
+	// so calling DeleteTranslationsByKey here without a nil guard is safe.
+	// If the compensation DeleteApplication also fails, the app record is left without localized
+	// metadata — an accepted gap that can be cleaned up manually or via a future sweep.
+	if writeErr := ds.writeLocalizedVariants(ctx, createdAppID, request); writeErr != nil {
+		logger.Error("Failed to write localized variants for DCR client; compensating by deleting app",
+			log.String("appID", createdAppID), log.String("error", writeErr.Error.DefaultValue))
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cleanupCancel()
+		for _, field := range []string{"name", "logo_uri", "tos_uri", "policy_uri"} {
+			if cleanErr := ds.i18nService.DeleteTranslationsByKey(
+				cleanupCtx, application.AppI18nNamespace(), application.AppI18nKey(createdAppID, field),
+			); cleanErr != nil {
+				logger.Error("Failed to clean up partial i18n row after write failure",
+					log.String("appID", createdAppID), log.String("field", field))
+			}
+		}
+		if delSvcErr := ds.appService.DeleteApplication(cleanupCtx, createdAppID); delSvcErr != nil {
+			logger.Error("Compensation delete failed after i18n write failure; app record may be orphaned",
+				log.String("appID", createdAppID))
+		}
+		return nil, writeErr
+	}
+
+	response.LocalizedClientName = request.LocalizedClientName
+	response.LocalizedLogoURI = request.LocalizedLogoURI
+	response.LocalizedTosURI = request.LocalizedTosURI
+	response.LocalizedPolicyURI = request.LocalizedPolicyURI
 
 	return response, nil
 }
@@ -165,7 +206,15 @@ func (ds *dcrService) convertDCRToApplication(request *DCRRegistrationRequest) (
 		scopes = strings.Fields(request.Scope)
 	}
 
-	// Generate client ID if client_name is not provided and use it as both app name and client ID
+	// Pre-generate the application ID so we can build an i18n template reference if needed.
+	appID, uuidErr := sysutils.GenerateUUIDv7()
+	if uuidErr != nil {
+		return nil, &ErrorServerError
+	}
+
+	// Generate client ID if client_name is not provided and use it as both app name and client ID.
+	// When localized variants are present without a client_name, use an i18n ref as the app name
+	// so the UI resolves the display name from the i18n table rather than falling back to the clientID.
 	var clientID string
 	appName := request.ClientName
 	if appName == "" {
@@ -174,7 +223,14 @@ func (ds *dcrService) convertDCRToApplication(request *DCRRegistrationRequest) (
 			return nil, &ErrorServerError
 		}
 		clientID = generatedClientID
-		appName = clientID
+		if len(request.LocalizedClientName) > 0 {
+			appName = application.AppI18nRef(appID, "name")
+		} else {
+			appName = clientID
+		}
+	} else if len(request.LocalizedClientName) > 0 {
+		// Store a template reference so the UI can resolve the name from the i18n table.
+		appName = application.AppI18nRef(appID, "name")
 	}
 
 	oauthAppConfig := &model.OAuthAppConfigDTO{
@@ -198,6 +254,7 @@ func (ds *dcrService) convertDCRToApplication(request *DCRRegistrationRequest) (
 	}
 
 	appDTO := &model.ApplicationDTO{
+		ID:                appID,
 		OUID:              request.OUID,
 		Name:              appName,
 		URL:               request.ClientURI,
@@ -301,6 +358,73 @@ func (ds *dcrService) convertApplicationToDCRResponse(appDTO *model.ApplicationD
 	}
 
 	return response, nil
+}
+
+// writeLocalizedVariants persists all localized variants from a DCR request to the i18n table.
+// The non-tagged default value for each field is also stored under SystemLanguage; an explicit
+// #SystemLanguage-tagged variant in the same request takes priority over the default.
+func (ds *dcrService) writeLocalizedVariants(
+	ctx context.Context, appID string, request *DCRRegistrationRequest) *serviceerror.ServiceError {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DCRService"))
+	if ds.i18nService == nil {
+		logger.Debug("i18n service not configured, skipping localized variant writes")
+		return nil
+	}
+	ns := application.AppI18nNamespace()
+	type fieldSpec struct {
+		variants    map[string]string
+		defaultVal  string
+		key         string
+		validateURI func(string) bool
+	}
+	fields := []fieldSpec{
+		{request.LocalizedClientName, request.ClientName, application.AppI18nKey(appID, "name"), nil},
+		{request.LocalizedLogoURI, request.LogoURI, application.AppI18nKey(appID, "logo_uri"), sysutils.IsValidLogoURI},
+		{request.LocalizedTosURI, request.TosURI, application.AppI18nKey(appID, "tos_uri"), sysutils.IsValidURI},
+		{request.LocalizedPolicyURI, request.PolicyURI,
+			application.AppI18nKey(appID, "policy_uri"), sysutils.IsValidURI},
+	}
+	entries := make(map[string]map[string]string)
+	for _, f := range fields {
+		for tag, val := range f.variants {
+			if f.validateURI != nil && !f.validateURI(val) {
+				return &ErrorInvalidClientMetadata
+			}
+			if entries[f.key] == nil {
+				entries[f.key] = make(map[string]string)
+			}
+			entries[f.key][tag] = val
+		}
+	}
+	for _, f := range fields {
+		if f.defaultVal == "" {
+			continue
+		}
+		if entries[f.key] == nil {
+			entries[f.key] = make(map[string]string)
+		}
+		if _, exists := entries[f.key][i18nmgt.SystemLanguage]; !exists {
+			entries[f.key][i18nmgt.SystemLanguage] = f.defaultVal
+		}
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	if svcErr := ds.i18nService.SetTranslationOverridesForNamespace(ctx, ns, entries); svcErr != nil {
+		if svcErr.Type == serviceerror.ClientErrorType {
+			logger.Debug("Invalid client metadata in localized variants",
+				log.String("appID", appID),
+				log.String("errorCode", svcErr.Code),
+				log.String("error", svcErr.Error.DefaultValue))
+			return &ErrorServerError
+		}
+		logger.Error("Failed to write localized variants",
+			log.String("appID", appID),
+			log.String("errorCode", svcErr.Code),
+			log.String("error", svcErr.Error.DefaultValue))
+		return &ErrorServerError
+	}
+	return nil
 }
 
 // mapApplicationErrorToDCRError maps Application service errors to DCR standard errors.

--- a/backend/internal/oauth/oauth2/dcr/service_test.go
+++ b/backend/internal/oauth/oauth2/dcr/service_test.go
@@ -25,13 +25,16 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/asgardeo/thunder/internal/application"
 	"github.com/asgardeo/thunder/internal/application/model"
 	"github.com/asgardeo/thunder/internal/cert"
 	inboundmodel "github.com/asgardeo/thunder/internal/inboundclient/model"
 	oauth2const "github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	i18ncore "github.com/asgardeo/thunder/internal/system/i18n/core"
+	i18nmgt "github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	"github.com/asgardeo/thunder/tests/mocks/applicationmock"
+	i18nmock "github.com/asgardeo/thunder/tests/mocks/i18n/mgtmock"
 	"github.com/asgardeo/thunder/tests/mocks/oumock"
 )
 
@@ -57,12 +60,12 @@ func (m *MockTransactioner) Transact(ctx context.Context, txFunc func(context.Co
 func (s *DCRServiceTestSuite) SetupTest() {
 	s.mockAppService = applicationmock.NewApplicationServiceInterfaceMock(s.T())
 	s.mockOUService = oumock.NewOrganizationUnitServiceInterfaceMock(s.T())
-	s.service = newDCRService(s.mockAppService, s.mockOUService, &MockTransactioner{})
+	s.service = newDCRService(s.mockAppService, s.mockOUService, nil, &MockTransactioner{})
 }
 
 // TestNewDCRService tests the service constructor
 func (s *DCRServiceTestSuite) TestNewDCRService() {
-	service := newDCRService(s.mockAppService, s.mockOUService, &MockTransactioner{})
+	service := newDCRService(s.mockAppService, s.mockOUService, nil, &MockTransactioner{})
 	s.NotNil(service)
 	s.Implements((*DCRServiceInterface)(nil), service)
 }
@@ -445,4 +448,301 @@ func (s *DCRServiceTestSuite) TestRegisterClient_EmptyInboundAuthConfig() {
 	s.NotNil(response)
 	s.Nil(err)
 	s.NotNil(response)
+}
+
+// TestRegisterClient_WithLocalizedVariants tests that localized fields are persisted and echoed,
+// and that the non-tagged default is stored under SystemLanguage.
+func (s *DCRServiceTestSuite) TestRegisterClient_WithLocalizedVariants() {
+	mockI18n := i18nmock.NewI18nServiceInterfaceMock(s.T())
+	svc := newDCRService(s.mockAppService, s.mockOUService, mockI18n, &MockTransactioner{})
+
+	request := &DCRRegistrationRequest{
+		OUID:                "test-ou-1",
+		ClientName:          "Test Client",
+		LocalizedClientName: map[string]string{"fr": "Client FR", "de": "Client DE"},
+		LocalizedLogoURI:    map[string]string{"fr": "https://example.fr/logo.png"},
+	}
+
+	appDTO := &model.ApplicationDTO{
+		ID:   "app-id",
+		Name: "Test Client",
+		InboundAuthConfig: []model.InboundAuthConfigDTO{
+			{
+				Type: model.OAuthInboundAuthType,
+				OAuthAppConfig: &model.OAuthAppConfigDTO{
+					ClientID:     "client-id",
+					ClientSecret: "client-secret",
+					Scopes:       []string{},
+				},
+			},
+		},
+	}
+
+	s.mockAppService.On(
+		"CreateApplication", mock.Anything, mock.AnythingOfType("*model.ApplicationDTO"),
+	).Return(appDTO, (*serviceerror.ServiceError)(nil))
+
+	mockI18n.On(
+		"SetTranslationOverridesForNamespace",
+		mock.Anything,
+		application.AppI18nNamespace(),
+		mock.MatchedBy(func(entries map[string]map[string]string) bool {
+			nameKey := application.AppI18nKey("app-id", "name")
+			logoKey := application.AppI18nKey("app-id", "logo_uri")
+			return entries[nameKey][i18nmgt.SystemLanguage] == "Test Client" &&
+				entries[nameKey]["fr"] == "Client FR" &&
+				entries[nameKey]["de"] == "Client DE" &&
+				entries[logoKey]["fr"] == "https://example.fr/logo.png" &&
+				entries[logoKey][i18nmgt.SystemLanguage] == ""
+		}),
+	).Return((*serviceerror.ServiceError)(nil))
+
+	response, err := svc.RegisterClient(context.Background(), request)
+
+	s.NotNil(response)
+	s.Nil(err)
+	s.Equal(map[string]string{"fr": "Client FR", "de": "Client DE"}, response.LocalizedClientName)
+	s.Equal(map[string]string{"fr": "https://example.fr/logo.png"}, response.LocalizedLogoURI)
+}
+
+// TestRegisterClient_DefaultOnlyStoresSystemLanguage verifies that when only the non-tagged
+// client_name is provided (no localized variants), it is stored under SystemLanguage.
+func (s *DCRServiceTestSuite) TestRegisterClient_DefaultOnlyStoresSystemLanguage() {
+	mockI18n := i18nmock.NewI18nServiceInterfaceMock(s.T())
+	svc := newDCRService(s.mockAppService, s.mockOUService, mockI18n, &MockTransactioner{})
+
+	request := &DCRRegistrationRequest{
+		OUID:       "test-ou-1",
+		ClientName: "My App",
+	}
+
+	appDTO := &model.ApplicationDTO{
+		ID:   "app-id",
+		Name: "My App",
+		InboundAuthConfig: []model.InboundAuthConfigDTO{
+			{
+				Type: model.OAuthInboundAuthType,
+				OAuthAppConfig: &model.OAuthAppConfigDTO{
+					ClientID: "client-id",
+					Scopes:   []string{},
+				},
+			},
+		},
+	}
+
+	s.mockAppService.On(
+		"CreateApplication", mock.Anything, mock.AnythingOfType("*model.ApplicationDTO"),
+	).Return(appDTO, (*serviceerror.ServiceError)(nil))
+
+	mockI18n.On(
+		"SetTranslationOverridesForNamespace",
+		mock.Anything,
+		application.AppI18nNamespace(),
+		mock.MatchedBy(func(entries map[string]map[string]string) bool {
+			nameKey := application.AppI18nKey("app-id", "name")
+			return entries[nameKey][i18nmgt.SystemLanguage] == "My App"
+		}),
+	).Return((*serviceerror.ServiceError)(nil))
+
+	response, err := svc.RegisterClient(context.Background(), request)
+
+	s.NotNil(response)
+	s.Nil(err)
+}
+
+// TestRegisterClient_TaggedSystemLanguageWinsOverDefault verifies that when both the non-tagged
+// default and an explicit #SystemLanguage-tagged variant are provided, the tagged variant wins.
+func (s *DCRServiceTestSuite) TestRegisterClient_TaggedSystemLanguageWinsOverDefault() {
+	mockI18n := i18nmock.NewI18nServiceInterfaceMock(s.T())
+	svc := newDCRService(s.mockAppService, s.mockOUService, mockI18n, &MockTransactioner{})
+
+	request := &DCRRegistrationRequest{
+		OUID:                "test-ou-1",
+		ClientName:          "My App",
+		LocalizedClientName: map[string]string{i18nmgt.SystemLanguage: "My App US"},
+	}
+
+	appDTO := &model.ApplicationDTO{
+		ID:   "app-id",
+		Name: "My App",
+		InboundAuthConfig: []model.InboundAuthConfigDTO{
+			{
+				Type: model.OAuthInboundAuthType,
+				OAuthAppConfig: &model.OAuthAppConfigDTO{
+					ClientID: "client-id",
+					Scopes:   []string{},
+				},
+			},
+		},
+	}
+
+	s.mockAppService.On(
+		"CreateApplication", mock.Anything, mock.AnythingOfType("*model.ApplicationDTO"),
+	).Return(appDTO, (*serviceerror.ServiceError)(nil))
+
+	mockI18n.On(
+		"SetTranslationOverridesForNamespace",
+		mock.Anything,
+		application.AppI18nNamespace(),
+		mock.MatchedBy(func(entries map[string]map[string]string) bool {
+			nameKey := application.AppI18nKey("app-id", "name")
+			// Tagged variant wins — must be "My App US", not "My App".
+			return entries[nameKey][i18nmgt.SystemLanguage] == "My App US"
+		}),
+	).Return((*serviceerror.ServiceError)(nil))
+
+	response, err := svc.RegisterClient(context.Background(), request)
+
+	s.NotNil(response)
+	s.Nil(err)
+	s.Equal(map[string]string{i18nmgt.SystemLanguage: "My App US"}, response.LocalizedClientName)
+}
+
+// TestRegisterClient_LocalizedVariantsWriteFailure tests that a failed i18n write triggers
+// partial-row cleanup and app compensation delete.
+func (s *DCRServiceTestSuite) TestRegisterClient_LocalizedVariantsWriteFailure() {
+	mockI18n := i18nmock.NewI18nServiceInterfaceMock(s.T())
+	svc := newDCRService(s.mockAppService, s.mockOUService, mockI18n, &MockTransactioner{})
+
+	request := &DCRRegistrationRequest{
+		OUID:                "test-ou-1",
+		ClientName:          "Test Client",
+		LocalizedClientName: map[string]string{"fr": "Client FR"},
+	}
+
+	appDTO := &model.ApplicationDTO{
+		ID:   "app-id",
+		Name: "Test Client",
+		InboundAuthConfig: []model.InboundAuthConfigDTO{
+			{
+				Type: model.OAuthInboundAuthType,
+				OAuthAppConfig: &model.OAuthAppConfigDTO{
+					ClientID: "client-id",
+					Scopes:   []string{},
+				},
+			},
+		},
+	}
+
+	i18nErr := &serviceerror.ServiceError{Code: "I18N-500"}
+
+	s.mockAppService.On(
+		"CreateApplication", mock.Anything, mock.AnythingOfType("*model.ApplicationDTO"),
+	).Return(appDTO, (*serviceerror.ServiceError)(nil))
+	mockI18n.On(
+		"SetTranslationOverridesForNamespace",
+		mock.Anything,
+		application.AppI18nNamespace(),
+		mock.Anything,
+	).Return(i18nErr)
+	mockI18n.On("DeleteTranslationsByKey", mock.Anything, application.AppI18nNamespace(), mock.Anything).
+		Return((*serviceerror.ServiceError)(nil))
+	s.mockAppService.On("DeleteApplication", mock.Anything, "app-id").
+		Return((*serviceerror.ServiceError)(nil))
+
+	response, err := svc.RegisterClient(context.Background(), request)
+
+	s.Nil(response)
+	s.NotNil(err)
+	s.Equal(ErrorServerError.Code, err.Code)
+	mockI18n.AssertExpectations(s.T())
+	s.mockAppService.AssertExpectations(s.T())
+}
+
+// TestRegisterClient_InvalidLocalizedURI tests AC-13: a localized URI variant that fails URI
+// validation must return ErrorInvalidClientMetadata and trigger the compensation rollback.
+func (s *DCRServiceTestSuite) TestRegisterClient_InvalidLocalizedURI() {
+	mockI18n := i18nmock.NewI18nServiceInterfaceMock(s.T())
+	svc := newDCRService(s.mockAppService, s.mockOUService, mockI18n, &MockTransactioner{})
+
+	request := &DCRRegistrationRequest{
+		OUID:             "test-ou-1",
+		ClientName:       "Test Client",
+		LocalizedLogoURI: map[string]string{"fr": "not-a-valid-uri"},
+	}
+
+	appDTO := &model.ApplicationDTO{
+		ID:   "app-id",
+		Name: "Test Client",
+		InboundAuthConfig: []model.InboundAuthConfigDTO{
+			{
+				Type: model.OAuthInboundAuthType,
+				OAuthAppConfig: &model.OAuthAppConfigDTO{
+					ClientID: "client-id",
+					Scopes:   []string{},
+				},
+			},
+		},
+	}
+
+	s.mockAppService.On(
+		"CreateApplication", mock.Anything, mock.AnythingOfType("*model.ApplicationDTO"),
+	).Return(appDTO, (*serviceerror.ServiceError)(nil))
+	// URI validation fails before any i18n writes; compensation still runs.
+	mockI18n.On("DeleteTranslationsByKey", mock.Anything, application.AppI18nNamespace(), mock.Anything).
+		Return((*serviceerror.ServiceError)(nil))
+	s.mockAppService.On("DeleteApplication", mock.Anything, "app-id").
+		Return((*serviceerror.ServiceError)(nil))
+
+	response, err := svc.RegisterClient(context.Background(), request)
+
+	s.Nil(response)
+	s.NotNil(err)
+	s.Equal(ErrorInvalidClientMetadata.Code, err.Code)
+	mockI18n.AssertExpectations(s.T())
+	s.mockAppService.AssertExpectations(s.T())
+}
+
+// TestRegisterClient_LocalizedVariantsWriteFailure_ClientError tests that a ClientErrorType
+// i18n error maps to ErrorServerError to avoid leaking internal details to external callers.
+func (s *DCRServiceTestSuite) TestRegisterClient_LocalizedVariantsWriteFailure_ClientError() {
+	mockI18n := i18nmock.NewI18nServiceInterfaceMock(s.T())
+	svc := newDCRService(s.mockAppService, s.mockOUService, mockI18n, &MockTransactioner{})
+
+	request := &DCRRegistrationRequest{
+		OUID:                "test-ou-1",
+		ClientName:          "Test Client",
+		LocalizedClientName: map[string]string{"fr": "Client FR"},
+	}
+
+	appDTO := &model.ApplicationDTO{
+		ID:   "app-id",
+		Name: "Test Client",
+		InboundAuthConfig: []model.InboundAuthConfigDTO{
+			{
+				Type: model.OAuthInboundAuthType,
+				OAuthAppConfig: &model.OAuthAppConfigDTO{
+					ClientID: "client-id",
+					Scopes:   []string{},
+				},
+			},
+		},
+	}
+
+	i18nClientErr := &serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "I18N-4001",
+	}
+
+	s.mockAppService.On(
+		"CreateApplication", mock.Anything, mock.AnythingOfType("*model.ApplicationDTO"),
+	).Return(appDTO, (*serviceerror.ServiceError)(nil))
+	mockI18n.On(
+		"SetTranslationOverridesForNamespace",
+		mock.Anything,
+		application.AppI18nNamespace(),
+		mock.Anything,
+	).Return(i18nClientErr)
+	mockI18n.On("DeleteTranslationsByKey", mock.Anything, application.AppI18nNamespace(), mock.Anything).
+		Return((*serviceerror.ServiceError)(nil))
+	s.mockAppService.On("DeleteApplication", mock.Anything, "app-id").
+		Return((*serviceerror.ServiceError)(nil))
+
+	response, err := svc.RegisterClient(context.Background(), request)
+
+	s.Nil(response)
+	s.NotNil(err)
+	s.Equal(ErrorServerError.Code, err.Code)
+	mockI18n.AssertExpectations(s.T())
+	s.mockAppService.AssertExpectations(s.T())
 }

--- a/backend/internal/system/i18n/mgt/I18nServiceInterface_mock_test.go
+++ b/backend/internal/system/i18n/mgt/I18nServiceInterface_mock_test.go
@@ -5,6 +5,8 @@
 package mgt
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -150,6 +152,194 @@ func (_c *I18nServiceInterfaceMock_ClearTranslationOverrides_Call) Return(servic
 }
 
 func (_c *I18nServiceInterfaceMock_ClearTranslationOverrides_Call) RunAndReturn(run func(language string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_ClearTranslationOverrides_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteTranslationsByKey provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) DeleteTranslationsByKey(ctx context.Context, namespace string, key string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, namespace, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByKey")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, namespace, key)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// I18nServiceInterfaceMock_DeleteTranslationsByKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByKey'
+type I18nServiceInterfaceMock_DeleteTranslationsByKey_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - key string
+func (_e *I18nServiceInterfaceMock_Expecter) DeleteTranslationsByKey(ctx interface{}, namespace interface{}, key interface{}) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	return &I18nServiceInterfaceMock_DeleteTranslationsByKey_Call{Call: _e.mock.On("DeleteTranslationsByKey", ctx, namespace, key)}
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call) Run(run func(ctx context.Context, namespace string, key string)) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call) Return(serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call) RunAndReturn(run func(ctx context.Context, namespace string, key string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteTranslationsByNamespace provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) DeleteTranslationsByNamespace(ctx context.Context, namespace string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByNamespace")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByNamespace'
+type I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+func (_e *I18nServiceInterfaceMock_Expecter) DeleteTranslationsByNamespace(ctx interface{}, namespace interface{}) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	return &I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call{Call: _e.mock.On("DeleteTranslationsByNamespace", ctx, namespace)}
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call) Run(run func(ctx context.Context, namespace string)) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call) Return(serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTranslationsByNamespace provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) GetTranslationsByNamespace(namespace string) (map[string]map[string]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTranslationsByNamespace")
+	}
+
+	var r0 map[string]map[string]string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string) (map[string]map[string]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(namespace)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) map[string]map[string]string); ok {
+		r0 = returnFunc(namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(namespace)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// I18nServiceInterfaceMock_GetTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTranslationsByNamespace'
+type I18nServiceInterfaceMock_GetTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// GetTranslationsByNamespace is a helper method to define mock.On call
+//   - namespace string
+func (_e *I18nServiceInterfaceMock_Expecter) GetTranslationsByNamespace(namespace interface{}) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
+	return &I18nServiceInterfaceMock_GetTranslationsByNamespace_Call{Call: _e.mock.On("GetTranslationsByNamespace", namespace)}
+}
+
+func (_c *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call) Run(run func(namespace string)) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call) Return(stringToStringToString map[string]map[string]string, serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
+	_c.Call.Return(stringToStringToString, serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call) RunAndReturn(run func(namespace string) (map[string]map[string]string, *serviceerror.ServiceError)) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -505,6 +695,71 @@ func (_c *I18nServiceInterfaceMock_SetTranslationOverrides_Call) Return(language
 }
 
 func (_c *I18nServiceInterfaceMock_SetTranslationOverrides_Call) RunAndReturn(run func(language string, translations map[string]map[string]string) (*LanguageTranslationsResponse, *serviceerror.ServiceError)) *I18nServiceInterfaceMock_SetTranslationOverrides_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetTranslationOverridesForNamespace provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) SetTranslationOverridesForNamespace(ctx context.Context, namespace string, entries map[string]map[string]string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, namespace, entries)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetTranslationOverridesForNamespace")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]map[string]string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, namespace, entries)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetTranslationOverridesForNamespace'
+type I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call struct {
+	*mock.Call
+}
+
+// SetTranslationOverridesForNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - entries map[string]map[string]string
+func (_e *I18nServiceInterfaceMock_Expecter) SetTranslationOverridesForNamespace(ctx interface{}, namespace interface{}, entries interface{}) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
+	return &I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call{Call: _e.mock.On("SetTranslationOverridesForNamespace", ctx, namespace, entries)}
+}
+
+func (_c *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call) Run(run func(ctx context.Context, namespace string, entries map[string]map[string]string)) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 map[string]map[string]string
+		if args[2] != nil {
+			arg2 = args[2].(map[string]map[string]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call) Return(serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string, entries map[string]map[string]string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/system/i18n/mgt/constants.go
+++ b/backend/internal/system/i18n/mgt/constants.go
@@ -44,6 +44,21 @@ var namespaceRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // Keys can contain alphanumeric characters, dots, underscores, and hyphens.
 var keyRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
+const maxBCP47TagLength = 35
+
+// NormaliseBCP47Tag returns the canonical BCP 47 form of tag (e.g. "en-US" for "en-us").
+// Returns ("", false) if the tag is empty, exceeds the length limit, or is not a valid BCP 47 tag.
+func NormaliseBCP47Tag(tag string) (string, bool) {
+	if tag == "" || len(tag) > maxBCP47TagLength {
+		return "", false
+	}
+	t, err := goi18n.Parse(tag)
+	if err != nil {
+		return "", false
+	}
+	return t.String(), true
+}
+
 // ValidateLanguage validates that a language tag is in the canonical form according to BCP 47 format.
 func ValidateLanguage(language string) bool {
 	tag, err := goi18n.BCP47.Parse(language)

--- a/backend/internal/system/i18n/mgt/file_based_store.go
+++ b/backend/internal/system/i18n/mgt/file_based_store.go
@@ -19,6 +19,7 @@
 package mgt
 
 import (
+	"context"
 	"errors"
 
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
@@ -160,6 +161,11 @@ func (f *fileBasedStore) UpsertTranslation(trans Translation) error {
 	return errors.New("UpsertTranslation is not supported in file-based store")
 }
 
+// UpsertTranslations is not supported in file-based store.
+func (f *fileBasedStore) UpsertTranslations(_ context.Context, _ []Translation) error {
+	return errors.New("UpsertTranslations is not supported in file-based store")
+}
+
 // DeleteTranslationsByLanguage is not supported in file-based store.
 func (f *fileBasedStore) DeleteTranslationsByLanguage(language string) error {
 	return errors.New("DeleteTranslationsByLanguage is not supported in file-based store")
@@ -168,6 +174,16 @@ func (f *fileBasedStore) DeleteTranslationsByLanguage(language string) error {
 // DeleteTranslation is not supported in file-based store.
 func (f *fileBasedStore) DeleteTranslation(language string, key string, namespace string) error {
 	return errors.New("DeleteTranslation is not supported in file-based store")
+}
+
+// DeleteTranslationsByNamespace is not supported in file-based store.
+func (f *fileBasedStore) DeleteTranslationsByNamespace(_ context.Context, _ string) error {
+	return errors.New("DeleteTranslationsByNamespace is not supported in file-based store")
+}
+
+// DeleteTranslationsByKey is not supported in file-based store.
+func (f *fileBasedStore) DeleteTranslationsByKey(_ context.Context, namespace string, key string) error {
+	return errors.New("DeleteTranslationsByKey is not supported in file-based store")
 }
 
 // IsTranslationDeclarative checks if a translation is immutable (exists in file store).

--- a/backend/internal/system/i18n/mgt/file_based_store_test.go
+++ b/backend/internal/system/i18n/mgt/file_based_store_test.go
@@ -19,6 +19,7 @@
 package mgt
 
 import (
+	"context"
 	"testing"
 
 	declarativeresource "github.com/asgardeo/thunder/internal/system/declarative_resource"
@@ -250,6 +251,18 @@ func (s *FileBasedStoreTestSuite) TestDeleteTranslationsByLanguage_NotSupported(
 
 func (s *FileBasedStoreTestSuite) TestDeleteTranslation_NotSupported() {
 	err := s.store.DeleteTranslation("en-US", "key", "ns")
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "not supported")
+}
+
+func (s *FileBasedStoreTestSuite) TestDeleteTranslationsByNamespace_NotSupported() {
+	err := s.store.DeleteTranslationsByNamespace(context.Background(), "app.test-id")
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "not supported")
+}
+
+func (s *FileBasedStoreTestSuite) TestDeleteTranslationsByKey_NotSupported() {
+	err := s.store.DeleteTranslationsByKey(context.Background(), "custom", "app.test-id.name")
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "not supported")
 }

--- a/backend/internal/system/i18n/mgt/i18nStoreInterface_mock_test.go
+++ b/backend/internal/system/i18n/mgt/i18nStoreInterface_mock_test.go
@@ -5,6 +5,8 @@
 package mgt
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -98,6 +100,69 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) RunAndReturn(run func(l
 	return _c
 }
 
+// DeleteTranslationsByKey provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByKey(ctx context.Context, namespace string, key string) error {
+	ret := _mock.Called(ctx, namespace, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, namespace, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// i18nStoreInterfaceMock_DeleteTranslationsByKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByKey'
+type i18nStoreInterfaceMock_DeleteTranslationsByKey_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - key string
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByKey(ctx interface{}, namespace interface{}, key interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslationsByKey_Call{Call: _e.mock.On("DeleteTranslationsByKey", ctx, namespace, key)}
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) Run(run func(ctx context.Context, namespace string, key string)) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) Return(err error) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) RunAndReturn(run func(ctx context.Context, namespace string, key string) error) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteTranslationsByLanguage provides a mock function for the type i18nStoreInterfaceMock
 func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByLanguage(language string) error {
 	ret := _mock.Called(language)
@@ -145,6 +210,63 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Return(err e
 }
 
 func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) RunAndReturn(run func(language string) error) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteTranslationsByNamespace provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByNamespace(ctx context.Context, namespace string) error {
+	ret := _mock.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByNamespace")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByNamespace'
+type i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByNamespace(ctx interface{}, namespace interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call{Call: _e.mock.On("DeleteTranslationsByNamespace", ctx, namespace)}
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) Run(run func(ctx context.Context, namespace string)) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) Return(err error) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string) error) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -436,6 +558,63 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Return(err error) *i18n
 }
 
 func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) RunAndReturn(run func(trans Translation) error) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertTranslations provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) UpsertTranslations(ctx context.Context, translations []Translation) error {
+	ret := _mock.Called(ctx, translations)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertTranslations")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []Translation) error); ok {
+		r0 = returnFunc(ctx, translations)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// i18nStoreInterfaceMock_UpsertTranslations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertTranslations'
+type i18nStoreInterfaceMock_UpsertTranslations_Call struct {
+	*mock.Call
+}
+
+// UpsertTranslations is a helper method to define mock.On call
+//   - ctx context.Context
+//   - translations []Translation
+func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslations(ctx interface{}, translations interface{}) *i18nStoreInterfaceMock_UpsertTranslations_Call {
+	return &i18nStoreInterfaceMock_UpsertTranslations_Call{Call: _e.mock.On("UpsertTranslations", ctx, translations)}
+}
+
+func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) Run(run func(ctx context.Context, translations []Translation)) *i18nStoreInterfaceMock_UpsertTranslations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []Translation
+		if args[1] != nil {
+			arg1 = args[1].([]Translation)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) Return(err error) *i18nStoreInterfaceMock_UpsertTranslations_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) RunAndReturn(run func(ctx context.Context, translations []Translation) error) *i18nStoreInterfaceMock_UpsertTranslations_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/system/i18n/mgt/service.go
+++ b/backend/internal/system/i18n/mgt/service.go
@@ -20,7 +20,9 @@
 package mgt
 
 import (
+	"context"
 	"slices"
+	"strings"
 
 	goi18n "golang.org/x/text/language"
 
@@ -44,7 +46,14 @@ type I18nServiceInterface interface {
 		*TranslationResponse, *serviceerror.ServiceError)
 	SetTranslationOverrideForKey(language string, namespace string, key string, value string) (
 		*TranslationResponse, *serviceerror.ServiceError)
+	SetTranslationOverridesForNamespace(ctx context.Context, namespace string,
+		entries map[string]map[string]string) *serviceerror.ServiceError
 	ClearTranslationOverrideForKey(language string, namespace string, key string) *serviceerror.ServiceError
+	DeleteTranslationsByNamespace(ctx context.Context, namespace string) *serviceerror.ServiceError
+	DeleteTranslationsByKey(ctx context.Context, namespace string, key string) *serviceerror.ServiceError
+	// GetTranslationsByNamespace returns all raw translations for a namespace as
+	// map[key]map[language]value without locale resolution or best-match logic.
+	GetTranslationsByNamespace(namespace string) (map[string]map[string]string, *serviceerror.ServiceError)
 }
 
 // i18nService is the default implementation of I18nServiceInterface.
@@ -166,6 +175,50 @@ func (s *i18nService) SetTranslationOverrideForKey(
 	}, nil
 }
 
+// SetTranslationOverridesForNamespace creates or updates all provided key/language/value entries
+// for a single namespace. When ctx carries an outer configDB transaction the writes join it.
+// entries is map[key]map[language]value.
+func (s *i18nService) SetTranslationOverridesForNamespace(
+	ctx context.Context, namespace string, entries map[string]map[string]string) *serviceerror.ServiceError {
+	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
+		return err
+	}
+	if !ValidateNamespace(namespace) {
+		return &ErrorInvalidNamespace
+	}
+	translations := make([]Translation, 0)
+	for key, langMap := range entries {
+		if !ValidateKey(key) {
+			return &ErrorInvalidKey
+		}
+		for language, value := range langMap {
+			if language == "" {
+				return &ErrorMissingLanguage
+			}
+			if !ValidateLanguage(language) {
+				return &ErrorInvalidLanguage
+			}
+			if value == "" {
+				return &ErrorMissingValue
+			}
+			translations = append(translations, Translation{
+				Key:       key,
+				Language:  language,
+				Namespace: namespace,
+				Value:     value,
+			})
+		}
+	}
+	if len(translations) == 0 {
+		return nil
+	}
+	if err := s.store.UpsertTranslations(ctx, translations); err != nil {
+		s.logger.Error("Failed to set translation overrides for namespace", log.Error(err))
+		return &serviceerror.InternalServerError
+	}
+	return nil
+}
+
 // ClearTranslationOverrideForKey removes the custom override for a single translation.
 func (s *i18nService) ClearTranslationOverrideForKey(
 	language string, namespace string, key string) *serviceerror.ServiceError {
@@ -243,6 +296,10 @@ func (s *i18nService) ResolveTranslations(
 	result := make(map[string]map[string]string)
 	for _, translations := range allTranslations {
 		translation := selectBestTranslation(translations, requestedLang)
+
+		if translation.Value == "" {
+			continue
+		}
 		if result[translation.Namespace] == nil {
 			result[translation.Namespace] = make(map[string]string)
 		}
@@ -331,6 +388,67 @@ func (s *i18nService) ClearTranslationOverrides(language string) *serviceerror.S
 	}
 
 	return nil
+}
+
+// DeleteTranslationsByKey removes all translations for a specific namespace+key pair.
+func (s *i18nService) DeleteTranslationsByKey(
+	ctx context.Context, namespace string, key string) *serviceerror.ServiceError {
+	if !ValidateNamespace(namespace) {
+		return &ErrorInvalidNamespace
+	}
+	if !ValidateKey(key) {
+		return &ErrorInvalidKey
+	}
+	if err := s.store.DeleteTranslationsByKey(ctx, namespace, key); err != nil {
+		s.logger.Error("Failed to delete translations by namespace and key", log.Error(err))
+		return &serviceerror.InternalServerError
+	}
+	return nil
+}
+
+// DeleteTranslationsByNamespace removes all translations under the given namespace.
+// When ctx carries an outer configDB transaction the delete joins it.
+func (s *i18nService) DeleteTranslationsByNamespace(
+	ctx context.Context, namespace string) *serviceerror.ServiceError {
+	if !ValidateNamespace(namespace) {
+		return &ErrorInvalidNamespace
+	}
+	if err := s.store.DeleteTranslationsByNamespace(ctx, namespace); err != nil {
+		s.logger.Error("Failed to delete translations by namespace", log.Error(err))
+		return &serviceerror.InternalServerError
+	}
+	return nil
+}
+
+// GetTranslationsByNamespace returns all raw translations for a namespace as
+// map[key]map[language]value without locale resolution. Used to load all locale
+// variants for a resource in a single query.
+func (s *i18nService) GetTranslationsByNamespace(
+	namespace string) (map[string]map[string]string, *serviceerror.ServiceError) {
+	if !ValidateNamespace(namespace) {
+		return nil, &ErrorInvalidNamespace
+	}
+	byNs, err := s.store.GetTranslationsByNamespace(namespace)
+	if err != nil {
+		s.logger.Error("Failed to get translations by namespace", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	result := make(map[string]map[string]string, len(byNs))
+	for compositeKey, langs := range byNs {
+		// compositeKey is "namespace|key" — drop the namespace prefix.
+		idx := strings.Index(compositeKey, "|")
+		if idx < 0 {
+			continue
+		}
+		fieldKey := compositeKey[idx+1:]
+		for lang, trans := range langs {
+			if result[fieldKey] == nil {
+				result[fieldKey] = make(map[string]string)
+			}
+			result[fieldKey][lang] = trans.Value
+		}
+	}
+	return result, nil
 }
 
 func (s *i18nService) clearAllOverrides(language string) error {

--- a/backend/internal/system/i18n/mgt/service_test.go
+++ b/backend/internal/system/i18n/mgt/service_test.go
@@ -19,6 +19,7 @@
 package mgt
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -518,6 +519,136 @@ func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AllNamespaces_Stor
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
+const testAppNamespace = "app-abc-123"
+
+// ResolveTranslations — non-system namespace exact-match behavior.
+
+// TestResolveTranslations_AppNamespace_ExactMatch verifies that when the requested language
+// exactly matches a stored translation in a non-system namespace, that value is returned.
+func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AppNamespace_ExactMatch() {
+	ns := testAppNamespace
+	dbTranslations := map[string]map[string]Translation{
+		ns + "|name": {
+			"fr": {Key: "name", Namespace: ns, Language: "fr", Value: "Mon Application"},
+		},
+	}
+	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbTranslations, nil)
+
+	result, err := suite.service.ResolveTranslations("fr", ns)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal("Mon Application", result.Translations[ns]["name"])
+}
+
+// TestResolveTranslations_AppNamespace_BestMatchFallback verifies that when the requested
+// language has no exact match in a non-system namespace, BCP47 best-match returns the closest
+// available translation (consistent with system-namespace behavior).
+func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_AppNamespace_BestMatchFallback() {
+	ns := testAppNamespace
+	// Only "fr" is stored; "en" is requested — best-match returns the only available value.
+	dbTranslations := map[string]map[string]Translation{
+		ns + "|name": {
+			"fr": {Key: "name", Namespace: ns, Language: "fr", Value: "Mon Application"},
+		},
+	}
+	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbTranslations, nil)
+
+	result, err := suite.service.ResolveTranslations("en", ns)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	// Best-match returns "fr" (the only stored language).
+	suite.Equal("Mon Application", result.Translations[ns]["name"])
+}
+
+// TestResolveTranslations_SystemNamespace_StillFallsBack verifies that the system namespace
+// continues to use BCP47 best-match fallback after the fix.
+func (suite *I18nMgtServiceTestSuite) TestResolveTranslations_SystemNamespace_StillFallsBack() {
+	key := testErrKey
+	frTranslation := Translation{Key: key, Namespace: SystemNamespace, Language: "fr", Value: "Erreur"}
+	dbTranslations := map[string]map[string]Translation{
+		SystemNamespace + "|" + key: {"fr": frTranslation},
+	}
+	suite.mockStore.On("GetTranslationsByNamespace", SystemNamespace).Return(dbTranslations, nil)
+
+	// Request "en-US" — no en-US stored, but system defaults fill it in.
+	result, err := suite.service.ResolveTranslations("en-US", SystemNamespace)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	// System default should be present (filled from sysi18n defaults), not the French value.
+	suite.Contains(result.Translations[SystemNamespace], key)
+	suite.NotEqual("Erreur", result.Translations[SystemNamespace][key])
+}
+
+// ResolveTranslationsForKey — non-system namespace exact-match behavior.
+
+// TestResolveTranslationsForKey_AppNamespace_ExactMatch verifies exact-match lookup for a key
+// in a non-system namespace when the requested language is stored.
+func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_AppNamespace_ExactMatch() {
+	ns := testAppNamespace
+	key := "name"
+	suite.mockStore.On("GetTranslationsByKey", key, ns).Return(map[string]Translation{
+		"fr": {Key: key, Namespace: ns, Language: "fr", Value: "Mon Application"},
+	}, nil)
+
+	result, err := suite.service.ResolveTranslationsForKey("fr", ns, key)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal("Mon Application", result.Value)
+}
+
+// TestResolveTranslationsForKey_AppNamespace_BestMatchFallback verifies that when the requested
+// language has no exact match in a non-system namespace, BCP47 best-match returns the closest
+// available translation (consistent with system-namespace behavior).
+func (suite *I18nMgtServiceTestSuite) TestResolveTranslationsForKey_AppNamespace_BestMatchFallback() {
+	ns := testAppNamespace
+	key := "name"
+	// Only "fr" stored; "en" requested — best-match returns the only available value.
+	suite.mockStore.On("GetTranslationsByKey", key, ns).Return(map[string]Translation{
+		"fr": {Key: key, Namespace: ns, Language: "fr", Value: "Mon Application"},
+	}, nil)
+
+	result, err := suite.service.ResolveTranslationsForKey("en", ns, key)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal("Mon Application", result.Value)
+}
+
+// NormaliseBCP47Tag Tests
+
+func TestNormaliseBCP47Tag(t *testing.T) {
+	tests := []struct {
+		name      string
+		tag       string
+		wantTag   string
+		wantValid bool
+	}{
+		{"EmptyTag", "", "", false},
+		{"TooLong", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "", false},
+		{"InvalidTag", "not-a-valid-!!-tag", "", false},
+		{"ValidSimple", "fr", "fr", true},
+		{"ValidWithRegion", "en-US", "en-US", true},
+		{"NormalisesCase", "en-us", "en-US", true},
+		{"NormalisesUppercase", "FR", "fr", true},
+		{"ValidComplex", "zh-Hans-CN", "zh-Hans-CN", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, valid := NormaliseBCP47Tag(tc.tag)
+			if valid != tc.wantValid {
+				t.Errorf("NormaliseBCP47Tag(%q) valid = %v, want %v", tc.tag, valid, tc.wantValid)
+			}
+			if tc.wantValid && got != tc.wantTag {
+				t.Errorf("NormaliseBCP47Tag(%q) tag = %q, want %q", tc.tag, got, tc.wantTag)
+			}
+		})
+	}
+}
+
 func (suite *I18nMgtServiceTestSuite) TestCompareLangs() {
 	// Directly test the unexported compareLangs function
 
@@ -664,4 +795,130 @@ func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrides_Declarative(
 
 	suite.NotNil(err)
 	suite.Equal(declarativeresource.ErrorDeclarativeResourceDeleteOperation.Code, err.Code)
+}
+
+// GetTranslationsByNamespace Tests
+
+func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_InvalidNamespace() {
+	result, err := suite.service.GetTranslationsByNamespace("invalid!")
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidNamespace.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_StoreError() {
+	suite.mockStore.On("GetTranslationsByNamespace", "app-test").
+		Return(nil, errors.New("db error"))
+
+	result, err := suite.service.GetTranslationsByNamespace("app-test")
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_Success() {
+	ns := "app-test"
+	dbData := map[string]map[string]Translation{
+		ns + "|name": {
+			"fr": {Key: "name", Namespace: ns, Language: "fr", Value: "Mon App"},
+			"de": {Key: "name", Namespace: ns, Language: "de", Value: "Meine App"},
+		},
+		ns + "|logo_uri": {
+			"fr": {Key: "logo_uri", Namespace: ns, Language: "fr", Value: "https://example.com/fr/logo.png"},
+		},
+	}
+	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbData, nil)
+
+	result, err := suite.service.GetTranslationsByNamespace(ns)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal("Mon App", result["name"]["fr"])
+	suite.Equal("Meine App", result["name"]["de"])
+	suite.Equal("https://example.com/fr/logo.png", result["logo_uri"]["fr"])
+}
+
+func (suite *I18nMgtServiceTestSuite) TestGetTranslationsByNamespace_SkipsMalformedCompositeKey() {
+	ns := "app-test"
+	// A key without "|" separator should be skipped
+	dbData := map[string]map[string]Translation{
+		"malformed-key": {
+			"fr": {Key: "name", Namespace: ns, Language: "fr", Value: "Mon App"},
+		},
+		ns + "|name": {
+			"en": {Key: "name", Namespace: ns, Language: "en", Value: "My App"},
+		},
+	}
+	suite.mockStore.On("GetTranslationsByNamespace", ns).Return(dbData, nil)
+
+	result, err := suite.service.GetTranslationsByNamespace(ns)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	// Malformed key is skipped; valid key is present
+	suite.Equal("My App", result["name"]["en"])
+	suite.NotContains(result, "malformed-key")
+}
+
+// DeleteTranslationsByNamespace Tests
+
+func (suite *I18nMgtServiceTestSuite) TestDeleteTranslationsByNamespace_InvalidNamespace() {
+	err := suite.service.DeleteTranslationsByNamespace(context.Background(), "invalid!")
+
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidNamespace.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestDeleteTranslationsByNamespace_StoreError() {
+	suite.mockStore.On("DeleteTranslationsByNamespace", mock.Anything, "app-test").
+		Return(errors.New("db error"))
+
+	err := suite.service.DeleteTranslationsByNamespace(context.Background(), "app-test")
+
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestDeleteTranslationsByNamespace_Success() {
+	suite.mockStore.On("DeleteTranslationsByNamespace", mock.Anything, "app-test").Return(nil)
+
+	err := suite.service.DeleteTranslationsByNamespace(context.Background(), "app-test")
+
+	suite.Nil(err)
+}
+
+// DeleteTranslationsByKey Tests
+
+func (suite *I18nMgtServiceTestSuite) TestDeleteTranslationsByKey_InvalidNamespace() {
+	err := suite.service.DeleteTranslationsByKey(context.Background(), "invalid!", "name")
+
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidNamespace.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestDeleteTranslationsByKey_InvalidKey() {
+	err := suite.service.DeleteTranslationsByKey(context.Background(), "custom", "invalid key!")
+
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidKey.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestDeleteTranslationsByKey_StoreError() {
+	suite.mockStore.On("DeleteTranslationsByKey", mock.Anything, "custom", "app.test-id.name").
+		Return(errors.New("db error"))
+
+	err := suite.service.DeleteTranslationsByKey(context.Background(), "custom", "app.test-id.name")
+
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestDeleteTranslationsByKey_Success() {
+	suite.mockStore.On("DeleteTranslationsByKey", mock.Anything, "custom", "app.test-id.name").Return(nil)
+
+	err := suite.service.DeleteTranslationsByKey(context.Background(), "custom", "app.test-id.name")
+
+	suite.Nil(err)
 }

--- a/backend/internal/system/i18n/mgt/store.go
+++ b/backend/internal/system/i18n/mgt/store.go
@@ -19,6 +19,7 @@
 package mgt
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -34,8 +35,11 @@ type i18nStoreInterface interface {
 	GetTranslationsByKey(key string, namespace string) (map[string]Translation, error)
 	UpsertTranslationsByLanguage(language string, translations []Translation) error
 	UpsertTranslation(trans Translation) error
+	UpsertTranslations(ctx context.Context, translations []Translation) error
 	DeleteTranslationsByLanguage(language string) error
 	DeleteTranslation(language string, key string, namespace string) error
+	DeleteTranslationsByNamespace(ctx context.Context, namespace string) error
+	DeleteTranslationsByKey(ctx context.Context, namespace string, key string) error
 }
 
 // i18nStore is the default implementation of i18nStoreInterface.
@@ -187,6 +191,24 @@ func (s *i18nStore) UpsertTranslation(trans Translation) error {
 	return nil
 }
 
+// UpsertTranslations creates or updates multiple translations.
+// When ctx carries an outer configDB transaction the upserts join it atomically.
+// Without an outer transaction each upsert runs independently.
+func (s *i18nStore) UpsertTranslations(ctx context.Context, translations []Translation) error {
+	dbClient, err := s.getDBClient()
+	if err != nil {
+		return err
+	}
+
+	for _, trans := range translations {
+		if _, err = dbClient.ExecuteContext(ctx, queryUpsertTranslation, trans.Key, trans.Language,
+			trans.Namespace, trans.Value, s.deploymentID); err != nil {
+			return fmt.Errorf("failed to upsert translation: %w", err)
+		}
+	}
+	return nil
+}
+
 // DeleteTranslation deletes a translation by language, key, and namespace.
 func (s *i18nStore) DeleteTranslation(language string, key string, namespace string) error {
 	dbClient, err := s.getDBClient()
@@ -211,6 +233,36 @@ func (s *i18nStore) DeleteTranslationsByLanguage(language string) error {
 	_, err = dbClient.Execute(queryDeleteTranslationsByLanguage, language, s.deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to delete translation: %w", err)
+	}
+	return nil
+}
+
+// DeleteTranslationsByKey deletes all translations for the given namespace and key.
+// When ctx carries an outer configDB transaction the delete joins it atomically.
+func (s *i18nStore) DeleteTranslationsByKey(ctx context.Context, namespace string, key string) error {
+	dbClient, err := s.getDBClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = dbClient.ExecuteContext(ctx, queryDeleteTranslationsByKey, namespace, key, s.deploymentID)
+	if err != nil {
+		return fmt.Errorf("failed to delete translations by namespace and key: %w", err)
+	}
+	return nil
+}
+
+// DeleteTranslationsByNamespace deletes all translations for the given namespace.
+// When ctx carries an outer configDB transaction the delete joins it atomically.
+func (s *i18nStore) DeleteTranslationsByNamespace(ctx context.Context, namespace string) error {
+	dbClient, err := s.getDBClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = dbClient.ExecuteContext(ctx, queryDeleteTranslationsByNamespace, namespace, s.deploymentID)
+	if err != nil {
+		return fmt.Errorf("failed to delete translations by namespace: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/system/i18n/mgt/store_constants.go
+++ b/backend/internal/system/i18n/mgt/store_constants.go
@@ -83,4 +83,16 @@ var (
 		ID:    "I18N-08",
 		Query: `DELETE FROM TRANSLATION WHERE LANGUAGE_CODE = $1 AND DEPLOYMENT_ID = $2`,
 	}
+
+	// queryDeleteTranslationsByNamespace deletes all translations for a given namespace.
+	queryDeleteTranslationsByNamespace = dbmodel.DBQuery{
+		ID:    "I18N-09",
+		Query: `DELETE FROM TRANSLATION WHERE NAMESPACE = $1 AND DEPLOYMENT_ID = $2`,
+	}
+
+	// queryDeleteTranslationsByKey deletes all translations for a given namespace and key.
+	queryDeleteTranslationsByKey = dbmodel.DBQuery{
+		ID:    "I18N-10",
+		Query: `DELETE FROM TRANSLATION WHERE NAMESPACE = $1 AND MESSAGE_KEY = $2 AND DEPLOYMENT_ID = $3`,
+	}
 )

--- a/backend/internal/system/i18n/mgt/store_test.go
+++ b/backend/internal/system/i18n/mgt/store_test.go
@@ -19,10 +19,12 @@
 package mgt
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/asgardeo/thunder/tests/mocks/database/modelmock"
@@ -457,4 +459,62 @@ func (suite *I18nStoreTestSuite) TestGetDBClient_Error() {
 	err = suite.store.DeleteTranslationsByLanguage("en")
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get database client")
+
+	err = suite.store.DeleteTranslationsByNamespace(context.Background(), "app-test")
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to get database client")
+
+	err = suite.store.DeleteTranslationsByKey(context.Background(), "custom", "app.test-id.name")
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to get database client")
+}
+
+// DeleteTranslationsByNamespace Tests
+
+func (suite *I18nStoreTestSuite) TestDeleteTranslationsByNamespace_Success() {
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On("ExecuteContext", mock.Anything,
+		queryDeleteTranslationsByNamespace, "app-test", testDeploymentID).
+		Return(int64(1), nil)
+
+	err := suite.store.DeleteTranslationsByNamespace(context.Background(), "app-test")
+
+	suite.NoError(err)
+}
+
+func (suite *I18nStoreTestSuite) TestDeleteTranslationsByNamespace_Error() {
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On("ExecuteContext", mock.Anything,
+		queryDeleteTranslationsByNamespace, "app-test", testDeploymentID).
+		Return(int64(0), errors.New("exec error"))
+
+	err := suite.store.DeleteTranslationsByNamespace(context.Background(), "app-test")
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to delete translations by namespace")
+}
+
+// DeleteTranslationsByKey Tests
+
+func (suite *I18nStoreTestSuite) TestDeleteTranslationsByKey_Success() {
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On("ExecuteContext", mock.Anything,
+		queryDeleteTranslationsByKey, "custom", "app.test-id.name", testDeploymentID).
+		Return(int64(1), nil)
+
+	err := suite.store.DeleteTranslationsByKey(context.Background(), "custom", "app.test-id.name")
+
+	suite.NoError(err)
+}
+
+func (suite *I18nStoreTestSuite) TestDeleteTranslationsByKey_Error() {
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On("ExecuteContext", mock.Anything,
+		queryDeleteTranslationsByKey, "custom", "app.test-id.name", testDeploymentID).
+		Return(int64(0), errors.New("exec error"))
+
+	err := suite.store.DeleteTranslationsByKey(context.Background(), "custom", "app.test-id.name")
+
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to delete translations by namespace and key")
 }

--- a/backend/tests/mocks/i18n/mgtmock/I18nServiceInterface_mock.go
+++ b/backend/tests/mocks/i18n/mgtmock/I18nServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package mgtmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 	"github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	mock "github.com/stretchr/testify/mock"
@@ -151,6 +153,194 @@ func (_c *I18nServiceInterfaceMock_ClearTranslationOverrides_Call) Return(servic
 }
 
 func (_c *I18nServiceInterfaceMock_ClearTranslationOverrides_Call) RunAndReturn(run func(language string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_ClearTranslationOverrides_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteTranslationsByKey provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) DeleteTranslationsByKey(ctx context.Context, namespace string, key string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, namespace, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByKey")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, namespace, key)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// I18nServiceInterfaceMock_DeleteTranslationsByKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByKey'
+type I18nServiceInterfaceMock_DeleteTranslationsByKey_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - key string
+func (_e *I18nServiceInterfaceMock_Expecter) DeleteTranslationsByKey(ctx interface{}, namespace interface{}, key interface{}) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	return &I18nServiceInterfaceMock_DeleteTranslationsByKey_Call{Call: _e.mock.On("DeleteTranslationsByKey", ctx, namespace, key)}
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call) Run(run func(ctx context.Context, namespace string, key string)) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call) Return(serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call) RunAndReturn(run func(ctx context.Context, namespace string, key string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteTranslationsByNamespace provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) DeleteTranslationsByNamespace(ctx context.Context, namespace string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByNamespace")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByNamespace'
+type I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+func (_e *I18nServiceInterfaceMock_Expecter) DeleteTranslationsByNamespace(ctx interface{}, namespace interface{}) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	return &I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call{Call: _e.mock.On("DeleteTranslationsByNamespace", ctx, namespace)}
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call) Run(run func(ctx context.Context, namespace string)) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call) Return(serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTranslationsByNamespace provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) GetTranslationsByNamespace(namespace string) (map[string]map[string]string, *serviceerror.ServiceError) {
+	ret := _mock.Called(namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTranslationsByNamespace")
+	}
+
+	var r0 map[string]map[string]string
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string) (map[string]map[string]string, *serviceerror.ServiceError)); ok {
+		return returnFunc(namespace)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) map[string]map[string]string); ok {
+		r0 = returnFunc(namespace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(namespace)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// I18nServiceInterfaceMock_GetTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTranslationsByNamespace'
+type I18nServiceInterfaceMock_GetTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// GetTranslationsByNamespace is a helper method to define mock.On call
+//   - namespace string
+func (_e *I18nServiceInterfaceMock_Expecter) GetTranslationsByNamespace(namespace interface{}) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
+	return &I18nServiceInterfaceMock_GetTranslationsByNamespace_Call{Call: _e.mock.On("GetTranslationsByNamespace", namespace)}
+}
+
+func (_c *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call) Run(run func(namespace string)) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call) Return(stringToStringToString map[string]map[string]string, serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
+	_c.Call.Return(stringToStringToString, serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call) RunAndReturn(run func(namespace string) (map[string]map[string]string, *serviceerror.ServiceError)) *I18nServiceInterfaceMock_GetTranslationsByNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -506,6 +696,71 @@ func (_c *I18nServiceInterfaceMock_SetTranslationOverrides_Call) Return(language
 }
 
 func (_c *I18nServiceInterfaceMock_SetTranslationOverrides_Call) RunAndReturn(run func(language string, translations map[string]map[string]string) (*mgt.LanguageTranslationsResponse, *serviceerror.ServiceError)) *I18nServiceInterfaceMock_SetTranslationOverrides_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetTranslationOverridesForNamespace provides a mock function for the type I18nServiceInterfaceMock
+func (_mock *I18nServiceInterfaceMock) SetTranslationOverridesForNamespace(ctx context.Context, namespace string, entries map[string]map[string]string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, namespace, entries)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetTranslationOverridesForNamespace")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]map[string]string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, namespace, entries)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetTranslationOverridesForNamespace'
+type I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call struct {
+	*mock.Call
+}
+
+// SetTranslationOverridesForNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - entries map[string]map[string]string
+func (_e *I18nServiceInterfaceMock_Expecter) SetTranslationOverridesForNamespace(ctx interface{}, namespace interface{}, entries interface{}) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
+	return &I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call{Call: _e.mock.On("SetTranslationOverridesForNamespace", ctx, namespace, entries)}
+}
+
+func (_c *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call) Run(run func(ctx context.Context, namespace string, entries map[string]map[string]string)) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 map[string]map[string]string
+		if args[2] != nil {
+			arg2 = args[2].(map[string]map[string]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call) Return(serviceError *serviceerror.ServiceError) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string, entries map[string]map[string]string) *serviceerror.ServiceError) *I18nServiceInterfaceMock_SetTranslationOverridesForNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/i18n/mgtmock/i18nStoreInterface_mock.go
+++ b/backend/tests/mocks/i18n/mgtmock/i18nStoreInterface_mock.go
@@ -5,6 +5,8 @@
 package mgtmock
 
 import (
+	"context"
+
 	"github.com/asgardeo/thunder/internal/system/i18n/mgt"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -99,6 +101,69 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslation_Call) RunAndReturn(run func(l
 	return _c
 }
 
+// DeleteTranslationsByKey provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByKey(ctx context.Context, namespace string, key string) error {
+	ret := _mock.Called(ctx, namespace, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, namespace, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// i18nStoreInterfaceMock_DeleteTranslationsByKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByKey'
+type i18nStoreInterfaceMock_DeleteTranslationsByKey_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - key string
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByKey(ctx interface{}, namespace interface{}, key interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslationsByKey_Call{Call: _e.mock.On("DeleteTranslationsByKey", ctx, namespace, key)}
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) Run(run func(ctx context.Context, namespace string, key string)) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) Return(err error) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call) RunAndReturn(run func(ctx context.Context, namespace string, key string) error) *i18nStoreInterfaceMock_DeleteTranslationsByKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteTranslationsByLanguage provides a mock function for the type i18nStoreInterfaceMock
 func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByLanguage(language string) error {
 	ret := _mock.Called(language)
@@ -146,6 +211,63 @@ func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) Return(err e
 }
 
 func (_c *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call) RunAndReturn(run func(language string) error) *i18nStoreInterfaceMock_DeleteTranslationsByLanguage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteTranslationsByNamespace provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) DeleteTranslationsByNamespace(ctx context.Context, namespace string) error {
+	ret := _mock.Called(ctx, namespace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteTranslationsByNamespace")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteTranslationsByNamespace'
+type i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call struct {
+	*mock.Call
+}
+
+// DeleteTranslationsByNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+func (_e *i18nStoreInterfaceMock_Expecter) DeleteTranslationsByNamespace(ctx interface{}, namespace interface{}) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
+	return &i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call{Call: _e.mock.On("DeleteTranslationsByNamespace", ctx, namespace)}
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) Run(run func(ctx context.Context, namespace string)) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) Return(err error) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call) RunAndReturn(run func(ctx context.Context, namespace string) error) *i18nStoreInterfaceMock_DeleteTranslationsByNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -437,6 +559,63 @@ func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) Return(err error) *i18n
 }
 
 func (_c *i18nStoreInterfaceMock_UpsertTranslation_Call) RunAndReturn(run func(trans mgt.Translation) error) *i18nStoreInterfaceMock_UpsertTranslation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertTranslations provides a mock function for the type i18nStoreInterfaceMock
+func (_mock *i18nStoreInterfaceMock) UpsertTranslations(ctx context.Context, translations []mgt.Translation) error {
+	ret := _mock.Called(ctx, translations)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertTranslations")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []mgt.Translation) error); ok {
+		r0 = returnFunc(ctx, translations)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// i18nStoreInterfaceMock_UpsertTranslations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertTranslations'
+type i18nStoreInterfaceMock_UpsertTranslations_Call struct {
+	*mock.Call
+}
+
+// UpsertTranslations is a helper method to define mock.On call
+//   - ctx context.Context
+//   - translations []mgt.Translation
+func (_e *i18nStoreInterfaceMock_Expecter) UpsertTranslations(ctx interface{}, translations interface{}) *i18nStoreInterfaceMock_UpsertTranslations_Call {
+	return &i18nStoreInterfaceMock_UpsertTranslations_Call{Call: _e.mock.On("UpsertTranslations", ctx, translations)}
+}
+
+func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) Run(run func(ctx context.Context, translations []mgt.Translation)) *i18nStoreInterfaceMock_UpsertTranslations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []mgt.Translation
+		if args[1] != nil {
+			arg1 = args[1].([]mgt.Translation)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) Return(err error) *i18nStoreInterfaceMock_UpsertTranslations_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *i18nStoreInterfaceMock_UpsertTranslations_Call) RunAndReturn(run func(ctx context.Context, translations []mgt.Translation) error) *i18nStoreInterfaceMock_UpsertTranslations_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/guides/guides/applications/dynamic-client-registration.mdx
+++ b/docs/content/guides/guides/applications/dynamic-client-registration.mdx
@@ -1,0 +1,107 @@
+---
+title: Dynamic Client Registration
+sidebar_position: 3
+persona: developer
+description: Register OAuth 2.0 clients programmatically via the DCR endpoint, including localized metadata fields using OIDC language tags.
+---
+
+# Dynamic Client Registration
+
+Dynamic Client Registration (DCR) lets you register OAuth 2.0 clients with Thunder programmatically, without using the Console. It follows [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591).
+
+**Endpoint:** `POST /oauth2/dcr/register`
+
+## Register a Client
+
+Send a JSON body with at minimum a redirect URI and grant type:
+
+```http
+POST /oauth2/dcr/register
+Content-Type: application/json
+
+{
+  "client_name": "My App",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "client_secret_basic"
+}
+```
+
+A successful registration returns `201 Created` with the assigned `client_id`, `client_secret` (when applicable), and the full set of registered metadata echoed back.
+
+```json
+{
+  "client_id": "abc123",
+  "client_secret": "s3cr3t",
+  "client_name": "My App",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "client_secret_basic"
+}
+```
+
+## Request Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `redirect_uris` | Yes | One or more URIs Thunder redirects to after authentication. |
+| `grant_types` | No | OAuth 2.0 grant types the client may use. Defaults to `["authorization_code"]`. |
+| `response_types` | No | OAuth 2.0 response types. Defaults to `["code"]`. |
+| `token_endpoint_auth_method` | No | How the client authenticates at the token endpoint (`client_secret_basic`, `client_secret_post`, `none`). Defaults to `client_secret_basic`. |
+| `client_name` | No | Human-readable name of the client. |
+| `logo_uri` | No | URL of the client logo image. |
+| `tos_uri` | No | URL of the client's Terms of Service. |
+| `policy_uri` | No | URL of the client's Privacy Policy. |
+| `contacts` | No | Array of administrator email addresses for this client. |
+| `scope` | No | Space-separated list of scopes the client is allowed to request. |
+
+## Localized Metadata
+
+You can provide translations of `client_name`, `logo_uri`, `tos_uri`, and `policy_uri` for different languages by appending a `#` and a [BCP 47](https://www.rfc-editor.org/rfc/rfc5646) language tag to the field name.
+
+**Syntax:** `<field>#<language-tag>`
+
+```http
+POST /oauth2/dcr/register
+Content-Type: application/json
+
+{
+  "client_name": "My App",
+  "client_name#fr": "Mon Application",
+  "client_name#ja": "マイアプリ",
+  "logo_uri": "https://app.example.com/logo.png",
+  "logo_uri#fr": "https://app.example.com/logo-fr.png",
+  "tos_uri": "https://app.example.com/terms",
+  "tos_uri#fr": "https://app.example.com/terms-fr",
+  "policy_uri": "https://app.example.com/privacy",
+  "policy_uri#fr": "https://app.example.com/privacy-fr",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "grant_types": ["authorization_code"]
+}
+```
+
+All localized fields are echoed back in the registration response.
+
+### Language Tag Rules
+
+| Rule | Details |
+|------|---------|
+| **Valid BCP 47 tag** | The tag must be a well-formed BCP 47 language tag (e.g. `fr`, `en-US`, `zh-Hant`). Invalid tags return `400`. |
+| **Canonical form required** | The tag must be in canonical form — `en-US` is accepted, `en-us` is not. Thunder normalizes the tag to its canonical BCP 47 form. |
+| **Maximum 20 variants per field** | You may provide at most 20 language variants for each field. Exceeding this limit returns `400`. |
+
+### Error Responses
+
+| HTTP Status | Error Code | Cause |
+|-------------|------------|-------|
+| `400` | `invalid_client_metadata` | A language tag is not a valid BCP 47 tag (e.g. `client_name#not-valid`). |
+| `400` | `invalid_client_metadata` | A language tag is not in canonical form (e.g. `client_name#en-us` instead of `client_name#en-US`). |
+| `400` | `invalid_client_metadata` | More than 20 language variants provided for a single field. |
+| `400` | `invalid_client_metadata` | A localized `logo_uri`, `tos_uri`, or `policy_uri` value is not a valid URI. |
+
+## Related Guides
+
+- [Manage Applications](./manage-applications) - Register and manage applications from the Thunder Console
+- [Application Settings](./application-settings) - Configure flows, tokens, and OAuth 2.0 settings

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -162,6 +162,11 @@ const sidebars: SidebarsConfig = {
               id: 'guides/guides/applications/application-settings',
               label: 'Application Settings',
             },
+            {
+              type: 'doc',
+              id: 'guides/guides/applications/dynamic-client-registration',
+              label: 'Dynamic Client Registration',
+            },
           ],
         },
         {

--- a/tests/integration/oauth/dcr/dcr_test.go
+++ b/tests/integration/oauth/dcr/dcr_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/asgardeo/thunder/tests/integration/testutils"
@@ -766,6 +767,73 @@ func (ts *DCRTestSuite) TestDCRRegistrationRedirectURIWithFragment2() {
 	ts.Assert().Equal(http.StatusBadRequest, statusCode)
 }
 
+// TestDCRRegistrationWithLocalizedVariants verifies that OIDC language-tagged fields
+// (e.g. "client_name#fr") are accepted and echoed back in the registration response.
+func (ts *DCRTestSuite) TestDCRRegistrationWithLocalizedVariants() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://localized.example.com/callback"},
+		ClientName:   "Localized Client",
+		TosURI:       "https://localized.example.com/tos",
+		PolicyURI:    "https://localized.example.com/policy",
+		LocalizedFields: map[string]string{
+			"client_name#fr": "Client localisé",
+			"client_name#de": "Lokalisierter Client",
+			"tos_uri#fr":     "https://localized.example.com/tos/fr",
+			"policy_uri#fr":  "https://localized.example.com/policy/fr",
+		},
+	}
+
+	response, statusCode := ts.registerClient(request)
+
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	ts.Assert().NotEmpty(response.ClientID)
+	ts.Assert().NotEmpty(response.AppID)
+	ts.Assert().Equal("Localized Client", response.ClientName)
+
+	// Echoed localized variants must appear in the response.
+	ts.Assert().Equal("Client localisé", response.LocalizedClientName["fr"])
+	ts.Assert().Equal("Lokalisierter Client", response.LocalizedClientName["de"])
+	ts.Assert().Equal("https://localized.example.com/tos/fr", response.LocalizedTosURI["fr"])
+	ts.Assert().Equal("https://localized.example.com/policy/fr", response.LocalizedPolicyURI["fr"])
+
+	ts.registeredAppIDs = append(ts.registeredAppIDs, response.AppID)
+}
+
+// TestDCRRegistrationInvalidBCP47Tag verifies that a malformed language tag in a
+// localized field (e.g. "client_name#bad@lang") is rejected with 400.
+func (ts *DCRTestSuite) TestDCRRegistrationInvalidBCP47Tag() {
+	// Build the request body manually so the invalid key bypasses Go struct marshaling.
+	rawBody := []byte(`{
+		"ou_id": "decl-ou-1",
+		"redirect_uris": ["https://invalid-tag.example.com/callback"],
+		"client_name": "Invalid Tag Client",
+		"client_name#bad@lang": "should be rejected"
+	}`)
+
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("POST", testServerURL+dcrEndpoint, bytes.NewReader(rawBody))
+	if err != nil {
+		ts.T().Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	token, err := testutils.GetAccessToken()
+	if err != nil {
+		ts.T().Fatalf("Failed to obtain access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		ts.T().Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
 // TestDCRRegistrationClientCredentialsWithResponseTypes2 tests client_credentials cannot have response_types.
 func (ts *DCRTestSuite) TestDCRRegistrationClientCredentialsWithResponseTypes2() {
 	request := DCRRegistrationRequest{
@@ -1481,4 +1549,355 @@ func (ts *DCRTestSuite) TestDCRRegistrationWithEmptyJWKSAndJWKSUri() {
 	ts.Assert().Equal(http.StatusBadRequest, statusCode)
 	ts.Assert().NotNil(errResp)
 	ts.Assert().Contains(errResp.Error, "invalid_client_metadata")
+}
+
+// TestDCRRegistrationLocalizedTagNormalization verifies AC-10: when the same tag appears in
+// different cases (e.g. "client_name#FR" and "client_name#fr"), they normalise to the same
+// canonical BCP 47 form and the request is accepted (last occurrence stored).
+func (ts *DCRTestSuite) TestDCRRegistrationLocalizedTagNormalization() {
+	rawBody := []byte(`{
+		"ou_id": "decl-ou-1",
+		"redirect_uris": ["https://tag-norm.example.com/callback"],
+		"client_name": "Tag Norm Client",
+		"client_name#FR": "Première valeur",
+		"client_name#fr": "Deuxième valeur"
+	}`)
+
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("POST", testServerURL+dcrEndpoint, bytes.NewReader(rawBody))
+	if err != nil {
+		ts.T().Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	token, err := testutils.GetAccessToken()
+	if err != nil {
+		ts.T().Fatalf("Failed to obtain access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		ts.T().Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusCreated, resp.StatusCode)
+
+	var response DCRRegistrationResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	ts.Require().NoError(err)
+	ts.Assert().NotEmpty(response.ClientID)
+	// Both tags normalise to "fr"; the map must have exactly one entry.
+	ts.Assert().Len(response.LocalizedClientName, 1)
+	ts.Assert().Contains(response.LocalizedClientName, "fr")
+
+	ts.registeredAppIDs = append(ts.registeredAppIDs, response.AppID)
+}
+
+// TestDCRRegistrationInvalidLocalizedLogoURI verifies AC-13: a localized logo_uri variant
+// with a malformed URL must be rejected with 400 invalid_client_metadata.
+func (ts *DCRTestSuite) TestDCRRegistrationInvalidLocalizedLogoURI() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://invalid-logo.example.com/callback"},
+		ClientName:   "Invalid Localized Logo Client",
+		LocalizedFields: map[string]string{
+			"logo_uri#fr": "not-a-valid-uri",
+		},
+	}
+
+	_, statusCode, errResp := ts.registerClientWithError(request)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRRegistrationInvalidLocalizedTosURI verifies AC-13: a localized tos_uri variant
+// with a malformed URL must be rejected with 400 invalid_client_metadata.
+func (ts *DCRTestSuite) TestDCRRegistrationInvalidLocalizedTosURI() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://invalid-tos.example.com/callback"},
+		ClientName:   "Invalid Localized TOS Client",
+		LocalizedFields: map[string]string{
+			"tos_uri#fr": "not-a-valid-uri",
+		},
+	}
+
+	_, statusCode, errResp := ts.registerClientWithError(request)
+
+	ts.Assert().Equal(http.StatusBadRequest, statusCode)
+	ts.Assert().NotNil(errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRRegistrationDefaultFieldAsSystemLanguage verifies AC-25: an untagged client_name
+// (no # variants) is stored in the i18n table under the system language (en-US) and is
+// returned by the i18n resolve API for that language.
+func (ts *DCRTestSuite) TestDCRRegistrationDefaultFieldAsSystemLanguage() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://default-lang.example.com/callback"},
+		ClientName:   "System Language Default",
+	}
+
+	response, statusCode := ts.registerClient(request)
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	ts.Assert().NotEmpty(response.AppID)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, response.AppID)
+
+	ns := "custom"
+	key := "app." + response.AppID + ".name"
+	translations := ts.resolveTranslations("en-US", ns)
+	ts.Assert().Equal("System Language Default", translations[ns][key])
+}
+
+// TestDCRRegistrationTaggedSystemLanguageWinsOverDefault verifies AC-26: when both an
+// untagged client_name and an explicit client_name#en-US variant are provided, the tagged
+// variant takes priority over the untagged default in the i18n table.
+func (ts *DCRTestSuite) TestDCRRegistrationTaggedSystemLanguageWinsOverDefault() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://tagged-wins.example.com/callback"},
+		ClientName:   "Default Name",
+		LocalizedFields: map[string]string{
+			"client_name#en-US": "Tagged Name",
+		},
+	}
+
+	response, statusCode := ts.registerClient(request)
+	ts.Assert().Equal(http.StatusCreated, statusCode)
+	ts.Assert().NotEmpty(response.AppID)
+	ts.Assert().Equal("Tagged Name", response.LocalizedClientName["en-US"])
+	ts.registeredAppIDs = append(ts.registeredAppIDs, response.AppID)
+
+	ns := "custom"
+	key := "app." + response.AppID + ".name"
+	translations := ts.resolveTranslations("en-US", ns)
+	ts.Assert().Equal("Tagged Name", translations[ns][key])
+}
+
+// resolveTranslations calls GET /i18n/languages/{language}/translations/resolve?namespace={namespace}
+// and returns the translations map (keyed by namespace then key).
+func (ts *DCRTestSuite) resolveTranslations(language, namespace string) map[string]map[string]string {
+	params := url.Values{}
+	params.Set("namespace", namespace)
+	reqURL := testServerURL + "/i18n/languages/" + language + "/translations/resolve?" + params.Encode()
+
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		ts.T().Fatalf("Failed to create i18n resolve request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		ts.T().Fatalf("Failed to send i18n resolve request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "i18n resolve request returned unexpected status")
+
+	var result struct {
+		Translations map[string]map[string]string `json:"translations"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		ts.T().Fatalf("Failed to decode i18n resolve response: %v", err)
+	}
+	return result.Translations
+}
+
+// TestDCRRegistrationMaxLocalizedVariants verifies AC-14: registering more than 20 variants
+// for a single localizable field must be rejected with 400 invalid_client_metadata.
+func (ts *DCRTestSuite) TestDCRRegistrationMaxLocalizedVariants() {
+	// Build a raw JSON body with 21 client_name# variants.
+	langs := []string{
+		"aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av",
+		"ay", "az", "ba", "be", "bg", "bh", "bi", "bm", "bn", "bo", "br",
+	}
+
+	body := `{"ou_id":"decl-ou-1","redirect_uris":["https://max-variants.example.com/callback"],"client_name":"Max Variants Client"`
+	for _, lang := range langs {
+		body += `,"client_name#` + lang + `":"Value ` + lang + `"`
+	}
+	body += `}`
+
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("POST", testServerURL+dcrEndpoint, bytes.NewReader([]byte(body)))
+	if err != nil {
+		ts.T().Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	token, err := testutils.GetAccessToken()
+	if err != nil {
+		ts.T().Fatalf("Failed to obtain access token: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		ts.T().Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errResp DCRErrorResponse
+	json.NewDecoder(resp.Body).Decode(&errResp)
+	ts.Assert().Equal("invalid_client_metadata", errResp.Error)
+}
+
+// TestDCRRegistrationLocalizedNameStoredAsTemplateRef verifies that when localized client_name
+// variants are provided, the application entity's name field is stored as an i18n template
+// reference ({{t(custom:app.{id}.name)}}) rather than the raw client_name string.
+func (ts *DCRTestSuite) TestDCRRegistrationLocalizedNameStoredAsTemplateRef() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://template-ref.example.com/callback"},
+		ClientName:   "Template Ref Client",
+		LocalizedFields: map[string]string{
+			"client_name#fr": "Client de référence",
+		},
+	}
+
+	response, statusCode := ts.registerClient(request)
+	ts.Require().Equal(http.StatusCreated, statusCode)
+	ts.Require().NotEmpty(response.AppID)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, response.AppID)
+
+	expectedRef := "{{t(custom:app." + response.AppID + ".name)}}"
+
+	client := testutils.GetHTTPClient()
+	req, err := http.NewRequest("GET", testServerURL+"/applications/"+response.AppID, nil)
+	ts.Require().NoError(err, "Failed to create GET request")
+
+	resp, err := client.Do(req)
+	ts.Require().NoError(err, "Failed to send GET request")
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusOK, resp.StatusCode)
+
+	var app map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&app)
+	ts.Require().NoError(err, "Failed to decode application response")
+
+	ts.Assert().Equal(expectedRef, app["name"], "Application name should be an i18n template reference")
+}
+
+// TestDCRRegistrationNonLocalizedNameRaw verifies that when no localized client_name variants
+// are provided, the application entity's name field is stored as the raw client_name string.
+func (ts *DCRTestSuite) TestDCRRegistrationNonLocalizedNameRaw() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://raw-name.example.com/callback"},
+		ClientName:   "Raw Name Client",
+	}
+
+	response, statusCode := ts.registerClient(request)
+	ts.Require().Equal(http.StatusCreated, statusCode)
+	ts.Require().NotEmpty(response.AppID)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, response.AppID)
+
+	client := testutils.GetHTTPClient()
+	req, err := http.NewRequest("GET", testServerURL+"/applications/"+response.AppID, nil)
+	ts.Require().NoError(err, "Failed to create GET request")
+
+	resp, err := client.Do(req)
+	ts.Require().NoError(err, "Failed to send GET request")
+	defer resp.Body.Close()
+
+	ts.Assert().Equal(http.StatusOK, resp.StatusCode)
+
+	var app map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&app)
+	ts.Require().NoError(err, "Failed to decode application response")
+
+	ts.Assert().Equal(request.ClientName, app["name"], "Application name should be stored as a raw string")
+}
+
+// TestDCRRegistrationUpdateLocalizedAppNameAllowed verifies that updating the name of an
+// application whose name is an i18n template reference with a plain string is allowed.
+// The i18n key is cleaned up and the app name is stored as the new plain string.
+func (ts *DCRTestSuite) TestDCRRegistrationUpdateLocalizedAppNameAllowed() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://update-allowed.example.com/callback"},
+		ClientName:   "Localized Client",
+		LocalizedFields: map[string]string{
+			"client_name#fr": "Client localisé",
+		},
+	}
+
+	response, statusCode := ts.registerClient(request)
+	ts.Require().Equal(http.StatusCreated, statusCode)
+	ts.Require().NotEmpty(response.AppID)
+	ts.registeredAppIDs = append(ts.registeredAppIDs, response.AppID)
+
+	httpClient := testutils.GetHTTPClient()
+
+	getReq, err := http.NewRequest("GET", testServerURL+"/applications/"+response.AppID, nil)
+	ts.Require().NoError(err, "Failed to create GET request")
+
+	getResp, err := httpClient.Do(getReq)
+	ts.Require().NoError(err, "Failed to send GET request")
+	defer getResp.Body.Close()
+	ts.Require().Equal(http.StatusOK, getResp.StatusCode)
+
+	var app map[string]interface{}
+	err = json.NewDecoder(getResp.Body).Decode(&app)
+	ts.Require().NoError(err, "Failed to decode application response")
+
+	app["name"] = "Plain Name"
+	appJSON, err := json.Marshal(app)
+	ts.Require().NoError(err, "Failed to marshal modified application")
+
+	putReq, err := http.NewRequest("PUT", testServerURL+"/applications/"+response.AppID, bytes.NewReader(appJSON))
+	ts.Require().NoError(err, "Failed to create PUT request")
+	putReq.Header.Set("Content-Type", "application/json")
+
+	putResp, err := httpClient.Do(putReq)
+	ts.Require().NoError(err, "Failed to send PUT request")
+	defer putResp.Body.Close()
+
+	ts.Assert().Equal(http.StatusOK, putResp.StatusCode,
+		"Updating an i18n-managed app name with a plain string should be allowed")
+
+	ns := "custom"
+	appNameKey := "app." + response.AppID + ".name"
+	translations := ts.resolveTranslations("en-US", ns)
+	ts.Assert().Empty(translations[ns][appNameKey], "i18n key should be cleaned up after plain text override")
+}
+
+// TestDCRRegistrationDeleteCleansUpI18n verifies that deleting an application with localized
+// name variants also removes its i18n entries — the resolve API returns empty for that namespace.
+func (ts *DCRTestSuite) TestDCRRegistrationDeleteCleansUpI18n() {
+	request := DCRRegistrationRequest{
+		OUID:         "decl-ou-1",
+		RedirectURIs: []string{"https://delete-cleanup.example.com/callback"},
+		ClientName:   "Delete Cleanup Client",
+		LocalizedFields: map[string]string{
+			"client_name#fr": "Client nettoyage",
+		},
+	}
+
+	response, statusCode := ts.registerClient(request)
+	ts.Require().Equal(http.StatusCreated, statusCode)
+	ts.Require().NotEmpty(response.AppID)
+
+	ns := "custom"
+	appNameKey := "app." + response.AppID + ".name"
+	translationsBefore := ts.resolveTranslations("en-US", ns)
+	ts.Assert().NotEmpty(translationsBefore[ns][appNameKey], "i18n entries should exist before deletion")
+
+	err := testutils.DeleteApplication(response.AppID)
+	ts.Require().NoError(err, "Failed to delete application")
+
+	translationsAfter := ts.resolveTranslations("en-US", ns)
+	ts.Assert().Empty(translationsAfter[ns][appNameKey], "i18n entries should be removed after app deletion")
 }

--- a/tests/integration/oauth/dcr/model.go
+++ b/tests/integration/oauth/dcr/model.go
@@ -18,6 +18,11 @@
 
 package dcr
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 // DCRRegistrationRequest represents the RFC 7591 Dynamic Client Registration request.
 type DCRRegistrationRequest struct {
 	OUID                               string                 `json:"ou_id,omitempty"`
@@ -35,6 +40,30 @@ type DCRRegistrationRequest struct {
 	TosURI                             string                 `json:"tos_uri,omitempty"`
 	PolicyURI                          string                 `json:"policy_uri,omitempty"`
 	RequirePushedAuthorizationRequests bool                   `json:"require_pushed_authorization_requests,omitempty"`
+
+	// LocalizedFields holds OIDC language-tagged fields (e.g. "client_name#fr": "Mon Client").
+	// These are serialized as top-level #-keyed JSON keys.
+	LocalizedFields map[string]string `json:"-"`
+}
+
+// MarshalJSON serializes DCRRegistrationRequest, injecting LocalizedFields as top-level #-keyed keys.
+func (r DCRRegistrationRequest) MarshalJSON() ([]byte, error) {
+	type Alias DCRRegistrationRequest
+	base, err := json.Marshal(Alias(r))
+	if err != nil {
+		return nil, err
+	}
+	if len(r.LocalizedFields) == 0 {
+		return base, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(base, &m); err != nil {
+		return nil, err
+	}
+	for k, v := range r.LocalizedFields {
+		m[k] = v
+	}
+	return json.Marshal(m)
 }
 
 // DCRRegistrationResponse represents the RFC 7591 Dynamic Client Registration response.
@@ -57,6 +86,63 @@ type DCRRegistrationResponse struct {
 	PolicyURI                          string                 `json:"policy_uri,omitempty"`
 	AppID                              string                 `json:"app_id,omitempty"`
 	RequirePushedAuthorizationRequests bool                   `json:"require_pushed_authorization_requests,omitempty"`
+
+	// Localized variant maps — populated from #-keyed top-level fields in the response JSON.
+	LocalizedClientName map[string]string `json:"-"`
+	LocalizedLogoURI    map[string]string `json:"-"`
+	LocalizedTosURI     map[string]string `json:"-"`
+	LocalizedPolicyURI  map[string]string `json:"-"`
+}
+
+// UnmarshalJSON decodes DCRRegistrationResponse, extracting #-keyed localized fields.
+func (r *DCRRegistrationResponse) UnmarshalJSON(data []byte) error {
+	// Reset localized maps so stale entries from a prior unmarshal do not survive.
+	r.LocalizedClientName = nil
+	r.LocalizedLogoURI = nil
+	r.LocalizedTosURI = nil
+	r.LocalizedPolicyURI = nil
+
+	type Alias DCRRegistrationResponse
+	if err := json.Unmarshal(data, (*Alias)(r)); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for key, val := range raw {
+		field, tag, ok := strings.Cut(key, "#")
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(val, &s); err != nil {
+			continue
+		}
+		switch field {
+		case "client_name":
+			if r.LocalizedClientName == nil {
+				r.LocalizedClientName = make(map[string]string)
+			}
+			r.LocalizedClientName[tag] = s
+		case "logo_uri":
+			if r.LocalizedLogoURI == nil {
+				r.LocalizedLogoURI = make(map[string]string)
+			}
+			r.LocalizedLogoURI[tag] = s
+		case "tos_uri":
+			if r.LocalizedTosURI == nil {
+				r.LocalizedTosURI = make(map[string]string)
+			}
+			r.LocalizedTosURI[tag] = s
+		case "policy_uri":
+			if r.LocalizedPolicyURI == nil {
+				r.LocalizedPolicyURI = make(map[string]string)
+			}
+			r.LocalizedPolicyURI[tag] = s
+		}
+	}
+	return nil
 }
 
 // DCRErrorResponse represents the RFC 7591 Dynamic Client Registration error response.


### PR DESCRIPTION
fixes #2106

### Purpose

OAuth 2.0 Dynamic Client Registration (RFC 7591) requires clients to register localized metadata
variants using OIDC language-tagged fields (e.g. `"client_name#fr": "Mon Client"`). Previously,
Thunder's DCR endpoint ignored these fields entirely, meaning clients could not register
language-specific display names, logo URIs, terms-of-service, or policy URIs.

This PR adds full support for OIDC language-tagged DCR metadata fields.

### Approach

**Parsing language-tagged fields (RFC 7591 §2.1)**

`DCRRegistrationRequest.UnmarshalJSON` now scans all top-level JSON keys for the `field#lang-tag`
pattern. Valid BCP 47 tags (normalised via `golang.org/x/text/language`) are extracted into four
typed maps: `LocalizedClientName`, `LocalizedLogoURI`, `LocalizedTosURI`, `LocalizedPolicyURI`.
Invalid tags are rejected immediately with a 400 error before any storage occurs.

`DCRRegistrationResponse.MarshalJSON` serializes those maps back as top-level `#`-keyed keys so
clients receive the echoed variants in the 201 response.

**Persisting to i18n store (transaction limitation + compensation)**

The DCR outer transactioner operates on the runtime DB, while both the application store and i18n
store use configDB. Because of this mismatch, they cannot participate in the same transaction.

Localized variants are written to the i18n store *after* the application record commits. On write
failure, a compensation path cleans up any partial i18n rows and deletes the newly-created
application, maintaining consistency without distributed transactions.

Each app's translations are stored under the namespace `app.<id>` with keys `client_name`,
`logo_uri`, `tos_uri`, `policy_uri`.

**i18n integration**

Added `SetTranslationOverridesForNamespace` to perform bulk writes of localized variants during DCR
registration, reducing multiple DB calls into a single operation.

A new `GetTranslationsByNamespace` method on `I18nServiceInterface` fetches all locale rows for a
namespace in a single query, avoiding the N+1 pattern. This is used to support localized metadata
handling within the DCR flow.

**Cleanup on application deletion**

The existing `deleteLocalizedVariants` call in the application service lifecycle ensures i18n rows
are cleaned up when an application is deleted.

### Related Issues
- Fixes #2106

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests — `backend/internal/oauth/oauth2/dcr/service_test.go`: covering
      `RegisterClient` with localized variants, i18n write failure compensation, and related scenarios
    - [x] Integration Tests — `tests/integration/oauth/dcr/dcr_test.go`: register with localized
      fields (assert echoed in response), invalid BCP 47 tag rejection (400)
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any secrets.