### PR TITLE
Email Executor No Operation, handling and Admin invite Improvements

### DIFF
--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -212,17 +212,167 @@
             "executor": {
                 "name": "AttributeUniquenessValidator"
             },
-            "onSuccess": "invite_generate",
+            "onSuccess": "prompt_invite_method",
             "onIncomplete": "prompt_email"
         },
         {
-            "id": "invite_generate",
+            "id": "prompt_invite_method",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "type": "TEXT",
+                        "id": "text_header_invite_method",
+                        "label": "{{ t(onboarding:forms.invite_mode.title) }}",
+                        "variant": "HEADING_1",
+                        "align": "center"
+                    },
+                    {
+                        "type": "TEXT",
+                        "id": "text_subtitle_invite_method",
+                        "label": "{{ t(onboarding:forms.invite_mode.subtitle) }}"
+                    },
+                    {
+                        "type": "BLOCK",
+                        "id": "block_invite_method_actions",
+                        "components": [
+                            {
+                                "type": "STACK",
+                                "id": "stack_invite_actions",
+                                "direction": "row",
+                                "justify": "center",
+                                "components": [
+                                    {
+                                        "type": "ACTION",
+                                        "id": "action_share_manually",
+                                        "label": "{{ t(onboarding:forms.invite_mode.actions.link.label) }}",
+                                        "variant": "OUTLINED",
+                                        "eventType": "SUBMIT"
+                                    },
+                                    {
+                                        "type": "ACTION",
+                                        "id": "action_send_email_invite",
+                                        "label": "{{ t(onboarding:forms.invite_mode.actions.email.label) }}",
+                                        "variant": "PRIMARY",
+                                        "eventType": "SUBMIT"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "prompts": [
+                {
+                    "action": {
+                        "ref": "action_send_email_invite",
+                        "nextNode": "invite_generate_email"
+                    }
+                },
+                {
+                    "action": {
+                        "ref": "action_share_manually",
+                        "nextNode": "invite_generate_manual"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "invite_generate_manual",
             "type": "TASK_EXECUTION",
             "executor": {
                 "name": "InviteExecutor",
                 "mode": "generate"
             },
             "onSuccess": "invite_link_status"
+        },
+        {
+            "id": "invite_generate_email",
+            "type": "TASK_EXECUTION",
+            "executor": {
+                "name": "InviteExecutor",
+                "mode": "generate"
+            },
+            "onSuccess": "send_invite_email"
+        },
+        {
+            "id": "send_invite_email",
+            "type": "TASK_EXECUTION",
+            "properties": {
+                "emailTemplate": "USER_INVITE"
+            },
+            "executor": {
+                "name": "EmailExecutor",
+                "mode": "send"
+            },
+            "onSuccess": "email_invite_status",
+            "onFailure": "invite_email_service_unavailable"
+        },
+        {
+            "id": "email_invite_status",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "email_status_icon",
+                        "label": "✅",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "email_status_heading",
+                        "label": "{{ t(onboarding:forms.invite_email_sent.title) }}",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "email_status_message",
+                        "label": "{{ t(onboarding:forms.invite_email_sent.message) }}"
+                    }
+                ]
+            },
+            "message": "{{ t(onboarding:forms.invite_email_sent.title) }}",
+            "next": "invite_verify"
+        },
+        {
+            "id": "invite_email_service_unavailable",
+            "type": "PROMPT",
+            "meta": {
+                "components": [
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "email_unavailable_icon",
+                        "label": "⚠️",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "email_unavailable_heading",
+                        "label": "{{ t(onboarding:forms.invite_email_unavailable.title) }}",
+                        "variant": "HEADING_1"
+                    },
+                    {
+                        "align": "center",
+                        "type": "TEXT",
+                        "id": "email_unavailable_message",
+                        "label": "{{ t(onboarding:forms.invite_email_unavailable.message) }}"
+                    },
+                    {
+                        "type": "COPYABLE_TEXT",
+                        "id": "email_unavailable_link_copyable",
+                        "label": "{{ t(onboarding:forms.invite_link_status.link_label) }}",
+                        "source": "inviteLink"
+                    }
+                ]
+            },
+            "message": "{{ t(onboarding:forms.invite_email_unavailable.title) }}",
+            "next": "invite_link_status"
         },
         {
             "id": "invite_link_status",

--- a/backend/cmd/server/bootstrap/i18n/en-US.json
+++ b/backend/cmd/server/bootstrap/i18n/en-US.json
@@ -41,6 +41,8 @@
       "forms.invite_mode.actions.link.label": "Get Invite Link",
       "forms.invite_email_sent.title": "Invitation Sent",
       "forms.invite_email_sent.message": "An invitation email has been sent to the user. They can complete their registration using the link in the email.",
+      "forms.invite_email_unavailable.title": "Email Delivery Failed",
+      "forms.invite_email_unavailable.message": "The invitation email could not be delivered. Please use the link below to share the invite manually.",
       "forms.invite_sms_sent.title": "Invitation Sent",
       "forms.invite_sms_sent.message": "An invitation SMS has been sent to the user. They can complete their registration using the link in the message.",
       "forms.invite_link_status.title": "Invite Link Ready",

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -30,7 +30,7 @@ import (
 )
 
 // emailExecutor sends emails based on the configured email template and runtime context data.
-// When email is not configured (emailClient is nil), it completes as a no-op with emailSent=false.
+// When email is not configured (emailClient is nil), it returns a failure status.
 type emailExecutor struct {
 	core.ExecutorInterface
 	logger          *log.Logger
@@ -39,7 +39,6 @@ type emailExecutor struct {
 }
 
 // newEmailExecutor creates a new instance of the email executor.
-// emailClient may be nil if SMTP is not configured; the executor completes as a no-op in that case.
 func newEmailExecutor(flowFactory core.FlowFactoryInterface, emailClient email.EmailClientInterface,
 	templateService template.TemplateServiceInterface) *emailExecutor {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "EmailExecutor"))
@@ -70,7 +69,7 @@ func (e *emailExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 }
 
 // executeSend resolves the email template, constructs the email, and sends it.
-// If the email client is not configured, it completes without sending (no-op).
+// If the email client is not configured, it returns a failure status.
 func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug("Executing email executor in send mode")
@@ -80,11 +79,11 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		RuntimeData:    make(map[string]string),
 	}
 
-	// If email client is not configured, complete as a no-op.
 	if e.emailClient == nil {
 		execResp.AdditionalData[common.DataEmailSent] = dataValueFalse
-		logger.Debug("Email client not configured, skipping email send")
-		execResp.Status = common.ExecComplete
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Email service is not configured"
+		logger.Debug("Email client not configured")
 		return execResp, nil
 	}
 

--- a/backend/internal/flow/executor/email_executor_test.go
+++ b/backend/internal/flow/executor/email_executor_test.go
@@ -62,7 +62,7 @@ func (suite *EmailExecutorTestSuite) SetupTest() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Success() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
@@ -108,7 +108,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Suc
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_InviteLinkNotExposed() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		FlowType:     common.FlowTypeRegistration,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
@@ -149,7 +149,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Invit
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRuntimeRecipient() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -191,7 +191,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesUserInputOverRunti
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
@@ -231,7 +231,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData()
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingRecipient() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
@@ -252,7 +252,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingRecipient() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingInviteLink() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -273,7 +273,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingInviteLink() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_MissingInviteLink() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		FlowType:     common.FlowTypeRegistration,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
@@ -295,7 +295,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Missi
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplateProperty_DefaultsToUserInvite() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -335,7 +335,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingTemplatePropert
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmptyTemplateString_DefaultsToUserInvite() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -376,7 +376,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmptyTemplateString_De
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_InvalidTemplateType_ReturnsError() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -398,7 +398,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_InvalidTemplateType_Re
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_TemplateRenderError() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -441,7 +441,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilTemplateService() {
 	noServiceExecutor := newEmailExecutor(mockFactory, suite.mockEmailClient, nil)
 
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -463,7 +463,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilTemplateService() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ClientError() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -498,7 +498,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ClientError() {
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ServerError() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
 			"email": "user@example.com",
@@ -530,8 +530,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ServerError() {
 	suite.Nil(resp)
 }
 
-func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_NoOp() {
-	// Create executor with nil email client (SMTP not configured)
+func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_ReturnsFailure() {
 	mockBaseExecutor := coremock.NewExecutorInterfaceMock(suite.T())
 	mockFactory := coremock.NewFlowFactoryInterfaceMock(suite.T())
 	mockFactory.On("CreateExecutor",
@@ -546,7 +545,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_NoOp() 
 	noEmailExecutor := newEmailExecutor(mockFactory, nil, suite.mockTemplateService)
 
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeSend,
 		UserInputs: map[string]string{
@@ -563,39 +562,14 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_NoOp() 
 	resp, err := noEmailExecutor.Execute(ctx)
 
 	suite.NoError(err)
-	suite.Equal(common.ExecComplete, resp.Status)
+	suite.Equal(common.ExecFailure, resp.Status)
 	suite.Equal(dataValueFalse, resp.AdditionalData[common.DataEmailSent])
-}
-
-func (suite *EmailExecutorTestSuite) TestExecute_SendMode_NilEmailClient_SelfRegistration_InviteLinkNotExposed() {
-	noEmailExecutor := newEmailExecutor(suite.mockFlowFactory, nil, suite.mockTemplateService)
-
-	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
-		FlowType:     common.FlowTypeRegistration,
-		ExecutorMode: ExecutorModeSend,
-		UserInputs: map[string]string{
-			"email": "user@example.com",
-		},
-		RuntimeData: map[string]string{
-			common.RuntimeKeyInviteLink: "https://localhost:5190/gate/invite?executionId=test&inviteToken=abc",
-		},
-		NodeProperties: map[string]interface{}{
-			"emailTemplate": "SELF_REGISTRATION",
-		},
-	}
-
-	resp, err := noEmailExecutor.Execute(ctx)
-
-	suite.NoError(err)
-	suite.Equal(common.ExecComplete, resp.Status)
-	suite.Equal(dataValueFalse, resp.AdditionalData[common.DataEmailSent])
-	suite.Empty(resp.AdditionalData[common.DataInviteLink])
+	suite.Equal("Email service is not configured", resp.FailureReason)
 }
 
 func (suite *EmailExecutorTestSuite) TestExecute_InvalidMode() {
 	ctx := &core.NodeContext{
-		ExecutionID:  "test-flow-id",
+		ExecutionID:  "test-execution-id",
 		ExecutorMode: "invalid",
 		UserInputs:   make(map[string]string),
 		RuntimeData:  make(map[string]string),

--- a/docs/content/guides/guides/users/manage-users.mdx
+++ b/docs/content/guides/guides/users/manage-users.mdx
@@ -56,8 +56,11 @@ Use this when you want the user to complete their own registration. Thunder gene
 1. Navigate to **Users** and click **Invite User**.
 2. Select the **User Type** for the invited user.
 3. Enter the user's **Email** address.
-4. Click **Next**. Thunder generates an **Invite Link**.
-5. Copy the link and share it with the user. The link takes them to a registration flow where they complete their profile.
+4. Click **Next**.
+5. Select an invite method:
+    - **Send email invite**: Thunder generates the invite and sends the email.
+    - **Share invite link manually**: Thunder shows **Invite Link Ready** and a copyable invite link.
+6. If the email service is unavailable, Thunder shows **Email service unavailable** and still provides a copyable invite link so you can share it manually.
 
 :::tip
 The attributes available on the registration form depend on the selected user type. See [User Schema Reference](./user-schema-reference) to understand the default user types. See [User Types](./user-types) to create your own user type.


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Refactor the email executor so it surface an error when the email client is not configured, and update the onboarding flow and tests to gracefully handle email service unavailability.

This change updates the onboarding UX to prompt users for an alternative invite method when email delivery is not possible, and adds a copyable invite link to the UI message shown when the email service is unavailable.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

- Change the email executor to return an error when the email client/service is not configured rather than silently no-oping. This makes failures explicit to callers and allows flows to react accordingly.
- Update onboarding flow JSON to include a fallback message and a copyable invite link for cases where email delivery is unavailable.
- Introduce or update constants in `backend/internal/flow/common/constants.go` used by the flow and executor.
- Update unit tests for the email executor and onboarding flow to cover the new error path and the fallback invite UI.
- Keep compatible for setups with a properly configured email client; only the error path is changed to be explicit.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2195

### Related PRs
- https://github.com/asgardeo/thunder/pull/2294

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added invite-method selection during onboarding: choose "Send email invite" or "Share invite link"; new screens for invite status and link generation.

* **Bug Fixes**
  * Email service unavailability now surfaces an explicit error state to users and still provides a copyable invite link for manual sharing.

* **Documentation**
  * User guide updated to describe the new invite selection flow and the email-unavailable scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


or `Fixes `#2195