### PR TITLE
Fix custom branding CSS overwritten on color scheme toggle

### DIFF
--- a/frontend/packages/thunder-design/src/contexts/Design/useDesign.tsx
+++ b/frontend/packages/thunder-design/src/contexts/Design/useDesign.tsx
@@ -46,7 +46,9 @@ export default function useDesign(baseTheme?: Theme): DesignContextType {
   // If a baseTheme is provided, override the transformedTheme
   const transformedTheme = useMemo(() => {
     if (baseTheme && !isEmpty(context.design?.theme)) {
-      const themeOptions = merge({...context.design?.theme} as CssVarsThemeOptions, {colorSchemeSelector: 'data'});
+      const themeOptions = merge({...context.design?.theme} as CssVarsThemeOptions, {
+        colorSchemeSelector: 'data-color-scheme',
+      });
 
       // MUI's extendTheme only accepts 'light' or 'dark' for defaultColorScheme.
       // 'system' is a Thunder-level runtime concept — remove it so MUI falls


### PR DESCRIPTION
### Purpose

Custom CSS added via the branding editor does not switch to the correct mode-specific values when the user toggles between dark and light mode. The `data-color-scheme` attribute on the HTML element stays stuck on its initial value after toggling.

The `colorSchemeSelector` in `useDesign` was set to `'data'`, which causes MUI to generate CSS selectors like `[data-light]` and `[data-dark]` (bare attributes) and manage those attributes on toggle. However, MUI's theme provider actually sets `data-color-scheme="light"` on the HTML element. The mismatch means:

- The generated CSS variables scoped to `[data-dark]` never activate (no such attribute exists)
- The `data-color-scheme` attribute is never updated on toggle because MUI thinks it should manage `data-light`/`data-dark` instead
- Custom CSS targeting `html[data-color-scheme="light"]` never matches after a toggle

### Approach

Change `colorSchemeSelector` from `'data'` to `'data-color-scheme'` so MUI generates `[data-color-scheme="light"]` / `[data-color-scheme="dark"]` selectors and correctly manages the `data-color-scheme` attribute on the HTML element during toggles.

### Related Issues
- Fixes #2284

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.