### PR TITLE
Change make build order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ prepare:
 clean:
 	./build.sh clean $(OS) $(ARCH)
 
-build: build_backend build_frontend build_samples
+build: build_frontend build_backend build_samples
 
 build_backend:
 	./build.sh build_backend $(OS) $(ARCH)


### PR DESCRIPTION
### Purpose
Change make build order to avoid using existing built frontend build.

### Approach
This pull request makes a minor update to the `Makefile`, changing the order of build targets in the `build` rule. This does not affect the functionality but may help clarify the build process.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build system efficiency by adjusting the build process execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->