### PR TITLE
Add SMS-based self-invite registration flow

### DIFF
--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_invite_email.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_invite_email.json
@@ -1,0 +1,411 @@
+{
+  "name": "Default Email Self-Invite Registration Flow",
+  "handle": "default-self-invite-email-flow",
+  "flowType": "REGISTRATION",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "START",
+      "onSuccess": "user_type_resolver"
+    },
+    {
+      "id": "user_type_resolver",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "UserTypeResolver"
+      },
+      "onSuccess": "prompt_email",
+      "onIncomplete": "prompt_usertype"
+    },
+    {
+      "id": "prompt_usertype",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "alt": "{{ t(signup:images.app_logo.alt) }}",
+            "category": "DISPLAY",
+            "height": "60",
+            "id": "image",
+            "resourceType": "ELEMENT",
+            "src": "{{ meta(application.logoUrl) }}",
+            "type": "IMAGE",
+            "width": ""
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "heading_usertype",
+            "label": "{{ t(signup:forms.user_type.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_usertype",
+            "components": [
+              {
+                "type": "SELECT",
+                "id": "usertype_input",
+                "ref": "userType",
+                "label": "{{ t(signup:forms.user_type.fields.user_type.label) }}",
+                "placeholder": "{{ t(signup:forms.user_type.fields.user_type.placeholder) }}",
+                "required": true,
+                "options": []
+              },
+              {
+                "type": "ACTION",
+                "id": "action_usertype",
+                "label": "{{ t(signup:forms.user_type.actions.continue.label) }}",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "usertype_input",
+              "identifier": "userType",
+              "type": "SELECT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_usertype",
+            "nextNode": "user_type_resolver"
+          }
+        }
+      ]
+    },
+    {
+      "id": "prompt_email",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "alt": "{{ t(signup:images.app_logo.alt) }}",
+            "category": "DISPLAY",
+            "height": "60",
+            "id": "image",
+            "resourceType": "ELEMENT",
+            "src": "{{ meta(application.logoUrl) }}",
+            "type": "IMAGE",
+            "width": ""
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "text_header_email",
+            "label": "{{ t(signup:forms.email.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_email",
+            "components": [
+              {
+                "id": "input_prompt_email",
+                "ref": "email",
+                "type": "EMAIL_INPUT",
+                "label": "{{ t(signup:forms.email.fields.email.label) }}",
+                "required": true,
+                "placeholder": "{{ t(signup:forms.email.fields.email.placeholder) }}"
+              },
+              {
+                "type": "ACTION",
+                "id": "action_submit_email",
+                "label": "{{ t(signup:forms.email.actions.next.label) }}",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "input_prompt_email",
+              "identifier": "email",
+              "type": "EMAIL_INPUT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_submit_email",
+            "nextNode": "check_email_uniqueness"
+          }
+        }
+      ]
+    },
+    {
+      "id": "check_email_uniqueness",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "AttributeUniquenessValidator"
+      },
+      "onSuccess": "invite_generate",
+      "onIncomplete": "prompt_email"
+    },
+    {
+      "id": "invite_generate",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "InviteExecutor",
+        "mode": "generate"
+      },
+      "onSuccess": "send_registration_email"
+    },
+    {
+      "id": "send_registration_email",
+      "type": "TASK_EXECUTION",
+      "properties": {
+        "emailTemplate": "SELF_REGISTRATION"
+      },
+      "executor": {
+        "name": "EmailExecutor",
+        "mode": "send"
+      },
+      "onSuccess": "registration_email_sent"
+    },
+    {
+      "id": "registration_email_sent",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "alt": "{{ t(signup:images.app_logo.alt) }}",
+            "category": "DISPLAY",
+            "height": "60",
+            "id": "image",
+            "src": "{{ meta(application.logoUrl) }}",
+            "type": "IMAGE",
+            "width": ""
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "email_sent_heading",
+            "label": "{{ t(signup:forms.email_sent.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "TEXT",
+            "id": "email_sent_message",
+            "label": "{{ t(signup:forms.email_sent.message) }}"
+          }
+        ]
+      },
+      "message": "Check your email for a verification link",
+      "next": "invite_verify"
+    },
+    {
+      "id": "invite_verify",
+      "type": "TASK_EXECUTION",
+      "inputs": [
+        {
+          "ref": "input_003",
+          "identifier": "inviteToken",
+          "type": "HIDDEN",
+          "required": true
+        }
+      ],
+      "executor": {
+        "name": "InviteExecutor",
+        "mode": "verify"
+      },
+      "onSuccess": "prompt_user_details"
+    },
+    {
+      "id": "prompt_user_details",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "alt": "{{ t(signup:images.app_logo.alt) }}",
+            "category": "DISPLAY",
+            "height": "60",
+            "id": "image",
+            "resourceType": "ELEMENT",
+            "src": "{{ meta(application.logoUrl) }}",
+            "type": "IMAGE",
+            "width": ""
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "text_header_details",
+            "label": "{{ t(signup:forms.user_details.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "type": "BLOCK",
+            "id": "block_user_details",
+            "components": [
+              {
+                "id": "input_prompt_username",
+                "ref": "username",
+                "type": "TEXT_INPUT",
+                "label": "{{ t(signup:forms.user_details.fields.username.label) }}",
+                "required": true,
+                "placeholder": "{{ t(signup:forms.user_details.fields.username.placeholder) }}"
+              },
+              {
+                "id": "input_prompt_given_name",
+                "ref": "given_name",
+                "type": "TEXT_INPUT",
+                "label": "{{ t(signup:forms.user_details.fields.first_name.label) }}",
+                "required": false,
+                "placeholder": "{{ t(signup:forms.user_details.fields.first_name.placeholder) }}"
+              },
+              {
+                "id": "input_prompt_family_name",
+                "ref": "family_name",
+                "type": "TEXT_INPUT",
+                "label": "{{ t(signup:forms.user_details.fields.last_name.label) }}",
+                "required": false,
+                "placeholder": "{{ t(signup:forms.user_details.fields.last_name.placeholder) }}"
+              },
+              {
+                "id": "input_prompt_password",
+                "ref": "password",
+                "type": "PASSWORD_INPUT",
+                "label": "{{ t(signup:forms.credential.fields.password.label) }}",
+                "required": true,
+                "placeholder": "{{ t(signup:forms.credential.fields.password.placeholder) }}"
+              },
+              {
+                "type": "ACTION",
+                "id": "action_submit_details",
+                "label": "{{ t(signup:forms.credential.actions.submit.label) }}",
+                "variant": "PRIMARY",
+                "eventType": "SUBMIT"
+              }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [
+            {
+              "ref": "input_prompt_username",
+              "identifier": "username",
+              "type": "TEXT_INPUT",
+              "required": true
+            },
+            {
+              "ref": "input_prompt_given_name",
+              "identifier": "given_name",
+              "type": "TEXT_INPUT",
+              "required": false
+            },
+            {
+              "ref": "input_prompt_family_name",
+              "identifier": "family_name",
+              "type": "TEXT_INPUT",
+              "required": false
+            },
+            {
+              "ref": "input_prompt_password",
+              "identifier": "password",
+              "type": "PASSWORD_INPUT",
+              "required": true
+            }
+          ],
+          "action": {
+            "ref": "action_submit_details",
+            "nextNode": "check_user_details_uniqueness"
+          }
+        }
+      ]
+    },
+    {
+      "id": "check_user_details_uniqueness",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "AttributeUniquenessValidator"
+      },
+      "onSuccess": "provisioning",
+      "onIncomplete": "prompt_user_details"
+    },
+    {
+      "id": "provisioning",
+      "type": "TASK_EXECUTION",
+      "inputs": [
+        {
+          "ref": "input_email",
+          "identifier": "email",
+          "type": "EMAIL_INPUT",
+          "required": true
+        },
+        {
+          "ref": "input_username",
+          "identifier": "username",
+          "type": "TEXT_INPUT",
+          "required": true
+        },
+        {
+          "ref": "input_password",
+          "identifier": "password",
+          "type": "PASSWORD_INPUT",
+          "required": true
+        },
+        {
+          "ref": "input_given_name",
+          "identifier": "given_name",
+          "type": "TEXT_INPUT",
+          "required": false
+        },
+        {
+          "ref": "input_family_name",
+          "identifier": "family_name",
+          "type": "TEXT_INPUT",
+          "required": false
+        }
+      ],
+      "executor": {
+        "name": "ProvisioningExecutor"
+      },
+      "onSuccess": "registration_complete"
+    },
+    {
+      "id": "registration_complete",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "registration_complete_icon",
+            "label": "✅",
+            "variant": "HEADING_1"
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "registration_complete_heading",
+            "label": "{{ t(invite:complete.title) }}",
+            "variant": "HEADING_1"
+          },
+          {
+            "align": "center",
+            "type": "TEXT",
+            "id": "registration_complete_message",
+            "label": "{{ t(invite:complete.description) }}"
+          }
+        ]
+      },
+      "message": "Registration complete",
+      "next": "end"
+    },
+    {
+      "id": "end",
+      "type": "END"
+    }
+  ]
+}

--- a/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_invite_sms.json
+++ b/backend/cmd/server/bootstrap/flows/registration/registration_flow_basic_invite_sms.json
@@ -1,6 +1,6 @@
 {
-  "name": "Default Self-Invite Registration Flow",
-  "handle": "default-self-invite-flow",
+  "name": "Default SMS Self-Invite Registration Flow",
+  "handle": "default-self-invite-sms-flow",
   "flowType": "REGISTRATION",
   "nodes": [
     {
@@ -14,7 +14,7 @@
       "executor": {
         "name": "UserTypeResolver"
       },
-      "onSuccess": "prompt_email",
+      "onSuccess": "prompt_phone",
       "onIncomplete": "prompt_usertype"
     },
     {
@@ -81,7 +81,7 @@
       ]
     },
     {
-      "id": "prompt_email",
+      "id": "prompt_phone",
       "type": "PROMPT",
       "meta": {
         "components": [
@@ -98,26 +98,26 @@
           {
             "align": "center",
             "type": "TEXT",
-            "id": "text_header_email",
-            "label": "{{ t(signup:forms.email.title) }}",
+            "id": "text_header_phone",
+            "label": "{{ t(signup:forms.phone.title) }}",
             "variant": "HEADING_1"
           },
           {
             "type": "BLOCK",
-            "id": "block_email",
+            "id": "block_phone",
             "components": [
               {
-                "id": "input_prompt_email",
-                "ref": "email",
-                "type": "EMAIL_INPUT",
-                "label": "{{ t(signup:forms.email.fields.email.label) }}",
+                "id": "input_prompt_phone",
+                "ref": "mobileNumber",
+                "type": "PHONE_INPUT",
+                "label": "{{ t(signup:forms.phone.fields.phone.label) }}",
                 "required": true,
-                "placeholder": "{{ t(signup:forms.email.fields.email.placeholder) }}"
+                "placeholder": "{{ t(signup:forms.phone.fields.phone.placeholder) }}"
               },
               {
                 "type": "ACTION",
-                "id": "action_submit_email",
-                "label": "{{ t(signup:forms.email.actions.next.label) }}",
+                "id": "action_submit_phone",
+                "label": "{{ t(signup:forms.phone.actions.next.label) }}",
                 "variant": "PRIMARY",
                 "eventType": "SUBMIT"
               }
@@ -129,27 +129,27 @@
         {
           "inputs": [
             {
-              "ref": "input_prompt_email",
-              "identifier": "email",
-              "type": "EMAIL_INPUT",
+              "ref": "input_prompt_phone",
+              "identifier": "mobileNumber",
+              "type": "PHONE_INPUT",
               "required": true
             }
           ],
           "action": {
-            "ref": "action_submit_email",
-            "nextNode": "check_email_uniqueness"
+            "ref": "action_submit_phone",
+            "nextNode": "check_phone_uniqueness"
           }
         }
       ]
     },
     {
-      "id": "check_email_uniqueness",
+      "id": "check_phone_uniqueness",
       "type": "TASK_EXECUTION",
       "executor": {
         "name": "AttributeUniquenessValidator"
       },
       "onSuccess": "invite_generate",
-      "onIncomplete": "prompt_email"
+      "onIncomplete": "prompt_phone"
     },
     {
       "id": "invite_generate",
@@ -158,22 +158,23 @@
         "name": "InviteExecutor",
         "mode": "generate"
       },
-      "onSuccess": "send_registration_email"
+      "onSuccess": "send_registration_sms"
     },
     {
-      "id": "send_registration_email",
+      "id": "send_registration_sms",
       "type": "TASK_EXECUTION",
       "properties": {
-        "emailTemplate": "SELF_REGISTRATION"
+        "senderId": "<your-sender-id>",
+        "smsTemplate": "SELF_REGISTRATION"
       },
       "executor": {
-        "name": "EmailExecutor",
+        "name": "SMSExecutor",
         "mode": "send"
       },
-      "onSuccess": "registration_email_sent"
+      "onSuccess": "registration_sms_sent"
     },
     {
-      "id": "registration_email_sent",
+      "id": "registration_sms_sent",
       "type": "PROMPT",
       "meta": {
         "components": [
@@ -189,18 +190,18 @@
           {
             "align": "center",
             "type": "TEXT",
-            "id": "email_sent_heading",
-            "label": "{{ t(signup:forms.email_sent.title) }}",
+            "id": "sms_sent_heading",
+            "label": "{{ t(signup:forms.sms_sent.title) }}",
             "variant": "HEADING_1"
           },
           {
             "type": "TEXT",
-            "id": "email_sent_message",
-            "label": "{{ t(signup:forms.email_sent.message) }}"
+            "id": "sms_sent_message",
+            "label": "{{ t(signup:forms.sms_sent.message) }}"
           }
         ]
       },
-      "message": "Check your email for a verification link",
+      "message": "Check your phone for a verification link",
       "next": "invite_verify"
     },
     {
@@ -338,9 +339,9 @@
       "type": "TASK_EXECUTION",
       "inputs": [
         {
-          "ref": "input_email",
-          "identifier": "email",
-          "type": "EMAIL_INPUT",
+          "ref": "input_mobile_number",
+          "identifier": "mobileNumber",
+          "type": "PHONE_INPUT",
           "required": true
         },
         {

--- a/backend/cmd/server/bootstrap/i18n/en-US.json
+++ b/backend/cmd/server/bootstrap/i18n/en-US.json
@@ -195,7 +195,13 @@
       "forms.credential.fields.password.placeholder": "Enter your password",
       "forms.credential.actions.submit.label": "Sign Up",
       "forms.email_sent.title": "Check Your Email",
-      "forms.email_sent.message": "We sent you a verification link. Please check your inbox and click the link to continue."
+      "forms.email_sent.message": "We sent you a verification link. Please check your inbox and click the link to continue.",
+      "forms.phone.title": "Sign Up",
+      "forms.phone.fields.phone.label": "Mobile Number",
+      "forms.phone.fields.phone.placeholder": "Enter your mobile number",
+      "forms.phone.actions.next.label": "Next",
+      "forms.sms_sent.title": "Check Your Phone",
+      "forms.sms_sent.message": "We sent you a verification link via SMS. Please check your messages and click the link to continue."
     }
   }
 }


### PR DESCRIPTION
### Purpose
Add a new bootstrap registration flow that delivers the self-invite link via SMS instead of email. This enables organizations to onboard users using only a mobile number, without requiring an email address at registration time.

### Approach
A new flow definition registration_flow_basic_invite_sms.json is introduced alongside the existing email-based invite flow. The flow follows the same structural pattern but replaces the email collection and delivery steps with phone-based equivalents:

- **Phone collection** — prompts the user for a mobileNumber (using PHONE_INPUT) instead of an email address
- **Uniqueness validation** — runs AttributeUniquenessValidator against the mobileNumber attribute before proceeding
- **Invite generation** — uses InviteExecutor in generate mode to produce the invite token, unchanged from the email flow
- **SMS delivery** — uses SMSExecutor in send mode with the SELF_REGISTRATION template to dispatch the invite link to the collected mobile number
- **Invite verification** — uses InviteExecutor in verify mode to validate the token when the user follows the link, unchanged from the email flow
- **Provisioning** — collects username, password, given name, and family name, then provisions the user with mobileNumber as the identifying attribute

Two i18n keys (forms.phone.* and forms.sms_sent.*) are added to the signup namespace in en-US.json to support the new prompt and confirmation screens.

No changes are made to existing flows, executors, or backend logic.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1929

### Related PRs
- https://github.com/asgardeo/thunder/pull/2128
- https://github.com/asgardeo/thunder/pull/2217
- https://github.com/asgardeo/thunder/pull/1970


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step SMS self-invite registration: phone entry, SMS delivery, verification, and account setup.
  * Added phone verification forms and SMS confirmation UI text.

* **Chores**
  * Clarified email registration display names to include an "Email" designation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->