### PR TITLE
Add PS256 (RSA-PSS) algorithm support for JWT signing

### DIFF
--- a/backend/internal/system/crypto/sign/model.go
+++ b/backend/internal/system/crypto/sign/model.go
@@ -22,10 +22,12 @@ package sign
 type SignAlgorithm string
 
 const (
-	// RSASHA256 represents RSA signature with SHA-256 hash
+	// RSASHA256 represents RSA signature with SHA-256 hash (PKCS1v15)
 	RSASHA256 SignAlgorithm = "RSA-SHA256"
-	// RSASHA512 represents RSA signature with SHA-512 hash
+	// RSASHA512 represents RSA signature with SHA-512 hash (PKCS1v15)
 	RSASHA512 SignAlgorithm = "RSA-SHA512"
+	// RSAPSSSHA256 represents RSA-PSS signature with SHA-256 hash
+	RSAPSSSHA256 SignAlgorithm = "RSA-PSS-SHA256"
 	// ECDSASHA256 represents ECDSA signature with SHA-256 hash
 	ECDSASHA256 SignAlgorithm = "ECDSA-SHA256"
 	// ECDSASHA384 represents ECDSA signature with SHA-384 hash

--- a/backend/internal/system/crypto/sign/utils.go
+++ b/backend/internal/system/crypto/sign/utils.go
@@ -51,6 +51,8 @@ func Generate(data []byte, alg SignAlgorithm, privateKey crypto.PrivateKey) ([]b
 	switch alg {
 	case RSASHA256, RSASHA512:
 		return newRSASign(hashed, hashFunc, privateKey)
+	case RSAPSSSHA256:
+		return newRSAPSSSign(hashed, hashFunc, privateKey)
 	case ECDSASHA256, ECDSASHA384, ECDSASHA512:
 		return newECDSASign(hashed, privateKey)
 	case ED25519:
@@ -70,6 +72,8 @@ func Verify(data []byte, signature []byte, alg SignAlgorithm, publicKey crypto.P
 	switch alg {
 	case RSASHA256, RSASHA512:
 		return verifyRSA(hashed, signature, hashFunc, publicKey)
+	case RSAPSSSHA256:
+		return verifyRSAPSS(hashed, signature, hashFunc, publicKey)
 	case ECDSASHA256, ECDSASHA384, ECDSASHA512:
 		return verifyECDSA(hashed, signature, publicKey)
 	case ED25519:
@@ -87,7 +91,7 @@ func hashData(data []byte, alg SignAlgorithm) ([]byte, crypto.Hash) {
 	var hashFunc crypto.Hash
 
 	switch alg {
-	case RSASHA256, ECDSASHA256:
+	case RSASHA256, RSAPSSSHA256, ECDSASHA256:
 		h = sha256.New()
 		hashFunc = crypto.SHA256
 	case RSASHA512, ECDSASHA512:
@@ -132,6 +136,40 @@ func verifyRSA(hashed, signature []byte, hashFunc crypto.Hash, publicKey crypto.
 	}
 
 	err := rsa.VerifyPKCS1v15(rsaPub, hashFunc, hashed, signature)
+	if err != nil {
+		return ErrInvalidSignature
+	}
+
+	return nil
+}
+
+// newRSAPSSSign creates a digital signature using RSA-PSS.
+// Salt length is set equal to the hash output size as required by RFC 7518 Section 3.5.
+func newRSAPSSSign(hashed []byte, hashFunc crypto.Hash, privateKey crypto.PrivateKey) ([]byte, error) {
+	rsaKey, ok := privateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, ErrInvalidPrivateKey
+	}
+
+	opts := &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: hashFunc}
+	signature, err := rsa.SignPSS(rand.Reader, rsaKey, hashFunc, hashed, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return signature, nil
+}
+
+// verifyRSAPSS verifies an RSA-PSS signature.
+// Salt length is set equal to the hash output size as required by RFC 7518 Section 3.5.
+func verifyRSAPSS(hashed, signature []byte, hashFunc crypto.Hash, publicKey crypto.PublicKey) error {
+	rsaPub, ok := publicKey.(*rsa.PublicKey)
+	if !ok {
+		return ErrInvalidPublicKey
+	}
+
+	opts := &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: hashFunc}
+	err := rsa.VerifyPSS(rsaPub, hashFunc, hashed, signature, opts)
 	if err != nil {
 		return ErrInvalidSignature
 	}

--- a/backend/internal/system/crypto/sign/utils_test.go
+++ b/backend/internal/system/crypto/sign/utils_test.go
@@ -78,6 +78,17 @@ func (suite *SignUtilsTestSuite) TestSignRSASHA256() {
 	assert.NoError(suite.T(), err)
 }
 
+func (suite *SignUtilsTestSuite) TestSignRSAPSSHA256() {
+	signature, err := Generate(suite.testData, RSAPSSSHA256, suite.rsaPrivateKey)
+
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), signature)
+
+	// Verify the signature
+	err = Verify(suite.testData, signature, RSAPSSSHA256, &suite.rsaPrivateKey.PublicKey)
+	assert.NoError(suite.T(), err)
+}
+
 func (suite *SignUtilsTestSuite) TestSignRSASHA512() {
 	signature, err := Generate(suite.testData, RSASHA512, suite.rsaPrivateKey)
 
@@ -155,9 +166,11 @@ func (suite *SignUtilsTestSuite) TestSignInvalidPrivateKey() {
 		privateKey crypto.PrivateKey
 	}{
 		{"RSA_WithECDSAKey", RSASHA256, suite.ecdsaPrivateKey},
+		{"RSAPSS_WithECDSAKey", RSAPSSSHA256, suite.ecdsaPrivateKey},
 		{"ECDSA_WithRSAKey", ECDSASHA256, suite.rsaPrivateKey},
 		{"ED25519_WithRSAKey", ED25519, suite.rsaPrivateKey},
 		{"RSA_WithNilKey", RSASHA256, nil},
+		{"RSAPSS_WithNilKey", RSAPSSSHA256, nil},
 		{"ECDSA_WithNilKey", ECDSASHA256, nil},
 		{"ED25519_WithNilKey", ED25519, nil},
 	}
@@ -180,9 +193,11 @@ func (suite *SignUtilsTestSuite) TestVerifyInvalidPublicKey() {
 		publicKey crypto.PublicKey
 	}{
 		{"RSA_WithECDSAKey", RSASHA256, &suite.ecdsaPrivateKey.PublicKey},
+		{"RSAPSS_WithECDSAKey", RSAPSSSHA256, &suite.ecdsaPrivateKey.PublicKey},
 		{"ECDSA_WithRSAKey", ECDSASHA256, &suite.rsaPrivateKey.PublicKey},
 		{"ED25519_WithRSAKey", ED25519, &suite.rsaPrivateKey.PublicKey},
 		{"RSA_WithNilKey", RSASHA256, nil},
+		{"RSAPSS_WithNilKey", RSAPSSSHA256, nil},
 		{"ECDSA_WithNilKey", ECDSASHA256, nil},
 		{"ED25519_WithNilKey", ED25519, nil},
 	}
@@ -473,4 +488,21 @@ func (suite *SignUtilsTestSuite) TestSignECDSAASN1Format() {
 	// The signature should be verifiable (using ASN.1 format)
 	err = Verify(suite.testData, signature, ECDSASHA256, &suite.ecdsaPrivateKey.PublicKey)
 	assert.NoError(suite.T(), err)
+}
+
+func (suite *SignUtilsTestSuite) TestRSAPSSAndPKCS1v15AreNotCrossVerifiable() {
+	// A PSS signature must not verify under PKCS1v15 and vice versa
+	pssSignature, err := Generate(suite.testData, RSAPSSSHA256, suite.rsaPrivateKey)
+	assert.NoError(suite.T(), err)
+
+	err = Verify(suite.testData, pssSignature, RSASHA256, &suite.rsaPrivateKey.PublicKey)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), ErrInvalidSignature, err)
+
+	pkcs1Signature, err := Generate(suite.testData, RSASHA256, suite.rsaPrivateKey)
+	assert.NoError(suite.T(), err)
+
+	err = Verify(suite.testData, pkcs1Signature, RSAPSSSHA256, &suite.rsaPrivateKey.PublicKey)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), ErrInvalidSignature, err)
 }

--- a/backend/internal/system/jose/jws/model.go
+++ b/backend/internal/system/jose/jws/model.go
@@ -22,10 +22,12 @@ package jws
 type Algorithm string
 
 const (
-	// RS256 represents RSA signature with SHA-256 hash for JWS
+	// RS256 represents RSA PKCS1v15 signature with SHA-256 hash for JWS
 	RS256 Algorithm = "RS256"
-	// RS512 represents RSA signature with SHA-512 hash for JWS
+	// RS512 represents RSA PKCS1v15 signature with SHA-512 hash for JWS
 	RS512 Algorithm = "RS512"
+	// PS256 represents RSA-PSS signature with SHA-256 hash for JWS
+	PS256 Algorithm = "PS256"
 	// ES256 represents ECDSA signature with SHA-256 hash for JWS
 	ES256 Algorithm = "ES256"
 	// ES384 represents ECDSA signature with SHA-384 hash for JWS

--- a/backend/internal/system/jose/jws/utils.go
+++ b/backend/internal/system/jose/jws/utils.go
@@ -61,6 +61,8 @@ func MapAlgorithmToSignAlg(jwsAlg Algorithm) (sign.SignAlgorithm, error) {
 		return sign.RSASHA256, nil
 	case RS512:
 		return sign.RSASHA512, nil
+	case PS256:
+		return sign.RSAPSSSHA256, nil
 	case ES256:
 		return sign.ECDSASHA256, nil
 	case ES384:

--- a/backend/internal/system/jose/jws/utils_test.go
+++ b/backend/internal/system/jose/jws/utils_test.go
@@ -135,6 +135,7 @@ func (suite *JWSUtilsTestSuite) TestMapAlgorithmToSignAlgAllSupported() {
 	}{
 		{"RS256", RS256, sign.RSASHA256},
 		{"RS512", RS512, sign.RSASHA512},
+		{"PS256", PS256, sign.RSAPSSSHA256},
 		{"ES256", ES256, sign.ECDSASHA256},
 		{"ES384", ES384, sign.ECDSASHA384},
 		{"ES512", ES512, sign.ECDSASHA512},

--- a/docs/content/guides/guides/trusted-issuer.mdx
+++ b/docs/content/guides/guides/trusted-issuer.mdx
@@ -91,7 +91,7 @@ Thunder picks the verification method based on the token's `iss` claim. If `iss`
 
 Each `required_claims` entry is matched by exact string equality: the claim must be present on the token and its value must match the configured `value` exactly.
 
-Thunder accepts tokens signed with `RS256`, `RS512`, `ES256`, `ES384`, `ES512`, or `EdDSA`. Tokens using any other algorithm are rejected. JWKS responses are cached in-process for `server.security.jwks_cache_ttl` seconds (default: 300), so plan external-server key rotations with at least that much overlap.
+Thunder accepts tokens signed with `RS256`, `PS256`, `RS512`, `ES256`, `ES384`, `ES512`, or `EdDSA`. Tokens using any other algorithm are rejected. JWKS responses are cached in-process for `server.security.jwks_cache_ttl` seconds (default: 300), so plan external-server key rotations with at least that much overlap.
 
 ## Helm Configuration
 


### PR DESCRIPTION
### Purpose
JWT signing currently only supports RS256 (PKCS#1 v1.5), which is not recommended under modern FIPS 186-5 guidance. This change introduces PS256 (RSA-PSS with SHA-256) as a supported signing algorithm primitive, advertises it in OIDC discovery, and keeps RS256 fully intact — no breaking change.

> Note: Making the signing algorithm runtime-configurable is a subsequent effort to be discussed with the team separately. 

### Goals

* Add PS256 (RSA-PSS with SHA-256) as a supported JWT signing algorithm primitive
* Advertise PS256 in the OIDC discovery `id_token_signing_alg_values_supported` list
* Keep RS256 behavior completely unchanged — no breaking change
* Provide full test coverage for the new PS256 signing path including cross-algorithm non-interoperability

### Approach

* Added `RSAPSSSHA256` constant in `sign/model.go` and RSA-PSS sign/verify functions (`rsa.SignPSS` / `rsa.VerifyPSS`) with explicit RFC 7518 §3.5 compliant salt length (`PSSSaltLengthEqualsHash`) in `sign/utils.go`
* Added `PS256` JWS algorithm constant in `jws/model.go` and wired it into `MapAlgorithmToSignAlg` in `jws/utils.go`
* Added `SigningAlgorithmPS256` constant and updated `GetSupportedIDTokenSigningAlgorithms()` to return both `["RS256", "PS256"]` in `constants.go`
* Added unit tests: PSS sign/verify happy path, invalid key cases, cross-algorithm non-interoperability test (`PS256` signature correctly fails `RS256` verification and vice versa), JWKS mapping test, and updated discovery test

> ### Notable points worth reviewing
> 
> -  🔐 **RFC 7518 §3.5 compliant** — `rsa.SignPSS` and `rsa.VerifyPSS` are called with explicit `PSSSaltLengthEqualsHash` (32 bytes for SHA-256) rather than Go's default `PSSSaltLengthAuto`, ensuring interoperability with all RFC-compliant JWT validators.
>  
> -  🔀 **Cross-algorithm non-interoperability verified** — PS256 signatures correctly fail RS256 verification and vice versa, confirmed by dedicated tests.
>  
> -  📋 **FIPS 186-5 alignment** — RSA-PSS (PS256) is the RSA signature scheme recommended by FIPS 186-5, replacing the older PKCS#1 v1.5 scheme used by RS256.
>  
> -  ⏭️ **Configurability is a follow-up** — runtime selection between RS256 and PS256 via `deployment.yaml` will be handled in a separate PR after team discussion.

### Related Issue
- https://github.com/asgardeo/thunder/issues/1987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RSA-PSS SHA-256 (PS256) as a supported JWT signing algorithm.

* **Documentation**
  * Updated Trusted Issuer documentation to include PS256 as an accepted JWT signing algorithm alongside RS256, RS512, ES256, ES384, ES512, and EdDSA.
  * Clarified that RS256 and RS512 use RSA PKCS#1 v1.5 padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->