### PR TITLE
Fix missing app logo and sign up URL ordering in generated flows

### DIFF
--- a/frontend/apps/thunder-console/src/features/flows/utils/__tests__/generateFlowGraph.test.ts
+++ b/frontend/apps/thunder-console/src/features/flows/utils/__tests__/generateFlowGraph.test.ts
@@ -24,11 +24,13 @@ interface Component {
   id: string;
   type?: string;
   label?: string;
+  src?: string;
   components?: Component[];
 }
 
-function findSignUpLinkInBlock(block: Component | undefined): Component | undefined {
-  return block?.components?.find((c) => c.id === 'self_sign_up_link');
+function getPromptComponents(result: ReturnType<typeof generateFlowGraph>): Component[] {
+  const promptNode = result.nodes.find((n) => n.type === FlowNodeType.PROMPT);
+  return (promptNode?.meta?.components as Component[]) ?? [];
 }
 
 describe('generateFlowGraph', () => {
@@ -42,16 +44,9 @@ describe('generateFlowGraph', () => {
     expect(request.handle).toBe('generated-basic-flow');
     expect(request.nodes).toHaveLength(5); // START, PROMPT, BASIC_EXEC, AUTH_ASSERT, END
 
-    const promptNode = request.nodes.find((n) => n.type === FlowNodeType.PROMPT);
-    expect(promptNode).toBeDefined();
-    expect(promptNode?.meta?.components).toBeDefined();
-
-    const components = promptNode?.meta?.components as Component[];
-    const basicBlock = components.find((c) => c.id === 'block_basic');
-    expect(basicBlock).toBeDefined();
-
-    const signUpLink = findSignUpLinkInBlock(basicBlock);
-    expect(signUpLink).toBeDefined();
+    const components = getPromptComponents(request);
+    expect(components.find((c) => c.id === 'block_basic')).toBeDefined();
+    expect(components.find((c) => c.id === 'self_sign_up_link')).toBeDefined();
   });
 
   it('should generate a Passkey flow', () => {
@@ -63,17 +58,10 @@ describe('generateFlowGraph', () => {
 
     expect(request.handle).toBe('generated-passkey-flow');
 
-    const promptNode = request.nodes.find((n) => n.type === FlowNodeType.PROMPT);
-    const components = promptNode?.meta?.components as Component[];
-
-    const passkeyBlock = components.find((c) => c.id === 'block_passkey');
-    expect(passkeyBlock).toBeDefined();
-
-    const basicBlock = components.find((c) => c.id === 'block_basic');
-    expect(basicBlock).toBeUndefined();
-
-    const signUpLink = findSignUpLinkInBlock(passkeyBlock);
-    expect(signUpLink).toBeDefined();
+    const components = getPromptComponents(request);
+    expect(components.find((c) => c.id === 'block_passkey')).toBeDefined();
+    expect(components.find((c) => c.id === 'block_basic')).toBeUndefined();
+    expect(components.find((c) => c.id === 'self_sign_up_link')).toBeDefined();
 
     // Executors
     const executors = request.nodes.filter((n) => n.type === FlowNodeType.TASK_EXECUTION);
@@ -91,17 +79,11 @@ describe('generateFlowGraph', () => {
 
     expect(request.handle).toBe('generated-basic-google-passkey-flow');
 
-    const promptNode = request.nodes.find((n) => n.type === FlowNodeType.PROMPT);
-    const components = promptNode?.meta?.components as Component[];
-
-    const basicBlock = components.find((c) => c.id === 'block_basic');
-    expect(basicBlock).toBeDefined();
+    const components = getPromptComponents(request);
+    expect(components.find((c) => c.id === 'block_basic')).toBeDefined();
     expect(components.find((c) => c.id === 'block_passkey')).toBeDefined();
     expect(components.find((c) => c.id === 'block_social')).toBeDefined();
-
-    // Sign-up link is inside block_basic (hasBasicAuth takes precedence)
-    const signUpLink = findSignUpLinkInBlock(basicBlock);
-    expect(signUpLink).toBeDefined();
+    expect(components.find((c) => c.id === 'self_sign_up_link')).toBeDefined();
 
     // Executors
     const executors = request.nodes.filter((n) => n.type === FlowNodeType.TASK_EXECUTION);
@@ -121,11 +103,8 @@ describe('generateFlowGraph', () => {
 
     expect(request.handle).toBe('generated-basic-github-flow');
 
-    const promptNode = request.nodes.find((n) => n.type === FlowNodeType.PROMPT);
-    const components = promptNode?.meta?.components as Component[];
-    const basicBlock = components.find((c) => c.id === 'block_basic');
-    const signUpLink = findSignUpLinkInBlock(basicBlock);
-    expect(signUpLink).toBeDefined();
+    const components = getPromptComponents(request);
+    expect(components.find((c) => c.id === 'self_sign_up_link')).toBeDefined();
 
     // Executors
     const executors = request.nodes.filter((n) => n.type === FlowNodeType.TASK_EXECUTION);
@@ -148,48 +127,74 @@ describe('generateFlowGraph', () => {
     expect(challengeNode?.properties?.relyingPartyId).toBe('my-app.com');
     expect(challengeNode?.properties?.relyingPartyName).toBe('My App');
 
-    const promptNode = request.nodes.find((n) => n.type === FlowNodeType.PROMPT);
-    const components = promptNode?.meta?.components as Component[];
-    const passkeyBlock = components.find((c) => c.id === 'block_passkey');
-    const signUpLink = findSignUpLinkInBlock(passkeyBlock);
-    expect(signUpLink).toBeDefined();
+    const components = getPromptComponents(request);
+    expect(components.find((c) => c.id === 'self_sign_up_link')).toBeDefined();
   });
 
-  it('should include a Self Sign Up Link inside the auth block for basic and passkey-only flows', () => {
-    const cases: {options: Parameters<typeof generateFlowGraph>[0]; blockId: string}[] = [
-      {options: {hasBasicAuth: true, hasPasskey: false, hasSmsOtp: false}, blockId: 'block_basic'},
-      {options: {hasBasicAuth: false, hasPasskey: true, hasSmsOtp: false}, blockId: 'block_passkey'},
-      {
-        options: {hasBasicAuth: true, hasPasskey: false, googleIdpId: 'google-id', hasSmsOtp: false},
-        blockId: 'block_basic',
-      },
-      {
-        options: {hasBasicAuth: true, hasPasskey: false, githubIdpId: 'github-id', hasSmsOtp: false},
-        blockId: 'block_basic',
-      },
+  it('should include a Self Sign Up Link as a top-level meta component for basic and passkey flows', () => {
+    const cases: Parameters<typeof generateFlowGraph>[0][] = [
+      {hasBasicAuth: true, hasPasskey: false, hasSmsOtp: false},
+      {hasBasicAuth: false, hasPasskey: true, hasSmsOtp: false},
+      {hasBasicAuth: true, hasPasskey: false, googleIdpId: 'google-id', hasSmsOtp: false},
+      {hasBasicAuth: true, hasPasskey: false, githubIdpId: 'github-id', hasSmsOtp: false},
     ];
 
-    for (const {options, blockId} of cases) {
+    for (const options of cases) {
       const request = generateFlowGraph(options);
-      const promptNode = request.nodes.find((n) => n.type === FlowNodeType.PROMPT);
-      const components = promptNode?.meta?.components as Component[];
-      const block = components.find((c) => c.id === blockId);
+      const components = getPromptComponents(request);
+      const signUpLink = components.find((c) => c.id === 'self_sign_up_link');
 
-      const signUpLink = findSignUpLinkInBlock(block);
       expect(signUpLink).toBeDefined();
       expect(signUpLink?.type).toBe('RICH_TEXT');
       expect(signUpLink?.label).toContain('{{meta(application.sign_up_url)}}');
     }
   });
 
-  it('should place the Self Sign Up Link as the last component inside the auth block', () => {
-    const request = generateFlowGraph({hasBasicAuth: true, hasPasskey: false, hasSmsOtp: false});
-    const promptNode = request.nodes.find((n) => n.type === FlowNodeType.PROMPT);
-    const components = promptNode?.meta?.components as Component[];
-    const basicBlock = components.find((c) => c.id === 'block_basic');
+  it('should not include a Self Sign Up Link for social-only flows', () => {
+    const request = generateFlowGraph({
+      hasBasicAuth: false,
+      hasPasskey: false,
+      googleIdpId: 'google-id',
+      hasSmsOtp: false,
+    });
 
-    const blockComponents = basicBlock?.components ?? [];
-    expect(blockComponents.length).toBeGreaterThan(0);
-    expect(blockComponents[blockComponents.length - 1].id).toBe('self_sign_up_link');
+    const components = getPromptComponents(request);
+    expect(components.find((c) => c.id === 'self_sign_up_link')).toBeUndefined();
+  });
+
+  it('should place the Self Sign Up Link as the last top-level meta component', () => {
+    const request = generateFlowGraph({hasBasicAuth: true, hasPasskey: false, hasSmsOtp: false});
+    const components = getPromptComponents(request);
+
+    expect(components.length).toBeGreaterThan(0);
+    expect(components[components.length - 1].id).toBe('self_sign_up_link');
+  });
+
+  it('should place the Self Sign Up Link after all auth blocks (basic + passkey + social)', () => {
+    const request = generateFlowGraph({
+      hasBasicAuth: true,
+      hasPasskey: true,
+      googleIdpId: 'google-id',
+      hasSmsOtp: false,
+    });
+    const components = getPromptComponents(request);
+
+    const signUpLinkIndex = components.findIndex((c) => c.id === 'self_sign_up_link');
+    const basicBlockIndex = components.findIndex((c) => c.id === 'block_basic');
+    const passkeyBlockIndex = components.findIndex((c) => c.id === 'block_passkey');
+    const socialBlockIndex = components.findIndex((c) => c.id === 'block_social');
+
+    expect(signUpLinkIndex).toBeGreaterThan(basicBlockIndex);
+    expect(signUpLinkIndex).toBeGreaterThan(passkeyBlockIndex);
+    expect(signUpLinkIndex).toBeGreaterThan(socialBlockIndex);
+  });
+
+  it('should include the application logo as the first meta component', () => {
+    const request = generateFlowGraph({hasBasicAuth: true, hasPasskey: false, hasSmsOtp: false});
+    const components = getPromptComponents(request);
+
+    expect(components[0].id).toBe('image');
+    expect(components[0].type).toBe('IMAGE');
+    expect(components[0].src).toContain('application.logoUrl');
   });
 });

--- a/frontend/apps/thunder-console/src/features/flows/utils/generateFlowGraph.ts
+++ b/frontend/apps/thunder-console/src/features/flows/utils/generateFlowGraph.ts
@@ -85,6 +85,18 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
       '<span class="rich-text-pre-wrap">Sign up</span></a></p>',
   };
 
+  // Application Logo
+  metaComponents.push({
+    category: 'DISPLAY',
+    type: 'IMAGE',
+    id: 'image',
+    src: '{{meta(application.logoUrl)}}',
+    alt: '{{t(signin:images.app_logo.alt)}}',
+    height: '60',
+    width: '',
+    resourceType: 'ELEMENT',
+  });
+
   // Header
   metaComponents.push({
     type: 'TEXT',
@@ -132,7 +144,6 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
           variant: 'PRIMARY',
           eventType: 'SUBMIT',
         },
-        selfSignUpLink,
       ],
     });
 
@@ -173,7 +184,6 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
           variant: hasBasicAuth ? 'SECONDARY' : 'PRIMARY',
           eventType: 'SUBMIT',
         },
-        ...(!hasBasicAuth ? [selfSignUpLink] : []),
       ],
     });
 
@@ -231,6 +241,11 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
       id: 'block_social',
       components: socialComponents,
     });
+  }
+
+  // Self Sign Up Link — always at the bottom, after all auth options
+  if (hasBasicAuth || hasPasskey) {
+    metaComponents.push(selfSignUpLink);
   }
 
   // Connect PROMPT node


### PR DESCRIPTION
### Purpose

Auto-generated authentication flows created during application onboarding were missing the application logo and had the "Don't have an account? Sign up" link misplaced — it was embedded inside the first auth block, causing it to render above passkey and social sign-in options rather than at the bottom of the form.

| Before | After |
|---|---|
| No app logo in generated flows | App logo renders at the top, consistent with static flows |
| Sign Up URL appeared above Passkey / Google sign-in buttons | Sign Up URL renders after all auth options at the bottom |

### Approach
Both issues are in `generateFlowGraph.ts`, which programmatically builds the `metaComponents` array for the prompt node during onboarding.

**Missing logo:** All hand-authored static bootstrap flows (e.g. `auth_flow_basic.json`) include an `IMAGE` component as the first meta component, resolved at runtime via `{{meta(application.logoUrl)}}`. The generator simply never added this component. Fixed by pushing it as the first entry in `metaComponents`, matching the structure of the static flows.

**Sign Up URL ordering:** The `selfSignUpLink` component was placed inside `block_basic` or `block_passkey` — whichever was built first. This meant it rendered between the primary auth block and any subsequent blocks. Fixed by removing it from individual auth blocks and pushing it as a standalone top-level meta component at the end, after all auth blocks are added.

Test assertions were updated accordingly — sign-up link lookups now target the top-level `metaComponents` array instead of searching inside individual blocks, and a new ordering test explicitly asserts the link appears after all auth blocks.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2306

### Related PRs
- https://github.com/asgardeo/thunder/pull/2250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the sign-up link appears as a top-level prompt component and is placed after auth blocks instead of nested inside them.

* **New Features**
  * Display the application logo image at the top of authentication flows.

* **Tests**
  * Updated and expanded flow tests to verify sign-up link placement, ordering relative to auth blocks, logo presence, and absence of the sign-up link for social-only configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->