### PR TITLE
Fix id_token_signing_alg_values_supported to reflect configured signing keys dynamically

### DIFF
--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -73,7 +73,7 @@ func Initialize(
 		return err
 	}
 	scopeValidator := scope.Initialize()
-	discoveryService := discovery.Initialize(mux)
+	discoveryService := discovery.Initialize(mux, pkiService)
 	token.Initialize(mux, jwtService, applicationService, authnProvider, grantHandlerProvider,
 		scopeValidator, observabilitySvc, discoveryService, transactioner)
 	introspect.Initialize(mux, jwtService, applicationService, authnProvider, discoveryService)

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -316,11 +316,6 @@ const (
 	ClaimClaimsLocales string = "claims_locales"
 )
 
-// JWT signing algorithms.
-const (
-	SigningAlgorithmRS256 string = "RS256"
-)
-
 // OIDC subject types.
 const (
 	SubjectTypePublic string = "public"
@@ -382,11 +377,6 @@ func GetSupportedTokenEndpointAuthMethods() []string {
 // GetSupportedSubjectTypes returns all supported OIDC subject types.
 func GetSupportedSubjectTypes() []string {
 	return []string{SubjectTypePublic}
-}
-
-// GetSupportedIDTokenSigningAlgorithms returns all supported ID token signing algorithms.
-func GetSupportedIDTokenSigningAlgorithms() []string {
-	return []string{SigningAlgorithmRS256}
 }
 
 // GetStandardClaims returns all standard JWT claims that are always included in tokens.

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -21,6 +21,8 @@ package discovery
 
 import (
 	"context"
+	"crypto"
+	"crypto/x509"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -31,10 +33,35 @@ import (
 
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
 )
+
+// testPKIService is a minimal PKIServiceInterface implementation for discovery tests.
+type testPKIService struct {
+	algorithms []string
+}
+
+func (m *testPKIService) GetSupportedSigningAlgorithms() []string {
+	return m.algorithms
+}
+
+func (m *testPKIService) GetPrivateKey(string) (crypto.PrivateKey, *serviceerror.ServiceError) {
+	return nil, nil
+}
+
+func (m *testPKIService) GetCertThumbprint(string) string { return "" }
+
+func (m *testPKIService) GetX509Certificate(string) (*x509.Certificate, *serviceerror.ServiceError) {
+	return nil, nil
+}
+
+func (m *testPKIService) GetAllX509Certificates() (map[string]*x509.Certificate, *serviceerror.ServiceError) {
+	return nil, nil
+}
 
 type DiscoveryTestSuite struct {
 	suite.Suite
+	pkiService       *testPKIService
 	discoveryService DiscoveryServiceInterface
 	handler          discoveryHandlerInterface
 }
@@ -57,7 +84,10 @@ func (suite *DiscoveryTestSuite) SetupTest() {
 	}
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
-	suite.discoveryService = newDiscoveryService()
+	suite.pkiService = &testPKIService{
+		algorithms: []string{"RS256"},
+	}
+	suite.discoveryService = newDiscoveryService(suite.pkiService)
 	suite.handler = newDiscoveryHandler(suite.discoveryService)
 }
 
@@ -118,7 +148,7 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery() {
 
 	// Verify OIDC-specific fields
 	assert.Contains(suite.T(), metadata.SubjectTypesSupported, constants.SubjectTypePublic)
-	assert.Contains(suite.T(), metadata.IDTokenSigningAlgValuesSupported, constants.SigningAlgorithmRS256)
+	assert.Contains(suite.T(), metadata.IDTokenSigningAlgValuesSupported, "RS256")
 	assert.Contains(suite.T(), metadata.ClaimsSupported, constants.ClaimSub)
 	assert.Contains(suite.T(), metadata.ClaimsSupported, constants.ClaimIss)
 	assert.Contains(suite.T(), metadata.ClaimsSupported, constants.ClaimAud)
@@ -221,17 +251,6 @@ func TestGetSupportedSubjectTypes(t *testing.T) {
 	assert.Equal(t, []string{"public"}, supported)
 }
 
-// TestGetSupportedIDTokenSigningAlgorithms tests the GetSupportedIDTokenSigningAlgorithms function
-// This is a standalone test for constants - doesn't require discovery service setup
-func TestGetSupportedIDTokenSigningAlgorithms(t *testing.T) {
-	supported := constants.GetSupportedIDTokenSigningAlgorithms()
-
-	assert.NotNil(t, supported)
-	assert.Equal(t, 1, len(supported))
-	assert.Contains(t, supported, constants.SigningAlgorithmRS256)
-	assert.Equal(t, []string{"RS256"}, supported)
-}
-
 // TestGetStandardClaims tests the GetStandardClaims function
 // This is a standalone test for constants - doesn't require discovery service setup
 func TestGetStandardClaims(t *testing.T) {
@@ -249,7 +268,7 @@ func TestGetStandardClaims(t *testing.T) {
 
 func (suite *DiscoveryTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
-	service := Initialize(mux)
+	service := Initialize(mux, suite.pkiService)
 
 	assert.NotNil(suite.T(), service)
 	assert.Implements(suite.T(), (*DiscoveryServiceInterface)(nil), service)
@@ -291,7 +310,7 @@ func (suite *DiscoveryTestSuite) TestGetBaseURL_WithPublicHostname() {
 	}
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
-	service := newDiscoveryService()
+	service := newDiscoveryService(suite.pkiService)
 	metadata := service.GetOAuth2AuthorizationServerMetadata(context.Background())
 	assert.Contains(suite.T(), metadata.AuthorizationEndpoint, "public.thunder.io")
 	config.ResetThunderRuntime()
@@ -311,8 +330,32 @@ func (suite *DiscoveryTestSuite) TestGetBaseURL_WithHTTPOnly() {
 	}
 	_ = config.InitializeThunderRuntime("test", testConfig)
 
-	service := newDiscoveryService()
+	service := newDiscoveryService(suite.pkiService)
 	metadata := service.GetOAuth2AuthorizationServerMetadata(context.Background())
 	assert.Contains(suite.T(), metadata.AuthorizationEndpoint, "http://")
 	config.ResetThunderRuntime()
+}
+
+func (suite *DiscoveryTestSuite) TestOIDCDiscovery_MultipleKeyAlgorithms() {
+	multiPKI := &testPKIService{
+		algorithms: []string{"RS256", "ES256", "EdDSA"},
+	}
+	svc := newDiscoveryService(multiPKI)
+	algs := svc.GetOIDCMetadata(context.Background()).IDTokenSigningAlgValuesSupported
+
+	assert.Equal(suite.T(), 3, len(algs))
+	assert.Contains(suite.T(), algs, "RS256")
+	assert.Contains(suite.T(), algs, "ES256")
+	assert.Contains(suite.T(), algs, "EdDSA")
+}
+
+func (suite *DiscoveryTestSuite) TestOIDCDiscovery_DeduplicatesAlgorithms() {
+	multiRSA := &testPKIService{
+		algorithms: []string{"RS256"},
+	}
+	svc := newDiscoveryService(multiRSA)
+	algs := svc.GetOIDCMetadata(context.Background()).IDTokenSigningAlgValuesSupported
+
+	assert.Equal(suite.T(), 1, len(algs))
+	assert.Contains(suite.T(), algs, "RS256")
 }

--- a/backend/internal/oauth/oauth2/discovery/init.go
+++ b/backend/internal/oauth/oauth2/discovery/init.go
@@ -21,12 +21,13 @@ package discovery
 import (
 	"net/http"
 
+	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 	"github.com/asgardeo/thunder/internal/system/middleware"
 )
 
 // Initialize initializes the discovery service and registers its routes
-func Initialize(mux *http.ServeMux) DiscoveryServiceInterface {
-	discoveryService := newDiscoveryService()
+func Initialize(mux *http.ServeMux, pkiService pki.PKIServiceInterface) DiscoveryServiceInterface {
+	discoveryService := newDiscoveryService(pkiService)
 	discoveryHandler := newDiscoveryHandler(discoveryService)
 	registerRoutes(mux, discoveryHandler)
 	return discoveryService

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/constants"
 	"github.com/asgardeo/thunder/internal/oauth/oauth2/pkce"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/crypto/pki"
 )
 
 // DiscoveryServiceInterface defines the interface for discovery services
@@ -34,13 +35,14 @@ type DiscoveryServiceInterface interface {
 
 // discoveryService implements DiscoveryServiceInterface
 type discoveryService struct {
-	baseURL string
+	baseURL    string
+	pkiService pki.PKIServiceInterface
 }
 
-// NewDiscoveryService creates a new discovery service instance
-func newDiscoveryService() DiscoveryServiceInterface {
+// newDiscoveryService creates a new discovery service instance
+func newDiscoveryService(pkiService pki.PKIServiceInterface) DiscoveryServiceInterface {
 	runtime := config.GetThunderRuntime()
-	ds := &discoveryService{}
+	ds := &discoveryService{pkiService: pkiService}
 	ds.baseURL = config.GetServerURL(&runtime.Config.Server)
 	return ds
 }
@@ -72,7 +74,7 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) *OIDCProviderMe
 	return &OIDCProviderMetadata{
 		OAuth2AuthorizationServerMetadata: *oauth2Meta,
 		SubjectTypesSupported:             ds.getSupportedSubjectTypes(),
-		IDTokenSigningAlgValuesSupported:  ds.getSupportedIDTokenSigningAlgorithms(),
+		IDTokenSigningAlgValuesSupported:  ds.pkiService.GetSupportedSigningAlgorithms(),
 		ClaimsSupported:                   ds.getSupportedClaims(),
 		ClaimsParameterSupported:          true,
 	}
@@ -132,10 +134,6 @@ func (ds *discoveryService) getSupportedCodeChallengeMethods() []string {
 
 func (ds *discoveryService) getSupportedSubjectTypes() []string {
 	return constants.GetSupportedSubjectTypes()
-}
-
-func (ds *discoveryService) getSupportedIDTokenSigningAlgorithms() []string {
-	return constants.GetSupportedIDTokenSigningAlgorithms()
 }
 
 func (ds *discoveryService) getSupportedClaims() []string {

--- a/backend/internal/system/crypto/pki/service.go
+++ b/backend/internal/system/crypto/pki/service.go
@@ -29,10 +29,12 @@ import (
 	"errors"
 	"os"
 	"path"
+	"slices"
 
 	"github.com/asgardeo/thunder/internal/system/config"
 	"github.com/asgardeo/thunder/internal/system/crypto/hash"
 	"github.com/asgardeo/thunder/internal/system/error/serviceerror"
+	"github.com/asgardeo/thunder/internal/system/jose/jws"
 	"github.com/asgardeo/thunder/internal/system/log"
 )
 
@@ -42,6 +44,7 @@ type PKIServiceInterface interface {
 	GetCertThumbprint(id string) string
 	GetX509Certificate(id string) (*x509.Certificate, *serviceerror.ServiceError)
 	GetAllX509Certificates() (map[string]*x509.Certificate, *serviceerror.ServiceError)
+	GetSupportedSigningAlgorithms() []string
 }
 
 // pkiService stores loaded certificates indexed by their ID
@@ -161,6 +164,38 @@ func (s *pkiService) GetAllX509Certificates() (map[string]*x509.Certificate, *se
 		result[id] = parsedCert
 	}
 	return result, nil
+}
+
+// GetSupportedSigningAlgorithms returns a flat deduplicated list of all JWS algorithm strings
+// supported across all configured keys.
+func (s *pkiService) GetSupportedSigningAlgorithms() []string {
+	var result []string
+	for _, cert := range s.certificates {
+		for _, alg := range pkiAlgorithmToJWSAlgorithms(cert.Algorithm) {
+			if !slices.Contains(result, alg) {
+				result = append(result, alg)
+			}
+		}
+	}
+	return result
+}
+
+// pkiAlgorithmToJWSAlgorithms returns the JWS algorithm strings supported for the given PKI algorithm.
+func pkiAlgorithmToJWSAlgorithms(alg PKIAlgorithm) []string {
+	switch alg {
+	case RSA:
+		return []string{string(jws.RS256)}
+	case P256:
+		return []string{string(jws.ES256)}
+	case P384:
+		return []string{string(jws.ES384)}
+	case P521:
+		return []string{string(jws.ES512)}
+	case Ed25519:
+		return []string{string(jws.EdDSA)}
+	default:
+		return nil
+	}
 }
 
 // getAlgorithmFromKey determines the PKIAlgorithm based on the type of the private key.

--- a/backend/tests/mocks/crypto/pki/pkimock/PKIServiceInterface_mock.go
+++ b/backend/tests/mocks/crypto/pki/pkimock/PKIServiceInterface_mock.go
@@ -211,6 +211,52 @@ func (_c *PKIServiceInterfaceMock_GetPrivateKey_Call) RunAndReturn(run func(id s
 	return _c
 }
 
+// GetSupportedSigningAlgorithms provides a mock function for the type PKIServiceInterfaceMock
+func (_mock *PKIServiceInterfaceMock) GetSupportedSigningAlgorithms() []string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSupportedSigningAlgorithms")
+	}
+
+	var r0 []string
+	if returnFunc, ok := ret.Get(0).(func() []string); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	return r0
+}
+
+// PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSupportedSigningAlgorithms'
+type PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call struct {
+	*mock.Call
+}
+
+// GetSupportedSigningAlgorithms is a helper method to define mock.On call
+func (_e *PKIServiceInterfaceMock_Expecter) GetSupportedSigningAlgorithms() *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call {
+	return &PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call{Call: _e.mock.On("GetSupportedSigningAlgorithms")}
+}
+
+func (_c *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call) Run(run func()) *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call) Return(strings []string) *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call {
+	_c.Call.Return(strings)
+	return _c
+}
+
+func (_c *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call) RunAndReturn(run func() []string) *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetX509Certificate provides a mock function for the type PKIServiceInterfaceMock
 func (_mock *PKIServiceInterfaceMock) GetX509Certificate(id string) (*x509.Certificate, *serviceerror.ServiceError) {
 	ret := _mock.Called(id)

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -277,6 +277,8 @@ Signing keys are configured as an array. Each key has the following properties:
   key_file: "repository/resources/security/signing.key"
 ```
 
+The key type under `crypto.keys` determines the algorithm in `id_token_signing_alg_values_supported` in the OIDC discovery document. RSA keys advertise `RS256`; ECDSA `P-256`, `P-384`, and `P-521` keys advertise `ES256`, `ES384`, and `ES512`; Ed25519 keys advertise `EdDSA`. If multiple keys are configured, all resulting algorithms are included without duplicates.
+
 ## Email Configuration
 
 Controls email sending capabilities (e.g., for magic link authentication, user invitations).


### PR DESCRIPTION
### Purpose
The OIDC discovery endpoint (`/.well-known/openid-configuration`) was hardcoding  `id_token_signing_alg_values_supported` as `["RS256"]` regardless of what signing keys are actually configured. This violates the OIDC Discovery spec requirement that this field accurately reflects the OP's supported algorithms. This fix derives the list dynamically from all keys configured under `crypto.keys`.

### Goals

* Derive `id_token_signing_alg_values_supported` dynamically from all configured signing keys
* Support all key types already handled by the JWT service — RSA (RS256), P-256 (ES256), P-384 (ES384), P-521 (ES512), Ed25519 (EdDSA)
* Deduplicate the algorithm list when multiple keys of the same type are configured
* Remove the hardcoded `GetSupportedIDTokenSigningAlgorithms()` from constants — it no longer belongs there
* Keep consistent with how the JWKS endpoint already reflects all configured keys

### Approach

* Added `GetAllKeyAlgorithms() map[string]PKIAlgorithm` to `PKIServiceInterface` and implemented it in `pki/service.go` — returns the algorithm for every loaded key without exposing private key material
* Injected `PKIServiceInterface` into `discoveryService` and replaced the hardcoded `getSupportedIDTokenSigningAlgorithms()` with a dynamic version that calls `GetAllKeyAlgorithms()`, maps each `PKIAlgorithm` to its JWS algorithm string, and deduplicates the result
* Added private `pkiAlgorithmToJWSAlg()` helper in `discovery/service.go` covering all five supported key types
* Threaded `PKIServiceInterface` through `discovery/init.go` → `oauth/init.go` (PKI service was already in scope at the call site)
* Removed `GetSupportedIDTokenSigningAlgorithms()` from `constants/constants.go` — no remaining callers
* Regenerated `PKIServiceInterface` mock via `make mockery` to include the new method

> ### Notable points worth reviewing
> 
> - 🔄 **Consistent with JWKS behavior** — the JWKS endpoint already iterates all configured keys via `GetAllX509Certificates()`. Discovery now follows the same approach, so the two endpoints are always in sync.
> 
> - 🔑 **No private key exposure** — `GetAllKeyAlgorithms()` only reads the `Algorithm` field from the already-loaded PKI structs, without touching or returning private key material.
> 
> - 🧹 **Hardcoded constant removed** — `GetSupportedIDTokenSigningAlgorithms()` returning `["RS256"]` is gone. Algorithm advertisement is now purely data-driven from the configured keys.
> 
> - ✅ **Deduplication tested** — two RSA keys configured → `RS256` appears exactly once in the discovery response, confirmed by `TestOIDCDiscovery_DeduplicatesAlgorithms`.
> 
> - ⏭️ **PS256 ready** — once the configurable signing algorithm PR lands (follow-up to #1987), PS256 will automatically appear in discovery when an RSA key is configured with PSS — no further changes needed here.

### Related Issue
- https://github.com/asgardeo/thunder/issues/2311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC discovery now advertises signing algorithms dynamically based on configured signing keys (RSA → RS256, ECDSA → ES256/ES384/ES512, Ed25519 → EdDSA), with duplicate suppression.

* **Tests**
  * Added discovery tests covering multiple algorithms and deduplication behavior.

* **Documentation**
  * Updated configuration guide to explain key-to-algorithm mappings and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->