### PR TITLE
Support generic OIDC providers as trusted issuer for Thunder instance

### DIFF
--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -438,6 +438,24 @@ func (js *jwtService) getJWKSKeys(jwksURL string) ([]map[string]interface{}, *se
 	return jwks.Keys, nil
 }
 
+// audienceMatches checks whether the aud claim matches the expected audience.
+// Supports both string and array forms of the aud claim.
+func audienceMatches(audClaim interface{}, expectedAud string) bool {
+	switch v := audClaim.(type) {
+	case string:
+		return v == expectedAud
+	case []interface{}:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == expectedAud {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
 // verifyJWTClaims verifies the standard claims of a JWT token.
 func (js *jwtService) verifyJWTClaims(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError {
 	// Decode the JWT payload
@@ -463,24 +481,23 @@ func (js *jwtService) verifyJWTClaims(jwtToken string, expectedAud, expectedIss 
 		return &ErrorInvalidJWTFormat
 	}
 
-	if nbf, ok := payload["nbf"].(float64); ok {
+	// Validate nbf only when present. Many OIDC providers omit this claim.
+	if nbfRaw, ok := payload["nbf"]; ok {
+		nbf, isNumber := nbfRaw.(float64)
+		if !isNumber {
+			js.logger.Debug("JWT token 'nbf' claim present but not a number")
+			return &ErrorInvalidJWTFormat
+		}
 		if now < int64(nbf)-leeway {
 			js.logger.Debug("JWT token is not valid yet (nbf claim)")
 			return &ErrorInvalidJWTFormat
 		}
-	} else {
-		js.logger.Debug("JWT token missing 'nbf' claim or it is not a number")
-		return &ErrorInvalidJWTFormat
 	}
 
+	// Validate aud claim. Supports both string and array forms.
 	if expectedAud != "" {
-		if aud, ok := payload["aud"].(string); ok {
-			if aud != expectedAud {
-				js.logger.Debug("Invalid audience: expected " + expectedAud + ", got " + aud)
-				return &ErrorInvalidJWTFormat
-			}
-		} else {
-			js.logger.Debug("Missing 'aud' claim or it is not a string")
+		if !audienceMatches(payload["aud"], expectedAud) {
+			js.logger.Debug("Invalid audience: expected " + expectedAud)
 			return &ErrorInvalidJWTFormat
 		}
 	}

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -1138,6 +1138,38 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTClaimsEdgeCases() {
 
 				return headerBase64 + "." + payloadBase64 + "." + signatureBase64
 			},
+			expectedAud: testAudience,
+			expectedIss: testIssuer,
+			expectError: false,
+		},
+		{
+			name: "AudClaimAsArrayContainingExpected",
+			setupFunc: func() string {
+				payload := map[string]interface{}{
+					"sub": "test-subject",
+					"aud": []interface{}{testAudience, "https://example.auth0.com/userinfo"},
+					"iss": testIssuer,
+					"exp": time.Now().Add(time.Hour).Unix(),
+					"iat": time.Now().Unix(),
+				}
+				return suite.createJWTWithCustomPayload(payload)
+			},
+			expectedAud: testAudience,
+			expectedIss: testIssuer,
+			expectError: false,
+		},
+		{
+			name: "AudClaimAsArrayWithoutExpected",
+			setupFunc: func() string {
+				payload := map[string]interface{}{
+					"sub": "test-subject",
+					"aud": []interface{}{"https://other.example.com", "https://example.auth0.com/userinfo"},
+					"iss": testIssuer,
+					"exp": time.Now().Add(time.Hour).Unix(),
+					"iat": time.Now().Unix(),
+				}
+				return suite.createJWTWithCustomPayload(payload)
+			},
 			expectedAud:   testAudience,
 			expectedIss:   testIssuer,
 			expectError:   true,

--- a/docs/content/guides/guides/trusted-issuer.mdx
+++ b/docs/content/guides/guides/trusted-issuer.mdx
@@ -57,6 +57,7 @@ window.__THUNDER_RUNTIME_CONFIG__ = {
     public_url: "https://auth.example.com",
     client_id: "FEDERATED_CONSOLE",
     scopes: ['openid', 'profile', 'email', 'group', 'ou', 'system', 'system:user', 'system:group', 'system:ou:view', 'system:userschema:view'],
+    type: "generic",
   },
 };
 ```
@@ -69,6 +70,7 @@ window.__THUNDER_RUNTIME_CONFIG__ = {
 | `public_url` | Fully-qualified URL of the external authorization server. Used by the console to build authorization requests. |
 | `client_id` | OAuth client ID registered on the external authorization server for this Thunder instance's console. |
 | `scopes` | Scopes the console requests from the external authorization server. Must include every scope Thunder's APIs require. |
+| `type` | Set to `"generic"` when the trusted issuer is a generic OIDC provider. When set, the console skips Thunder-specific bootstrap calls (flow metadata, branding preferences) that would fail against a generic provider and uses the IdP's `end_session_endpoint` for sign-out. Defaults to `"thunder"`. |
 
 When this block is present, the console delegates login to the external authorization server. When omitted, the console authenticates against this Thunder instance normally.
 
@@ -78,14 +80,28 @@ The external authorization server must permit this Thunder instance's origin in 
 
 ## How Validation Works
 
+:::info JWT Validation Update
+Thunder's trusted issuer token validation now accepts tokens that omit the `nbf` (not before) claim, aligning with [RFC 7519 Section 4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5). The `aud` (audience) claim is now accepted as either a single string or a JSON array of strings per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). These changes improve compatibility with commercial OIDC providers that do not emit `nbf` or that issue array-form `aud`. No client-side migration is required; tokens that were accepted before remain valid.
+:::
+
 When trusted issuer is configured and a request carries a bearer token, Thunder:
 
 1. Parses the JWT and confirms its `iss` claim matches `trusted_issuer.issuer`.
 2. Fetches signing keys from `trusted_issuer.jwks_url` and verifies the signature.
-3. Confirms the `aud` claim matches `trusted_issuer.audience`.
-4. Checks that every entry in `required_claims` is present with the expected value.
+3. Checks the `exp` claim and rejects expired tokens.
+4. If the `nbf` (not before) claim is present, checks that the current time is not before the `nbf` value. If `nbf` is absent, the token is still accepted.
+5. Confirms the `aud` claim matches `trusted_issuer.audience`. The `aud` claim can be either a single string or a JSON array of strings; Thunder accepts the token if the configured audience appears in either form.
+6. Checks that every entry in `required_claims` is present with the expected value.
 
 If any step fails, the token is rejected.
+
+### Claim Handling Details
+
+**`nbf` (Not Before):** This claim is optional per [RFC 7519 Section 4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5). Many commercial OIDC providers do not include `nbf` in their tokens. Thunder accepts tokens that omit `nbf` entirely. When `nbf` is present, Thunder enforces it with the configured clock-skew leeway.
+
+**`aud` (Audience):** This claim can be a single string or an array of strings per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). Some identity providers issue array-form `aud` when multiple audiences are bound to the application (for example, the resource API together with the provider's own `/userinfo` endpoint). Thunder matches the configured `trusted_issuer.audience` value against both forms: exact string equality for single-string `aud`, and membership for array `aud`.
+
+**`exp` (Expiry):** This claim is required. Tokens that omit `exp` or provide a non-numeric value are rejected.
 
 Thunder picks the verification method based on the token's `iss` claim. If `iss` matches `trusted_issuer.issuer`, the token is verified against the configured JWKS endpoint. Otherwise, if `iss` matches one of this server's own issuers, Thunder verifies it with its local signing key. Any other `iss` is rejected.
 
@@ -122,6 +138,7 @@ configuration:
       publicUrl: "https://auth.example.com"
       clientId: "FEDERATED_CONSOLE"
       scopes: "['openid', 'profile', 'email', 'group', 'ou', 'system', 'system:user', 'system:group', 'system:ou:view', 'system:userschema:view']"
+      type: "generic"
 ```
 
 ## Troubleshooting

--- a/frontend/apps/thunder-console/src/__tests__/AppWithDecorators.test.tsx
+++ b/frontend/apps/thunder-console/src/__tests__/AppWithDecorators.test.tsx
@@ -26,6 +26,7 @@ const mockGetTrustedIssuerClientId = vi.fn();
 const mockGetTrustedIssuerScopes = vi.fn();
 const mockGetClientUrl = vi.fn();
 const mockGetServerUrl = vi.fn();
+const mockIsTrustedIssuerGenericOidc = vi.fn().mockReturnValue(false);
 const mockConfig: Record<string, unknown> = {};
 
 // Mock the useConfig hook
@@ -36,6 +37,7 @@ vi.mock('@thunder/contexts', () => ({
     getTrustedIssuerScopes: mockGetTrustedIssuerScopes,
     getClientUrl: mockGetClientUrl,
     getServerUrl: mockGetServerUrl,
+    isTrustedIssuerGenericOidc: mockIsTrustedIssuerGenericOidc,
     config: mockConfig,
   }),
 }));

--- a/frontend/apps/thunder-console/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/thunder-console/src/hocs/__tests__/withConfig.test.tsx
@@ -34,6 +34,7 @@ const mockGetScopes = vi.fn();
 const mockGetTrustedIssuerUrl = vi.fn();
 const mockGetTrustedIssuerClientId = vi.fn();
 const mockGetTrustedIssuerScopes = vi.fn();
+const mockIsTrustedIssuerGenericOidc = vi.fn();
 const mockConfig: Record<string, unknown> = {};
 
 vi.mock('@thunder/contexts', () => ({
@@ -45,6 +46,7 @@ vi.mock('@thunder/contexts', () => ({
     getTrustedIssuerUrl: mockGetTrustedIssuerUrl,
     getTrustedIssuerClientId: mockGetTrustedIssuerClientId,
     getTrustedIssuerScopes: mockGetTrustedIssuerScopes,
+    isTrustedIssuerGenericOidc: mockIsTrustedIssuerGenericOidc,
     config: mockConfig,
   }),
 }));
@@ -58,6 +60,8 @@ vi.mock('@asgardeo/react', () => ({
     afterSignInUrl,
     scopes,
     signInOptions,
+    preferences,
+    sendCookiesInRequests,
     /* eslint-enable react/require-default-props */
   }: {
     children: React.ReactNode;
@@ -66,8 +70,18 @@ vi.mock('@asgardeo/react', () => ({
     afterSignInUrl?: string;
     scopes?: string[];
     signInOptions?: Record<string, string>;
+    preferences?: Record<string, unknown>;
+    sendCookiesInRequests?: boolean;
   }) => {
-    capturedProviderProps = {baseUrl, clientId, afterSignInUrl, scopes, signInOptions};
+    capturedProviderProps = {
+      baseUrl,
+      clientId,
+      afterSignInUrl,
+      scopes,
+      signInOptions,
+      preferences,
+      sendCookiesInRequests,
+    };
     return (
       <div
         data-testid="asgardeo-provider"
@@ -94,6 +108,7 @@ describe('withConfig (console)', () => {
     mockGetTrustedIssuerUrl.mockReturnValue('https://server.example.com');
     mockGetTrustedIssuerClientId.mockReturnValue('client-id');
     mockGetTrustedIssuerScopes.mockReturnValue([]);
+    mockIsTrustedIssuerGenericOidc.mockReturnValue(false);
   });
 
   it('renders without crashing', () => {
@@ -273,6 +288,57 @@ describe('withConfig (console)', () => {
 
       render(<WithConfigComponent />);
       expect(capturedProviderProps.signInOptions).toBeUndefined();
+    });
+
+    it('does not pass preferences when the trusted issuer is a Thunder instance', () => {
+      mockConfig.trusted_issuer = {hostname: 'localhost', port: 8090, http_only: true, type: 'thunder'};
+      mockIsTrustedIssuerGenericOidc.mockReturnValue(false);
+      mockGetServerUrl.mockReturnValue('http://localhost:9443');
+      mockGetTrustedIssuerUrl.mockReturnValue('http://localhost:8090');
+      mockGetTrustedIssuerClientId.mockReturnValue('FEDERATED_CONSOLE');
+      mockGetClientUrl.mockReturnValue('http://localhost:9443/console');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.preferences).toBeUndefined();
+    });
+
+    it('disables Asgardeo vendor-specific bootstrap calls for generic OIDC trusted issuers', () => {
+      mockConfig.trusted_issuer = {hostname: 'tenant.auth0.com', port: 443, http_only: false, type: 'generic'};
+      mockIsTrustedIssuerGenericOidc.mockReturnValue(true);
+      mockGetServerUrl.mockReturnValue('https://tenant.example.com:9443');
+      mockGetTrustedIssuerUrl.mockReturnValue('https://tenant.auth0.com');
+      mockGetTrustedIssuerClientId.mockReturnValue('AUTH0_CLIENT_ID');
+      mockGetClientUrl.mockReturnValue('https://tenant.example.com:9443/console');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.preferences).toEqual({
+        resolveFromMeta: false,
+        theme: {inheritFromBranding: false},
+      });
+    });
+
+    it('leaves sendCookiesInRequests at SDK default when the trusted issuer is a Thunder instance', () => {
+      mockConfig.trusted_issuer = {hostname: 'localhost', port: 8090, http_only: true, type: 'thunder'};
+      mockIsTrustedIssuerGenericOidc.mockReturnValue(false);
+      mockGetServerUrl.mockReturnValue('http://localhost:9443');
+      mockGetTrustedIssuerUrl.mockReturnValue('http://localhost:8090');
+      mockGetTrustedIssuerClientId.mockReturnValue('FEDERATED_CONSOLE');
+      mockGetClientUrl.mockReturnValue('http://localhost:9443/console');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.sendCookiesInRequests).toBeUndefined();
+    });
+
+    it('sets sendCookiesInRequests=false for generic OIDC trusted issuers (CORS credentialed fetch fix)', () => {
+      mockConfig.trusted_issuer = {hostname: 'tenant.auth0.com', port: 443, http_only: false, type: 'generic'};
+      mockIsTrustedIssuerGenericOidc.mockReturnValue(true);
+      mockGetServerUrl.mockReturnValue('https://tenant.example.com:9443');
+      mockGetTrustedIssuerUrl.mockReturnValue('https://tenant.auth0.com');
+      mockGetTrustedIssuerClientId.mockReturnValue('AUTH0_CLIENT_ID');
+      mockGetClientUrl.mockReturnValue('https://tenant.example.com:9443/console');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.sendCookiesInRequests).toBe(false);
     });
   });
 });

--- a/frontend/apps/thunder-console/src/hocs/withConfig.tsx
+++ b/frontend/apps/thunder-console/src/hocs/withConfig.tsx
@@ -22,12 +22,51 @@ import type {JSX, ComponentType} from 'react';
 
 export default function withConfig<P extends object>(WrappedComponent: ComponentType<P>) {
   return function WithConfig(props: P): JSX.Element {
-    const {getTrustedIssuerUrl, getTrustedIssuerClientId, getClientUrl, getTrustedIssuerScopes, getServerUrl, config} =
-      useConfig();
+    const {
+      getTrustedIssuerUrl,
+      getTrustedIssuerClientId,
+      getClientUrl,
+      getTrustedIssuerScopes,
+      getServerUrl,
+      isTrustedIssuerGenericOidc,
+      config,
+    } = useConfig();
 
     const signInOptions: Record<string, string> | undefined = config.trusted_issuer
       ? {resource: getServerUrl()}
       : undefined;
+
+    // When the trusted issuer is a generic OIDC provider, suppress the SDK's
+    // Thunder-specific bootstrap calls that would otherwise 404 / be CORS-blocked
+    // at the external authorization server: flow metadata (`{baseUrl}/flow/meta`)
+    // and branding preferences. The user profile is already derived from ID token
+    // claims under the AsgardeoV2 platform, so no additional profile configuration
+    // is required.
+    const genericOidc = isTrustedIssuerGenericOidc();
+    const preferences = genericOidc
+      ? {
+          resolveFromMeta: false,
+          theme: {
+            inheritFromBranding: false,
+          },
+        }
+      : undefined;
+
+    // Generic OIDC authorization servers typically respond to the `/oauth/token`
+    // endpoint with `access-control-allow-credentials:
+    // false`, so a credentialed fetch from the browser is blocked by CORS and the
+    // SDK never sees the issued token. The Asgardeo SDK defaults
+    // `sendCookiesInRequests` to `true`, which makes it issue the token request
+    // with `credentials: 'include'`. Forcing it to `false` switches the request
+    // to `credentials: 'same-origin'`, which is uncredentialed for cross-origin
+    // requests and therefore CORS-safe against any compliant OIDC provider.
+    //
+    // The field is declared on the SDK's legacy auth client config and read at
+    // runtime (see @asgardeo/javascript DefaultConfig and requestAccessToken),
+    // but it is not surfaced on the v2 `AsgardeoProvider` prop type. The
+    // provider spreads unknown props through to the underlying client via
+    // `...rest`, so passing it here is the SDK-supported escape hatch.
+    const genericOidcExtraProps: {sendCookiesInRequests?: boolean} = genericOidc ? {sendCookiesInRequests: false} : {};
 
     return (
       <AsgardeoProvider
@@ -42,6 +81,8 @@ export default function withConfig<P extends object>(WrappedComponent: Component
             enabled: true,
           },
         }}
+        preferences={preferences}
+        {...genericOidcExtraProps}
       >
         <WrappedComponent {...props} />
       </AsgardeoProvider>

--- a/frontend/apps/thunder-console/src/layouts/DashboardLayout.tsx
+++ b/frontend/apps/thunder-console/src/layouts/DashboardLayout.tsx
@@ -17,6 +17,7 @@
  */
 
 import {SignOutButton, User, useAsgardeo} from '@asgardeo/react';
+import {useConfig} from '@thunder/contexts';
 import {useLogger} from '@thunder/logger/react';
 import {
   AppShell,
@@ -45,11 +46,35 @@ import {useTranslation} from 'react-i18next';
 import {Link as NavigateLink, Outlet} from 'react-router';
 
 export default function DashboardLayout(): ReactNode {
-  const {signIn} = useAsgardeo();
+  const {signIn, clearSession, discovery} = useAsgardeo();
+  const {isTrustedIssuerGenericOidc, getTrustedIssuerClientId, getClientUrl} = useConfig();
   const {t} = useTranslation();
   const logger = useLogger();
 
   const handleSignOut = (signOut: () => Promise<void>): void => {
+    if (isTrustedIssuerGenericOidc()) {
+      try {
+        clearSession();
+      } catch (error: unknown) {
+        logger.error('Failed to clear local session before IdP sign out', {error});
+      }
+
+      const endSessionEndpoint = discovery?.wellKnown?.end_session_endpoint;
+      if (!endSessionEndpoint) {
+        logger.warn('end_session_endpoint missing from IdP discovery document; ending local session only');
+        // eslint-disable-next-line react-hooks/immutability
+        window.location.href = getClientUrl();
+        return;
+      }
+
+      const logoutUrl = new URL(endSessionEndpoint);
+      logoutUrl.searchParams.set('client_id', getTrustedIssuerClientId());
+      logoutUrl.searchParams.set('post_logout_redirect_uri', getClientUrl());
+      // eslint-disable-next-line react-hooks/immutability
+      window.location.href = logoutUrl.toString();
+      return;
+    }
+
     signOut()
       .then(() => signIn())
       .catch((error: unknown) => {

--- a/frontend/apps/thunder-console/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/frontend/apps/thunder-console/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -17,23 +17,42 @@
  */
 
 import {render, screen, userEvent, waitFor} from '@thunder/test-utils';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {afterEach, describe, it, expect, vi, beforeEach} from 'vitest';
 import DashboardLayout from '../DashboardLayout';
 
 const mockSignIn = vi.fn();
 const mockSignOut = vi.fn();
+const mockClearSession = vi.fn();
 const mockLoggerError = vi.fn();
+const mockLoggerWarn = vi.fn();
 const mockUserData = vi.fn();
+let mockDiscovery: {wellKnown?: {end_session_endpoint?: string}} | undefined;
+let mockIsTrustedIssuerGenericOidc = false;
 
 // Mock Asgardeo
 vi.mock('@asgardeo/react', () => ({
   useAsgardeo: () => ({
     signIn: mockSignIn,
+    clearSession: mockClearSession,
+    discovery: mockDiscovery,
   }),
   User: ({children}: {children: (user: unknown) => React.ReactNode}) => children(mockUserData()),
   SignOutButton: ({children}: {children: (props: {signOut: () => void}) => React.ReactNode}) =>
     children({signOut: mockSignOut}),
 }));
+
+// Mock @thunder/contexts
+vi.mock('@thunder/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunder/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({
+      isTrustedIssuerGenericOidc: () => mockIsTrustedIssuerGenericOidc,
+      getTrustedIssuerClientId: () => 'test-client-id',
+      getClientUrl: () => 'https://localhost:5191/console',
+    }),
+  };
+});
 
 // Mock react-i18next
 vi.mock('react-i18next', () => ({
@@ -46,8 +65,8 @@ vi.mock('react-i18next', () => ({
 vi.mock('@thunder/logger/react', () => ({
   useLogger: () => ({
     error: mockLoggerError,
+    warn: mockLoggerWarn,
     info: vi.fn(),
-    warn: vi.fn(),
     debug: vi.fn(),
   }),
 }));
@@ -70,6 +89,8 @@ describe('DashboardLayout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUserData.mockReturnValue({name: 'Test User', email: 'test@example.com'});
+    mockIsTrustedIssuerGenericOidc = false;
+    mockDiscovery = undefined;
   });
 
   it('renders AppShell layout', () => {
@@ -168,5 +189,61 @@ describe('DashboardLayout', () => {
     render(<DashboardLayout />);
 
     expect(screen.getByTestId('outlet')).toBeInTheDocument();
+  });
+
+  describe('generic OIDC sign out', () => {
+    let originalLocation: Location;
+
+    beforeEach(() => {
+      mockIsTrustedIssuerGenericOidc = true;
+      originalLocation = window.location;
+      Object.defineProperty(window, 'location', {
+        value: {...originalLocation, href: ''},
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('clears local session and redirects to client URL when end_session_endpoint is missing', async () => {
+      mockDiscovery = {wellKnown: {}};
+      const user = userEvent.setup();
+
+      render(<DashboardLayout />);
+
+      const userMenuTrigger = screen.getByLabelText('Test User');
+      await user.click(userMenuTrigger);
+
+      const signOutButton = await screen.findByText('common:userMenu.signOut');
+      await user.click(signOutButton);
+
+      expect(mockClearSession).toHaveBeenCalled();
+      expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('end_session_endpoint missing'));
+      expect(window.location.href).toBe('https://localhost:5191/console');
+    });
+
+    it('clears local session and redirects to IdP end_session_endpoint when available', async () => {
+      mockDiscovery = {wellKnown: {end_session_endpoint: 'https://idp.example.com/logout'}};
+      const user = userEvent.setup();
+
+      render(<DashboardLayout />);
+
+      const userMenuTrigger = screen.getByLabelText('Test User');
+      await user.click(userMenuTrigger);
+
+      const signOutButton = await screen.findByText('common:userMenu.signOut');
+      await user.click(signOutButton);
+
+      expect(mockClearSession).toHaveBeenCalled();
+      expect(window.location.href).toContain('https://idp.example.com/logout');
+      expect(window.location.href).toContain('client_id=test-client-id');
+    });
   });
 });

--- a/frontend/packages/thunder-contexts/src/Config/ConfigContext.tsx
+++ b/frontend/packages/thunder-contexts/src/Config/ConfigContext.tsx
@@ -100,6 +100,19 @@ export interface ConfigContextType {
    * @returns The trusted issuer scopes array
    */
   getTrustedIssuerScopes: () => string[];
+
+  /**
+   * Indicates whether the configured trusted issuer is a generic OIDC provider
+   * rather than a Thunder / Asgardeo instance. When true, the console must suppress
+   * Thunder / Asgardeo specific bootstrap calls (flow metadata, branding preferences) that
+   * would otherwise fail against a generic OIDC provider.
+   *
+   * Returns false when no trusted issuer is configured, and when the configured
+   * trusted issuer type is `thunder` (the default).
+   *
+   * @returns True if the trusted issuer is a generic OIDC provider
+   */
+  isTrustedIssuerGenericOidc: () => boolean;
 }
 
 /**

--- a/frontend/packages/thunder-contexts/src/Config/ConfigProvider.tsx
+++ b/frontend/packages/thunder-contexts/src/Config/ConfigProvider.tsx
@@ -161,6 +161,7 @@ export default function ConfigProvider({children}: ConfigProviderProps) {
         }
         return config.client.scopes ?? [];
       },
+      isTrustedIssuerGenericOidc: () => config.trusted_issuer?.type === 'generic',
     }),
     [config],
   );

--- a/frontend/packages/thunder-contexts/src/Config/types.ts
+++ b/frontend/packages/thunder-contexts/src/Config/types.ts
@@ -157,6 +157,17 @@ export interface TrustedIssuerConfig {
    * @example ["openid", "profile", "email", "system"]
    */
   scopes?: string[];
+
+  /**
+   * Type of external authorization server. Set to `generic` when the trusted
+   * issuer is a generic OIDC provider rather than another Thunder instance.
+   * When `generic`, the console skips Thunder-specific bootstrap calls
+   * (flow metadata, branding preferences) that would otherwise fail against a generic OIDC provider.
+   *
+   * Defaults to `thunder` for backward compatibility with existing
+   * Thunder-to-Thunder federation deployments.
+   */
+  type?: 'thunder' | 'generic';
 }
 
 /**

--- a/install/helm/conf/apps/console/config.js
+++ b/install/helm/conf/apps/console/config.js
@@ -47,6 +47,9 @@ window.__THUNDER_RUNTIME_CONFIG__ = {
     {{- if .Values.configuration.consoleClient.trustedIssuer.scopes }}
     scopes: {{ .Values.configuration.consoleClient.trustedIssuer.scopes }},
     {{- end }}
+    {{- if .Values.configuration.consoleClient.trustedIssuer.type }}
+    type: {{ .Values.configuration.consoleClient.trustedIssuer.type | quote }},
+    {{- end }}
   },
   {{- end }}
 };

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -196,6 +196,12 @@ configuration:
     #   publicUrl: "https://cp.example.com"
     #   clientId: "FEDERATED_CONSOLE"
     #   scopes: "['openid', 'profile', 'email', 'group', 'ou', 'system', 'system:user', 'system:group', 'system:ou:view', 'system:userschema:view']"
+    #   # Type of external authorization server. Set to `generic` when the trusted
+    #   # issuer is a generic OIDC provider. When `generic`, the console skips
+    #   # Thunder-specific bootstrap calls (flow metadata, branding preferences)
+    #   # that would otherwise fail against a generic OIDC provider.
+    #   # Defaults to `thunder`.
+    #   type: "thunder"
 
   # TLS configuration
   tls:


### PR DESCRIPTION
### Purpose

Allow Thunder to accept access tokens issued by generic OIDC providers (Auth0, Okta, Keycloak, Cognito, etc.) as a trusted issuer. Previously, trusted issuer support assumed the external authorization server was another Thunder instance. This change relaxes JWT validation to align with RFC 7519 (optional `nbf`, string-or-array `aud`) and adds a `kind: "oidc"` option so the console can skip Thunder/Asgardeo-specific bootstrap calls that would fail against a generic OIDC provider.

### Approach

**Backend (JWT validation):**
- Make the `nbf` claim optional per RFC 7519 §4.1.5 — many commercial IdPs omit it. When present, it is still enforced with clock-skew leeway.
- Support both string and array forms of the `aud` claim per RFC 7519 §4.1.3. A new `audienceMatches` helper handles both shapes.

**Frontend (Console):**
- Read a new `kind` field from the `trusted_issuer` console config. When `kind` is `"oidc"`, the console suppresses Thunder-specific SDK calls (flow metadata, branding preferences) that would 404 or CORS-fail against a generic OIDC provider.
- Set `sendCookiesInRequests: false` for generic OIDC providers to avoid CORS credential failures on the token endpoint.
- Handle sign-out for generic OIDC providers by clearing the local session and redirecting to the IdP's end_session_endpoint when available, or falling back to a local-only sign-out when the discovery document does not expose one.

**Helm / Config:**
- Add the new kind field to the console client's trustedIssuer block in values.yaml (commented-out) and config.js template.

**Documentation:**
- Update trusted-issuer.mdx with nbf and aud claim handling details and add PS256 to the supported algorithms list.
- Add an info banner to apis.mdx documenting the JWT validation changes for trusted issuer tokens.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2318

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided.
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring generic OpenID Connect (OIDC) providers as trusted issuers, complementing the existing Thunder issuer option
  * Improved sign-out flow for generic OIDC providers to use standard endpoint configuration
  * Enhanced authentication validation for greater flexibility with various OIDC providers

* **Documentation**
  * Updated trusted issuer configuration guide with generic OIDC examples and setup instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->