### PR TITLE
Add configurable parentOuId property for OUExecutor

### DIFF
--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -20,6 +20,7 @@ package executor
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
@@ -96,7 +97,11 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 	}
 
 	// Create the OU using the OU service.
-	ouRequest := o.getOrganizationUnitRequest(ctx)
+	ouRequest, err := o.getOrganizationUnitRequest(ctx)
+	if err != nil {
+		logger.Error("Failed to build organization unit request", log.String("error", err.Error()))
+		return nil, err
+	}
 	createdOU, svcErr := o.ouService.CreateOrganizationUnit(ctx.Context, ouRequest)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
@@ -133,17 +138,25 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 }
 
 // getOrganizationUnitRequest constructs an OrganizationUnitRequest from the NodeContext.
-func (o *ouExecutor) getOrganizationUnitRequest(ctx *core.NodeContext) ou.OrganizationUnitRequest {
+func (o *ouExecutor) getOrganizationUnitRequest(ctx *core.NodeContext) (ou.OrganizationUnitRequest, error) {
 	ouRequest := ou.OrganizationUnitRequest{
 		Name:        ctx.UserInputs[userInputOuName],
 		Handle:      ctx.UserInputs[userInputOuHandle],
 		Description: ctx.UserInputs[userInputOuDesc],
 	}
 
-	// Set parent OU ID if defaultOUID is present in runtime data
-	if val, ok := ctx.RuntimeData[defaultOUIDKey]; ok && val != "" {
+	// Check if parentOuId is explicitly set in node properties.
+	if val, ok := ctx.NodeProperties["parentOuId"]; ok {
+		strVal, isStr := val.(string)
+		if !isStr {
+			return ouRequest, fmt.Errorf("parentOuId must be a string, got %T", val)
+		}
+		if strVal != "" {
+			ouRequest.Parent = &strVal
+		}
+	} else if val, ok := ctx.RuntimeData[defaultOUIDKey]; ok && val != "" {
 		ouRequest.Parent = &val
 	}
 
-	return ouRequest
+	return ouRequest, nil
 }

--- a/backend/internal/flow/executor/ou_executor_test.go
+++ b/backend/internal/flow/executor/ou_executor_test.go
@@ -528,6 +528,118 @@ func (suite *OUExecutorTestSuite) TestExecute_EmptyOUID() {
 	suite.mockOUService.AssertExpectations(suite.T())
 }
 
+func (suite *OUExecutorTestSuite) TestExecute_ParentOuIdProperty() {
+	parentOUID := "specific-parent-ou-id"
+
+	testCases := []struct {
+		name            string
+		nodeProperties  map[string]interface{}
+		runtimeData     map[string]string
+		expectedRequest ou.OrganizationUnitRequest
+	}{
+		{
+			name:           "parentOuId set to specific UUID",
+			nodeProperties: map[string]interface{}{"parentOuId": "specific-parent-ou-id"},
+			runtimeData:    map[string]string{},
+			expectedRequest: ou.OrganizationUnitRequest{
+				Name:   "Engineering",
+				Handle: "engineering",
+				Parent: &parentOUID,
+			},
+		},
+		{
+			name:           "parentOuId set to empty string creates root-level OU",
+			nodeProperties: map[string]interface{}{"parentOuId": ""},
+			runtimeData:    map[string]string{},
+			expectedRequest: ou.OrganizationUnitRequest{
+				Name:   "Engineering",
+				Handle: "engineering",
+			},
+		},
+		{
+			name:           "parentOuId overrides defaultOUID from RuntimeData",
+			nodeProperties: map[string]interface{}{"parentOuId": "specific-parent-ou-id"},
+			runtimeData:    map[string]string{defaultOUIDKey: "default-ou-from-runtime"},
+			expectedRequest: ou.OrganizationUnitRequest{
+				Name:   "Engineering",
+				Handle: "engineering",
+				Parent: &parentOUID,
+			},
+		},
+		{
+			name:           "empty parentOuId overrides defaultOUID from RuntimeData",
+			nodeProperties: map[string]interface{}{"parentOuId": ""},
+			runtimeData:    map[string]string{defaultOUIDKey: "default-ou-from-runtime"},
+			expectedRequest: ou.OrganizationUnitRequest{
+				Name:   "Engineering",
+				Handle: "engineering",
+			},
+		},
+		{
+			name:           "parentOuId omitted falls back to defaultOUID",
+			nodeProperties: map[string]interface{}{},
+			runtimeData:    map[string]string{defaultOUIDKey: "default-ou-from-runtime"},
+			expectedRequest: func() ou.OrganizationUnitRequest {
+				val := "default-ou-from-runtime"
+				return ou.OrganizationUnitRequest{
+					Name:   "Engineering",
+					Handle: "engineering",
+					Parent: &val,
+				}
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			ctx := &core.NodeContext{
+				ExecutionID:    "flow-123",
+				FlowType:       common.FlowTypeRegistration,
+				NodeProperties: tc.nodeProperties,
+				UserInputs: map[string]string{
+					userInputOuName:   "Engineering",
+					userInputOuHandle: "engineering",
+				},
+				RuntimeData: tc.runtimeData,
+			}
+
+			suite.mockOUService.On("CreateOrganizationUnit", mock.Anything, tc.expectedRequest).
+				Return(ou.OrganizationUnit{ID: testOUID}, nil)
+
+			result, err := suite.executor.Execute(ctx)
+
+			assert.NoError(suite.T(), err)
+			assert.NotNil(suite.T(), result)
+			assert.Equal(suite.T(), common.ExecComplete, result.Status)
+			assert.Equal(suite.T(), testOUID, result.RuntimeData[ouIDKey])
+			suite.mockOUService.AssertExpectations(suite.T())
+		})
+	}
+
+	suite.Run("non-string parentOuId returns error", func() {
+		suite.SetupTest()
+
+		ctx := &core.NodeContext{
+			ExecutionID:    "flow-123",
+			FlowType:       common.FlowTypeRegistration,
+			NodeProperties: map[string]interface{}{"parentOuId": 123},
+			UserInputs: map[string]string{
+				userInputOuName:   "Engineering",
+				userInputOuHandle: "engineering",
+			},
+			RuntimeData: map[string]string{},
+		}
+
+		result, err := suite.executor.Execute(ctx)
+
+		assert.Error(suite.T(), err)
+		assert.Nil(suite.T(), result)
+		assert.Contains(suite.T(), err.Error(), "parentOuId must be a string")
+	})
+}
+
 func (suite *OUExecutorTestSuite) TestExecutorHelperMethods() {
 	testCases := []struct {
 		name     string
@@ -604,8 +716,9 @@ func (suite *OUExecutorTestSuite) TestExecutorHelperMethods() {
 					},
 				}
 
-				request := suite.executor.getOrganizationUnitRequest(ctx)
+				request, err := suite.executor.getOrganizationUnitRequest(ctx)
 
+				assert.NoError(suite.T(), err)
 				assert.Equal(suite.T(), "Engineering", request.Name)
 				assert.Equal(suite.T(), "engineering", request.Handle)
 			},

--- a/docs/content/guides/guides/flows/flow-reference.mdx
+++ b/docs/content/guides/guides/flows/flow-reference.mdx
@@ -91,7 +91,7 @@ Executors are backend operation nodes. Each Executor performs one specific opera
 | **Provisioning** | Creates or updates the user record in the store. |
 | **Attribute Collector** | Collects additional user attributes defined in the user schema. |
 | **Authorization** | Evaluates authorization policies for the current user. |
-| **OU Creation** | Creates an organizational unit for the user. |
+| **OU Creation** | Creates an organizational unit for the user. Supports an optional `parentOuId` property to control where the new organizational unit is placed in the hierarchy. |
 | **User Type Resolver** | Resolves the user type based on configured rules. |
 | **Identity Resolver** | Looks up and resolves a user identity across providers. |
 | **User Consent** | Records explicit user consent for defined scopes or terms. |
@@ -122,7 +122,36 @@ Some Executors run entirely in the background and do not need a preceding View t
 | **Provisioning** | After identity collection in registration flows | — |
 | **Identity Resolver** | Early in the flow, after the user submits an identifier | — |
 | **User Type Resolver** | After Identity Resolver | — |
-| **OU Creation** | After Provisioning in registration flows | OU name and handle inputs must be present in the flow context |
+| **OU Creation** | After Provisioning in registration flows | OU name and handle inputs must be present in the flow context. Accepts an optional `parentOuId` property (see below). |
+
+### OU Creation Properties
+
+The **OU Creation** executor accepts the following optional node property:
+
+| Property | Type | Description |
+|---|---|---|
+| `parentOuId` | `string` | Controls the parent organizational unit for the newly created organizational unit. |
+
+`parentOuId` behavior:
+
+- **Set to a UUID** - Creates the organizational unit as a child of the specified parent.
+- **Set to an empty string (`""`)** - Creates the organizational unit at the root level with no parent.
+- **Omitted** - Falls back to the default organizational unit resolved earlier in the flow (for example, by the **User Type Resolver** executor).
+
+```json title="Example: OU Creation Node with parentOuId"
+{
+  "id": "ou_creation",
+  "type": "TASK_EXECUTION",
+  "properties": {
+    "parentOuId": "019d94ff-072c-7d7f-a5c5-0a638c1f62bc"
+  },
+  "executor": {
+    "name": "OUExecutor"
+  },
+  "onSuccess": "next_node",
+  "onFailure": "error_prompt"
+}
+```
 
 ## Related Guides
 


### PR DESCRIPTION
## Summary

- Add `parentOuId` property to the `OUExecutor` flow node, allowing flow authors to configure where new OUs are created in the hierarchy
- When `parentOuId` is set to a UUID, the OU is created under that specific parent
- When `parentOuId` is set to an empty string, the OU is created at root level (no parent)
- When the property is omitted, existing behavior is preserved (uses `defaultOUID` from RuntimeData)

Resolves #2278

## Test plan

- [x] Unit tests covering all three `parentOuId` scenarios (specific UUID, empty string, omitted)
- [x] Unit tests verifying `parentOuId` overrides `defaultOUID` from RuntimeData
- [x] Manual E2E: verified root-level OU creation with `parentOuId: ""`
- [x] Manual E2E: verified child OU creation with `parentOuId: "<uuid>"`
- [x] Existing tests pass (backward compatible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced how organization unit parent IDs are determined, now supporting property-based configuration with improved fallback behavior to default values

* **Tests**
  * Added comprehensive test coverage for organization unit creation across multiple parent unit specification scenarios, including custom values, empty values, and default fallback cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->