### PR TITLE
Set required flag to true by default for flow builder input elements

### DIFF
--- a/frontend/apps/thunder-console/src/features/flows/data/elements.json
+++ b/frontend/apps/thunder-console/src/features/flows/data/elements.json
@@ -19,7 +19,7 @@
     "inputType": "text",
     "hint": "",
     "label": "Text",
-    "required": false,
+    "required": true,
     "placeholder": "Enter your text"
   },
   {
@@ -34,7 +34,7 @@
     "inputType": "password",
     "hint": "",
     "label": "Password",
-    "required": false,
+    "required": true,
     "placeholder": "Enter your password"
   },
   {
@@ -48,7 +48,7 @@
     "inputType": "email",
     "hint": "",
     "label": "Email",
-    "required": false,
+    "required": true,
     "placeholder": "Enter your email"
   },
   {
@@ -62,7 +62,7 @@
     "inputType": "tel",
     "hint": "",
     "label": "Phone",
-    "required": false,
+    "required": true,
     "placeholder": "Enter your phone number"
   },
   {
@@ -76,7 +76,7 @@
     "inputType": "number",
     "hint": "",
     "label": "Number",
-    "required": false,
+    "required": true,
     "placeholder": "Enter a number"
   },
   {
@@ -90,7 +90,7 @@
     "inputType": "date",
     "hint": "",
     "label": "Date",
-    "required": false,
+    "required": true,
     "placeholder": "dd-mm-yyyy"
   },
   {
@@ -105,7 +105,7 @@
     "hint": "",
     "ref": "otp",
     "label": "OTP",
-    "required": false,
+    "required": true,
     "placeholder": ""
   },
   {
@@ -130,7 +130,7 @@
     },
     "hint": "",
     "label": "Checkbox",
-    "required": false
+    "required": true
   },
   {
     "resourceType": "ELEMENT",
@@ -142,7 +142,7 @@
     },
     "hint": "",
     "label": "Select",
-    "required": false,
+    "required": true,
     "placeholder": "Select an option",
     "options": []
   },
@@ -157,7 +157,7 @@
     },
     "hint": "",
     "label": "Choice",
-    "required": false,
+    "required": true,
     "defaultValue": "option1",
     "options": [
       {


### PR DESCRIPTION
### Purpose

When creating a flow definition through the flow builder UI, the `required` flag for input elements defaults to `false`. If a flow is saved with all-optional inputs and the first step contains a single action, the backend auto-selects the action without prompting the user, causing flow execution to fail.

This PR changes the default `required` flag to `true` for all input elements in the flow builder, preventing this scenario.

### Approach

Updated the default value of `required` from `false` to `true` for all 10 FIELD-category input elements in `elements.json`: TEXT_INPUT, PASSWORD_INPUT, EMAIL_INPUT, PHONE_INPUT, NUMBER_INPUT, DATE_INPUT, OTP_INPUT, CHECKBOX, SELECT, and DROPDOWN.

Users can still toggle `required` off in the property panel if they explicitly want optional inputs.

### Related Issues
- Fixes #2194

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated form field configuration: Text, Password, Email, Phone, Number, Date, OTP, Checkbox, Select, and Dropdown fields are now required by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->