### PR TITLE
Refactor in-memory cache implementation to improve performance

### DIFF
--- a/backend/internal/system/cache/cache.go
+++ b/backend/internal/system/cache/cache.go
@@ -21,7 +21,6 @@ package cache
 
 import (
 	"context"
-	"sync"
 
 	"github.com/asgardeo/thunder/internal/system/log"
 )
@@ -43,7 +42,6 @@ type Cache[T any] struct {
 	enabled   bool
 	cacheName string
 	cacheImpl CacheInterface[T]
-	mu        sync.RWMutex
 }
 
 // GetName returns the name of the cache.
@@ -57,9 +55,6 @@ func (c *Cache[T]) Set(ctx context.Context, key CacheKey, value T) error {
 		log.String("cacheName", c.cacheName))
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-
 		if err := c.cacheImpl.Set(ctx, key, value); err != nil {
 			logger.Warn("Failed to set value in the cache", log.String("key", key.ToString()), log.Error(err))
 		}
@@ -71,9 +66,6 @@ func (c *Cache[T]) Set(ctx context.Context, key CacheKey, value T) error {
 // Get retrieves a value from the cache.
 func (c *Cache[T]) Get(ctx context.Context, key CacheKey) (T, bool) {
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
-		c.mu.RLock()
-		defer c.mu.RUnlock()
-
 		if value, found := c.cacheImpl.Get(ctx, key); found {
 			return value, true
 		}
@@ -89,9 +81,6 @@ func (c *Cache[T]) Delete(ctx context.Context, key CacheKey) error {
 		log.String("cacheName", c.cacheName))
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-
 		if err := c.cacheImpl.Delete(ctx, key); err != nil {
 			logger.Warn("Failed to delete value from the cache", log.String("key", key.ToString()), log.Error(err))
 		}
@@ -107,9 +96,6 @@ func (c *Cache[T]) Clear(ctx context.Context) error {
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
 		logger.Debug("Clearing all entries in the cache")
-
-		c.mu.Lock()
-		defer c.mu.Unlock()
 
 		if err := c.cacheImpl.Clear(ctx); err != nil {
 			logger.Warn("Failed to clear the cache", log.Error(err))
@@ -135,8 +121,6 @@ func (c *Cache[T]) GetStats() CacheStat {
 // CleanupExpired cleans up expired entries in the cache.
 func (c *Cache[T]) CleanupExpired() {
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
-		c.mu.Lock()
-		defer c.mu.Unlock()
 		c.cacheImpl.CleanupExpired()
 	}
 }

--- a/backend/internal/system/cache/inmemorycache.go
+++ b/backend/internal/system/cache/inmemorycache.go
@@ -23,6 +23,7 @@ import (
 	"container/list"
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/asgardeo/thunder/internal/system/config"
@@ -94,9 +95,9 @@ type inMemoryCache[T any] struct {
 	size           int
 	ttl            time.Duration
 	evictionPolicy evictionPolicy
-	hitCount       int64
-	missCount      int64
-	evictCount     int64
+	hitCount       atomic.Int64
+	missCount      atomic.Int64
+	evictCount     atomic.Int64
 }
 
 // getEvictionPolicy retrieves the eviction policy from the cache configuration.
@@ -260,7 +261,7 @@ func (c *inMemoryCache[T]) Get(_ context.Context, key CacheKey) (T, bool) {
 
 	entry, exists := c.cache[key]
 	if !exists {
-		c.missCount++
+		c.missCount.Add(1)
 		var zero T
 		return zero, false
 	}
@@ -268,7 +269,7 @@ func (c *inMemoryCache[T]) Get(_ context.Context, key CacheKey) (T, bool) {
 	// Check if the entry has expired
 	if time.Now().After(entry.ExpiryTime) {
 		c.deleteEntry(key, entry)
-		c.missCount++
+		c.missCount.Add(1)
 		var zero T
 		return zero, false
 	}
@@ -277,7 +278,7 @@ func (c *inMemoryCache[T]) Get(_ context.Context, key CacheKey) (T, bool) {
 	entry.lastAccess = time.Now()
 	entry.accessCount++
 	c.accessOrder.MoveToFront(entry.listElement)
-	c.hitCount++
+	c.hitCount.Add(1)
 
 	// Update the heap item for LFU eviction
 	if c.evictionPolicy == evictionPolicyLFU && entry.heapItem != nil {
@@ -322,9 +323,9 @@ func (c *inMemoryCache[T]) Clear(_ context.Context) error {
 	c.accessOrder.Init()
 	c.lfuHeap = &lfuHeap{}
 	heap.Init(c.lfuHeap)
-	c.hitCount = 0
-	c.missCount = 0
-	c.evictCount = 0
+	c.hitCount.Store(0)
+	c.missCount.Store(0)
+	c.evictCount.Store(0)
 
 	logger.Debug("Cleared all entries in the cache")
 	return nil
@@ -347,23 +348,25 @@ func (c *inMemoryCache[T]) GetStats() CacheStat {
 	}
 
 	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	size := len(c.cache)
-	totalOps := c.hitCount + c.missCount
+	c.mu.RUnlock()
+
+	hits := c.hitCount.Load()
+	misses := c.missCount.Load()
+	totalOps := hits + misses
 	var hitRate float64
 	if totalOps > 0 {
-		hitRate = float64(c.hitCount) / float64(totalOps)
+		hitRate = float64(hits) / float64(totalOps)
 	}
 
 	return CacheStat{
 		Enabled:    true,
 		Size:       size,
 		MaxSize:    c.size,
-		HitCount:   c.hitCount,
-		MissCount:  c.missCount,
+		HitCount:   hits,
+		MissCount:  misses,
 		HitRate:    hitRate,
-		EvictCount: c.evictCount,
+		EvictCount: c.evictCount.Load(),
 	}
 }
 
@@ -391,7 +394,7 @@ func (c *inMemoryCache[T]) evictOldest() {
 		key := oldest.Value.(CacheKey)
 		if entry, exists := c.cache[key]; exists {
 			c.deleteEntry(key, entry)
-			c.evictCount++
+			c.evictCount.Add(1)
 			logger.Debug("Cache entry evicted", log.String("key", key.ToString()))
 		}
 	}
@@ -411,7 +414,7 @@ func (c *inMemoryCache[T]) evictLeastFrequent() {
 
 	if entry, exists := c.cache[leastFrequentItem.key]; exists {
 		c.deleteEntry(leastFrequentItem.key, entry)
-		c.evictCount++
+		c.evictCount.Add(1)
 		logger.Debug("Cache entry evicted (LFU)", log.String("key", leastFrequentItem.key.ToString()),
 			log.Any("accessCount", leastFrequentItem.accessCount))
 	}


### PR DESCRIPTION
### Purpose
This pull request refactors the cache implementation to improve concurrency safety and performance. The main changes involve removing unnecessary locking from the generic `Cache` wrapper and making cache statistics in the in-memory cache (`inMemoryCache`) thread-safe by using atomic counters.

**Thread safety and performance improvements:**

* Removed the `sync.RWMutex` lock from the generic `Cache` struct and eliminated all locking/unlocking in its methods, relying on the underlying cache implementation for concurrency control. [[1]](diffhunk://#diff-e58e60779f1960804a306927f19b02c605f886e5cd839fa792e995e5af0e9e18L24) [[2]](diffhunk://#diff-e58e60779f1960804a306927f19b02c605f886e5cd839fa792e995e5af0e9e18L46) [[3]](diffhunk://#diff-e58e60779f1960804a306927f19b02c605f886e5cd839fa792e995e5af0e9e18L60-L62) [[4]](diffhunk://#diff-e58e60779f1960804a306927f19b02c605f886e5cd839fa792e995e5af0e9e18L74-L76) [[5]](diffhunk://#diff-e58e60779f1960804a306927f19b02c605f886e5cd839fa792e995e5af0e9e18L92-L94) [[6]](diffhunk://#diff-e58e60779f1960804a306927f19b02c605f886e5cd839fa792e995e5af0e9e18L111-L113) [[7]](diffhunk://#diff-e58e60779f1960804a306927f19b02c605f886e5cd839fa792e995e5af0e9e18L138-L139)

**Atomic counters for cache statistics:**

* Replaced plain `int64` fields for `hitCount`, `missCount`, and `evictCount` in `inMemoryCache` with `atomic.Int64` to ensure thread-safe updates. All increments and resets now use atomic operations. [[1]](diffhunk://#diff-bb8949ed5be5609456416529313c6dc071ced240453c6e3147f78120ef6bd373R26) [[2]](diffhunk://#diff-bb8949ed5be5609456416529313c6dc071ced240453c6e3147f78120ef6bd373L97-R100) [[3]](diffhunk://#diff-bb8949ed5be5609456416529313c6dc071ced240453c6e3147f78120ef6bd373L263-R272) [[4]](diffhunk://#diff-bb8949ed5be5609456416529313c6dc071ced240453c6e3147f78120ef6bd373L280-R281) [[5]](diffhunk://#diff-bb8949ed5be5609456416529313c6dc071ced240453c6e3147f78120ef6bd373L325-R328) [[6]](diffhunk://#diff-bb8949ed5be5609456416529313c6dc071ced240453c6e3147f78120ef6bd373L394-R397) [[7]](diffhunk://#diff-bb8949ed5be5609456416529313c6dc071ced240453c6e3147f78120ef6bd373L414-R417)

**Cache statistics calculation:**

* Updated the `GetStats` method in `inMemoryCache` to read statistics using atomic loads, ensuring accurate and safe concurrent access.

These changes ensure that cache operations and statistics are safe in concurrent environments without unnecessary locking overhead.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2252

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined cache synchronization and reduced wrapper-level locking around cache operations.
  * Switched cache counters to atomic updates for more accurate, concurrent-safe metrics.
  * Cache statistics are now reported without holding locks for the whole computation, improving responsiveness and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->