### PR TITLE
Fix generated flow graphs crashing in flow builder

### DIFF
--- a/frontend/apps/thunder-console/src/features/flows/components/resources/elements/adapters/ButtonAdapter.tsx
+++ b/frontend/apps/thunder-console/src/features/flows/components/resources/elements/adapters/ButtonAdapter.tsx
@@ -143,10 +143,10 @@ function ButtonAdapter({resource, elementIndex = undefined}: ButtonAdapterPropsI
   const startIcon = useMemo(() => {
     // Check resource.startIcon first (new format), then resource.image for backwards compatibility,
     // then config.image, then variant default
-    if (buttonElement?.startIcon) {
+    if (buttonElement?.startIcon && typeof buttonElement.startIcon === 'string') {
       return <img src={resolveStaticResourcePath(buttonElement.startIcon)} height={20} alt="" />;
     }
-    if (buttonElement?.image) {
+    if (buttonElement?.image && typeof buttonElement.image === 'string') {
       return <img src={resolveStaticResourcePath(buttonElement.image)} height={20} alt="" />;
     }
     if (buttonConfig?.image) {
@@ -159,7 +159,7 @@ function ButtonAdapter({resource, elementIndex = undefined}: ButtonAdapterPropsI
   }, [buttonElement?.startIcon, buttonElement?.image, buttonConfig?.image, image]);
 
   const endIcon = useMemo(() => {
-    if (buttonElement?.endIcon) {
+    if (buttonElement?.endIcon && typeof buttonElement.endIcon === 'string') {
       return <img src={resolveStaticResourcePath(buttonElement.endIcon)} height={20} alt="" />;
     }
     return undefined;

--- a/frontend/apps/thunder-console/src/features/flows/utils/generateFlowGraph.ts
+++ b/frontend/apps/thunder-console/src/features/flows/utils/generateFlowGraph.ts
@@ -207,7 +207,7 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
         label: 'Sign in with Google',
         variant: 'OUTLINED',
         eventType: 'TRIGGER',
-        startIcon: {icon: 'google'},
+        image: 'assets/images/icons/google.svg',
       });
 
       promptPrompts.push({
@@ -225,7 +225,7 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
         label: 'Sign in with GitHub',
         variant: 'OUTLINED',
         eventType: 'TRIGGER',
-        startIcon: {icon: 'github'},
+        image: 'assets/images/icons/github.svg',
       });
 
       promptPrompts.push({


### PR DESCRIPTION
## Summary
- Generated flows with Google/GitHub social login used `startIcon: {icon: 'google'}` (an object) instead of `image: 'assets/images/icons/google.svg'` (a string path). When the flow builder rendered these buttons, `ButtonAdapter` passed the object to `resolveStaticResourcePath` > `isAbsoluteUrl`, throwing `TypeError: e.startsWith is not a function`.
- Use `image` property with correct SVG asset paths in `generateFlowGraph`, matching the format used by widget templates
- Add `typeof` guards in `ButtonAdapter` to protect against non-string icon values in previously persisted flows

Fixes #2208

## Test plan
- [ ] Create a new application with Basic+Passkey+Google sign-in options
- [ ] Navigate to the flows list view
- [ ] Click on the generated flow and verify it opens in the flow builder without errors
- [ ] Verify Google/GitHub buttons display their icons correctly in the flow builder
- [ ] Verify existing manually-created flows still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button icon rendering with proper type validation to ensure icons display correctly when conditions are met
  * Updated Google and GitHub authentication button icons with new visual assets for improved consistency

* **Style**
  * Enhanced visual presentation of authentication buttons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->