### PR TITLE
Encrypt flow context full object

### DIFF
--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -118,6 +118,28 @@ type FlowContextDB struct {
 	UpdatedAt   time.Time
 }
 
+// isEncrypted reports whether the Context field is still in encrypted form.
+func (f *FlowContextDB) isEncrypted() bool {
+	var encCheck struct {
+		Algorithm string `json:"alg"`
+	}
+	return json.Unmarshal([]byte(f.Context), &encCheck) == nil && encCheck.Algorithm != ""
+}
+
+// decrypt decrypts the Context field in-place if it is still encrypted.
+func (f *FlowContextDB) decrypt() error {
+	if !f.isEncrypted() {
+		return nil
+	}
+	encryptionService := encrypt.GetEncryptionService()
+	decrypted, err := encryptionService.DecryptString(f.Context)
+	if err != nil {
+		return err
+	}
+	f.Context = decrypted
+	return nil
+}
+
 // flowContextContent holds all flow state serialized into the CONTEXT JSON column.
 type flowContextContent struct {
 	AppID               string  `json:"appId"`
@@ -138,8 +160,21 @@ type flowContextContent struct {
 	AuthUser            *string `json:"authUser,omitempty"`
 }
 
+// encrypt marshals and encrypts the content, returning the encrypted string.
+func (c *flowContextContent) encrypt() (string, error) {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	encryptionService := encrypt.GetEncryptionService()
+	return encryptionService.EncryptString(string(data))
+}
+
 // GetGraphID extracts the graph ID from the context JSON.
 func (f *FlowContextDB) GetGraphID() (string, error) {
+	if err := f.decrypt(); err != nil {
+		return "", err
+	}
 	var content flowContextContent
 	if err := json.Unmarshal([]byte(f.Context), &content); err != nil {
 		return "", err
@@ -149,6 +184,10 @@ func (f *FlowContextDB) GetGraphID() (string, error) {
 
 // ToEngineContext converts the database model to the flow engine context.
 func (f *FlowContextDB) ToEngineContext(graph core.GraphInterface) (EngineContext, error) {
+	// Ensure context is decrypted before parsing
+	if err := f.decrypt(); err != nil {
+		return EngineContext{}, err
+	}
 	var content flowContextContent
 	if err := json.Unmarshal([]byte(f.Context), &content); err != nil {
 		return EngineContext{}, err
@@ -183,15 +222,9 @@ func (f *FlowContextDB) ToEngineContext(graph core.GraphInterface) (EngineContex
 		userAttributes = make(map[string]interface{})
 	}
 
-	// Decrypt token if present
 	var token string
-	if content.Token != nil && *content.Token != "" {
-		encryptionService := encrypt.GetEncryptionService()
-		decrypted, err := encryptionService.DecryptString(*content.Token)
-		if err != nil {
-			return EngineContext{}, err
-		}
-		token = decrypted
+	if content.Token != nil {
+		token = *content.Token
 	}
 
 	// Parse available attributes
@@ -332,15 +365,9 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 		userType = &ctx.AuthenticatedUser.UserType
 	}
 
-	// Encrypt and store token if present
-	var encryptedToken *string
+	var token *string
 	if ctx.AuthenticatedUser.Token != "" {
-		encryptionService := encrypt.GetEncryptionService()
-		encrypted, err := encryptionService.EncryptString(ctx.AuthenticatedUser.Token)
-		if err != nil {
-			return nil, err
-		}
-		encryptedToken = &encrypted
+		token = &ctx.AuthenticatedUser.Token
 	}
 
 	// Serialize available attributes
@@ -385,18 +412,18 @@ func FromEngineContext(ctx EngineContext) (*FlowContextDB, error) {
 		UserType:            userType,
 		UserInputs:          &userInputs,
 		UserAttributes:      &userAttributes,
-		Token:               encryptedToken,
+		Token:               token,
 		AvailableAttributes: availableAttributes,
 		AuthUser:            authUserStr,
 	}
 
-	contextJSON, err := json.Marshal(content)
+	encryptedContext, err := content.encrypt()
 	if err != nil {
 		return nil, err
 	}
 
 	return &FlowContextDB{
 		ExecutionID: ctx.ExecutionID,
-		Context:     string(contextJSON),
+		Context:     encryptedContext,
 	}, nil
 }

--- a/backend/internal/flow/flowexec/model_test.go
+++ b/backend/internal/flow/flowexec/model_test.go
@@ -58,8 +58,10 @@ func TestModelTestSuite(t *testing.T) {
 }
 
 func (s *ModelTestSuite) getContextContent(dbModel *FlowContextDB) flowContextContent {
+	err := dbModel.decrypt()
+	s.NoError(err)
 	var content flowContextContent
-	err := json.Unmarshal([]byte(dbModel.Context), &content)
+	err = json.Unmarshal([]byte(dbModel.Context), &content)
 	s.NoError(err)
 	return content
 }
@@ -108,12 +110,9 @@ func (s *ModelTestSuite) TestFromEngineContext_WithToken() {
 	s.NotNil(content.UserID)
 	s.Equal("user-123", *content.UserID)
 
-	// Verify token is encrypted (not equal to original)
+	// Verify token is stored in decrypted context
 	s.NotNil(content.Token)
-	s.NotEqual(testToken, *content.Token)
-
-	// Verify token can be decrypted back
-	s.Greater(len(*content.Token), 0)
+	s.Equal(testToken, *content.Token)
 }
 
 func (s *ModelTestSuite) TestFromEngineContext_WithoutToken() {
@@ -304,16 +303,15 @@ func (s *ModelTestSuite) TestTokenEncryptionDecryptionRoundTrip() {
 				Graph:            mockGraph,
 			}
 
-			// Convert to DB model (encrypts token)
+			// Convert to DB model (encrypts entire context)
 			dbModel, err := FromEngineContext(ctx)
 			s.NoError(err)
-			content := s.getContextContent(dbModel)
-			s.NotNil(content.Token)
 
-			// Verify token is encrypted
-			s.NotEqual(testToken, *content.Token)
+			// Verify context is encrypted (contains ciphertext envelope)
+			s.Contains(dbModel.Context, `"ct"`, "context should be encrypted")
 
-			// Convert back to EngineContext (decrypts token)
+			// Decrypt and convert back to EngineContext
+			s.NoError(dbModel.decrypt())
 			resultCtx, err := dbModel.ToEngineContext(mockGraph)
 			s.NoError(err)
 
@@ -323,37 +321,237 @@ func (s *ModelTestSuite) TestTokenEncryptionDecryptionRoundTrip() {
 	}
 }
 
-func (s *ModelTestSuite) TestToEngineContext_WithInvalidEncryptedToken() {
-	// Setup - Create a DB model with invalid encrypted token
-	mockGraph := coremock.NewGraphInterfaceMock(s.T())
-
-	invalidToken := "invalid-encrypted-data" //nolint:gosec // G101: This is test data, not a real credential
-	userInputs := `{}`
-	runtimeData := `{}`
-	userAttributes := `{}`
-	executionHistory := `{}`
-
-	content := flowContextContent{
-		AppID:            "test-app-id",
-		GraphID:          "test-graph-id",
-		IsAuthenticated:  true,
-		UserInputs:       &userInputs,
-		RuntimeData:      &runtimeData,
-		UserAttributes:   &userAttributes,
-		ExecutionHistory: &executionHistory,
-		Token:            &invalidToken,
+func (s *ModelTestSuite) TestDecrypt_WithInvalidCiphertext() {
+	// Context is valid JSON with the encrypted envelope structure but has corrupted ciphertext.
+	testCases := []struct {
+		name    string
+		context string
+	}{
+		{
+			name:    "invalid base64 in ct field",
+			context: `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
+		},
+		{
+			name:    "empty ct field",
+			context: `{"alg":"AES-GCM","ct":"","kid":"key-1"}`,
+		},
+		{
+			name:    "ct too short to contain nonce",
+			context: `{"alg":"AES-GCM","ct":"dGVzdA==","kid":"key-1"}`,
+		},
 	}
-	contextJSON, _ := json.Marshal(content)
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			dbModel := &FlowContextDB{ExecutionID: "test-flow-id", Context: tc.context}
+			err := dbModel.decrypt()
+			s.Error(err)
+		})
+	}
+}
+
+func (s *ModelTestSuite) TestGetGraphID_WithDecryptionFailure() {
+	// Verifies that GetGraphID propagates a decryption error when the context
+	// looks encrypted but cannot be decrypted.
 	dbModel := &FlowContextDB{
 		ExecutionID: "test-flow-id",
-		Context:     string(contextJSON),
+		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
 	}
 
-	// Execute
-	_, err := dbModel.ToEngineContext(mockGraph)
-
-	// Verify - Should return error for invalid encrypted token
+	graphID, err := dbModel.GetGraphID()
 	s.Error(err)
+	s.Empty(graphID)
+}
+
+func (s *ModelTestSuite) TestToEngineContext_WithDecryptionFailure() {
+	// Verifies that ToEngineContext propagates a decryption error when the context
+	// looks encrypted but cannot be decrypted.
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+
+	dbModel := &FlowContextDB{
+		ExecutionID: "test-flow-id",
+		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
+	}
+
+	result, err := dbModel.ToEngineContext(mockGraph)
+	s.Error(err)
+	s.Equal(EngineContext{}, result)
+}
+
+func (s *ModelTestSuite) TestDecrypt_WithDecryptionFailure() {
+	// Verifies that decrypt returns an error (and does not panic) when
+	// the context looks encrypted but the ciphertext is invalid.
+	dbModel := &FlowContextDB{
+		ExecutionID: "test-flow-id",
+		Context:     `{"alg":"AES-GCM","ct":"not-valid-base64!!!","kid":"key-1"}`,
+	}
+
+	s.True(dbModel.isEncrypted(), "context should be detected as encrypted before attempt")
+
+	err := dbModel.decrypt()
+	s.Error(err)
+	// Context should remain unchanged (still in its original encrypted form)
+	s.True(dbModel.isEncrypted(), "context should remain encrypted after failed decryption")
+}
+
+func (s *ModelTestSuite) TestContextEncryptionRoundTrip() {
+	// Tests that the entire context JSON is encrypted and all fields survive the round trip.
+	testCases := []struct {
+		name    string
+		appID   string
+		userID  string
+		inputs  map[string]string
+		runtime map[string]string
+	}{
+		{
+			name:    "full context",
+			appID:   "app-full-context",
+			userID:  "user-full-context",
+			inputs:  map[string]string{"username": "testuser", "password": "secret"},
+			runtime: map[string]string{"state": "abc123", "nonce": "xyz789"},
+		},
+		{
+			name:    "minimal context",
+			appID:   "app-minimal",
+			userID:  "",
+			inputs:  map[string]string{},
+			runtime: map[string]string{},
+		},
+	}
+
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("test-graph-id").Maybe()
+	mockGraph.On("GetType").Return(common.FlowTypeAuthentication).Maybe()
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			ctx := EngineContext{
+				ExecutionID: "test-flow-id",
+				AppID:       tc.appID,
+				FlowType:    common.FlowTypeAuthentication,
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					IsAuthenticated: tc.userID != "",
+					UserID:          tc.userID,
+					Attributes:      map[string]interface{}{},
+				},
+				UserInputs:       tc.inputs,
+				RuntimeData:      tc.runtime,
+				ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+				Graph:            mockGraph,
+			}
+
+			// Encrypt
+			dbModel, err := FromEngineContext(ctx)
+			s.NoError(err)
+
+			// Verify context is encrypted: ciphertext envelope present, plain fields hidden
+			s.Contains(dbModel.Context, `"ct"`, "encrypted context should contain ciphertext field")
+			s.NotContains(dbModel.Context, tc.appID, "appId should not be visible in encrypted context")
+
+			// Decrypt and verify all fields are restored
+			err = dbModel.decrypt()
+			s.NoError(err)
+			s.NotContains(dbModel.Context, `"ct"`, "decrypted context should not contain ciphertext field")
+			s.Contains(dbModel.Context, `"appId"`, "decrypted context should expose plain appId field")
+
+			resultCtx, err := dbModel.ToEngineContext(mockGraph)
+			s.NoError(err)
+			s.Equal(tc.appID, resultCtx.AppID)
+			s.Equal(tc.userID, resultCtx.AuthenticatedUser.UserID)
+			s.Equal(len(tc.inputs), len(resultCtx.UserInputs))
+			s.Equal(len(tc.runtime), len(resultCtx.RuntimeData))
+		})
+	}
+}
+
+func (s *ModelTestSuite) TestIsEncrypted() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("test-graph-id")
+
+	ctx := EngineContext{
+		ExecutionID: "test-flow-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            mockGraph,
+	}
+
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+
+	// Freshly created DB model should have encrypted context
+	s.True(dbModel.isEncrypted(), "freshly encrypted context should be detected as encrypted")
+
+	// After decryption, should no longer be detected as encrypted
+	err = dbModel.decrypt()
+	s.NoError(err)
+	s.False(dbModel.isEncrypted(), "decrypted context should not be detected as encrypted")
+
+	// Plain JSON without "alg" field should not be detected as encrypted
+	plainModel := &FlowContextDB{
+		ExecutionID: "plain-id",
+		Context:     `{"appId":"test","graphId":"graph-1","isAuthenticated":false}`,
+	}
+	s.False(plainModel.isEncrypted(), "plain JSON context should not be detected as encrypted")
+
+	// Non-JSON string should not be detected as encrypted
+	invalidModel := &FlowContextDB{ExecutionID: "invalid-id", Context: "not-json-at-all"}
+	s.False(invalidModel.isEncrypted(), "non-JSON string should not be detected as encrypted")
+}
+
+func (s *ModelTestSuite) TestDecrypt_WithEncryptedContext() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("test-graph-id")
+	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
+
+	ctx := EngineContext{
+		ExecutionID: "test-flow-id",
+		AppID:       "ensure-decrypt-app",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          "user-ensure",
+			Token:           "ensure-token",
+			Attributes:      map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            mockGraph,
+	}
+
+	dbModel, err := FromEngineContext(ctx)
+	s.NoError(err)
+	s.True(dbModel.isEncrypted())
+
+	err = dbModel.decrypt()
+	s.NoError(err)
+	s.False(dbModel.isEncrypted(), "context should be decrypted after decrypt")
+
+	// Verify context is usable after decrypt
+	resultCtx, err := dbModel.ToEngineContext(mockGraph)
+	s.NoError(err)
+	s.Equal("ensure-decrypt-app", resultCtx.AppID)
+	s.Equal("user-ensure", resultCtx.AuthenticatedUser.UserID)
+	s.Equal("ensure-token", resultCtx.AuthenticatedUser.Token)
+}
+
+func (s *ModelTestSuite) TestDecrypt_WithPlainContext() {
+	// Plain JSON context should pass through decrypt unchanged
+	plainJSON := `{"appId":"test-app","graphId":"graph-1","isAuthenticated":false}`
+	dbModel := &FlowContextDB{ExecutionID: "test-flow-id", Context: plainJSON}
+
+	s.False(dbModel.isEncrypted())
+	originalContext := dbModel.Context
+
+	err := dbModel.decrypt()
+	s.NoError(err)
+	s.Equal(originalContext, dbModel.Context, "plain context should be unchanged by decrypt")
 }
 
 func (s *ModelTestSuite) TestFromEngineContext_PreservesOtherFields() {

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -258,16 +258,9 @@ func (s *flowExecService) loadContextFromStore(ctx context.Context, executionID 
 		return nil, &ErrorInvalidExecutionID
 	}
 
-	dbModel, err := s.flowStore.GetFlowContext(ctx, executionID)
-	if err != nil {
-		logger.Error("Error retrieving flow context from store",
-			log.String(log.LoggerKeyExecutionID, executionID),
-			log.Error(err))
-		return nil, &serviceerror.InternalServerError
-	}
-
-	if dbModel == nil {
-		return nil, &ErrorInvalidExecutionID
+	dbModel, flowCtxErr := s.getFlowContext(ctx, executionID, logger)
+	if flowCtxErr != nil {
+		return nil, flowCtxErr
 	}
 
 	graphID, err := dbModel.GetGraphID()
@@ -554,4 +547,33 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 
 	logger.Debug("Flow initiated successfully", log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	return engineCtx.ExecutionID, nil
+}
+
+// getFlowContext retrieves the flow context from the store based on the given execution ID.
+// It also ensures that the retrieved context is decrypted before returning.
+func (s *flowExecService) getFlowContext(ctx context.Context, executionID string, logger *log.Logger) (
+	*FlowContextDB, *serviceerror.ServiceError) {
+	if executionID == "" {
+		return nil, &ErrorInvalidExecutionID
+	}
+
+	dbModel, err := s.flowStore.GetFlowContext(ctx, executionID)
+	if err != nil {
+		logger.Error("Error retrieving flow context from store",
+			log.String(log.LoggerKeyExecutionID, executionID),
+			log.String("error", err.Error()))
+		return nil, &serviceerror.InternalServerError
+	}
+
+	if dbModel == nil {
+		return nil, &ErrorInvalidExecutionID
+	}
+
+	if decryptErr := dbModel.decrypt(); decryptErr != nil {
+		logger.Error("Failed to decrypt flow context",
+			log.String(log.LoggerKeyExecutionID, executionID), log.Error(decryptErr))
+		return nil, &serviceerror.InternalServerError
+	}
+
+	return dbModel, nil
 }

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	appmodel "github.com/asgardeo/thunder/internal/application/model"
+	authncm "github.com/asgardeo/thunder/internal/authn/common"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/flow/core"
 	flowmgt "github.com/asgardeo/thunder/internal/flow/mgt"
@@ -466,4 +467,100 @@ func TestGetFlowExpirySeconds(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestExecute_ContextDecryptionFailure(t *testing.T) {
+	// Tests that when the stored flow context cannot be decrypted,
+	// Execute returns an InternalServerError without proceeding further.
+	testConfig := &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
+			},
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+
+	// Context looks encrypted (has "alg" field) but the ciphertext is invalid
+	invalidCtx := &FlowContextDB{
+		ExecutionID: "existing-execution-id",
+		Context:     `{"alg":"AES-GCM","ct":"not-valid-ciphertext!!!","kid":"key-1"}`,
+	}
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(invalidCtx, nil)
+
+	service := &flowExecService{
+		flowStore: mockStore,
+	}
+
+	_, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{})
+
+	assert.NotNil(t, svcErr)
+	assert.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func TestExecute_ContextDecryptionSuccess(t *testing.T) {
+	// Tests that a properly encrypted stored context is decrypted and used
+	// to continue flow execution without error.
+	testConfig := &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
+			},
+		},
+	}
+	config.ResetThunderRuntime()
+	_ = config.InitializeThunderRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize()
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+
+	// Build a properly encrypted FlowContextDB
+	engineCtx := EngineContext{
+		ExecutionID: "existing-execution-id",
+		AppID:       "test-app-id",
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{},
+		},
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+		Graph:            testGraph,
+	}
+	dbModel, err := FromEngineContext(engineCtx)
+	assert.NoError(t, err)
+	assert.Contains(t, dbModel.Context, `"ct"`, "context should be encrypted before retrieval")
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowMgtSvc := flowmgtmock.NewFlowMgtServiceInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockAppService := applicationmock.NewApplicationServiceInterfaceMock(t)
+
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(dbModel, nil)
+	mockFlowMgtSvc.EXPECT().GetGraph(mock.Anything, "test-graph-id").Return(testGraph, nil)
+	mockAppService.EXPECT().GetApplication(mock.Anything, "test-app-id").Return(
+		&appmodel.Application{ID: "test-app-id", AuthFlowID: "test-graph-id"}, nil)
+	mockEngine.EXPECT().Execute(mock.Anything).Return(FlowStep{Status: common.FlowStatusIncomplete}, nil)
+	mockStore.EXPECT().UpdateFlowContext(
+		mock.MatchedBy(func(ctx context.Context) bool { return ctx.Value(txMarkerKey{}) == "tx" }),
+		mock.AnythingOfType("EngineContext")).Return(nil)
+
+	service := &flowExecService{
+		flowStore:      mockStore,
+		flowMgtService: mockFlowMgtSvc,
+		flowEngine:     mockEngine,
+		appService:     mockAppService,
+		transactioner:  &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{})
+
+	assert.Nil(t, svcErr)
+	assert.NotNil(t, flowStep)
+	assert.Equal(t, common.FlowStatusIncomplete, flowStep.Status)
 }

--- a/backend/internal/flow/flowexec/store_test.go
+++ b/backend/internal/flow/flowexec/store_test.go
@@ -32,6 +32,7 @@ import (
 	managerpkg "github.com/asgardeo/thunder/internal/authnprovider/manager"
 	"github.com/asgardeo/thunder/internal/flow/common"
 	"github.com/asgardeo/thunder/internal/system/config"
+	"github.com/asgardeo/thunder/internal/system/crypto/encrypt"
 
 	"github.com/asgardeo/thunder/tests/mocks/database/providermock"
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
@@ -63,8 +64,10 @@ func TestStoreTestSuite(t *testing.T) {
 }
 
 func (s *StoreTestSuite) getContextContent(dbModel *FlowContextDB) flowContextContent {
+	err := dbModel.decrypt()
+	s.NoError(err)
 	var content flowContextContent
-	err := json.Unmarshal([]byte(dbModel.Context), &content)
+	err = json.Unmarshal([]byte(dbModel.Context), &content)
 	s.NoError(err)
 	return content
 }
@@ -235,6 +238,9 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	dbModel, err := FromEngineContext(ctx)
 	s.NoError(err)
 
+	// Save encrypted context before getContextContent decrypts it in place
+	encryptedContext := dbModel.Context
+
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.Token)
 
@@ -245,7 +251,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	results := []map[string]interface{}{
 		{
 			"flow_id":     "test-flow-id",
-			"context":     dbModel.Context,
+			"context":     encryptedContext,
 			"expiry_time": expiryTime,
 		},
 	}
@@ -267,12 +273,11 @@ func (s *StoreTestSuite) TestGetFlowContext_WithToken() {
 	s.NotNil(result)
 	s.Equal("test-flow-id", result.ExecutionID)
 
+	// getContextContent decrypts result in place; ToEngineContext works on the decrypted context
 	content = s.getContextContent(result)
 	s.True(content.IsAuthenticated)
 	s.NotNil(content.Token)
-	s.Equal(dbModel.Context, result.Context) // JSON should match
 
-	// Verify we can decrypt it back to original
 	restoredCtx, err := result.ToEngineContext(mockGraph)
 	s.NoError(err)
 	s.Equal(testToken, restoredCtx.AuthenticatedUser.Token)
@@ -288,18 +293,20 @@ func (s *StoreTestSuite) TestGetFlowContext_WithoutToken() {
 
 	expiryTime := time.Now().Add(30 * time.Minute)
 
-	// Create serialized context
+	// Create and encrypt context
 	contextJSON, err := json.Marshal(flowContextContent{
 		AppID:           "test-app-id",
 		IsAuthenticated: false,
 		GraphID:         "test-graph-id",
 	})
 	s.NoError(err)
+	encryptedContext, err := encrypt.GetEncryptionService().EncryptString(string(contextJSON))
+	s.NoError(err)
 
 	results := []map[string]interface{}{
 		{
 			"flow_id":     "test-flow-id",
-			"context":     string(contextJSON),
+			"context":     encryptedContext,
 			"expiry_time": expiryTime,
 		},
 	}
@@ -331,7 +338,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithoutToken() {
 
 func (s *StoreTestSuite) TestStoreAndRetrieve_TokenRoundTrip() {
 	// This is an integration-style test that simulates the full round trip
-	// of storing and retrieving a flow context with an encrypted token
+	// of storing and retrieving a flow context with a token
 
 	// Setup
 	originalToken := "integration-test-token-secret"
@@ -368,20 +375,24 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_TokenRoundTrip() {
 		Graph: mockGraph,
 	}
 
-	// Step 1: Convert to DB model (encrypts token)
+	// Step 1: Convert to DB model (encrypts entire context)
 	dbModel, err := FromEngineContext(originalCtx)
 	s.NoError(err)
 	s.NotNil(dbModel)
 
-	content := s.getContextContent(dbModel)
-	s.NotNil(content.Token)
-	s.NotEqual(originalToken, *content.Token, "Token should be encrypted")
+	// Verify the context is encrypted
+	s.Contains(dbModel.Context, `"ct"`, "context should be encrypted")
 
 	// Step 2: Simulate storing and retrieving from DB
 	// In a real scenario, this would be inserted into DB and read back
 	// For this test, we'll directly use the dbModel
 
-	// Step 3: Convert back to EngineContext (decrypts token)
+	// Step 3: Decrypt context and read the content
+	content := s.getContextContent(dbModel)
+	s.NotNil(content.Token)
+	s.Equal(originalToken, *content.Token)
+
+	// Step 4: Convert to EngineContext (context already decrypted by getContextContent)
 	retrievedCtx, err := dbModel.ToEngineContext(mockGraph)
 	s.NoError(err)
 
@@ -400,6 +411,77 @@ func (s *StoreTestSuite) TestStoreAndRetrieve_TokenRoundTrip() {
 	// Verify other fields
 	s.Equal(len(originalCtx.UserInputs), len(retrievedCtx.UserInputs))
 	s.Equal(len(originalCtx.RuntimeData), len(retrievedCtx.RuntimeData))
+	s.Equal(len(originalCtx.ExecutionHistory), len(retrievedCtx.ExecutionHistory))
+}
+
+func (s *StoreTestSuite) TestStoreAndRetrieve_ContextEncryptionRoundTrip() {
+	// Verifies that the entire context is encrypted (not just the token field),
+	// so that no sensitive fields are readable in the raw stored value.
+	sensitiveAppID := "app-sensitive-12345"
+	sensitiveUserID := "user-sensitive-67890"
+	sensitiveInput := "sensitive-input-value"
+	sensitiveRuntimeData := "sensitive-runtime-value"
+
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("context-enc-graph-id")
+	mockGraph.On("GetType").Return(common.FlowTypeAuthentication)
+
+	originalCtx := EngineContext{
+		ExecutionID: "context-enc-flow-id",
+		AppID:       sensitiveAppID,
+		Verbose:     false,
+		FlowType:    common.FlowTypeAuthentication,
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			IsAuthenticated: true,
+			UserID:          sensitiveUserID,
+			OUID:            "org-sensitive",
+			Attributes:      map[string]interface{}{"email": "sensitive@test.com"},
+		},
+		UserInputs:  map[string]string{"input_key": sensitiveInput},
+		RuntimeData: map[string]string{"runtime_key": sensitiveRuntimeData},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{
+			"node-enc-1": {NodeID: "node-enc-1"},
+		},
+		Graph: mockGraph,
+	}
+
+	// Step 1: Convert to DB model (encrypts entire context)
+	dbModel, err := FromEngineContext(originalCtx)
+	s.NoError(err)
+	s.NotNil(dbModel)
+
+	// Step 2: Verify entire context is encrypted — no plain fields visible
+	s.Contains(dbModel.Context, `"ct"`, "encrypted context should contain ciphertext field")
+	s.NotContains(dbModel.Context, sensitiveAppID, "appId should not be visible in encrypted context")
+	s.NotContains(dbModel.Context, sensitiveUserID, "userId should not be visible in encrypted context")
+	s.NotContains(dbModel.Context, sensitiveInput, "userInputs should not be visible in encrypted context")
+	s.NotContains(dbModel.Context, sensitiveRuntimeData, "runtimeData should not be visible in encrypted context")
+
+	// Step 3: Decrypt and verify all fields are restored
+	content := s.getContextContent(dbModel)
+	s.Equal(sensitiveAppID, content.AppID)
+	s.NotNil(content.UserID)
+	s.Equal(sensitiveUserID, *content.UserID)
+	s.NotNil(content.UserInputs)
+
+	var userInputs map[string]string
+	s.NoError(json.Unmarshal([]byte(*content.UserInputs), &userInputs))
+	s.Equal(sensitiveInput, userInputs["input_key"])
+	s.NotNil(content.RuntimeData)
+	var runtimeData map[string]string
+	s.NoError(json.Unmarshal([]byte(*content.RuntimeData), &runtimeData))
+	s.Equal(sensitiveRuntimeData, runtimeData["runtime_key"])
+
+	// Step 4: Convert to EngineContext and verify all data is preserved
+	retrievedCtx, err := dbModel.ToEngineContext(mockGraph)
+	s.NoError(err)
+	s.Equal(originalCtx.ExecutionID, retrievedCtx.ExecutionID)
+	s.Equal(originalCtx.AppID, retrievedCtx.AppID)
+	s.Equal(originalCtx.AuthenticatedUser.IsAuthenticated, retrievedCtx.AuthenticatedUser.IsAuthenticated)
+	s.Equal(originalCtx.AuthenticatedUser.UserID, retrievedCtx.AuthenticatedUser.UserID)
+	s.Equal(originalCtx.AuthenticatedUser.OUID, retrievedCtx.AuthenticatedUser.OUID)
+	s.Equal(sensitiveInput, retrievedCtx.UserInputs["input_key"])
+	s.Equal(sensitiveRuntimeData, retrievedCtx.RuntimeData["runtime_key"])
 	s.Equal(len(originalCtx.ExecutionHistory), len(retrievedCtx.ExecutionHistory))
 }
 
@@ -650,6 +732,9 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	dbModel, err := FromEngineContext(ctx)
 	s.NoError(err)
 
+	// Save encrypted context before getContextContent decrypts it in place
+	encryptedContext := dbModel.Context
+
 	content := s.getContextContent(dbModel)
 	s.NotNil(content.AvailableAttributes)
 
@@ -660,7 +745,7 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	results := []map[string]interface{}{
 		{
 			"flow_id":     "test-flow-id",
-			"context":     dbModel.Context,
+			"context":     encryptedContext,
 			"expiry_time": expiryTime,
 		},
 	}
@@ -682,10 +767,10 @@ func (s *StoreTestSuite) TestGetFlowContext_WithAvailableAttributes() {
 	s.NotNil(result)
 	s.Equal("test-flow-id", result.ExecutionID)
 
+	// getContextContent decrypts result in place; ToEngineContext works on the decrypted context
 	content = s.getContextContent(result)
 	s.True(content.IsAuthenticated)
 	s.NotNil(content.AvailableAttributes)
-	s.Equal(dbModel.Context, result.Context) // Serialized context should match
 
 	// Verify we can deserialize it back to original
 	restoredCtx, err := result.ToEngineContext(mockGraph)


### PR DESCRIPTION
### Purpose
The flow execution context stored in `FlowContextDB` previously encrypted only the `token` field within the context JSON. All other sensitive data — appId, userId, userInputs, runtimeData, executionHistory, user attributes — were stored as plain text in the database.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
This change encrypts the `Context` attribute (the `flowContextContent` object) in `flowContextDB`. Shift from per-field encryption to whole-context encryption: the entire `flowContextContent` JSON converted in to string  is AES-GCM encrypted before being written to the database, and decrypted after retrieval.

#### model.go:

- FromEngineContext: removed the isolated token encryption block; the full serialized flowContextContent JSON is now encrypted as a single unit at the end, producing an AES-GCM ciphertext envelope ({"alg":..., "ct":..., "kid":...})
- ToEngineContext: removed token-specific decryption; reads token directly from the already-decrypted content
- Added Decrypt() — decrypts FlowContextDB.Context in-place, replacing the ciphertext envelope with plain JSON
- Added isEncrypted() — detects whether the context is still encrypted by checking for the "alg" field in the JSON, without requiring a separate boolean property
- Added ensureDecrypted() — auto-decrypts with a warning log if GetGraphID or ToEngineContext are called before an explicit Decrypt() (safety net against call-order bugs)


#### service.go:

- In loadContextFromStore, explicitly calls Decrypt() on the retrieved FlowContextDB immediately after GetFlowContext, before any further processing. This is the primary decryption point in the service layer.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2011

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Entire persisted flow contexts are now encrypted before storage; tokens and sensitive fields are protected. Tokens remain readable in memory only after successful decryption.

* **Bug Fixes**
  * Contexts are decrypted when loaded; load fails early and surfaces an internal error if decryption fails.

* **Tests**
  * Expanded tests for full-context encryption/decryption, corruption cases, load-time failures, and successful round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->